### PR TITLE
Concurrent tool execution and delegate_task simplification

### DIFF
--- a/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/notes.md
+++ b/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/notes.md
@@ -1,0 +1,57 @@
+# Concurrent Tool Calls & Delegate Simplification — Notes
+
+## Session Log
+
+### Phase 1 — tool_call_id plumbing (done)
+- Added `current_tool_call_id` to Context, auto-included in `publish()`
+- Agent loop sets/clears around each tool call
+- Confirmation matching uses tool_call_id when available
+
+### Phase 2 — config (done)
+- Added `max_concurrent_tools` (default 5) to Config
+
+### Phase 3 — concurrent execution (done)
+- Rewrote `_execute_tool_calls` with `asyncio.gather` + semaphore
+- Added `fork_for_tool_call` to Context — copies all fields tools need
+- Cancel watcher pattern for emergency stop
+- 4 new tests: concurrent timing, semaphore, partial failure, ordering
+
+### Phase 4 — UI updates (done)
+- Mattermost ConversationDisplay tracks by tool_call_id dict
+- Confirmation flow threads tool_call_id through emoji polling, HTTP buttons, web websocket
+
+### Phase 5 — delegate simplification (done)
+- Renamed delegate → delegate_task, flat schema: just `task: str`
+- Child inherits all parent tools/skills, no more tools/system_prompt params
+
+### Phase 6 — docs (done)
+- Updated delegation.md, README.md, CLAUDE.md
+
+### Bug fixes found during QA
+- **MCP shutdown traceback**: `CancelledError` is `BaseException`, not `Exception`
+- **Uvicorn shutdown traceback**: use `server.should_exit = True` instead of task cancel
+- **Confirmation broken by strict tool_call_id matching**: relaxed to require match only when both sides have it
+- **Frontend not echoing tool_call_id**: confirm_request/response now carries tool_call_id through the browser
+- **Child agent events invisible to parent UI**: added `event_context_id` so children publish under parent's context_id
+- **Child agents missing skill instructions**: include activated skill SKILL.md bodies in child system prompt
+- **Child system prompt too minimal**: added explicit "check tools, don't refuse" instructions
+- **All confirmations disappearing on click**: `respondToConfirm` was filtering by context_id; now filters by tool_call_id
+- **Wrong command confirmed on click**: confirm-view now passes tool_call_id directly from the confirm card
+- **Text appearing after tool results**: added `text_before_tools` event to flush assistant text before tools start
+- **respondToConfirm signature mismatch**: added default params for cache resilience
+- **activated_skills not copied in fork_for_tool_call**: children had tools but no skill context; the root cause of skill-ignoring behavior
+- **Zero-tolerance convention**: added to CLAUDE.md
+
+### Filed
+- #72 — Add unit tests for web UI headless logic
+
+## Key Lessons
+
+- **fork_for_tool_call field list is fragile**: missing `activated_skills` caused the most confusing bug of the session. Any new Context field that tools or child agents depend on must be added here. Consider a shallow-copy approach in the future.
+- **Prompt nudging is not a substitute for data**: the child agents weren't ignoring instructions — they literally didn't have them. The real fix was always the missing `activated_skills` copy, not stronger wording.
+- **Browser cache breaks API changes**: changing JS function signatures without cache busting causes silent failures. Need a versioning strategy for the web UI static assets.
+- **Live QA catches what unit tests don't**: the entire confirmation flow (event → websocket → browser → response → matcher) had multiple interacting bugs that no single unit test would have found.
+
+## Summary
+
+All planned phases complete plus 12 bug fixes found during live QA. 449 tests passing, lint and typecheck clean. Branch `concurrent-tools-delegate` with 18 commits ready for review and merge.

