### PR TITLE
Add health/status diagnostic command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,14 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/skills/` — Skills system: discovery, parsing, catalog, bundled skills
 - `src/decafclaw/skills/tabstack/` — Bundled Tabstack skill (SKILL.md + tools.py)
 - `src/decafclaw/http_server.py` — HTTP server (Starlette/uvicorn): interactive button callbacks, health check
+- `src/decafclaw/skills/health/` — Bundled `!health` command: agent diagnostic status
 - `src/decafclaw/skills/claude_code/` — Claude Code subagent skill (sessions, permissions, output logging)
 - `src/decafclaw/eval/` — Eval harness (YAML tests, failure reflection)
 - `src/decafclaw/mcp_client.py` — MCP client: config, registry, server connections, auto-restart
 - `src/decafclaw/heartbeat.py` — Heartbeat: periodic wake-up, section parsing, timer, cycle runner
 - `src/decafclaw/media.py` — Media handling: ToolResult, MediaHandler interface, workspace ref scanning
-- `src/decafclaw/tools/` — Tool registry: core, memory, todo, workspace, file_share, shell, conversation, skill activation, MCP status, delegation
+- `src/decafclaw/tools/` — Tool registry: core, memory, todo, workspace, file_share, shell, conversation, skill activation, MCP status, health, delegation
+- `src/decafclaw/tools/health.py` — Health/diagnostic status tool: uptime, MCP, heartbeat, tools, embeddings
 - `src/decafclaw/tools/delegate.py` — Sub-agent delegation: `delegate_task` forks a child agent for a single subtask (call multiple times for parallel work)
 - `src/decafclaw/tools/tool_registry.py` — Tool classification (always-loaded vs deferred), token estimation, deferred list formatting
 - `src/decafclaw/tools/search_tools.py` — `tool_search` tool: keyword and exact-name lookup for deferred tools

--- a/src/decafclaw/heartbeat.py
+++ b/src/decafclaw/heartbeat.py
@@ -209,7 +209,7 @@ def _heartbeat_timestamp_path(config):
     return config.workspace_path / ".heartbeat_last_run"
 
 
-def _read_last_heartbeat(config) -> float:
+def read_last_heartbeat(config) -> float:
     """Read the last heartbeat timestamp from disk. Returns 0 if not found."""
     path = _heartbeat_timestamp_path(config)
     try:
@@ -251,7 +251,7 @@ async def run_heartbeat_timer(config, event_bus, shutdown_event,
         log.info("Heartbeat disabled (no interval configured)")
         return
 
-    last_run = _read_last_heartbeat(config)
+    last_run = read_last_heartbeat(config)
     if last_run > 0:
         elapsed = time.time() - last_run
         remaining = max(0, interval - elapsed)
@@ -275,7 +275,7 @@ async def run_heartbeat_timer(config, event_bus, shutdown_event,
             break
 
         # Check if enough time has passed since last heartbeat
-        last_run = _read_last_heartbeat(config)
+        last_run = read_last_heartbeat(config)
         if last_run > 0 and (time.time() - last_run) < interval:
             continue  # not yet due
 

--- a/src/decafclaw/skills/health/SKILL.md
+++ b/src/decafclaw/skills/health/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: health
+description: Show agent diagnostic status — process, MCP, heartbeat, tools, embeddings
+user-invocable: true
+context: inline
+allowed-tools: health_status
+---
+
+Call the `health_status` tool and share the full output with the user. Do not summarize or omit any sections.

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -7,6 +7,7 @@ from ..media import ToolResult
 from .conversation_tools import CONVERSATION_TOOL_DEFINITIONS, CONVERSATION_TOOLS
 from .core import CORE_TOOL_DEFINITIONS, CORE_TOOLS
 from .delegate import DELEGATE_TOOL_DEFINITIONS, DELEGATE_TOOLS
+from .health import HEALTH_TOOL_DEFINITIONS, HEALTH_TOOLS
 from .heartbeat_tools import HEARTBEAT_TOOL_DEFINITIONS, HEARTBEAT_TOOLS
 from .mcp_tools import MCP_TOOL_DEFINITIONS, MCP_TOOLS
 from .memory_tools import MEMORY_TOOL_DEFINITIONS, MEMORY_TOOLS
@@ -20,13 +21,14 @@ log = logging.getLogger(__name__)
 # Combined registry (tabstack via skill, MCP tools via registry)
 TOOLS = {**CORE_TOOLS, **MEMORY_TOOLS, **TODO_TOOLS,
          **CONVERSATION_TOOLS, **WORKSPACE_TOOLS, **SHELL_TOOLS,
-         **SKILL_TOOLS, **MCP_TOOLS, **HEARTBEAT_TOOLS, **DELEGATE_TOOLS}
+         **SKILL_TOOLS, **MCP_TOOLS, **HEARTBEAT_TOOLS, **HEALTH_TOOLS,
+         **DELEGATE_TOOLS}
 TOOL_DEFINITIONS = (CORE_TOOL_DEFINITIONS
                     + MEMORY_TOOL_DEFINITIONS + TODO_TOOL_DEFINITIONS
                     + CONVERSATION_TOOL_DEFINITIONS + WORKSPACE_TOOL_DEFINITIONS
                     + SHELL_TOOL_DEFINITIONS + SKILL_TOOL_DEFINITIONS
                     + MCP_TOOL_DEFINITIONS + HEARTBEAT_TOOL_DEFINITIONS
-                    + DELEGATE_TOOL_DEFINITIONS)
+                    + HEALTH_TOOL_DEFINITIONS + DELEGATE_TOOL_DEFINITIONS)
 
 
 async def _run_with_cancel(coro, cancel_event):

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -1,0 +1,59 @@
+"""Health/diagnostic status tool — reports agent operational state."""
+
+import logging
+import resource
+import sys
+import time
+
+log = logging.getLogger(__name__)
+
+# Captured at import time for uptime calculation
+_start_time = time.monotonic()
+
+
+def _format_uptime(seconds: float) -> str:
+    """Format seconds into human-readable uptime like '2h 14m 32s'."""
+    parts = []
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    parts.append(f"{secs}s")
+    return " ".join(parts)
+
+
+def _process_section() -> list[str]:
+    """Gather process uptime and memory usage."""
+    uptime = time.monotonic() - _start_time
+    uptime_str = _format_uptime(uptime)
+
+    # RSS memory — macOS reports bytes, Linux reports KB
+    ru = resource.getrusage(resource.RUSAGE_SELF)
+    if sys.platform == "darwin":
+        rss_mb = ru.ru_maxrss / (1024 * 1024)
+    else:
+        rss_mb = ru.ru_maxrss / 1024
+
+    return [
+        "### Process",
+        f"- **Uptime:** {uptime_str}",
+        f"- **Memory (RSS):** {rss_mb:.1f} MB",
+    ]
+
+
+async def tool_health_status(ctx) -> str:
+    """Show agent health and diagnostic status."""
+    log.info("[tool:health_status]")
+
+    sections = ["## Agent Health", ""]
+
+    # Process
+    try:
+        sections.extend(_process_section())
+    except Exception as e:
+        sections.append(f"### Process\n- [error: {e}]")
+
+    return "\n".join(sections)

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -111,6 +111,33 @@ def _heartbeat_section(config) -> list[str]:
     return lines
 
 
+def _tools_section(ctx) -> list[str]:
+    """Gather tool deferral stats."""
+    from . import TOOL_DEFINITIONS
+    from .tool_registry import classify_tools, estimate_tool_tokens
+
+    # Collect all tool definitions the agent currently has
+    all_defs = TOOL_DEFINITIONS + ctx.extra_tool_definitions
+    # Add MCP tool definitions if available
+    from ..mcp_client import get_registry
+
+    registry = get_registry()
+    if registry:
+        for state in registry.servers.values():
+            all_defs = all_defs + state.tool_definitions
+
+    fetched = ctx.skill_data.get("fetched_tools", set())
+    active, deferred = classify_tools(all_defs, ctx.config, fetched)
+    total_tokens = estimate_tool_tokens(all_defs)
+    budget = ctx.config.tool_context_budget
+
+    return [
+        "### Tools",
+        f"- **Active:** {len(active)} | **Deferred:** {len(deferred)}",
+        f"- **Token usage:** ~{total_tokens:,} / {budget:,} budget",
+    ]
+
+
 async def tool_health_status(ctx) -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
@@ -138,5 +165,13 @@ async def tool_health_status(ctx) -> str:
         sections.extend(_heartbeat_section(ctx.config))
     except Exception as e:
         sections.append(f"### Heartbeat\n- [error: {e}]")
+
+    sections.append("")
+
+    # Tools
+    try:
+        sections.extend(_tools_section(ctx))
+    except Exception as e:
+        sections.append(f"### Tools\n- [error: {e}]")
 
     return "\n".join(sections)

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -44,6 +44,25 @@ def _process_section() -> list[str]:
     ]
 
 
+def _mcp_section() -> list[str]:
+    """Gather MCP server connection status."""
+    from ..mcp_client import get_registry
+
+    registry = get_registry()
+    if not registry or not registry.servers:
+        return ["### MCP Servers", "No MCP servers configured."]
+
+    lines = [
+        "### MCP Servers",
+        "| Server | Status | Tools | Retries |",
+        "|--------|--------|-------|---------|",
+    ]
+    for name, state in registry.servers.items():
+        tool_count = len(state.tools)
+        lines.append(f"| {name} | {state.status} | {tool_count} | {state.retry_count} |")
+    return lines
+
+
 async def tool_health_status(ctx) -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
@@ -55,5 +74,13 @@ async def tool_health_status(ctx) -> str:
         sections.extend(_process_section())
     except Exception as e:
         sections.append(f"### Process\n- [error: {e}]")
+
+    sections.append("")
+
+    # MCP Servers
+    try:
+        sections.extend(_mcp_section())
+    except Exception as e:
+        sections.append(f"### MCP Servers\n- [error: {e}]")
 
     return "\n".join(sections)

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -215,3 +215,28 @@ async def tool_health_status(ctx) -> str:
         sections.append(f"### Embeddings\n- [error: {e}]")
 
     return "\n".join(sections)
+
+
+HEALTH_TOOLS = {
+    "health_status": tool_health_status,
+}
+
+HEALTH_TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "health_status",
+            "description": (
+                "Show agent health and diagnostic status. "
+                "Reports process uptime, memory usage, MCP server connections, "
+                "heartbeat timing, tool deferral stats, and embedding index size. "
+                "Use when asked about agent status, health, diagnostics, or uptime."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+]

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -138,6 +138,38 @@ def _tools_section(ctx) -> list[str]:
     ]
 
 
+def _embeddings_section(config) -> list[str]:
+    """Gather embedding index stats."""
+    import sqlite3
+
+    db_path = config.workspace_path / "embeddings.db"
+    if not db_path.exists():
+        return ["### Embeddings", "No embedding database found."]
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            total = conn.execute(
+                "SELECT COUNT(*) FROM memory_embeddings"
+            ).fetchone()[0]
+            memory = conn.execute(
+                "SELECT COUNT(*) FROM memory_embeddings WHERE source_type = 'memory'"
+            ).fetchone()[0]
+            conversation = conn.execute(
+                "SELECT COUNT(*) FROM memory_embeddings WHERE source_type = 'conversation'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        return ["### Embeddings", f"- [error reading database: {e}]"]
+
+    return [
+        "### Embeddings",
+        f"- **Total entries:** {total}",
+        f"- **Memory:** {memory} | **Conversation:** {conversation}",
+    ]
+
+
 async def tool_health_status(ctx) -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
@@ -173,5 +205,13 @@ async def tool_health_status(ctx) -> str:
         sections.extend(_tools_section(ctx))
     except Exception as e:
         sections.append(f"### Tools\n- [error: {e}]")
+
+    sections.append("")
+
+    # Embeddings
+    try:
+        sections.extend(_embeddings_section(ctx.config))
+    except Exception as e:
+        sections.append(f"### Embeddings\n- [error: {e}]")
 
     return "\n".join(sections)

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -63,6 +63,54 @@ def _mcp_section() -> list[str]:
     return lines
 
 
+def _format_relative_time(seconds: float) -> str:
+    """Format a time delta as relative text like '5m ago' or 'in 25m'."""
+    abs_secs = abs(seconds)
+    if abs_secs < 60:
+        label = f"{int(abs_secs)}s"
+    elif abs_secs < 3600:
+        label = f"{int(abs_secs // 60)}m"
+    else:
+        h = int(abs_secs // 3600)
+        m = int((abs_secs % 3600) // 60)
+        label = f"{h}h {m}m" if m else f"{h}h"
+
+    if seconds < 0:
+        return f"overdue by {label}"
+    return f"in {label}"
+
+
+def _heartbeat_section(config) -> list[str]:
+    """Gather heartbeat timing status."""
+    from ..heartbeat import parse_interval, read_last_heartbeat
+
+    interval = parse_interval(config.heartbeat.interval)
+    if interval is None:
+        return ["### Heartbeat", "- **Status:** disabled"]
+
+    lines = [
+        "### Heartbeat",
+        "- **Status:** enabled",
+        f"- **Interval:** {config.heartbeat.interval}",
+    ]
+
+    last_run = read_last_heartbeat(config)
+    if last_run > 0:
+        from datetime import datetime, timezone
+
+        dt = datetime.fromtimestamp(last_run, tz=timezone.utc).astimezone()
+        elapsed = time.time() - last_run
+        elapsed_str = _format_uptime(elapsed)
+        lines.append(f"- **Last run:** {dt.strftime('%Y-%m-%d %H:%M:%S')} ({elapsed_str} ago)")
+
+        remaining = interval - elapsed
+        lines.append(f"- **Next due:** {_format_relative_time(remaining)}")
+    else:
+        lines.append("- **Last run:** never")
+
+    return lines
+
+
 async def tool_health_status(ctx) -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
@@ -82,5 +130,13 @@ async def tool_health_status(ctx) -> str:
         sections.extend(_mcp_section())
     except Exception as e:
         sections.append(f"### MCP Servers\n- [error: {e}]")
+
+    sections.append("")
+
+    # Heartbeat
+    try:
+        sections.extend(_heartbeat_section(ctx.config))
+    except Exception as e:
+        sections.append(f"### Heartbeat\n- [error: {e}]")
 
     return "\n".join(sections)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -111,3 +111,15 @@ async def test_health_embeddings_with_data(ctx):
     result = await tool_health_status(ctx)
     assert "Memory:" in result
     assert "Conversation:" in result
+
+
+@pytest.mark.asyncio
+async def test_health_full_report_all_sections(ctx):
+    """Full report includes all five section headers."""
+    result = await tool_health_status(ctx)
+    assert "## Agent Health" in result
+    assert "### Process" in result
+    assert "### MCP Servers" in result
+    assert "### Heartbeat" in result
+    assert "### Tools" in result
+    assert "### Embeddings" in result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -78,3 +78,36 @@ async def test_health_tools_section(ctx):
     result = await tool_health_status(ctx)
     assert "### Tools" in result
     assert "Active:" in result
+
+
+@pytest.mark.asyncio
+async def test_health_embeddings_no_db(ctx):
+    """Embeddings section handles missing database."""
+    result = await tool_health_status(ctx)
+    assert "No embedding" in result or "Embeddings" in result
+
+
+@pytest.mark.asyncio
+async def test_health_embeddings_with_data(ctx):
+    """Embeddings section shows counts when DB exists."""
+    import sqlite3
+
+    db_path = ctx.config.workspace_path / "embeddings.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""CREATE TABLE memory_embeddings (
+        id INTEGER PRIMARY KEY, file_path TEXT, entry_hash TEXT UNIQUE,
+        entry_text TEXT, embedding BLOB, source_type TEXT DEFAULT 'memory',
+        created_at TEXT)""")
+    conn.execute(
+        "INSERT INTO memory_embeddings VALUES (1,'f','h1','t',X'00','memory','2024-01-01')"
+    )
+    conn.execute(
+        "INSERT INTO memory_embeddings VALUES (2,'f','h2','t',X'00','conversation','2024-01-01')"
+    )
+    conn.commit()
+    conn.close()
+
+    result = await tool_health_status(ctx)
+    assert "Memory:" in result
+    assert "Conversation:" in result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,7 @@
 """Tests for the health_status diagnostic tool."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from decafclaw.tools.health import tool_health_status
@@ -14,3 +16,27 @@ async def test_health_process_section(ctx):
     assert "Uptime:" in result
     assert "Memory (RSS):" in result
     assert "MB" in result
+
+
+@pytest.mark.asyncio
+async def test_health_mcp_section_no_servers(ctx):
+    """MCP section handles no registry gracefully."""
+    with patch("decafclaw.mcp_client.get_registry", return_value=None):
+        result = await tool_health_status(ctx)
+    assert "No MCP servers configured" in result
+
+
+@pytest.mark.asyncio
+async def test_health_mcp_section_with_servers(ctx):
+    """MCP section shows server status table."""
+    mock_registry = MagicMock()
+    mock_state = MagicMock()
+    mock_state.status = "connected"
+    mock_state.tools = {"mcp__test__a": None, "mcp__test__b": None}
+    mock_state.retry_count = 0
+    mock_registry.servers = {"test-server": mock_state}
+
+    with patch("decafclaw.mcp_client.get_registry", return_value=mock_registry):
+        result = await tool_health_status(ctx)
+    assert "test-server" in result
+    assert "connected" in result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -70,3 +70,11 @@ async def test_health_heartbeat_enabled(ctx):
     result = await tool_health_status(ctx)
     assert "30m" in result
     assert "ago" in result
+
+
+@pytest.mark.asyncio
+async def test_health_tools_section(ctx):
+    """Tools section shows active/deferred counts."""
+    result = await tool_health_status(ctx)
+    assert "### Tools" in result
+    assert "Active:" in result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,16 @@
+"""Tests for the health_status diagnostic tool."""
+
+import pytest
+
+from decafclaw.tools.health import tool_health_status
+
+
+@pytest.mark.asyncio
+async def test_health_process_section(ctx):
+    """Process section shows uptime and memory."""
+    result = await tool_health_status(ctx)
+    assert "## Agent Health" in result
+    assert "### Process" in result
+    assert "Uptime:" in result
+    assert "Memory (RSS):" in result
+    assert "MB" in result

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,5 +1,7 @@
 """Tests for the health_status diagnostic tool."""
 
+import dataclasses
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,3 +42,31 @@ async def test_health_mcp_section_with_servers(ctx):
         result = await tool_health_status(ctx)
     assert "test-server" in result
     assert "connected" in result
+
+
+@pytest.mark.asyncio
+async def test_health_heartbeat_disabled(ctx):
+    """Heartbeat section shows disabled when no interval."""
+    ctx.config = dataclasses.replace(
+        ctx.config,
+        heartbeat=dataclasses.replace(ctx.config.heartbeat, interval=""),
+    )
+    result = await tool_health_status(ctx)
+    assert "disabled" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_health_heartbeat_enabled(ctx):
+    """Heartbeat section shows timing info when enabled."""
+    ctx.config = dataclasses.replace(
+        ctx.config,
+        heartbeat=dataclasses.replace(ctx.config.heartbeat, interval="30m"),
+    )
+    # Write a fake last-run timestamp
+    ts_path = ctx.config.workspace_path / ".heartbeat_last_run"
+    ts_path.parent.mkdir(parents=True, exist_ok=True)
+    ts_path.write_text(str(time.time() - 300))  # 5 min ago
+
+    result = await tool_health_status(ctx)
+    assert "30m" in result
+    assert "ago" in result


### PR DESCRIPTION
## Summary

- Add `health_status` tool that reports agent diagnostic state: process uptime/memory, MCP server connections, heartbeat timing, tool deferral stats, and embedding index size
- Add `!health` user-invokable command (inline skill) that triggers the tool
- Each report section is independently error-isolated — one subsystem failure won't crash the whole report
- Rename `_read_last_heartbeat` → `read_last_heartbeat` for cross-module access

Closes #88

## Test plan

- [x] 9 new tests in `test_health.py` covering each section and the full report (602 total pass)
- [x] `make check` passes (ruff + pyright + tsc)
- [ ] Test `!health` live in Mattermost
- [ ] Test `/health` in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)