### PR TITLE
Protect skill activation turns from compaction

### DIFF
--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -74,6 +74,21 @@ def _split_into_turns(messages: list[dict]) -> list[list[dict]]:
     return turns
 
 
+# Tool names whose results should be preserved verbatim during compaction.
+# Skill activation injects SKILL.md content as a tool result — summarizing
+# it away loses the skill's instructions for the rest of the conversation.
+PROTECTED_TOOL_NAMES = {"activate_skill"}
+
+
+def _turn_has_protected_tool(turn: list[dict]) -> bool:
+    """Check if a turn contains a tool call whose result should not be summarized."""
+    for msg in turn:
+        for tc in msg.get("tool_calls", []):
+            if tc.get("function", {}).get("name") in PROTECTED_TOOL_NAMES:
+                return True
+    return False
+
+
 def flatten_messages(messages: list[dict]) -> str:
     """Flatten messages into a readable text format for the compaction LLM."""
     lines = []
@@ -193,10 +208,24 @@ async def compact_history(ctx, history: list) -> bool:
         log.info(f"Compaction skipped: only {len(turns)} turns, need >{preserve} to compact")
         return False
 
-    # Split: old turns to summarize, recent turns to keep
-    old_turns = turns[:-preserve]
+    # Split: old turns to summarize, recent turns to keep.
+    # Turns containing protected tool calls (e.g. activate_skill) are moved
+    # from old to preserved so their content survives compaction.
+    old_turns = []
+    protected_turns = []
+    for turn in turns[:-preserve]:
+        if _turn_has_protected_tool(turn):
+            protected_turns.append(turn)
+        else:
+            old_turns.append(turn)
     recent_turns = turns[-preserve:]
+    if protected_turns:
+        log.info(f"Protecting {len(protected_turns)} skill activation turn(s) from compaction")
+    if not old_turns:
+        log.info("Compaction skipped: all old turns are protected")
+        return False
     old_messages = [msg for turn in old_turns for msg in turn]
+    protected_messages = [msg for turn in protected_turns for msg in turn]
     recent_messages = [msg for turn in recent_turns for msg in turn]
 
     # Check for incremental compaction
@@ -287,7 +316,7 @@ async def compact_history(ctx, history: list) -> bool:
             log.warning("Compaction LLM returned empty summary, skipping")
             return False
 
-        # Rebuild history: summary + recent messages
+        # Rebuild history: summary + protected turns + recent messages
         summary_msg = {
             "role": "user",
             "content": f"{SUMMARY_PREFIX}{summary}",
@@ -295,13 +324,15 @@ async def compact_history(ctx, history: list) -> bool:
 
         history.clear()
         history.append(summary_msg)
+        history.extend(protected_messages)
         history.extend(recent_messages)
 
         # Persist compacted working history so future turns don't re-expand from archive
         write_compacted_history(config, conv_id, list(history))
 
         log.info(f"Compaction complete: {len(old_messages)} messages -> "
-                 f"1 summary + {len(recent_messages)} recent = {len(history)} total")
+                 f"1 summary + {len(protected_messages)} protected + "
+                 f"{len(recent_messages)} recent = {len(history)} total")
         return True
 
     except Exception as e:

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -83,7 +83,7 @@ PROTECTED_TOOL_NAMES = {"activate_skill"}
 def _turn_has_protected_tool(turn: list[dict]) -> bool:
     """Check if a turn contains a tool call whose result should not be summarized."""
     for msg in turn:
-        for tc in msg.get("tool_calls", []):
+        for tc in (msg.get("tool_calls") or []):
             if tc.get("function", {}).get("name") in PROTECTED_TOOL_NAMES:
                 return True
     return False
@@ -255,8 +255,20 @@ async def compact_history(ctx, history: list) -> bool:
         # archive at that time. We can count: the compacted sidecar had
         # (total_compacted - 1) recent messages covering archive positions
         # [prev_archive_len - (total_compacted - 1) : prev_archive_len].
+        # Note: the sidecar may also contain protected turns (e.g. skill
+        # activations) between the summary and recent messages — subtract
+        # those so we count only actual recent messages.
         compacted = read_compacted_history(config, conv_id)
-        prev_recent_count = len(compacted) - 1 if compacted else 0
+        if compacted:
+            non_summary = compacted[1:]
+            compacted_turns = _split_into_turns(non_summary)
+            protected_msg_count = sum(
+                len(turn) for turn in compacted_turns
+                if _turn_has_protected_tool(turn)
+            )
+            prev_recent_count = len(compacted) - 1 - protected_msg_count
+        else:
+            prev_recent_count = 0
         prev_old_msg_count = prev_archive_len - prev_recent_count
 
         # Walk old_turns to find those with messages past the previous boundary

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -287,6 +287,14 @@ class TestTurnHasProtectedTool:
         ]
         assert _turn_has_protected_tool(turn) is False
 
