### PR TITLE
Incremental compaction: only summarize newly-old turns

### DIFF
--- a/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/notes.md
+++ b/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/notes.md
@@ -1,0 +1,5 @@
+# Notes
+
+## Session log
+
+- Started session for incremental compaction (#57)

--- a/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/plan.md
+++ b/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/plan.md
@@ -1,0 +1,47 @@
+# Plan: Incremental Compaction
+
+## Context
+
+The compacted sidecar (`{conv_id}.compacted.jsonl`) stores `[summary_msg] + [recent_messages]`. The summary message has role "user" with content prefixed `[Conversation summary]:`. The full archive (`{conv_id}.jsonl`) is append-only and never modified.
+
+Currently `compact_history` always reads the full archive, splits all turns into old/recent, and summarizes all old turns from scratch.
+
+## Step 1: Extract previous summary from compacted history
+
+**What**: Add a helper `_extract_previous_summary` that reads the compacted sidecar and returns the summary text (if any) and the timestamp of the last message in the compacted history.
+
+**Why**: We need to know what was already summarized and where the boundary is.
+
+**Prompt**: In `compaction.py`, add a function that:
+- Calls `read_compacted_history(config, conv_id)`
+- If the first message starts with `[Conversation summary]:`, extract the summary text
+- Return `(summary_text, last_compacted_timestamp)` or `(None, None)` if no previous compaction
+
+## Step 2: Identify newly-old turns
+
+**What**: Modify `compact_history` to compare the full archive against the previous compaction boundary. Only turns between the old summary and the current recent-preserve window are "newly old" and need summarizing.
+
+**Why**: This is the core optimization — skip turns that were already summarized.
+
+**Prompt**: In `compact_history`:
+- After reading the archive and splitting into turns, check for a previous summary via `_extract_previous_summary`
+- If a previous summary exists, find the turns in the archive that come after the previous compaction boundary but before the current recent-preserve window
+- These are the "newly-old" turns that need to be folded into the summary
+- If there are no newly-old turns (recent window hasn't moved), skip compaction
+
+## Step 3: Incremental summarization
+
+**What**: When a previous summary exists, combine it with newly-old turns and produce an updated summary, rather than re-summarizing everything.
+
+**Why**: This is the payoff — each compaction only processes a small delta.
+
+**Prompt**: Modify the summarization call:
+- If we have a previous summary + newly-old turns, build the input as: `"Previous summary:\n{old_summary}\n\nNew turns to incorporate:\n{flattened_new_turns}"`
+- Use a slightly modified prompt that instructs the LLM to update the summary with new information rather than summarize from scratch
+- If no previous summary, fall through to the existing full-summarize path
+
+## Step 4: Lint, test, commit
+
+**What**: Verify everything passes, commit the change.
+
+**Prompt**: Run `make check && make test`. Fix any issues. Commit with a message referencing #57.

--- a/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/spec.md
+++ b/.claude/dev-sessions/2026-03-17-1600-incremental-compaction/spec.md
@@ -1,0 +1,21 @@
+# Incremental Compaction
+
+## Problem
+
+`compact_history` reads the full original archive and re-summarizes all old turns from scratch on every compaction run. Cost grows linearly with conversation length.
+
+## Goal
+
+Use the previous compaction summary as a base and only summarize newly-old turns (turns that have fallen off the recent-preserve window since the last compaction).
+
+## Scope
+
+- Modify `compact_history` in `compaction.py` to work incrementally
+- Preserve the existing sidecar `.compacted.jsonl` format
+- No changes to archive format or tool interfaces
+
+## References
+
+- Issue: #57
+- Prior session: `docs/dev-sessions/2026-03-14-1024-conversation-compaction/`
+- Key files: `src/decafclaw/compaction.py`, `src/decafclaw/archive.py`

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -17,6 +17,15 @@ Summarize the following conversation, preserving:
 
 Be concise but don't lose critical details. Format as a brief narrative."""
 
+INCREMENTAL_COMPACTION_PROMPT = """\
+You have an existing conversation summary and new turns that need to be incorporated.
+Update the summary to include the new information while preserving all important details
+from the original summary. Do not lose any key facts, decisions, or user preferences.
+
+Be concise but don't lose critical details. Format as a brief narrative."""
+
+SUMMARY_PREFIX = "[Conversation summary]: "
+
 
 def _load_compaction_prompt(config) -> str:
     """Load custom prompt from workspace, or use default."""
@@ -24,6 +33,24 @@ def _load_compaction_prompt(config) -> str:
     if prompt_path.exists():
         return prompt_path.read_text().strip()
     return DEFAULT_COMPACTION_PROMPT
+
+
+def _extract_previous_summary(config, conv_id: str) -> tuple[str | None, str | None]:
+    """Extract the previous summary text and the last compacted timestamp.
+
+    Returns (summary_text, last_timestamp) or (None, None) if no
+    previous compaction exists.
+    """
+    compacted = read_compacted_history(config, conv_id)
+    if not compacted:
+        return None, None
+    first = compacted[0]
+    content = first.get("content", "")
+    if first.get("role") == "user" and content.startswith(SUMMARY_PREFIX):
+        summary_text = content[len(SUMMARY_PREFIX):]
+        last_ts = compacted[-1].get("timestamp", "")
+        return summary_text, last_ts
+    return None, None
 
 
 def _split_into_turns(messages: list[dict]) -> list[list[dict]]:
@@ -139,8 +166,9 @@ async def _chunked_summarize(ctx, config, turns: list[list[dict]],
 async def compact_history(ctx, history: list) -> bool:
     """Compact conversation history using the archive as source.
 
-    Reads the full archive, splits into old/recent, summarizes old
-    messages, and replaces history with [summary] + [recent].
+    If a previous compaction exists, performs incremental compaction:
+    folds only newly-old turns into the existing summary. Otherwise
+    falls back to full compaction from scratch.
 
     Returns True if compaction was performed, False if skipped.
     """
@@ -164,22 +192,60 @@ async def compact_history(ctx, history: list) -> bool:
     # Split: old turns to summarize, recent turns to keep
     old_turns = turns[:-preserve]
     recent_turns = turns[-preserve:]
-
     old_messages = [msg for turn in old_turns for msg in turn]
     recent_messages = [msg for turn in recent_turns for msg in turn]
 
+    # Check for incremental compaction
+    prev_summary, prev_last_ts = _extract_previous_summary(config, conv_id)
+    incremental = False
+    newly_old_turns: list[list[dict]] = []
+
+    if prev_summary and prev_last_ts:
+        # Find how many archive messages existed at the time of the last
+        # compaction by finding the boundary using the last compacted timestamp.
+        # Everything in the archive up to that timestamp was covered.
+        prev_archive_len = 0
+        for i, msg in enumerate(archive):
+            if msg.get("timestamp", "") <= prev_last_ts:
+                prev_archive_len = i + 1
+            else:
+                break
+
+        # At the previous compaction, the old turns covered archive[0:prev_old_count].
+        # The recent turns covered archive[prev_old_count:prev_archive_len].
+        # Now old_turns may extend further. Newly-old turns are those whose
+        # messages start at or after prev_old_count in the archive.
+        # prev_old_count = prev_archive_len - prev_recent_count, but we don't
+        # know prev_recent_count directly. However, the summary message in the
+        # sidecar replaced everything before the recent window. The recent
+        # messages in the sidecar correspond to the last N messages of the
+        # archive at that time. We can count: the compacted sidecar had
+        # (total_compacted - 1) recent messages covering archive positions
+        # [prev_archive_len - (total_compacted - 1) : prev_archive_len].
+        compacted = read_compacted_history(config, conv_id)
+        prev_recent_count = len(compacted) - 1 if compacted else 0
+        prev_old_msg_count = prev_archive_len - prev_recent_count
+
+        # Walk old_turns to find those with messages past the previous boundary
+        msg_idx = 0
+        for turn in old_turns:
+            turn_end = msg_idx + len(turn)
+            if turn_end > prev_old_msg_count:
+                newly_old_turns.append(turn)
+            msg_idx = turn_end
+
+        if not newly_old_turns:
+            log.info("No newly-old turns since last compaction, skipping")
+            return False
+        incremental = True
+
     log.info(f"Compacting {len(old_messages)} messages ({len(old_turns)} turns) "
-             f"into summary, preserving {len(recent_messages)} messages ({len(recent_turns)} turns)")
+             f"into summary, preserving {len(recent_messages)} messages "
+             f"({len(recent_turns)} turns)"
+             f"{f', incremental ({len(newly_old_turns)} new turns)' if incremental else ''}")
 
-    # Load the summarization prompt
-    prompt = _load_compaction_prompt(config)
-
-    # Flatten old messages
-    flattened = _flatten_messages(old_messages)
-
-    # Check if we need chunked compaction
     budget = config.compaction_context_budget
-    estimated = _estimate_tokens(flattened)
+    estimated = 0
 
     import time as _time
     before_messages = len(history)
@@ -188,18 +254,40 @@ async def compact_history(ctx, history: list) -> bool:
     try:
         await ctx.publish("compaction_start")
 
-        if estimated > budget:
-            log.info(f"Flattened text ({estimated} est. tokens) exceeds compaction budget ({budget}), using chunked compaction")
-            summary = await _chunked_summarize(ctx, config, old_turns, prompt, budget)
+        if incremental:
+            # Fold newly-old turns into existing summary
+            newly_old_flat = _flatten_messages(
+                [msg for turn in newly_old_turns for msg in turn])
+            combined_input = (
+                f"Existing summary:\n{prev_summary}\n\n"
+                f"New conversation turns to incorporate:\n{newly_old_flat}"
+            )
+            estimated = _estimate_tokens(combined_input)
+            log.info(f"Incremental summarization: ~{estimated} est. tokens")
+            summary = await _single_summarize(
+                ctx, config, combined_input, INCREMENTAL_COMPACTION_PROMPT)
         else:
-            summary = await _single_summarize(ctx, config, flattened, prompt)
+            # Full compaction from scratch
+            prompt = _load_compaction_prompt(config)
+            flattened = _flatten_messages(old_messages)
+            estimated = _estimate_tokens(flattened)
+            if estimated > budget:
+                log.info(f"Flattened text ({estimated} est. tokens) exceeds "
+                         f"budget ({budget}), using chunked compaction")
+                summary = await _chunked_summarize(
+                    ctx, config, old_turns, prompt, budget)
+            else:
+                summary = await _single_summarize(ctx, config, flattened, prompt)
 
         if not summary:
             log.warning("Compaction LLM returned empty summary, skipping")
             return False
 
         # Rebuild history: summary + recent messages
-        summary_msg = {"role": "user", "content": f"[Conversation summary]: {summary}"}
+        summary_msg = {
+            "role": "user",
+            "content": f"{SUMMARY_PREFIX}{summary}",
+        }
 
         history.clear()
         history.append(summary_msg)

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -4,9 +4,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from decafclaw.archive import append_message
+from decafclaw.archive import append_message, write_compacted_history
 from decafclaw.compaction import (
+    SUMMARY_PREFIX,
     _estimate_tokens,
+    _extract_previous_summary,
     _flatten_messages,
     _split_into_turns,
     compact_history,
@@ -183,4 +185,81 @@ class TestCompactHistory:
         with patch("decafclaw.compaction.call_llm", new_callable=AsyncMock, return_value=mock_response):
             result = await compact_history(ctx, history)
 
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_incremental_compaction(self, ctx, config):
+        """Second compaction should only summarize newly-old turns."""
+        conv_id = "test-conv"
+        # Create 10 turns
+        for i in range(10):
+            append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
+            append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
+
+        ctx.config.compaction_preserve_turns = 5
+
+        # Simulate a previous compaction that summarized turns 0-4,
+        # preserving turns 5-9 (10 messages) as recent.
+        prev_summary = f"{SUMMARY_PREFIX}Summary of turns 0-4."
+        prev_recent = []
+        for i in range(5, 10):
+            prev_recent.append({"role": "user", "content": f"message {i}"})
+            prev_recent.append({"role": "assistant", "content": f"response {i}"})
+        write_compacted_history(config, conv_id, [
+            {"role": "user", "content": prev_summary},
+            *prev_recent,
+        ])
+
+        # Now add 3 more turns (turns 10-12) to the archive
+        for i in range(10, 13):
+            append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
+            append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
+
+        # 13 turns total, preserve 5 → 8 old turns.
+        # Previous compaction covered 5 old turns. So 3 newly-old turns.
+        history = [{"role": "user", "content": "placeholder"}]
+
+        mock_response = {
+            "content": "Updated summary including turns 0-7.",
+            "tool_calls": None,
+            "role": "assistant",
+            "usage": None,
+        }
+
+        with patch("decafclaw.compaction.call_llm", new_callable=AsyncMock, return_value=mock_response) as mock_llm:
+            result = await compact_history(ctx, history)
+
+        assert result is True
+        # Verify the LLM was called with incremental prompt (existing summary + new turns)
+        call_args = mock_llm.call_args
+        messages = call_args[0][1]  # second positional arg
+        user_content = messages[1]["content"]
+        assert "Existing summary:" in user_content
+        assert "Summary of turns 0-4." in user_content
+        assert "New conversation turns to incorporate:" in user_content
+
+    @pytest.mark.asyncio
+    async def test_incremental_skips_when_no_new_turns(self, ctx, config):
+        """If no turns have aged out since last compaction, skip."""
+        conv_id = "test-conv"
+        # Create 8 turns
+        for i in range(8):
+            append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
+            append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
+
+        ctx.config.compaction_preserve_turns = 5
+
+        # Previous compaction summarized turns 0-2, preserved turns 3-7 (10 msgs).
+        prev_recent = []
+        for i in range(3, 8):
+            prev_recent.append({"role": "user", "content": f"message {i}"})
+            prev_recent.append({"role": "assistant", "content": f"response {i}"})
+        write_compacted_history(config, conv_id, [
+            {"role": "user", "content": f"{SUMMARY_PREFIX}Summary of turns 0-2."},
+            *prev_recent,
+        ])
+
+        # No new messages added — same 8 turns, same boundary.
+        history = [{"role": "user", "content": "placeholder"}]
+        result = await compact_history(ctx, history)
         assert result is False


### PR DESCRIPTION
## Summary

- Instead of re-summarizing the full archive on every compaction, detect which turns have aged out of the recent-preserve window since the last compaction
- Fold only those newly-old turns into the existing summary via an incremental prompt ("update this summary with these new turns")
- Uses timestamps from the compacted sidecar to find the boundary between previously-summarized and newly-old turns
- Falls back to full compaction when no previous summary exists (first compaction)
- Skips compaction entirely when no turns have aged out since last time

Closes #57

## Test plan

- [x] `make check` passes
- [x] `make test` passes (435 tests, 2 new)
- [x] New test: incremental compaction only sends newly-old turns + existing summary to LLM
- [x] New test: skips compaction when no turns have aged out
- [ ] Live test: compact a long conversation twice, verify second compaction is faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)