### PR TITLE
Flexible config: nested sub-dataclasses, JSON file, CLI tool

### DIFF
--- a/.claude/dev-sessions/2026-03-19-1420-flexible-config/notes.md
+++ b/.claude/dev-sessions/2026-03-19-1420-flexible-config/notes.md
@@ -1,0 +1,33 @@
+# Flexible Config (JSON/YAML) — Notes
+
+## Session Recap
+
+Redesigned the configuration system from a flat 54-env-var monolith to a nested, layered config system with JSON file support and a CLI tool.
+
+### What we built
+- **config_types.py** — 8 sub-dataclasses (LlmConfig, MattermostConfig, CompactionConfig, EmbeddingConfig, HeartbeatConfig, HttpConfig, AgentConfig, SkillsConfig) with field metadata for secrets and env aliases
+- **config.py rewrite** — Generic `_load_sub_config()` loader: defaults → config.json → env vars
+- **config_cli.py** — CLI: `decafclaw config show/get/set` with secret masking
+- **resolved() pattern** — CompactionConfig and EmbeddingConfig have `resolved(config)` methods for LLM fallback resolution at call site
+- **25 config loader tests + 9 CLI tests**
+
+### Key design decisions
+1. **Bootstrap phase** — `data_home` and `agent_id` resolved from env only (not config file) since they determine where the file lives
+2. **Fallback at call site** — compaction/embedding `resolved(config)` method instead of loader-time resolution
+3. **Field metadata** — `secret=True` for masking, `env_alias` for backward-compat env var names
+4. **Compat shim** — temporary `__getattr__`/`__setattr__` enabled incremental migration, then removed
+5. **List fields** — `list[str]` type with JSON parse → comma-split fallback for env vars
+6. **Separate files stay separate** — mcp_servers.json, skill_permissions.json, shell_allow_patterns.json not merged
+
+### Stats
+- 54 flat config fields → 8 grouped sub-dataclasses
+- ~20 source modules refactored to nested access
+- ~15 test files updated
+- 34 new tests (25 loader + 9 CLI)
+- All 564 tests passing, lint + pyright + tsc clean
+
+### Session observations
+- The compat shim was crucial for de-risking the migration — enabled running tests between each batch of module updates
+- Parallel agents for the codebase refactor saved a lot of time (5 agents covering 23 modules)
+- `__future__.annotations` in config_types.py caused `f.type` to return strings instead of types — fixed by using `typing.get_type_hints()` in the loader
+- Les's .env file leaked into config tests via `load_dotenv()` — fixed with autouse fixture

--- a/.claude/dev-sessions/2026-03-19-1420-flexible-config/plan.md
+++ b/.claude/dev-sessions/2026-03-19-1420-flexible-config/plan.md
@@ -1,0 +1,676 @@
+# Flexible Config (JSON/YAML) — Plan
+
+## Status: Ready
+
+## Overview
+
+Six phases. Phase 1 creates the sub-dataclasses. Phase 2 rewrites the loader with JSON file support. Phase 3 does the codebase-wide refactor to nested access. Phase 4 updates tests. Phase 5 adds the CLI tool. Phase 6 updates docs. Each phase ends with lint + test passing and a commit.
+
+The riskiest part is Phase 3 (mechanical refactor of ~50 access sites across ~20 modules). To de-risk, Phase 2 adds a temporary `__getattr__` on Config that maps old flat names to nested paths, so the codebase keeps working between phases. Phase 3 removes it.
+
+---
+
+## Phase 1: Create config_types.py — sub-dataclasses
+
+**Goal**: Define all 8 sub-dataclasses with field metadata (secrets, env aliases). Pure new code, no existing files changed.
+
+**File**: `src/decafclaw/config_types.py`
+
+### Prompt
+
+Create `src/decafclaw/config_types.py` with these dataclasses. Use `field(metadata={...})` for `secret` and `env_alias` markers. All types are standard: `str`, `int`, `float`, `bool`, `list[str]`.
+
+Read the spec at `.claude/dev-sessions/2026-03-19-1420-flexible-config/spec.md` for the full field tables.
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class LlmConfig:
+    url: str = "http://192.168.0.199:4000/v1/chat/completions"
+    model: str = "gemini-2.5-flash"
+    api_key: str = field(default="dummy", metadata={"secret": True})
+    streaming: bool = True
+
+@dataclass
+class MattermostConfig:
+    url: str = ""
+    token: str = field(default="", metadata={"secret": True})
+    bot_username: str = ""
+    ignore_bots: bool = True
+    ignore_webhooks: bool = False
+    debounce_ms: int = 1000
+    cooldown_ms: int = 1000
+    require_mention: bool = True
+    user_rate_limit_ms: int = 500
+    channel_blocklist: list[str] = field(default_factory=list)
+    circuit_breaker_max: int = 10
+    circuit_breaker_window_sec: int = 30
+    circuit_breaker_pause_sec: int = 60
+    enable_emoji_confirms: bool = True
+    stream_throttle_ms: int = 200
+
+@dataclass
+class CompactionConfig:
+    url: str = ""       # empty = resolve from llm at load time
+    model: str = ""     # empty = resolve from llm at load time
+    api_key: str = field(default="", metadata={"secret": True})  # empty = resolve from llm
+    max_tokens: int = 100000
+    llm_max_tokens: int = 0  # 0 = use max_tokens
+    preserve_turns: int = 5
+
+@dataclass
+class EmbeddingConfig:
+    model: str = "text-embedding-004"
+    url: str = ""       # empty = resolve from llm at load time
+    api_key: str = field(default="", metadata={"secret": True})  # empty = resolve from llm
+    search_strategy: str = "substring"
+
+@dataclass
+class HeartbeatConfig:
+    interval: str = "30m"
+    user: str = ""
+    channel: str = ""
+    suppress_ok: bool = True
+
+@dataclass
+class HttpConfig:
+    enabled: bool = False
+    host: str = "0.0.0.0"
+    port: int = 18880
+    secret: str = field(default="", metadata={"secret": True})
+    base_url: str = ""
+
+@dataclass
+class AgentConfig:
+    data_home: str = "./data"
+    id: str = "decafclaw"
+    user_id: str = "user"
+    max_tool_iterations: int = 200
+    max_concurrent_tools: int = 5
+    max_message_length: int = 50000
+    tool_context_budget_pct: float = 0.10
+    always_loaded_tools: list[str] = field(default_factory=list)
+    child_max_tool_iterations: int = 10
+    child_timeout_sec: int = 300
+
+@dataclass
+class TabstackConfig:
+    api_key: str = field(default="", metadata={"secret": True, "env_alias": "TABSTACK_API_KEY"})
+    api_url: str = field(default="", metadata={"env_alias": "TABSTACK_API_URL"})
+
+@dataclass
+class ClaudeCodeConfig:
+    model: str = field(default="", metadata={"env_alias": "CLAUDE_CODE_MODEL"})
+    budget_default: float = field(default=2.0, metadata={"env_alias": "CLAUDE_CODE_BUDGET_DEFAULT"})
+    budget_max: float = field(default=10.0, metadata={"env_alias": "CLAUDE_CODE_BUDGET_MAX"})
+    session_timeout: str = field(default="30m", metadata={"env_alias": "CLAUDE_CODE_SESSION_TIMEOUT"})
+
+@dataclass
+class SkillsConfig:
+    tabstack: TabstackConfig = field(default_factory=TabstackConfig)
+    claude_code: ClaudeCodeConfig = field(default_factory=ClaudeCodeConfig)
+```
+
+Add a module-level helper to check field metadata:
+
+```python
+def is_secret(dc_class, field_name: str) -> bool:
+    """Check if a dataclass field is marked as secret."""
+    ...
+
+def get_env_alias(dc_class, field_name: str) -> str | None:
+    """Get the env var alias for a dataclass field, if any."""
+    ...
+```
+
+Lint after. No tests yet (Phase 4).
+
+---
+
+## Phase 2: Rewrite config.py — JSON loader + compat shim
+
+**Goal**: Rewrite `load_config()` to support JSON file + env vars + defaults. Add temporary `__getattr__` on Config for backward compat. Existing code keeps working without changes.
+
+**File**: `src/decafclaw/config.py`
+
+### Prompt
+
+Read the current `src/decafclaw/config.py` and the spec at `.claude/dev-sessions/2026-03-19-1420-flexible-config/spec.md`.
+
+Rewrite `config.py` with:
+
+**1. New top-level Config dataclass:**
+
+```python
+from .config_types import (
+    LlmConfig, MattermostConfig, CompactionConfig, EmbeddingConfig,
+    HeartbeatConfig, HttpConfig, AgentConfig, SkillsConfig,
+)
+
+@dataclass
+class Config:
+    llm: LlmConfig = field(default_factory=LlmConfig)
+    mattermost: MattermostConfig = field(default_factory=MattermostConfig)
+    compaction: CompactionConfig = field(default_factory=CompactionConfig)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    heartbeat: HeartbeatConfig = field(default_factory=HeartbeatConfig)
+    http: HttpConfig = field(default_factory=HttpConfig)
+    agent: AgentConfig = field(default_factory=AgentConfig)
+    skills: SkillsConfig = field(default_factory=SkillsConfig)
+
+    # Runtime-only (not in config file)
+    system_prompt: str = ""
+    discovered_skills: list = field(default_factory=list)
+
+    @property
+    def agent_path(self) -> Path:
+        return Path(self.agent.data_home) / self.agent.id
+
+    @property
+    def workspace_path(self) -> Path:
+        return self.agent_path / "workspace"
+
+    @property
+    def http_callback_base(self) -> str:
+        if self.http.base_url:
+            return self.http.base_url.rstrip("/")
+        return f"http://{self.http.host}:{self.http.port}"
+
+    @property
+    def tool_context_budget(self) -> int:
+        return int(self.compaction.max_tokens * self.agent.tool_context_budget_pct)
+
+    @property
+    def compaction_context_budget(self) -> int:
+        return self.compaction.llm_max_tokens or self.compaction.max_tokens
+```
+
+**2. Temporary backward-compat `__getattr__`:**
+
+Add a `__getattr__` that maps old flat names to nested access so existing code keeps working during migration. Log a deprecation warning on first use of each old name to help find stragglers.
+
+Build the mapping automatically: iterate over sub-config dataclass fields and construct `{old_flat_name: (group_name, field_name)}`. Special cases:
+- `mattermost_*` fields → `mattermost.*`
+- `llm_*` fields → `llm.*`
+- `compaction_*` fields → `compaction.*`
+- `embedding_*` / `memory_search_strategy` → `embedding.*`
+- `heartbeat_*` → `heartbeat.*`
+- `http_*` → `http.*`
+- `data_home` / `agent_id` / `agent_user_id` → `agent.*` (note: `agent_id` maps to `agent.id`, `agent_user_id` maps to `agent.user_id`)
+- `max_tool_iterations` etc → `agent.*`
+- `tabstack_*` → `skills.tabstack.*`
+- `claude_code_*` → `skills.claude_code.*`
+- `llm_stream_throttle_ms` → `mattermost.stream_throttle_ms` (moved field)
+
+Also support `__setattr__` for the compat names — tests mutate config fields directly.
+
+**3. Generic loader helpers:**
+
+```python
+def _parse_bool(value: str, default: bool = False) -> bool: ...  # keep existing
+
+def _parse_list(value: str) -> list[str]:
+    """Parse env var to list. Try JSON first, fall back to comma-split."""
+    ...
+
+def _load_sub_config(dc_class, json_data: dict, env_prefix: str, env_aliases: dict | None = None):
+    """Populate a sub-dataclass from JSON + env vars.
+
+    For each field in dc_class:
+    1. Check env var {ENV_PREFIX}_{FIELD_NAME_UPPER}
+    2. Check env alias if defined in field metadata
+    3. Check json_data[field_name]
+    4. Use dataclass default
+
+    Type coercion based on field type annotation.
+    """
+    ...
+```
+
+**4. New `load_config()` function:**
+
+```python
+def load_config() -> Config:
+    load_dotenv()
+
+    # Bootstrap: resolve data_home and agent_id from env only
+    data_home = os.getenv("DATA_HOME", AgentConfig.data_home)
+    agent_id = os.getenv("AGENT_ID", AgentConfig.id)
+
+    # Load config file if it exists
+    config_path = Path(data_home) / agent_id / "config.json"
+    file_data = {}
+    if config_path.exists():
+        file_data = json.loads(config_path.read_text())
+
+    # Build each sub-config
+    llm = _load_sub_config(LlmConfig, file_data.get("llm", {}), "LLM")
+    mattermost = _load_sub_config(MattermostConfig, file_data.get("mattermost", {}), "MATTERMOST")
+    agent = _load_sub_config(AgentConfig, file_data.get("agent", {}), "",
+                             env_aliases={"data_home": "DATA_HOME", "id": "AGENT_ID", "user_id": "AGENT_USER_ID", ...})
+    # ... etc for all groups
+
+    # Fallback resolution
+    if not compaction.url:
+        compaction.url = llm.url
+    if not compaction.model:
+        compaction.model = llm.model
+    if not compaction.api_key:
+        compaction.api_key = llm.api_key
+    if not embedding.url:
+        embedding.url = llm.url.replace("/chat/completions", "/embeddings")
+    if not embedding.api_key:
+        embedding.api_key = llm.api_key
+
+    return Config(llm=llm, mattermost=mattermost, compaction=compaction, ...)
+```
+
+The `agent` group needs special env var handling since its fields don't follow a clean prefix (e.g., `DATA_HOME` not `AGENT_DATA_HOME`). Use explicit `env_aliases` for these. Same for `embedding.search_strategy` → `MEMORY_SEARCH_STRATEGY`.
+
+**5. Keep `_parse_bool` helper** — still used.
+
+Lint and run existing tests — they should pass via the compat shim.
+
+---
+
+## Phase 3: Codebase refactor — nested access
+
+**Goal**: Update all modules to use nested config access. Remove the compat `__getattr__`/`__setattr__`.
+
+**Files**: Every module listed below.
+
+### Prompt
+
+The Config class now has nested sub-configs. Update all access from flat (`config.mattermost_url`) to nested (`config.mattermost.url`). Read each file, make the mechanical replacements, and move on.
+
+**Mapping reference** (old → new):
+
+LLM group:
+- `config.llm_url` → `config.llm.url`
+- `config.llm_model` → `config.llm.model`
+- `config.llm_api_key` → `config.llm.api_key`
+- `config.llm_streaming` → `config.llm.streaming`
+- `config.llm_stream_throttle_ms` → `config.mattermost.stream_throttle_ms`
+
+Mattermost group:
+- `config.mattermost_url` → `config.mattermost.url`
+- `config.mattermost_token` → `config.mattermost.token`
+- `config.mattermost_bot_username` → `config.mattermost.bot_username`
+- `config.mattermost_ignore_bots` → `config.mattermost.ignore_bots`
+- `config.mattermost_ignore_webhooks` → `config.mattermost.ignore_webhooks`
+- `config.mattermost_debounce_ms` → `config.mattermost.debounce_ms`
+- `config.mattermost_cooldown_ms` → `config.mattermost.cooldown_ms`
+- `config.mattermost_require_mention` → `config.mattermost.require_mention`
+- `config.mattermost_user_rate_limit_ms` → `config.mattermost.user_rate_limit_ms`
+- `config.mattermost_channel_blocklist` → `config.mattermost.channel_blocklist`
+- `config.mattermost_circuit_breaker_max` → `config.mattermost.circuit_breaker_max`
+- `config.mattermost_circuit_breaker_window_sec` → `config.mattermost.circuit_breaker_window_sec`
+- `config.mattermost_circuit_breaker_pause_sec` → `config.mattermost.circuit_breaker_pause_sec`
+- `config.mattermost_enable_emoji_confirms` → `config.mattermost.enable_emoji_confirms`
+
+Compaction group:
+- `config.compaction_url` → `config.compaction.url` (was a property — now a direct field, resolved at load time)
+- `config.compaction_model` → `config.compaction.model`
+- `config.compaction_api_key` → `config.compaction.api_key`
+- `config.compaction_max_tokens` → `config.compaction.max_tokens`
+- `config.compaction_llm_max_tokens` → `config.compaction.llm_max_tokens`
+- `config.compaction_preserve_turns` → `config.compaction.preserve_turns`
+
+Embedding group:
+- `config.embedding_model` → `config.embedding.model`
+- `config.effective_embedding_url` → `config.embedding.url` (resolved at load time now)
+- `config.effective_embedding_api_key` → `config.embedding.api_key` (resolved at load time now)
+- `config.memory_search_strategy` → `config.embedding.search_strategy`
+
+Heartbeat group:
+- `config.heartbeat_interval` → `config.heartbeat.interval`
+- `config.heartbeat_user` → `config.heartbeat.user`
+- `config.heartbeat_channel` → `config.heartbeat.channel`
+- `config.heartbeat_suppress_ok` → `config.heartbeat.suppress_ok`
+
+HTTP group:
+- `config.http_enabled` → `config.http.enabled`
+- `config.http_host` → `config.http.host`
+- `config.http_port` → `config.http.port`
+- `config.http_secret` → `config.http.secret`
+- `config.http_base_url` → `config.http.base_url`
+
+Agent group:
+- `config.data_home` → `config.agent.data_home`
+- `config.agent_id` → `config.agent.id`
+- `config.agent_user_id` → `config.agent.user_id`
+- `config.max_tool_iterations` → `config.agent.max_tool_iterations`
+- `config.max_concurrent_tools` → `config.agent.max_concurrent_tools`
+- `config.max_message_length` → `config.agent.max_message_length`
+- `config.tool_context_budget_pct` → `config.agent.tool_context_budget_pct`
+- `config.always_loaded_tools` → `config.agent.always_loaded_tools`
+- `config.child_max_tool_iterations` → `config.agent.child_max_tool_iterations`
+- `config.child_timeout_sec` → `config.agent.child_timeout_sec`
+
+Skills group:
+- `config.tabstack_api_key` → `config.skills.tabstack.api_key`
+- `config.tabstack_api_url` → `config.skills.tabstack.api_url`
+- `config.claude_code_model` → `config.skills.claude_code.model`
+- `config.claude_code_budget_default` → `config.skills.claude_code.budget_default`
+- `config.claude_code_budget_max` → `config.skills.claude_code.budget_max`
+- `config.claude_code_session_timeout` → `config.skills.claude_code.session_timeout`
+
+Properties that stay on top-level Config (no change needed):
+- `config.agent_path`
+- `config.workspace_path`
+- `config.http_callback_base`
+- `config.tool_context_budget`
+- `config.compaction_context_budget`
+
+**Modules to update** (sorted by impact):
+
+1. `src/decafclaw/mattermost.py` — heaviest user (~20 field accesses)
+2. `src/decafclaw/runner.py` — startup dispatch (~10 accesses)
+3. `src/decafclaw/agent.py` — agent loop (~6 accesses)
+4. `src/decafclaw/__init__.py` — entry point (~4 accesses)
+5. `src/decafclaw/llm.py` — LLM calls (~4 accesses)
+6. `src/decafclaw/compaction.py` — compaction (~2 accesses)
+7. `src/decafclaw/embeddings.py` — embeddings (~3 accesses)
+8. `src/decafclaw/http_server.py` — HTTP server (~5 accesses)
+9. `src/decafclaw/web/websocket.py` — web socket handler (~2 accesses)
+10. `src/decafclaw/web/auth.py` — web auth (~1 access)
+11. `src/decafclaw/web/conversations.py` — web conversations (~1 access)
+12. `src/decafclaw/prompts/__init__.py` — prompt loader (~1 access)
+13. `src/decafclaw/tools/delegate.py` — child agent config (~4 accesses, plus `dataclasses.replace`)
+14. `src/decafclaw/tools/core.py` — workspace path (~2 accesses)
+15. `src/decafclaw/tools/workspace_tools.py` — workspace path (~2 accesses)
+16. `src/decafclaw/tools/memory_tools.py` — search strategy (~3 accesses)
+17. `src/decafclaw/tools/shell_tools.py` — workspace/agent path (~2 accesses)
+18. `src/decafclaw/tools/skill_tools.py` — agent path (~1 access)
+19. `src/decafclaw/tools/heartbeat_tools.py` — heartbeat config (~5 accesses)
+20. `src/decafclaw/memory.py` — workspace path (~1 access)
+21. `src/decafclaw/todos.py` — workspace path (~1 access)
+22. `src/decafclaw/persistence.py` — workspace path (~2 accesses)
+23. `src/decafclaw/eval/runner.py` — multiple fields + `dataclasses.replace`
+
+**Special cases for `dataclasses.replace()`:**
+
+In `delegate.py`, the current code:
+```python
+child_config = replace(config, max_tool_iterations=config.child_max_tool_iterations, system_prompt="...")
+```
+Becomes:
+```python
+child_config = replace(config,
+    agent=replace(config.agent, max_tool_iterations=config.agent.child_max_tool_iterations),
+    system_prompt="...",
+)
+```
+
+In `eval/runner.py`:
+```python
+test_config = replace(config, data_home=tmp, agent_id="eval")
+```
+Becomes:
+```python
+test_config = replace(config, agent=replace(config.agent, data_home=tmp, id="eval"))
+```
+
+**After all modules updated**: remove `__getattr__` and `__setattr__` compat from Config in `config.py`.
+
+Also update `mattermost.channel_blocklist` usage — it was a comma-separated string, now it's `list[str]`. Find any `.split(",")` calls on it and remove them.
+
+Lint and test after.
+
+---
+
+## Phase 4: Update tests
+
+**Goal**: Update all test files to construct Config with nested sub-configs and access fields via nested paths.
+
+**Files**: `tests/conftest.py`, `tests/test_agent_turn.py`, `tests/test_compaction.py`, `tests/test_skills.py`, `tests/test_delegate.py`, `tests/test_workspace_tools.py`, `tests/test_tool_registry.py`, `tests/test_heartbeat.py`, `tests/test_web_auth.py`, `tests/test_web_conversations.py`, `tests/test_todos.py`, `tests/test_claude_code_permissions.py`, `tests/test_mcp.py`, `tests/test_handle_posted.py`, `tests/test_llm_streaming.py`, `tests/test_context.py`
+
+### Prompt
+
+Read each test file and update:
+
+**1. Config construction in conftest.py fixture:**
+```python
+# Old:
+Config(data_home=str(tmp_data), agent_id="test-agent", agent_user_id="testuser")
+
+# New:
+from decafclaw.config_types import AgentConfig
+Config(agent=AgentConfig(data_home=str(tmp_data), id="test-agent", user_id="testuser"))
+```
+
+**2. Direct field mutation in tests:**
+```python
+# Old:
+ctx.config.llm_streaming = False
+ctx.config.max_tool_iterations = 5
+ctx.config.compaction_preserve_turns = 2
+
+# New:
+ctx.config.llm.streaming = False
+ctx.config.agent.max_tool_iterations = 5
+ctx.config.compaction.preserve_turns = 2
+```
+
+**3. Direct field reads in assertions:**
+```python
+# Old:
+assert ctx.config.max_tool_iterations == 10
+
+# New:
+assert ctx.config.agent.max_tool_iterations == 10
+```
+
+**4. Add new tests for the config loader itself** — in a new `tests/test_config.py`:
+- `test_defaults` — Config() with no file/env gives expected defaults
+- `test_json_file_loading` — write a config.json, verify fields loaded
+- `test_env_var_override` — set env vars, verify they override file and defaults
+- `test_env_alias` — verify TABSTACK_API_KEY works as alias for SKILLS_TABSTACK_API_KEY
+- `test_list_field_comma` — `MATTERMOST_CHANNEL_BLOCKLIST=a,b` → `["a", "b"]`
+- `test_list_field_json` — `MATTERMOST_CHANNEL_BLOCKLIST=["a","b"]` → `["a", "b"]`
+- `test_fallback_resolution` — compaction/embedding fields resolve from llm
+- `test_bootstrap_order` — data_home/id from env only, not from config file
+- `test_secret_metadata` — verify secret fields are marked correctly
+- `test_compat_removed` — verify old flat names raise AttributeError
+
+Lint and run full test suite.
+
+---
+
+## Phase 5: CLI tool
+
+**Goal**: Add `python -m decafclaw config` subcommand with show/get/set.
+
+**Files**: `src/decafclaw/__init__.py` (or a new `src/decafclaw/cli.py`)
+
+### Prompt
+
+Read `src/decafclaw/__init__.py` to see how the current entry point works.
+
+Add CLI config subcommand handling. When `sys.argv[1] == "config"`, dispatch to the config CLI instead of starting the agent. This can live in a new `src/decafclaw/config_cli.py` to keep it separate.
+
+**`config_cli.py`:**
+
+```python
+import argparse
+import json
+from dataclasses import fields
+from pathlib import Path
+from .config import load_config, Config
+from .config_types import is_secret
+
+def cmd_show(args):
+    """Show resolved config, optionally filtered by group."""
+    config = load_config()
+    reveal = args.reveal
+    group_filter = args.group
+
+    for group_field in fields(config):
+        if group_field.name in ("system_prompt", "discovered_skills"):
+            continue  # runtime-only
+        group = getattr(config, group_field.name)
+        if not hasattr(group, "__dataclass_fields__"):
+            continue  # skip non-dataclass fields
+        if group_filter and group_field.name != group_filter:
+            continue
+
+        _print_group(group_field.name, group, reveal)
+
+def _print_group(prefix, dc_instance, reveal):
+    """Print all fields of a dataclass with dotted prefix."""
+    for f in fields(dc_instance):
+        value = getattr(dc_instance, f.name)
+        # Recurse for nested dataclasses (e.g., skills.tabstack)
+        if hasattr(value, "__dataclass_fields__"):
+            _print_group(f"{prefix}.{f.name}", value, reveal)
+            continue
+        display = _format_value(value, f, reveal)
+        print(f"{prefix}.{f.name} = {display}")
+
+def _format_value(value, field_info, reveal):
+    if not reveal and field_info.metadata.get("secret") and value:
+        return "****"
+    if isinstance(value, list):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+def cmd_get(args):
+    """Get a single config value."""
+    config = load_config()
+    parts = args.path.split(".")
+    obj = config
+    for part in parts:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            print(f"Unknown config path: {args.path}", file=sys.stderr)
+            sys.exit(1)
+    print(obj)
+
+def cmd_set(args):
+    """Set a config value in config.json."""
+    config = load_config()
+    config_path = config.agent_path / "config.json"
+
+    # Load existing file or start fresh
+    if config_path.exists():
+        file_data = json.loads(config_path.read_text())
+    else:
+        file_data = {}
+
+    # Navigate to the right nesting level
+    parts = args.path.split(".")
+    # Coerce value based on field type
+    value = _coerce_value(config, parts, args.value)
+
+    # Set in nested dict
+    d = file_data
+    for part in parts[:-1]:
+        d = d.setdefault(part, {})
+    d[parts[-1]] = value
+
+    config_path.write_text(json.dumps(file_data, indent=2) + "\n")
+    print(f"Set {args.path} = {value}")
+
+def main():
+    parser = argparse.ArgumentParser(prog="decafclaw config")
+    sub = parser.add_subparsers(dest="command")
+
+    show_p = sub.add_parser("show")
+    show_p.add_argument("group", nargs="?")
+    show_p.add_argument("--reveal", action="store_true")
+
+    get_p = sub.add_parser("get")
+    get_p.add_argument("path")
+
+    set_p = sub.add_parser("set")
+    set_p.add_argument("path")
+    set_p.add_argument("value")
+
+    args = parser.parse_args()
+    if args.command == "show":
+        cmd_show(args)
+    elif args.command == "get":
+        cmd_get(args)
+    elif args.command == "set":
+        cmd_set(args)
+    else:
+        parser.print_help()
+```
+
+**Wire into `__init__.py`:**
+```python
+if len(sys.argv) > 1 and sys.argv[1] == "config":
+    from .config_cli import main as config_main
+    sys.argv = sys.argv[1:]  # shift so argparse sees "config show" not "decafclaw config show"
+    config_main()
+    sys.exit(0)
+```
+
+**Add tests** in `tests/test_config_cli.py`:
+- `test_show` — verify output format, secrets masked
+- `test_show_reveal` — secrets shown
+- `test_show_group` — filter by group name
+- `test_get` — single value retrieval
+- `test_set` — writes to config.json, verify file contents
+- `test_set_creates_file` — creates config.json if missing
+
+Lint and test after.
+
+---
+
+## Phase 6: Docs and cleanup
+
+**Goal**: Update documentation, example files, CLAUDE.md.
+
+**Files**: `.env.example`, `CLAUDE.md`, `README.md`, `docs/`
+
+### Prompt
+
+**1. Create `data/decafclaw/config.json.example`** — minimal example with comments-as-docs (JSON doesn't support comments, so use a separate `CONFIG.md` or inline descriptions in the example's values).
+
+Actually, since JSON doesn't support comments, create a documented example as a markdown file `docs/config.md` that shows the full schema with descriptions, and a minimal `config.json.example` at the data level.
+
+**2. Update `.env.example`** — add a note at the top pointing to config.json as the preferred approach. Keep the env var examples for secrets.
+
+**3. Update `CLAUDE.md`**:
+- Key files: add `config_types.py`, `config_cli.py`
+- Conventions: update "Config via env vars" to mention config.json
+- Update `dataclasses.replace()` convention with nested example
+
+**4. Update `README.md`** — config table, CLI usage.
+
+**5. Add `docs/config.md`** — full config reference with all groups, fields, defaults, env vars.
+
+**6. Add Makefile target**: `make config` → `python -m decafclaw config show`
+
+Lint after. Final commit.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (config_types.py — pure new code)
+  ↓
+Phase 2 (config.py rewrite — loader + compat shim)
+  ↓
+Phase 3 (codebase refactor — nested access everywhere)
+  ↓
+Phase 4 (tests — update + add new config tests)
+  ↓
+Phase 5 (CLI tool)
+  ↓
+Phase 6 (docs + cleanup)
+```
+
+Phases are strictly sequential — each depends on the previous.
+
+## Risk Notes
+
+- **Phase 3 is the biggest risk** — 20+ modules, ~60 access sites. The compat shim from Phase 2 means we can do this incrementally (update a few modules, test, continue). If a module is missed, the shim catches it with a deprecation warning.
+- **`channel_blocklist` type change** — was comma-separated string, now `list[str]`. Any code that calls `.split(",")` on it will break. Search for this pattern.
+- **`enable_emoji_confirms` behavior change** — was auto-derived from `http_enabled`. Now defaults to `true`. Users who relied on auto-detection need to explicitly set it to `false` in config. Document this.
+- **Test mutation patterns** — tests that do `ctx.config.field = value` need updating to `ctx.config.group.field = value`. The compat shim handles this during transition but must be removed.

