### PR TITLE
Self-reflection: evaluate responses before delivery

### DIFF
--- a/.claude/dev-sessions/2026-03-19-1549-self-reflection/notes.md
+++ b/.claude/dev-sessions/2026-03-19-1549-self-reflection/notes.md
@@ -1,0 +1,31 @@
+# Self-Reflection / Retry — Notes
+
+## Session Recap
+
+Implemented the Reflexion pattern for self-evaluation of agent responses before delivery. A separate judge LLM call evaluates whether the response adequately addresses the user's request. On failure, critique is injected and the agent retries.
+
+### What we built
+- **reflection.py** — judge module: prompt assembly, LLM call, JSON verdict parsing, fail-open error handling
+- **ReflectionConfig** — separate model config with `resolved()` fallback to LLM (like compaction/embedding)
+- **Agent loop integration** — reflection check after final response, critique injection as user-role message, `continue` for retry within existing iteration loop
+- **UI visibility** — `reflection_result` event handled in Mattermost and web UI, three modes (hidden/visible/debug)
+- **22 new tests** — 16 unit tests for reflection.py, 6 integration tests for agent loop
+
+### Key design decisions
+1. **Reflexion pattern** — binary pass/fail with verbal critique, not multi-dimensional scoring
+2. **Chain-of-thought before verdict** (G-Eval) — judge reasons first, then outputs JSON
+3. **Fail-open** — judge errors, parse failures, and network issues all treated as pass
+4. **User-role critique messages** — higher weight than system messages for most models
+5. **Within iteration budget** — reflection retries consume from `max_tool_iterations`, not additional
+6. **Reflection disabled in test fixtures** — tests opt in explicitly to avoid mock complexity
+
+### Stats
+- 590 tests passing, lint + pyright + tsc clean
+- ~180 lines in reflection.py
+- ~30 lines added to agent.py
+- ~20 lines each for Mattermost/web UI event handling
+
+### Session observations
+- The test fixture issue was the trickiest part — reflection is on by default, so the existing mocked tests were hitting the real LLM as the judge. Disabling in conftest was the right call.
+- Patching the deferred import (`from .reflection import evaluate_response` inside the function) required patching at the source module, not `decafclaw.agent.evaluate_response`.
+- The pyright warning about `client.config` on MattermostClient caught a real issue — config isn't stored on the client, so we had to pass `reflection_visibility` as a parameter.