--- a/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/plan.md
+++ b/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/plan.md
@@ -1,0 +1,293 @@
+# Concurrent Tool Calls & Delegate Simplification — Plan
+
+## Status: Ready
+
+## Overview
+
+Six phases, each building on the last. Every phase ends with lint + test passing and a commit. The first four phases deliver concurrent tool execution. Phase 5 simplifies the delegate tool. Phase 6 is cleanup and docs.
+
+---
+
+## Phase 1: Add tool_call_id to ctx and events (plumbing)
+
+**Goal**: Thread `tool_call_id` through the system without changing execution behavior. After this phase, all tool events carry the ID but tools still run sequentially.
+
+**Files**: `context.py`, `agent.py`, `confirmation.py`
+
+### Prompt
+
+Read these files for context:
+- `src/decafclaw/context.py` — the Context class
+- `src/decafclaw/agent.py` — focus on `_execute_tool_calls` (lines 177-214) and the event publishes
+- `src/decafclaw/tools/confirmation.py` — `request_confirmation` function
+
+Make these changes:
+
+1. **`context.py`**: Add `current_tool_call_id: str = ""` to `Context.__init__`. Update `publish()` to auto-include `tool_call_id` from `self.current_tool_call_id` when it's set and `"tool_call_id"` is not already in kwargs.
+
+2. **`agent.py`**: In `_execute_tool_calls`, set `ctx.current_tool_call_id = tc["id"]` before each tool call's `tool_start` publish. Add `tool_call_id=tc["id"]` explicitly to the `tool_start` and `tool_end` publish calls as well. Clear `ctx.current_tool_call_id = ""` after each tool completes (in a finally block). This ensures both the explicit event fields AND any `tool_status` events published by tools themselves carry the ID.
+
+3. **`confirmation.py`**: Add `tool_call_id: str = ""` parameter to `request_confirmation`. Include it in the `tool_confirm_request` event publish. Update the `on_confirm` matcher to also match on `tool_call_id` when provided — i.e. if `tool_call_id` was passed, the response must also have that `tool_call_id` to match. Fall back to the existing `context_id` + `tool_name` matching when `tool_call_id` is empty (backward compat). Update call sites in `shell_tools.py` and `skill_tools.py` to pass `tool_call_id=ctx.current_tool_call_id`.
+
+Do NOT change execution from sequential to concurrent yet. Lint and run tests after. This is pure plumbing.
+
+---
+
+## Phase 2: Add config and concurrency infrastructure
+
+**Goal**: Add the `max_concurrent_tools` config field.
+
+**Files**: `config.py`
+
+### Prompt
+
+Read `src/decafclaw/config.py` for context.
+
+1. Add `max_concurrent_tools: int = 5` to the `Config` dataclass, in the "Agent settings" group near `max_tool_iterations`.
+
+2. Add `MAX_CONCURRENT_TOOLS` to `load_config()`: `max_concurrent_tools=int(os.getenv("MAX_CONCURRENT_TOOLS", "5"))`.
+
+That's it for this phase. Lint and run tests.
+
+---
+
+## Phase 3: Rewrite _execute_tool_calls for concurrency
+
+**Goal**: Replace the sequential loop with concurrent execution via `asyncio.gather` + semaphore. This is the core change.
+
+**Files**: `agent.py`
+
+### Prompt
+
+Read `src/decafclaw/agent.py` — focus on `_execute_tool_calls` (the current sequential implementation), `_check_cancelled`, and `_archive`.
+
+### The ctx fork problem
+
+With concurrent execution, multiple coroutines sharing a single `ctx` will race on `ctx.current_tool_call_id`. If tool A sets the ID, yields at an `await`, then tool B sets a different ID, tool A's next `ctx.publish("tool_status", ...)` will get the wrong ID.
+
+**Solution**: Fork `ctx` per tool call. Each concurrent tool gets its own ctx with its own `current_tool_call_id`. The fork must preserve these fields from the parent:
+- `context_id` — **must be the same** as parent (events route by this)
+- `event_bus` — shared (fork handles this automatically)
+- `config` — shared (fork handles this automatically)
+- `cancelled` — same cancel event as parent
+- `extra_tools`, `extra_tool_definitions` — for execute_tool lookups
+- `skill_data` — for skills like vault that read from it
+- `allowed_tools` — for tool access control
+- `conv_id`, `channel_id` — for archiving and event routing
+
+Add a helper to Context: `def fork_for_tool_call(self, tool_call_id: str) -> Context` that forks with all the above fields copied and `current_tool_call_id` set.
+
+### Rewrite
+
+1. Extract a new async helper `_execute_single_tool(call_ctx, tc, semaphore)` that:
+   - Acquires the semaphore
+   - Parses `tc["function"]["arguments"]`
+   - Publishes `tool_start` with `tool_call_id`
+   - Calls `execute_tool(call_ctx, fn_name, fn_args)`
+   - Publishes `tool_end` with `tool_call_id`
+   - Archives the tool result message via `_archive(call_ctx, tool_msg)`
+   - Returns a tuple `(tool_msg_dict, media_list)`
+   - On exception, returns an error tool_msg and empty media (does NOT re-raise)
+   - Semaphore release and cleanup in a `finally` block
+
+2. Rewrite `_execute_tool_calls` to:
+   - Check cancelled once before starting
+   - Create semaphore: `sem = asyncio.Semaphore(ctx.config.max_concurrent_tools)`
+   - For each tool call: `call_ctx = ctx.fork_for_tool_call(tc["id"])`, create coroutine `_execute_single_tool(call_ctx, tc, sem)`
+   - Create explicit `asyncio.Task` objects for each coroutine (we need task handles for cancellation)
+   - Monitor the cancel event in parallel: if it fires, cancel all in-flight tasks
+   - Use `asyncio.gather(*tasks, return_exceptions=True)` — but first set up a cancel watcher task that calls `task.cancel()` on each task when the cancel event fires
+   - After gather: iterate results in order, append tool_msg dicts to `history` and `messages`, aggregate media into `pending_media`
+   - Return a ToolResult if cancelled, None otherwise
+
+### Cancellation implementation
+
+```python
+# Sketch — not exact code
+tasks = [asyncio.create_task(_execute_single_tool(call_ctx, tc, sem)) for ...]
+
+async def _cancel_watcher():
+    await cancel_event.wait()
+    for t in tasks:
+        t.cancel()
+
+watcher = asyncio.create_task(_cancel_watcher()) if cancel_event else None
+try:
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+finally:
+    if watcher:
+        watcher.cancel()
+```
+
+### Tests
+
+Add tests for `_execute_tool_calls`:
+- Multiple tool calls run concurrently (mock tools with `asyncio.sleep(0.1)`, assert total time < 2× single sleep)
+- Semaphore limits concurrency (set max=1, verify sequential behavior)
+- One tool fails, others succeed — all results returned
+- Cancellation kills in-flight tasks
+
+Lint and run tests after. Existing tests should pass since single-tool-call behavior is unchanged.
+
+---
+
+## Phase 4: Update UI event handlers for tool_call_id
+
+**Goal**: Mattermost and web UI track concurrent tools by `tool_call_id` instead of tool name.
+
+**Files**: `mattermost.py`, `web/websocket.py`, `http_server.py`
+
+### Prompt
+
+Read these files for context:
+- `src/decafclaw/mattermost.py` — focus on `ConversationDisplay.on_tool_start`, `on_tool_status`, `on_tool_end`, `on_confirm_request` (lines ~910-1040), and the event subscriber (lines ~620-650)
+- `src/decafclaw/mattermost.py` — `_poll_confirmation` (line ~684) — publishes `tool_confirm_response` and needs to include `tool_call_id`
+- `src/decafclaw/http_server.py` — `build_confirm_buttons` (line ~343) — builds button context and needs to include `tool_call_id`
+- `src/decafclaw/web/websocket.py` — `on_turn_event` and tool event forwarding, plus `confirm_response` message handler
+
+### Part 4a: Mattermost ConversationDisplay
+
+1. Replace the single `_tool_post_id` field with a dict: `_tool_posts: dict[str, str] = {}` mapping `tool_call_id` → Mattermost post ID. Keep a `_first_tool_in_batch: bool` flag to track whether we've finalized text yet.
+
+2. Update `on_tool_start(self, tool_name, args, tool_call_id="")`:
+   - On the first tool_start in a batch (no entries in `_tool_posts` yet), finalize current text and optionally reuse the thinking placeholder
+   - On subsequent concurrent tool_starts, always create a new post
+   - Store post ID in `self._tool_posts[tool_call_id]`
+
+3. Update `on_tool_status(self, tool_name, message, tool_call_id="")`:
+   - Look up `self._tool_posts.get(tool_call_id)` to find the right post to edit. Fall back to editing the most recent post if `tool_call_id` not found (backward compat).
+
+4. Update `on_tool_end(self, tool_name, result_text, display_text, media, tool_call_id="")`:
+   - Look up and edit the right post by `tool_call_id`
+   - Remove from `_tool_posts` when done
+   - Handle media attachment per-post
+
+5. Update the event subscriber (lines ~620-650) to pass `event.get("tool_call_id", "")` to all ConversationDisplay tool methods.
+
+### Part 4b: Mattermost confirmation echo-back
+
+1. **`_poll_confirmation`**: Add `tool_call_id` parameter. Include it in the `tool_confirm_response` event published by `_resolve`.
+
+2. **`on_confirm_request`**: Accept `tool_call_id` parameter. Pass it through to `_poll_confirmation` and to `build_confirm_buttons`.
+
+3. **`http_server.py` — `build_confirm_buttons`**: Add `tool_call_id` parameter. Include it in `base_context` and in the token registry `_make_token` calls. The HTTP callback handler that fires when a button is clicked must include `tool_call_id` in the `tool_confirm_response` event it publishes.
+
+4. Update the event subscriber to pass `tool_call_id` to `on_confirm_request`.
+
+### Part 4c: Web UI websocket
+
+1. Update the `on_turn_event` tool event forwarding to include `tool_call_id` in all tool-related messages sent to the browser: `tool_start`, `tool_status`, `tool_end`, `confirm_request`.
+
+2. Update the `confirm_response` message handler (the `elif msg_type == "confirm_response"` branch) to forward `tool_call_id` from the browser message to the event bus publish.
+
+3. The frontend JavaScript changes are out of scope for this phase — the backend just needs to forward the field. The frontend can be updated separately.
+
+Lint and run tests after.
+
+---
+
+## Phase 5: Simplify delegate tool
+
+**Goal**: Replace `delegate` (nested array schema) with `delegate_task` (single string parameter). Child inherits parent's tools/skills.
+
+**Files**: `tools/delegate.py`, `tools/__init__.py`
+
+### Prompt
+
+Read these files for context:
+- `src/decafclaw/tools/delegate.py` — the current implementation
+- `src/decafclaw/tools/__init__.py` — where delegate tools are registered (imports `DELEGATE_TOOLS`, `DELEGATE_TOOL_DEFINITIONS`)
+
+Rewrite the delegate tool:
+
+1. Rename `tool_delegate` to `tool_delegate_task`. Change signature to `async def tool_delegate_task(ctx, task: str) -> str`.
+
+2. Simplify `_run_child_turn`:
+   - Remove the `tools` parameter — child inherits all parent tools
+   - Remove `system_prompt` parameter — always use default
+   - Compute `allowed_tools` from the full tool registry (core TOOLS + parent's extra_tools) minus `delegate_task`, `activate_skill`, `refresh_skills`
+   - Carry over `extra_tools`, `extra_tool_definitions`, `skill_data` from parent ctx
+   - Keep `discovered_skills = []`, `on_stream_chunk = None`, timeout, child iterations
+
+3. Update `DELEGATE_TOOLS` dict: key is now `"delegate_task"`, value is `tool_delegate_task`.
+
+4. Update `DELEGATE_TOOL_DEFINITIONS` with the new flat schema:
+   - Name: `delegate_task`
+   - Single parameter: `task` (string, required)
+   - Description: mention that for parallel work, call delegate_task multiple times in the same response
+
+5. Remove all the multi-task batching logic (the `if len(tasks) == 1` branch, the gather, the task validation loop, the result formatting). `delegate_task` runs exactly one child turn and returns its result directly.
+
+6. Update the excluded set in `_run_child_turn` from `"delegate"` to `"delegate_task"`.
+
+7. Search the codebase for references to the old `"delegate"` tool name and update:
+   - `tools/__init__.py` imports (should auto-resolve since we kept the dict/list names)
+   - Any prompt files (AGENT.md, SOUL.md) that reference "delegate"
+   - Any docs that reference the old schema
+   - The `tool_status` publish in the current delegate code (remove it — single-task doesn't need a "delegating N tasks" status)
+
+Lint and run tests after.
+
+---
+
+## Phase 6: Docs, cleanup, and issue closure
+
+**Goal**: Update documentation, clean up any loose ends, close the issue.
+
+**Files**: `CLAUDE.md`, `docs/`, `README.md`
+
+### Prompt
+
+1. Update `CLAUDE.md`:
+   - Add convention: "Tool calls run concurrently when the model emits multiple in one response. `max_concurrent_tools` (default 5) caps parallelism."
+   - Update the delegate tool description: `delegate_task` with single `task` parameter, child inherits parent tools/skills
+   - Update key files list if `tools/delegate.py` changed significantly
+
+2. Update `docs/` pages:
+   - Update any docs that reference the `delegate` tool or its schema
+   - Add a note about concurrent tool execution if there's an architecture doc
+
+3. Update `README.md` tool table if delegate is listed there.
+
+4. Add a comment to issue #71 summarizing what was done, then close it.
+
+Lint, test, commit.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (plumbing: tool_call_id in events)
+  ↓
+Phase 2 (config: max_concurrent_tools)
+  ↓
+Phase 3 (core: concurrent _execute_tool_calls)  ← the big one
+  ↓
+Phase 4 (UI: Mattermost + web tracking by ID)
+  ↓
+Phase 5 (delegate_task simplification)           ← independent of 3/4, but sequenced after for testing
+  ↓
+Phase 6 (docs + cleanup)
+```
+
+Phases 1-3 are the critical path. Phase 4 can be done in parallel with Phase 5 if needed. Phase 5 is independently valuable (fixes #71) and could be done first if we want a quick win, but the spec orders concurrent execution first since delegate_task's concurrency story depends on it.
+
+## Testing Strategy
+
+- **Phases 1-2**: Existing tests pass unchanged (no behavior change)
+- **Phase 3**: Existing tests cover single-tool-call paths. Add tests:
+  - Multiple mock tools with `asyncio.sleep` verify concurrent execution (total time < sum)
+  - Semaphore limits concurrency (max=1 → sequential timing)
+  - One tool fails, others succeed — all results returned in order
+  - Cancel event kills all in-flight tasks
+  - Media aggregated correctly from concurrent results
+- **Phase 4**: Manual testing in Mattermost and web UI with multiple concurrent tool calls. Verify each tool gets its own progress message.
+- **Phase 5**: Update any existing delegate tests. Test single-task delegation. Verify old `delegate` name is gone. Verify child inherits parent's extra_tools and skill_data.
+- **Phase 6**: No new tests — doc review only.
+
+## Risk Notes
+
+- **Phase 3 ctx fork**: The `fork_for_tool_call` helper must copy all fields that tools or `execute_tool` depend on. If a new field is added to Context later and not included in the fork, concurrent tools will silently lose it. Consider: should `fork_for_tool_call` do a shallow copy of all fields instead of an explicit list? Trade-off: explicit is safer against accidental sharing, but fragile against new fields.
+- **Phase 4 Mattermost race**: Multiple `on_tool_start` events arriving near-simultaneously could race on placeholder reuse and text finalization. Use the `_tool_posts` dict emptiness as the "first tool" signal, and guard text finalization with a flag.
+- **Phase 4 confirmation buttons**: The HTTP button callback flow in `http_server.py` stores pending confirmations in a module-level `_token_registry`. Tokens must now include `tool_call_id` so responses route correctly. Verify the token creation and validation both handle the new field.

--- a/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/spec.md
+++ b/.claude/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/spec.md
@@ -1,0 +1,154 @@
+# Concurrent Tool Calls & Delegate Simplification — Spec
+
+## Status: Ready
+
+## Background
+
+The agent loop currently executes tool calls sequentially, even when the model emits multiple calls in a single response — a signal that they're independent. This wastes time on I/O-bound tools (vault reads, web fetches, memory searches).
+
+Separately, the `delegate` tool has a nested array-of-objects schema that causes Gemini 2.5 Flash to produce `malformed_function_call` errors (see [#71](https://github.com/lmorchard/decafclaw/issues/71)). The nested schema is unnecessary if the agent loop itself handles concurrency.
+
+## Goals
+
+1. Run tool calls concurrently when the model emits multiple calls in one response.
+2. Simplify the delegate tool to a flat, single-task schema that any model can generate.
+3. Keep the UI coherent when multiple tools are in flight simultaneously.
+
+## Part 1: Concurrent Tool Execution
+
+### Behavior
+
+When the model returns multiple tool calls in a single response, execute them concurrently via `asyncio.gather`. No safe-list or opt-in mechanism — all tools are treated as concurrent-safe by default. If concurrency causes problems with specific tools, we'll revise their descriptions or add guards later.
+
+### Concurrency Limit
+
+Add a configurable maximum number of concurrent tool calls (`max_concurrent_tools` in config). Use an `asyncio.Semaphore` to cap how many tool calls run at once. This prevents resource exhaustion when the model emits many calls (e.g. 10+ delegate_task or web fetch calls). Default TBD — something like 5-10.
+
+### tool_call_id Everywhere
+
+Add `tool_call_id` to **all** tool-related events so that every piece of a tool call's lifecycle can be tracked and reassembled:
+
+- `tool_start` events
+- `tool_status` events (mid-execution progress updates)
+- `tool_end` events
+- `tool_confirm_request` and `tool_confirm_response` events
+- Archive entries (tool result messages already have `tool_call_id` via the model response)
+
+This is the primary mechanism for tracking concurrent calls. Events will naturally interleave (e.g. `tool_start(A)` → `tool_start(B)` → `tool_status(B)` → `tool_end(B)` → `tool_end(A)`), and consumers use `tool_call_id` to correlate them.
+
+### tool_call_id Threading Into Tools
+
+`execute_tool` currently doesn't receive `tool_call_id`. However, some tools publish their own `tool_status` events mid-execution (tabstack, claude_code, delegate). These status events need `tool_call_id` to be correlatable with the right tool call in the UI.
+
+Fix: set `ctx.current_tool_call_id` before calling `execute_tool` (or pass it as a field on a per-call context fork). Tools that publish `tool_status` via `ctx.publish` will include it automatically if the publish helper adds it from the context. This avoids changing every tool's signature — the ID flows through `ctx`.
+
+### Confirmation
+
+`request_confirmation` currently matches responses by `context_id` + `tool_name`. This breaks when two calls to the same tool (e.g. two `shell` commands) run concurrently — both would match the same response.
+
+Fix: add `tool_call_id` to both `tool_confirm_request` and `tool_confirm_response` events, and match on `tool_call_id` instead of (or in addition to) `tool_name`. This requires threading `tool_call_id` through to `request_confirmation` and updating the Mattermost and web UI confirmation handlers to echo it back.
+
+### UI Changes
+
+- **Mattermost**: `ConversationDisplay` currently tracks tool state by tool name (`on_tool_start`, `on_tool_status`, `on_tool_end`). Needs to be refactored to track by `tool_call_id` so each concurrent call gets its own progress placeholder, updated independently. Multiple tool progress messages may be visible simultaneously.
+- **Web UI**: Same — the websocket event forwarding and frontend tool status tracking need to key on `tool_call_id` instead of tool name.
+
+### Result Ordering
+
+`asyncio.gather` preserves input order in its return values. Tool results are archived in completion order (as they finish), but the history assembled for the model preserves the original call order (matched by `tool_call_id`).
+
+### Cancellation
+
+When the cancel event fires, all in-flight concurrent tool tasks are cancelled immediately. This is an emergency stop — no graceful completion of remaining tasks.
+
+### Error Handling
+
+If one tool call fails, the others continue running. Failed calls return an error `ToolResult` as they do today. The model receives all results (successes and failures) and decides how to proceed.
+
+### Media Collection
+
+Each concurrent tool task collects its own media. After `asyncio.gather` completes, media is aggregated from all results in call order and appended to `pending_media`. No shared mutable list during concurrent execution.
+
+### Archiving
+
+Tool result messages are archived as each concurrent call completes (completion order). Each archive entry carries `tool_call_id`, so the correct order can be reconstructed if needed. The history assembled for the model uses call order (preserved by `asyncio.gather`).
+
+### Implementation Target
+
+`_execute_tool_calls` in `agent.py` — replace the sequential `for` loop with `asyncio.gather` gated by an `asyncio.Semaphore(max_concurrent_tools)`. Each tool call becomes a coroutine that:
+1. Sets `ctx.current_tool_call_id` (or uses a per-call ctx fork)
+2. Acquires the semaphore
+3. Publishes `tool_start` (with `tool_call_id`)
+4. Calls `execute_tool`
+5. Publishes `tool_end` (with `tool_call_id`)
+6. Archives its tool result message
+7. Returns `(tool_result_msg, media_list)`
+
+After gather completes:
+- Append all result messages to history/messages in original call order
+- Aggregate media from all results into `pending_media`
+
+`ctx.publish` should automatically include `tool_call_id` from `ctx.current_tool_call_id` when present, so tools that emit `tool_status` events don't need code changes.
+
+**Config addition**: `max_concurrent_tools` (int, default 5) in `config.py`.
+
+## Part 2: Delegate Tool Simplification
+
+### Current Problem
+
+The `delegate` tool schema uses a nested array of objects:
+```
+tasks: array → items: object → { task: string, tools: array of strings, system_prompt: string }
+```
+This causes Gemini to produce `malformed_function_call` with 0 completion tokens.
+
+### New Design
+
+Rename `delegate` to `delegate_task`. Accept a single flat parameter:
+
+| Parameter | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `task`    | string | yes      | Task description — becomes the child agent's input |
+
+That's it. No `tools`, no `system_prompt`, no nested objects.
+
+- **Tools**: The child agent inherits all of the parent's available tools and activated skills, minus `delegate_task` itself (to prevent recursion).
+- **System prompt**: Uses the default child system prompt. Removed as a parameter — can be re-added if a real need surfaces.
+- **Concurrency**: When the model wants to run multiple subtasks in parallel, it emits multiple `delegate_task` calls in one response. Part 1 (concurrent tool execution) handles the parallelism.
+
+### Schema
+
+```json
+{
+  "type": "function",
+  "function": {
+    "name": "delegate_task",
+    "description": "Delegate a subtask to a child agent. The child runs as an independent agent turn with access to the same tools and skills. Use when a request has an independent part that can be handled separately. For parallel work, call delegate_task multiple times in the same response.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "task": {
+          "type": "string",
+          "description": "Task description with enough context for the child agent to work independently"
+        }
+      },
+      "required": ["task"]
+    }
+  }
+}
+```
+
+### Child Agent Behavior
+
+- Inherits parent's `extra_tools`, `extra_tool_definitions`, and `skill_data`
+- `allowed_tools` excludes `delegate_task`, `activate_skill`, `refresh_skills`
+- `discovered_skills` cleared (children don't discover/activate new skills)
+- Uses `child_max_tool_iterations` from config
+- Timeout via `child_timeout_sec` from config
+- No streaming (child results returned as text to parent)
+
+## Out of Scope
+
+- Tool-level concurrency guards or safe-lists (handle reactively if needed)
+- Streaming from child agents to the UI
+- Nested delegation (child calling delegate_task)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/heartbeat.py` — Heartbeat: periodic wake-up, section parsing, timer, cycle runner
 - `src/decafclaw/media.py` — Media handling: ToolResult, MediaHandler interface, workspace ref scanning
 - `src/decafclaw/tools/` — Tool registry: core, memory, todo, workspace, file_share, shell, conversation, skill activation, MCP status, delegation
