### PR TITLE
Truncate oversized user messages

### DIFF
--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -212,6 +212,16 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
 
     try:
         # Add user message to history
+        # Truncate oversized user messages
+        max_len = config.max_message_length
+        if max_len and len(user_message) > max_len:
+            original_len = len(user_message)
+            user_message = (
+                user_message[:max_len]
+                + f"\n\n[truncated at {max_len:,} chars, original was {original_len:,}]"
+            )
+            log.warning(f"User message truncated: {original_len:,} -> {max_len:,} chars")
+
         user_msg = {"role": "user", "content": user_message}
         history.append(user_msg)
         _archive(ctx, user_msg)

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -106,6 +106,7 @@ class Config:
     # Agent settings (system_prompt is assembled from prompt files at startup)
     system_prompt: str = ""
     max_tool_iterations: int = 200
+    max_message_length: int = 50000  # truncate user messages beyond this (chars)
 
     # HTTP server settings
     http_enabled: bool = False
@@ -188,4 +189,5 @@ def load_config() -> Config:
         claude_code_session_timeout=os.getenv("CLAUDE_CODE_SESSION_TIMEOUT", "30m"),
         system_prompt=os.getenv("SYSTEM_PROMPT", Config.system_prompt),
         max_tool_iterations=int(os.getenv("MAX_TOOL_ITERATIONS", "30")),
+        max_message_length=int(os.getenv("MAX_MESSAGE_LENGTH", "50000")),
     )


### PR DESCRIPTION
## Summary

- Add `MAX_MESSAGE_LENGTH` config (default 50,000 chars, env var configurable)
- Truncate user messages in `run_agent_turn()`, below both Mattermost and web UI
- Appends `[truncated at N chars, original was M]` so the LLM knows content was cut
- Logs a warning when truncation happens

Closes #6

## Test plan

- [x] `make check` passes
- [x] `make test` passes (433 tests)
- [ ] Paste a large message, verify truncation note appears in the response context

🤖 Generated with [Claude Code](https://claude.com/claude-code)