--- a/.claude/dev-sessions/2026-03-19-1549-self-reflection/plan.md
+++ b/.claude/dev-sessions/2026-03-19-1549-self-reflection/plan.md
@@ -1,0 +1,338 @@
+# Self-Reflection / Retry — Plan
+
+## Status: Ready
+
+## Overview
+
+Four phases. Phase 1 adds the config and the core reflection module. Phase 2 integrates it into the agent loop. Phase 3 adds visibility (events for Mattermost/web UI). Phase 4 adds tests and docs. Each phase ends with lint + test passing and a commit.
+
+The reflection feature is a single `call_llm()` to a judge model after the agent produces a final response. If the judge says fail, the critique is injected as a user-role message and the agent loop `continue`s. This means the core implementation is small — most of the work is in the agent loop integration and the UI visibility.
+
+---
+
+## Phase 1: Config + reflection module
+
+**Goal**: Add `ReflectionConfig` to the config system and create `reflection.py` with the judge logic — prompt assembly, LLM call, result parsing. No integration with the agent loop yet.
+
+**Files**: `src/decafclaw/config_types.py`, `src/decafclaw/config.py`, `src/decafclaw/reflection.py`
+
+### Prompt
+
+**Step 1a: Add ReflectionConfig**
+
+Read `src/decafclaw/config_types.py` and add a new `ReflectionConfig` dataclass:
+
+```python
+@dataclass
+class ReflectionConfig:
+    enabled: bool = True
+    url: str = ""       # empty = resolve from llm
+    model: str = ""     # empty = resolve from llm
+    api_key: str = field(default="", metadata={"secret": True})
+    max_retries: int = 2
+    visibility: str = "hidden"  # hidden | visible | debug
+
+    def resolved(self, config) -> ReflectionConfig:
+        """Return copy with empty url/model/api_key filled from config.llm."""
+        return replace(self,
+            url=self.url or config.llm.url,
+            model=self.model or config.llm.model,
+            api_key=self.api_key or config.llm.api_key,
+        )
+```
+
+Add `reflection: ReflectionConfig` to the top-level `Config` class in `config.py`. Wire it into `load_config()` with env prefix `"REFLECTION"`. Add it to the config CLI's show/get/set support (it's a dataclass sub-config, so it should work automatically).
+
+Lint and test after.
+
+**Step 1b: Create reflection.py**
+
+Create `src/decafclaw/reflection.py` with:
+
+1. **Default judge prompt** — hardcoded string constant with `{user_message}`, `{tool_results_summary}`, `{agent_response}` placeholders.
+
+2. **`load_reflection_prompt(config)`** — returns the prompt template. Checks for `data/{agent_id}/REFLECTION.md` override file; if not found, returns the default.
+
+3. **`build_tool_summary(history, turn_start_index)`** — extracts tool call/result pairs from history starting at `turn_start_index` (where the user message was appended). For each tool call, formats as:
+   ```
+   Tool: {name}({key_args})
+   Result: {truncated_result}
+   ```
+   Truncates results to 500 chars. Returns empty string if no tools were used.
+
+4. **`async def evaluate_response(config, user_message, agent_response, tool_summary)`** — the main judge function:
+   - Loads the prompt template
+   - Fills in the template variables
+   - Calls `call_llm()` with the reflection model (via `config.reflection.resolved(config)`)
+   - Parses the JSON verdict from the response
+   - Returns a `ReflectionResult` dataclass:
+     ```python
+     @dataclass
+     class ReflectionResult:
+         passed: bool
+         critique: str = ""
+         raw_response: str = ""  # full judge output for debug mode
+         error: str = ""         # if the judge call failed
+     ```
+   - On any error (network, parse, etc.), returns `ReflectionResult(passed=True, error="...")` — fail-open.
+
+5. **JSON parsing** — the judge response may have the JSON embedded in reasoning text. Extract the JSON object containing `"pass"` and `"critique"` keys. Try `json.loads()` on the full response first; if that fails, regex search for `{...}` patterns. If all parsing fails, treat as pass.
+
+Lint after. No integration yet — this is a standalone module.
+
+---
+
+## Phase 2: Agent loop integration
+
+**Goal**: Wire reflection into `run_agent_turn()`. After the agent produces a final response, call the judge. If it fails, inject critique and continue the loop.
+
+**Files**: `src/decafclaw/agent.py`, `src/decafclaw/context.py`, `src/decafclaw/tools/delegate.py`
+
+### Prompt
+
+Read the spec at `.claude/dev-sessions/2026-03-19-1549-self-reflection/spec.md` and `src/decafclaw/agent.py`.
+
+**Step 2a: Add `is_child` flag to Context**
+
+In `src/decafclaw/context.py`, add `self.is_child: bool = False` to `__init__`.
+
+In `src/decafclaw/tools/delegate.py`, set `child_ctx.is_child = True` after forking the child context.
+
+**Step 2b: Integrate reflection into the agent loop**
+
+In `run_agent_turn()`, modify the "No tool calls — final response" path (currently lines ~456-479). The current flow is:
+
+```python
+# No tool calls — final response
+content = response.get("content") or ""
+# ... empty retry logic ...
+final_msg = {"role": "assistant", "content": content}
+history.append(final_msg)
+_archive(ctx, final_msg)
+# ... compaction, media extraction, return ...
+```
+
+Change to:
+
+```python
+# No tool calls — final response
+content = response.get("content") or ""
+# ... empty retry logic ...
+
+# Reflection check
+if _should_reflect(ctx, config, content, reflection_retries):
+    from .reflection import evaluate_response, build_tool_summary
+    tool_summary = build_tool_summary(history, turn_start_index)
+    result = await evaluate_response(config, user_message, content, tool_summary)
+
+    # Publish reflection event (for UI visibility)
+    await ctx.publish("reflection_result",
+        passed=result.passed,
+        critique=result.critique,
+        raw_response=result.raw_response,
+        retry_number=reflection_retries + 1,
+        error=result.error)
+
+    if not result.passed and not result.error:
+        # Add the failed response to history
+        failed_msg = {"role": "assistant", "content": content}
+        history.append(failed_msg)
+        messages.append(failed_msg)
+        _archive(ctx, failed_msg)
+
+        # Add critique as user message
+        critique_msg = {
+            "role": "user",
+            "content": (
+                f"[reflection] Your previous response may not fully address "
+                f"the user's request.\nFeedback: {result.critique}\n"
+                f"Please try again, addressing the feedback above."
+            ),
+        }
+        history.append(critique_msg)
+        messages.append(critique_msg)
+        _archive(ctx, critique_msg)
+
+        reflection_retries += 1
+        continue  # back to LLM call
+
+# Normal final response path (unchanged from here)
+final_msg = {"role": "assistant", "content": content}
+history.append(final_msg)
+_archive(ctx, final_msg)
+# ... etc ...
+```
+
+Add these variables at the top of the try block (before the iteration loop):
+- `reflection_retries = 0`
+- `turn_start_index = len(history)` (before the user message is appended — actually, capture it right after appending the user message: `turn_start_index = len(history) - 1`)
+
+**`_should_reflect()` helper:**
+
+```python
+def _should_reflect(ctx, config, content, reflection_retries) -> bool:
+    """Check whether reflection should run on this response."""
+    if not config.reflection.enabled:
+        return False
+    if reflection_retries >= config.reflection.max_retries:
+        return False
+    if ctx.is_child:
+        return False
+    if not content or not content.strip():
+        return False
+    if getattr(ctx, 'cancelled', None) and ctx.cancelled.is_set():
+        return False
+    return True
+```
+
+Note: the "max iterations hit" skip condition is handled naturally — if we've exhausted the iteration loop, we never reach the reflection check (we exit the for loop).
+
+Lint and test after. Existing tests should still pass since reflection is on by default but the judge just calls the LLM — in tests, the LLM is mocked.
+
+---
+
+## Phase 3: UI visibility
+
+**Goal**: Handle `reflection_result` events in Mattermost and web UI based on visibility mode.
+
+**Files**: `src/decafclaw/mattermost.py`, `src/decafclaw/web/websocket.py`
+
+### Prompt
+
+Read `src/decafclaw/mattermost.py` — look at how `_subscribe_progress` and `ConversationDisplay` handle events like `tool_start`/`tool_end`.
+
+Read `src/decafclaw/web/websocket.py` — look at `on_turn_event()`.
+
+**Step 3a: Mattermost visibility**
+
+In `_subscribe_progress` / the event handler, add handling for the `reflection_result` event:
+
+```python
+elif event_name == "reflection_result":
+    visibility = config.reflection.visibility
+    if visibility == "hidden":
+        pass  # suppress
+    elif visibility == "visible":
+        passed = data.get("passed", True)
+        if not passed:
+            critique = data.get("critique", "")
+            retry_num = data.get("retry_number", 0)
+            display.on_reflection(
+                passed=False,
+                critique=critique,
+                retry_number=retry_num,
+            )
+    elif visibility == "debug":
+        display.on_reflection_debug(
+            passed=data.get("passed", True),
+            critique=data.get("critique", ""),
+            raw_response=data.get("raw_response", ""),
+            retry_number=data.get("retry_number", 0),
+            error=data.get("error", ""),
+        )
+```
+
+Add `on_reflection()` and `on_reflection_debug()` methods to `ConversationDisplay`. These should update the current message with a collapsed attachment (Mattermost supports this via `props.attachments`):
+
+For `visible` mode:
+```
+[Reflection retry 1/2] Response may not fully address the question.
+Feedback: {critique}
+```
+
+For `debug` mode, include the full raw judge response and error info.
+
+**Step 3b: Web UI visibility**
+
+In `on_turn_event()` in websocket.py, add handling for `reflection_result`:
+
+```python
+elif event_name == "reflection_result":
+    visibility = config.reflection.visibility
+    if visibility != "hidden":
+        await ws_send({
+            "type": "reflection_result",
+            "conv_id": conv_id,
+            "passed": data.get("passed", True),
+            "critique": data.get("critique", ""),
+            "retry_number": data.get("retry_number", 0),
+            "raw_response": data.get("raw_response", "") if visibility == "debug" else "",
+            "error": data.get("error", ""),
+        })
+```
+
+The web frontend can render this however it likes — we just send the data.
+
+Lint and test after.
+
+---
+
+## Phase 4: Tests and docs
+
+**Goal**: Add tests for the reflection module and agent loop integration. Update docs.
+
+**Files**: `tests/test_reflection.py`, `tests/test_agent_turn.py`, `CLAUDE.md`, `docs/`
+
+### Prompt
+
+**Step 4a: Unit tests for reflection.py**
+
+Create `tests/test_reflection.py`:
+
+- `test_build_tool_summary_no_tools` — empty history returns empty string
+- `test_build_tool_summary_with_tools` — formats tool calls correctly
+- `test_build_tool_summary_truncates` — long results are truncated
+- `test_evaluate_response_pass` — mock LLM returns pass verdict, returns ReflectionResult(passed=True)
+- `test_evaluate_response_fail` — mock LLM returns fail verdict with critique
+- `test_evaluate_response_unparseable` — mock LLM returns garbage, treated as pass
+- `test_evaluate_response_network_error` — mock LLM raises, treated as pass with error
+- `test_evaluate_response_json_in_reasoning` — JSON embedded in reasoning text is extracted
+- `test_load_reflection_prompt_default` — no override file, returns default
+- `test_load_reflection_prompt_override` — file exists, returns its content
+
+**Step 4b: Integration tests in test_agent_turn.py**
+
+Add to existing test file:
+
+- `test_reflection_pass_delivers_response` — mock judge returns pass, response delivered normally
+- `test_reflection_fail_retries` — mock judge returns fail then pass, verify critique injected and second response delivered
+- `test_reflection_max_retries_delivers_last` — mock judge always fails, verify last response delivered after max retries
+- `test_reflection_disabled_skips` — set `config.reflection.enabled = False`, verify no judge call
+- `test_reflection_child_skips` — set `ctx.is_child = True`, verify no judge call
+- `test_reflection_error_delivers_response` — mock judge errors, response delivered as-is
+- `test_reflection_within_iteration_budget` — verify reflection retries consume iterations from `max_tool_iterations`
+
+For all tests, mock `call_llm` to return canned responses. The reflection judge is just another `call_llm` call with different params — intercept based on the model parameter.
+
+**Step 4c: Docs**
+
+- Create `docs/reflection.md` — feature documentation covering config, prompt customization, visibility modes, how it works
+- Update `docs/index.md` — add reflection page
+- Update `CLAUDE.md` — add `reflection.py` to key files, add convention note about reflection
+- Update `docs/config.md` — add reflection group to config reference
+
+Lint and test after. Final commit.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (config + reflection.py module)
+  ↓
+Phase 2 (agent loop integration)
+  ↓
+Phase 3 (UI visibility — Mattermost + web)
+  ↓
+Phase 4 (tests + docs)
+```
+
+Phases are strictly sequential. Phase 1 is standalone code. Phase 2 depends on Phase 1. Phase 3 depends on Phase 2 (needs the event). Phase 4 depends on all.
+
+## Risk Notes
+
+- **Judge false positives** (~10%) — the retry budget limits damage but could still cause 1-2 unnecessary retries per turn. The default prompt needs careful tuning to bias toward passing. "If adequate, even if imperfect, pass it" is the key instruction.
+- **Latency** — adds one LLM call per turn (or more on retries). With a fast model like Flash, this should be <1s. But it's blocking — the user waits. Consider logging timing.
+- **History pollution** — failed responses + critiques stay in history. Over a long conversation, this could accumulate noise. Compaction should handle this naturally (the compaction summarizer will condense old reflection exchanges).
+- **Prompt template override** — if `REFLECTION.md` has bugs (missing placeholders, bad instructions), the judge will behave unpredictably. The fail-open design (treat parse errors as pass) mitigates this.
+- **Testing complexity** — the agent loop tests need to mock two different LLM calls (main model + judge). Pattern: intercept `call_llm` and dispatch based on the model parameter or call sequence.

--- a/.claude/dev-sessions/2026-03-19-1549-self-reflection/spec.md
+++ b/.claude/dev-sessions/2026-03-19-1549-self-reflection/spec.md
@@ -1,0 +1,199 @@
+# Self-Reflection / Retry — Spec
+
+## Status: Ready
+
+## Background
+
+The agent sometimes produces responses that don't actually answer the user's question — tool loops that lose the thread, partial answers to multi-part questions, or deflections when the agent has the tools to help. Currently there's no mechanism to catch this before the response reaches the user.
+
+This implements the Reflexion pattern (Shinn et al., NeurIPS 2023): after the agent produces a final response, a separate "judge" LLM call evaluates whether it adequately addresses the user's request. If not, the critique is injected into the conversation and the agent retries.
+
+Closes #16.
+
+## References
+
+- [Reflexion: Language Agents with Verbal Reinforcement Learning (arXiv)](https://arxiv.org/abs/2303.11366) — the core pattern: binary eval + verbal reflection + retry
+- [Reflexion GitHub repo](https://github.com/noahshinn/reflexion) — reference implementation
+- [Reflexion - Prompt Engineering Guide](https://www.promptingguide.ai/techniques/reflexion) — accessible overview
+- [LangGraph Reflection Agents](https://blog.langchain.com/reflection-agents/) — production patterns for critique-then-revise loops
+- [G-Eval](https://www.confident-ai.com/blog/g-eval-the-definitive-guide) — chain-of-thought before scoring improves judge accuracy
+
+## Goals
+
+1. Catch inadequate responses before they reach the user
+2. Use a cheap/fast model as the judge to keep costs low
+3. Retry with specific feedback so the agent can improve
+4. Make the reflection process configurable and optionally visible
+5. Fail gracefully — never make the user experience worse than no reflection
+
+## Design
+
+### Where it runs
+
+Integrated into the agent loop in `agent.py`. When the agent produces a final response (no more tool calls), the reflection check runs before the response is delivered. This is the interception point at approximately line 456-479 of `agent.py`.
+
+### What the judge sees
+
+The judge receives the turn's message chain — not the full conversation history. Specifically:
+
+1. The user's message that started this turn
+2. Tool call/result pairs from this turn (condensed — tool name, arguments, result text)
+3. The agent's final response
+
+This keeps the judge context window small and focused. The judge doesn't need prior conversation history — it only evaluates whether this turn's response addresses this turn's request.
+
+### Judge prompt
+
+The judge uses a chain-of-thought-before-verdict prompt (G-Eval pattern):
+
+```
+You are evaluating whether an AI assistant's response adequately addresses
+the user's request.
+
+Review the interaction below, then:
+1. Identify what the user asked for
+2. Assess whether the response addresses it
+3. Note any specific gaps or problems
+
+Then output your verdict as JSON:
+{"pass": true/false, "critique": "specific feedback if failed"}
+
+If the response is adequate, even if imperfect, pass it.
+Only fail responses that clearly miss the point, ignore the question,
+or contain significant errors relative to the tool results.
+
+---
+
+User: {user_message}
+
+{tool_results_summary}
+
+Assistant response: {agent_response}
+```
+
+**Default prompt is hardcoded.** An override file at `data/{agent_id}/REFLECTION.md` replaces it entirely if present. The file receives the same `{user_message}`, `{tool_results_summary}`, and `{agent_response}` template variables.
+
+### Retry mechanics
+
+When the judge returns `pass: false`:
+
+1. The agent's failed response stays in history as an assistant message
+2. A `user`-role message is injected with the critique (user-role because most models weight it more heavily than system messages, matching the Reflexion pattern):
+   ```
+   [reflection] Your previous response may not fully address the user's request.
+   Feedback: {critique}
+   Please try again, addressing the feedback above.
+   ```
+3. The agent loop `continue`s back to the LLM call step within the existing iteration loop — no nested loop. The agent sees its failed response + the critique and generates a new response. It can make new tool calls if needed.
+4. The new response goes through reflection again (up to `max_retries`).
+
+A `reflection_retries` counter tracks how many times reflection has triggered in this turn. The reflection check is skipped when `reflection_retries >= max_retries`.
+
+**Retry budget:** `max_retries` (default 2) counts reflection failures per turn. This is independent of `max_tool_iterations`, but retries consume iterations from the same `max_tool_iterations` budget. If the iteration budget is exhausted during a retry, the turn ends with whatever the agent has produced — no further reflection.
+
+### Skip conditions
+
+Reflection is automatically skipped when:
+
+- **Reflection is disabled** (`reflection.enabled = false`)
+- **Max iterations hit** — the agent already hit `max_tool_iterations`, retrying won't help
+- **Cancelled turn** — user interrupted
+- **Child agent turn** — delegation subtasks aren't evaluated individually; the parent turn is. Detected via a new `ctx.is_child` flag, set by `delegate.py` when forking child contexts.
+- **Empty response** — nothing to evaluate (already handled by the empty retry logic)
+- **Max retries exhausted** — deliver the last response as-is
+
+### Visibility modes
+
+Configured via `reflection.visibility`:
+
+- **`hidden`** (default) — the user sees only the final (possibly retried) response. Reflection messages don't appear in the UI. They remain in the internal history for diagnostics.
+- **`visible`** — reflection results appear in the UI like collapsed tool calls. Shows the verdict and critique text.
+- **`debug`** — full details: the judge's chain-of-thought reasoning, score, retry count, model used, token usage.
+
+In all modes, the failed response + critique messages stay in the conversation history (for both the agent's benefit on future turns and diagnostic purposes).
+
+Visibility is implemented via a `reflection_result` event published through `ctx.publish()`. Mattermost and web UI subscribers render it based on the configured visibility mode — hidden (suppress), visible (collapsed attachment), or debug (full details).
+
+### Judge model
+
+The judge uses a separate model configuration that falls back to the main LLM config, following the same `resolved()` pattern as compaction and embedding:
+
+```python
+@dataclass
+class ReflectionConfig:
+    enabled: bool = True
+    url: str = ""       # empty = resolve from llm
+    model: str = ""     # empty = resolve from llm
+    api_key: str = ""   # empty = resolve from llm
+    max_retries: int = 2
+    visibility: str = "hidden"  # hidden | visible | debug
+
+    def resolved(self, config) -> "ReflectionConfig":
+        ...
+```
+
+This lets you run Gemini Pro as the main model and Flash as the judge, for example.
+
+### Config
+
+New `reflection` group in config.json:
+
+```json
+{
+  "reflection": {
+    "enabled": true,
+    "model": "gemini-2.5-flash",
+    "max_retries": 2,
+    "visibility": "hidden"
+  }
+}
+```
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `enabled` | bool | `true` | `REFLECTION_ENABLED` | |
+| `url` | str | (from llm) | `REFLECTION_URL` | |
+| `model` | str | (from llm) | `REFLECTION_MODEL` | |
+| `api_key` | str | (from llm) | `REFLECTION_API_KEY` | yes |
+| `max_retries` | int | `2` | `REFLECTION_MAX_RETRIES` | |
+| `visibility` | str | `hidden` | `REFLECTION_VISIBILITY` | |
+
+### Tool results summary format
+
+The judge needs a condensed view of tool activity. For each tool call in the turn:
+
+```
+Tool: {tool_name}({key_args})
+Result: {truncated_result}
+```
+
+Results are truncated to a reasonable length (e.g. 500 chars) to keep the judge context small. If there are many tool calls, group them:
+
+```
+Tools used this turn:
+1. memory_search(query="weather API") → Found 2 results: ...
+2. workspace_read(path="config.yaml") → (284 chars)
+3. shell(command="curl ...") → {"temperature": 72, ...}
+```
+
+### Error handling
+
+- **Judge call fails** (network error, model error) — deliver the response as-is, log the error. Never block the user because reflection broke.
+- **Judge returns unparseable output** — treat as pass, log warning.
+- **Judge false positive** (says fail when response is fine, ~10% rate per research) — the retry budget limits damage. After `max_retries`, deliver whatever the agent has.
+
+### What this does NOT do
+
+- **Post-delivery correction** — no follow-up messages after the response is sent
+- **Multi-dimensional scoring** — binary pass/fail only, no rubrics
+- **Cross-turn learning** — no persistent reflection memory across conversations
+- **Evaluation of tool choice** — the judge evaluates the response, not whether the agent picked the right tools
+
+## Files Changed
+
+- **New**: `src/decafclaw/reflection.py` — judge call, prompt assembly, result parsing
+- **Update**: `src/decafclaw/agent.py` — reflection check after final response, retry loop
+- **Update**: `src/decafclaw/config_types.py` — add ReflectionConfig
+- **Update**: `src/decafclaw/config.py` — load reflection config
+- **New**: `data/decafclaw/REFLECTION.md` — (optional) custom judge prompt override
+- **Update**: tests, docs, CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/tools/delegate.py` — Sub-agent delegation: `delegate_task` forks a child agent for a single subtask (call multiple times for parallel work)
 - `src/decafclaw/tools/tool_registry.py` — Tool classification (always-loaded vs deferred), token estimation, deferred list formatting
 - `src/decafclaw/tools/search_tools.py` — `tool_search` tool: keyword and exact-name lookup for deferred tools
