### PR TITLE
Vault tools redesign: 29 tools → 5 line-oriented tools

### DIFF
--- a/.claude/dev-sessions/2026-03-19-1327-vault-redesign/notes.md
+++ b/.claude/dev-sessions/2026-03-19-1327-vault-redesign/notes.md
@@ -1,0 +1,33 @@
+# Vault Tools Redesign — Notes
+
+## Session Recap
+
+Redesigned the markdown vault skill from 29 tools to 5. The key insight: most vault operations overlap with existing workspace tools. The vault skill only needs to add what workspace tools can't do — section awareness, cross-file line moves, daily path computation, and template creation.
+
+### What we built
+- `vault_daily_path` — date → workspace path (base_path as parameter, no state)
+- `md_show` — section display with absolute line numbers
+- `md_move_lines` — move specific lines by number between files
+- `md_section` — consolidated section ops (add/remove/rename/move)
+- `md_create` — template-based file creation
+
+### What we removed
+24 tools including all the substring-matching checklist operations (check, uncheck, replace_item, find_items), all tag operations, vault base path state management (set_path, get_path), and duplicate file operations (vault_read, vault_list, vault_append, vault_prepend, vault_insert, vault_delete).
+
+### Key design decisions
+1. **Line numbers, not substring matching** — md_show always shows absolute line numbers. The agent uses these with workspace tools for editing.
+2. **No vault base path state** — dropped set_path/get_path. vault_daily_path takes base_path as a parameter. Everything else uses workspace-relative paths.
+3. **Workspace tools for basic ops** — read, edit, insert, delete, list all use existing workspace tools. No duplication.
+4. **General-purpose markdown tools** — renamed from vault_* to md_* since they work on any markdown file.
+
+### Stats
+- 29 tools → 5 tools
+- -1173/+202 lines in tools.py
+- 130 library tests preserved, 16 new tool tests added
+- Tested with real daily notes — works
+
+## Session observations
+
+- This was the last item in a marathon session that also covered: concurrent tools (#71), web UI tests (#72), tool search (#35), code quality sweep (13 items), user commands (#45), and a TypeError error message fix.
+- The brainstorm was unusually productive — Les's question "what's the overlap with workspace tools?" collapsed the scope dramatically. We went from "redesign 29 tools" to "keep 5, delete the rest."
+- The "what do you actually use" question cut the tool list from 29 to ~12. Then recognizing workspace overlap cut it to 5.

--- a/.claude/dev-sessions/2026-03-19-1327-vault-redesign/plan.md
+++ b/.claude/dev-sessions/2026-03-19-1327-vault-redesign/plan.md
@@ -1,0 +1,212 @@
+# Vault Tools Redesign — Plan
+
+## Status: Ready
+
+## Overview
+
+Three phases. Phase 1 rewrites tools.py with the 5 new tools, keeping the Document/Section parsing library intact. Phase 2 rewrites SKILL.md with updated workflows. Phase 3 updates tests and docs. Each phase ends with lint + test passing and a commit.
+
+This is a rewrite, not incremental changes — we replace the tool functions and definitions in one go since the old and new APIs are incompatible.
+
+---
+
+## Phase 1: Rewrite tools.py — 5 new tools
+
+**Goal**: Replace 29 tool functions and definitions with 5. Keep the Document/Section/ChecklistItem library code at the top of the file (still used internally by md_show, md_move_lines, md_section).
+
+**Files**: `src/decafclaw/skills/markdown_vault/tools.py`
+
+### Prompt
+
+Read `src/decafclaw/skills/markdown_vault/tools.py` — the file has two parts:
+1. Lines 1-640: Document model (patterns, Section, ChecklistItem, Document class, tree helpers, cross-file move helpers). **Keep all of this.**
+2. Lines 640+: Tool functions, TOOLS dict, TOOL_DEFINITIONS list. **Replace all of this.**
+
+Also read the spec at `.claude/dev-sessions/2026-03-19-1327-vault-redesign/spec.md`.
+
+Replace everything after the library code with:
+
+### `vault_daily_path(ctx, date=None, offset=0, base_path="")`
+
+Keep the existing `daily_path()` helper function. The tool wraps it and prepends `base_path`:
+
+```python
+def tool_vault_daily_path(ctx, base_path: str = "", date: str | None = None, offset: int = 0) -> ToolResult:
+    path = daily_path(date=date, offset=offset)
+    if base_path:
+        path = f"{base_path}/{path}"
+    return ToolResult(text=path)
+```
+
+If `base_path` is empty, just return the bare journal path — the agent handles prefixing.
+
+### `md_show(ctx, file, section=None)`
+
+Uses the existing Document class to parse the file. Two modes:
+
+**Outline mode** (no section): show all headings with line numbers.
+```
+  5: # today
+ 12: # tonight
+ 16: # tomorrow
+```
+
+**Section mode**: show the section heading + all content lines with absolute line numbers.
+```
+# today (line 5)
+  6: - [ ] consider renovatebot
+  7: - [ ] check out [onecli](https://github.com/...)
+  8: - [x] take a look at octonous
+```
+
+The file path is workspace-relative (resolved via `config.workspace_path`). No vault base path resolution.
+
+### `md_move_lines(ctx, from_file, to_file, to_section, lines)`
+
+- Parse `lines` as comma-separated integers
+- Read both files as Document objects
+- Find the target section in to_file
+- Collect the specified lines from from_file (by absolute line number)
+- Remove them from source (reverse order to preserve indices)
+- Append to target section
+- Save both files
+- Return summary
+
+### `md_section(ctx, file, action, section=None, title=None, level=1, after=None, before=None, parent=None)`
+
+Dispatch on `action`:
+- `add`: use Document.add_section(title, level, after/before/parent)
+- `remove`: use Document.remove_section(section)
+- `rename`: use Document.rename_section(section, title)
+- `move`: use Document.move_section(section, after/before)
+
+### `md_create(ctx, file, template=None, content="")`
+
+Same logic as current vault_create_file but resolves paths from workspace root (no vault base path). Template `{{date}}` and `{{date:FORMAT}}` substitution.
+
+### Registry
+
+```python
+TOOLS = {
+    "vault_daily_path": tool_vault_daily_path,
+    "md_show": tool_md_show,
+    "md_move_lines": tool_md_move_lines,
+    "md_section": tool_md_section,
+    "md_create": tool_md_create,
+}
+```
+
+TOOL_DEFINITIONS with 5 entries. Keep parameter names simple and predictable — `file` (not `path`), `section`, `action`, `lines`, `template`.
+
+### What to delete
+
+- `init()` function and `_workspace_path` global — no longer needed (tools resolve from ctx.config.workspace_path)
+- `_resolve()` function — replace with a simpler `_resolve_workspace(config, path)` that resolves from workspace root
+- All 29 `tool_vault_*` functions
+- All 29 TOOL_DEFINITIONS entries
+- `_get_vault_base`, `_set_vault_base` helpers
+
+### What to keep
+
+- All library code: patterns (HEADING_RE, CHECKBOX_RE, TAG_RE, WIKILINK_RE), helper functions (extract_tags, daily_path, normalize_title, _ensure_newlines), dataclasses (Section, ChecklistItem), Document class, tree helpers (_build_tree, _walk_path, _flatten_sections, _section_path), cross-file helpers (move_item_across_files, bulk_move_items)
+
+Lint and test after — existing tests will break (expected, fixed in Phase 3).
+
+---
+
+## Phase 2: Rewrite SKILL.md
+
+**Goal**: Update the skill documentation with new tool set, workflows, and guidance on using workspace tools for basic operations.
+
+**File**: `src/decafclaw/skills/markdown_vault/SKILL.md`
+
+### Prompt
+
+Rewrite SKILL.md with:
+
+1. **Concepts**: explain that the vault lives in the workspace, basic file operations use workspace tools, this skill adds section awareness and daily path helpers.
+
+2. **Getting Started**: check memory for vault base path, use it with vault_daily_path.
+
+3. **Available Tools**: document the 5 tools with parameters and examples.
+
+4. **Using Workspace Tools**: explain that workspace_read, workspace_edit, workspace_insert, workspace_replace_lines, workspace_list are the primary tools for reading and editing vault files. The md_* tools add section navigation and cross-file moves.
+
+5. **Common Workflows** — updated for new tools:
+   - "Check off X" → md_show to find line number → workspace_replace_lines to toggle checkbox
+   - "Add a task to today" → md_show to find section end → workspace_insert
+   - "Move unchecked items" → md_show both files → md_move_lines with specific line numbers
+   - "Create today's note" → vault_daily_path → md_create with template
+   - "What's in my today section?" → vault_daily_path → md_show with section="today"
+
+6. **Safety Protocols**: keep existing (append-only by default, confirm before deletion).
+
+---
+
+## Phase 3: Tests and docs
+
+**Goal**: Rewrite tests for the new tool set. Update CLAUDE.md and README.
+
+**Files**: `src/decafclaw/skills/markdown_vault/tests/test_vault.py`, `CLAUDE.md`
+
+### Prompt
+
+Read `src/decafclaw/skills/markdown_vault/tests/test_vault.py` — currently 1000+ lines testing the Document model and old tool functions.
+
+**Keep**: all Document model tests (parsing, sections, checklist items, tags, round-trip). These test the library code which is unchanged.
+
+**Replace**: any tests that call old tool functions (tool_vault_read, tool_vault_check, etc.) with tests for the 5 new tools.
+
+**New tests for each tool:**
+
+`md_show`:
+- Outline mode shows all headings with line numbers
+- Section mode shows content with line numbers
+- Section not found returns error
+- File not found returns error
+
+`md_move_lines`:
+- Move specific lines between files
+- Lines removed from source, appended to target section
+- Invalid line numbers handled gracefully
+- Same-file move works
+
+`md_section`:
+- Add section at end / after / before / as child
+- Remove section
+- Rename section
+- Move section
+
+`md_create`:
+- Create from template with date substitution
+- Create with content
+- Won't overwrite existing file
+
+`vault_daily_path`:
+- With base_path
+- Without base_path
+- With offset
+
+**Update CLAUDE.md**: update key files description for markdown_vault skill.
+
+Lint and test after.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (rewrite tools.py — 5 new tools)
+  ↓
+Phase 2 (rewrite SKILL.md)
+  ↓
+Phase 3 (tests + docs)
+```
+
+Phases 1 and 2 can be done in either order (independent files), but Phase 1 first lets us verify the code compiles. Phase 3 must come last.
+
+## Risk Notes
+
+- **Breaking change**: all 29 old tool names stop working immediately. Any conversation that has them in history will see "unknown tool" errors on retry. This is acceptable — skills are per-conversation and activate fresh each time.
+- **Two-step workflows**: "check off an item" is now md_show → workspace_replace_lines (two calls) instead of vault_check (one call). This is more round-trips but more reliable — the agent sees exact content before editing.
+- **Document model kept but partially unused**: some Document methods (bulk_check, find_items, etc.) are no longer called by tools. They're still tested and could be useful for future tools. Not worth removing — dead code in a library is less harmful than premature deletion.

--- a/.claude/dev-sessions/2026-03-19-1327-vault-redesign/spec.md
+++ b/.claude/dev-sessions/2026-03-19-1327-vault-redesign/spec.md
@@ -1,0 +1,165 @@
+# Vault Tools Redesign — Spec
+
+## Status: Ready
+
+## Background
+
+The markdown vault skill has 29 tools with complex parameters (substring matching, nested section paths, separate check/uncheck/replace/tag operations). This causes failures with content containing markdown links, silent move failures, and parameter name confusion with deferred tool loading.
+
+The vault lives in the workspace. Most vault operations (read, edit, insert, delete, list) overlap with existing workspace tools. The redesign strips the vault skill to its unique value — section awareness, daily paths, and cross-file moves — and delegates everything else to workspace tools.
+
+## Goals
+
+1. Reduce from 29 tools to 5
+2. Line-number-based operations instead of substring matching
+3. No vault base path resolution — all tools take workspace-relative paths (consistent with workspace tools)
+4. Section-aware display with line numbers so the agent always has precise coordinates
+
+## New Tool Set
+
+### `vault_daily_path`
+
+The only vault-path-aware tool. Returns the workspace-relative path for a daily journal file.
+
+**Parameters:**
+- `date` (string, optional) — ISO date (YYYY-MM-DD). Default: today.
+- `offset` (int, optional) — Day offset (-1 = yesterday, 1 = tomorrow). Default: 0.
+
+**Returns:** path like `obsidian/main/journals/2026/2026-03-19.md`
+
+**Unchanged** from current implementation except: the vault base path must be stored in memory (the agent remembers it), and the tool reads it from `ctx.skill_data["vault_base_path"]`. If not set, returns an error telling the agent to save the base path to memory and set it via the tool's config.
+
+Actually — **simplification**: the vault base path is ONLY used by this one tool. So instead of the set_path/get_path machinery, just add `base_path` as an optional parameter:
+
+```
+vault_daily_path(date=None, offset=0, base_path="obsidian/main")
+```
+
+The agent passes the base path from memory. No state management needed.
+
+### `md_show`
+
+Show a markdown file's section structure or a specific section's content, with line numbers.
+
+**Parameters:**
+- `file` (string, required) — workspace-relative path
+- `section` (string, optional) — section path (e.g. "today", "notes/standup"). If omitted, shows document outline.
+
+**Returns:**
+
+Without section — outline with line numbers:
+```
+5: # today
+12: # tonight
+16: # tomorrow
+18: # this week
+27: # [[someday]]
+29: # notes
+31: ## standup
+```
+
+With section — full content with line numbers:
+```
+# today (line 5)
+  6: - [ ] consider renovatebot as alternative to dependabot?
+  7: - [ ] check out [onecli](https://github.com/onecli/onecli) for credential vault
+  8: - [x] take a look at octonous for automations
+  9:
+ 10: Some prose note here
+ 11: - [ ] Cancel personal claude?
+```
+
+Line numbers are absolute (file-wide), always shown. The agent uses these numbers with workspace tools (`workspace_edit`, `workspace_insert`, `workspace_replace_lines`) for editing, and with `md_move_lines` for moving.
+
+Section path matching: case-insensitive, wiki-link-aware (`[[someday]]` matches `someday`). Slash-separated for nested sections (`notes/standup`).
+
+### `md_move_lines`
+
+Move specific lines from one file to another (or within the same file), inserting them at a target section.
+
+**Parameters:**
+- `from_file` (string, required) — source file (workspace-relative)
+- `to_file` (string, required) — target file (workspace-relative)
+- `to_section` (string, required) — target section path (lines appended to end of section)
+- `lines` (string, required) — comma-separated line numbers to move (e.g. "6,7,11")
+
+**Behavior:**
+- Lines are removed from source and appended to the target section
+- Lines are moved in the order specified
+- Deletion happens in reverse order (highest line number first) to preserve line numbers
+- Both files are saved after the operation
+- Returns a summary: "Moved 3 line(s) from source.md to target.md/today"
+
+This replaces `vault_move_items` and `vault_move_item`. No filters (unchecked_only, etc.) — the agent reads the section with `md_show`, sees line numbers and content, and picks exactly which lines to move.
+
+### `md_section`
+
+Section-level operations on a markdown file.
+
+**Parameters:**
+- `file` (string, required) — workspace-relative path
+- `action` (string, required) — one of: `add`, `remove`, `rename`, `move`
+- `section` (string, required for remove/rename/move) — section path
+- `title` (string, required for add/rename) — heading text
+- `level` (int, optional, default 1) — heading level for `add`
+- `after` / `before` / `parent` (string, optional) — positioning for `add` and `move`
+
+**Unchanged** logic from current section operations, just consolidated into one tool with an action parameter.
+
+### `md_create`
+
+Create a new markdown file from a template.
+
+**Parameters:**
+- `file` (string, required) — workspace-relative path for the new file
+- `template` (string, optional) — workspace-relative path to template file
+- `content` (string, optional) — initial content (if no template)
+
+**Behavior:**
+- `{{date}}` and `{{date:FORMAT}}` in templates replaced with today's ISO date
+- Won't overwrite existing files
+- Creates parent directories as needed
+
+## What Gets Removed
+
+All of these are replaced by workspace tools + the 5 new tools:
+
+- `vault_set_path`, `vault_get_path` — no longer needed (daily_path takes base_path param, everything else uses workspace paths)
+- `vault_read` → `workspace_read`
+- `vault_list` → `workspace_list`
+- `vault_items`, `vault_find_items` → `md_show` (items are just lines with checkboxes)
+- `vault_check`, `vault_uncheck`, `vault_bulk_check`, `vault_bulk_uncheck` → `workspace_edit` or `workspace_replace_lines` (toggle checkbox by editing the line)
+- `vault_append`, `vault_prepend`, `vault_insert` → `workspace_insert` or `workspace_append`
+- `vault_delete` → line deletion via `workspace_replace_lines` with empty content
+- `vault_replace_item` → `workspace_replace_lines`
+- `vault_move_item` → `md_move_lines` with single line
+- `vault_move_items` → `md_move_lines`
+- `vault_add_section`, `vault_remove_section`, `vault_move_section`, `vault_rename_section`, `vault_replace_section` → `md_section`
+- `vault_tags`, `vault_tagged`, `vault_add_tag`, `vault_remove_tag` → agent edits lines directly via workspace tools
+- `vault_create_file` → `md_create`
+
+## SKILL.md Updates
+
+The SKILL.md needs a major rewrite to:
+- Document the 5 new tools
+- Explain that workspace tools are used for basic file operations
+- Update workflow recipes (daily migration, etc.) to use the new tool set
+- Remove the old 27-tool reference section
+
+## Library Code
+
+The Document/Section/ChecklistItem parsing classes in tools.py are still useful for `md_show`, `md_move_lines`, and `md_section`. They stay but are only used internally — no more exposing parsed checklist items or substring matching to the LLM.
+
+## Migration
+
+This is a breaking change for the tool API. Since skills are lazy-loaded and per-agent, the migration is:
+1. Replace tools.py with the new 5-tool implementation
+2. Rewrite SKILL.md
+3. Update tests
+4. Old tool names stop working immediately (they're no longer registered)
+
+## Out of Scope
+
+- Workspace tools changes (they already support everything needed)
+- Vault base path state management (agent uses memory)
+- Fuzzy section matching beyond wiki-links

--- a/src/decafclaw/skills/markdown_vault/SKILL.md
+++ b/src/decafclaw/skills/markdown_vault/SKILL.md
@@ -1,200 +1,90 @@
 ---
 name: markdown_vault
-description: "Read and edit markdown notes in the workspace. Handles section navigation, checklist management (check/uncheck/add/delete items), content manipulation (append/prepend), and #tag-based organization. Use for any task involving the user's notes, to-do lists, daily pages, or tagged items. Triggers on: 'check off,' 'add to my list,' 'what's on my list,' 'mark done,' 'add a task,' 'show my notes,' 'what's in my today section,' 'find tagged,' 'tag this,' or references to note files."
+description: "Section-aware markdown tools for daily notes and to-do lists. Adds line-numbered section display, cross-file line moves, and section manipulation to workspace tools. Use for navigating note files, migrating to-dos between daily pages, or managing sections. Triggers on: 'show my notes,' 'what's on my list,' 'move todos,' 'create today's note,' or references to daily pages."
 ---
 
-# Markdown Vault — Note Editing Tools
+# Markdown Vault — Section-Aware Note Tools
 
-Tools for reading and surgically editing markdown notes organized by headings, checklists, and tags.
+Tools for navigating and manipulating markdown notes organized by headings. Works alongside workspace tools — use workspace_read, workspace_edit, workspace_insert for basic file operations; these tools add section awareness and cross-file moves.
+
+## Getting Started
+
+1. Check your memory for the vault base path (e.g. `obsidian/main`). You'll pass it to `vault_daily_path`.
+2. Use `vault_daily_path` to get the workspace-relative path for today's note.
+3. Use `md_show` to see section structure and line numbers.
+4. Use workspace tools (workspace_read, workspace_edit, workspace_replace_lines, workspace_insert) for reading and editing file content.
 
 ## Concepts
 
-- **Vault base path**: The vault may live in a subdirectory of the workspace (e.g. `obsidian/main`). Use `vault_set_path` at the start of a conversation to set this. Once set, all file paths in other vault tools resolve relative to the vault base — you don't need to include the base in every path. Use `vault_get_path` to check the current setting.
-- **File**: A markdown file within the vault, addressed by relative path (e.g. `journals/2026/2026-03-17.md`). Paths are relative to the vault base path if set, otherwise relative to the workspace root.
-- **Section path**: Slash-separated heading path within a file (e.g. `today`, `notes/standup`). Case-insensitive, wiki-link-aware (`[[someday]]` matches `someday`)
-- **Item selection**: Checklist items within a section are selected by `match` (substring) or `index` (0-based position, negatives ok). You must provide one or the other.
-- **Checklist format**: Items are `- [ ] text` (unchecked) or `- [x] text` (checked). When creating new items with `vault_append`, `vault_prepend`, or `vault_insert`, always use this format — e.g. `- [ ] buy groceries`. Plain text without the checkbox prefix will be inserted as prose, not a checklist item.
-- **Tags**: `#hashtags` anywhere in a line — `#word`, `#CamelCase`, or `#multi-word-tag`. Tags can appear on checklist items or plain prose lines. They're used for cross-section categorization (e.g. `#storyidea`, `#research`, `#urgent`).
-- **Prose lines**: Not all content in a section is checklist items. Sections can contain plain prose paragraphs, indented sub-items, and other markdown. Tags work on both checklist items and prose lines — use `match` to select a prose line by substring, or `index` to select a checklist item by position.
-
-## Getting Started — REQUIRED before any other vault tool
-
-**You MUST set the vault base path before using any other vault tools.** Follow these steps in order — do NOT skip to asking the user:
-
-1. Call `vault_get_path` — the path may already be set from earlier in this conversation. If it returns a path, you're done.
-2. If not set, call `memory_search("markdown vault base path")` to check if the user has told you the path before. **You MUST call memory_search — do not skip this step.**
-3. If memory returns a vault path, call `vault_set_path` with that path.
-4. **Only if memory_search returns nothing relevant**, ask the user where their vault is located.
-
-**NEVER ask the user for the vault path without searching memory first.**
+- **Workspace-relative paths**: all tools take paths relative to the workspace root (e.g. `obsidian/main/journals/2026/2026-03-19.md`). Use `vault_daily_path` to compute daily note paths.
+- **Line numbers**: `md_show` displays every line with its absolute line number. Use these numbers with workspace tools and `md_move_lines`.
+- **Section path**: headings form a navigable tree. Use slash-separated paths like `today`, `notes/standup`. Case-insensitive, wiki-link-aware (`[[someday]]` matches `someday`).
 
 ## Available Tools
 
-### Vault path
+### `vault_daily_path` — Get daily journal path
+Returns the workspace-relative path for a daily journal file. Pass `base_path` from memory.
 
-#### `vault_set_path` — Set the vault base path
-Set the subdirectory within the workspace where the vault lives (e.g. `obsidian/main`). **Call this before using other vault tools** if the vault isn't at the workspace root. All file paths in subsequent calls resolve relative to this base.
+### `md_show` — Show sections with line numbers
+Without `section`: shows document outline (all headings with line numbers).
+With `section`: shows that section's content with line numbers on every line.
 
-#### `vault_get_path` — Get the current vault base path
-Returns the current vault base path, or indicates none is set (using workspace root).
+### `md_move_lines` — Move lines between files
+Move specific lines (by number) from one file to a section in another file. Use `md_show` first to see line numbers. Lines are appended to the target section.
 
-### File operations
+### `md_section` — Section operations
+Add, remove, rename, or move sections. Actions: `add`, `remove`, `rename`, `move`.
 
-#### `vault_read` — Read an entire file
-Read a markdown file's full content as text. Use when you need the whole file, not just a section.
+### `md_create` — Create file from template
+Create a new markdown file, optionally from a template. `{{date}}` in templates is replaced with today's date.
 
-#### `vault_create_file` — Create a new file
-Create a new markdown file, optionally from a template. `{{date}}` in templates is replaced with today's date (ISO format). Will not overwrite existing files. Creates parent directories as needed.
+## Using Workspace Tools
 
-#### `vault_daily_path` — Get a daily journal path
-Returns the relative path for a daily journal file (e.g. `journals/2026/2026-03-17.md`). Accepts an optional date and offset (-1 for yesterday, 1 for tomorrow). **Always use this instead of constructing date paths manually.**
+For basic file operations, use the standard workspace tools:
 
-#### `vault_list` — List files in the vault
-List markdown files and directories at a given path. Use to discover what notes exist.
+| Task | Workspace Tool |
+|------|---------------|
+| Read a file | `workspace_read` |
+| Edit a line (check/uncheck, change text) | `workspace_replace_lines` |
+| Insert a new line/item | `workspace_insert` |
+| Append to end of file | `workspace_append` |
+| List files | `workspace_list` |
+| Search files | `workspace_search` |
 
-### Navigation
+**To check off a to-do item**: use `md_show` to find the line number, then `workspace_replace_lines` to change `- [ ]` to `- [x]`.
 
-#### `vault_show` — Show a section or document outline
-With a section path: shows the heading and its content. Without: shows the document's heading outline (useful for navigating an unfamiliar file).
-
-#### `vault_items` — List checklist items in a section
-Returns indexed checklist items with their checked/unchecked state. Use the indices with other item tools.
-
-#### `vault_find_items` — Search for items across sections
-Search all sections in a file for checklist items matching a substring. Returns section name and item for each match. Useful when you know *what* you're looking for but not *where* it is.
-
-### Checklist item operations
-
-#### `vault_check` / `vault_uncheck` — Toggle a single item
-Mark an item done or not done. Select by substring match or index.
-
-#### `vault_bulk_check` / `vault_bulk_uncheck` — Toggle all items in a section
-Mark all checklist items in a section done or not done.
-
-#### `vault_append` / `vault_prepend` — Add content to a section
-Append adds to the end of a section (before the next heading). Prepend adds right after the heading. Items are placed contiguously with existing items — no extra blank lines.
-
-#### `vault_insert` — Insert at a specific position
-Insert text at a specific item index within a section. Index 0 = before first item.
-
-#### `vault_replace_item` — Edit a checklist item's text
-Replace the text of a checklist item while preserving its checked/unchecked state.
-
-#### `vault_move_item` — Move an item between sections
-Move a checklist item from one section to another (same file). The item is appended to the target section.
-
-#### `vault_move_items` — Bulk move items across files
-Move multiple checklist items between files and/or sections in a single operation. Supports filters: `unchecked_only`, `checked_only`, or specific `indices`. **This is the primary tool for daily task migration** — e.g. moving unchecked items from yesterday's "today" section to today's "today" section.
-
-#### `vault_delete` — Remove a checklist item
-Delete by substring match or index.
-
-### Tag operations
-
-#### `vault_tags` — List all tags in a file
-Discover all unique `#tags` in a document, sorted alphabetically.
-
-#### `vault_tagged` — Find all lines with a given tag
-Search the entire file for lines containing a specific `#tag`. Returns section name and line text. Works on both checklist items and plain prose lines.
-
-#### `vault_add_tag` — Add a tag to a checklist item
-Append a `#tag` to an item. Idempotent — won't duplicate if already present.
-
-#### `vault_remove_tag` — Remove a tag from a checklist item
-Remove a `#tag` from an item. Case-insensitive matching.
-
-### Section operations
-
-#### `vault_add_section` — Add a new section
-Create a new heading (with optional initial content). Position with `after`, `before`, or `parent` (insert as child). Omit all three to append at end of document.
-
-#### `vault_rename_section` — Rename a section heading
-Change a heading's text without affecting level, content, or position.
-
-#### `vault_replace_section` — Replace a section's content
-Overwrite a section's body while preserving the heading and any child sections.
-
-#### `vault_remove_section` — Remove an entire section
-Remove a heading and all its content, including any child sections. **Always confirm with the user first.**
-
-#### `vault_move_section` — Move a section to a new position
-Relocate a section (heading + content + children) within the document. Position with `after` or `before`. Omit both to move to end.
-
-## Safety Protocols
-
-- **Append-only by default.** Creating new files and appending content is fine. Checking/unchecking items is fine. But **do not delete items, sections, or files without explicit user confirmation** for each change.
-- **Protected directories.** Some directories (e.g. `blog/`, publishing pipelines) should never be written to without a direct, explicit, per-instance command from the user. When in doubt, ask.
-- **No bulk operations without confirmation.** Moving, renaming, or batch-editing multiple files requires explicit approval.
-
-## Daily Notes
-
-Daily journal files live at `journals/YYYY/YYYY-MM-DD.md`. They combine to-do lists, meeting notes, and general journaling, organized by heading sections. A template exists at `templates/daily.md`.
-
-Common daily note tasks:
-- **Append items** to the current day's note (to-dos, meeting notes, quick thoughts)
-- **Check off items** as they're completed
-- **Someday sweep**: On request, scan recent daily journals for items under `# [[someday]]` headings and consolidate them into `pages/someday.md`
+**To add a task**: use `md_show` to find the section's last line number, then `workspace_insert` at the next line.
 
 ## Common Workflows
 
-### "Check off X on my list"
-1. `vault_find_items` to locate the item (if section unknown), or `vault_items` if you know the section
-2. `vault_check` with the match text or index
+### "What's on my list today?"
+1. `vault_daily_path(base_path="obsidian/main")` → get today's path
+2. `md_show(file=path, section="today")` → see items with line numbers
+
+### "Check off X"
+1. `md_show` to find the line number
+2. `workspace_replace_lines(path, start_line=N, end_line=N, content="- [x] ...")` to toggle the checkbox
 
 ### "Add a task to today"
-1. `vault_append` on the target section with `- [ ] task description`
+1. `md_show` to see the section and find where to insert
+2. `workspace_insert(path, line_number=N, content="- [ ] new task\n")`
 
 ### "Move unchecked items from yesterday to today"
-1. `vault_daily_path` with offset=-1 → get yesterday's file path
-2. `vault_daily_path` → get today's file path
-3. `vault_move_items` from yesterday's file "today" section to today's file "today" section, with `unchecked_only=true`
-
-### "Move today/tomorrow items to the next day"
-1. `vault_daily_path` → today's file
-2. `vault_daily_path` with offset=1 → tomorrow's file
-3. `vault_move_items` from today's "tomorrow" section to tomorrow's "today" section
-
-### "What's tagged #research?"
-1. `vault_tagged` with tag `research` — searches the whole file
+1. `vault_daily_path(base_path="obsidian/main", offset=-1)` → yesterday's path
+2. `vault_daily_path(base_path="obsidian/main")` → today's path
+3. `md_show(yesterday, section="today")` → see items with line numbers
+4. Identify unchecked items (lines with `- [ ]`)
+5. `md_move_lines(from_file=yesterday, to_file=today, to_section="today", lines="6,7,11")`
 
 ### "Create today's daily note"
-1. `vault_daily_path` → get the path
-2. `vault_create_file` with that path and template `templates/daily.md`
+1. `vault_daily_path(base_path="obsidian/main")` → get path
+2. `md_create(file=path, template="obsidian/main/templates/daily.md")`
 
-### "Sweep someday items to someday.md"
-1. `vault_daily_path` → today's file
-2. `vault_show` the `someday` section
-3. `vault_move_items` from today's file "someday" section to `pages/someday.md` "someday" section (or use `vault_read` + `vault_prepend` if someday.md has a flat structure)
+## Daily Notes
 
-## Choosing the Right Tool
+Daily journal files live at `{base_path}/journals/YYYY/YYYY-MM-DD.md`. They combine to-do lists, meeting notes, and general journaling, organized by heading sections. A template typically exists at `{base_path}/templates/daily.md`.
 
-| Task | Tool |
-|------|------|
-| Set vault location within workspace | `vault_set_path` |
-| Check current vault location | `vault_get_path` |
-| Get a daily journal path | `vault_daily_path` |
-| Read an entire file | `vault_read` |
-| Create a new file (or from template) | `vault_create_file` |
-| See what files exist | `vault_list` |
-| See what sections a file has | `vault_show` (no section) |
-| Read a section's content | `vault_show` (with section) |
-| See checklist items with indices | `vault_items` |
-| Find items by text across sections | `vault_find_items` |
-| Mark something done | `vault_check` |
-| Mark something not done | `vault_uncheck` |
-| Mark all items done/not done | `vault_bulk_check` / `vault_bulk_uncheck` |
-| Edit an item's text | `vault_replace_item` |
-| Move an item to another section | `vault_move_item` |
-| Bulk move items across files | `vault_move_items` |
-| Add a new task/item | `vault_append` or `vault_prepend` |
-| Add at a specific position | `vault_insert` |
-| Remove an item (ask first!) | `vault_delete` |
-| List all tags in a file | `vault_tags` |
-| Find lines with a tag | `vault_tagged` |
-| Tag an item | `vault_add_tag` |
-| Untag an item | `vault_remove_tag` |
-| Add a new section | `vault_add_section` |
-| Rename a section | `vault_rename_section` |
-| Rewrite a section's content | `vault_replace_section` |
-| Remove a section (ask first!) | `vault_remove_section` |
-| Rearrange sections | `vault_move_section` |
+## Safety Protocols
+
+- **Append-only by default.** Creating new files and adding items is fine. But **do not delete items, sections, or files without explicit user confirmation**.
+- **Protected directories.** Some directories (e.g. `blog/`) should never be written to without a direct command from the user.

--- a/src/decafclaw/skills/markdown_vault/tests/test_vault.py
+++ b/src/decafclaw/skills/markdown_vault/tests/test_vault.py
@@ -12,6 +12,11 @@ from decafclaw.skills.markdown_vault.tools import (
     extract_tags,
     move_item_across_files,
     normalize_title,
+    tool_md_create,
+    tool_md_move_lines,
+    tool_md_section,
+    tool_md_show,
+    tool_vault_daily_path,
 )
 
 # -- Fixture document used by most tests --
@@ -1056,3 +1061,171 @@ class TestRoundTrip:
         doc = Document.from_file(p)
         doc.save(p)
         assert p.read_text() == SAMPLE
+
+
+# -- New tool tests (5 tools) -------------------------------------------------
+
+
+class _FakeConfig:
+    def __init__(self, workspace):
+        self.workspace_path = workspace
+
+
+class _FakeCtx:
+    def __init__(self, workspace):
+        self.config = _FakeConfig(workspace)
+
+
+class TestVaultDailyPath:
+    def test_with_base_path(self):
+        ctx = _FakeCtx(None)
+        result = tool_vault_daily_path(ctx, base_path="obsidian/main")
+        import datetime as dt
+        today = dt.date.today().isoformat()
+        assert result.text == f"obsidian/main/journals/{dt.date.today().year}/{today}.md"
+
+    def test_without_base_path(self):
+        ctx = _FakeCtx(None)
+        result = tool_vault_daily_path(ctx)
+        assert "journals/" in result.text
+        assert result.text.startswith("journals/")
+
+    def test_with_offset(self):
+        ctx = _FakeCtx(None)
+        result = tool_vault_daily_path(ctx, base_path="vault", offset=-1)
+        assert "vault/journals/" in result.text
+
+
+class TestMdShow:
+    def test_outline(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# today\n- [ ] task one\n\n# tomorrow\n- [ ] task two\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_show(ctx, file="test.md")
+        assert "# today" in result.text
+        assert "# tomorrow" in result.text
+        assert "1:" in result.text  # line numbers
+
+    def test_section_content(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# today\n- [ ] task one\n- [x] done task\n\n# tomorrow\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_show(ctx, file="test.md", section="today")
+        assert "task one" in result.text
+        assert "done task" in result.text
+        assert "2:" in result.text  # line numbers on content
+
+    def test_section_not_found(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# today\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_show(ctx, file="test.md", section="nonexistent")
+        assert "error" in result.text
+
+    def test_file_not_found(self, tmp_path):
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_show(ctx, file="nope.md")
+        assert "error" in result.text
+
+
+class TestMdMoveLines:
+    def test_move_lines_between_files(self, tmp_path):
+        src = tmp_path / "yesterday.md"
+        src.write_text("# today\n- [ ] task A\n- [ ] task B\n- [x] done\n\n# tonight\n")
+        dst = tmp_path / "today.md"
+        dst.write_text("# today\n- [ ] existing\n\n# tonight\n")
+        ctx = _FakeCtx(tmp_path)
+
+        result = tool_md_move_lines(ctx, "yesterday.md", "today.md", "today", "2,3")
+        assert "Moved 2" in result.text
+
+        # Source should have lost lines 2,3
+        src_text = src.read_text()
+        assert "task A" not in src_text
+        assert "task B" not in src_text
+        assert "done" in src_text  # line 4 stays
+
+        # Target should have gained them
+        dst_text = dst.read_text()
+        assert "task A" in dst_text
+        assert "task B" in dst_text
+
+    def test_same_file_move(self, tmp_path):
+        """Move lines within the same file between sections."""
+        p = tmp_path / "notes.md"
+        p.write_text("# today\n- [ ] task A\n- [ ] task B\n\n# tomorrow\n")
+        ctx = _FakeCtx(tmp_path)
+
+        result = tool_md_move_lines(ctx, "notes.md", "notes.md", "tomorrow", "2,3")
+        assert "Moved 2" in result.text
+
+        text = p.read_text()
+        # Lines should be gone from today
+        assert text.index("# tomorrow") < text.index("task A")
+        assert text.index("# tomorrow") < text.index("task B")
+
+    def test_invalid_line_number(self, tmp_path):
+        src = tmp_path / "test.md"
+        src.write_text("# today\nline\n")
+        dst = tmp_path / "other.md"
+        dst.write_text("# today\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_move_lines(ctx, "test.md", "other.md", "today", "999")
+        assert "error" in result.text
+
+
+class TestMdSection:
+    def test_add_section(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# existing\ncontent\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_section(ctx, "test.md", action="add", title="new section")
+        assert "Added" in result.text
+        assert "# new section" in p.read_text()
+
+    def test_remove_section(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# keep\ncontent\n\n# remove me\nstuff\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_section(ctx, "test.md", action="remove", section="remove me")
+        assert "Removed" in result.text
+        assert "remove me" not in p.read_text()
+
+    def test_rename_section(self, tmp_path):
+        p = tmp_path / "test.md"
+        p.write_text("# old name\ncontent\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_section(ctx, "test.md", action="rename", section="old name", title="new name")
+        assert "Renamed" in result.text
+        assert "# new name" in p.read_text()
+
+
+class TestMdCreate:
+    def test_create_with_content(self, tmp_path):
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_create(ctx, "new.md", content="# Hello\n")
+        assert "Done" in result.text
+        assert (tmp_path / "new.md").read_text() == "# Hello\n"
+
+    def test_create_from_template(self, tmp_path):
+        tmpl = tmp_path / "template.md"
+        tmpl.write_text("# {{date}}\n")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_create(ctx, "new.md", template="template.md")
+        assert "Done" in result.text
+        import datetime as dt
+        assert dt.date.today().isoformat() in (tmp_path / "new.md").read_text()
+
+    def test_wont_overwrite(self, tmp_path):
+        p = tmp_path / "exists.md"
+        p.write_text("original")
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_create(ctx, "exists.md", content="overwrite")
+        assert "error" in result.text
+        assert p.read_text() == "original"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        ctx = _FakeCtx(tmp_path)
+        result = tool_md_create(ctx, "sub/dir/new.md", content="# Deep\n")
+        assert "Done" in result.text
+        assert (tmp_path / "sub" / "dir" / "new.md").exists()

--- a/src/decafclaw/skills/markdown_vault/tools.py
+++ b/src/decafclaw/skills/markdown_vault/tools.py
@@ -640,121 +640,222 @@ def bulk_move_items(
 
 log = logging.getLogger(__name__)
 
-_workspace_path: Path | None = None
+
+# ---------------------------------------------------------------------------
+# Path resolution (workspace-relative, no vault base path)
+# ---------------------------------------------------------------------------
 
 
-def init(config):
-    """Initialize using the agent workspace path. Called by the skill loader on activation."""
-    global _workspace_path
-    _workspace_path = config.workspace_path.resolve()
-    log.info(f"Markdown vault initialized at workspace {_workspace_path}")
+def _resolve_workspace(config, path_str: str) -> Path:
+    """Resolve a workspace-relative path with safety check."""
+    workspace = config.workspace_path.resolve()
+    target = (workspace / path_str).resolve()
+    if not target.is_relative_to(workspace):
+        raise ValueError(f"Path escapes workspace: {path_str}")
+    return target
 
 
-def _get_vault_base(ctx) -> str | None:
-    """Read the vault base path from ctx.skill_data."""
-    skill_data = ctx.skill_data if ctx else {}
-    return skill_data.get("vault_base_path")
+# ---------------------------------------------------------------------------
+# Tool implementations (5 tools, down from 29)
+# ---------------------------------------------------------------------------
 
 
-def _set_vault_base(ctx, path: str) -> None:
-    """Store the vault base path in ctx.skill_data."""
-    if not hasattr(ctx, "skill_data"):
-        ctx.skill_data = {}
-    ctx.skill_data["vault_base_path"] = path
-
-
-def _resolve(file: str, ctx=None) -> Path:
-    """Resolve a relative file path within the vault, with safety check.
-
-    Requires a vault base path to be set via vault_set_path. This ensures the
-    agent explicitly configures which vault it's working with.
-    """
-    if _workspace_path is None:
-        raise RuntimeError("Vault not initialized — skill not activated?")
-    vault_base = _get_vault_base(ctx)
-    if not vault_base:
-        raise ValueError(
-            "No vault base path set. Call memory_search(\"markdown vault "
-            "base path\") to look it up, then call vault_set_path with the "
-            "result. Only ask the user if memory has nothing."
-        )
-    base = (_workspace_path / vault_base).resolve()
-    if not base.is_relative_to(_workspace_path):
-        raise ValueError(f"Vault base path escapes workspace: {vault_base}")
-    resolved = (base / file).resolve()
-    if not resolved.is_relative_to(_workspace_path):
-        raise ValueError(f"Path escapes workspace: {file}")
-    return resolved
-
-
-# -- Tool implementations ---------------------------------------------------
-
-
-def tool_vault_set_path(ctx, path: str) -> ToolResult:
-    """Set the vault base path (relative to workspace) for this conversation.
-
-    All subsequent vault tool calls will resolve file paths relative to this
-    directory. For example, set_path("obsidian/main") means vault_read("journals/today.md")
-    resolves to workspace/obsidian/main/journals/today.md.
-    """
-    log.info(f"[tool:vault_set_path] path={path!r}")
+def tool_vault_daily_path(
+    ctx, base_path: str = "", date: str | None = None, offset: int = 0,
+) -> ToolResult:
+    """Get the workspace-relative path for a daily journal file."""
+    log.info(f"[tool:vault_daily_path] base_path={base_path!r} date={date!r} offset={offset}")
     try:
-        if _workspace_path is None:
-            return ToolResult(text="[error: vault not initialized]")
-        base = (_workspace_path / path).resolve()
-        if not base.is_relative_to(_workspace_path):
-            return ToolResult(text=f"[error: path escapes workspace: {path}]")
-        if not base.is_dir():
-            return ToolResult(text=f"[error: not a directory: {path}]")
-        _set_vault_base(ctx, path)
-        return ToolResult(text=f"Vault base path set to: {path}")
+        path = daily_path(date=date, offset=offset)
+        if base_path:
+            path = f"{base_path.rstrip('/')}/{path}"
+        return ToolResult(text=path)
     except Exception as e:
         return ToolResult(text=f"[error: {e}]")
 
 
-def tool_vault_get_path(ctx) -> ToolResult:
-    """Get the current vault base path for this conversation."""
-    log.info("[tool:vault_get_path]")
-    base = _get_vault_base(ctx)
-    if base:
-        return ToolResult(text=base)
-    return ToolResult(text="(not set — use vault_set_path first)")
-
-
-def tool_vault_read(ctx, file: str) -> ToolResult:
-    """Read an entire markdown file as text."""
-    log.info(f"[tool:vault_read] file={file!r}")
+def tool_md_show(ctx, file: str, section: str | None = None) -> ToolResult:
+    """Show a markdown file's section structure or a section's content with line numbers."""
+    log.info(f"[tool:md_show] file={file!r} section={section!r}")
     try:
-        path = _resolve(file, ctx)
+        path = _resolve_workspace(ctx.config, file)
         if not path.is_file():
             return ToolResult(text=f"[error: file not found: {file}]")
-        return ToolResult(text=path.read_text())
+
+        doc = Document.from_file(path)
+
+        if section:
+            sec = doc.find_section(section)
+            if not sec:
+                return ToolResult(text=f"[error: section not found: {section}]")
+            # Show section heading + all content with line numbers
+            lines = []
+            lines.append(f"{'#' * sec.level} {sec.title} (line {sec.heading_line + 1})")
+            for i in range(sec.content_start, sec.content_end):
+                line_text = doc.lines[i].rstrip("\n")
+                lines.append(f"{i + 1:4d}: {line_text}")
+            return ToolResult(text="\n".join(lines))
+        else:
+            # Outline mode: show all headings with line numbers
+            lines = []
+            for _, sec in doc.list_sections():
+                lines.append(f"{sec.heading_line + 1:4d}: {'#' * sec.level} {sec.title}")
+            return ToolResult(text="\n".join(lines))
     except Exception as e:
         return ToolResult(text=f"[error: {e}]")
 
 
-def tool_vault_create_file(
-    ctx, file: str, content: str = "", template: str | None = None,
+def tool_md_move_lines(
+    ctx, from_file: str, to_file: str, to_section: str, lines: str,
 ) -> ToolResult:
-    """Create a new markdown file, optionally from a template.
-
-    If template is given, its content is used as the starting point
-    (with {{date}} replaced by today's date). content is ignored if
-    template is provided. Will not overwrite an existing file.
-    """
-    log.info(f"[tool:vault_create_file] file={file!r} template={template!r}")
+    """Move specific lines (by number) from one file to another section."""
+    log.info(f"[tool:md_move_lines] {from_file!r} -> {to_file!r}/{to_section!r} lines={lines!r}")
     try:
-        path = _resolve(file, ctx)
+        # Parse line numbers (1-based from user, convert to 0-based), deduplicate
+        parsed = [int(n.strip()) - 1 for n in lines.split(",") if n.strip()]
+        line_nums = sorted(set(parsed), reverse=True)
+        if not line_nums:
+            return ToolResult(text="[error: no line numbers provided]")
+
+        from_path = _resolve_workspace(ctx.config, from_file)
+        to_path = _resolve_workspace(ctx.config, to_file)
+
+        if not from_path.is_file():
+            return ToolResult(text=f"[error: file not found: {from_file}]")
+        if not to_path.is_file():
+            return ToolResult(text=f"[error: file not found: {to_file}]")
+
+        # Read source lines
+        source_lines = from_path.read_text().splitlines(keepends=True)
+
+        # Validate line numbers
+        for ln in line_nums:
+            if ln < 0 or ln >= len(source_lines):
+                return ToolResult(
+                    text=f"[error: line {ln + 1} out of range (file has {len(source_lines)} lines)]"
+                )
+
+        # Collect lines to move (in original order, not reversed)
+        moving = []
+        for ln in sorted(line_nums):
+            moving.append(source_lines[ln])
+
+        same_file = from_path == to_path
+
+        if same_file:
+            # Same-file move: operate on a single Document to avoid corruption
+            doc = Document(from_path.read_text())
+            to_sec = doc.find_section(to_section)
+            if not to_sec:
+                return ToolResult(text=f"[error: section not found in {to_file}: {to_section}]")
+            # Delete lines (reverse order), then append to target
+            for ln in line_nums:  # already sorted reverse
+                doc._delete_lines(ln, 1)
+            for line in moving:
+                to_sec = doc.find_section(to_section)
+                if not to_sec:
+                    break
+                doc.append(to_sec, line.rstrip("\n"))
+            doc.save(from_path)
+        else:
+            # Cross-file move
+            # Remove from source (reverse order preserves indices)
+            for ln in line_nums:  # already sorted reverse
+                del source_lines[ln]
+
+            # Parse target and find section
+            to_doc = Document(to_path.read_text())
+            to_sec = to_doc.find_section(to_section)
+            if not to_sec:
+                return ToolResult(text=f"[error: section not found in {to_file}: {to_section}]")
+
+            # Append moving lines to target section
+            for line in moving:
+                raw = line.rstrip("\n")
+                to_doc.append(to_sec, raw)
+                to_sec = to_doc.find_section(to_section)
+                if not to_sec:
+                    break
+
+            # Save both files
+            from_path.write_text("".join(source_lines))
+            to_doc.save(to_path)
+
+        return ToolResult(text=f"Moved {len(moving)} line(s) from {from_file} to {to_file}/{to_section}")
+    except Exception as e:
+        return ToolResult(text=f"[error: {e}]")
+
+
+def tool_md_section(
+    ctx, file: str, action: str,
+    section: str | None = None, title: str | None = None,
+    level: int = 1,
+    after: str | None = None, before: str | None = None, parent: str | None = None,
+) -> ToolResult:
+    """Section operations: add, remove, rename, move."""
+    log.info(f"[tool:md_section] file={file!r} action={action!r} section={section!r}")
+    try:
+        path = _resolve_workspace(ctx.config, file)
+        if not path.is_file():
+            return ToolResult(text=f"[error: file not found: {file}]")
+
+        doc = Document.from_file(path)
+
+        if action == "add":
+            if not title:
+                return ToolResult(text="[error: 'title' required for add]")
+            if doc.add_section(title, level=level, after=after, before=before, parent=parent):
+                doc.save(path)
+                return ToolResult(text=f"Added section: {title}")
+            return ToolResult(text="[error: target section not found]")
+
+        elif action == "remove":
+            if not section:
+                return ToolResult(text="[error: 'section' required for remove]")
+            removed = doc.remove_section(section)
+            if removed is not None:
+                doc.save(path)
+                return ToolResult(text=f"Removed section: {section}")
+            return ToolResult(text=f"[error: section not found: {section}]")
+
+        elif action == "rename":
+            if not section or not title:
+                return ToolResult(text="[error: 'section' and 'title' required for rename]")
+            if doc.rename_section(section, title):
+                doc.save(path)
+                return ToolResult(text=f"Renamed section: {section} → {title}")
+            return ToolResult(text=f"[error: section not found: {section}]")
+
+        elif action == "move":
+            if not section:
+                return ToolResult(text="[error: 'section' required for move]")
+            if doc.move_section(section, after=after, before=before):
+                doc.save(path)
+                return ToolResult(text=f"Moved section: {section}")
+            return ToolResult(text="[error: section or target not found]")
+
+        else:
+            return ToolResult(text=f"[error: unknown action: {action}. Use add/remove/rename/move]")
+    except Exception as e:
+        return ToolResult(text=f"[error: {e}]")
+
+
+def tool_md_create(
+    ctx, file: str, template: str | None = None, content: str = "",
+) -> ToolResult:
+    """Create a new markdown file, optionally from a template."""
+    log.info(f"[tool:md_create] file={file!r} template={template!r}")
+    try:
+        path = _resolve_workspace(ctx.config, file)
         if path.exists():
             return ToolResult(text=f"[error: file already exists: {file}]")
 
         if template:
-            tmpl_path = _resolve(template, ctx)
+            tmpl_path = _resolve_workspace(ctx.config, template)
             if not tmpl_path.is_file():
                 return ToolResult(text=f"[error: template not found: {template}]")
             body = tmpl_path.read_text()
             today = datetime.date.today().isoformat()
-            # Replace {{date}} and {{date:FORMAT}} variants (e.g. {{date:YYYY-MM-DD}})
             body = re.sub(r"\{\{date(?::[^}]*)?\}\}", today, body)
         else:
             body = content
@@ -766,533 +867,38 @@ def tool_vault_create_file(
         return ToolResult(text=f"[error: {e}]")
 
 
-def tool_vault_list(ctx, path: str = "") -> ToolResult:
-    """List markdown files at a path within the vault."""
-    log.info(f"[tool:vault_list] path={path!r}")
-    try:
-        target = _resolve(path, ctx)
-        if not target.is_dir():
-            return ToolResult(text=f"[error: not a directory: {path}]")
-
-        entries = sorted(target.iterdir())
-        lines = []
-        for entry in entries:
-            rel = entry.relative_to(_workspace_path)  # type: ignore[arg-type]  # guarded by _resolve
-            if entry.is_dir():
-                lines.append(f"  {rel}/")
-            elif entry.suffix in (".md", ".markdown"):
-                lines.append(f"  {rel}")
-        if not lines:
-            return ToolResult(text="(no markdown files found)")
-        return ToolResult(text="\n".join(lines))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_show(ctx, file: str, section: str | None = None) -> ToolResult:
-    """Show a section's content, or the document outline if no section given."""
-    log.info(f"[tool:vault_show] file={file!r} section={section!r}")
-    try:
-        doc = Document.from_file(_resolve(file, ctx))
-        if section:
-            sec = doc.find_section(section)
-            if not sec:
-                return ToolResult(text=f"[error: section not found: {section}]")
-            return ToolResult(text="".join(sec.all_lines(doc.lines)))
-        else:
-            lines = []
-            for depth, sec in doc.list_sections():
-                indent = "  " * depth
-                lines.append(f"{indent}{'#' * sec.level} {sec.title}")
-            return ToolResult(text="\n".join(lines))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_items(ctx, file: str, section: str) -> ToolResult:
-    """List checklist items in a section with their indices."""
-    log.info(f"[tool:vault_items] file={file!r} section={section!r}")
-    try:
-        doc = Document.from_file(_resolve(file, ctx))
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        items = doc.get_items(sec)
-        if not items:
-            return ToolResult(text="(no checklist items)")
-        lines = []
-        for i, item in enumerate(items):
-            mark = "x" if item.checked else " "
-            lines.append(f"  {i}: [{mark}] {item.text}")
-        return ToolResult(text="\n".join(lines))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_check(ctx, file: str, section: str, match: str | None = None, index: int | None = None) -> ToolResult:
-    """Mark a checklist item as done."""
-    log.info(f"[tool:vault_check] file={file!r} section={section!r} match={match!r} index={index!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.check_item(sec, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_uncheck(ctx, file: str, section: str, match: str | None = None, index: int | None = None) -> ToolResult:
-    """Mark a checklist item as not done."""
-    log.info(f"[tool:vault_uncheck] file={file!r} section={section!r} match={match!r} index={index!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.uncheck_item(sec, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_append(ctx, file: str, section: str, text: str) -> ToolResult:
-    """Append text to the end of a section."""
-    log.info(f"[tool:vault_append] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        doc.append(sec, text)
-        doc.save(path)
-        return ToolResult(text="Done.")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_prepend(ctx, file: str, section: str, text: str) -> ToolResult:
-    """Prepend text to the start of a section."""
-    log.info(f"[tool:vault_prepend] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        doc.prepend(sec, text)
-        doc.save(path)
-        return ToolResult(text="Done.")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_insert(ctx, file: str, section: str, index: int, text: str) -> ToolResult:
-    """Insert text at a specific item index within a section."""
-    log.info(f"[tool:vault_insert] file={file!r} section={section!r} index={index}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        doc.insert_item(sec, index, text)
-        doc.save(path)
-        return ToolResult(text="Done.")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_delete(ctx, file: str, section: str, match: str | None = None, index: int | None = None) -> ToolResult:
-    """Delete a checklist item from a section."""
-    log.info(f"[tool:vault_delete] file={file!r} section={section!r} match={match!r} index={index!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.delete_item(sec, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_add_section(
-    ctx, file: str, title: str, level: int = 1, content: str = "",
-    after: str | None = None, before: str | None = None, parent: str | None = None,
-) -> ToolResult:
-    """Add a new section to a markdown file."""
-    log.info(f"[tool:vault_add_section] file={file!r} title={title!r} level={level}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        if doc.add_section(title, level=level, content=content, after=after, before=before, parent=parent):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: target section not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_remove_section(ctx, file: str, section: str) -> ToolResult:
-    """Remove a section (heading + all content including children)."""
-    log.info(f"[tool:vault_remove_section] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        removed = doc.remove_section(section)
-        if removed is not None:
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text=f"[error: section not found: {section}]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_move_section(
-    ctx, file: str, section: str,
-    after: str | None = None, before: str | None = None,
-) -> ToolResult:
-    """Move a section (heading + content + children) to a new position."""
-    log.info(f"[tool:vault_move_section] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        if doc.move_section(section, after=after, before=before):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: section or target not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_replace_item(
-    ctx, file: str, section: str, text: str,
-    match: str | None = None, index: int | None = None,
-) -> ToolResult:
-    """Replace a checklist item's text, preserving its checked state."""
-    log.info(f"[tool:vault_replace_item] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.replace_item(sec, text, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_move_item(
-    ctx, file: str, from_section: str, to_section: str,
-    match: str | None = None, index: int | None = None,
-) -> ToolResult:
-    """Move a checklist item from one section to another."""
-    log.info(f"[tool:vault_move_item] file={file!r} from={from_section!r} to={to_section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        from_sec = doc.find_section(from_section)
-        if not from_sec:
-            return ToolResult(text=f"[error: source section not found: {from_section}]")
-        to_sec = doc.find_section(to_section)
-        if not to_sec:
-            return ToolResult(text=f"[error: target section not found: {to_section}]")
-        if doc.move_item(from_sec, to_sec, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_bulk_check(ctx, file: str, section: str) -> ToolResult:
-    """Mark all checklist items in a section as done."""
-    log.info(f"[tool:vault_bulk_check] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        count = doc.bulk_check(sec)
-        doc.save(path)
-        return ToolResult(text=f"Checked {count} item(s).")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_bulk_uncheck(ctx, file: str, section: str) -> ToolResult:
-    """Mark all checklist items in a section as not done."""
-    log.info(f"[tool:vault_bulk_uncheck] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        count = doc.bulk_uncheck(sec)
-        doc.save(path)
-        return ToolResult(text=f"Unchecked {count} item(s).")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_find_items(ctx, file: str, query: str) -> ToolResult:
-    """Search all sections for checklist items matching a substring."""
-    log.info(f"[tool:vault_find_items] file={file!r} query={query!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        results = doc.find_items(query)
-        if not results:
-            return ToolResult(text="(no matching items)")
-        lines = []
-        for sec, item in results:
-            mark = "x" if item.checked else " "
-            lines.append(f"  {sec.title}: [{mark}] {item.text}")
-        return ToolResult(text="\n".join(lines))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_rename_section(ctx, file: str, section: str, title: str) -> ToolResult:
-    """Rename a section's heading text."""
-    log.info(f"[tool:vault_rename_section] file={file!r} section={section!r} title={title!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        if doc.rename_section(section, title):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text=f"[error: section not found: {section}]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_replace_section(ctx, file: str, section: str, content: str) -> ToolResult:
-    """Replace a section's body content, preserving heading and children."""
-    log.info(f"[tool:vault_replace_section] file={file!r} section={section!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        if doc.replace_section_content(section, content):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text=f"[error: section not found: {section}]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_tags(ctx, file: str) -> ToolResult:
-    """List all unique tags in a markdown file."""
-    log.info(f"[tool:vault_tags] file={file!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        tags = doc.list_tags()
-        if not tags:
-            return ToolResult(text="(no tags)")
-        return ToolResult(text="\n".join(f"  #{t}" for t in tags))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_tagged(ctx, file: str, tag: str) -> ToolResult:
-    """Find all lines with a given tag."""
-    log.info(f"[tool:vault_tagged] file={file!r} tag={tag!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        results = doc.find_tagged(tag)
-        if not results:
-            return ToolResult(text="(no matching lines)")
-        lines = []
-        for sec, _line_idx, text in results:
-            section_name = sec.title if sec else "(top)"
-            lines.append(f"  {section_name}: {text}")
-        return ToolResult(text="\n".join(lines))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_add_tag(
-    ctx, file: str, section: str, tag: str,
-    match: str | None = None, index: int | None = None,
-) -> ToolResult:
-    """Add a tag to a checklist item."""
-    log.info(f"[tool:vault_add_tag] file={file!r} section={section!r} tag={tag!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.add_tag(sec, tag, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_remove_tag(
-    ctx, file: str, section: str, tag: str,
-    match: str | None = None, index: int | None = None,
-) -> ToolResult:
-    """Remove a tag from a checklist item."""
-    log.info(f"[tool:vault_remove_tag] file={file!r} section={section!r} tag={tag!r}")
-    try:
-        path = _resolve(file, ctx)
-        doc = Document.from_file(path)
-        sec = doc.find_section(section)
-        if not sec:
-            return ToolResult(text=f"[error: section not found: {section}]")
-        if doc.remove_tag(sec, tag, match=match, index=index):
-            doc.save(path)
-            return ToolResult(text="Done.")
-        return ToolResult(text="[error: item not found]")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_daily_path(ctx, date: str | None = None, offset: int = 0) -> ToolResult:
-    """Return the vault path for a daily journal file."""
-    log.info(f"[tool:vault_daily_path] date={date!r} offset={offset}")
-    try:
-        return ToolResult(text=daily_path(date=date, offset=offset))
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-def tool_vault_move_items(
-    ctx, from_file: str, from_section: str,
-    to_file: str, to_section: str,
-    indices: str | None = None,
-    checked_only: bool = False,
-    unchecked_only: bool = False,
-) -> ToolResult:
-    """Move multiple checklist items between files/sections."""
-    log.info(f"[tool:vault_move_items] {from_file!r}:{from_section!r} -> {to_file!r}:{to_section!r}")
-    try:
-        from_path = _resolve(from_file, ctx)
-        to_path = _resolve(to_file, ctx)
-        from_doc = Document.from_file(from_path)
-        to_doc = Document.from_file(to_path) if to_path != from_path else from_doc
-
-        idx_list = None
-        if indices:
-            idx_list = [int(i.strip()) for i in indices.split(",")]
-
-        count = bulk_move_items(
-            from_doc, from_section,
-            to_doc, to_section,
-            indices=idx_list,
-            checked_only=checked_only,
-            unchecked_only=unchecked_only,
-        )
-        if count > 0:
-            from_doc.save(from_path)
-            if to_path != from_path:
-                to_doc.save(to_path)
-        return ToolResult(text=f"Moved {count} item(s).")
-    except Exception as e:
-        return ToolResult(text=f"[error: {e}]")
-
-
-# -- Registry ---------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
 
 TOOLS = {
-    "vault_set_path": tool_vault_set_path,
-    "vault_get_path": tool_vault_get_path,
     "vault_daily_path": tool_vault_daily_path,
-    "vault_move_items": tool_vault_move_items,
-    "vault_read": tool_vault_read,
-    "vault_create_file": tool_vault_create_file,
-    "vault_list": tool_vault_list,
-    "vault_show": tool_vault_show,
-    "vault_items": tool_vault_items,
-    "vault_check": tool_vault_check,
-    "vault_uncheck": tool_vault_uncheck,
-    "vault_append": tool_vault_append,
-    "vault_prepend": tool_vault_prepend,
-    "vault_insert": tool_vault_insert,
-    "vault_delete": tool_vault_delete,
-    "vault_replace_item": tool_vault_replace_item,
-    "vault_move_item": tool_vault_move_item,
-    "vault_bulk_check": tool_vault_bulk_check,
-    "vault_bulk_uncheck": tool_vault_bulk_uncheck,
-    "vault_find_items": tool_vault_find_items,
-    "vault_add_section": tool_vault_add_section,
-    "vault_remove_section": tool_vault_remove_section,
-    "vault_move_section": tool_vault_move_section,
-    "vault_rename_section": tool_vault_rename_section,
-    "vault_replace_section": tool_vault_replace_section,
-    "vault_tags": tool_vault_tags,
-    "vault_tagged": tool_vault_tagged,
-    "vault_add_tag": tool_vault_add_tag,
-    "vault_remove_tag": tool_vault_remove_tag,
+    "md_show": tool_md_show,
+    "md_move_lines": tool_md_move_lines,
+    "md_section": tool_md_section,
+    "md_create": tool_md_create,
 }
 
 TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
-            "name": "vault_set_path",
-            "description": "REQUIRED before any other vault tool. Set the vault base path for this conversation. If you don't know the path, call memory_search(\"markdown vault base path\") first — do NOT ask the user without checking memory. All file paths in other vault tools resolve relative to this directory. Example: vault_set_path('obsidian/main').",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Relative path from workspace root to the vault directory (e.g. 'obsidian/main')",
-                    },
-                },
-                "required": ["path"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_get_path",
-            "description": "Get the current vault base path for this conversation. Returns the path set by vault_set_path, or indicates that the workspace root is being used.",
-            "parameters": {
-                "type": "object",
-                "properties": {},
-                "required": [],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
             "name": "vault_daily_path",
-            "description": "Get the vault file path for a daily journal. Returns a path like 'journals/2026/2026-03-17.md'. Use this to avoid constructing date-based paths manually.",
+            "description": "Get the workspace-relative path for a daily journal file. Returns a path like 'obsidian/main/journals/2026/2026-03-19.md'.",
             "parameters": {
                 "type": "object",
                 "properties": {
+                    "base_path": {
+                        "type": "string",
+                        "description": "Vault base path within workspace (e.g. 'obsidian/main'). Check memory if unknown.",
+                    },
                     "date": {
                         "type": "string",
-                        "description": "ISO date string (YYYY-MM-DD). Omit for today.",
+                        "description": "ISO date (YYYY-MM-DD). Default: today.",
                     },
                     "offset": {
                         "type": "integer",
-                        "description": "Days to shift: -1 for yesterday, 1 for tomorrow, etc. Applied after date. Default: 0.",
+                        "description": "Day offset (-1=yesterday, 1=tomorrow). Default: 0.",
                     },
                 },
                 "required": [],
@@ -1302,683 +908,122 @@ TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
-            "name": "vault_move_items",
-            "description": "Move multiple checklist items between files and/or sections. Can move all items, only checked, only unchecked, or specific indices. Use for daily task migration (e.g. unchecked items from yesterday's 'today' to today's 'today').",
+            "name": "md_show",
+            "description": "Show a markdown file's section structure (headings with line numbers) or a specific section's content with line numbers. Use this to see what's in a file before editing with workspace tools.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Workspace-relative path to the markdown file",
+                    },
+                    "section": {
+                        "type": "string",
+                        "description": "Section path (e.g. 'today', 'notes/standup'). Omit for document outline.",
+                    },
+                },
+                "required": ["file"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "md_move_lines",
+            "description": "Move specific lines (by line number) from one markdown file to a section in another file. Use md_show first to see line numbers. Good for migrating to-do items between daily notes.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "from_file": {
                         "type": "string",
-                        "description": "Source file (relative path)",
-                    },
-                    "from_section": {
-                        "type": "string",
-                        "description": "Source section path",
+                        "description": "Source file (workspace-relative path)",
                     },
                     "to_file": {
                         "type": "string",
-                        "description": "Target file (relative path, can be same as from_file)",
+                        "description": "Target file (workspace-relative path)",
                     },
                     "to_section": {
                         "type": "string",
-                        "description": "Target section path",
+                        "description": "Target section path (lines appended to end of section)",
                     },
-                    "indices": {
+                    "lines": {
                         "type": "string",
-                        "description": "Comma-separated item indices to move (e.g. '0,2,3'). Omit to move all.",
-                    },
-                    "checked_only": {
-                        "type": "boolean",
-                        "description": "Only move checked items (default: false)",
-                    },
-                    "unchecked_only": {
-                        "type": "boolean",
-                        "description": "Only move unchecked items (default: false)",
+                        "description": "Comma-separated line numbers to move (e.g. '6,7,11')",
                     },
                 },
-                "required": ["from_file", "from_section", "to_file", "to_section"],
+                "required": ["from_file", "to_file", "to_section", "lines"],
             },
         },
     },
     {
         "type": "function",
         "function": {
-            "name": "vault_read",
-            "description": "Read an entire markdown file as text. Use when you need the full file content, not just a section.",
+            "name": "md_section",
+            "description": "Section operations on a markdown file: add, remove, rename, or move a section.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "file": {
                         "type": "string",
-                        "description": "Relative path to the markdown file within the workspace",
+                        "description": "Workspace-relative path to the markdown file",
                     },
-                },
-                "required": ["file"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_create_file",
-            "description": "Create a new markdown file. Optionally use a template (with {{date}} substitution). Will not overwrite existing files. Creates parent directories as needed.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
+                    "action": {
                         "type": "string",
-                        "description": "Relative path for the new file (e.g. 'journals/2026/2026-03-17.md')",
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "Initial file content (ignored if template is provided)",
-                    },
-                    "template": {
-                        "type": "string",
-                        "description": "Relative path to a template file (e.g. 'templates/daily.md'). {{date}} in template is replaced with today's date.",
-                    },
-                },
-                "required": ["file"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_list",
-            "description": "List markdown files at a path within the vault.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Relative directory path within the vault (empty string for root)",
-                    }
-                },
-                "required": [],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_show",
-            "description": "Show a section's content from a markdown file, or the document's heading outline if no section is given.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file within the vault",
+                        "description": "Operation: 'add', 'remove', 'rename', or 'move'",
                     },
                     "section": {
                         "type": "string",
-                        "description": "Section path (e.g. 'today' or 'notes/standup'). Omit to see the document outline.",
-                    },
-                },
-                "required": ["file"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_items",
-            "description": "List checklist items in a section with their indices and checked state.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file within the vault",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path (e.g. 'today')",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_check",
-            "description": "Mark a checklist item as done. Select by substring match or index.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_uncheck",
-            "description": "Mark a checklist item as not done. Select by substring match or index.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_append",
-            "description": "Append text (e.g. a new checklist item) to the end of a section.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "Text to append (e.g. '- [ ] new task')",
-                    },
-                },
-                "required": ["file", "section", "text"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_prepend",
-            "description": "Prepend text to the start of a section (right after the heading).",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "Text to prepend (e.g. '- [ ] urgent task')",
-                    },
-                },
-                "required": ["file", "section", "text"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_insert",
-            "description": "Insert text at a specific item index within a section.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index to insert before (0-based)",
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "Text to insert",
-                    },
-                },
-                "required": ["file", "section", "index", "text"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_delete",
-            "description": "Delete a checklist item from a section. Select by substring match or index.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_add_section",
-            "description": "Add a new section to a markdown file. Position with after/before/parent, or omit to append at end.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
+                        "description": "Section path (required for remove/rename/move)",
                     },
                     "title": {
                         "type": "string",
-                        "description": "Heading text for the new section",
+                        "description": "Heading text (required for add/rename)",
                     },
                     "level": {
                         "type": "integer",
-                        "description": "Heading level 1-6 (default: 1)",
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "Initial content for the section",
+                        "description": "Heading level 1-6 (for add, default 1)",
                     },
                     "after": {
                         "type": "string",
-                        "description": "Insert after this section",
+                        "description": "Position after this section (for add/move)",
                     },
                     "before": {
                         "type": "string",
-                        "description": "Insert before this section",
+                        "description": "Position before this section (for add/move)",
                     },
                     "parent": {
                         "type": "string",
-                        "description": "Insert as last child of this section",
+                        "description": "Insert as child of this section (for add)",
                     },
                 },
-                "required": ["file", "title"],
+                "required": ["file", "action"],
             },
         },
     },
     {
         "type": "function",
         "function": {
-            "name": "vault_remove_section",
-            "description": "Remove an entire section (heading + all content + children). ALWAYS confirm with the user before calling this.",
+            "name": "md_create",
+            "description": "Create a new markdown file, optionally from a template. {{date}} in templates is replaced with today's date. Won't overwrite existing files.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "file": {
                         "type": "string",
-                        "description": "Relative path to the markdown file",
+                        "description": "Workspace-relative path for the new file",
                     },
-                    "section": {
+                    "template": {
                         "type": "string",
-                        "description": "Section path to remove (e.g. 'notes/standup')",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_move_section",
-            "description": "Move a section (heading + content + children) to a new position. Specify after or before to position relative to another section, or omit both to move to end.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path to move",
-                    },
-                    "after": {
-                        "type": "string",
-                        "description": "Place after this section",
-                    },
-                    "before": {
-                        "type": "string",
-                        "description": "Place before this section",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_replace_item",
-            "description": "Replace a checklist item's text, preserving its checked/unchecked state. Select by match or index.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "text": {
-                        "type": "string",
-                        "description": "New text for the item (without the checkbox prefix)",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in current item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section", "text"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_move_item",
-            "description": "Move a checklist item from one section to another. The item is appended to the target section.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "from_section": {
-                        "type": "string",
-                        "description": "Source section path",
-                    },
-                    "to_section": {
-                        "type": "string",
-                        "description": "Target section path",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "from_section", "to_section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_bulk_check",
-            "description": "Mark ALL checklist items in a section as done.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_bulk_uncheck",
-            "description": "Mark ALL checklist items in a section as not done.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                },
-                "required": ["file", "section"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_find_items",
-            "description": "Search all sections in a file for checklist items matching a substring. Returns section name and item text for each match.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "query": {
-                        "type": "string",
-                        "description": "Substring to search for in item text",
-                    },
-                },
-                "required": ["file", "query"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_rename_section",
-            "description": "Rename a section's heading text, preserving its level, content, and position.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path to rename",
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "New heading text",
-                    },
-                },
-                "required": ["file", "section", "title"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_replace_section",
-            "description": "Replace a section's body content while preserving the heading and any child sections.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
+                        "description": "Workspace-relative path to template file",
                     },
                     "content": {
                         "type": "string",
-                        "description": "New content for the section body",
-                    },
-                },
-                "required": ["file", "section", "content"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_tags",
-            "description": "List all unique #tags in a markdown file. Use for tag discovery.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
+                        "description": "Initial content (if no template)",
                     },
                 },
                 "required": ["file"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_tagged",
-            "description": "Find all lines with a given #tag. Returns section name and line text for each match.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "tag": {
-                        "type": "string",
-                        "description": "Tag to search for (with or without # prefix)",
-                    },
-                },
-                "required": ["file", "tag"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_add_tag",
-            "description": "Add a #tag to a checklist item. The tag is appended to the end of the item text.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "tag": {
-                        "type": "string",
-                        "description": "Tag to add (with or without # prefix)",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section", "tag"],
-            },
-        },
-    },
-    {
-        "type": "function",
-        "function": {
-            "name": "vault_remove_tag",
-            "description": "Remove a #tag from a checklist item.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "file": {
-                        "type": "string",
-                        "description": "Relative path to the markdown file",
-                    },
-                    "section": {
-                        "type": "string",
-                        "description": "Section path",
-                    },
-                    "tag": {
-                        "type": "string",
-                        "description": "Tag to remove (with or without # prefix)",
-                    },
-                    "match": {
-                        "type": "string",
-                        "description": "Substring to match in item text",
-                    },
-                    "index": {
-                        "type": "integer",
-                        "description": "Item index (0-based, negatives ok)",
-                    },
-                },
-                "required": ["file", "section", "tag"],
             },
         },
     },
 ]
+


### PR DESCRIPTION
## Summary

Redesign the markdown vault skill from 29 parsed-checklist tools to 5 lean, line-oriented tools. Basic file operations (read, edit, insert, delete) now use workspace tools directly.

**Before:** 29 tools with substring matching, vault base path resolution, checkbox parsing. Failed on content with markdown links, silent move failures, parameter name confusion.

**After:** 5 tools + workspace tools. Line-number-based operations. No substring matching. No vault base path resolution (except vault_daily_path). -1173/+202 lines in tools.py.

## New tools

| Tool | Purpose |
|------|---------|
| `vault_daily_path` | Date → workspace-relative journal path (base_path as parameter) |
| `md_show` | Section-aware display with absolute line numbers |
| `md_move_lines` | Move specific lines (by number) between files |
| `md_section` | Section operations: add/remove/rename/move |
| `md_create` | Create file from template with {{date}} substitution |

## Removed (use workspace tools instead)

vault_read, vault_write, vault_list, vault_check, vault_uncheck, vault_append, vault_prepend, vault_insert, vault_delete, vault_items, vault_find_items, vault_replace_item, vault_move_item, vault_move_items, vault_bulk_check, vault_bulk_uncheck, vault_tags, vault_tagged, vault_add_tag, vault_remove_tag, vault_set_path, vault_get_path, vault_show (replaced by md_show), vault_create_file (replaced by md_create), and 5 vault_*_section tools (replaced by md_section)

## Test plan

- [x] 130 library tests unchanged, all passing
- [x] 16 new tool tests for the 5 tools
- [x] 530 main suite tests passing
- [x] Lint + typecheck clean
- [x] Live QA: daily todo migration workflow

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)