-- `src/decafclaw/tools/delegate.py` — Sub-agent delegation: fork child agents for concurrent subtasks
+- `src/decafclaw/tools/delegate.py` — Sub-agent delegation: `delegate_task` forks a child agent for a single subtask (call multiple times for parallel work)
 - `src/decafclaw/tools/confirmation.py` — Shared confirmation request helper (event-bus-based user approval)
 - `src/decafclaw/runner.py` — Top-level orchestrator: manages MCP, HTTP server, Mattermost, heartbeat as parallel tasks
 - `src/decafclaw/web/` — Web gateway: auth, conversations, WebSocket chat handler
@@ -92,6 +92,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Conversation state in `ConversationState` dataclass.** Per-conversation state (history, skill state, busy flag, etc.) is tracked via `ConversationState` in mattermost.py, not parallel dicts.
 - **Tools receive `ctx` as first param.** All tool functions take a runtime context, even if they don't use it yet.
 - **Sync vs async tools.** `execute_tool` auto-detects via `asyncio.iscoroutinefunction`. Sync tools run in `asyncio.to_thread`.
+- **Tool calls run concurrently.** When the model emits multiple tool calls in one response, they execute via `asyncio.gather` with a semaphore (`max_concurrent_tools`, default 5). Each call gets a forked ctx with its own `current_tool_call_id`. All tool events carry `tool_call_id` for UI correlation.
 - **Events for progress.** Tools publish `tool_status` events via `ctx.publish()`. The agent loop publishes `llm_start/end` and `tool_start/end`. Subscribers (Mattermost, terminal) handle display.
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholder management, threading logic — all in `MattermostClient`.
 - **Mattermost PATCH API quirks.** Omitting `props` from a PATCH preserves existing props (including attachments). To strip attachments, you must explicitly send `props: {"attachments": []}`. However, sending a PATCH with only `props` and no `message` field clears the message text, showing "(message deleted)". Always include the message text when patching props — fetch it first if needed.
@@ -101,6 +102,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Test live in Mattermost after merging**, not just lint/pytest. Real agent behavior differs from unit tests.
 - **Tool descriptions are a control surface.** Wording changes ("MUST", "NEVER", checklists, "prefer X over Y") measurably change LLM behavior. Use the eval loop to validate.
 - **Group tools by noun, not verb.** `conversation_search` + `conversation_compact` in one module, not scattered across core.
+- **Zero tolerance for warnings and traceback noise.** Warnings, tracebacks, and noisy error output obscure real issues. If you see them — even on shutdown, even if they're "harmless" — fix them. Catch exceptions at the right level, suppress expected cancellation errors, and keep logs clean.
 - **Commit after each logical step.** Lint and test before committing.
 - **Work in a branch for iterative changes.** When making multiple related fixes (especially to UX-sensitive code like streaming/placeholder logic), work in a branch and test the full set before merging to main. Don't push rapid-fire fixes directly to main — regressions compound.
 - **One agent turn per conversation at a time.** Concurrent conversations (different threads/channels) are fine.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See [docs/installation.md](docs/installation.md) for full setup and configuratio
 | `refresh_skills` | Re-scan skill directories |
 | `mcp_status` | Show/restart MCP server connections |
 | `heartbeat_trigger` | Manually fire a heartbeat cycle |
-| `delegate` | Fork child agents for concurrent subtasks |
+| `delegate_task` | Delegate a subtask to a child agent (call multiple times for parallel work) |
 
 Skills and MCP servers provide additional tools on demand.
 

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -1,39 +1,42 @@
 # Sub-Agent Delegation
 