+- `src/decafclaw/reflection.py` — Self-reflection: judge call, prompt assembly, result parsing (Reflexion pattern)
 - `src/decafclaw/commands.py` — User-invokable commands: trigger parsing, argument substitution, execution (fork/inline)
 - `src/decafclaw/tools/confirmation.py` — Shared confirmation request helper (event-bus-based user approval)
 - `src/decafclaw/runner.py` — Top-level orchestrator: manages MCP, HTTP server, Mattermost, heartbeat as parallel tasks
@@ -124,6 +125,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Skills must use absolute imports.** The skill loader uses `importlib.spec_from_file_location` without package context, so relative imports (`from .` or `from ...`) fail at runtime. Use `from decafclaw.skills.my_skill.module import ...` instead.
 - **MCP servers are globally available.** Configured in `data/{agent_id}/mcp_servers.json` (Claude Code compatible format). Connected eagerly on startup, tools namespaced as `mcp__<server>__<tool>`. Module-level global registry in `mcp_client.py`.
 - **MCP auto-restart.** Crashed stdio servers auto-reconnect on next tool call with exponential backoff (max 3 retries). Use `mcp_status(action="restart")` for manual control.
+- **Self-reflection is fail-open.** The reflection judge evaluates responses before delivery, but errors (network, parse, etc.) always pass through the response as-is. Retries consume `max_tool_iterations` budget. Skipped for child agents, cancelled turns, and empty responses.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 
 ## Keeping docs current