+    def test_handles_none_tool_calls(self):
+        """tool_calls: None is a valid LLM response shape — should not crash."""
+        turn = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi", "tool_calls": None},
+        ]
+        assert _turn_has_protected_tool(turn) is False
+
     def test_handles_no_tool_calls(self):
         turn = [
             {"role": "user", "content": "hello"},

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -9,6 +9,7 @@ from decafclaw.compaction import (
     SUMMARY_PREFIX,
     _extract_previous_summary,
     _split_into_turns,
+    _turn_has_protected_tool,
     compact_history,
     estimate_tokens,
     flatten_messages,
@@ -261,5 +262,112 @@ class TestCompactHistory:
 
         # No new messages added — same 8 turns, same boundary.
         history = [{"role": "user", "content": "placeholder"}]
+        result = await compact_history(ctx, history)
+        assert result is False
+
+
+class TestTurnHasProtectedTool:
+    def test_detects_activate_skill(self):
+        turn = [
+            {"role": "user", "content": "activate tabstack"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {"name": "activate_skill", "arguments": '{"name": "tabstack"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "skill body here"},
+        ]
+        assert _turn_has_protected_tool(turn) is True
+
+    def test_ignores_regular_tools(self):
+        turn = [
+            {"role": "user", "content": "run ls"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {"name": "shell", "arguments": '{"command": "ls"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc1", "content": "file1.txt"},
+        ]
+        assert _turn_has_protected_tool(turn) is False
+
+    def test_handles_no_tool_calls(self):
+        turn = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert _turn_has_protected_tool(turn) is False
+
+
+class TestSkillProtectionDuringCompaction:
+    @pytest.fixture
+    def archive_with_skill(self, config):
+        """Create an archive with a skill activation in turn 1 (of 8)."""
+        conv_id = "test-conv"
+        # Turn 0: regular
+        append_message(config, conv_id, {"role": "user", "content": "hello"})
+        append_message(config, conv_id, {"role": "assistant", "content": "hi"})
+        # Turn 1: skill activation
+        append_message(config, conv_id, {"role": "user", "content": "activate tabstack"})
+        append_message(config, conv_id, {
+            "role": "assistant", "content": None,
+            "tool_calls": [{"id": "tc1", "function": {
+                "name": "activate_skill", "arguments": '{"name": "tabstack"}'
+            }}],
+        })
+        append_message(config, conv_id, {
+            "role": "tool", "tool_call_id": "tc1",
+            "content": "# Tabstack Skill\nFull skill body with instructions...",
+        })
+        append_message(config, conv_id, {
+            "role": "assistant", "content": "Tabstack is now active.",
+        })
+        # Turns 2-7: regular
+        for i in range(2, 8):
+            append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
+            append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
+        return conv_id
+
+    @pytest.mark.asyncio
+    async def test_skill_turn_preserved(self, ctx, archive_with_skill):
+        """Skill activation turn should survive compaction."""
+        ctx.config.compaction.preserve_turns = 5
+        history = [{"role": "user", "content": "placeholder"}]
+
+        mock_response = {
+            "content": "Summary of non-skill turns.",
+            "tool_calls": None, "role": "assistant", "usage": None,
+        }
+
+        with patch("decafclaw.compaction.call_llm", new_callable=AsyncMock, return_value=mock_response):
+            result = await compact_history(ctx, history)
+
+        assert result is True
+        # History should be: summary + protected skill turn + 5 recent turns
+        assert history[0]["content"].startswith(SUMMARY_PREFIX)
+        # Find the skill content in the protected messages
+        skill_content = [m for m in history if (m.get("content") or "").startswith("# Tabstack Skill")]
+        assert len(skill_content) == 1, "Skill body should be preserved verbatim"
+
+    @pytest.mark.asyncio
+    async def test_all_old_turns_protected_skips(self, ctx, config):
+        """If every old turn is a skill activation, compaction should skip."""
+        conv_id = "test-conv"
+        # Turn 0: skill activation
+        append_message(config, conv_id, {"role": "user", "content": "activate tabstack"})
+        append_message(config, conv_id, {
+            "role": "assistant", "content": None,
+            "tool_calls": [{"id": "tc1", "function": {
+                "name": "activate_skill", "arguments": '{"name": "tabstack"}'
+            }}],
+        })
+        append_message(config, conv_id, {
+            "role": "tool", "tool_call_id": "tc1", "content": "skill body",
+        })
+        append_message(config, conv_id, {"role": "assistant", "content": "activated"})
+        # Turns 1-5: regular (these will be the "recent" window)
+        for i in range(1, 6):
+            append_message(config, conv_id, {"role": "user", "content": f"message {i}"})
+            append_message(config, conv_id, {"role": "assistant", "content": f"response {i}"})
+
+        ctx.config.compaction.preserve_turns = 5
+        history = [{"role": "user", "content": "placeholder"}]
+
         result = await compact_history(ctx, history)
         assert result is False


### PR DESCRIPTION
## Summary
- Skill activation turns (`activate_skill` tool calls) are now excluded from the summarization bucket during compaction
- Protected turns are re-injected between the summary and recent messages, preserving SKILL.md content verbatim
- If all old turns are protected (nothing to summarize), compaction is skipped
- Added `PROTECTED_TOOL_NAMES` set for extensibility

Closes #33

## Test plan
- [x] `_turn_has_protected_tool` detects activate_skill calls, ignores regular tools
- [x] Skill activation turn preserved verbatim through compaction
- [x] Compaction skips when all old turns are protected
- [x] All 620 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)