-The `delegate` tool lets the agent fork child agents to handle focused subtasks. Multiple tasks run concurrently.
+The `delegate_task` tool lets the agent fork a child agent to handle a focused subtask. For parallel work, the agent calls `delegate_task` multiple times in the same response — the agent loop runs them concurrently.
 
 ## Usage
 
-The agent calls the `delegate` tool with a list of tasks:
+The agent calls `delegate_task` with a task description:
 
 ```json
-{
-  "tasks": [
-    {"task": "Look up the weather in Portland", "tools": ["tabstack_research"]},
-    {"task": "Search my memories for cocktail recipes", "tools": ["memory_search"]}
-  ]
-}
+{"task": "Look up the weather in Portland"}
 ```
 
-Each task spawns an independent child agent that:
+For parallel subtasks, the model emits multiple `delegate_task` calls in one response:
+
+```json
+// tool_call 1
+{"task": "Look up the weather in Portland"}
+// tool_call 2
+{"task": "Search my memories for cocktail recipes"}
+```
+
+Each call spawns an independent child agent that:
 - Gets a fresh, empty conversation history
-- Only has access to the specified tools
+- Inherits the parent's tools and activated skills (minus `delegate_task` to prevent recursion)
 - Uses a focused system prompt ("Complete the following task. Be concise and focused. Return your result directly.")
 - Shares the parent's cancel event (so user cancellation stops children too)
+- Inherits skill_data (e.g. vault base path)
 
-## Task fields
+## Parameters
 
 | Field | Required | Description |
 |-------|----------|-------------|
 | `task` | Yes | Task description — becomes the child agent's user message |
-| `tools` | Yes | List of tool names the child can use |
-| `system_prompt` | No | Override the default child system prompt |
 
 ## Results
 
-- **Single task**: returns the child's text response directly
-- **Multiple tasks**: returns labeled results (`Task 1: ...\nTask 2: ...`)
-- **Failures**: returned as error text per task — one child failing doesn't cancel siblings
+- Returns the child's text response directly
+- Failures returned as error text — one child failing doesn't affect siblings
+- Timeouts return `[subtask timed out after Ns]`
 
 ## Configuration
 
@@ -41,10 +44,11 @@ Each task spawns an independent child agent that:
 |---------|---------|-------------|
 | `CHILD_MAX_TOOL_ITERATIONS` | 10 | Max tool call rounds per child agent |
 | `CHILD_TIMEOUT_SEC` | 300 | Timeout in seconds per child agent |
+| `MAX_CONCURRENT_TOOLS` | 5 | Max parallel tool calls (applies to all tools, including concurrent delegate_task calls) |
 
-## Limitations (v1)
+## Limitations
 
-- No nested delegation — children cannot call `delegate`
+- No nested delegation — children cannot call `delegate_task`
 - Children use the same LLM model as the parent
-- No streaming of child progress to the UI
+- No streaming of child LLM text to the UI (tool progress and confirmations are visible)
 - No persistent child conversations — results are ephemeral

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -174,44 +174,124 @@ async def _call_llm_with_events(ctx, config, messages, tools) -> dict:
     return response
 
 
-async def _execute_tool_calls(ctx, tool_calls, history, messages, pending_media):
-    """Execute tool calls and add results to history. Returns ToolResult if cancelled."""
-    for tc in tool_calls:
-        cancelled = _check_cancelled(ctx, history)
-        if cancelled:
-            return cancelled
+async def _execute_single_tool(call_ctx, tc, semaphore):
+    """Execute one tool call. Returns (tool_msg, media_list).
 
-        fn_name = tc["function"]["name"]
+    Designed to run concurrently — uses its own forked ctx so
+    current_tool_call_id doesn't race with other calls.
+    """
+    from .media import ToolResult
+
+    tool_call_id = tc["id"]
+    fn_name = tc["function"]["name"]
+    try:
+        fn_args = json.loads(tc["function"]["arguments"])
+    except json.JSONDecodeError as e:
+        log.error(f"Malformed tool call arguments for {fn_name}: {e}")
+        fn_args = {}
+
+    log.info(f"Tool call: {fn_name}({fn_args})")
+
+    result = ToolResult(text=f"[error: {fn_name} did not complete]")
+    async with semaphore:
         try:
-            fn_args = json.loads(tc["function"]["arguments"])
-        except json.JSONDecodeError as e:
-            log.error(f"Malformed tool call arguments for {fn_name}: {e}")
-            fn_args = {}
+            await call_ctx.publish("tool_start", tool=fn_name, args=fn_args,
+                                   tool_call_id=tool_call_id)
+            result = await execute_tool(call_ctx, fn_name, fn_args)
+            log.debug(f"Tool result [{fn_name}]: {result.text[:200]}...")
+        except asyncio.CancelledError:
+            result = ToolResult(text=f"[cancelled: {fn_name}]")
+        except Exception as e:
+            log.error(f"Tool call {fn_name} failed: {e}", exc_info=True)
+            result = ToolResult(text=f"[error executing {fn_name}: {e}]")
+        finally:
+            await call_ctx.publish("tool_end", tool=fn_name,
+                                   result_text=result.text,
+                                   display_text=getattr(result, "display_text", None),
+                                   media=result.media or [],
+                                   tool_call_id=tool_call_id)
 
-        log.info(f"Tool call: {fn_name}({fn_args})")
+    tool_msg = {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": result.text,
+    }
+    _archive(call_ctx, tool_msg)
+    return tool_msg, result.media or []
 
-        await ctx.publish("tool_start", tool=fn_name, args=fn_args)
-        result = await execute_tool(ctx, fn_name, fn_args)
-        await ctx.publish("tool_end", tool=fn_name,
-                          result_text=result.text,
-                          display_text=getattr(result, "display_text", None),
-                          media=result.media or [])
-        log.debug(f"Tool result: {result.text[:200]}...")
 
-        # Accumulate media from tool results
-        if result.media:
-            pending_media.extend(result.media)
+async def _execute_tool_calls(ctx, tool_calls, history, messages, pending_media):
+    """Execute tool calls concurrently, add results to history.
 
-        tool_msg = {
-            "role": "tool",
-            "tool_call_id": tc["id"],
-            "content": result.text,
-        }
-        history.append(tool_msg)
-        messages.append(tool_msg)
-        _archive(ctx, tool_msg)
+    Returns ToolResult if cancelled, None otherwise.
+    """
+    cancelled = _check_cancelled(ctx, history)
+    if cancelled:
+        return cancelled
 
-    return None  # not cancelled
+    semaphore = asyncio.Semaphore(ctx.config.max_concurrent_tools)
+
+    # Fork ctx per tool call so concurrent tools don't race on current_tool_call_id
+    tasks = []
+    for tc in tool_calls:
+        call_ctx = ctx.fork_for_tool_call(tc["id"])
+        task = asyncio.create_task(
+            _execute_single_tool(call_ctx, tc, semaphore),
+            name=f"tool-{tc['function']['name']}-{tc['id'][:8]}",
+        )
+        tasks.append(task)
+
+    # Cancel watcher: if the cancel event fires, cancel all in-flight tasks
+    cancel_event = getattr(ctx, "cancelled", None)
+
+    async def _cancel_watcher():
+        if cancel_event:
+            await cancel_event.wait()
+            for t in tasks:
+                t.cancel()
+
+    watcher = asyncio.create_task(_cancel_watcher()) if cancel_event else None
+
+    try:
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+    finally:
+        if watcher:
+            watcher.cancel()
+            try:
+                await watcher
+            except asyncio.CancelledError:
+                pass
+
+    # Check if we were cancelled during execution
+    cancelled = _check_cancelled(ctx, history)
+    if cancelled:
+        return cancelled
+
+    # Collect results in original call order (gather preserves order)
+    for i, result in enumerate(results):
+        if isinstance(result, BaseException):
+            # Task was cancelled or failed — gather with return_exceptions.
+            # _execute_single_tool normally handles errors internally,
+            # so this only fires for unexpected failures (e.g. CancelledError
+            # from the cancel watcher).
+            err_type = type(result).__name__
+            err_text = str(result) or err_type
+            tool_msg = {
+                "role": "tool",
+                "tool_call_id": tool_calls[i]["id"],
+                "content": f"[error: {err_text}]",
+            }
+            history.append(tool_msg)
+            messages.append(tool_msg)
+            _archive(ctx, tool_msg)
+        else:
+            tool_msg, media = result  # type: ignore[misc]
+            history.append(tool_msg)
+            messages.append(tool_msg)
+            if media:
+                pending_media.extend(media)
+
+    return None
 
 
 # -- Main agent turn -----------------------------------------------------------
@@ -307,9 +387,12 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
                 messages.append(assistant_msg)
                 _archive(ctx, assistant_msg)
 
-                # Preserve text from this iteration (e.g. "Let me check...")
+                # Flush any text content to the UI before starting tool execution.
+                # Without this, text like "Let me check the weather..." appears
+                # after tool results instead of before.
                 if iter_content:
                     accumulated_text_parts.append(iter_content)