--- a/docs/config.md
+++ b/docs/config.md
@@ -106,6 +106,19 @@ Semantic search embedding settings. Empty `url`/`api_key` fall back to `llm` gro
 | `api_key` | str | (from llm) | `EMBEDDING_API_KEY` | yes |
 | `search_strategy` | str | `substring` | `MEMORY_SEARCH_STRATEGY` | |
 
+### `reflection`
+
+Self-reflection judge settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. See [Self-Reflection](reflection.md) for full details.
+
+| Field | Type | Default | Env Var | Secret |
+|-------|------|---------|---------|--------|
+| `enabled` | bool | `true` | `REFLECTION_ENABLED` | |
+| `url` | str | (from llm) | `REFLECTION_URL` | |
+| `model` | str | (from llm) | `REFLECTION_MODEL` | |
+| `api_key` | str | (from llm) | `REFLECTION_API_KEY` | yes |
+| `max_retries` | int | `2` | `REFLECTION_MAX_RETRIES` | |
+| `visibility` | str | `hidden` | `REFLECTION_VISIBILITY` | |
+
 ### `heartbeat`
 
 Periodic wake-up settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@
 - [Sub-Agent Delegation](delegation.md) — Fork child agents for concurrent subtasks
 - [User Commands](commands.md) — User-invokable commands (!command / /command) with argument substitution
 - [Tool Search / Deferred Loading](tool-search.md) — Defer tool definitions behind search when context budget exceeded
