### PR TITLE
Auto-load older messages on scroll to top

### DIFF
--- a/src/decafclaw/web/static/components/chat-view.js
+++ b/src/decafclaw/web/static/components/chat-view.js
@@ -29,6 +29,7 @@ export class ChatView extends LitElement {
     this._convId = null;
     this._scrollOnLoad = false;
     this._hasMore = false;
+    this._loadingMore = false;
     this._savedScrollHeight = 0;
   }
 
@@ -50,12 +51,14 @@ export class ChatView extends LitElement {
         this._scrollOnLoad = true;
         this._showScrollBtn = false;
         this._savedScrollHeight = 0;
+        this._loadingMore = false;
       }
 
       // Older messages were prepended (load more) — anchor scroll position
       if (this._savedScrollHeight > 0 && this._messages.length > prevMsgCount) {
         const saved = this._savedScrollHeight;
         this._savedScrollHeight = 0;
+        this._loadingMore = false;
         requestAnimationFrame(() => {
           this.scrollTop = this.scrollHeight - saved;
         });
@@ -72,9 +75,12 @@ export class ChatView extends LitElement {
       }
     };
     this.store?.addEventListener('change', this._onStoreChange);
-    // Track scroll position
+    // Track scroll position + auto-load older messages
     this.addEventListener('scroll', () => {
       this._showScrollBtn = !this.#isNearBottom();
+      if (this._hasMore && !this._loadingMore && this.scrollTop < 100) {
+        this.#handleLoadMore();
+      }
     });
   }
 
@@ -103,6 +109,8 @@ export class ChatView extends LitElement {
   }
 
   #handleLoadMore() {
+    if (this._loadingMore) return;
+    this._loadingMore = true;
     this._savedScrollHeight = this.scrollHeight;
     this.store?.loadMoreHistory();
   }
@@ -113,10 +121,8 @@ export class ChatView extends LitElement {
     }
 
     return html`
-      ${this._hasMore ? html`
-        <div class="load-more">
-          <button class="outline" @click=${this.#handleLoadMore}>Load older messages</button>
-        </div>
+      ${this._loadingMore ? html`
+        <div class="load-more"><small>Loading...</small></div>
       ` : nothing}
 
       ${this._messages.map(m => html`


### PR DESCRIPTION
## Summary
- Replaces the manual "Load older messages" button with automatic loading when scrollTop < 100px
- `_loadingMore` guard prevents duplicate requests while a fetch is in flight
- Guard cleared when new messages arrive (scroll anchor handler) or conversation changes
- Shows a small "Loading..." indicator at top during fetch

Closes #62

## Test plan
- [x] All 626 tests pass, lint/typecheck clean
- [ ] Open a conversation with enough history to paginate — scroll to top, verify auto-load triggers
- [ ] Verify scroll position stays anchored after older messages load
- [ ] Verify no rapid-fire requests when sitting at scroll top

🤖 Generated with [Claude Code](https://claude.com/claude-code)