+                    await ctx.publish("text_before_tools", text=iter_content)
 
                 cancelled = await _execute_tool_calls(
                     ctx, tool_calls, history, messages, pending_media

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -106,6 +106,7 @@ class Config:
     # Agent settings (system_prompt is assembled from prompt files at startup)
     system_prompt: str = ""
     max_tool_iterations: int = 200
+    max_concurrent_tools: int = 5    # max parallel tool calls per model response
     max_message_length: int = 50000  # truncate user messages beyond this (chars)
 
     # Child agent (delegation) settings
@@ -193,6 +194,7 @@ def load_config() -> Config:
         claude_code_session_timeout=os.getenv("CLAUDE_CODE_SESSION_TIMEOUT", "30m"),
         system_prompt=os.getenv("SYSTEM_PROMPT", Config.system_prompt),
         max_tool_iterations=int(os.getenv("MAX_TOOL_ITERATIONS", "30")),
+        max_concurrent_tools=int(os.getenv("MAX_CONCURRENT_TOOLS", "5")),
         max_message_length=int(os.getenv("MAX_MESSAGE_LENGTH", "50000")),
         child_max_tool_iterations=int(os.getenv("CHILD_MAX_TOOL_ITERATIONS", "10")),
         child_timeout_sec=int(os.getenv("CHILD_TIMEOUT_SEC", "300")),

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -34,6 +34,8 @@ class Context:
         self.total_completion_tokens: int = 0
         self.last_prompt_tokens: int = 0
         self.allowed_tools: set | None = None
+        self.current_tool_call_id: str = ""
+        self.event_context_id: str = ""  # publish events under this ID instead of context_id
 
     def fork(self, **overrides) -> "Context":
         """Create a child context with a new ID, sharing the event bus."""
@@ -46,7 +48,41 @@ class Context:
             setattr(child, key, value)
         return child
 
+    def fork_for_tool_call(self, tool_call_id: str) -> "Context":
+        """Create a lightweight context fork for a concurrent tool call.
+
+        Shares the same context_id and event_bus so events route correctly,
+        but has its own current_tool_call_id so concurrent tools don't race.
+        """
+        child = Context(
+            config=self.config,
+            event_bus=self.event_bus,
+            context_id=self.context_id,
+        )
+        child.current_tool_call_id = tool_call_id
+        child.event_context_id = self.event_context_id
+        child.cancelled = self.cancelled
+        child.extra_tools = self.extra_tools
+        child.extra_tool_definitions = self.extra_tool_definitions
+        child.activated_skills = self.activated_skills
+        child.skill_data = self.skill_data
+        child.allowed_tools = self.allowed_tools
+        child.conv_id = self.conv_id
+        child.channel_id = self.channel_id
+        child.channel_name = self.channel_name
+        child.thread_id = self.thread_id
+        child.user_id = self.user_id
+        child.media_handler = self.media_handler
+        return child
+
     async def publish(self, event_type: str, **kwargs) -> None:
-        """Convenience: publish an event with context_id auto-included."""
-        event = {"type": event_type, "context_id": self.context_id, **kwargs}
+        """Convenience: publish an event with context_id auto-included.
+
+        Automatically includes tool_call_id from current_tool_call_id
+        when set, unless explicitly provided in kwargs.
+        """
+        ctx_id = self.event_context_id or self.context_id
+        event = {"type": event_type, "context_id": ctx_id, **kwargs}
+        if self.current_tool_call_id and "tool_call_id" not in kwargs:
+            event["tool_call_id"] = self.current_tool_call_id
         await self.event_bus.publish(event)

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -91,11 +91,13 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
             context_id = token_data["context_id"]
             tool_name = token_data["tool"]
             original_message = token_data["original_message"]
+            tool_call_id = token_data.get("tool_call_id", "")
         else:
             action = context.get("action", "")
             context_id = context.get("context_id", "")
             tool_name = context.get("tool", "")
             original_message = context.get("original_message", "")
+            tool_call_id = context.get("tool_call_id", "")
 
         log.info(f"Confirm callback: action={action} tool={tool_name} context={context_id[:8]}")
 
@@ -110,6 +112,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
             "context_id": context_id,
             "tool": tool_name,
             "approved": approved,
+            **({"tool_call_id": tool_call_id} if tool_call_id else {}),
             **({"always": True} if always else {}),
             **({"add_pattern": True} if add_pattern else {}),
         })
@@ -342,7 +345,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
 def build_confirm_buttons(config, tool_name: str, command: str,
                           suggested_pattern: str, context_id: str,
-                          original_message: str) -> list[dict]:
+                          original_message: str, tool_call_id: str = "") -> list[dict]:
     """Build Mattermost attachment with interactive action buttons.
 
     Returns the attachments list to include in a post's props.
@@ -359,6 +362,7 @@ def build_confirm_buttons(config, tool_name: str, command: str,
             original_message=original_message[:2000],
             server_secret=config.http_secret,
             action=action,
+            tool_call_id=tool_call_id,
         )
 
     base_url = f"{config.http_callback_base}/actions/confirm"
@@ -367,6 +371,7 @@ def build_confirm_buttons(config, tool_name: str, command: str,
     base_context = {
         "context_id": context_id,
         "tool": tool_name,
+        **({"tool_call_id": tool_call_id} if tool_call_id else {}),
     }
 
     if tool_name == "shell" and suggested_pattern:
@@ -472,8 +477,12 @@ def build_stop_button(config, conv_id: str) -> list[dict]:
     }]
 
 
+_http_server = None  # uvicorn.Server instance, set by run_http_server
+
+
 async def run_http_server(config, event_bus, app_ctx=None) -> None:
     """Start the HTTP server as an asyncio task."""
+    global _http_server
     import uvicorn
     app = create_app(config, event_bus, app_ctx=app_ctx)
     server_config = uvicorn.Config(
@@ -482,6 +491,12 @@ async def run_http_server(config, event_bus, app_ctx=None) -> None:
         port=config.http_port,
         log_level="info",
     )
-    server = uvicorn.Server(server_config)
+    _http_server = uvicorn.Server(server_config)
     log.info(f"HTTP server starting on {config.http_host}:{config.http_port}")
-    await server.serve()
+    await _http_server.serve()
+
+
+async def shutdown_http_server() -> None:
+    """Gracefully shut down the HTTP server (avoids CancelledError tracebacks)."""
+    if _http_server is not None:
+        _http_server.should_exit = True

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -627,18 +627,26 @@ class MattermostClient:
                 content = event.get("content")
                 if content:
                     await conv_display.on_text_complete(content)
+            elif event_type == "text_before_tools" and conv_display:
+                # Flush any streamed text before tool calls start
+                content = event.get("text", "")
+                if content and not streaming:
+                    await conv_display.on_text_complete(content)
             elif event_type == "tool_start" and conv_display:
                 await conv_display.on_tool_start(
-                    event.get("tool", "tool"), event.get("args", {}))
+                    event.get("tool", "tool"), event.get("args", {}),
+                    tool_call_id=event.get("tool_call_id", ""))
             elif event_type == "tool_status" and conv_display:
                 await conv_display.on_tool_status(
-                    event.get("tool", "tool"), event.get("message", ""))
+                    event.get("tool", "tool"), event.get("message", ""),
+                    tool_call_id=event.get("tool_call_id", ""))
             elif event_type == "tool_end" and conv_display:
                 await conv_display.on_tool_end(
                     event.get("tool", "tool"),
                     event.get("result_text", ""),
                     event.get("display_text"),
                     event.get("media", []),
+                    tool_call_id=event.get("tool_call_id", ""),
                 )
             elif event_type == "tool_confirm_request" and conv_display:
                 await conv_display.on_confirm_request(
@@ -646,6 +654,7 @@ class MattermostClient:
                     event.get("command", ""),
                     event.get("suggested_pattern", ""),
                     event_bus, context_id,
+                    tool_call_id=event.get("tool_call_id", ""),
                 )
             # Compaction stays as-is (separate message)
             elif event_type == "compaction_start" and channel_id:
@@ -682,7 +691,7 @@ class MattermostClient:
     # -- Reaction polling ------------------------------------------------------
 
     async def _poll_confirmation(self, post_id, event_bus, context_id, tool_name,
-                                 timeout=60, poll_interval=2):
+                                 timeout=60, poll_interval=2, tool_call_id=""):
         """Poll a post for thumbs up/down reactions to approve/deny a tool."""
 
         async def _resolve(approved, always=False, add_pattern=False, label=""):
@@ -691,6 +700,7 @@ class MattermostClient:
                 "context_id": context_id,
                 "tool": tool_name,
                 "approved": approved,
+                **({"tool_call_id": tool_call_id} if tool_call_id else {}),
                 **({"always": True} if always else {}),
                 **({"add_pattern": True} if add_pattern else {}),
             })
@@ -817,8 +827,9 @@ class ConversationDisplay:
         self._text_buffer = ""
         self._text_has_content = False  # True if any real text was written
 
-        # Tool call state
-        self._tool_post_id = None
+        # Tool call state — maps tool_call_id → Mattermost post ID
+        self._tool_posts: dict[str, str] = {}
+        self._tools_text_finalized = False
 
         # Throttling
         self._last_edit_time = 0
@@ -907,49 +918,64 @@ class ConversationDisplay:
 
     # -- Tool call lifecycle ---------------------------------------------------
 
-    async def on_tool_start(self, tool_name, args):
+    async def on_tool_start(self, tool_name, args, tool_call_id=""):
         """Tool execution starting — finalize text, post tool call message."""
         msg = f"\U0001f527 {tool_name}..."
 
-        # If still on thinking placeholder with no text, reuse it for the tool call
-        if self._current_type == "thinking" and self._current_post_id and not self._text_has_content:
-            await self._force_edit(self._current_post_id, msg)
-            self._tool_post_id = self._current_post_id
-            self._current_post_id = None
+        # First tool in a batch: finalize text / reuse thinking placeholder
+        if not self._tools_text_finalized:
+            self._tools_text_finalized = True
+            if self._current_type == "thinking" and self._current_post_id and not self._text_has_content:
+                await self._force_edit(self._current_post_id, msg)
+                post_id = self._current_post_id
+                self._current_post_id = None
+            else:
+                await self._finalize_current_text()
+                post_id = await self.client.send(
+                    self._channel_id, msg, root_id=self._root_id,
+                    attachments=self._stop_attachments,
+                )
+                if self._stop_attachments:
+                    self._stop_on_post = post_id
         else:
-            await self._finalize_current_text()
-            self._tool_post_id = await self.client.send(
+            # Subsequent concurrent tool — always a new post
+            post_id = await self.client.send(
                 self._channel_id, msg, root_id=self._root_id,
-                attachments=self._stop_attachments,
             )
-            if self._stop_attachments:
-                self._stop_on_post = self._tool_post_id
+
+        self._tool_posts[tool_call_id] = post_id
         self._current_type = "tool"
 
-    async def on_tool_status(self, tool_name, message):
-        """Tool status update — edit tool call message."""
-        if self._tool_post_id:
+    async def on_tool_status(self, tool_name, message, tool_call_id=""):
+        """Tool status update — edit the tool call's progress message."""
+        post_id = self._tool_posts.get(tool_call_id)
+        if not post_id and self._tool_posts:
+            # Fallback: use most recent post if tool_call_id not found
+            post_id = list(self._tool_posts.values())[-1]
+        if post_id:
             try:
                 await self.client.edit_message(
-                    self._tool_post_id,
+                    post_id,
                     f"\U0001f527 {tool_name}: {message}",
                 )
             except Exception:
                 pass
 
-    async def on_tool_end(self, tool_name, result_text, display_text, media):
+    async def on_tool_end(self, tool_name, result_text, display_text, media,
+                          tool_call_id=""):
         """Tool finished — edit tool call message with result, handle media."""
         if display_text:
             msg = display_text
         else:
             msg = f"\U0001f527 {tool_name} \u2714\ufe0f"
 