+- [Self-Reflection](reflection.md) — Binary judge + critique + retry before delivering responses (Reflexion pattern)
 
 ## Architecture
 

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -1,0 +1,127 @@
+# Self-Reflection
+
+Self-reflection evaluates the agent's response before delivering it to the user. If the response doesn't adequately address the request, a critique is fed back and the agent retries. This implements the [Reflexion pattern](https://arxiv.org/abs/2303.11366) (Shinn et al., NeurIPS 2023).
+
+## How it works
+
+1. The agent produces a final response (no more tool calls).
+2. A separate "judge" LLM call evaluates whether the response addresses the user's request.
+3. If the judge says **pass**, the response is delivered normally.
+4. If the judge says **fail**, the critique is injected as a user-role message and the agent retries from the LLM call step within the existing iteration loop.
+5. The retried response goes through reflection again, up to `max_retries`.
+
+The judge uses a chain-of-thought-before-verdict prompt (G-Eval pattern): it reasons about what the user asked, whether the response addresses it, and notes gaps before outputting a binary `{"pass": true/false, "critique": "..."}` verdict.
+
+### What the judge sees
+
+The judge receives only the current turn's context, not the full conversation history:
+
+- The user's message that started this turn
+- A condensed summary of tool calls and results (each result truncated to 500 chars)
+- The agent's final response
+
+This keeps the judge context small and focused.
+
+### Retry mechanics
+
+When the judge returns `pass: false`:
+
+1. The failed response stays in history as an assistant message.
+2. A user-role critique message is injected (user-role because models weight it more heavily than system messages).
+3. The agent loop continues back to the LLM call step — no nested loop.
+4. The new response goes through reflection again (up to `max_retries`).
+
+Retries consume iterations from the `max_tool_iterations` budget. If that budget is exhausted during a retry, the turn ends with whatever the agent has produced.
+
+## Quick start
+
+Reflection is enabled by default but **invisible** — the default visibility is `hidden`, so you won't see anything happening. To verify it's working:
+
+```bash
+# Show all reflection evaluations (pass and fail)
+decafclaw config set reflection.visibility debug
+
+# Or just show failures/retries
+decafclaw config set reflection.visibility visible
+```
+
+Restart the bot after changing config. In `debug` mode, every response will show the judge's evaluation. In `visible` mode, you'll only see output when the judge triggers a retry.
+
+To use a cheaper model for the judge (recommended):
+
+```bash
+decafclaw config set reflection.model gemini-2.5-flash
+```
+
+## Configuration
+
+All settings live under the `reflection` group in `config.json`. See [Configuration Reference](config.md#reflection) for the full table.
+
+```json
+{
+  "reflection": {
+    "enabled": true,
+    "model": "gemini-2.5-flash",
+    "max_retries": 2,
+    "visibility": "hidden"
+  }
+}
+```
+
+### Judge model
+
+The judge can use a separate model from the main LLM. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. This lets you run an expensive model for the agent and a cheap/fast one as the judge.
+
+## Visibility modes
+
+Configured via `reflection.visibility`:
+
+| Mode | Behavior |
+|------|----------|
+| `hidden` (default) | User sees only the final response. No reflection UI. |
+| `visible` | Only failed reflections (retries) appear in the UI as collapsed entries with critique text. |
+| `debug` | All reflections shown (pass and fail), including the full raw judge output in a collapsible detail. |
+
+In all modes, the failed response and critique messages remain in conversation history for the agent's benefit on future turns.
+
+Visibility is implemented via a `reflection_result` event published through `ctx.publish()`. Mattermost and web UI subscribers render based on the configured mode.
+
+## Custom judge prompt
+
+The default judge prompt lives in `src/decafclaw/prompts/REFLECTION.md`. To override it, place a file at `data/{agent_id}/REFLECTION.md`. If present, it replaces the bundled prompt entirely.
+
+The template receives these variables:
+
+| Variable | Content |
+|----------|---------|
+| `{user_message}` | The user's message that started this turn |
+| `{tool_results_summary}` | Condensed tool call/result pairs, or "(no tools used)" |
+| `{agent_response}` | The agent's final response text |
+
+**Important:** The template uses Python `str.format()`. Any literal `{` or `}` in your prompt (e.g. JSON examples) must be escaped as `{{` and `}}`, otherwise the prompt will fail to render and reflection will silently pass.
+
+## Skip conditions
+
+Reflection is automatically skipped when:
+
+- **Disabled** — `reflection.enabled = false`
+- **Max iterations hit** — the agent already exhausted `max_tool_iterations`
+- **Cancelled turn** — user interrupted
+- **Child agent turn** — delegation subtasks aren't evaluated; the parent turn is (detected via `ctx.is_child`)
+- **Empty response** — nothing to evaluate
+- **Max retries exhausted** — deliver the last response as-is
+
+## Error handling
+
+Reflection is fail-open. The agent's response is always delivered even if reflection breaks:
+
+- **Judge call fails** (network error, model error) — deliver as-is, log the error.
+- **Unparseable judge output** — treat as pass, log warning.
+- **False positives** (judge incorrectly fails a good response) — the retry budget limits damage. After `max_retries`, deliver whatever the agent has.
+
+## Files
+
+- `src/decafclaw/reflection.py` — judge call, prompt assembly, result parsing
+- `src/decafclaw/agent.py` — reflection check after final response, retry integration
+- `src/decafclaw/config_types.py` — `ReflectionConfig` dataclass
+- `data/{agent_id}/REFLECTION.md` — optional custom judge prompt override

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -104,6 +104,21 @@ def _check_cancelled(ctx, history):
     return None
 
 
+def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
+    """Check whether reflection should run on this response."""
+    if not config.reflection.enabled:
+        return False
+    if reflection_retries >= config.reflection.max_retries:
+        return False
+    if ctx.is_child:
+        return False
+    if not content or not content.strip():
+        return False
+    if getattr(ctx, "cancelled", None) and ctx.cancelled.is_set():
+        return False
+    return True
+
+
 def _collect_all_tool_defs(ctx) -> list:
     """Gather all available tool definitions (core + skill + MCP + extra).
 
@@ -391,6 +406,9 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
 
         prompt_tokens = 0
         empty_retries = 0
+        reflection_retries = 0
+        last_reflection = None  # last ReflectionResult, for archiving after final response
+        turn_start_index = len(history)  # index of user message we're about to add
 
         accumulated_text_parts = []  # text from iterations that also had tool calls
 
@@ -463,9 +481,83 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
                     log.warning("LLM returned empty response, retrying")
                     continue
                 log.warning("LLM returned empty content with no tool calls (after retry)")
+
+            # Reflection check — evaluate before delivering
+            log.debug("Reflection check: enabled=%s, retries=%d/%d, is_child=%s, has_content=%s",
+                       config.reflection.enabled, reflection_retries,
+                       config.reflection.max_retries, ctx.is_child, bool(content))
+            if not _should_reflect(ctx, config, content, reflection_retries):
+                last_reflection = None  # clear stale result from prior retry
+            else:
+                from .reflection import build_tool_summary, evaluate_response
+
+                tool_summary = build_tool_summary(history, turn_start_index)
+                result = await evaluate_response(
+                    config, user_message, content, tool_summary)
+
+                last_reflection = result
+                log.info("Reflection result: passed=%s, critique=%s, error=%s",
+                         result.passed, result.critique[:200] if result.critique else "",
+                         result.error[:100] if result.error else "")
+
+                await ctx.publish("reflection_result",
+                    passed=result.passed,
+                    critique=result.critique,
+                    raw_response=result.raw_response,
+                    retry_number=reflection_retries + 1,
+                    error=result.error)
+
+                if not result.passed and not result.error:
+                    log.info("Reflection failed (retry %d/%d): %s",
+                             reflection_retries + 1,
+                             config.reflection.max_retries,
+                             result.critique[:200])
+                    # Add the failed response to history
+                    failed_msg = {"role": "assistant", "content": content}
+                    history.append(failed_msg)
+                    messages.append(failed_msg)
+                    _archive(ctx, failed_msg)
+
+                    # Add critique as user message for retry
+                    critique_msg = {
+                        "role": "user",
+                        "content": (
+                            "[reflection] Your previous response may not fully "
+                            "address the user's request.\n"
+                            f"Feedback: {result.critique}\n"
+                            "Please try again, addressing the feedback above."
+                        ),
+                    }
+                    history.append(critique_msg)
+                    messages.append(critique_msg)
+                    _archive(ctx, critique_msg)
+
+                    reflection_retries += 1
+                    continue  # back to LLM call
+
             final_msg = {"role": "assistant", "content": content}
             history.append(final_msg)
             _archive(ctx, final_msg)
+
+            # Archive reflection result after the final response (correct ordering)
+            # Only archive if reflection ran for this specific response
+            # (last_reflection is cleared when reflection is skipped)
+            if last_reflection is not None:
+                visibility = config.reflection.visibility
+                r = last_reflection
+                # Match visibility filtering: hidden=none, visible=failures, debug=all
+                should_archive = (
+                    visibility == "debug"
+                    or (visibility == "visible" and not r.passed)
+                )
+                if should_archive:
+                    detail = r.raw_response or r.critique or (
+                        "Response passed evaluation" if r.passed else "No details")
+                    label = ("reflection: PASS" if r.passed
+                             else f"reflection: retry {reflection_retries}")
+                    _archive(ctx, {"role": "reflection", "tool": label,
+                                   "content": detail})
+
             await _maybe_compact(ctx, config, history, prompt_tokens)
 
             # Scan for workspace image references and combine with tool media

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -25,6 +25,7 @@ from .config_types import (
     HttpConfig,
     LlmConfig,
     MattermostConfig,
+    ReflectionConfig,
     SkillsConfig,
     TabstackConfig,
 )
@@ -140,6 +141,7 @@ class Config:
     http: HttpConfig = field(default_factory=HttpConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
     skills: SkillsConfig = field(default_factory=SkillsConfig)
+    reflection: ReflectionConfig = field(default_factory=ReflectionConfig)
 
     # Custom environment variables from config.json "env" section
     env: dict[str, str] = field(default_factory=dict)
@@ -261,6 +263,9 @@ def load_config() -> Config:
         ClaudeCodeConfig, skills_data.get("claude_code", {}), "SKILLS_CLAUDE_CODE")
     skills = SkillsConfig(tabstack=tabstack, claude_code=claude_code)
 
+    reflection = _load_sub_config(
+        ReflectionConfig, file_data.get("reflection", {}), "REFLECTION")
+
     # Custom env vars from config file
     env_vars: dict[str, str] = {
         str(k): str(v) for k, v in file_data.get("env", {}).items()
@@ -278,6 +283,7 @@ def load_config() -> Config:
         http=http,
         agent=agent,
         skills=skills,
+        reflection=reflection,
         env=env_vars,
         system_prompt=system_prompt,
     )

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -105,6 +105,24 @@ class AgentConfig:
 
 
 @dataclass
+class ReflectionConfig:
+    enabled: bool = True
+    url: str = ""       # empty = resolve from llm
+    model: str = ""     # empty = resolve from llm
+    api_key: str = field(default="", metadata={"secret": True})
+    max_retries: int = 2
+    visibility: str = "hidden"  # hidden | visible | debug
+
+    def resolved(self, config) -> ReflectionConfig:
+        """Return copy with empty url/model/api_key filled from config.llm."""
+        return replace(self,
+            url=self.url or config.llm.url,
+            model=self.model or config.llm.model,
+            api_key=self.api_key or config.llm.api_key,
+        )
+
+
+@dataclass
 class TabstackConfig:
     api_key: str = field(
         default="", metadata={"secret": True, "env_alias": "TABSTACK_API_KEY"})

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -39,6 +39,7 @@ class Context:
         self.deferred_tool_pool: list = []  # tool defs available via tool_search
         self.preapproved_tools: set = set()  # tools pre-approved by command invocation
         self._current_iteration: int = 1
+        self.is_child: bool = False
 
     def fork(self, **overrides) -> "Context":
         """Create a child context with a new ID, sharing the event bus."""

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -382,6 +382,7 @@ class MattermostClient:
             channel_id=channel_id, root_id=root_id,
             streaming=app_ctx.config.llm.streaming,
             conv_display=conv_display,
+            reflection_visibility=app_ctx.config.reflection.visibility,
         )
 
         return req_ctx, conv_display, cancel_task, sub_id
@@ -657,7 +658,7 @@ class MattermostClient:
 
     def _subscribe_progress(self, event_bus, context_id,
                             channel_id=None, root_id=None, streaming=False,
-                            conv_display=None):
+                            conv_display=None, reflection_visibility="hidden"):
         """Subscribe to progress events and route to ConversationDisplay.
 
         Returns the subscription ID for later unsubscribe.
@@ -707,6 +708,28 @@ class MattermostClient:
                     event_bus, context_id,
                     tool_call_id=event.get("tool_call_id", ""),
                 )
+            elif event_type == "reflection_result" and conv_display:
+                visibility = reflection_visibility
+                if visibility != "hidden":
+                    passed = event.get("passed", True)
+                    critique = event.get("critique", "")
+                    retry_num = event.get("retry_number", 0)
+                    raw = event.get("raw_response", "")
+                    error = event.get("error", "")
+                    if visibility == "debug":
+                        text = (f"\U0001f50d **Reflection** (retry {retry_num}): "
+                                f"{'PASS' if passed else 'FAIL'}")
+                        if critique:
+                            text += f"\nCritique: {critique}"
+                        if error:
+                            text += f"\nError: {error}"
+                        if raw:
+                            text += f"\n\n<details><summary>Raw judge output</summary>\n\n{raw}\n</details>"
+                        await conv_display.on_tool_status("reflection", text)
+                    elif not passed:
+                        text = (f"\U0001f50d Reflection retry {retry_num}: "
+                                f"{critique}")
+                        await conv_display.on_tool_status("reflection", text)
             # Compaction stays as-is (separate message)
             elif event_type == "compaction_start" and channel_id:
                 import time as _time

--- a/src/decafclaw/prompts/REFLECTION.md
+++ b/src/decafclaw/prompts/REFLECTION.md
@@ -1,0 +1,22 @@
+You are evaluating whether an AI assistant's response adequately addresses
+the user's request.
+
+Review the interaction below, then:
+1. Identify what the user asked for
+2. Assess whether the response addresses it
+3. Note any specific gaps or problems
+
+Then output your verdict as JSON:
+{{"pass": true/false, "critique": "specific feedback if failed"}}
+
+If the response is adequate, even if imperfect, pass it.
+Only fail responses that clearly miss the point, ignore the question,
+or contain significant errors relative to the tool results.
+
+---
+
+User: {user_message}
+
+{tool_results_summary}
+
+Assistant response: {agent_response}

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -1,0 +1,187 @@
+"""Self-reflection — evaluate agent responses before delivery.
+
+Uses the Reflexion pattern: a separate judge LLM call evaluates whether
+the agent's response adequately addresses the user's request. If not,
+a critique is returned for retry.
+
+References:
+  - Reflexion (Shinn et al., NeurIPS 2023): https://arxiv.org/abs/2303.11366
+  - G-Eval chain-of-thought scoring: https://www.confident-ai.com/blog/g-eval
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .llm import call_llm
+
+log = logging.getLogger(__name__)
+
+_BUNDLED_PROMPT = Path(__file__).parent / "prompts" / "REFLECTION.md"
+
+MAX_TOOL_RESULT_LEN = 500
+
+
+@dataclass
+class ReflectionResult:
+    """Result of a reflection evaluation."""
+    passed: bool
+    critique: str = ""
+    raw_response: str = ""  # full judge output for debug mode
+    error: str = ""         # non-empty if the judge call failed
+
+
+def load_reflection_prompt(config) -> str:
+    """Load the judge prompt template.
+
+    Priority: agent-level override > bundled default.
+    Override file: data/{agent_id}/REFLECTION.md
+    Bundled default: src/decafclaw/prompts/REFLECTION.md
+    """
+    override_path = config.agent_path / "REFLECTION.md"
+    if override_path.exists():
+        try:
+            return override_path.read_text()
+        except OSError as exc:
+            log.warning("Failed to read %s: %s", override_path, exc)
+    return _BUNDLED_PROMPT.read_text()
+
+
+def build_tool_summary(history: list, turn_start_index: int) -> str:
+    """Extract tool call/result pairs from this turn's history.
+
+    Scans history from turn_start_index onward for assistant messages with
+    tool_calls and their corresponding tool-role result messages.
+    """
+    tool_lines: list[str] = []
+
+    for msg in history[turn_start_index:]:
+        # Assistant messages with tool_calls
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                fn = tc.get("function", {})
+                name = fn.get("name", "unknown")
+                args_str = fn.get("arguments", "")
+                # Summarize args
+                try:
+                    args = json.loads(args_str) if isinstance(args_str, str) else args_str
+                    if isinstance(args, dict):
+                        key_args = ", ".join(
+                            f'{k}="{v}"' if isinstance(v, str) else f"{k}={v}"
+                            for k, v in list(args.items())[:3]
+                        )
+                    else:
+                        key_args = str(args)[:100]
+                except (json.JSONDecodeError, TypeError):
+                    key_args = str(args_str)[:100]
+                tool_lines.append(f"Tool: {name}({key_args})")
+
+        # Tool result messages
+        if msg.get("role") == "tool":
+            content = msg.get("content", "")
+            if len(content) > MAX_TOOL_RESULT_LEN:
+                content = content[:MAX_TOOL_RESULT_LEN] + "..."
+            tool_lines.append(f"Result: {content}")
+
+    if not tool_lines:
+        return ""
+    return "Tools used this turn:\n" + "\n".join(tool_lines)
+
+
+def _coerce_bool(value) -> bool | None:
+    """Coerce a JSON value to bool. Returns None if not interpretable."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    if isinstance(value, str):
+        lower = value.strip().lower()
+        if lower in ("true", "1", "yes"):
+            return True
+        if lower in ("false", "0", "no"):
+            return False
+    return None
+
+
+def _extract_verdict(data: dict) -> tuple[bool | None, str]:
+    """Extract pass/fail from a parsed JSON dict."""
+    if "pass" not in data:
+        return (None, "")
+    passed = _coerce_bool(data["pass"])
+    return (passed, data.get("critique", ""))
+
+
+def _parse_verdict(text: str) -> tuple[bool | None, str]:
+    """Extract pass/fail verdict and critique from judge response.
+
+    Returns (passed, critique). passed is None if parsing fails.
+    """
+    # Try parsing the whole response as JSON
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            result = _extract_verdict(data)
+            if result[0] is not None:
+                return result
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Search for JSON object in the response text
+    for match in re.finditer(r'\{[^{}]*\}', text):
+        try:
+            data = json.loads(match.group())
+            if isinstance(data, dict):
+                result = _extract_verdict(data)
+                if result[0] is not None:
+                    return result
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    return (None, "")
+
+
+async def evaluate_response(
+    config,
+    user_message: str,
+    agent_response: str,
+    tool_summary: str,
+) -> ReflectionResult:
+    """Run the judge LLM to evaluate the agent's response.
+
+    Returns ReflectionResult. On any error, returns passed=True (fail-open).
+    """
+    try:
+        prompt_template = load_reflection_prompt(config)
+        prompt = prompt_template.format(
+            user_message=user_message,
+            tool_results_summary=tool_summary or "(no tools used)",
+            agent_response=agent_response,
+        )
+
+        rc = config.reflection.resolved(config)
+        messages = [{"role": "user", "content": prompt}]
+
+        response = await call_llm(
+            config, messages,
+            llm_url=rc.url,
+            llm_model=rc.model,
+            llm_api_key=rc.api_key,
+        )
+
+        raw = response.get("content", "")
+        passed, critique = _parse_verdict(raw)
+
+        if passed is None:
+            log.warning("Reflection judge returned unparseable output: %s", raw[:200])
+            return ReflectionResult(passed=True, raw_response=raw,
+                                    error="unparseable judge output")
+
+        return ReflectionResult(passed=passed, critique=critique, raw_response=raw)
+
+    except Exception as exc:
+        log.error("Reflection judge call failed: %s", exc)
+        return ReflectionResult(passed=True, error=str(exc))

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -73,8 +73,9 @@ async def _run_child_turn(parent_ctx, task):
     # Propagate command pre-approved tools to child
     child_ctx.preapproved_tools = parent_ctx.preapproved_tools
 
-    # No streaming for child agents
+    # No streaming or reflection for child agents
     child_ctx.on_stream_chunk = None
+    child_ctx.is_child = True
 
     timeout = config.agent.child_timeout_sec
 

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -37,6 +37,10 @@ export class ChatMessage extends LitElement {
       return html`<div class="compaction-notice">${this.content}</div>`;
     }
 
+    if (this.role === 'reflection') {
+      return html`<tool-message .tool=${this.tool || 'reflection'} .content=${this.content} .icon=${'\u{1f441}'}></tool-message>`;
+    }
+
     if (this.role === 'tool_call') {
       return html`<tool-call-message variant="tool_call" .content=${this.content}></tool-call-message>`;
     }

--- a/src/decafclaw/web/static/components/messages/tool-message.js
+++ b/src/decafclaw/web/static/components/messages/tool-message.js
@@ -5,6 +5,7 @@ export class ToolMessage extends LitElement {
   static properties = {
     tool: { type: String },
     content: { type: String },
+    icon: { type: String },
     _expanded: { type: Boolean, state: true },
   };
 
@@ -14,6 +15,7 @@ export class ToolMessage extends LitElement {
     super();
     this.tool = '';
     this.content = '';
+    this.icon = '\u{1f527}';
     this._expanded = false;
   }
 
@@ -32,7 +34,7 @@ export class ToolMessage extends LitElement {
     return html`
       <div class="message tool">
         <div class="tool-result-header" @click=${hasContent ? this.#toggleExpand : nothing}>
-          <span class="tool-icon">\u{1f527}</span>
+          <span class="tool-icon">${this.icon}</span>
           <span class="tool-name">${this.tool}</span>
           ${hasContent ? html`
             <span class="tool-preview">${this.#truncate(this.content)}</span>

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -341,6 +341,24 @@ export class ConversationStore extends EventTarget {
         }];
         break;
 
+      case 'reflection_result':
+        if (msg.conv_id === this.#currentConvId) {
+          const passed = msg.passed;
+          const critique = msg.critique || '';
+          const raw = msg.raw_response || '';
+          const retryNum = msg.retry_number || 0;
+          // Content shown when expanded (raw judge output or critique)
+          const detail = raw || critique || (passed ? 'Response passed evaluation' : 'No details');
+          this.#currentMessages.push({
+            role: 'reflection',
+            // tool-message uses .tool for the header label
+            tool: passed ? 'reflection: PASS' : `reflection: retry ${retryNum}`,
+            content: detail,
+            timestamp: new Date().toISOString(),
+          });
+        }
+        break;
+
       case 'compaction_done':
         if (msg.conv_id === this.#currentConvId) {
           this.#currentMessages.push({

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -394,6 +394,27 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     "tool_call_id": event.get("tool_call_id", ""),
                 })
 