--- a/.claude/dev-sessions/2026-03-19-1420-flexible-config/spec.md
+++ b/.claude/dev-sessions/2026-03-19-1420-flexible-config/spec.md
@@ -1,0 +1,296 @@
+# Flexible Config (JSON/YAML) — Spec
+
+## Status: Ready
+
+## Background
+
+The `.env` file has grown to 50+ variables with a flat namespace. Lists are comma-separated strings, related settings are scattered, and defaults are duplicated between the `Config` dataclass and `load_config()`. Structured config (MCP servers, skill permissions) already uses separate JSON files. This redesign unifies configuration into a layered system with a config file, env var overrides, and grouped sub-configs.
+
+Closes #1.
+
+## Goals
+
+1. Single config file at `data/{agent_id}/config.json` with grouped, nested structure
+2. Layered resolution: defaults → config file → env vars (highest priority)
+3. Sub-dataclasses grouped by concern, defined in `config_types.py`
+4. All fields remain overridable via env var (flat underscore names)
+5. CLI tool for get/set/show with secret masking
+6. Backward compatible — existing `.env` files keep working
+
+## Non-Goals
+
+- Migrating `mcp_servers.json`, `skill_permissions.json`, or `shell_allow_patterns.json` into the unified config (they're managed by agent interactions or follow external conventions)
+- YAML support (JSON first; YAML can be added later since the loader is format-agnostic internally)
+
+## Config File Structure
+
+Location: `data/{agent_id}/config.json`
+
+The file is optional. Absent keys use defaults. Only populate overrides you need.
+
+```json
+{
+  "llm": {
+    "url": "http://192.168.0.199:4000/v1/chat/completions",
+    "model": "gemini-2.5-flash",
+    "streaming": true
+  },
+  "mattermost": {
+    "url": "https://comms.lmorchard.com",
+    "bot_username": "decafclaw",
+    "channel_blocklist": ["channel-id-1", "channel-id-2"],
+    "require_mention": true
+  },
+  "agent": {
+    "data_home": "./data",
+    "id": "decafclaw",
+    "max_tool_iterations": 200
+  },
+  "compaction": {
+    "max_tokens": 100000
+  },
+  "skills": {
+    "tabstack": {
+      "api_key": "sk-..."
+    }
+  }
+}
+```
+
+## Config Groups
+
+### `llm`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | `http://192.168.0.199:4000/v1/chat/completions` | `LLM_URL` | |
+| `model` | str | `gemini-2.5-flash` | `LLM_MODEL` | |
+| `api_key` | str | `dummy` | `LLM_API_KEY` | yes |
+| `streaming` | bool | `true` | `LLM_STREAMING` | |
+
+### `mattermost`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | `""` | `MATTERMOST_URL` | |
+| `token` | str | `""` | `MATTERMOST_TOKEN` | yes |
+| `bot_username` | str | `""` | `MATTERMOST_BOT_USERNAME` | |
+| `ignore_bots` | bool | `true` | `MATTERMOST_IGNORE_BOTS` | |
+| `ignore_webhooks` | bool | `false` | `MATTERMOST_IGNORE_WEBHOOKS` | |
+| `debounce_ms` | int | `1000` | `MATTERMOST_DEBOUNCE_MS` | |
+| `cooldown_ms` | int | `1000` | `MATTERMOST_COOLDOWN_MS` | |
+| `require_mention` | bool | `true` | `MATTERMOST_REQUIRE_MENTION` | |
+| `user_rate_limit_ms` | int | `500` | `MATTERMOST_USER_RATE_LIMIT_MS` | |
+| `channel_blocklist` | list[str] | `[]` | `MATTERMOST_CHANNEL_BLOCKLIST` | |
+| `circuit_breaker_max` | int | `10` | `MATTERMOST_CIRCUIT_BREAKER_MAX` | |
+| `circuit_breaker_window_sec` | int | `30` | `MATTERMOST_CIRCUIT_BREAKER_WINDOW_SEC` | |
+| `circuit_breaker_pause_sec` | int | `60` | `MATTERMOST_CIRCUIT_BREAKER_PAUSE_SEC` | |
+| `enable_emoji_confirms` | bool | `true` | `MATTERMOST_ENABLE_EMOJI_CONFIRMS` | |
+| `stream_throttle_ms` | int | `200` | `MATTERMOST_STREAM_THROTTLE_MS` | |
+
+Note: `stream_throttle_ms` moves from `llm_stream_throttle_ms` to mattermost (it only controls Mattermost placeholder update frequency). `enable_emoji_confirms` default changes — currently auto-set to `not http_enabled` at load time; new behavior: default `true`, override explicitly if needed.
+
+### `compaction`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | (from llm) | `COMPACTION_LLM_URL` | |
+| `model` | str | (from llm) | `COMPACTION_LLM_MODEL` | |
+| `api_key` | str | (from llm) | `COMPACTION_LLM_API_KEY` | yes |
+| `max_tokens` | int | `100000` | `COMPACTION_MAX_TOKENS` | |
+| `llm_max_tokens` | int | `0` | `COMPACTION_LLM_MAX_TOKENS` | |
+| `preserve_turns` | int | `5` | `COMPACTION_PRESERVE_TURNS` | |
+
+Omitted fields resolve from `llm` group at load time. `0` for `llm_max_tokens` means "use `max_tokens`".
+
+### `embedding`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `model` | str | `text-embedding-004` | `EMBEDDING_MODEL` | |
+| `url` | str | (from llm) | `EMBEDDING_URL` | |
+| `api_key` | str | (from llm) | `EMBEDDING_API_KEY` | yes |
+| `search_strategy` | str | `substring` | `MEMORY_SEARCH_STRATEGY` | |
+
+Omitted `url`/`api_key` resolve from `llm` group at load time (url with `/chat/completions` → `/embeddings` substitution).
+
+### `heartbeat`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `interval` | str | `30m` | `HEARTBEAT_INTERVAL` | |
+| `user` | str | `""` | `HEARTBEAT_USER` | |
+| `channel` | str | `""` | `HEARTBEAT_CHANNEL` | |
+| `suppress_ok` | bool | `true` | `HEARTBEAT_SUPPRESS_OK` | |
+
+### `http`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `enabled` | bool | `false` | `HTTP_ENABLED` | |
+| `host` | str | `0.0.0.0` | `HTTP_HOST` | |
+| `port` | int | `18880` | `HTTP_PORT` | |
+| `secret` | str | `""` | `HTTP_SECRET` | yes |
+| `base_url` | str | `""` | `HTTP_BASE_URL` | |
+
+### `agent`
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `data_home` | str | `./data` | `DATA_HOME` | |
+| `id` | str | `decafclaw` | `AGENT_ID` | |
+| `user_id` | str | `user` | `AGENT_USER_ID` | |
+| `max_tool_iterations` | int | `200` | `MAX_TOOL_ITERATIONS` | |
+| `max_concurrent_tools` | int | `5` | `MAX_CONCURRENT_TOOLS` | |
+| `max_message_length` | int | `50000` | `MAX_MESSAGE_LENGTH` | |
+| `tool_context_budget_pct` | float | `0.10` | `TOOL_CONTEXT_BUDGET_PCT` | |
+| `always_loaded_tools` | list[str] | `[]` | `ALWAYS_LOADED_TOOLS` | |
+| `child_max_tool_iterations` | int | `10` | `CHILD_MAX_TOOL_ITERATIONS` | |
+| `child_timeout_sec` | int | `300` | `CHILD_TIMEOUT_SEC` | |
+
+### `skills`
+Container for per-skill config. Each skill gets a sub-key.
+
+#### `skills.tabstack`
+| Field | Type | Default | Env Var | Alias | Secret |
+|-------|------|---------|---------|-------|--------|
+| `api_key` | str | `""` | `SKILLS_TABSTACK_API_KEY` | `TABSTACK_API_KEY` | yes |
+| `api_url` | str | `""` | `SKILLS_TABSTACK_API_URL` | `TABSTACK_API_URL` | |
+
+#### `skills.claude_code`
+| Field | Type | Default | Env Var | Alias | Secret |
+|-------|------|---------|---------|-------|--------|
+| `model` | str | `""` | `SKILLS_CLAUDE_CODE_MODEL` | `CLAUDE_CODE_MODEL` | |
+| `budget_default` | float | `2.0` | `SKILLS_CLAUDE_CODE_BUDGET_DEFAULT` | `CLAUDE_CODE_BUDGET_DEFAULT` | |
+| `budget_max` | float | `10.0` | `SKILLS_CLAUDE_CODE_BUDGET_MAX` | `CLAUDE_CODE_BUDGET_MAX` | |
+| `session_timeout` | str | `30m` | `SKILLS_CLAUDE_CODE_SESSION_TIMEOUT` | `CLAUDE_CODE_SESSION_TIMEOUT` | |
+
+## Field Metadata
+
+Dataclass fields use `field(metadata={...})` for loader hints:
+
+- `secret: True` — masked in `config show` output unless `--reveal`
+- `env_alias: "NAME"` — alternative env var name (checked after the systematic name)
+
+```python
+api_key: str = field(default="", metadata={"secret": True, "env_alias": "TABSTACK_API_KEY"})
+```
+
+## Resolution Order
+
+### Bootstrap phase
+
+`agent.data_home` and `agent.id` are resolved first (env vars → defaults only) to locate the config file at `{data_home}/{id}/config.json`. These two fields are NOT read from the config file — they determine where the file lives.
+
+### Main resolution
+
+For each remaining field, the loader checks (first non-empty wins):
+
+1. **Env var** (systematic name, then alias if defined)
+2. **Config file** value at the corresponding JSON path
+3. **Dataclass default**
+
+### List fields via env var
+
+`list[str]` fields accept either format from env vars:
+- Comma-separated: `MATTERMOST_CHANNEL_BLOCKLIST=id1,id2`
+- JSON array: `MATTERMOST_CHANNEL_BLOCKLIST=["id1","id2"]`
+
+The loader tries JSON parse first; if that fails, splits on commas. This preserves backward compat with existing comma-separated values.
+
+### Fallback resolution
+
+After all fields are populated:
+- `compaction.url` empty → copy from `llm.url`
+- `compaction.model` empty → copy from `llm.model`
+- `compaction.api_key` empty → copy from `llm.api_key`
+- `embedding.url` empty → derive from `llm.url` (replace `/chat/completions` with `/embeddings`)
+- `embedding.api_key` empty → copy from `llm.api_key`
+
+## Derived Properties
+
+These stay as `@property` on the top-level `Config`:
+- `agent_path` → `Path(agent.data_home) / agent.id`
+- `workspace_path` → `agent_path / "workspace"`
+- `http_callback_base` → `http.base_url` or `http://{http.host}:{http.port}`
+- `tool_context_budget` → `int(compaction.max_tokens * agent.tool_context_budget_pct)`
+- `compaction_context_budget` → `compaction.llm_max_tokens or compaction.max_tokens`
+
+## Top-Level Config Dataclass
+
+```python
+@dataclass
+class Config:
+    llm: LlmConfig = field(default_factory=LlmConfig)
+    mattermost: MattermostConfig = field(default_factory=MattermostConfig)
+    compaction: CompactionConfig = field(default_factory=CompactionConfig)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    heartbeat: HeartbeatConfig = field(default_factory=HeartbeatConfig)
+    http: HttpConfig = field(default_factory=HttpConfig)
+    agent: AgentConfig = field(default_factory=AgentConfig)
+    skills: SkillsConfig = field(default_factory=SkillsConfig)
+
+    # Runtime-only (not in config file)
+    system_prompt: str = ""
+    discovered_skills: list = field(default_factory=list)
+
+    @property
+    def agent_path(self) -> Path: ...
+    @property
+    def workspace_path(self) -> Path: ...
+```
+
+## CLI Tool
+
+Invoked as `python -m decafclaw config <command>`.
+
+### `config show [group]`
+Show resolved config (all sources merged). Secrets masked as `****` unless `--reveal`.
+
+```
+$ python -m decafclaw config show
+llm.url = http://192.168.0.199:4000/v1/chat/completions
+llm.model = gemini-2.5-flash
+llm.api_key = ****
+llm.streaming = true
+mattermost.url = https://comms.lmorchard.com
+mattermost.token = ****
+...
+
+$ python -m decafclaw config show mattermost
+mattermost.url = https://comms.lmorchard.com
+mattermost.token = ****
+mattermost.bot_username = decafclaw
+...
+
+$ python -m decafclaw config show --reveal
+llm.api_key = dummy
+mattermost.token = xoxb-actual-token
+```
+
+### `config get <path>`
+Get a single resolved value.
+
+```
+$ python -m decafclaw config get mattermost.url
+https://comms.lmorchard.com
+```
+
+### `config set <path> <value>`
+Write a value to `config.json`. Creates the file and parent keys if needed.
+
+```
+$ python -m decafclaw config set mattermost.require_mention false
+$ python -m decafclaw config set mattermost.channel_blocklist '["id1","id2"]'
+```
+
+Type coercion based on the dataclass field type (bool, int, float, list, str).
+
+## Migration Path
+
+1. Existing `.env` files keep working — env vars are highest priority
+2. All internal code updated to nested access (`ctx.config.mattermost.url` instead of `ctx.config.mattermost_url`) in a single pass — this is a codebase-internal breaking change but there are no external consumers
+3. `.env.example` updated to document the config file as the preferred approach
+4. `dataclasses.replace()` with nested configs: to override a sub-config field, build the sub-config first: `dataclasses.replace(config, mattermost=dataclasses.replace(config.mattermost, url="..."))`. This is more verbose but explicit. Consider a helper if the pattern appears often in tests.
+
+## Files Changed
+
+- **New**: `src/decafclaw/config_types.py` — all sub-dataclasses
+- **Rewrite**: `src/decafclaw/config.py` — loader (JSON parse + env overlay + fallbacks), CLI entry point
+- **Update**: every module that reads `ctx.config.*` — update to nested access
+- **Update**: `tests/conftest.py` and test files — update Config construction
+- **Update**: `.env.example` — add config file documentation
+- **New**: `data/decafclaw/config.json.example` — example config file

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Configuration can also be set in data/{agent_id}/config.json
+# Env vars override config file values. See: decafclaw config show
+
 # LLM settings (LiteLLM endpoint)
 LLM_URL=http://192.168.0.199:4000/v1/chat/completions
 LLM_MODEL=gemini-2.5-flash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/mattermost.py` — Mattermost client, message handling, flood protection, progress subscriber
 - `src/decafclaw/llm.py` — LLM client (OpenAI-compatible)
 - `src/decafclaw/config.py` — Dataclass config from env vars / .env
+- `src/decafclaw/config_types.py` — Config sub-dataclasses (LlmConfig, MattermostConfig, etc.)
+- `src/decafclaw/config_cli.py` — CLI tool for config show/get/set
 - `src/decafclaw/context.py` — Forkable runtime context
 - `src/decafclaw/events.py` — In-process pub/sub event bus
 - `src/decafclaw/memory.py` — Memory file read/write operations
@@ -59,6 +61,7 @@ make test         # Run pytest
 make vendor       # Rebuild web UI vendor bundle (npm + esbuild)
 make reindex      # Rebuild embedding index from memory files
 make build-eval-fixtures  # Rebuild eval embedding fixtures
+make config       # Show resolved config values
 ```
 
 **Important:** Only one bot instance can connect to Mattermost at a time. A second instance will silently miss websocket events. Les likely has `make dev` running in another terminal — do NOT start `make run`, `make dev`, or `make debug` without checking first. If you need to run an instance for log capture or debugging, ask Les to kill the existing one.
@@ -100,8 +103,8 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Events for progress.** Tools publish `tool_status` events via `ctx.publish()`. The agent loop publishes `llm_start/end` and `tool_start/end`. Subscribers (Mattermost, terminal) handle display.
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholder management, threading logic — all in `MattermostClient`.
 - **Mattermost PATCH API quirks.** Omitting `props` from a PATCH preserves existing props (including attachments). To strip attachments, you must explicitly send `props: {"attachments": []}`. However, sending a PATCH with only `props` and no `message` field clears the message text, showing "(message deleted)". Always include the message text when patching props — fetch it first if needed.
-- **Config via env vars.** All config comes from `.env` / environment. Dataclass defaults in `config.py`.
-- **Use `dataclasses.replace()` to copy Config.** Never copy fields manually — new fields get silently lost. This caused a real bug with semantic search in the eval runner.
+- **Config via defaults → config.json → env vars.** Config is resolved in priority order: dataclass defaults → `data/{agent_id}/config.json` → env vars. Env vars are highest priority. Dataclass defaults in `config.py`, sub-dataclasses in `config_types.py`.
+- **Use `dataclasses.replace()` to copy Config.** Never copy fields manually — new fields get silently lost. This caused a real bug with semantic search in the eval runner. For nested sub-dataclasses, use the nested pattern: `dataclasses.replace(config, agent=dataclasses.replace(config.agent, data_home=tmp, id="eval"))`.
 - **Check for running bot instances before starting one.** Only one websocket connection per Mattermost bot account. A second instance silently misses events.
 - **Test live in Mattermost after merging**, not just lint/pytest. Real agent behavior differs from unit tests.
 - **Tool descriptions are a control surface.** Wording changes ("MUST", "NEVER", checklists, "prefer X over Y") measurably change LLM behavior. Use the eval loop to validate.

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ reindex:
 vendor:
 	cd src/decafclaw/web/static && npm install && npm run build
 
+# Show resolved config
+config:
+	uv run decafclaw config show
+
 # Rebuild eval embedding fixtures (run when changing embedding models)
 build-eval-fixtures:
 	uv run python scripts/build-eval-fixtures.py

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ uv sync
 # Configure
 cp .env.example .env
 # Edit .env with your LLM endpoint and optional Mattermost keys
+# Or use data/{agent_id}/config.json — env vars take priority
 
 # Run interactively (no Mattermost needed)
 make run
@@ -107,6 +108,7 @@ make check        # Lint + type check (Python + JS)
 make vendor       # Rebuild web UI vendor bundle
 make lint-fix     # Auto-fix lint issues
 make fmt          # Format with ruff
+make config       # Show resolved config values
 ```
 
 ## What this is NOT

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,205 @@
+# Configuration Reference
+
+DecafClaw uses a layered configuration system. Values are resolved in this order (first wins):
+
+1. **Environment variables** — highest priority, good for secrets and deployment overrides
+2. **Config file** — `data/{agent_id}/config.json`, good for structured settings
+3. **Dataclass defaults** — built-in fallbacks
+
+The config file is optional. You can use env vars alone (via `.env` or real env), a config file alone, or both.
+
+## Config file
+
+Location: `data/{agent_id}/config.json` (default: `data/decafclaw/config.json`)
+
+Only include settings you want to override — absent keys use defaults.
+
+```json
+{
+  "llm": {
+    "url": "http://192.168.0.199:4000/v1/chat/completions",
+    "model": "gemini-2.5-flash"
+  },
+  "mattermost": {
+    "url": "https://comms.example.com",
+    "bot_username": "decafclaw",
+    "channel_blocklist": ["channel-id-1"]
+  },
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-..."
+  }
+}
+```
+
+## CLI tool
+
+```bash
+decafclaw config show              # all resolved values (secrets masked)
+decafclaw config show llm          # filter by group
+decafclaw config show --reveal     # show secret values
+decafclaw config get llm.model     # single value
+decafclaw config set llm.model gemini-2.5-pro   # write to config.json
+decafclaw config import            # convert .env to config.json
+decafclaw config import .env.prod  # from a specific file
+```
+
+`make config` is a shortcut for `decafclaw config show`.
+
+## Config groups
+
+### `llm`
+
+LLM endpoint settings.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | `http://192.168.0.199:4000/v1/chat/completions` | `LLM_URL` | |
+| `model` | str | `gemini-2.5-flash` | `LLM_MODEL` | |
+| `api_key` | str | `dummy` | `LLM_API_KEY` | yes |
+| `streaming` | bool | `true` | `LLM_STREAMING` | |
+
+### `mattermost`
+
+Mattermost bot connection and behavior.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | `""` | `MATTERMOST_URL` | |
+| `token` | str | `""` | `MATTERMOST_TOKEN` | yes |
+| `bot_username` | str | `""` | `MATTERMOST_BOT_USERNAME` | |
+| `ignore_bots` | bool | `true` | `MATTERMOST_IGNORE_BOTS` | |
+| `ignore_webhooks` | bool | `false` | `MATTERMOST_IGNORE_WEBHOOKS` | |
+| `debounce_ms` | int | `1000` | `MATTERMOST_DEBOUNCE_MS` | |
+| `cooldown_ms` | int | `1000` | `MATTERMOST_COOLDOWN_MS` | |
+| `require_mention` | bool | `true` | `MATTERMOST_REQUIRE_MENTION` | |
+| `user_rate_limit_ms` | int | `500` | `MATTERMOST_USER_RATE_LIMIT_MS` | |
+| `channel_blocklist` | list | `[]` | `MATTERMOST_CHANNEL_BLOCKLIST` | |
+| `circuit_breaker_max` | int | `10` | `MATTERMOST_CIRCUIT_BREAKER_MAX` | |
+| `circuit_breaker_window_sec` | int | `30` | `MATTERMOST_CIRCUIT_BREAKER_WINDOW_SEC` | |
+| `circuit_breaker_pause_sec` | int | `60` | `MATTERMOST_CIRCUIT_BREAKER_PAUSE_SEC` | |
+| `enable_emoji_confirms` | bool | `true` | `MATTERMOST_ENABLE_EMOJI_CONFIRMS` | |
+| `stream_throttle_ms` | int | `200` | `MATTERMOST_STREAM_THROTTLE_MS` | |
+
+List fields accept comma-separated (`a,b,c`) or JSON array (`["a","b"]`) format from env vars.
+
+### `compaction`
+
+History compaction settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.compaction.resolved(config)`.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `url` | str | (from llm) | `COMPACTION_LLM_URL` | |
+| `model` | str | (from llm) | `COMPACTION_LLM_MODEL` | |
+| `api_key` | str | (from llm) | `COMPACTION_LLM_API_KEY` | yes |
+| `max_tokens` | int | `100000` | `COMPACTION_MAX_TOKENS` | |
+| `llm_max_tokens` | int | `0` | `COMPACTION_LLM_MAX_TOKENS` | |
+| `preserve_turns` | int | `5` | `COMPACTION_PRESERVE_TURNS` | |
+
+### `embedding`
+
+Semantic search embedding settings. Empty `url`/`api_key` fall back to `llm` group via `config.embedding.resolved(config)`.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `model` | str | `text-embedding-004` | `EMBEDDING_MODEL` | |
+| `url` | str | (from llm) | `EMBEDDING_URL` | |
+| `api_key` | str | (from llm) | `EMBEDDING_API_KEY` | yes |
+| `search_strategy` | str | `substring` | `MEMORY_SEARCH_STRATEGY` | |
+
+### `heartbeat`
+
+Periodic wake-up settings.
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `interval` | str | `30m` | `HEARTBEAT_INTERVAL` |
+| `user` | str | `""` | `HEARTBEAT_USER` |
+| `channel` | str | `""` | `HEARTBEAT_CHANNEL` |
+| `suppress_ok` | bool | `true` | `HEARTBEAT_SUPPRESS_OK` |
+
+### `http`
+
+HTTP server for interactive buttons and web UI.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `enabled` | bool | `false` | `HTTP_ENABLED` | |
+| `host` | str | `0.0.0.0` | `HTTP_HOST` | |
+| `port` | int | `18880` | `HTTP_PORT` | |
+| `secret` | str | `""` | `HTTP_SECRET` | yes |
+| `base_url` | str | `""` | `HTTP_BASE_URL` | |
+
+### `agent`
+
+Agent identity, loop limits, tool loading, and delegation.
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `data_home` | str | `./data` | `DATA_HOME` |
+| `id` | str | `decafclaw` | `AGENT_ID` |
+| `user_id` | str | `user` | `AGENT_USER_ID` |
+| `max_tool_iterations` | int | `200` | `MAX_TOOL_ITERATIONS` |
+| `max_concurrent_tools` | int | `5` | `MAX_CONCURRENT_TOOLS` |
+| `max_message_length` | int | `50000` | `MAX_MESSAGE_LENGTH` |
+| `tool_context_budget_pct` | float | `0.10` | `TOOL_CONTEXT_BUDGET_PCT` |
+| `always_loaded_tools` | list | `[]` | `ALWAYS_LOADED_TOOLS` |
+| `child_max_tool_iterations` | int | `10` | `CHILD_MAX_TOOL_ITERATIONS` |
+| `child_timeout_sec` | int | `300` | `CHILD_TIMEOUT_SEC` |
+
+`data_home` and `id` are resolved from env vars only (not from the config file) since they determine where the config file lives.
+
+### `skills`
+
+Per-skill configuration. Each skill gets a sub-key.
+
+#### `skills.tabstack`
+
+| Field | Type | Default | Env Var | Alias | Secret |
+|-------|------|---------|---------|-------|--------|
+| `api_key` | str | `""` | `SKILLS_TABSTACK_API_KEY` | `TABSTACK_API_KEY` | yes |
+| `api_url` | str | `""` | `SKILLS_TABSTACK_API_URL` | `TABSTACK_API_URL` | |
+
+#### `skills.claude_code`
+
+| Field | Type | Default | Env Var | Alias |
+|-------|------|---------|---------|-------|
+| `model` | str | `""` | `SKILLS_CLAUDE_CODE_MODEL` | `CLAUDE_CODE_MODEL` |
+| `budget_default` | float | `2.0` | `SKILLS_CLAUDE_CODE_BUDGET_DEFAULT` | `CLAUDE_CODE_BUDGET_DEFAULT` |
+| `budget_max` | float | `10.0` | `SKILLS_CLAUDE_CODE_BUDGET_MAX` | `CLAUDE_CODE_BUDGET_MAX` |
+| `session_timeout` | str | `30m` | `SKILLS_CLAUDE_CODE_SESSION_TIMEOUT` | `CLAUDE_CODE_SESSION_TIMEOUT` |
+
+Alias env vars are checked after the systematic name, for backward compatibility.
+
+### `env`
+
+Arbitrary environment variables set at startup. Useful for API keys and tool-specific config that doesn't have a dedicated config field.
+
+```json
+{
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-...",
+    "CUSTOM_TOOL_ENDPOINT": "https://..."
+  }
+}
+```
+
+- Only sets vars not already in the environment (real env vars and `.env` take priority)
+- Displayed as secrets in `config show` (masked unless `--reveal`)
+- `config set env.MY_VAR value` and `config get env.MY_VAR` work
+- `reload_env(config)` re-reads the env section at runtime
+
+## Migrating from .env
+
+```bash
+decafclaw config import        # reads .env, writes config.json
+```
+
+Known env var names are mapped to their config paths (e.g. `LLM_MODEL` → `llm.model`). Unknown vars are placed in the `env` section. After import, you can review with `decafclaw config show` and optionally remove the `.env` file.
+
+## Separate config files
+
+These files remain separate from config.json (managed by agent interactions or following external conventions):
+
+- `data/{agent_id}/mcp_servers.json` — MCP server definitions (Claude Code compatible format)
+- `data/{agent_id}/skill_permissions.json` — per-skill activation permissions
+- `data/{agent_id}/shell_allow_patterns.json` — shell command allow list

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 ## Getting Started
 
 - [Installation & Setup](installation.md) — Prerequisites, configuration, running
+- [Configuration Reference](config.md) — Config file, env vars, CLI tool, all settings
 - [Deployment](deployment.md) — Systemd service on a Debian VM
 
 ## Features

--- a/src/decafclaw/__init__.py
+++ b/src/decafclaw/__init__.py
@@ -19,6 +19,13 @@ def main():
         format="%(asctime)s %(name)s %(levelname)s: %(message)s",
     )
 
+    # CLI subcommand: python -m decafclaw config ...
+    if len(sys.argv) > 1 and sys.argv[1] == "config":
+        sys.argv = sys.argv[1:]  # shift so argparse sees "config show"
+        from .config_cli import main as config_main
+        config_main()
+        return
+
     config = load_config()
 
     # Assemble system prompt from markdown files (bundled + workspace overrides)
@@ -29,7 +36,7 @@ def main():
     app_ctx = Context(config=config, event_bus=bus)
 
     # Server mode (Mattermost and/or HTTP) vs interactive terminal mode
-    if config.mattermost_url or config.http_enabled:
+    if config.mattermost.url or config.http.enabled:
         try:
             from .runner import run_all
             asyncio.run(run_all(app_ctx))

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -56,7 +56,7 @@ def _archive(ctx, msg) -> None:
 
     # Index user/assistant messages for conversation search (fire and forget)
     # Requires an embedding model to be configured
-    if ctx.config.embedding_model and msg.get("role") in ("user", "assistant"):
+    if ctx.config.embedding.model and msg.get("role") in ("user", "assistant"):
         content = msg.get("content")
         if content and len(content) > 20:  # skip trivial messages
             task = asyncio.create_task(_index_conversation_message(ctx, msg))
@@ -79,9 +79,9 @@ async def _index_conversation_message(ctx, msg) -> None:
 async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
     """Trigger compaction if token budget is exceeded."""
     log.info(f"Compaction check: prompt_tokens={prompt_tokens}, "
-             f"threshold={config.compaction_max_tokens}")
-    if prompt_tokens and prompt_tokens > config.compaction_max_tokens:
-        log.info(f"Token budget exceeded ({prompt_tokens} > {config.compaction_max_tokens}), "
+             f"threshold={config.compaction.max_tokens}")
+    if prompt_tokens and prompt_tokens > config.compaction.max_tokens:
+        log.info(f"Token budget exceeded ({prompt_tokens} > {config.compaction.max_tokens}), "
                  f"triggering compaction")
         try:
             await compact_history(ctx, history)
@@ -180,7 +180,7 @@ async def _call_llm_with_events(ctx, config, messages, tools) -> dict:
     """Call the LLM with event publishing for progress tracking."""
     iteration = ctx._current_iteration
     await ctx.publish("llm_start", iteration=iteration)
-    if config.llm_streaming:
+    if config.llm.streaming:
         from .llm import call_llm_streaming
         on_chunk = ctx.on_stream_chunk
         cancel_event = ctx.cancelled
@@ -266,7 +266,7 @@ async def _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
     if cancelled:
         return cancelled
 
-    semaphore = asyncio.Semaphore(ctx.config.max_concurrent_tools)
+    semaphore = asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)
 
     # Fork ctx per tool call so concurrent tools don't race on current_tool_call_id
     tasks = []
@@ -369,7 +369,7 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
     try:
         # Add user message to history
         # Truncate oversized user messages
-        max_len = config.max_message_length
+        max_len = config.agent.max_message_length
         if max_len and len(user_message) > max_len:
             original_len = len(user_message)
             user_message = (
@@ -394,7 +394,7 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
 
         accumulated_text_parts = []  # text from iterations that also had tool calls
 
-        for iteration in range(config.max_tool_iterations):
+        for iteration in range(config.agent.max_tool_iterations):
             cancelled = _check_cancelled(ctx, history)
             if cancelled:
                 return cancelled
@@ -480,7 +480,7 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
 
         # Hit max iterations — preserve accumulated text from tool-call iterations
         limit_note = (f"\n\n[Agent reached max tool iterations "
-                      f"({config.max_tool_iterations}) without a final response]")
+                      f"({config.agent.max_tool_iterations}) without a final response]")
         accumulated = "\n\n".join(accumulated_text_parts)
         msg = accumulated + limit_note if accumulated else limit_note.strip()
         final_msg = {"role": "assistant", "content": msg}
@@ -515,7 +515,7 @@ def _setup_interactive_context(ctx) -> None:
     ctx.conv_id = "interactive"
     ctx.media_handler = TerminalMediaHandler(config.workspace_path)
 
-    if config.llm_streaming:
+    if config.llm.streaming:
         async def _terminal_stream_chunk(chunk_type, data):
             if chunk_type == "text":
                 print(data, end="", flush=True)
@@ -530,7 +530,7 @@ def _print_banner(config) -> None:
     from .mcp_client import get_registry
 
     print("DecafClaw interactive mode. Type 'quit' to exit.")
-    print(f"Model: {config.llm_model}")
+    print(f"Model: {config.llm.model}")
     print(f"Tools: {', '.join(t['function']['name'] for t in TOOL_DEFINITIONS)}")
     skills = getattr(config, "discovered_skills", [])
     if skills:
@@ -648,7 +648,7 @@ async def run_interactive(ctx):
             result = await run_agent_turn(ctx, user_input, history)
             from .media import process_media_for_terminal
 
-            if config.llm_streaming:
+            if config.llm.streaming:
                 # Text was already printed token-by-token; handle media only
                 if result.media:
                     output = process_media_for_terminal(result, config.workspace_path)

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -110,11 +110,12 @@ async def _single_summarize(ctx, config, flattened_text: str, prompt: str) -> st
         {"role": "system", "content": prompt},
         {"role": "user", "content": flattened_text},
     ]
+    cc = config.compaction.resolved(config)
     response = await call_llm(
         config, summary_messages,
-        llm_url=config.compaction_url,
-        llm_model=config.compaction_model,
-        llm_api_key=config.compaction_api_key,
+        llm_url=cc.url,
+        llm_model=cc.model,
+        llm_api_key=cc.api_key,
     )
     return response.get("content", "")
 
@@ -183,7 +184,7 @@ async def compact_history(ctx, history: list) -> bool:
 
     # Split into turns
     turns = _split_into_turns(archive)
-    preserve = config.compaction_preserve_turns
+    preserve = config.compaction.preserve_turns
 
     if len(turns) <= preserve:
         log.info(f"Compaction skipped: only {len(turns)} turns, need >{preserve} to compact")

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -1,11 +1,40 @@
-"""Configuration loaded from environment variables / .env file."""
+"""Configuration loaded from config.json, environment variables, and defaults.
 
+Resolution order (first non-empty wins):
+  1. Environment variable (systematic name, then alias)
+  2. Config file value (data/{agent_id}/config.json)
+  3. Dataclass default
+"""
+
+import json
+import logging
 import os
 from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
 from pathlib import Path
+from typing import Any, get_origin
 
 from dotenv import load_dotenv
 
+from .config_types import (
+    AgentConfig,
+    ClaudeCodeConfig,
+    CompactionConfig,
+    EmbeddingConfig,
+    HeartbeatConfig,
+    HttpConfig,
+    LlmConfig,
+    MattermostConfig,
+    SkillsConfig,
+    TabstackConfig,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
 
 def _parse_bool(value: str, default: bool = False) -> bool:
     """Parse a string to boolean. Returns default if empty/None."""
@@ -14,198 +43,268 @@ def _parse_bool(value: str, default: bool = False) -> bool:
     return value.strip().lower() in ("true", "1", "yes")
 
 
+def _parse_list(value: str) -> list[str]:
+    """Parse env var to list. Try JSON first, fall back to comma-split."""
+    value = value.strip()
+    if not value:
+        return []
+    if value.startswith("["):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        except json.JSONDecodeError:
+            pass
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _coerce(value: str, field_type) -> object:
+    """Coerce a string value to the target field type."""
+    origin = get_origin(field_type)
+    if origin is list:
+        return _parse_list(value)
+    if field_type is bool:
+        return _parse_bool(value)
+    if field_type is int:
+        return int(value)
+    if field_type is float:
+        return float(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Generic sub-config loader
+# ---------------------------------------------------------------------------
+
+def _load_sub_config(
+    dc_class: type,
+    json_data: dict,
+    env_prefix: str,
+    env_aliases: dict[str, str] | None = None,
+) -> Any:
+    """Build a sub-config dataclass from JSON data + env vars + defaults.
+
+    For each field:
+      1. Check env var {ENV_PREFIX}_{FIELD_UPPER} (skipped if prefix empty)
+      2. Check env alias from field metadata or env_aliases dict
+      3. Check json_data[field_name]
+      4. Fall through to dataclass default
+    """
+    kwargs: dict[str, object] = {}
+    aliases = env_aliases or {}
+
+    # Resolve type hints (may be strings due to __future__.annotations)
+    import typing
+    hints = typing.get_type_hints(dc_class)
+
+    for f in dc_fields(dc_class):
+        field_type = hints.get(f.name, f.type)
+        env_val = None
+
+        # 1. Systematic env var: PREFIX_FIELDNAME
+        if env_prefix:
+            env_name = f"{env_prefix}_{f.name.upper()}"
+            env_val = os.getenv(env_name)
+
+        # 2. Env alias from field metadata or explicit aliases dict
+        if not env_val:
+            alias = f.metadata.get("env_alias") or aliases.get(f.name)
+            if alias:
+                env_val = os.getenv(alias)
+
+        if env_val is not None and env_val != "":
+            kwargs[f.name] = _coerce(env_val, field_type)
+        elif f.name in json_data:
+            json_val = json_data[f.name]
+            # JSON already has correct types for most things
+            if isinstance(json_val, str) and field_type not in (str, "str"):
+                kwargs[f.name] = _coerce(json_val, field_type)
+            else:
+                kwargs[f.name] = json_val
+        # else: use dataclass default
+
+    return dc_class(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Top-level Config
+# ---------------------------------------------------------------------------
+
 @dataclass
 class Config:
-    # LLM settings
-    llm_url: str = "http://192.168.0.199:4000/v1/chat/completions"
-    llm_model: str = "gemini-2.5-flash"
-    llm_api_key: str = "dummy"
+    llm: LlmConfig = field(default_factory=LlmConfig)
+    mattermost: MattermostConfig = field(default_factory=MattermostConfig)
+    compaction: CompactionConfig = field(default_factory=CompactionConfig)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+    heartbeat: HeartbeatConfig = field(default_factory=HeartbeatConfig)
+    http: HttpConfig = field(default_factory=HttpConfig)
+    agent: AgentConfig = field(default_factory=AgentConfig)
+    skills: SkillsConfig = field(default_factory=SkillsConfig)
 
-    # Mattermost settings
-    mattermost_url: str = ""  # e.g. "https://comms.lmorchard.com"
-    mattermost_token: str = ""
-    mattermost_bot_username: str = ""
-    mattermost_ignore_bots: bool = True
-    mattermost_ignore_webhooks: bool = False
-    mattermost_debounce_ms: int = 1000  # batch messages within this window
-    mattermost_cooldown_ms: int = 1000  # min time between agent turns per channel
-    mattermost_require_mention: bool = True  # in public/private channels, only respond when @-mentioned
-    mattermost_user_rate_limit_ms: int = 500  # min time between messages per user
-    mattermost_channel_blocklist: str = ""  # comma-separated channel IDs to ignore
-    mattermost_circuit_breaker_max: int = 10  # max agent turns per channel in window
-    mattermost_circuit_breaker_window_sec: int = 30  # sliding window for circuit breaker
-    mattermost_circuit_breaker_pause_sec: int = 60  # pause duration after breaker trips
+    # Custom environment variables from config.json "env" section
+    env: dict[str, str] = field(default_factory=dict)
 
-    # Workspace settings
-    data_home: str = "./data"
-    agent_id: str = "decafclaw"
-    agent_user_id: str = "user"  # single configured user (temporary)
+    # Runtime-only (not in config file)
+    system_prompt: str = ""
+    discovered_skills: list = field(default_factory=list)
+
+    def apply_env(self) -> None:
+        """Apply env vars from the config. Only sets vars not already in the environment.
+
+        Priority: real env vars > .env file > config.json env section.
+        Call at startup and after config reload.
+        """
+        for key, value in self.env.items():
+            if key not in os.environ:
+                os.environ[key] = value
 
     @property
     def agent_path(self) -> Path:
         """Admin-level agent directory (read-only to agent)."""
-        return Path(self.data_home) / self.agent_id
+        return Path(self.agent.data_home) / self.agent.id
 
     @property
     def workspace_path(self) -> Path:
         """Agent read/write sandbox."""
-        return Path(self.data_home) / self.agent_id / "workspace"
-
-    # Embedding / semantic search settings
-    embedding_model: str = "text-embedding-004"
-    embedding_url: str = ""      # default: falls back to llm_url
-    embedding_api_key: str = ""  # default: falls back to llm_api_key
-    memory_search_strategy: str = "substring"  # substring | semantic
-
-    @property
-    def effective_embedding_url(self) -> str:
-        return self.embedding_url or self.llm_url.replace("/chat/completions", "/embeddings")
-
-    @property
-    def effective_embedding_api_key(self) -> str:
-        return self.embedding_api_key or self.llm_api_key
-
-    # Tabstack settings
-    tabstack_api_key: str = ""
-    tabstack_api_url: str = ""  # empty = SDK default (production)
-
-    # Compaction settings
-    compaction_llm_url: str = ""        # default: falls back to llm_url
-    compaction_llm_model: str = ""      # default: falls back to llm_model
-    compaction_llm_api_key: str = ""    # default: falls back to llm_api_key
-    compaction_max_tokens: int = 100000 # compact when prompt_tokens exceeds this
-    compaction_llm_max_tokens: int = 0  # compaction LLM's context budget (0 = use compaction_max_tokens)
-    compaction_preserve_turns: int = 5  # keep this many recent turns intact
-
-    @property
-    def compaction_url(self) -> str:
-        return self.compaction_llm_url or self.llm_url
-
-    @property
-    def compaction_model(self) -> str:
-        return self.compaction_llm_model or self.llm_model
-
-    @property
-    def compaction_api_key(self) -> str:
-        return self.compaction_llm_api_key or self.llm_api_key
-
-    @property
-    def compaction_context_budget(self) -> int:
-        return self.compaction_llm_max_tokens or self.compaction_max_tokens
-
-    # Heartbeat settings
-    heartbeat_interval: str = "30m"
-    heartbeat_user: str = ""
-    heartbeat_channel: str = ""
-    heartbeat_suppress_ok: bool = True
-
-    # Streaming settings
-    llm_streaming: bool = True
-    llm_stream_throttle_ms: int = 200
-
-    # Agent settings (system_prompt is assembled from prompt files at startup)
-    system_prompt: str = ""
-    max_tool_iterations: int = 200
-    max_concurrent_tools: int = 5    # max parallel tool calls per model response
-    max_message_length: int = 50000  # truncate user messages beyond this (chars)
-
-    # Tool search / deferred loading
-    tool_context_budget_pct: float = 0.10  # fraction of compaction_max_tokens for tool defs
-    always_loaded_tools: str = ""  # comma-separated tool names to add to always-loaded set
-
-    @property
-    def tool_context_budget(self) -> int:
-        return int(self.compaction_max_tokens * self.tool_context_budget_pct)
-
-    # Child agent (delegation) settings
-    child_max_tool_iterations: int = 10
-    child_timeout_sec: int = 300
-
-    # HTTP server settings
-    http_enabled: bool = False
-    http_host: str = "0.0.0.0"
-    http_port: int = 18880
-    http_secret: str = ""
-    http_base_url: str = ""  # auto-detected if empty
+        return self.agent_path / "workspace"
 
     @property
     def http_callback_base(self) -> str:
         """Base URL for HTTP callbacks. Auto-detected from host/port if not set."""
-        if self.http_base_url:
-            return self.http_base_url.rstrip("/")
-        return f"http://{self.http_host}:{self.http_port}"
+        if self.http.base_url:
+            return self.http.base_url.rstrip("/")
+        return f"http://{self.http.host}:{self.http.port}"
 
-    # Mattermost confirmation settings
-    mattermost_enable_emoji_confirms: bool = True  # auto-set to False when http_enabled
+    @property
+    def tool_context_budget(self) -> int:
+        return int(self.compaction.max_tokens * self.agent.tool_context_budget_pct)
 
-    # Claude Code skill settings
-    claude_code_model: str = ""  # empty = SDK default
-    claude_code_budget_default: float = 2.0
-    claude_code_budget_max: float = 10.0
-    claude_code_session_timeout: str = "30m"
+    @property
+    def compaction_context_budget(self) -> int:
+        return self.compaction.llm_max_tokens or self.compaction.max_tokens
 
-    # Discovered skills (populated by load_system_prompt at startup)
-    discovered_skills: list = field(default_factory=list)
 
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
 
 def load_config() -> Config:
+    """Load config from defaults → config.json → env vars."""
     load_dotenv()
-    return Config(
-        llm_url=os.getenv("LLM_URL", Config.llm_url),
-        llm_model=os.getenv("LLM_MODEL", Config.llm_model),
-        llm_api_key=os.getenv("LLM_API_KEY", Config.llm_api_key),
-        mattermost_url=os.getenv("MATTERMOST_URL", ""),
-        mattermost_token=os.getenv("MATTERMOST_TOKEN", ""),
-        mattermost_bot_username=os.getenv("MATTERMOST_BOT_USERNAME", ""),
-        mattermost_ignore_bots=_parse_bool(os.getenv("MATTERMOST_IGNORE_BOTS", ""), default=True),
-        mattermost_ignore_webhooks=_parse_bool(os.getenv("MATTERMOST_IGNORE_WEBHOOKS", ""), default=False),
-        mattermost_debounce_ms=int(os.getenv("MATTERMOST_DEBOUNCE_MS", "1000")),
-        mattermost_cooldown_ms=int(os.getenv("MATTERMOST_COOLDOWN_MS", "1000")),
-        mattermost_require_mention=_parse_bool(os.getenv("MATTERMOST_REQUIRE_MENTION", ""), default=True),
-        mattermost_user_rate_limit_ms=int(os.getenv("MATTERMOST_USER_RATE_LIMIT_MS", "500")),
-        mattermost_channel_blocklist=os.getenv("MATTERMOST_CHANNEL_BLOCKLIST", ""),
-        mattermost_circuit_breaker_max=int(os.getenv("MATTERMOST_CIRCUIT_BREAKER_MAX", "10")),
-        mattermost_circuit_breaker_window_sec=int(os.getenv("MATTERMOST_CIRCUIT_BREAKER_WINDOW_SEC", "30")),
-        mattermost_circuit_breaker_pause_sec=int(os.getenv("MATTERMOST_CIRCUIT_BREAKER_PAUSE_SEC", "60")),
-        compaction_llm_url=os.getenv("COMPACTION_LLM_URL", ""),
-        compaction_llm_model=os.getenv("COMPACTION_LLM_MODEL", ""),
-        compaction_llm_api_key=os.getenv("COMPACTION_LLM_API_KEY", ""),
-        compaction_max_tokens=int(os.getenv("COMPACTION_MAX_TOKENS", "100000")),
-        compaction_llm_max_tokens=int(os.getenv("COMPACTION_LLM_MAX_TOKENS", "0")),
-        compaction_preserve_turns=int(os.getenv("COMPACTION_PRESERVE_TURNS", "5")),
-        embedding_model=os.getenv("EMBEDDING_MODEL", Config.embedding_model),
-        embedding_url=os.getenv("EMBEDDING_URL", ""),
-        embedding_api_key=os.getenv("EMBEDDING_API_KEY", ""),
-        memory_search_strategy=os.getenv("MEMORY_SEARCH_STRATEGY", Config.memory_search_strategy),
-        data_home=os.getenv("DATA_HOME", Config.data_home),
-        agent_id=os.getenv("AGENT_ID", Config.agent_id),
-        agent_user_id=os.getenv("AGENT_USER_ID", Config.agent_user_id),
-        tabstack_api_key=os.getenv("TABSTACK_API_KEY", ""),
-        tabstack_api_url=os.getenv("TABSTACK_API_URL", ""),
-        heartbeat_interval=os.getenv("HEARTBEAT_INTERVAL", Config.heartbeat_interval),
-        heartbeat_user=os.getenv("HEARTBEAT_USER", ""),
-        heartbeat_channel=os.getenv("HEARTBEAT_CHANNEL", ""),
-        heartbeat_suppress_ok=_parse_bool(os.getenv("HEARTBEAT_SUPPRESS_OK", ""), default=True),
-        llm_streaming=_parse_bool(os.getenv("LLM_STREAMING", ""), default=True),
-        llm_stream_throttle_ms=int(os.getenv("LLM_STREAM_THROTTLE_MS", "200")),
-        http_enabled=_parse_bool(os.getenv("HTTP_ENABLED", ""), default=False),
-        http_host=os.getenv("HTTP_HOST", Config.http_host),
-        http_port=int(os.getenv("HTTP_PORT", "18880")),
-        http_secret=os.getenv("HTTP_SECRET", ""),
-        http_base_url=os.getenv("HTTP_BASE_URL", ""),
-        mattermost_enable_emoji_confirms=_parse_bool(
-            os.getenv("MATTERMOST_ENABLE_EMOJI_CONFIRMS", ""),
-            default=not _parse_bool(os.getenv("HTTP_ENABLED", ""), default=False)),
-        claude_code_model=os.getenv("CLAUDE_CODE_MODEL", ""),
-        claude_code_budget_default=float(os.getenv("CLAUDE_CODE_BUDGET_DEFAULT", "2.0")),
-        claude_code_budget_max=float(os.getenv("CLAUDE_CODE_BUDGET_MAX", "10.0")),
-        claude_code_session_timeout=os.getenv("CLAUDE_CODE_SESSION_TIMEOUT", "30m"),
-        system_prompt=os.getenv("SYSTEM_PROMPT", Config.system_prompt),
-        max_tool_iterations=int(os.getenv("MAX_TOOL_ITERATIONS", "200")),
-        max_concurrent_tools=int(os.getenv("MAX_CONCURRENT_TOOLS", "5")),
-        tool_context_budget_pct=float(os.getenv("TOOL_CONTEXT_BUDGET_PCT", "0.10")),
-        always_loaded_tools=os.getenv("ALWAYS_LOADED_TOOLS", ""),
-        max_message_length=int(os.getenv("MAX_MESSAGE_LENGTH", "50000")),
-        child_max_tool_iterations=int(os.getenv("CHILD_MAX_TOOL_ITERATIONS", "10")),
-        child_timeout_sec=int(os.getenv("CHILD_TIMEOUT_SEC", "300")),
+
+    # Bootstrap: resolve data_home and agent_id from env only
+    data_home = os.getenv("DATA_HOME", AgentConfig.data_home)
+    agent_id = os.getenv("AGENT_ID", AgentConfig.id)
+
+    # Load config file if it exists
+    config_path = Path(data_home) / agent_id / "config.json"
+    file_data: dict = {}
+    if config_path.exists():
+        try:
+            file_data = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Failed to load %s: %s", config_path, exc)
+
+    # Build each sub-config
+    llm = _load_sub_config(
+        LlmConfig, file_data.get("llm", {}), "LLM")
+
+    mattermost = _load_sub_config(
+        MattermostConfig, file_data.get("mattermost", {}), "MATTERMOST",
+        env_aliases={"stream_throttle_ms": "LLM_STREAM_THROTTLE_MS"})
+
+    compaction = _load_sub_config(
+        CompactionConfig, file_data.get("compaction", {}), "COMPACTION",
+        env_aliases={
+            "url": "COMPACTION_LLM_URL",
+            "model": "COMPACTION_LLM_MODEL",
+            "api_key": "COMPACTION_LLM_API_KEY",
+            "llm_max_tokens": "COMPACTION_LLM_MAX_TOKENS",
+        })
+
+    embedding = _load_sub_config(
+        EmbeddingConfig, file_data.get("embedding", {}), "EMBEDDING",
+        env_aliases={"search_strategy": "MEMORY_SEARCH_STRATEGY"})
+
+    heartbeat = _load_sub_config(
+        HeartbeatConfig, file_data.get("heartbeat", {}), "HEARTBEAT")
+
+    http = _load_sub_config(
+        HttpConfig, file_data.get("http", {}), "HTTP")
+
+    agent = _load_sub_config(
+        AgentConfig, file_data.get("agent", {}), "",
+        env_aliases={
+            "data_home": "DATA_HOME",
+            "id": "AGENT_ID",
+            "user_id": "AGENT_USER_ID",
+            "max_tool_iterations": "MAX_TOOL_ITERATIONS",
+            "max_concurrent_tools": "MAX_CONCURRENT_TOOLS",
+            "max_message_length": "MAX_MESSAGE_LENGTH",
+            "tool_context_budget_pct": "TOOL_CONTEXT_BUDGET_PCT",
+            "always_loaded_tools": "ALWAYS_LOADED_TOOLS",
+            "child_max_tool_iterations": "CHILD_MAX_TOOL_ITERATIONS",
+            "child_timeout_sec": "CHILD_TIMEOUT_SEC",
+        })
+
+    # Force bootstrap values — these determine the config file location,
+    # so the JSON file must not override them
+    agent.data_home = data_home
+    agent.id = agent_id
+
+    # Skills sub-configs
+    skills_data = file_data.get("skills", {})
+    tabstack = _load_sub_config(
+        TabstackConfig, skills_data.get("tabstack", {}), "SKILLS_TABSTACK")
+    claude_code = _load_sub_config(
+        ClaudeCodeConfig, skills_data.get("claude_code", {}), "SKILLS_CLAUDE_CODE")
+    skills = SkillsConfig(tabstack=tabstack, claude_code=claude_code)
+
+    # Custom env vars from config file
+    env_vars: dict[str, str] = {
+        str(k): str(v) for k, v in file_data.get("env", {}).items()
+    }
+
+    # Runtime-only field
+    system_prompt = os.getenv("SYSTEM_PROMPT", "")
+
+    config = Config(
+        llm=llm,
+        mattermost=mattermost,
+        compaction=compaction,
+        embedding=embedding,
+        heartbeat=heartbeat,
+        http=http,
+        agent=agent,
+        skills=skills,
+        env=env_vars,
+        system_prompt=system_prompt,
     )
+
+    # Apply custom env vars (only sets those not already in environment)
+    config.apply_env()
+
+    return config
+
+
+def reload_env(config: Config) -> dict[str, str]:
+    """Re-read the env section from config.json and apply new vars.
+
+    Returns dict of newly applied vars (name → value).
+    """
+    config_path = config.agent_path / "config.json"
+    if not config_path.exists():
+        return {}
+    try:
+        file_data = json.loads(config_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+    new_env = {str(k): str(v) for k, v in file_data.get("env", {}).items()}
+    applied: dict[str, str] = {}
+    for key, value in new_env.items():
+        if key not in os.environ:
+            os.environ[key] = value
+            applied[key] = value
+    config.env = new_env
+    return applied

--- a/src/decafclaw/config_cli.py
+++ b/src/decafclaw/config_cli.py
@@ -1,0 +1,323 @@
+"""CLI tool for config inspection and editing.
+
+Usage:
+    python -m decafclaw config show [group] [--reveal]
+    python -m decafclaw config get <path>
+    python -m decafclaw config set <path> <value>
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import fields
+
+from .config import Config, load_config
+
+
+def _print_group(prefix: str, dc_instance, reveal: bool) -> None:
+    """Print all fields of a dataclass with dotted prefix."""
+    for f in fields(dc_instance):
+        value = getattr(dc_instance, f.name)
+        if hasattr(value, "__dataclass_fields__"):
+            _print_group(f"{prefix}.{f.name}", value, reveal)
+            continue
+        display = _format_value(value, f, reveal)
+        print(f"{prefix}.{f.name} = {display}")
+
+
+def _format_value(value, field_info, reveal: bool) -> str:
+    if not reveal and field_info.metadata.get("secret") and value:
+        return "****"
+    if isinstance(value, list):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _resolve_field(config: Config, path: str):
+    """Walk dotted path and return (parent_obj, field_info, value)."""
+    parts = path.split(".")
+    obj = config
+    for part in parts[:-1]:
+        obj = getattr(obj, part, None)
+        if obj is None:
+            return None
+    if not hasattr(obj, "__dataclass_fields__"):
+        return None
+    for f in fields(obj):
+        if f.name == parts[-1]:
+            return (obj, f, getattr(obj, f.name))
+    return None
+
+
+def _coerce_cli_value(field_info, raw: str):
+    """Coerce a CLI string value based on the field's type."""
+    field_type = field_info.type
+    # Handle string type annotations
+    if field_type in (bool, "bool"):
+        return raw.strip().lower() in ("true", "1", "yes")
+    if field_type in (int, "int"):
+        return int(raw)
+    if field_type in (float, "float"):
+        return float(raw)
+    if field_type in ("list[str]",) or (
+        hasattr(field_type, "__origin__") and field_type.__origin__ is list
+    ):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return parsed
+        except json.JSONDecodeError:
+            return [s.strip() for s in raw.split(",") if s.strip()]
+    return raw
+
+
+def cmd_show(args) -> None:
+    """Show resolved config, optionally filtered by group."""
+    config = load_config()
+
+    valid_groups = set()
+    for group_field in fields(config):
+        if group_field.name in ("system_prompt", "discovered_skills"):
+            continue
+        group = getattr(config, group_field.name)
+        if hasattr(group, "__dataclass_fields__"):
+            valid_groups.add(group_field.name)
+            if args.group and group_field.name != args.group:
+                continue
+            _print_group(group_field.name, group, args.reveal)
+
+    # Show env section (treated as secrets by default)
+    valid_groups.add("env")
+    if not args.group or args.group == "env":
+        for key in sorted(config.env):
+            display = config.env[key] if args.reveal else "****"
+            print(f"env.{key} = {display}")
+
+    if args.group and args.group not in valid_groups:
+        print(f"Unknown group: {args.group}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_get(args) -> None:
+    """Get a single config value."""
+    config = load_config()
+    # Handle env.* paths specially
+    if args.path.startswith("env."):
+        key = args.path[4:]
+        if key in config.env:
+            print(config.env[key])
+        else:
+            print(f"Unknown config path: {args.path}", file=sys.stderr)
+            sys.exit(1)
+        return
+    resolved = _resolve_field(config, args.path)
+    if resolved is None:
+        print(f"Unknown config path: {args.path}", file=sys.stderr)
+        sys.exit(1)
+    _, _, value = resolved
+    if isinstance(value, list):
+        print(json.dumps(value))
+    elif isinstance(value, bool):
+        print(str(value).lower())
+    else:
+        print(value)
+
+
+def cmd_set(args) -> None:
+    """Set a config value in config.json."""
+    config = load_config()
+    config_path = config.agent_path / "config.json"
+
+    # env.* paths are freeform — always strings, no validation needed
+    is_env = args.path.startswith("env.")
+    if not is_env:
+        resolved = _resolve_field(config, args.path)
+        if resolved is None:
+            print(f"Unknown config path: {args.path}", file=sys.stderr)
+            sys.exit(1)
+        _, field_info, _ = resolved
+        value = _coerce_cli_value(field_info, args.value)
+    else:
+        value = args.value
+
+    # Load existing file or start fresh
+    if config_path.exists():
+        file_data = json.loads(config_path.read_text())
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        file_data = {}
+
+    # Set in nested dict, validating intermediate keys are dicts
+    parts = args.path.split(".")
+    d = file_data
+    for part in parts[:-1]:
+        if part not in d:
+            d[part] = {}
+        elif not isinstance(d[part], dict):
+            print(
+                f"Cannot set {args.path}: key '{part}' is not a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        d = d[part]
+    d[parts[-1]] = value
+
+    config_path.write_text(json.dumps(file_data, indent=2) + "\n")
+    print(f"Set {args.path} = {json.dumps(value) if isinstance(value, list) else value}")
+
+
+# Mapping of env var names → JSON config paths
+_ENV_TO_PATH: dict[str, str] = {
+    # llm
+    "LLM_URL": "llm.url", "LLM_MODEL": "llm.model",
+    "LLM_API_KEY": "llm.api_key", "LLM_STREAMING": "llm.streaming",
+    # mattermost
+    "MATTERMOST_URL": "mattermost.url", "MATTERMOST_TOKEN": "mattermost.token",
+    "MATTERMOST_BOT_USERNAME": "mattermost.bot_username",
+    "MATTERMOST_IGNORE_BOTS": "mattermost.ignore_bots",
+    "MATTERMOST_IGNORE_WEBHOOKS": "mattermost.ignore_webhooks",
+    "MATTERMOST_DEBOUNCE_MS": "mattermost.debounce_ms",
+    "MATTERMOST_COOLDOWN_MS": "mattermost.cooldown_ms",
+    "MATTERMOST_REQUIRE_MENTION": "mattermost.require_mention",
+    "MATTERMOST_USER_RATE_LIMIT_MS": "mattermost.user_rate_limit_ms",
+    "MATTERMOST_CHANNEL_BLOCKLIST": "mattermost.channel_blocklist",
+    "MATTERMOST_CIRCUIT_BREAKER_MAX": "mattermost.circuit_breaker_max",
+    "MATTERMOST_CIRCUIT_BREAKER_WINDOW_SEC": "mattermost.circuit_breaker_window_sec",
+    "MATTERMOST_CIRCUIT_BREAKER_PAUSE_SEC": "mattermost.circuit_breaker_pause_sec",
+    "MATTERMOST_ENABLE_EMOJI_CONFIRMS": "mattermost.enable_emoji_confirms",
+    "LLM_STREAM_THROTTLE_MS": "mattermost.stream_throttle_ms",
+    "MATTERMOST_STREAM_THROTTLE_MS": "mattermost.stream_throttle_ms",
+    # compaction
+    "COMPACTION_LLM_URL": "compaction.url", "COMPACTION_LLM_MODEL": "compaction.model",
+    "COMPACTION_LLM_API_KEY": "compaction.api_key",
+    "COMPACTION_MAX_TOKENS": "compaction.max_tokens",
+    "COMPACTION_LLM_MAX_TOKENS": "compaction.llm_max_tokens",
+    "COMPACTION_PRESERVE_TURNS": "compaction.preserve_turns",
+    # embedding
+    "EMBEDDING_MODEL": "embedding.model", "EMBEDDING_URL": "embedding.url",
+    "EMBEDDING_API_KEY": "embedding.api_key",
+    "MEMORY_SEARCH_STRATEGY": "embedding.search_strategy",
+    # heartbeat
+    "HEARTBEAT_INTERVAL": "heartbeat.interval", "HEARTBEAT_USER": "heartbeat.user",
+    "HEARTBEAT_CHANNEL": "heartbeat.channel",
+    "HEARTBEAT_SUPPRESS_OK": "heartbeat.suppress_ok",
+    # http
+    "HTTP_ENABLED": "http.enabled", "HTTP_HOST": "http.host",
+    "HTTP_PORT": "http.port", "HTTP_SECRET": "http.secret",
+    "HTTP_BASE_URL": "http.base_url",
+    # agent (DATA_HOME and AGENT_ID excluded — they're bootstrap-only,
+    # determined by env vars, not the config file)
+    "AGENT_USER_ID": "agent.user_id",
+    "MAX_TOOL_ITERATIONS": "agent.max_tool_iterations",
+    "MAX_CONCURRENT_TOOLS": "agent.max_concurrent_tools",
+    "MAX_MESSAGE_LENGTH": "agent.max_message_length",
+    "TOOL_CONTEXT_BUDGET_PCT": "agent.tool_context_budget_pct",
+    "ALWAYS_LOADED_TOOLS": "agent.always_loaded_tools",
+    "CHILD_MAX_TOOL_ITERATIONS": "agent.child_max_tool_iterations",
+    "CHILD_TIMEOUT_SEC": "agent.child_timeout_sec",
+    # skills
+    "TABSTACK_API_KEY": "skills.tabstack.api_key",
+    "TABSTACK_API_URL": "skills.tabstack.api_url",
+    "CLAUDE_CODE_MODEL": "skills.claude_code.model",
+    "CLAUDE_CODE_BUDGET_DEFAULT": "skills.claude_code.budget_default",
+    "CLAUDE_CODE_BUDGET_MAX": "skills.claude_code.budget_max",
+    "CLAUDE_CODE_SESSION_TIMEOUT": "skills.claude_code.session_timeout",
+}
+
+
+def cmd_import_env(args) -> None:
+    """Convert .env file to config.json."""
+    from pathlib import Path
+
+    env_path = Path(args.file)
+    if not env_path.exists():
+        print(f"File not found: {env_path}", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_config()
+    config_path = config.agent_path / "config.json"
+
+    # Load existing config.json or start fresh
+    if config_path.exists():
+        file_data = json.loads(config_path.read_text())
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        file_data = {}
+
+    # Parse .env file
+    imported = 0
+    env_imported = 0
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        # Strip surrounding quotes
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+
+        path = _ENV_TO_PATH.get(key)
+        if path is not None:
+            # Known config field — resolve type and set at the mapped path
+            resolved = _resolve_field(config, path)
+            if resolved is not None:
+                _, field_info, _ = resolved
+                coerced = _coerce_cli_value(field_info, value)
+                parts = path.split(".")
+                d = file_data
+                for part in parts[:-1]:
+                    d = d.setdefault(part, {})
+                d[parts[-1]] = coerced
+                imported += 1
+                continue
+
+        # Unknown var → import into env section
+        env_section = file_data.setdefault("env", {})
+        env_section[key] = value
+        env_imported += 1
+
+    config_path.write_text(json.dumps(file_data, indent=2) + "\n")
+    parts = [f"Imported {imported} settings"]
+    if env_imported:
+        parts.append(f"{env_imported} env vars")
+    print(f"{' + '.join(parts)} to {config_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="decafclaw config")
+    sub = parser.add_subparsers(dest="command")
+
+    show_p = sub.add_parser("show", help="Show resolved config values")
+    show_p.add_argument("group", nargs="?", help="Filter by config group")
+    show_p.add_argument("--reveal", action="store_true",
+                        help="Show secret values (masked by default)")
+
+    get_p = sub.add_parser("get", help="Get a single config value")
+    get_p.add_argument("path", help="Dotted path (e.g. mattermost.url)")
+
+    set_p = sub.add_parser("set", help="Set a value in config.json")
+    set_p.add_argument("path", help="Dotted path (e.g. mattermost.url)")
+    set_p.add_argument("value", help="Value to set")
+
+    import_p = sub.add_parser("import", help="Import settings from .env file")
+    import_p.add_argument("file", nargs="?", default=".env",
+                          help="Path to .env file (default: .env)")
+
+    args = parser.parse_args()
+    if args.command == "show":
+        cmd_show(args)
+    elif args.command == "get":
+        cmd_get(args)
+    elif args.command == "set":
+        cmd_set(args)
+    elif args.command == "import":
+        cmd_import_env(args)
+    else:
+        parser.print_help()

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -1,0 +1,146 @@
+"""Configuration sub-dataclasses grouped by concern.
+
+Each dataclass represents a config group (llm, mattermost, etc.).
+Field metadata supports:
+  - secret: True — masked in `config show` unless --reveal
+  - env_alias: "NAME" — alternative env var (checked after systematic name)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from dataclasses import fields as dc_fields
+
+
+@dataclass
+class LlmConfig:
+    url: str = "http://192.168.0.199:4000/v1/chat/completions"
+    model: str = "gemini-2.5-flash"
+    api_key: str = field(default="dummy", metadata={"secret": True})
+    streaming: bool = True
+
+
+@dataclass
+class MattermostConfig:
+    url: str = ""
+    token: str = field(default="", metadata={"secret": True})
+    bot_username: str = ""
+    ignore_bots: bool = True
+    ignore_webhooks: bool = False
+    debounce_ms: int = 1000
+    cooldown_ms: int = 1000
+    require_mention: bool = True
+    user_rate_limit_ms: int = 500
+    channel_blocklist: list[str] = field(default_factory=list)
+    circuit_breaker_max: int = 10
+    circuit_breaker_window_sec: int = 30
+    circuit_breaker_pause_sec: int = 60
+    enable_emoji_confirms: bool = True
+    stream_throttle_ms: int = 200
+
+
+@dataclass
+class CompactionConfig:
+    url: str = ""       # empty = resolve from llm via resolved()
+    model: str = ""     # empty = resolve from llm via resolved()
+    api_key: str = field(default="", metadata={"secret": True})
+    max_tokens: int = 100000
+    llm_max_tokens: int = 0  # 0 = use max_tokens
+    preserve_turns: int = 5
+
+    def resolved(self, config) -> CompactionConfig:
+        """Return copy with empty fields filled from config.llm."""
+        return replace(self,
+            url=self.url or config.llm.url,
+            model=self.model or config.llm.model,
+            api_key=self.api_key or config.llm.api_key,
+        )
+
+
+@dataclass
+class EmbeddingConfig:
+    model: str = "text-embedding-004"
+    url: str = ""       # empty = resolve from llm via resolved()
+    api_key: str = field(default="", metadata={"secret": True})
+    search_strategy: str = "substring"
+
+    def resolved(self, config) -> EmbeddingConfig:
+        """Return copy with empty fields filled from config.llm."""
+        return replace(self,
+            url=self.url or config.llm.url.replace(
+                "/chat/completions", "/embeddings"),
+            api_key=self.api_key or config.llm.api_key,
+        )
+
+
+@dataclass
+class HeartbeatConfig:
+    interval: str = "30m"
+    user: str = ""
+    channel: str = ""
+    suppress_ok: bool = True
+
+
+@dataclass
+class HttpConfig:
+    enabled: bool = False
+    host: str = "0.0.0.0"
+    port: int = 18880
+    secret: str = field(default="", metadata={"secret": True})
+    base_url: str = ""
+
+
+@dataclass
+class AgentConfig:
+    data_home: str = "./data"
+    id: str = "decafclaw"
+    user_id: str = "user"
+    max_tool_iterations: int = 200
+    max_concurrent_tools: int = 5
+    max_message_length: int = 50000
+    tool_context_budget_pct: float = 0.10
+    always_loaded_tools: list[str] = field(default_factory=list)
+    child_max_tool_iterations: int = 10
+    child_timeout_sec: int = 300
+
+
+@dataclass
+class TabstackConfig:
+    api_key: str = field(
+        default="", metadata={"secret": True, "env_alias": "TABSTACK_API_KEY"})
+    api_url: str = field(
+        default="", metadata={"env_alias": "TABSTACK_API_URL"})
+
+
+@dataclass
+class ClaudeCodeConfig:
+    model: str = field(
+        default="", metadata={"env_alias": "CLAUDE_CODE_MODEL"})
+    budget_default: float = field(
+        default=2.0, metadata={"env_alias": "CLAUDE_CODE_BUDGET_DEFAULT"})
+    budget_max: float = field(
+        default=10.0, metadata={"env_alias": "CLAUDE_CODE_BUDGET_MAX"})
+    session_timeout: str = field(
+        default="30m", metadata={"env_alias": "CLAUDE_CODE_SESSION_TIMEOUT"})
+
+
+@dataclass
+class SkillsConfig:
+    tabstack: TabstackConfig = field(default_factory=TabstackConfig)
+    claude_code: ClaudeCodeConfig = field(default_factory=ClaudeCodeConfig)
+
+
+def is_secret(dc_class: type, field_name: str) -> bool:
+    """Check if a dataclass field is marked as secret."""
+    for f in dc_fields(dc_class):
+        if f.name == field_name:
+            return f.metadata.get("secret", False)
+    return False
+
+
+def get_env_alias(dc_class: type, field_name: str) -> str | None:
+    """Get the env var alias for a dataclass field, if any."""
+    for f in dc_fields(dc_class):
+        if f.name == field_name:
+            return f.metadata.get("env_alias")
+    return None

--- a/src/decafclaw/embeddings.py
+++ b/src/decafclaw/embeddings.py
@@ -82,21 +82,20 @@ def _entry_hash(text: str) -> str:
 
 async def embed_text(config, text: str) -> list[float] | None:
     """Call the embedding API and return the vector."""
-    url = config.effective_embedding_url
-    api_key = config.effective_embedding_api_key
+    ec = config.embedding.resolved(config)
 
     body = {
-        "model": config.embedding_model,
+        "model": ec.model,
         "input": text,
     }
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {api_key}",
+        "Authorization": f"Bearer {ec.api_key}",
     }
 
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post(url, json=body, headers=headers, timeout=30)
+            resp = await client.post(ec.url, json=body, headers=headers, timeout=30)
         resp.raise_for_status()
         data = resp.json()
         return data["data"][0]["embedding"]
@@ -108,9 +107,9 @@ async def embed_text(config, text: str) -> list[float] | None:
 def _check_model(config, conn):
     """Verify the DB was built with the same embedding model. Warns on mismatch."""
     row = conn.execute("SELECT value FROM metadata WHERE key='embedding_model'").fetchone()
-    if row and row[0] != config.embedding_model:
+    if row and row[0] != config.embedding.model:
         log.warning(f"Embedding model mismatch: DB was built with '{row[0]}', "
-                    f"config uses '{config.embedding_model}'. "
+                    f"config uses '{config.embedding.model}'. "
                     f"Run 'decafclaw-reindex' to rebuild.")
 
 
@@ -118,7 +117,7 @@ def _set_model(config, conn):
     """Record which embedding model was used."""
     conn.execute(
         "INSERT OR REPLACE INTO metadata (key, value) VALUES ('embedding_model', ?)",
-        (config.embedding_model,),
+        (config.embedding.model,),
     )
 
 
@@ -297,7 +296,7 @@ def reindex_cli():
         db_path.unlink()
         print(f"Deleted existing index: {db_path}")
 
-    print(f"Embedding model: {config.embedding_model}")
+    print(f"Embedding model: {config.embedding.model}")
 
     async def _reindex_all():
         mem_count = await reindex_all(config)

--- a/src/decafclaw/eval/__main__.py
+++ b/src/decafclaw/eval/__main__.py
@@ -53,7 +53,7 @@ def main():
         sys.exit(1)
 
     config = load_config()
-    model_name = args.model or config.llm_model
+    model_name = args.model or config.llm.model
     judge_model = args.judge_model or model_name
 
     print(f"\ndecafclaw eval — {model_name} — {args.path}\n")

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -42,7 +42,7 @@ async def _setup_workspace(config, test_case: dict):
         )
 
     # Index memories for semantic search if strategy is semantic
-    if config.memory_search_strategy == "semantic" and memories:
+    if config.embedding.search_strategy == "semantic" and memories:
         from ..embeddings import index_entry
         for mem in memories:
             tag_str = ", ".join(mem.get("tags", []))
@@ -117,7 +117,7 @@ async def run_test(config: Config, test_case: dict) -> dict:
     ctx.channel_id = "eval"
     ctx.channel_name = "eval"
     ctx.thread_id = ""
-    ctx.user_id = config.agent_user_id
+    ctx.user_id = config.agent.user_id
 
     # Set allowed tools if specified (disallowed tools return an error)
     allowed_tools = test_case.get("allowed_tools")
@@ -201,9 +201,9 @@ async def run_eval(yaml_data: list[dict], config: Config,
     import tempfile
 
     if model:
-        config.llm_model = model
+        config.llm.model = model
 
-    effective_model = config.llm_model
+    effective_model = config.llm.model
     timestamp = datetime.now().strftime("%Y-%m-%d-%H%M")
 
     results = {
@@ -222,8 +222,7 @@ async def run_eval(yaml_data: list[dict], config: Config,
         with tempfile.TemporaryDirectory() as tmp:
             from dataclasses import replace
             test_config = replace(config,
-                data_home=tmp,
-                agent_id="eval",
+                agent=replace(config.agent, data_home=tmp, id="eval"),
             )
 
             result = await run_test(test_config, test_case)

--- a/src/decafclaw/heartbeat.py
+++ b/src/decafclaw/heartbeat.py
@@ -246,7 +246,7 @@ async def run_heartbeat_timer(config, event_bus, shutdown_event,
                   (running + reporting). If provided, on_results is ignored.
         on_results: optional async callback(results) called after the default cycle.
     """
-    interval = parse_interval(config.heartbeat_interval)
+    interval = parse_interval(config.heartbeat.interval)
     if interval is None:
         log.info("Heartbeat disabled (no interval configured)")
         return
@@ -255,10 +255,10 @@ async def run_heartbeat_timer(config, event_bus, shutdown_event,
     if last_run > 0:
         elapsed = time.time() - last_run
         remaining = max(0, interval - elapsed)
-        log.info(f"Heartbeat timer starting: interval={config.heartbeat_interval} ({interval}s), "
+        log.info(f"Heartbeat timer starting: interval={config.heartbeat.interval} ({interval}s), "
                  f"last run {elapsed:.0f}s ago, next in {remaining:.0f}s")
     else:
-        log.info(f"Heartbeat timer starting: interval={config.heartbeat_interval} ({interval}s), "
+        log.info(f"Heartbeat timer starting: interval={config.heartbeat.interval} ({interval}s), "
                  f"no previous run recorded")
 
     cycle_running = False

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -28,7 +28,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
         # Also check static secret as fallback (defense in depth)
         secret = request.query_params.get("secret", "")
-        has_valid_secret = config.http_secret and secret == config.http_secret
+        has_valid_secret = config.http.secret and secret == config.http.secret
 
         if not token_data and not has_valid_secret:
             log.warning("Confirm callback rejected: invalid token and no valid secret")
@@ -293,12 +293,12 @@ async def run_http_server(config, event_bus, app_ctx=None) -> None:
     app = create_app(config, event_bus, app_ctx=app_ctx)
     server_config = uvicorn.Config(
         app,
-        host=config.http_host,
-        port=config.http_port,
+        host=config.http.host,
+        port=config.http.port,
         log_level="info",
     )
     _http_server = uvicorn.Server(server_config)
-    log.info(f"HTTP server starting on {config.http_host}:{config.http_port}")
+    log.info(f"HTTP server starting on {config.http.host}:{config.http.port}")
     await _http_server.serve()
 
 

--- a/src/decafclaw/llm.py
+++ b/src/decafclaw/llm.py
@@ -31,9 +31,9 @@ async def call_llm(config, messages, tools=None,
       - "tool_calls": list or None (tool calls the LLM wants to make)
       - "usage": dict or None (token usage from the API)
     """
-    url = llm_url or config.llm_url
-    model = llm_model or config.llm_model
-    api_key = llm_api_key or config.llm_api_key
+    url = llm_url or config.llm.url
+    model = llm_model or config.llm.model
+    api_key = llm_api_key or config.llm.api_key
 
     body = {
         "model": model,
@@ -90,9 +90,9 @@ async def call_llm_streaming(config, messages, tools=None,
     """
     from httpx_sse import aconnect_sse
 
-    url = llm_url or config.llm_url
-    model = llm_model or config.llm_model
-    api_key = llm_api_key or config.llm_api_key
+    url = llm_url or config.llm.url
+    model = llm_model or config.llm.model
+    api_key = llm_api_key or config.llm.api_key
 
     body = {
         "model": model,

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -78,24 +78,21 @@ class MattermostClient:
     """Minimal Mattermost client for a single bot."""
 
     def __init__(self, config):
-        self.url = config.mattermost_url.rstrip("/")
-        self.token = config.mattermost_token
+        self.url = config.mattermost.url.rstrip("/")
+        self.token = config.mattermost.token
         self.bot_user_id = None
-        self.bot_username = config.mattermost_bot_username
-        self.ignore_bots = config.mattermost_ignore_bots
-        self.ignore_webhooks = config.mattermost_ignore_webhooks
-        self.debounce_ms = config.mattermost_debounce_ms
-        self.cooldown_ms = config.mattermost_cooldown_ms
-        self.require_mention = config.mattermost_require_mention
-        self.user_rate_limit_ms = config.mattermost_user_rate_limit_ms
-        self.channel_blocklist = set(
-            ch.strip() for ch in config.mattermost_channel_blocklist.split(",")
-            if ch.strip()
-        )
+        self.bot_username = config.mattermost.bot_username
+        self.ignore_bots = config.mattermost.ignore_bots
+        self.ignore_webhooks = config.mattermost.ignore_webhooks
+        self.debounce_ms = config.mattermost.debounce_ms
+        self.cooldown_ms = config.mattermost.cooldown_ms
+        self.require_mention = config.mattermost.require_mention
+        self.user_rate_limit_ms = config.mattermost.user_rate_limit_ms
+        self.channel_blocklist = set(config.mattermost.channel_blocklist)
         self.circuit_breaker = CircuitBreaker(
-            max_turns=config.mattermost_circuit_breaker_max,
-            window_sec=config.mattermost_circuit_breaker_window_sec,
-            pause_sec=config.mattermost_circuit_breaker_pause_sec,
+            max_turns=config.mattermost.circuit_breaker_max,
+            window_sec=config.mattermost.circuit_breaker_window_sec,
+            pause_sec=config.mattermost.circuit_breaker_pause_sec,
         )
         self._http = httpx.AsyncClient(
             base_url=self.url + "/api/v4",
@@ -326,7 +323,7 @@ class MattermostClient:
         from .media import MattermostMediaHandler
 
         req_ctx = app_ctx.fork(
-            user_id=app_ctx.config.agent_user_id,
+            user_id=app_ctx.config.agent.user_id,
             channel_id=channel_id,
             channel_name="",
             thread_id=root_id or "",
@@ -343,14 +340,14 @@ class MattermostClient:
         # Create conversation display for this turn
         conv_display = ConversationDisplay(
             self, channel_id, root_id,
-            throttle_ms=app_ctx.config.llm_stream_throttle_ms,
+            throttle_ms=app_ctx.config.mattermost.stream_throttle_ms,
             initial_post_id=placeholder_id,
             config=app_ctx.config,
             conv_id=conv_id,
         )
 
         # Set streaming callback
-        if app_ctx.config.llm_streaming:
+        if app_ctx.config.llm.streaming:
             req_ctx.on_stream_chunk = conv_display.on_stream_chunk
 
         # Set up cancellation event and poll for stop reaction
@@ -383,7 +380,7 @@ class MattermostClient:
         sub_id = self._subscribe_progress(
             req_ctx.event_bus, req_ctx.context_id,
             channel_id=channel_id, root_id=root_id,
-            streaming=app_ctx.config.llm_streaming,
+            streaming=app_ctx.config.llm.streaming,
             conv_display=conv_display,
         )
 
@@ -1069,7 +1066,7 @@ class ConversationDisplay:
 
         # Add emoji instructions (unless disabled)
         # Show emoji instructions if enabled (default: on when HTTP off, off when HTTP on)
-        show_emoji = not config or config.mattermost_enable_emoji_confirms
+        show_emoji = not config or config.mattermost.enable_emoji_confirms
         if show_emoji:
             if tool_name == "shell" and suggested_pattern:
                 msg += (

--- a/src/decafclaw/mattermost_ui.py
+++ b/src/decafclaw/mattermost_ui.py
@@ -64,7 +64,7 @@ def build_confirm_buttons(config, tool_name: str, command: str,
     Returns the attachments list to include in a post's props.
     Returns [] if HTTP server is not enabled.
     """
-    if not config.http_enabled:
+    if not config.http.enabled:
         return []
 
     def _make_token(action: str) -> str:
@@ -72,7 +72,7 @@ def build_confirm_buttons(config, tool_name: str, command: str,
             context_id=context_id,
             tool_name=tool_name,
             original_message=original_message[:2000],
-            server_secret=config.http_secret,
+            server_secret=config.http.secret,
             action=action,
             tool_call_id=tool_call_id,
         )
@@ -161,14 +161,14 @@ def build_stop_button(config, conv_id: str) -> list[dict]:
 
     Returns [] if HTTP server is not enabled.
     """
-    if not config.http_enabled:
+    if not config.http.enabled:
         return []
 
     token = _token_registry.create(
         context_id=conv_id,
         tool_name="_cancel",
         original_message="",
-        server_secret=config.http_secret,
+        server_secret=config.http.secret,
     )
     base_url = f"{config.http_callback_base}/actions/cancel"
 

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -51,15 +51,15 @@ async def run_all(app_ctx):
 
     try:
         # Start HTTP server (button callbacks + web gateway)
-        if config.http_enabled:
+        if config.http.enabled:
             from .http_server import run_http_server
             http_task = asyncio.create_task(
                 run_http_server(config, app_ctx.event_bus, app_ctx=app_ctx)
             )
-            log.info(f"HTTP server enabled on {config.http_host}:{config.http_port}")
+            log.info(f"HTTP server enabled on {config.http.host}:{config.http.port}")
 
         # Start Mattermost client
-        if config.mattermost_url and config.mattermost_token:
+        if config.mattermost.url and config.mattermost.token:
             from .mattermost import MattermostClient
             client = MattermostClient(config)
             mattermost_task = asyncio.create_task(
@@ -68,9 +68,9 @@ async def run_all(app_ctx):
             log.info("Mattermost client starting")
 
         # Start heartbeat timer
-        if parse_interval(config.heartbeat_interval) is not None:
+        if parse_interval(config.heartbeat.interval) is not None:
             # Use Mattermost heartbeat cycle if available, otherwise basic
-            if config.mattermost_url and config.mattermost_token:
+            if config.mattermost.url and config.mattermost.token:
                 from .tools.heartbeat_tools import _guarded_heartbeat
 
                 async def on_cycle():
@@ -88,7 +88,7 @@ async def run_all(app_ctx):
                         config, app_ctx.event_bus, shutdown_event,
                     )
                 )
-            has_channel = config.heartbeat_channel or config.heartbeat_user
+            has_channel = config.heartbeat.channel or config.heartbeat.user
             log.info(f"Heartbeat timer started (reporting={'enabled' if has_channel else 'silent'})")
         else:
             log.info("Heartbeat disabled (interval not set)")

--- a/src/decafclaw/tools/core.py
+++ b/src/decafclaw/tools/core.py
@@ -171,7 +171,7 @@ def tool_context_stats(ctx) -> str | ToolResult:
     total_estimated = system_tokens + tools_tokens + history_tokens
     prompt_tokens_actual = ctx.total_prompt_tokens
     completion_tokens_actual = ctx.total_completion_tokens
-    compaction_max = config.compaction_max_tokens
+    compaction_max = config.compaction.max_tokens
 
     # Archive size
     from ..archive import archive_path

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -40,7 +40,7 @@ async def _run_child_turn(parent_ctx, task):
     parent_conv = getattr(parent_ctx, "conv_id", "") or getattr(parent_ctx, "channel_id", "")
     child_config = replace(
         config,
-        max_tool_iterations=config.child_max_tool_iterations,
+        agent=replace(config.agent, max_tool_iterations=config.agent.child_max_tool_iterations),
         system_prompt="\n".join(prompt_parts),
     )
     # Children don't discover or activate skills — they inherit parent's
@@ -76,7 +76,7 @@ async def _run_child_turn(parent_ctx, task):
     # No streaming for child agents
     child_ctx.on_stream_chunk = None
 
-    timeout = config.child_timeout_sec
+    timeout = config.agent.child_timeout_sec
 
     try:
         result = await asyncio.wait_for(

--- a/src/decafclaw/tools/heartbeat_tools.py
+++ b/src/decafclaw/tools/heartbeat_tools.py
@@ -27,7 +27,7 @@ async def tool_heartbeat_trigger(ctx) -> str:
     # Fire and forget — run the cycle in the background
     asyncio.create_task(_guarded_heartbeat(ctx.config, ctx.event_bus))
 
-    has_channel = ctx.config.heartbeat_channel or ctx.config.heartbeat_user
+    has_channel = ctx.config.heartbeat.channel or ctx.config.heartbeat.user
     if has_channel:
         return f"Heartbeat triggered: {len(sections)} section(s) queued. Results will be posted to the heartbeat channel."
     return f"Heartbeat triggered: {len(sections)} section(s) queued. No reporting channel configured — running silently."
@@ -67,7 +67,7 @@ async def _run_heartbeat_to_channel(config, event_bus) -> None:
         except Exception as e:
             log.error(f"Failed to resolve heartbeat channel: {e}")
 
-    suppress_ok = config.heartbeat_suppress_ok
+    suppress_ok = config.heartbeat.suppress_ok
     timestamp_str = datetime.now().strftime("%Y-%m-%d %H:%M")
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 
@@ -154,12 +154,12 @@ async def _run_heartbeat_to_channel(config, event_bus) -> None:
 
 def _make_http_client(config) -> httpx.AsyncClient | None:
     """Create an HTTP client for Mattermost posting. Returns None if not configured."""
-    if not config.mattermost_url or not config.mattermost_token:
+    if not config.mattermost.url or not config.mattermost.token:
         return None
 
-    base_url = config.mattermost_url.rstrip("/") + "/api/v4"
+    base_url = config.mattermost.url.rstrip("/") + "/api/v4"
     headers = {
-        "Authorization": f"Bearer {config.mattermost_token}",
+        "Authorization": f"Bearer {config.mattermost.token}",
         "Content-Type": "application/json",
     }
     return httpx.AsyncClient(base_url=base_url, headers=headers, timeout=30)
@@ -167,16 +167,16 @@ def _make_http_client(config) -> httpx.AsyncClient | None:
 
 async def _resolve_channel(http, config) -> str | None:
     """Resolve the heartbeat channel ID from config. Returns None if not configured."""
-    if config.heartbeat_channel:
-        return config.heartbeat_channel
+    if config.heartbeat.channel:
+        return config.heartbeat.channel
 
-    if config.heartbeat_user:
+    if config.heartbeat.user:
         me_resp = await http.get("/users/me")
         me_resp.raise_for_status()
         bot_user_id = me_resp.json()["id"]
 
         dm_resp = await http.post("/channels/direct",
-                                 json=[bot_user_id, config.heartbeat_user])
+                                 json=[bot_user_id, config.heartbeat.user])
         dm_resp.raise_for_status()
         return dm_resp.json()["id"]
 

--- a/src/decafclaw/tools/memory_tools.py
+++ b/src/decafclaw/tools/memory_tools.py
@@ -19,7 +19,7 @@ async def tool_memory_save(ctx, tags: list[str], content: str) -> str:
         content=content,
     )
     # Index for semantic search if enabled
-    if ctx.config.memory_search_strategy == "semantic":
+    if ctx.config.embedding.search_strategy == "semantic":
         try:
             from datetime import datetime
 
@@ -43,9 +43,9 @@ async def tool_memory_save(ctx, tags: list[str], content: str) -> str:
 
 async def tool_memory_search(ctx, query: str) -> str:
     """Search memories."""
-    log.info(f"[tool:memory_search] query={query} strategy={ctx.config.memory_search_strategy}")
+    log.info(f"[tool:memory_search] query={query} strategy={ctx.config.embedding.search_strategy}")
 
-    if ctx.config.memory_search_strategy == "semantic":
+    if ctx.config.embedding.search_strategy == "semantic":
         try:
             from .. import embeddings
             # Ensure index exists (reindex on first search if needed)

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -20,11 +20,7 @@ def estimate_tool_tokens(tool_defs: list[dict]) -> int:
 
 def get_always_loaded_names(config) -> set[str]:
     """Return the set of tool names that should always be loaded."""
-    extra = {
-        name.strip()
-        for name in getattr(config, "always_loaded_tools", "").split(",")
-        if name.strip()
-    }
+    extra = set(config.agent.always_loaded_tools)
     return DEFAULT_ALWAYS_LOADED | extra
 
 
@@ -41,7 +37,7 @@ def classify_tools(
     if fetched_names is None:
         fetched_names = set()
 
-    budget = getattr(config, "tool_context_budget", 10000)
+    budget = config.tool_context_budget
     total_tokens = estimate_tool_tokens(all_tool_defs)
 
     if total_tokens <= budget:

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -76,7 +76,7 @@ async def _handle_load_history(ws_send, index, username, msg, state):
     response = {
         "type": "conv_history", "conv_id": conv_id,
         "messages": messages, "has_more": has_more,
-        "context_limit": config.compaction_max_tokens,
+        "context_limit": config.compaction.max_tokens,
     }
     if estimated_tokens is not None:
         response["estimated_tokens"] = estimated_tokens
@@ -323,7 +323,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
             # (next iteration) or message_complete (end of turn)
             pass
 
-    if config.llm_streaming:
+    if config.llm.streaming:
         ctx.on_stream_chunk = on_stream_chunk
 
     # Track streaming state across LLM iterations
@@ -442,7 +442,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                 "completion_tokens": ctx.total_completion_tokens,
                 "total_tokens": ctx.total_prompt_tokens + ctx.total_completion_tokens,
             },
-            "context_limit": config.compaction_max_tokens,
+            "context_limit": config.compaction.max_tokens,
         })
 
         # Update conversation metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig
 from decafclaw.context import Context
 from decafclaw.events import EventBus
 
@@ -19,9 +20,11 @@ def tmp_data(tmp_path):
 def config(tmp_data):
     """Provides a Config pointing at temporary directories."""
     return Config(
-        data_home=str(tmp_data),
-        agent_id="test-agent",
-        agent_user_id="testuser",
+        agent=AgentConfig(
+            data_home=str(tmp_data),
+            id="test-agent",
+            user_id="testuser",
+        ),
     )
 
 

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -194,7 +194,7 @@ async def test_execute_tool_calls_concurrent(ctx):
 @pytest.mark.asyncio
 async def test_execute_tool_calls_semaphore_limits(ctx):
     """With max_concurrent_tools=1, execution is effectively sequential."""
-    ctx.config.max_concurrent_tools = 1
+    ctx.config.agent.max_concurrent_tools = 1
     concurrency_high_water = 0
     current_concurrency = 0
 
@@ -288,7 +288,7 @@ def _mock_llm_response(content="Hello!", tool_calls=None, usage=None):
 @pytest.mark.asyncio
 async def test_run_agent_turn_simple_response(ctx):
     """LLM returns a simple text response with no tool calls."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
 
     with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
@@ -307,7 +307,7 @@ async def test_run_agent_turn_simple_response(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_with_tool_call(ctx):
     """LLM calls a tool, gets result, then responds."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
 
     tool_call_response = _mock_llm_response(
@@ -340,7 +340,7 @@ async def test_run_agent_turn_with_tool_call(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_cancellation(ctx):
     """Turn is cancelled before LLM is called."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
     ctx.cancelled = asyncio.Event()
     ctx.cancelled.set()
@@ -353,9 +353,9 @@ async def test_run_agent_turn_cancellation(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_max_iterations(ctx):
     """LLM keeps calling tools until max iterations is reached."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
-    ctx.config.max_tool_iterations = 2
+    ctx.config.agent.max_tool_iterations = 2
 
     tool_call_response = _mock_llm_response(
         content=None,
@@ -379,9 +379,9 @@ async def test_run_agent_turn_max_iterations(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_max_iterations_preserves_text(ctx):
     """Max iterations preserves text from tool-call iterations."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
-    ctx.config.max_tool_iterations = 2
+    ctx.config.agent.max_tool_iterations = 2
 
     tool_call_response = _mock_llm_response(
         content="Let me check that for you.",
@@ -406,7 +406,7 @@ async def test_run_agent_turn_max_iterations_preserves_text(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_empty_response(ctx):
     """LLM returns empty content with no tool calls."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
 
     with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
@@ -420,7 +420,7 @@ async def test_run_agent_turn_empty_response(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_tracks_token_usage(ctx):
     """Token usage from LLM response is accumulated on context."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
 
     with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
@@ -437,7 +437,7 @@ async def test_run_agent_turn_tracks_token_usage(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_archives_messages(ctx):
     """Messages are archived during the turn."""
-    ctx.config.llm_streaming = False
+    ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
 
     with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -119,7 +119,7 @@ class TestCompactHistory:
     @pytest.mark.asyncio
     async def test_compacts_when_enough_turns(self, ctx, populated_archive):
         """With 8 turns and preserve=5, should compact 3 old turns."""
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
         history = [
             {"role": "user", "content": f"message {i}"}
             for i in range(8)
@@ -148,7 +148,7 @@ class TestCompactHistory:
         append_message(config, conv_id, {"role": "user", "content": "hello"})
         append_message(config, conv_id, {"role": "assistant", "content": "hi"})
 
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
         history = [{"role": "user", "content": "hello"}]
 
         result = await compact_history(ctx, history)
@@ -164,7 +164,7 @@ class TestCompactHistory:
     @pytest.mark.asyncio
     async def test_handles_llm_failure(self, ctx, populated_archive):
         """If LLM call fails, should return False and not modify history."""
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
         history = [{"role": "user", "content": "test"}]
         original_len = len(history)
 
@@ -177,7 +177,7 @@ class TestCompactHistory:
     @pytest.mark.asyncio
     async def test_handles_empty_summary(self, ctx, populated_archive):
         """If LLM returns empty summary, should skip."""
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
         history = [{"role": "user", "content": "test"}]
 
         mock_response = {"content": "", "tool_calls": None, "role": "assistant", "usage": None}
@@ -196,7 +196,7 @@ class TestCompactHistory:
             append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
             append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
 
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
 
         # Simulate a previous compaction that summarized turns 0-4,
         # preserving turns 5-9 (10 messages) as recent.
@@ -247,7 +247,7 @@ class TestCompactHistory:
             append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
             append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
 
-        ctx.config.compaction_preserve_turns = 5
+        ctx.config.compaction.preserve_turns = 5
 
         # Previous compaction summarized turns 0-2, preserved turns 3-7 (10 msgs).
         prev_recent = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,291 @@
+"""Tests for the config loader (JSON file + env vars + defaults)."""
+
+import json
+import os
+
+import pytest
+
+from decafclaw.config import Config, load_config
+from decafclaw.config_types import (
+    AgentConfig,
+    CompactionConfig,
+    EmbeddingConfig,
+    LlmConfig,
+    MattermostConfig,
+    is_secret,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Prevent .env file from leaking into tests."""
+    monkeypatch.setattr("decafclaw.config.load_dotenv", lambda **kw: None)
+    # Clear common env vars that .env may have set
+    for key in list(os.environ):
+        if any(key.startswith(p) for p in (
+            "LLM_", "MATTERMOST_", "COMPACTION_", "EMBEDDING_",
+            "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
+            "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
+        )):
+            monkeypatch.delenv(key, raising=False)
+
+
+class TestDefaults:
+    def test_default_config(self):
+        """Config() with no args gives expected defaults."""
+        c = Config()
+        assert c.llm.url == "http://192.168.0.199:4000/v1/chat/completions"
+        assert c.llm.model == "gemini-2.5-flash"
+        assert c.llm.streaming is True
+        assert c.mattermost.url == ""
+        assert c.mattermost.channel_blocklist == []
+        assert c.agent.data_home == "./data"
+        assert c.agent.id == "decafclaw"
+        assert c.agent.always_loaded_tools == []
+        assert c.compaction.max_tokens == 100000
+        assert c.embedding.search_strategy == "substring"
+
+    def test_derived_properties(self):
+        c = Config(agent=AgentConfig(data_home="/tmp/test", id="mybot"))
+        assert str(c.agent_path) == "/tmp/test/mybot"
+        assert str(c.workspace_path) == "/tmp/test/mybot/workspace"
+
+    def test_tool_context_budget(self):
+        c = Config(
+            compaction=CompactionConfig(max_tokens=100000),
+            agent=AgentConfig(tool_context_budget_pct=0.10),
+        )
+        assert c.tool_context_budget == 10000
+
+    def test_compaction_context_budget(self):
+        c = Config(compaction=CompactionConfig(max_tokens=100000, llm_max_tokens=50000))
+        assert c.compaction_context_budget == 50000
+
+    def test_compaction_context_budget_fallback(self):
+        c = Config(compaction=CompactionConfig(max_tokens=100000, llm_max_tokens=0))
+        assert c.compaction_context_budget == 100000
+
+
+class TestJsonFileLoading:
+    def test_loads_from_json(self, tmp_path, monkeypatch):
+        """Config file values are loaded."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        config_file = agent_dir / "config.json"
+        config_file.write_text(json.dumps({
+            "llm": {"model": "test-model"},
+            "mattermost": {"url": "https://mm.test.com"},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        # Clear env vars that .env may have set so JSON values win
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        monkeypatch.delenv("MATTERMOST_URL", raising=False)
+        c = load_config()
+        assert c.llm.model == "test-model"
+        assert c.mattermost.url == "https://mm.test.com"
+
+    def test_missing_file_uses_defaults(self, tmp_path, monkeypatch):
+        """Missing config file gracefully falls back to defaults."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+        c = load_config()
+        assert c.llm.model == "gemini-2.5-flash"
+
+
+class TestEnvVarOverride:
+    def test_env_overrides_file(self, tmp_path, monkeypatch):
+        """Env vars take priority over config file."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        config_file = agent_dir / "config.json"
+        config_file.write_text(json.dumps({
+            "llm": {"model": "from-file"},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("LLM_MODEL", "from-env")
+        c = load_config()
+        assert c.llm.model == "from-env"
+
+    def test_env_alias(self, tmp_path, monkeypatch):
+        """TABSTACK_API_KEY works as alias for SKILLS_TABSTACK_API_KEY."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("TABSTACK_API_KEY", "sk-alias")
+        monkeypatch.delenv("SKILLS_TABSTACK_API_KEY", raising=False)
+        c = load_config()
+        assert c.skills.tabstack.api_key == "sk-alias"
+
+    def test_systematic_env_takes_priority_over_alias(self, tmp_path, monkeypatch):
+        """SKILLS_TABSTACK_API_KEY beats TABSTACK_API_KEY."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("SKILLS_TABSTACK_API_KEY", "sk-systematic")
+        monkeypatch.setenv("TABSTACK_API_KEY", "sk-alias")
+        c = load_config()
+        assert c.skills.tabstack.api_key == "sk-systematic"
+
+
+class TestListFields:
+    def test_comma_separated(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("MATTERMOST_CHANNEL_BLOCKLIST", "a,b,c")
+        c = load_config()
+        assert c.mattermost.channel_blocklist == ["a", "b", "c"]
+
+    def test_json_array(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("MATTERMOST_CHANNEL_BLOCKLIST", '["x","y"]')
+        c = load_config()
+        assert c.mattermost.channel_blocklist == ["x", "y"]
+
+    def test_empty_string(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("MATTERMOST_CHANNEL_BLOCKLIST", "")
+        c = load_config()
+        assert c.mattermost.channel_blocklist == []
+
+    def test_list_from_json_file(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "mattermost": {"channel_blocklist": ["id1", "id2"]},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.delenv("MATTERMOST_CHANNEL_BLOCKLIST", raising=False)
+        c = load_config()
+        assert c.mattermost.channel_blocklist == ["id1", "id2"]
+
+
+class TestFallbackResolution:
+    def test_compaction_resolved(self):
+        """CompactionConfig.resolved() fills from llm."""
+        c = Config(
+            llm=LlmConfig(url="http://llm", model="llm-model", api_key="llm-key"),
+            compaction=CompactionConfig(),  # all empty
+        )
+        cc = c.compaction.resolved(c)
+        assert cc.url == "http://llm"
+        assert cc.model == "llm-model"
+        assert cc.api_key == "llm-key"
+
+    def test_compaction_override(self):
+        """Explicit compaction values are preserved."""
+        c = Config(
+            llm=LlmConfig(url="http://llm", model="llm-model"),
+            compaction=CompactionConfig(url="http://compact", model="compact-model"),
+        )
+        cc = c.compaction.resolved(c)
+        assert cc.url == "http://compact"
+        assert cc.model == "compact-model"
+
+    def test_embedding_resolved(self):
+        """EmbeddingConfig.resolved() derives URL from llm."""
+        c = Config(
+            llm=LlmConfig(
+                url="http://llm/v1/chat/completions",
+                api_key="llm-key",
+            ),
+            embedding=EmbeddingConfig(),
+        )
+        ec = c.embedding.resolved(c)
+        assert ec.url == "http://llm/v1/embeddings"
+        assert ec.api_key == "llm-key"
+
+    def test_embedding_override(self):
+        c = Config(
+            llm=LlmConfig(url="http://llm/v1/chat/completions"),
+            embedding=EmbeddingConfig(url="http://custom-embed"),
+        )
+        ec = c.embedding.resolved(c)
+        assert ec.url == "http://custom-embed"
+
+
+class TestBootstrapOrder:
+    def test_data_home_from_env_not_file(self, tmp_path, monkeypatch):
+        """data_home comes from env, not from config file."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "agent": {"data_home": "/should/be/ignored"},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        # The file's data_home is ignored because DATA_HOME env var wins
+        # (and DATA_HOME is checked first during bootstrap)
+        assert c.agent.data_home == str(tmp_path)
+
+
+class TestSecretMetadata:
+    def test_llm_api_key_is_secret(self):
+        assert is_secret(LlmConfig, "api_key") is True
+
+    def test_llm_model_not_secret(self):
+        assert is_secret(LlmConfig, "model") is False
+
+    def test_mattermost_token_is_secret(self):
+        assert is_secret(MattermostConfig, "token") is True
+
+    def test_compaction_api_key_is_secret(self):
+        assert is_secret(CompactionConfig, "api_key") is True
+
+    def test_embedding_api_key_is_secret(self):
+        assert is_secret(EmbeddingConfig, "api_key") is True
+
+
+class TestEnvSection:
+    def test_env_loaded_from_json(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "env": {"MY_CUSTOM_VAR": "hello", "ANOTHER": "world"},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.delenv("MY_CUSTOM_VAR", raising=False)
+        monkeypatch.delenv("ANOTHER", raising=False)
+        c = load_config()
+        assert c.env == {"MY_CUSTOM_VAR": "hello", "ANOTHER": "world"}
+        assert os.environ["MY_CUSTOM_VAR"] == "hello"
+        assert os.environ["ANOTHER"] == "world"
+
+    def test_env_does_not_override_existing(self, tmp_path, monkeypatch):
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "env": {"EXISTING_VAR": "from-config"},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("EXISTING_VAR", "from-env")
+        load_config()
+        assert os.environ["EXISTING_VAR"] == "from-env"
+
+    def test_apply_env_idempotent(self):
+        c = Config(env={"TEST_APPLY": "val"})
+        os.environ.pop("TEST_APPLY", None)
+        c.apply_env()
+        assert os.environ["TEST_APPLY"] == "val"
+        # Second call shouldn't fail
+        c.apply_env()
+        assert os.environ["TEST_APPLY"] == "val"
+        os.environ.pop("TEST_APPLY", None)
+
+
+class TestCompatRemoved:
+    def test_old_flat_names_raise(self):
+        """Old flat names should raise AttributeError."""
+        c = Config()
+        with pytest.raises(AttributeError):
+            _ = c.mattermost_url
+        with pytest.raises(AttributeError):
+            _ = c.llm_model
+        with pytest.raises(AttributeError):
+            _ = c.data_home

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -1,0 +1,134 @@
+"""Tests for the config CLI tool."""
+
+import json
+import os
+
+import pytest
+
+from decafclaw.config_cli import cmd_get, cmd_import_env, cmd_set, cmd_show
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Prevent .env file from leaking into tests."""
+    monkeypatch.setattr("decafclaw.config.load_dotenv", lambda **kw: None)
+    for key in list(os.environ):
+        if any(key.startswith(p) for p in (
+            "LLM_", "MATTERMOST_", "COMPACTION_", "EMBEDDING_",
+            "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
+            "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
+        )):
+            monkeypatch.delenv(key, raising=False)
+
+
+class _Args:
+    """Simple namespace for argparse-like args."""
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_show_masks_secrets(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group="llm", reveal=False))
+    out = capsys.readouterr().out
+    assert "****" in out
+    assert "llm.url" in out
+
+
+def test_show_reveal(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group="llm", reveal=True))
+    out = capsys.readouterr().out
+    assert "****" not in out
+    assert "llm.api_key = dummy" in out
+
+
+def test_show_group_filter(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group="heartbeat", reveal=False))
+    out = capsys.readouterr().out
+    assert "heartbeat.interval" in out
+    assert "llm." not in out
+
+
+def test_get(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_get(_Args(path="llm.model"))
+    out = capsys.readouterr().out.strip()
+    assert out == "gemini-2.5-flash"
+
+
+def test_get_unknown_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    with pytest.raises(SystemExit):
+        cmd_get(_Args(path="nonexistent.field"))
+
+
+def test_set_creates_file(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_set(_Args(path="llm.model", value="new-model"))
+    config_file = agent_dir / "config.json"
+    assert config_file.exists()
+    data = json.loads(config_file.read_text())
+    assert data["llm"]["model"] == "new-model"
+
+
+def test_set_preserves_existing(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    config_file = agent_dir / "config.json"
+    config_file.write_text(json.dumps({"llm": {"url": "http://existing"}}))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_set(_Args(path="llm.model", value="added-model"))
+    data = json.loads(config_file.read_text())
+    assert data["llm"]["url"] == "http://existing"
+    assert data["llm"]["model"] == "added-model"
+
+
+def test_set_bool_coercion(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_set(_Args(path="mattermost.require_mention", value="false"))
+    data = json.loads((agent_dir / "config.json").read_text())
+    assert data["mattermost"]["require_mention"] is False
+
+
+def test_set_int_coercion(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_set(_Args(path="mattermost.debounce_ms", value="2000"))
+    data = json.loads((agent_dir / "config.json").read_text())
+    assert data["mattermost"]["debounce_ms"] == 2000
+
+
+def test_import_env(capsys, monkeypatch, tmp_path):
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    env_file = tmp_path / "test.env"
+    env_file.write_text(
+        '# Comment\n'
+        'LLM_MODEL=test-model\n'
+        'MATTERMOST_URL=https://mm.test.com\n'
+        'HTTP_PORT=9999\n'
+        'CUSTOM_API_KEY=secret123\n'
+    )
+    cmd_import_env(_Args(file=str(env_file)))
+    data = json.loads((agent_dir / "config.json").read_text())
+    assert data["llm"]["model"] == "test-model"
+    assert data["mattermost"]["url"] == "https://mm.test.com"
+    assert data["http"]["port"] == 9999
+    # Unknown vars go to env section
+    assert data["env"]["CUSTOM_API_KEY"] == "secret123"
+    out = capsys.readouterr().out
+    assert "3 settings" in out
+    assert "1 env vars" in out

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -54,7 +54,8 @@ def test_fork_accepts_overrides(ctx):
 
 
 def test_fork_can_override_config(ctx):
-    new_config = Config(data_home="/tmp/other", agent_id="other-agent")
+    from decafclaw.config_types import AgentConfig
+    new_config = Config(agent=AgentConfig(data_home="/tmp/other", id="other-agent"))
     child = ctx.fork(config=new_config)
     assert child.config is new_config
     assert child.config is not ctx.config

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -43,7 +43,7 @@ class TestRunChildTurn:
         # Check the child context
         call_args = mock_run.call_args
         child_ctx = call_args[0][0]
-        assert child_ctx.config.max_tool_iterations == 10
+        assert child_ctx.config.agent.max_tool_iterations == 10
         assert child_ctx.config.system_prompt == DEFAULT_CHILD_SYSTEM_PROMPT
 
     @pytest.mark.asyncio
@@ -96,7 +96,7 @@ class TestRunChildTurn:
         async def slow_turn(*args, **kwargs):
             await asyncio.sleep(10)
 
-        ctx.config.child_timeout_sec = 0.1
+        ctx.config.agent.child_timeout_sec = 0.1
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock, side_effect=slow_turn):
             result = await _run_child_turn(ctx, "slow task")

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -97,4 +97,4 @@ def test_model_sentinel(config):
     row = conn.execute("SELECT value FROM metadata WHERE key='embedding_model'").fetchone()
     conn.close()
     assert row is not None
-    assert row[0] == config.embedding_model
+    assert row[0] == config.embedding.model

--- a/tests/test_handle_posted.py
+++ b/tests/test_handle_posted.py
@@ -3,22 +3,23 @@
 import json
 
 from decafclaw.config import Config
+from decafclaw.config_types import MattermostConfig
 from decafclaw.mattermost import MattermostClient
 
 
 def _make_config(**overrides):
     """Create a config with Mattermost settings."""
     defaults = dict(
-        mattermost_url="https://mm.example.com",
-        mattermost_token="test-token",
-        mattermost_bot_username="testbot",
-        mattermost_ignore_bots=True,
-        mattermost_ignore_webhooks=False,
-        mattermost_require_mention=True,
-        mattermost_channel_blocklist="",
+        url="https://mm.example.com",
+        token="test-token",
+        bot_username="testbot",
+        ignore_bots=True,
+        ignore_webhooks=False,
+        require_mention=True,
+        channel_blocklist=[],
     )
     defaults.update(overrides)
-    return Config(**defaults)
+    return Config(mattermost=MattermostConfig(**defaults))
 
 
 def _make_client(config=None):
@@ -89,7 +90,7 @@ def test_ignores_empty_messages():
 
 
 def test_ignores_bot_messages_when_configured():
-    client = _make_client(_make_config(mattermost_ignore_bots=True))
+    client = _make_client(_make_config(ignore_bots=True))
     received = []
     evt = _make_event(from_bot="true")
     client._handle_posted(evt, received.append)
@@ -97,7 +98,7 @@ def test_ignores_bot_messages_when_configured():
 
 
 def test_allows_bot_messages_when_not_configured():
-    client = _make_client(_make_config(mattermost_ignore_bots=False))
+    client = _make_client(_make_config(ignore_bots=False))
     received = []
     evt = _make_event(from_bot="true", channel_type="D")
     client._handle_posted(evt, received.append)
@@ -105,7 +106,7 @@ def test_allows_bot_messages_when_not_configured():
 
 
 def test_ignores_webhook_messages_when_configured():
-    client = _make_client(_make_config(mattermost_ignore_webhooks=True))
+    client = _make_client(_make_config(ignore_webhooks=True))
     received = []
     evt = _make_event(from_webhook="true")
     client._handle_posted(evt, received.append)
@@ -113,7 +114,7 @@ def test_ignores_webhook_messages_when_configured():
 
 
 def test_allows_webhook_messages_when_not_configured():
-    client = _make_client(_make_config(mattermost_ignore_webhooks=False))
+    client = _make_client(_make_config(ignore_webhooks=False))
     received = []
     evt = _make_event(from_webhook="true", channel_type="D")
     client._handle_posted(evt, received.append)
@@ -121,7 +122,7 @@ def test_allows_webhook_messages_when_not_configured():
 
 
 def test_channel_blocklist():
-    config = _make_config(mattermost_channel_blocklist="blocked-chan,other-blocked")
+    config = _make_config(channel_blocklist=["blocked-chan", "other-blocked"])
     client = _make_client(config)
     received = []
     evt = _make_event(channel_id="blocked-chan")
@@ -130,7 +131,7 @@ def test_channel_blocklist():
 
 
 def test_channel_not_in_blocklist():
-    config = _make_config(mattermost_channel_blocklist="blocked-chan")
+    config = _make_config(channel_blocklist=["blocked-chan"])
     client = _make_client(config)
     received = []
     evt = _make_event(channel_id="allowed-chan", channel_type="D")
@@ -140,7 +141,7 @@ def test_channel_not_in_blocklist():
 
 def test_require_mention_in_public_channel():
     """In public channels with require_mention, messages without @-mention are ignored."""
-    config = _make_config(mattermost_require_mention=True)
+    config = _make_config(require_mention=True)
     client = _make_client(config)
     received = []
     evt = _make_event(message="hello", channel_type="O")
@@ -150,7 +151,7 @@ def test_require_mention_in_public_channel():
 
 def test_mention_in_public_channel():
     """In public channels, messages with @-mention are dispatched."""
-    config = _make_config(mattermost_require_mention=True)
+    config = _make_config(require_mention=True)
     client = _make_client(config)
     received = []
     evt = _make_event(message="@testbot hello", channel_type="O")
@@ -162,7 +163,7 @@ def test_mention_in_public_channel():
 
 def test_dm_does_not_require_mention():
     """DM messages don't require @-mention even if require_mention is True."""
-    config = _make_config(mattermost_require_mention=True)
+    config = _make_config(require_mention=True)
     client = _make_client(config)
     received = []
     evt = _make_event(message="hello", channel_type="D")
@@ -172,7 +173,7 @@ def test_dm_does_not_require_mention():
 
 def test_thread_reply_does_not_require_mention():
     """Thread replies don't require @-mention."""
-    config = _make_config(mattermost_require_mention=True)
+    config = _make_config(require_mention=True)
     client = _make_client(config)
     received = []
     evt = _make_event(message="hello", channel_type="O", root_id="parent-post-id")

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -260,7 +260,7 @@ async def test_run_heartbeat_cycle_isolated_history(config):
 @pytest.mark.asyncio
 async def test_timer_disabled(config):
     """Timer returns immediately when interval is disabled."""
-    config.heartbeat_interval = ""
+    config.heartbeat.interval = ""
     shutdown = asyncio.Event()
     # Should return immediately, not block
     await asyncio.wait_for(
@@ -274,7 +274,7 @@ async def test_timer_fires_callback(config):
     """Timer fires on_results callback after interval."""
     from decafclaw.events import EventBus
 
-    config.heartbeat_interval = "1"  # 1 second
+    config.heartbeat.interval = "1"  # 1 second
 
     admin_path = config.agent_path / "HEARTBEAT.md"
     admin_path.parent.mkdir(parents=True, exist_ok=True)
@@ -315,7 +315,7 @@ async def test_timer_respects_shutdown(config):
     """Timer stops when shutdown event is set."""
     from decafclaw.events import EventBus
 
-    config.heartbeat_interval = "300"  # 5 minutes — would block without shutdown
+    config.heartbeat.interval = "300"  # 5 minutes — would block without shutdown
     shutdown = asyncio.Event()
 
     # Signal shutdown after a short delay

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -13,11 +13,11 @@ from decafclaw.mattermost_ui import build_confirm_buttons, get_token_registry
 @pytest.fixture
 def http_config(config):
     """Config with HTTP enabled."""
-    config.http_enabled = True
-    config.http_secret = "test-secret"
-    config.http_host = "127.0.0.1"
-    config.http_port = 18880
-    config.http_base_url = ""
+    config.http.enabled = True
+    config.http.secret = "test-secret"
+    config.http.host = "127.0.0.1"
+    config.http.port = 18880
+    config.http.base_url = ""
     return config
 
 
@@ -237,7 +237,7 @@ async def test_confirm_response_includes_original_message(client):
 
 
 def test_buttons_empty_when_http_disabled(config):
-    config.http_enabled = False
+    config.http.enabled = False
     result = build_confirm_buttons(
         config, "shell", "ls", "ls *", "ctx-1", "msg"
     )

--- a/tests/test_llm_streaming.py
+++ b/tests/test_llm_streaming.py
@@ -73,7 +73,8 @@ def _make_tool_call_events(name, arguments_chunks, tool_id="call_0", index=0):
 def _config():
     """Minimal config for testing."""
     from decafclaw.config import Config
-    return Config(llm_url="http://test/v1/chat/completions")
+    from decafclaw.config_types import LlmConfig
+    return Config(llm=LlmConfig(url="http://test/v1/chat/completions"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -55,7 +55,7 @@ class TestGetAlwaysLoadedNames:
         assert "shell" in names
 
     def test_user_override_extends(self, config):
-        config.always_loaded_tools = "my_custom_tool,another_one"
+        config.agent.always_loaded_tools = ["my_custom_tool", "another_one"]
         names = get_always_loaded_names(config)
         assert "my_custom_tool" in names
         assert "another_one" in names
@@ -63,7 +63,7 @@ class TestGetAlwaysLoadedNames:
         assert "think" in names
 
     def test_empty_override(self, config):
-        config.always_loaded_tools = ""
+        config.agent.always_loaded_tools = []
         names = get_always_loaded_names(config)
         assert names == DEFAULT_ALWAYS_LOADED
 
@@ -75,7 +75,7 @@ class TestClassifyTools:
     def test_under_budget_no_deferral(self, config):
         """When tools fit in budget, all are active, none deferred."""
         tools = [_make_tool_def(f"tool_{i}") for i in range(3)]
-        config.compaction_max_tokens = 1000000  # huge budget
+        config.compaction.max_tokens = 1000000  # huge budget
         active, deferred = classify_tools(tools, config)
         assert len(active) == 3
         assert len(deferred) == 0
@@ -86,7 +86,7 @@ class TestClassifyTools:
         tools = [_make_tool_def(f"tool_{i}", "x" * 200) for i in range(20)]
         # Add an always-loaded tool
         tools.append(_make_tool_def("think", "Internal reasoning"))
-        config.compaction_max_tokens = 100  # tiny budget → 10 token budget
+        config.compaction.max_tokens = 100  # tiny budget → 10 token budget
 
         active, deferred = classify_tools(tools, config)
         active_names = {td["function"]["name"] for td in active}
@@ -100,7 +100,7 @@ class TestClassifyTools:
     def test_fetched_tools_in_active(self, config):
         """Fetched tools stay in the active set."""
         tools = [_make_tool_def(f"tool_{i}", "x" * 200) for i in range(20)]
-        config.compaction_max_tokens = 100
+        config.compaction.max_tokens = 100
 
         active, deferred = classify_tools(tools, config, fetched_names={"tool_5"})
         active_names = {td["function"]["name"] for td in active}

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -66,11 +66,11 @@ def test_multiple_tokens_same_user(config):
 
 @pytest.fixture
 def http_config(config):
-    config.http_enabled = True
-    config.http_secret = "test-secret"
-    config.http_host = "127.0.0.1"
-    config.http_port = 18880
-    config.http_base_url = ""
+    config.http.enabled = True
+    config.http.secret = "test-secret"
+    config.http.host = "127.0.0.1"
+    config.http.port = 18880
+    config.http.base_url = ""
     config.agent_path.mkdir(parents=True, exist_ok=True)
     return config
 

--- a/tests/test_web_conversations.py
+++ b/tests/test_web_conversations.py
@@ -138,11 +138,11 @@ def test_load_history_pagination(config):
 
 @pytest.fixture
 def http_config(config):
-    config.http_enabled = True
-    config.http_secret = "test-secret"
-    config.http_host = "127.0.0.1"
-    config.http_port = 18880
-    config.http_base_url = ""
+    config.http.enabled = True
+    config.http.secret = "test-secret"
+    config.http.host = "127.0.0.1"
+    config.http.port = 18880
+    config.http.base_url = ""
     config.agent_path.mkdir(parents=True, exist_ok=True)
     return config
 

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -46,7 +46,7 @@ def test_resolve_safe_rejects_absolute(config):
 def test_resolve_safe_rejects_prefix_attack(config, tmp_data):
     """Workspace '/tmp/ws' should not allow access to '/tmp/ws2/...'."""
     # Create a sibling directory whose name starts with the workspace path
-    sibling = tmp_data / config.agent_id / "workspace2"
+    sibling = tmp_data / config.agent.id / "workspace2"
     sibling.mkdir(parents=True, exist_ok=True)
     (sibling / "secret.txt").write_text("secret")
     # The attack: workspace is '.../workspace', try to reach '.../workspace2'


### PR DESCRIPTION
## Summary

- Redesign configuration from 54 flat env vars to a layered system: defaults → `data/{agent_id}/config.json` → env vars
- 8 grouped sub-dataclasses in `config_types.py` with field metadata for secrets and env var aliases
- Generic loader with bootstrap phase, type coercion, list field parsing
- CLI tool: `decafclaw config show/get/set/import` with secret masking
- `resolved()` pattern on CompactionConfig/EmbeddingConfig for LLM fallbacks at call site
- `env` section for arbitrary environment variables from config.json
- `config import` converts .env files to config.json (unknown vars go to env section)
- All 20+ source modules and 15+ test files updated to nested access
- 37 new tests, 568 total passing
- Full docs at `docs/config.md`

Closes #1

## Test plan

- [ ] `make check` passes (lint + pyright + tsc)
- [ ] `make test` passes (568 tests)
- [ ] `decafclaw config show` displays all groups with secrets masked
- [ ] `decafclaw config show --reveal` shows secret values
- [ ] `decafclaw config set llm.model test && decafclaw config get llm.model` round-trips
- [ ] `decafclaw config import .env` creates config.json with correct structure
- [ ] Bot starts and connects to Mattermost with existing .env (backward compat)
- [ ] Bot starts with config.json only (no .env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)