-        if self._tool_post_id:
+        post_id = self._tool_posts.pop(tool_call_id, None)
+        if post_id:
             try:
                 await self.client.edit_message(
-                    self._tool_post_id, msg, props={"attachments": []},
+                    post_id, msg, props={"attachments": []},
                 )
-                if self._stop_on_post == self._tool_post_id:
+                if self._stop_on_post == post_id:
                     self._stop_on_post = None
             except Exception:
                 pass
@@ -970,13 +996,15 @@ class ConversationDisplay:
                 except Exception as e:
                     log.debug(f"Failed to attach tool media: {e}")
 
-        self._tool_post_id = None
-        self._current_type = None
+        # Reset tool state when all concurrent tools are done
+        if not self._tool_posts:
+            self._current_type = None
+            self._tools_text_finalized = False
 
     # -- Confirmation ----------------------------------------------------------
 
     async def on_confirm_request(self, tool_name, command, suggested_pattern,
-                                  event_bus, context_id):
+                                  event_bus, context_id, tool_call_id=""):
         """Tool needs confirmation — show prompt with buttons and/or emoji."""
         from .http_server import build_confirm_buttons
 
@@ -1002,13 +1030,14 @@ class ConversationDisplay:
         if config:
             attachments = build_confirm_buttons(
                 config, tool_name, command, suggested_pattern,
-                context_id, msg,
+                context_id, msg, tool_call_id=tool_call_id,
             )
             if attachments:
                 import json as _json
                 log.debug(f"Confirm buttons: {_json.dumps(attachments, indent=2)}")
 
-        if self._tool_post_id:
+        tool_post_id = self._tool_posts.get(tool_call_id)
+        if tool_post_id:
             # Edit existing post — can't add attachments to edit, so send new
             if attachments:
                 confirm_post_id = await self.client.send(
@@ -1017,23 +1046,23 @@ class ConversationDisplay:
                 )
             else:
                 try:
-                    await self.client.edit_message(self._tool_post_id, msg)
+                    await self.client.edit_message(tool_post_id, msg)
                 except Exception:
                     pass
-                confirm_post_id = self._tool_post_id
+                confirm_post_id = tool_post_id
         else:
             confirm_post_id = await self.client.send(
                 self._channel_id, msg, root_id=self._root_id,
                 attachments=attachments,
             )
-            self._tool_post_id = confirm_post_id
+            self._tool_posts[tool_call_id] = confirm_post_id
 
-        # Start emoji reaction polling (unless emoji is disabled)
         # Start emoji reaction polling if emoji confirms are enabled
         if confirm_post_id and show_emoji:
             asyncio.create_task(
                 self.client._poll_confirmation(
                     confirm_post_id, event_bus, context_id, tool_name,
+                    tool_call_id=tool_call_id,
                 )
             )
 

--- a/src/decafclaw/mcp_client.py
+++ b/src/decafclaw/mcp_client.py
@@ -467,6 +467,8 @@ class MCPRegistry:
         if state._exit_stack:
             try:
                 await state._exit_stack.__aexit__(None, None, None)
+            except asyncio.CancelledError:
+                log.debug(f"MCP server {name!r} disconnect cancelled")
             except Exception as e:
                 log.debug(f"Error closing MCP server {name!r}: {e}")
             state._exit_stack = None
@@ -486,6 +488,8 @@ class MCPRegistry:
             )
         except asyncio.TimeoutError:
             log.warning("MCP disconnect timed out after 5s")
+        except asyncio.CancelledError:
+            log.debug("MCP disconnect cancelled during shutdown")
 
     async def _disconnect_all_inner(self):
         for name in list(self.servers.keys()):

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -101,7 +101,18 @@ async def run_all(app_ctx):
 
         # Stop subsystems in reverse order
         await _cancel_task(heartbeat_task, "heartbeat")
-        await _cancel_task(http_task, "HTTP server")
+
+        # Graceful HTTP server shutdown (avoids uvicorn CancelledError tracebacks)
+        if http_task:
+            from .http_server import shutdown_http_server
+            await shutdown_http_server()
+            try:
+                await asyncio.wait_for(http_task, timeout=5)
+            except asyncio.TimeoutError:
+                log.warning("HTTP server shutdown timed out, cancelling")
+                await _cancel_task(http_task, "HTTP server")
+            except asyncio.CancelledError:
+                pass
 
         # Mattermost handles its own in-flight task cleanup
         if mattermost_task:

--- a/src/decafclaw/tools/confirmation.py
+++ b/src/decafclaw/tools/confirmation.py
@@ -21,15 +21,29 @@ async def request_confirmation(
     May also contain "always", "add_pattern", etc. depending on the
     response.
 
+    Matches responses by context_id + tool_name. When tool_call_id is
+    available (via ctx.current_tool_call_id), it's included in the request
+    and used for stricter matching — required for concurrent tool calls
+    to the same tool.
+
     Times out after `timeout` seconds, returning {"approved": False}.
     """
     confirm_event = asyncio.Event()
     result = {"approved": False}
+    tool_call_id = getattr(ctx, "current_tool_call_id", "")
+    # Match against the context_id used for publishing (event_context_id if set,
+    # otherwise context_id). Child agents publish under the parent's event_context_id.
+    match_context_id = getattr(ctx, "event_context_id", "") or ctx.context_id
 
     def on_confirm(event):
         if (event.get("type") == "tool_confirm_response"
-                and event.get("context_id") == ctx.context_id
+                and event.get("context_id") == match_context_id
                 and event.get("tool") == tool_name):
+            # When both sides have tool_call_id, require match (concurrent safety).
+            # If the response omits it, accept anyway (backward compat with older UIs).
+            resp_id = event.get("tool_call_id", "")
+            if tool_call_id and resp_id and resp_id != tool_call_id:
+                return
             result.update(event)
             confirm_event.set()
 
@@ -40,6 +54,7 @@ async def request_confirmation(
             tool=tool_name,
             command=command,
             message=message,
+            tool_call_id=tool_call_id,
             **extra_event_fields,
         )
         try:

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -8,44 +8,65 @@ log = logging.getLogger(__name__)
 
 DEFAULT_CHILD_SYSTEM_PROMPT = (
     "Complete the following task. Be concise and focused. "
-    "Return your result directly."
+    "Return your result directly.\n\n"
+    "IMPORTANT: You have tools available — check your tool list and USE them. "
+    "Do NOT say you lack capabilities without first checking your available tools. "
+    "When a skill below shows bash/curl commands, run them with the shell tool."
 )
 
 
-async def _run_child_turn(parent_ctx, task, tools, system_prompt=None):
-    """Run a single child agent turn with restricted tools and config.
+async def _run_child_turn(parent_ctx, task):
+    """Run a single child agent turn, inheriting parent's tools and skills.
 
     Returns the child's text response, or an error string on failure.
     """
     from ..agent import run_agent_turn
+    from . import TOOLS
 
     config = parent_ctx.config
-    child_prompt = system_prompt or DEFAULT_CHILD_SYSTEM_PROMPT
+
+    # Build child system prompt: base + activated skill bodies
+    activated = getattr(parent_ctx, "activated_skills", set())
+    skill_map = {s.name: s for s in getattr(config, "discovered_skills", [])}
+    prompt_parts = [DEFAULT_CHILD_SYSTEM_PROMPT]
+    for name in sorted(activated):
+        skill = skill_map.get(name)
+        if skill and skill.body:
+            prompt_parts.append(f"\n\n--- Skill: {name} ---\n{skill.body}")
 
     # Fork context with fresh ID, propagate cancel event
     parent_conv = getattr(parent_ctx, "conv_id", "") or getattr(parent_ctx, "channel_id", "")
     child_config = replace(
         config,
         max_tool_iterations=config.child_max_tool_iterations,
-        system_prompt=child_prompt,
+        system_prompt="\n".join(prompt_parts),
     )
-    # Children don't discover or activate skills — they get a flat tool list
+    # Children don't discover or activate skills — they inherit parent's
     child_config.discovered_skills = []
     child_ctx = parent_ctx.fork(config=child_config)
     child_ctx.conv_id = f"{parent_conv}--child-{child_ctx.context_id[:8]}"
     child_ctx.cancelled = getattr(parent_ctx, "cancelled", None)
 
-    # Restrict tools — exclude delegate, skill tools, and confirmation-prone tools.
-    # Children see a flat tool list, no skills concept.
-    excluded = {"delegate", "activate_skill", "refresh_skills"}
-    allowed = set(tools) - excluded
-    child_ctx.allowed_tools = allowed
+    # Route child events to the parent's UI subscriber so confirmations
+    # and tool progress are visible in the parent conversation
+    parent_event_id = getattr(parent_ctx, "event_context_id", "") or parent_ctx.context_id
+    child_ctx.event_context_id = parent_event_id
 
-    # Carry over parent's activated skill tools (callables + definitions)
+    # Child inherits parent's tools minus delegation/activation.
+    # If parent has restricted allowed_tools, respect that restriction.
+    excluded = {"delegate_task", "activate_skill", "refresh_skills"}
+    all_tools = set(TOOLS) | set(getattr(parent_ctx, "extra_tools", {}))
+    parent_allowed = getattr(parent_ctx, "allowed_tools", None)
+    if parent_allowed is not None:
+        all_tools = all_tools & parent_allowed
+    child_ctx.allowed_tools = all_tools - excluded
+
+    # Carry over parent's activated skill tools and data
     child_ctx.extra_tools = getattr(parent_ctx, "extra_tools", {})
     child_ctx.extra_tool_definitions = getattr(parent_ctx, "extra_tool_definitions", [])
+    child_ctx.skill_data = getattr(parent_ctx, "skill_data", {})
 
-    # Clear skill state so children can't activate or see skills
+    # Clear skill state so children can't activate new skills
     child_ctx.activated_skills = set()
 
     # No streaming for child agents
@@ -65,100 +86,44 @@ async def _run_child_turn(parent_ctx, task, tools, system_prompt=None):
         return f"[subtask failed: {e}]"
 
 
-async def tool_delegate(ctx, tasks: list) -> str:
-    """Delegate subtasks to child agents, running them concurrently."""
-    log.info(f"[tool:delegate] {len(tasks)} task(s)")
+async def tool_delegate_task(ctx, task: str) -> str:
+    """Delegate a subtask to a child agent."""
+    log.info(f"[tool:delegate_task] {task[:80]}...")
 
-    if not tasks:
-        return "[error: no tasks provided]"
+    if not task or not task.strip():
+        return "[error: task description is required]"
 
-    # Validate
-    for i, t in enumerate(tasks):
-        if not isinstance(t, dict) or "task" not in t or "tools" not in t:
-            return f"[error: task {i + 1} must have 'task' and 'tools' fields]"
-        if not isinstance(t["task"], str) or not t["task"].strip():
-            return f"[error: task {i + 1} 'task' must be a non-empty string]"
-        if not isinstance(t["tools"], list) or not all(isinstance(x, str) for x in t["tools"]):
-            return f"[error: task {i + 1} 'tools' must be a list of strings]"
-
-    # Publish progress: what we're delegating
-    task_summaries = []
-    for i, t in enumerate(tasks):
-        tools_str = ", ".join(t["tools"]) if t["tools"] else "none"
-        preview = t["task"][:80] + ("..." if len(t["task"]) > 80 else "")
-        task_summaries.append(f"{i + 1}. {preview} (tools: {tools_str})")
-    status_msg = f"Delegating {len(tasks)} subtask(s):\n" + "\n".join(task_summaries)
-    await ctx.publish("tool_status", tool_name="delegate", message=status_msg)
-
-    if len(tasks) == 1:
-        # Single task — run directly, return result
-        t = tasks[0]
-        result = await _run_child_turn(
-            ctx, t["task"], t["tools"], t.get("system_prompt"),
-        )
-        return result
-
-    # Multiple tasks — run concurrently
-    coros = [
-        _run_child_turn(ctx, t["task"], t["tools"], t.get("system_prompt"))
-        for t in tasks
-    ]
-    results = await asyncio.gather(*coros, return_exceptions=True)
-
-    parts = []
-    for i, result in enumerate(results):
-        if isinstance(result, Exception):
-            parts.append(f"Task {i + 1}: [error: {result}]")
-        else:
-            parts.append(f"Task {i + 1}: {result}")
-    return "\n\n".join(parts)
+    return await _run_child_turn(ctx, task)
 
 
 DELEGATE_TOOLS = {
-    "delegate": tool_delegate,
+    "delegate_task": tool_delegate_task,
 }
 
 DELEGATE_TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
-            "name": "delegate",
+            "name": "delegate_task",
             "description": (
-                "Delegate subtasks to child agents. Each task runs as an independent "
-                "agent turn with its own tool set. Multiple tasks run concurrently. "
-                "Use this when a request has independent parts that can be handled "
-                "in parallel (e.g. researching multiple topics, searching different "
-                "sources). Provide enough context in each task description for the "
-                "child agent to work independently."
+                "Delegate a subtask to a child agent. The child runs as an "
+                "independent agent turn with access to the same tools and "
+                "skills. Use when a request has an independent part that can "
+                "be handled separately. For parallel work, call delegate_task "
+                "multiple times in the same response."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "tasks": {
-                        "type": "array",
-                        "description": "List of subtasks to delegate",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "task": {
-                                    "type": "string",
-                                    "description": "Task description — becomes the child agent's input",
-                                },
-                                "tools": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": "Tool names the child agent can use",
-                                },
-                                "system_prompt": {
-                                    "type": "string",
-                                    "description": "Optional system prompt override for this child",
-                                },
-                            },
-                            "required": ["task", "tools"],
-                        },
+                    "task": {
+                        "type": "string",
+                        "description": (
+                            "Task description with enough context for the "
+                            "child agent to work independently"
+                        ),
                     },
                 },