+            elif event_type == "reflection_result":
+                visibility = config.reflection.visibility
+                passed = event.get("passed", True)
+                # hidden: suppress all; visible: only failures; debug: everything
+                if visibility == "hidden":
+                    pass
+                elif visibility == "visible" and passed:
+                    pass
+                else:
+                    await ws_send({
+                        "type": "reflection_result", "conv_id": conv_id,
+                        "passed": passed,
+                        "critique": event.get("critique", ""),
+                        "retry_number": event.get("retry_number", 0),
+                        "raw_response": (
+                            event.get("raw_response", "")
+                            if visibility == "debug" else ""
+                        ),
+                        "error": event.get("error", ""),
+                    })
+
             elif event_type == "compaction_end":
                 await ws_send({
                     "type": "compaction_done", "conv_id": conv_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from decafclaw.config import Config
-from decafclaw.config_types import AgentConfig
+from decafclaw.config_types import AgentConfig, ReflectionConfig
 from decafclaw.context import Context
 from decafclaw.events import EventBus
 
@@ -25,6 +25,7 @@ def config(tmp_data):
             id="test-agent",
             user_id="testuser",
         ),
+        reflection=ReflectionConfig(enabled=False),
     )
 
 

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -13,7 +13,9 @@ from decafclaw.agent import (
     _execute_tool_calls,
     run_agent_turn,
 )