-                "required": ["tasks"],
+                "required": ["task"],
             },
         },
     },

--- a/src/decafclaw/web/static/components/confirm-view.js
+++ b/src/decafclaw/web/static/components/confirm-view.js
@@ -22,11 +22,12 @@ export class ConfirmView extends LitElement {
   /**
    * @param {string} contextId
    * @param {string} tool
+   * @param {string} toolCallId
    * @param {boolean} approved
    * @param {object} [extra]
    */
-  #handleConfirm(contextId, tool, approved, extra = {}) {
-    this.store?.respondToConfirm(contextId, tool, approved, extra);
+  #handleConfirm(contextId, tool, toolCallId, approved, extra = {}) {
+    this.store?.respondToConfirm(contextId, tool, toolCallId, approved, extra);
   }
 
   render() {
@@ -39,18 +40,18 @@ export class ConfirmView extends LitElement {
           <pre class="confirm-command">${c.command}</pre>
         </div>
         <div class="confirm-buttons">
-          <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, true)}>
+          <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true)}>
             Approve
           </button>
-          <button class="outline secondary" @click=${() => this.#handleConfirm(c.context_id, c.tool, false)}>
+          <button class="outline secondary" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, false)}>
             Deny
           </button>
           ${c.tool === 'shell' && c.suggested_pattern ? html`
-            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, true, { add_pattern: true })}>
+            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { add_pattern: true })}>
               Allow: ${c.suggested_pattern}
             </button>
           ` : html`
-            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, true, { always: true })}>
+            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { always: true })}>
               Always
             </button>
           `}

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -22,6 +22,7 @@
  * @typedef {object} PendingConfirm
  * @property {string} context_id
  * @property {string} tool
+ * @property {string} tool_call_id
  * @property {string} command
  * @property {string} suggested_pattern
  * @property {string} message
@@ -174,19 +175,25 @@ export class ConversationStore extends EventTarget {
   /**
    * @param {string} contextId
    * @param {string} tool
+   * @param {string} toolCallId
    * @param {boolean} approved
    * @param {object} [extra]
    */
-  respondToConfirm(contextId, tool, approved, extra = {}) {
+  respondToConfirm(contextId, tool, toolCallId = '', approved = false, extra = {}) {
     this.#ws.send({
       type: 'confirm_response',
       context_id: contextId,
       tool,
       approved,
+      ...(toolCallId ? { tool_call_id: toolCallId } : {}),
       ...extra,
     });
-    // Remove from pending
-    this.#pendingConfirms = this.#pendingConfirms.filter(c => c.context_id !== contextId);
+    // Remove only this specific confirm
+    if (toolCallId) {
+      this.#pendingConfirms = this.#pendingConfirms.filter(c => c.tool_call_id !== toolCallId);
+    } else {
+      this.#pendingConfirms = this.#pendingConfirms.filter(c => !(c.context_id === contextId && c.tool === tool));
+    }
     this.#emitChange();
   }
 
@@ -327,6 +334,7 @@ export class ConversationStore extends EventTarget {
         this.#pendingConfirms = [...this.#pendingConfirms, {
           context_id: msg.context_id,
           tool: msg.tool,
+          tool_call_id: msg.tool_call_id || '',
           command: msg.command || '',
           suggested_pattern: msg.suggested_pattern || '',
           message: msg.message || '',

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -241,11 +241,13 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx):
 
             elif msg_type == "confirm_response":
                 # Bridge confirmation back to event bus
+                tool_call_id = msg.get("tool_call_id", "")
                 await event_bus.publish({
                     "type": "tool_confirm_response",
                     "context_id": msg.get("context_id", ""),
                     "tool": msg.get("tool", ""),
                     "approved": msg.get("approved", False),
+                    **({"tool_call_id": tool_call_id} if tool_call_id else {}),
                     **({"always": True} if msg.get("always") else {}),
                     **({"add_pattern": True} if msg.get("add_pattern") else {}),
                 })
@@ -326,10 +328,21 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     })
                     streaming_buffer["text"] = ""
 
+            elif event_type == "text_before_tools":
+                # Flush streamed text as a complete message before tools start
+                text = streaming_buffer["text"] or event.get("text", "")
+                if text:
+                    await ws_send({
+                        "type": "message_complete", "conv_id": conv_id,
+                        "role": "assistant", "text": text,
+                    })
+                    streaming_buffer["text"] = ""
+
             elif event_type == "tool_start":
                 await ws_send({
                     "type": "tool_start", "conv_id": conv_id,
                     "tool": event.get("tool", ""),
+                    "tool_call_id": event.get("tool_call_id", ""),
                 })
 
             elif event_type == "tool_status":
@@ -337,6 +350,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     "type": "tool_status", "conv_id": conv_id,
                     "tool": event.get("tool", ""),
                     "message": event.get("message", ""),
+                    "tool_call_id": event.get("tool_call_id", ""),
                 })
 
             elif event_type == "tool_end":
@@ -344,6 +358,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     "type": "tool_end", "conv_id": conv_id,
                     "tool": event.get("tool", ""),
                     "result_text": event.get("result_text", ""),
+                    "tool_call_id": event.get("tool_call_id", ""),
                 })
 
             elif event_type == "tool_confirm_request":
@@ -355,6 +370,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     "command": event.get("command", ""),
                     "suggested_pattern": event.get("suggested_pattern", ""),
                     "message": event.get("message", ""),
+                    "tool_call_id": event.get("tool_call_id", ""),
                 })
 
             elif event_type == "compaction_end":

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -153,6 +153,124 @@ async def test_execute_tool_calls_cancellation(ctx):
     assert "cancelled" in result.text
 
 
+# -- Concurrent tool execution tests -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_concurrent(ctx):
+    """Multiple tool calls run concurrently — verified via barrier synchronization."""
+    barrier_reached = asyncio.Event()
+    all_started = []
+
+    async def _concurrent_tool(ctx_arg, name, args):
+        all_started.append(ctx_arg.current_tool_call_id)
+        if len(all_started) >= 3:
+            barrier_reached.set()
+        # Wait for all to start — proves they're running concurrently
+        await asyncio.wait_for(barrier_reached.wait(), timeout=2.0)
+        return ToolResult(text="done")
+
+    tool_calls = [
+        {
+            "id": f"tc{i}",
+            "function": {"name": "slow_tool", "arguments": "{}"},
+        }
+        for i in range(3)
+    ]
+    history = []
+    messages = []
+    pending_media = []
+
+    with patch("decafclaw.agent.execute_tool", side_effect=_concurrent_tool):
+        result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+
+    assert result is None
+    assert len(history) == 3
+    # All 3 started before any completed — proves concurrency
+    assert len(all_started) == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_semaphore_limits(ctx):
+    """With max_concurrent_tools=1, execution is effectively sequential."""
+    ctx.config.max_concurrent_tools = 1
+    concurrency_high_water = 0
+    current_concurrency = 0
+
+    async def _tracked_tool(ctx_arg, name, args):
+        nonlocal current_concurrency, concurrency_high_water
+        current_concurrency += 1
+        concurrency_high_water = max(concurrency_high_water, current_concurrency)
+        await asyncio.sleep(0.01)
+        current_concurrency -= 1
+        return ToolResult(text="done")
+
+    tool_calls = [
+        {"id": f"tc{i}", "function": {"name": "slow_tool", "arguments": "{}"}}
+        for i in range(3)
+    ]
+    history = []
+    messages = []
+    pending_media = []
+
+    with patch("decafclaw.agent.execute_tool", side_effect=_tracked_tool):
+        await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+
+    # With semaphore=1, max concurrency should be exactly 1
+    assert concurrency_high_water == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_one_fails_others_succeed(ctx):
+    """One tool failing doesn't prevent others from completing."""
+
+    async def _maybe_fail(ctx_arg, name, args):
+        # Fail based on tool_call_id, not execution order
+        if ctx_arg.current_tool_call_id == "tc1":
+            raise RuntimeError("boom")
+        return ToolResult(text=f"ok-{ctx_arg.current_tool_call_id}")
+
+    tool_calls = [
+        {"id": f"tc{i}", "function": {"name": "tool", "arguments": "{}"}}
+        for i in range(3)
+    ]
+    history = []
+    messages = []
+    pending_media = []
+
+    with patch("decafclaw.agent.execute_tool", side_effect=_maybe_fail):
+        result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+
+    assert result is None
+    assert len(history) == 3
+    # Results in call order: tc0 succeeded, tc1 failed, tc2 succeeded
+    assert "ok-tc0" in history[0]["content"]
+    assert "error" in history[1]["content"]
+    assert "ok-tc2" in history[2]["content"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_preserves_order(ctx):
+    """Results are returned in call order, not completion order."""
+    async def _variable_speed(ctx_arg, name, args):
+        return ToolResult(text=f"result-{ctx_arg.current_tool_call_id}")
+
+    tool_calls = [
+        {"id": f"tc{i}", "function": {"name": "tool", "arguments": "{}"}}
+        for i in range(3)
+    ]
+    history = []
+    messages = []
+    pending_media = []
+
+    with patch("decafclaw.agent.execute_tool", side_effect=_variable_speed):
+        await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+
+    assert history[0]["tool_call_id"] == "tc0"
+    assert history[1]["tool_call_id"] == "tc1"
+    assert history[2]["tool_call_id"] == "tc2"
+
+
 # -- run_agent_turn integration tests ------------------------------------------
 
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -8,7 +8,7 @@ import pytest
 from decafclaw.tools.delegate import (
     DEFAULT_CHILD_SYSTEM_PROMPT,
     _run_child_turn,
-    tool_delegate,
+    tool_delegate_task,
 )
 
 
@@ -29,7 +29,7 @@ class TestRunChildTurn:
             from decafclaw.media import ToolResult
             mock_run.return_value = ToolResult(text="child says hello")
 
-            result = await _run_child_turn(ctx, "say hello", ["memory_search"])
+            result = await _run_child_turn(ctx, "say hello")
 
         assert result == "child says hello"
         mock_run.assert_called_once()
@@ -37,34 +37,52 @@ class TestRunChildTurn:
         # Check the child context
         call_args = mock_run.call_args
         child_ctx = call_args[0][0]
-        assert child_ctx.allowed_tools == {"memory_search"}
         assert child_ctx.config.max_tool_iterations == 10
         assert child_ctx.config.system_prompt == DEFAULT_CHILD_SYSTEM_PROMPT
 
     @pytest.mark.asyncio
-    async def test_custom_system_prompt(self, ctx):
-        """Child uses custom system prompt when provided."""
+    async def test_delegate_task_excluded_from_child(self, ctx):
+        """The delegate_task tool is excluded from child's allowed tools."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             from decafclaw.media import ToolResult
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task", ["memory_search"], system_prompt="Be a pirate.")
+            await _run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
-        assert child_ctx.config.system_prompt == "Be a pirate."
+        assert "delegate_task" not in child_ctx.allowed_tools
+        assert "activate_skill" not in child_ctx.allowed_tools
+        # Core tools should be inherited
+        assert "memory_search" in child_ctx.allowed_tools
 
     @pytest.mark.asyncio
-    async def test_delegate_excluded_from_child(self, ctx):
-        """The delegate tool is excluded from child's allowed tools."""
+    async def test_inherits_parent_skill_data(self, ctx):
+        """Child inherits parent's skill_data."""
+        ctx.skill_data = {"vault_base_path": "obsidian/main"}
+
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             from decafclaw.media import ToolResult
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task", ["memory_search", "delegate"])
+            await _run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
-        assert "delegate" not in child_ctx.allowed_tools
-        assert "memory_search" in child_ctx.allowed_tools
+        assert child_ctx.skill_data == {"vault_base_path": "obsidian/main"}
+
+    @pytest.mark.asyncio
+    async def test_inherits_parent_extra_tools(self, ctx):
+        """Child inherits parent's extra_tools from activated skills."""
+        ctx.extra_tools = {"vault_read": lambda ctx, **kw: "data"}
+
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            from decafclaw.media import ToolResult
+            mock_run.return_value = ToolResult(text="ok")
+
+            await _run_child_turn(ctx, "task")
+
+        child_ctx = mock_run.call_args[0][0]
+        assert "vault_read" in child_ctx.extra_tools
+        assert "vault_read" in child_ctx.allowed_tools
 
     @pytest.mark.asyncio
     async def test_timeout(self, ctx):
@@ -75,7 +93,7 @@ class TestRunChildTurn:
         ctx.config.child_timeout_sec = 0.1
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock, side_effect=slow_turn):
-            result = await _run_child_turn(ctx, "slow task", [])
+            result = await _run_child_turn(ctx, "slow task")
 
         assert "timed out" in result
 
@@ -83,7 +101,7 @@ class TestRunChildTurn:
     async def test_child_error(self, ctx):
         """Child that raises returns error text."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock, side_effect=Exception("boom")):
-            result = await _run_child_turn(ctx, "bad task", [])
+            result = await _run_child_turn(ctx, "bad task")
 
         assert "subtask failed" in result
         assert "boom" in result
@@ -98,69 +116,29 @@ class TestRunChildTurn:
             from decafclaw.media import ToolResult
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task", [])
+            await _run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.cancelled is cancel
 
 
-class TestToolDelegate:
+class TestToolDelegateTask:
     @pytest.mark.asyncio
     async def test_single_task(self, ctx):
         """Single task returns result directly."""
         with patch("decafclaw.tools.delegate._run_child_turn", new_callable=AsyncMock, return_value="result one"):
-            result = await tool_delegate(ctx, [{"task": "do thing", "tools": ["shell"]}])
+            result = await tool_delegate_task(ctx, "do thing")
 
         assert result == "result one"
 
     @pytest.mark.asyncio
-    async def test_parallel_tasks(self, ctx):
-        """Multiple tasks run concurrently and return labeled results."""
-        call_count = 0
-
-        async def mock_child(ctx, task, tools, system_prompt=None):
-            nonlocal call_count
-            call_count += 1
-            return f"result for: {task}"
-
-        with patch("decafclaw.tools.delegate._run_child_turn", side_effect=mock_child):
-            result = await tool_delegate(ctx, [
-                {"task": "task A", "tools": ["shell"]},
-                {"task": "task B", "tools": ["memory_search"]},
-            ])
-
-        assert call_count == 2
-        assert "Task 1:" in result
-        assert "Task 2:" in result
-        assert "result for: task A" in result
-        assert "result for: task B" in result
-
-    @pytest.mark.asyncio
-    async def test_empty_tasks(self, ctx):
-        """Empty task list returns error."""
-        result = await tool_delegate(ctx, [])
+    async def test_empty_task(self, ctx):
+        """Empty task returns error."""
+        result = await tool_delegate_task(ctx, "")
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_invalid_task(self, ctx):
-        """Task missing required fields returns error."""
-        result = await tool_delegate(ctx, [{"task": "no tools field"}])
+    async def test_whitespace_task(self, ctx):
+        """Whitespace-only task returns error."""
+        result = await tool_delegate_task(ctx, "   ")
         assert "error" in result
-
-    @pytest.mark.asyncio
-    async def test_parallel_partial_failure(self, ctx):
-        """One failing task doesn't prevent other results."""
-        async def mock_child(ctx, task, tools, system_prompt=None):
-            if "fail" in task:
-                raise Exception("kaboom")
-            return f"ok: {task}"
-
-        with patch("decafclaw.tools.delegate._run_child_turn", side_effect=mock_child):
-            result = await tool_delegate(ctx, [
-                {"task": "good task", "tools": []},
-                {"task": "fail task", "tools": []},
-            ])
-
-        assert "ok: good task" in result
-        assert "error" in result
-        assert "kaboom" in result


### PR DESCRIPTION
## Summary

- **Concurrent tool calls**: When the model emits multiple tool calls in one response, they now run via `asyncio.gather` with a configurable semaphore (`max_concurrent_tools`, default 5). Each call gets a forked ctx with its own `tool_call_id`.
- **`delegate_task` replaces `delegate`**: Flat single-parameter schema (`task: str`) instead of nested array-of-objects. Fixes Gemini `malformed_function_call` errors (#71). Child inherits parent's tools, skills, and skill_data.
- **`tool_call_id` everywhere**: All tool events, confirmations, and UI tracking keyed by `tool_call_id` for concurrent safety.
- **Child agent events visible in parent UI**: `event_context_id` routes child events to the parent conversation's subscribers.
- **Text before tools**: Assistant text that accompanies tool calls now appears before tool progress, not after.

## Bug fixes (found during QA)

- MCP shutdown `CancelledError` traceback
- Uvicorn shutdown traceback (graceful `should_exit` instead of task cancel)
- Confirmation matching too strict / frontend not echoing `tool_call_id`
- Wrong command confirmed when clicking concurrent confirmations
- Child agents missing skill instructions (`activated_skills` not copied in fork)
- All confirmations disappearing when one clicked

## Test plan

- [x] 449 tests passing, lint + typecheck clean
- [x] Concurrent timing test (multiple tools faster than sequential)
- [x] Semaphore limits concurrency (max=1 → sequential)
- [x] Partial failure (one tool fails, others succeed)
- [x] Result ordering preserved
- [x] Live QA: 4-city weather via delegate_task with per-command confirmation in web UI

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)