+from decafclaw.config_types import ReflectionConfig
 from decafclaw.media import ToolResult
+from decafclaw.reflection import ReflectionResult
 
 # -- Helper tests --------------------------------------------------------------
 
@@ -451,3 +453,142 @@ async def test_run_agent_turn_archives_messages(ctx):
     assert len(archived) == 2
     assert archived[0]["role"] == "user"
     assert archived[1]["role"] == "assistant"
+
+
+# -- Reflection integration tests --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reflection_pass_delivers_normally(ctx):
+    """When the judge passes, the response is delivered as-is."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("Good answer")
+        mock_eval.return_value = ReflectionResult(passed=True)
+
+        history = []
+        result = await run_agent_turn(ctx, "question", history)
+
+    assert result.text == "Good answer"
+    assert len(history) == 2  # user + assistant
+    mock_eval.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reflection_fail_retries(ctx):
+    """When the judge fails, critique is injected and agent retries."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True, max_retries=2)
+
+    call_count = 0
+
+    async def mock_llm_side_effect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _mock_llm_response("Bad answer")
+        return _mock_llm_response("Better answer")
+
+    eval_count = 0
+
+    async def mock_eval_side_effect(*args, **kwargs):
+        nonlocal eval_count
+        eval_count += 1
+        if eval_count == 1:
+            return ReflectionResult(passed=False, critique="You missed the point")
+        return ReflectionResult(passed=True)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock,
+               side_effect=mock_llm_side_effect), \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock,
+               side_effect=mock_eval_side_effect):
+        history = []
+        result = await run_agent_turn(ctx, "question", history)
+
+    assert result.text == "Better answer"
+    # History: user, failed assistant, critique (user), final assistant
+    assert len(history) == 4
+    assert history[1]["content"] == "Bad answer"
+    assert "[reflection]" in history[2]["content"]
+    assert history[3]["content"] == "Better answer"
+
+
+@pytest.mark.asyncio
+async def test_reflection_max_retries_delivers_last(ctx):
+    """After max retries, deliver the last response regardless."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True, max_retries=1)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("Mediocre answer")
+        # Always fails
+        mock_eval.return_value = ReflectionResult(
+            passed=False, critique="Still not great")
+
+        history = []
+        result = await run_agent_turn(ctx, "question", history)
+
+    # After 1 retry (max_retries=1), delivers whatever it has
+    assert result.text == "Mediocre answer"
+    # Judge called once (first attempt), then retry delivers without reflection
+    assert mock_eval.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reflection_disabled_skips(ctx):
+    """Reflection disabled means no judge call."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=False)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("response")
+        history = []
+        await run_agent_turn(ctx, "hi", history)
+
+    mock_eval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reflection_child_skips(ctx):
+    """Child agents skip reflection."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+    ctx.is_child = True
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("child response")
+        history = []
+        await run_agent_turn(ctx, "task", history)
+
+    mock_eval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reflection_error_delivers_response(ctx):
+    """If the judge errors, deliver the response as-is."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("response")
+        mock_eval.return_value = ReflectionResult(
+            passed=True, error="connection timeout")
+
+        history = []
+        result = await run_agent_turn(ctx, "hi", history)
+
+    assert result.text == "response"
+    assert len(history) == 2  # no retry

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,220 @@
+"""Tests for the reflection module — judge prompt, tool summary, verdict parsing."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig, LlmConfig, ReflectionConfig
+from decafclaw.reflection import (
+    ReflectionResult,
+    _parse_verdict,
+    build_tool_summary,
+    evaluate_response,
+    load_reflection_prompt,
+)
+
+# ---------------------------------------------------------------------------
+# build_tool_summary
+# ---------------------------------------------------------------------------
+
+class TestBuildToolSummary:
+    def test_no_tools(self):
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        assert build_tool_summary(history, 0) == ""
+
+    def test_with_tools(self):
+        history = [
+            {"role": "user", "content": "search for cats"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "memory_search",
+                    "arguments": json.dumps({"query": "cats"}),
+                }},
+            ]},
+            {"role": "tool", "content": "Found: cat facts document"},
+            {"role": "assistant", "content": "Here are some cat facts."},
+        ]
+        result = build_tool_summary(history, 0)
+        assert "memory_search" in result
+        assert "cats" in result
+        assert "cat facts document" in result
+
+    def test_truncates_long_results(self):
+        long_result = "x" * 1000
+        history = [
+            {"role": "user", "content": "test"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "workspace_read",
+                    "arguments": json.dumps({"path": "big.txt"}),
+                }},
+            ]},
+            {"role": "tool", "content": long_result},
+        ]
+        result = build_tool_summary(history, 0)
+        assert len(result) < 1000
+        assert "..." in result
+
+    def test_respects_turn_start_index(self):
+        """Only includes tools from the current turn."""
+        history = [
+            # Previous turn
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc0", "function": {
+                    "name": "old_tool", "arguments": "{}",
+                }},
+            ]},
+            {"role": "tool", "content": "old result"},
+            {"role": "assistant", "content": "old answer"},
+            # Current turn starts at index 4
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+        result = build_tool_summary(history, 4)
+        assert result == ""  # no tools in current turn
+        result_old = build_tool_summary(history, 0)
+        assert "old_tool" in result_old
+
+
+# ---------------------------------------------------------------------------
+# _parse_verdict
+# ---------------------------------------------------------------------------
+
+class TestParseVerdict:
+    def test_clean_json(self):
+        passed, critique = _parse_verdict('{"pass": true, "critique": ""}')
+        assert passed is True
+        assert critique == ""
+
+    def test_fail_with_critique(self):
+        passed, critique = _parse_verdict(
+            '{"pass": false, "critique": "You missed the point"}')
+        assert passed is False
+        assert critique == "You missed the point"
+
+    def test_json_embedded_in_text(self):
+        text = (
+            "Let me evaluate this response.\n\n"
+            "The user asked about weather but the agent talked about sports.\n\n"
+            '{"pass": false, "critique": "Off topic"}'
+        )
+        passed, critique = _parse_verdict(text)
+        assert passed is False
+        assert critique == "Off topic"
+
+    def test_unparseable(self):
+        passed, critique = _parse_verdict("This is just plain text with no JSON")
+        assert passed is None
+
+    def test_empty_string(self):
+        passed, critique = _parse_verdict("")
+        assert passed is None
+
+    def test_string_false(self):
+        """Judge returns "pass": "false" as string — should be treated as False."""
+        passed, critique = _parse_verdict('{"pass": "false", "critique": "bad"}')
+        assert passed is False
+        assert critique == "bad"
+
+    def test_string_true(self):
+        passed, _ = _parse_verdict('{"pass": "true", "critique": ""}')
+        assert passed is True
+
+    def test_integer_0(self):
+        passed, _ = _parse_verdict('{"pass": 0, "critique": "nope"}')
+        assert passed is False
+
+    def test_integer_1(self):
+        passed, _ = _parse_verdict('{"pass": 1, "critique": ""}')
+        assert passed is True
+
+
+# ---------------------------------------------------------------------------
+# load_reflection_prompt
+# ---------------------------------------------------------------------------
+
+class TestLoadReflectionPrompt:
+    def test_default(self, tmp_path):
+        config = Config(agent=AgentConfig(data_home=str(tmp_path), id="test"))
+        result = load_reflection_prompt(config)
+        assert "{user_message}" in result
+        assert "{agent_response}" in result
+
+    def test_override_file(self, tmp_path):
+        agent_dir = tmp_path / "test"
+        agent_dir.mkdir()
+        override = agent_dir / "REFLECTION.md"
+        override.write_text("Custom prompt: {user_message}")
+        config = Config(agent=AgentConfig(data_home=str(tmp_path), id="test"))
+        result = load_reflection_prompt(config)
+        assert result == "Custom prompt: {user_message}"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_response
+# ---------------------------------------------------------------------------
+
+class TestEvaluateResponse:
+    @pytest.fixture
+    def config(self, tmp_path):
+        return Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                           model="test-model", api_key="test-key"),
+            reflection=ReflectionConfig(enabled=True),
+        )
+
+    @pytest.mark.asyncio
+    async def test_pass(self, config):
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                    return_value=mock_response):
+            result = await evaluate_response(config, "hello", "Hi there!", "")
+        assert result.passed is True
+        assert result.critique == ""
+        assert result.error == ""
+
+    @pytest.mark.asyncio
+    async def test_fail_with_critique(self, config):
+        mock_response = {
+            "content": '{"pass": false, "critique": "Did not greet the user"}'
+        }
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                    return_value=mock_response):
+            result = await evaluate_response(config, "hello", "The weather is nice", "")
+        assert result.passed is False
+        assert result.critique == "Did not greet the user"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_treated_as_pass(self, config):
+        mock_response = {"content": "I can't decide, this is fine I guess"}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                    return_value=mock_response):
+            result = await evaluate_response(config, "hello", "Hi!", "")
+        assert result.passed is True
+        assert "unparseable" in result.error
+
+    @pytest.mark.asyncio
+    async def test_network_error_treated_as_pass(self, config):
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                    side_effect=ConnectionError("timeout")):
+            result = await evaluate_response(config, "hello", "Hi!", "")
+        assert result.passed is True
+        assert "timeout" in result.error
+
+    @pytest.mark.asyncio
+    async def test_uses_reflection_model(self, config):
+        config.reflection.model = "cheap-judge-model"
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                    return_value=mock_response) as mock_call:
+            await evaluate_response(config, "hello", "Hi!", "")
+        # Check that the judge model was used
+        _, kwargs = mock_call.call_args
+        assert kwargs["llm_model"] == "cheap-judge-model"


### PR DESCRIPTION
## Summary

- Implements the [Reflexion pattern](https://arxiv.org/abs/2303.11366): a separate judge LLM evaluates whether the agent's response adequately addresses the user's request before delivery
- On failure, critique is injected as a user-role message and the agent retries (up to `max_retries`, default 2)
- Judge uses chain-of-thought-before-verdict prompt (G-Eval pattern) with binary pass/fail + verbal critique
- Separate model config for the judge — use a cheap/fast model (e.g. Flash) while the main agent runs Pro
- Three visibility modes: `hidden` (default), `visible` (show failures), `debug` (show all evaluations with full judge output)
- Fail-open: judge errors, parse failures, and network issues all treated as pass
- Reflection results archived and rendered in web UI (collapsible tool-message style) and Mattermost
- Default prompt lives in `prompts/REFLECTION.md`, overridable at `data/{agent_id}/REFLECTION.md`
- 22 new tests, 590 total passing

Closes #16

## Test plan

- [x] `make check` passes (lint + pyright + tsc)
- [x] `make test` passes (590 tests)
- [x] Set `reflection.visibility` to `debug`, verify reflections appear in web UI after responses
- [x] Set `reflection.model` to a cheap model, verify it's used for judge calls (check logs)
- [x] Send a vague message that should trigger a retry, verify critique + retry in debug mode
- [x] Set `reflection.enabled` to `false`, verify no judge calls
- [x] Reload a conversation, verify reflection results persist in correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)