### PR TITLE
Cron-style scheduled tasks subsystem

### DIFF
--- a/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/notes.md
+++ b/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/notes.md
@@ -1,0 +1,9 @@
+# Session Notes — Scheduled Tasks
+
+## Session started: 2026-03-23
+
+### Context
+- Issue #8: Scheduled tasks (cron-like)
+- Extending the existing heartbeat system with cron-style per-task scheduling
+- Key insight from discussion: rather than a new subsystem, extend heartbeat
+  sections to support cron expressions and point at different prompt files

--- a/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/plan.md
+++ b/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/plan.md
@@ -1,0 +1,725 @@
+# Scheduled Tasks Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add cron-style scheduled tasks as a new subsystem. Each task is a markdown file with YAML frontmatter (cron expression, channel, effort, tools, skills). A timer loop discovers tasks, checks if they're due via `croniter`, and executes them as independent agent turns.
+
+**Architecture:** Schedule files live in `data/{agent_id}/schedules/` (admin) and `workspace/schedules/` (agent-writable). A `run_schedule_timer` polls every 60s, discovers files, checks cron expressions against per-task last-run timestamps, and runs due tasks via `run_agent_turn`. Results post to a configured Mattermost channel or log.
+
+**Tech Stack:** Python, `croniter` library, existing context/agent/heartbeat patterns.
+
+**Review notes (pre-execution):**
+- Reuse `_split_frontmatter()` from `skills/__init__.py` instead of writing a new regex parser
+- PyYAML already a dependency — no issue
+- `MattermostClient` has no `resolve_channel` by name — heartbeat uses channel IDs directly. Need to add channel-name-to-ID resolution for `#channel-name` format in Task 6
+- Heartbeat reporting uses its own httpx client (`_make_http_client`), not MattermostClient — schedule reporting should follow the same pattern for consistency
+
+---
+
+### Task 1: Add `croniter` dependency and schedule file parser
+
+**Files:**
+- Modify: `pyproject.toml` — add `croniter` dependency
+- Create: `src/decafclaw/schedules.py` — schedule file parsing and discovery
+- Create: `tests/test_schedules.py` — parser tests
+
+- [ ] **Step 1: Add `croniter` dependency**
+
+Add `croniter` to `pyproject.toml` dependencies, then run `uv sync`.
+
+- [ ] **Step 2: Write failing tests for schedule file parsing**
+
+```python
+# tests/test_schedules.py
+"""Tests for scheduled task parsing and discovery."""
+
+import pytest
+
+from decafclaw.schedules import ScheduleTask, parse_schedule_file
+
+
+class TestParseScheduleFile:
+    def test_basic_parse(self, tmp_path):
+        f = tmp_path / "daily-summary.md"
+        f.write_text(
+            "---\n"
+            'schedule: "0 9 * * 1-5"\n'
+            'channel: "#reports"\n'
+            "---\n\n"
+            "Summarize the day.\n"
+        )
+        task = parse_schedule_file(f)
+        assert task is not None
+        assert task.name == "daily-summary"
+        assert task.schedule == "0 9 * * 1-5"
+        assert task.channel == "#reports"
+        assert task.enabled is True
+        assert "Summarize the day." in task.body
+
+    def test_all_frontmatter_fields(self, tmp_path):
+        f = tmp_path / "check.md"
+        f.write_text(
+            "---\n"
+            'schedule: "*/15 * * * *"\n'
+            "enabled: false\n"
+            "effort: fast\n"
+            "allowed-tools:\n"
+            "  - workspace_read\n"
+            "  - workspace_list\n"
+            "required-skills:\n"
+            "  - tabstack\n"
+            "---\n\n"
+            "Check things.\n"
+        )
+        task = parse_schedule_file(f)
+        assert task.enabled is False
+        assert task.effort == "fast"
+        assert task.allowed_tools == ["workspace_read", "workspace_list"]
+        assert task.required_skills == ["tabstack"]
+
+    def test_missing_schedule_returns_none(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("---\nchannel: '#foo'\n---\n\nNo schedule.\n")
+        assert parse_schedule_file(f) is None
+
+    def test_invalid_cron_returns_none(self, tmp_path):
+        f = tmp_path / "bad-cron.md"
+        f.write_text("---\nschedule: 'not a cron'\n---\n\nBad cron.\n")
+        assert parse_schedule_file(f) is None
+
+    def test_no_frontmatter_returns_none(self, tmp_path):
+        f = tmp_path / "plain.md"
+        f.write_text("Just a plain markdown file.\n")
+        assert parse_schedule_file(f) is None
+```
+
+- [ ] **Step 3: Implement `ScheduleTask` dataclass and `parse_schedule_file`**
+
+```python
+# src/decafclaw/schedules.py
+"""Scheduled tasks — cron-style task files with per-task scheduling."""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from croniter import croniter
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ScheduleTask:
+    """A parsed schedule file."""
+    name: str
+    schedule: str  # 5-field cron expression
+    body: str
+    source: str  # "admin" or "workspace"
+    path: Path
+    channel: str = ""
+    enabled: bool = True
+    effort: str = "default"
+    allowed_tools: list[str] = field(default_factory=list)
+    required_skills: list[str] = field(default_factory=list)
+
+
+# Regex to split YAML frontmatter from body
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)", re.DOTALL)
+
+
+def parse_schedule_file(path: Path) -> ScheduleTask | None:
+    """Parse a schedule markdown file. Returns None if invalid."""
+    try:
+        text = path.read_text()
+    except OSError as e:
+        log.warning(f"Cannot read schedule file {path}: {e}")
+        return None
+
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        log.debug(f"No frontmatter in {path.name}, skipping")
+        return None
+
+    try:
+        meta = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as e:
+        log.warning(f"Invalid YAML in {path.name}: {e}")
+        return None
+
+    schedule = meta.get("schedule", "")
+    if not schedule:
+        log.warning(f"No schedule field in {path.name}, skipping")
+        return None
+
+    # Validate cron expression
+    if not croniter.is_valid(schedule):
+        log.warning(f"Invalid cron expression in {path.name}: {schedule!r}")
+        return None
+
+    body = match.group(2).strip()
+    name = path.stem
+
+    return ScheduleTask(
+        name=name,
+        schedule=schedule,
+        body=body,
+        source="",  # set by caller
+        path=path,
+        channel=meta.get("channel", ""),
+        enabled=meta.get("enabled", True),
+        effort=meta.get("effort", "default"),
+        allowed_tools=meta.get("allowed-tools", []),
+        required_skills=meta.get("required-skills", []),
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `make check && pytest tests/test_schedules.py -v`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add croniter dependency and schedule file parser
+```
+
+---
+
+### Task 2: Schedule file discovery
+
+**Files:**
+- Modify: `src/decafclaw/schedules.py` — add `discover_schedules()`
+- Modify: `tests/test_schedules.py` — discovery tests
+
+- [ ] **Step 1: Write failing tests for discovery**
+
+```python
+class TestDiscoverSchedules:
+    def test_discovers_from_both_dirs(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "admin-task.md").write_text(
+            "---\nschedule: '0 9 * * *'\n---\nAdmin task.\n"
+        )
+        workspace = config.workspace_path / "schedules"
+        workspace.mkdir(parents=True)
+        (workspace / "agent-task.md").write_text(
+            "---\nschedule: '0 12 * * *'\n---\nAgent task.\n"
+        )
+        tasks = discover_schedules(config)
+        names = {t.name for t in tasks}
+        assert "admin-task" in names
+        assert "agent-task" in names
+
+    def test_admin_takes_precedence_on_collision(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "task.md").write_text(
+            "---\nschedule: '0 9 * * *'\n---\nAdmin version.\n"
+        )
+        workspace = config.workspace_path / "schedules"
+        workspace.mkdir(parents=True)
+        (workspace / "task.md").write_text(
+            "---\nschedule: '0 12 * * *'\n---\nWorkspace version.\n"
+        )
+        tasks = discover_schedules(config)
+        assert len([t for t in tasks if t.name == "task"]) == 1
+        task = [t for t in tasks if t.name == "task"][0]
+        assert task.source == "admin"
+
+    def test_empty_dirs(self, config):
+        assert discover_schedules(config) == []
+```
+
+- [ ] **Step 2: Implement `discover_schedules()`**
+
+```python
+def discover_schedules(config) -> list[ScheduleTask]:
+    """Discover schedule files from admin and workspace directories.
+
+    Admin tasks take precedence when names collide.
+    """
+    tasks_by_name: dict[str, ScheduleTask] = {}
+
+    for source, base_dir in [
+        ("admin", config.agent_path / "schedules"),
+        ("workspace", config.workspace_path / "schedules"),
+    ]:
+        if not base_dir.is_dir():
+            continue
+        for path in sorted(base_dir.glob("*.md")):
+            task = parse_schedule_file(path)
+            if task is None:
+                continue
+            task.source = source
+            # Admin takes precedence
+            if task.name not in tasks_by_name or source == "admin":
+                tasks_by_name[task.name] = task
+
+    return list(tasks_by_name.values())
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `make check && pytest tests/test_schedules.py -v`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```
+feat: add schedule file discovery from admin and workspace dirs
+```
+
+---
+
+### Task 3: Last-run tracking
+
+**Files:**
+- Modify: `src/decafclaw/schedules.py` — add last-run read/write and `is_due()`
+- Modify: `tests/test_schedules.py` — last-run and due-check tests
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+class TestLastRun:
+    def test_read_no_file(self, config):
+        assert read_last_run(config, "nonexistent") == 0
+
+    def test_write_and_read(self, config):
+        write_last_run(config, "my-task", 1700000000.0)
+        assert read_last_run(config, "my-task") == 1700000000.0
+
+
+class TestIsDue:
+    def test_never_run_is_due(self, config):
+        """A task that has never run should be due."""
+        task = ScheduleTask(
+            name="test", schedule="* * * * *", body="test",
+            source="admin", path=Path("/fake"),
+        )
+        assert is_due(config, task) is True
+
+    def test_recently_run_not_due(self, config):
+        """A task that just ran should not be due."""
+        import time
+        task = ScheduleTask(
+            name="test", schedule="0 9 * * *", body="test",
+            source="admin", path=Path("/fake"),
+        )
+        write_last_run(config, "test", time.time())
+        assert is_due(config, task) is False
+```
+
+- [ ] **Step 2: Implement last-run tracking and `is_due()`**
+
+```python
+import time
+from datetime import datetime
+
+
+def _last_run_path(config, task_name: str) -> Path:
+    return config.workspace_path / ".schedule_last_run" / task_name
+
+
+def read_last_run(config, task_name: str) -> float:
+    """Read last-run timestamp. Returns 0 if never run."""
+    path = _last_run_path(config, task_name)
+    try:
+        if path.exists():
+            return float(path.read_text().strip())
+    except (ValueError, OSError):
+        pass
+    return 0
+
+
+def write_last_run(config, task_name: str, timestamp: float | None = None) -> None:
+    """Write last-run timestamp (defaults to now)."""
+    path = _last_run_path(config, task_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(timestamp or time.time()))
+
+
+def is_due(config, task: ScheduleTask) -> bool:
+    """Check if a scheduled task is due to run."""
+    last_run = read_last_run(config, task.name)
+    if last_run == 0:
+        return True  # never run before
+
+    # Use croniter to find the next fire time after last_run
+    cron = croniter(task.schedule, datetime.fromtimestamp(last_run))
+    next_fire = cron.get_next(float)
+    return time.time() >= next_fire
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `make check && pytest tests/test_schedules.py -v`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```
+feat: add per-task last-run tracking and is_due() check
+```
+
+---
+
+### Task 4: Task execution
+
+**Files:**
+- Modify: `src/decafclaw/schedules.py` — add `run_schedule_task()`
+- Modify: `tests/test_schedules.py` — execution tests
+
+- [ ] **Step 1: Write failing test for task execution**
+
+```python
+class TestRunScheduleTask:
+    @pytest.mark.asyncio
+    async def test_runs_agent_turn(self, config):
+        """Task execution calls run_agent_turn with correct context."""
+        from unittest.mock import AsyncMock, patch
+
+        task = ScheduleTask(
+            name="test-task", schedule="* * * * *",
+            body="Do the thing.", source="admin", path=Path("/fake"),
+            effort="fast",
+        )
+        mock_response = MagicMock()
+        mock_response.text = "Done."
+
+        with patch("decafclaw.schedules.run_agent_turn",
+                    new_callable=AsyncMock, return_value=mock_response):
+            result = await run_schedule_task(config, EventBus(), task)
+
+        assert result["response"] == "Done."
+        assert result["is_ok"] is False
+        assert result["task_name"] == "test-task"
+```
+
+- [ ] **Step 2: Implement `run_schedule_task()`**
+
+```python
+async def run_schedule_task(config, event_bus, task: ScheduleTask) -> dict:
+    """Run a single scheduled task as an agent turn.
+
+    Returns {"task_name", "response", "is_ok", "context_id"}.
+    """
+    from .agent import run_agent_turn
+    from .context import Context
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    ctx = Context(config=config, event_bus=event_bus)
+    ctx.user_id = f"schedule-{task.source}"
+    ctx.channel_id = "schedule"
+    ctx.channel_name = "schedule"
+    ctx.conv_id = f"schedule-{task.name}-{timestamp}"
+    ctx.effort = task.effort
+
+    if task.allowed_tools:
+        ctx.allowed_tools = set(task.allowed_tools)
+
+    # Pre-activate required skills
+    if task.required_skills:
+        discovered = getattr(config, "discovered_skills", [])
+        skill_map = {s.name: s for s in discovered}
+        from .tools.skill_tools import activate_skill_internal
+        for skill_name in task.required_skills:
+            skill_info = skill_map.get(skill_name)
+            if skill_info:
+                try:
+                    await activate_skill_internal(ctx, skill_info)
+                except Exception as e:
+                    log.error(f"Failed to activate skill '{skill_name}' for task '{task.name}': {e}")
+
+    preamble = (
+        f'You are running a scheduled task: "{task.name}".\n'
+        "Execute the following task and report your findings.\n"
+        "If there is nothing to report, respond with HEARTBEAT_OK.\n"
+        "Prefer workspace tools (workspace_read, workspace_write, workspace_list) "
+        "over shell commands.\n\n"
+    )
+    prompt = preamble + task.body
+
+    try:
+        result = await run_agent_turn(ctx, prompt, history=[])
+        response = result.text or "(no response)"
+        from .heartbeat import is_heartbeat_ok
+        ok = is_heartbeat_ok(response)
+        return {
+            "task_name": task.name,
+            "response": response,
+            "is_ok": ok,
+            "context_id": ctx.context_id,
+        }
+    except Exception as e:
+        log.error(f"Scheduled task '{task.name}' failed: {e}", exc_info=True)
+        return {
+            "task_name": task.name,
+            "response": f"[error: scheduled task failed: {e}]",
+            "is_ok": False,
+            "context_id": None,
+        }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `make check && pytest tests/test_schedules.py -v`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```
+feat: add run_schedule_task() for executing scheduled tasks
+```
+
+---
+
+### Task 5: Timer loop and runner integration
+
+**Files:**
+- Modify: `src/decafclaw/schedules.py` — add `run_schedule_timer()`
+- Modify: `src/decafclaw/runner.py` — start schedule timer alongside heartbeat
+- Modify: `tests/test_schedules.py` — timer tests
+
+- [ ] **Step 1: Write failing test for timer loop**
+
+```python
+class TestRunScheduleTimer:
+    @pytest.mark.asyncio
+    async def test_executes_due_task(self, config):
+        """Timer should execute tasks that are due."""
+        # Create a schedule file with a "run every minute" cron
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "test.md").write_text(
+            "---\nschedule: '* * * * *'\n---\nDo the thing.\n"
+        )
+
+        shutdown = asyncio.Event()
+        executed = []
+
+        async def fake_run(cfg, bus, task):
+            executed.append(task.name)
+            return {"task_name": task.name, "response": "ok",
+                    "is_ok": True, "context_id": None}
+
+        with patch("decafclaw.schedules.run_schedule_task", side_effect=fake_run):
+            # Run one tick then shut down
+            async def stop_after_tick():
+                await asyncio.sleep(0.1)
+                shutdown.set()
+            asyncio.create_task(stop_after_tick())
+            await run_schedule_timer(config, EventBus(), shutdown, poll_interval=0.05)
+
+        assert "test" in executed
+```
+
+- [ ] **Step 2: Implement `run_schedule_timer()`**
+
+```python
+_SCHEDULE_POLL_INTERVAL = 60
+
+
+async def run_schedule_timer(config, event_bus, shutdown_event,
+                              on_result=None, poll_interval=None):
+    """Run the schedule timer loop.
+
+    Discovers schedule files, checks if tasks are due, and runs them.
+    """
+    interval = poll_interval or _SCHEDULE_POLL_INTERVAL
+    running_tasks: set[str] = set()
+
+    log.info("Schedule timer starting")
+
+    while not shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
+            break
+        except asyncio.TimeoutError:
+            pass
+
+        if shutdown_event.is_set():
+            break
+
+        tasks = discover_schedules(config)
+        if not tasks:
+            continue
+
+        for task in tasks:
+            if not task.enabled:
+                continue
+            if task.name in running_tasks:
+                log.debug(f"Schedule '{task.name}' still running, skipping")
+                continue
+            if not is_due(config, task):
+                continue
+
+            log.info(f"Schedule '{task.name}' is due, executing")
+            running_tasks.add(task.name)
+
+            async def _run(t=task):
+                try:
+                    write_last_run(config, t.name)
+                    result = await run_schedule_task(config, event_bus, t)
+                    if on_result:
+                        try:
+                            await on_result(result)
+                        except Exception as e:
+                            log.error(f"Schedule result callback failed: {e}")
+                    elif result["is_ok"]:
+                        log.info(f"Schedule '{t.name}': HEARTBEAT_OK")
+                    else:
+                        log.info(f"Schedule '{t.name}' response: "
+                                 f"{result['response'][:200]}")
+                except Exception as e:
+                    log.error(f"Schedule '{t.name}' execution failed: {e}")
+                finally:
+                    running_tasks.discard(t.name)
+
+            asyncio.create_task(_run())
+
+    log.info("Schedule timer stopped")
+```
+
+- [ ] **Step 3: Wire into runner.py**
+
+In `runner.py`, after the heartbeat task setup:
+
+```python
+# Start schedule timer
+from .schedules import run_schedule_timer
+
+schedule_on_result = None
+if config.mattermost.url and config.mattermost.token:
+    # Wire Mattermost reporting for scheduled tasks
+    schedule_on_result = _make_schedule_reporter(config, client)
+
+schedule_task = asyncio.create_task(
+    run_schedule_timer(
+        config, app_ctx.event_bus, shutdown_event,
+        on_result=schedule_on_result,
+    )
+)
+log.info("Schedule timer started")
+```
+
+Add `schedule_task` to the shutdown sequence (cancel before heartbeat).
+
+- [ ] **Step 4: Run tests**
+
+Run: `make check && make test`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add schedule timer loop and wire into runner
+```
+
+---
+
+### Task 6: Mattermost channel reporting
+
+**Files:**
+- Modify: `src/decafclaw/runner.py` — add schedule result reporter
+- Modify: `tests/test_schedules.py` — reporting test
+
+- [ ] **Step 1: Implement Mattermost reporting for scheduled tasks**
+
+In `runner.py`, add a helper that posts schedule results to the configured channel:
+
+```python
+def _make_schedule_reporter(config, mattermost_client):
+    """Create an on_result callback that posts to Mattermost."""
+    async def _report(result):
+        channel = result.get("channel", "")
+        if not channel:
+            return  # no channel configured, log only
+        if result["is_ok"]:
+            return  # suppress OK results
+
+        response = result["response"]
+        task_name = result["task_name"]
+        text = f"**Scheduled task: {task_name}**\n\n{response}"
+
+        # Resolve channel name to ID
+        channel_id = await mattermost_client.resolve_channel(channel)
+        if channel_id:
+            await mattermost_client.send_message(channel_id, text)
+        else:
+            log.warning(f"Could not resolve channel '{channel}' for task '{task_name}'")
+
+    return _report
+```
+
+Note: `run_schedule_task` result dict needs to include `channel` from the task. Update `run_schedule_task` to include `"channel": task.channel` in the returned dict.
+
+- [ ] **Step 2: Add `resolve_channel` to MattermostClient if not present**
+
+Check if the Mattermost client already has a method to resolve channel names to IDs. If not, add a simple one that calls the Mattermost API.
+
+- [ ] **Step 3: Write test**
+
+```python
+class TestScheduleReporting:
+    @pytest.mark.asyncio
+    async def test_posts_to_channel(self):
+        """Non-OK results with a channel get posted to Mattermost."""
+        ...
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `make check && make test`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add Mattermost channel reporting for scheduled tasks
+```
+
+---
+
+### Task 7: Health status and docs
+
+**Files:**
+- Modify: `src/decafclaw/tools/health.py` — add schedule status section
+- Modify: `CLAUDE.md` — add key files, conventions
+- Modify: `README.md` — add schedule config docs if applicable
+- Create: `docs/schedules.md` — feature documentation
+
+- [ ] **Step 1: Add schedule status to health tool**
+
+Add a `_schedule_section()` and `get_schedule_data()` to `tools/health.py`:
+- Number of discovered tasks (admin vs workspace)
+- Next due task and when
+- Last-run times
+
+Wire into both `get_health_data()` (JSON) and `tool_health_status()` (markdown).
+
+- [ ] **Step 2: Update CLAUDE.md**
+
+Add to key files:
+- `src/decafclaw/schedules.py` — Scheduled tasks: discovery, parsing, execution, timer
+
+Add to conventions:
+- "Scheduled tasks via cron-style files." Explain the two directories, frontmatter format, and how the timer works.
+
+- [ ] **Step 3: Create `docs/schedules.md`**
+
+Document the feature: file format, directories, frontmatter fields, examples, how the timer works.
+
+- [ ] **Step 4: Run checks**
+
+Run: `make check && make test`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```
+docs: add scheduled tasks to health status, CLAUDE.md, and docs
+```

--- a/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/spec.md
+++ b/.claude/dev-sessions/2026-03-23-1509-scheduled-tasks/spec.md
@@ -1,0 +1,143 @@
+# Scheduled Tasks (Cron-style)
+
+## Overview
+
+Extend DecafClaw with cron-style scheduled tasks. Each task is a markdown file with frontmatter specifying a cron schedule and execution options. The body is the prompt fed to the agent when the task fires.
+
+This is a new subsystem alongside heartbeat — not an extension of it. Scheduled tasks have their own timer loop, per-task scheduling, and independent last-run tracking.
+
+## References
+
+- Issue: https://github.com/lmorchard/decafclaw/issues/8
+- Related: #39 (heartbeat active hours / per-section intervals — partially overlaps)
+- Deferred: Web UI named channel support (for viewing scheduled task output in web UI)
+
+## Schedule File Format
+
+Schedule files are markdown with YAML frontmatter. They live in two directories:
+
+- `data/{agent_id}/schedules/` — admin-authored, read-only to the agent
+- `data/{agent_id}/workspace/schedules/` — agent-writable, created under user direction
+
+### Example
+
+```markdown
+---
+schedule: "0 9 * * 1-5"
+channel: "abc123channelid"
+enabled: true
+effort: default
+allowed-tools:
+  - workspace_read
+  - workspace_list
+  - semantic_search
+required-skills:
+  - tabstack
+---
+
+Summarize what happened in the workspace in the last 24 hours.
+Check for any new memories or conversation archives since yesterday.
+Report key themes and anything that needs attention.
+```
+
+### Frontmatter Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `schedule` | string | yes | — | 5-field cron expression (min hour dom month dow) |
+| `channel` | string | no | — | Mattermost channel or user DM to report to. If omitted, output goes to agent log only |
+| `enabled` | bool | no | `true` | Quick toggle without deleting the file |
+| `effort` | string | no | `default` | Effort level for model routing (`fast`, `default`, `strong`) |
+| `allowed-tools` | list | no | all | Restrict which tools the task can use |
+| `required-skills` | list | no | — | Skills to pre-activate before running the task |
+
+### File Discovery
+
+- Scan both directories for `*.md` files
+- Task name derived from filename (minus `.md` extension)
+- Admin tasks take precedence if names collide (same as skill scan order)
+- Files with `enabled: false` are discovered but skipped at execution time
+
+## Cron Expression Parsing
+
+Use the `croniter` library for cron expression evaluation.
+
+- Standard 5-field format: `minute hour day-of-month month day-of-week`
+- Examples: `0 9 * * 1-5` (weekdays at 9am), `*/15 * * * *` (every 15 min), `0 0 1 * *` (monthly)
+- Invalid expressions logged as warnings, task skipped
+
+## Last-Run Tracking
+
+Each task tracks its last execution time independently.
+
+- Storage: `workspace/.schedule_last_run/{task_name}` — plain text file containing epoch timestamp
+- On startup, read existing timestamps to avoid re-firing tasks that already ran
+- On each execution attempt, write the current time before running the task (prevents rapid re-runs on crash/restart)
+
+## Timer Loop
+
+A new `run_schedule_timer` function, independent of `run_heartbeat_timer`.
+
+### Behavior
+
+1. Poll every 60 seconds (same as heartbeat poll interval)
+2. On each tick:
+   - Discover all schedule files from both directories
+   - For each enabled task with a valid cron expression:
+     - Read last-run timestamp
+     - Use `croniter` to check if the task was due since last run
+     - If due, execute the task
+3. Overlap protection: skip tasks that are still running from a previous tick
+4. Graceful shutdown via the shared `shutdown_event`
+
+### Runner Integration
+
+- New task in `runner.py` alongside heartbeat, HTTP, and Mattermost
+- Starts unconditionally (discovers tasks at runtime; no tasks = no-op)
+- Does not depend on heartbeat being enabled
+
+## Task Execution
+
+Each scheduled task runs as an independent agent turn, similar to heartbeat sections.
+
+### Execution Flow
+
+1. Parse the schedule file (frontmatter + body)
+2. Build prompt from the file body (with preamble similar to heartbeat sections)
+3. Fork a `Context` with:
+   - `user_id`: `"schedule-{source}"` (admin or workspace)
+   - `conv_id`: `"schedule-{task_name}-{timestamp}"`
+   - `effort`: from frontmatter (resolved via `resolve_effort`)
+   - `allowed_tools`: from frontmatter if specified
+4. Pre-activate `required-skills` (load tools onto context without permission checks)
+5. Run `run_agent_turn` with the prompt and empty history
+6. Handle response:
+   - If `channel` specified: post to that Mattermost channel/user DM
+   - If no channel: log the response
+   - Apply `HEARTBEAT_OK` / suppress logic (reuse `is_heartbeat_ok`)
+
+### Preamble
+
+```
+You are running a scheduled task: "{task_name}".
+Execute the following task and report your findings.
+If there is nothing to report, respond with HEARTBEAT_OK.
+Prefer workspace tools (workspace_read, workspace_write, workspace_list) over shell commands.
+```
+
+## Configuration
+
+No new config dataclass needed initially. The schedule timer discovers tasks from the filesystem.
+
+Future enhancement: `ScheduleConfig` dataclass for global settings like:
+- `poll_interval`: override the 60s default
+- `suppress_ok`: global default (currently per-heartbeat)
+- `default_channel`: fallback when tasks don't specify one
+
+## What's NOT in Scope
+
+- **Web UI channel support** — scheduled task output in web UI requires named channels, which don't exist yet. Deferred to a follow-up issue.
+- **Agent self-scheduling tools** — tools like `create_schedule(name, cron, prompt)` could let the agent manage its own tasks via chat. Deferred — the agent can use `workspace_write` to create files in `workspace/schedules/` for now.
+- **Cron extensions** — no support for seconds, `@reboot`, `@yearly` etc. Standard 5-field only.
+- **Dependency chains** — no "run task B after task A completes" ordering.
+- **Heartbeat migration** — existing HEARTBEAT.md sections continue to work as-is. No migration path needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/eval/` — Eval harness (YAML tests, failure reflection)
 - `src/decafclaw/mcp_client.py` — MCP client: config, registry, server connections, auto-restart
 - `src/decafclaw/heartbeat.py` — Heartbeat: periodic wake-up, section parsing, timer, cycle runner
+- `src/decafclaw/schedules.py` — Scheduled tasks: cron-style task files, discovery, execution, timer loop
 - `src/decafclaw/media.py` — Media handling: ToolResult, MediaHandler interface, workspace ref scanning
 - `src/decafclaw/tools/` — Tool registry: core, memory, todo, workspace, file_share, shell, conversation, skill activation, MCP status, health, delegation
 - `src/decafclaw/tools/health.py` — Health/diagnostic status tool: uptime, MCP, heartbeat, tools, embeddings
@@ -130,6 +131,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Effort levels for model routing.** Three levels: `fast` (cheap/compliant), `default` (normal), `strong` (complex reasoning). Configured in `config.json` `models` section mapping levels to partial LLM configs. Set per-conversation via `set_effort` tool or `!think-harder`/`!think-faster`/`!think-normal` commands. Skills declare `effort` in SKILL.md frontmatter (forked contexts only). `delegate_task` accepts optional `effort` parameter. Resolved at turn start by forking config with the resolved LLM settings. Persisted in conversation sidecar.
 - **MCP servers are globally available.** Configured in `data/{agent_id}/mcp_servers.json` (Claude Code compatible format). Connected eagerly on startup, tools namespaced as `mcp__<server>__<tool>`. Module-level global registry in `mcp_client.py`.
 - **MCP auto-restart.** Crashed stdio servers auto-reconnect on next tool call with exponential backoff (max 3 retries). Use `mcp_status(action="restart")` for manual control.
+- **Scheduled tasks via cron-style files.** Markdown files with YAML frontmatter in `data/{agent_id}/schedules/` (admin) and `workspace/schedules/` (agent-writable). Frontmatter fields: `schedule` (5-field cron), `channel` (Mattermost channel **ID** — `#name` resolution not yet implemented), `enabled`, `effort`, `allowed-tools`, `required-skills`. Independent timer loop (60s poll), per-task last-run tracking in `workspace/.schedule_last_run/`. Uses `croniter` for cron evaluation. Mattermost channel reporting not yet wired — results currently go to agent log.
 - **Self-reflection is fail-open.** The reflection judge evaluates responses before delivery, but errors (network, parse, etc.) always pass through the response as-is. Retries consume `max_tool_iterations` budget. Skipped for child agents, cancelled turns, and empty responses.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 
@@ -141,6 +143,8 @@ Documentation lives in `docs/` — see `docs/index.md` for the full list. When a
 - **Update `README.md`** — tool table, config table, project structure
 - **Update `docs/context-map.md`** — if changing system prompt, tool definitions, or context assembly
 - Docs should stay in sync with the code. If you change behavior, check if the docs need updating too. Stale docs are worse than no docs.
+
+**Docs are part of the feature, not an afterthought.** When adding a new subsystem or feature, create the `docs/` page as part of the implementation PR — not as a follow-up. Same for CLAUDE.md key files and conventions.
 
 **At the end of every dev session:**
 - Review all `docs/` pages for accuracy — features built, config added, files moved.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@
 - [Semantic Search](semantic-search.md) — Embedding-based search over memories and conversations
 - [Eval Loop](eval-loop.md) — Test prompts and tools with real LLM calls
 - [Heartbeat](heartbeat.md) — Periodic agent wake-up for monitoring and recurring tasks
+- [Scheduled Tasks](schedules.md) — Cron-style per-task scheduling with effort, tool, and skill configuration
 - [File Attachments](file-attachments.md) — Upload files, MCP media, workspace image refs, rich cards
 - [Streaming](streaming.md) — Stream LLM tokens as they arrive, configurable throttle
 - [HTTP Server & Interactive Buttons](http-server.md) — Button-based confirmations, HTTP callback server

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -1,0 +1,195 @@
+# Scheduled Tasks
+
+DecafClaw supports cron-style scheduled tasks — markdown files with a cron expression that run as independent agent turns at specified times. This is separate from [Heartbeat](heartbeat.md), which runs all sections on a single interval.
+
+Use scheduled tasks when you need time-of-day or day-of-week control, per-task intervals, or different configurations per task.
+
+## Schedule file format
+
+Each task is a markdown file with YAML frontmatter. The body is the prompt fed to the agent when the task fires.
+
+```markdown
+---
+schedule: "0 9 * * 1-5"
+channel: "abc123channelid"
+effort: default
+allowed-tools:
+  - workspace_read
+  - workspace_list
+  - semantic_search
+required-skills:
+  - tabstack
+---
+
+Summarize what happened in the workspace in the last 24 hours.
+Check for any new memories or conversation archives since yesterday.
+Report key themes and anything that needs attention.
+```
+
+### Frontmatter fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `schedule` | string | yes | — | 5-field cron expression (min hour dom month dow) |
+| `channel` | string | no | — | Mattermost channel **ID** to report to. If omitted, output goes to agent log only. Channel name resolution (`#name`) is not yet supported. |
+| `enabled` | bool | no | `true` | Quick toggle without deleting the file |
+| `effort` | string | no | `default` | Effort level for model routing (`fast`, `default`, `strong`) |
+| `allowed-tools` | list | no | all | Restrict which tools the task can use |
+| `required-skills` | list | no | — | Skills to pre-activate before running the task |
+
+### Cron expressions
+
+Standard 5-field format: `minute hour day-of-month month day-of-week`
+
+| Expression | Meaning |
+|------------|---------|
+| `0 9 * * 1-5` | Weekdays at 9:00 AM |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 0 1 * *` | First of every month at midnight |
+| `30 8,17 * * *` | 8:30 AM and 5:30 PM daily |
+| `0 */6 * * *` | Every 6 hours |
+
+Powered by [croniter](https://github.com/kiorky/croniter). Invalid expressions are logged as warnings and the task is skipped.
+
+## File locations
+
+Schedule files are discovered from two directories:
+
+| Location | Writable by agent | Purpose |
+|----------|-------------------|---------|
+| `data/{agent_id}/schedules/*.md` | No | Admin-managed scheduled tasks |
+| `data/{agent_id}/workspace/schedules/*.md` | Yes | Agent-managed tasks (created via `workspace_write`) |
+
+- Task name is derived from the filename (minus `.md`)
+- Admin tasks take precedence when names collide
+- Both directories are scanned on every poll tick (changes take effect within 60 seconds)
+
+## How it works
+
+1. A timer loop polls every 60 seconds (independent of heartbeat)
+2. On each tick, all schedule files are discovered and parsed
+3. For each enabled task with a valid cron expression:
+   - The per-task last-run timestamp is checked
+   - `croniter` determines if the task was due since its last run
+   - If due, the task executes as an independent agent turn
+4. Last-run timestamps are stored per-task in `workspace/.schedule_last_run/`
+
+### Overlap protection
+
+If a task is still running from a previous tick, it's skipped. This prevents runaway concurrent executions of slow tasks.
+
+### HEARTBEAT_OK
+
+Same pattern as heartbeat — if a task has nothing to report, the agent should respond with `HEARTBEAT_OK` (case-insensitive, within the first 300 characters). OK responses are logged but not posted to channels.
+
+## Reporting
+
+- **With `channel`**: results are posted to the specified Mattermost channel ID
+- **Without `channel`**: results are logged only (useful for tasks that write files or update workspace state)
+
+## Task configuration
+
+### Effort levels
+
+Use `effort` to control which model runs the task:
+
+```yaml
+effort: fast      # cheap model for simple checks
+effort: default   # normal model
+effort: strong    # capable model for complex analysis
+```
+
+### Tool restrictions
+
+Use `allowed-tools` to limit what the task can do:
+
+```yaml
+allowed-tools:
+  - workspace_read
+  - workspace_list
+  - semantic_search
+```
+
+If omitted, all tools are available.
+
+### Pre-activated skills
+
+Use `required-skills` to activate skills before the task runs:
+
+```yaml
+required-skills:
+  - tabstack
+  - health
+```
+
+Skills are activated without permission checks (same as heartbeat admin sections).
+
+## Examples
+
+### Daily workspace summary
+
+```markdown
+---
+schedule: "0 9 * * 1-5"
+channel: "abc123channelid"
+effort: default
+---
+
+Summarize what happened in the workspace in the last 24 hours.
+Check for any new memories or conversation archives since yesterday.
+Report key themes and anything that needs attention.
+```
+
+### Hourly health check (silent)
+
+```markdown
+---
+schedule: "0 * * * *"
+effort: fast
+---
+
+Run health_status and check for any issues.
+If everything looks normal, respond with HEARTBEAT_OK.
+If any MCP servers are down or heartbeat is overdue, write a note
+to workspace memories.
+```
+
+### Weekly web check
+
+```markdown
+---
+schedule: "0 10 * * 1"
+channel: "abc123channelid"
+effort: default
+required-skills:
+  - tabstack
+---
+
+Use Tabstack to check if https://example.com is up and responding.
+Report the HTTP status code and page title.
+```
+
+### Disabled task (kept for reference)
+
+```markdown
+---
+schedule: "0 6 * * *"
+enabled: false
+---
+
+This task is disabled but the file is kept so it's easy to re-enable.
+```
+
+## Differences from heartbeat
+
+| | Heartbeat | Scheduled Tasks |
+|---|---|---|
+| **Timing** | Single interval for all sections | Per-task cron expression |
+| **Format** | `## Section` headers in one file | One file per task |
+| **Config** | `HEARTBEAT_INTERVAL` env var | `schedule` frontmatter per file |
+| **Effort** | Inherits default | Per-task `effort` field |
+| **Tools** | All available | Per-task `allowed-tools` |
+| **Skills** | None pre-activated | Per-task `required-skills` |
+| **Timer** | Shared timer loop | Independent timer loop |
+
+Both can coexist — heartbeat for simple recurring checks on a single interval, scheduled tasks for time-specific or individually-configured tasks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "starlette>=0.52.1",
     "tabstack>=2.3.0",
     "uvicorn>=0.41.0",
+    "croniter>=6.0.0",
     "websockets>=16.0",
 ]
 

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -48,6 +48,7 @@ async def run_all(app_ctx):
     http_task = None
     mattermost_task = None
     heartbeat_task = None
+    schedule_task = None
 
     try:
         # Start HTTP server (button callbacks + web gateway)
@@ -93,6 +94,13 @@ async def run_all(app_ctx):
         else:
             log.info("Heartbeat disabled (interval not set)")
 
+        # Start schedule timer
+        from .schedules import run_schedule_timer
+        schedule_task = asyncio.create_task(
+            run_schedule_timer(config, app_ctx.event_bus, shutdown_event)
+        )
+        log.info("Schedule timer started")
+
         # Wait for shutdown
         await shutdown_event.wait()
 
@@ -100,6 +108,7 @@ async def run_all(app_ctx):
         log.info("Shutting down...")
 
         # Stop subsystems in reverse order
+        await _cancel_task(schedule_task, "schedule timer")
         await _cancel_task(heartbeat_task, "heartbeat")
 
         # Graceful HTTP server shutdown (avoids uvicorn CancelledError tracebacks)

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -1,0 +1,301 @@
+"""Scheduled tasks — cron-style task files with per-task scheduling."""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+from croniter import croniter
+
+from .skills import _split_frontmatter
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ScheduleTask:
+    """A parsed schedule file."""
+    name: str
+    schedule: str  # 5-field cron expression
+    body: str
+    source: str  # "admin" or "workspace"
+    path: Path
+    channel: str = ""
+    enabled: bool = True
+    effort: str = "default"
+    allowed_tools: list[str] = field(default_factory=list)
+    required_skills: list[str] = field(default_factory=list)
+
+
+def parse_schedule_file(path: Path) -> ScheduleTask | None:
+    """Parse a schedule markdown file. Returns None if invalid."""
+    try:
+        text = path.read_text()
+    except OSError as e:
+        log.warning(f"Cannot read schedule file {path}: {e}")
+        return None
+
+    meta, body = _split_frontmatter(text)
+    if meta is None:
+        log.debug(f"No frontmatter in {path.name}, skipping")
+        return None
+
+    schedule = meta.get("schedule", "")
+    if not schedule:
+        log.warning(f"No schedule field in {path.name}, skipping")
+        return None
+
+    if not croniter.is_valid(schedule):
+        log.warning(f"Invalid cron expression in {path.name}: {schedule!r}")
+        return None
+
+    # Type coercion — YAML can produce unexpected types (e.g. 'false' as string)
+    enabled = meta.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = str(enabled).lower() not in ("false", "0", "no", "off")
+
+    allowed_tools = meta.get("allowed-tools", [])
+    if not isinstance(allowed_tools, list):
+        allowed_tools = [str(allowed_tools)] if allowed_tools else []
+
+    required_skills = meta.get("required-skills", [])
+    if not isinstance(required_skills, list):
+        required_skills = [str(required_skills)] if required_skills else []
+
+    return ScheduleTask(
+        name=path.stem,
+        schedule=schedule,
+        body=body.strip(),
+        source="",  # set by caller
+        path=path,
+        channel=str(meta.get("channel", "")),
+        enabled=enabled,
+        effort=str(meta.get("effort", "default")),
+        allowed_tools=[str(t) for t in allowed_tools],
+        required_skills=[str(s) for s in required_skills],
+    )
+
+
+# -- Discovery ----------------------------------------------------------------
+
+
+def discover_schedules(config) -> list[ScheduleTask]:
+    """Discover schedule files from admin and workspace directories.
+
+    Admin tasks take precedence when names collide.
+    """
+    tasks_by_name: dict[str, ScheduleTask] = {}
+
+    for source, base_dir in [
+        ("admin", config.agent_path / "schedules"),
+        ("workspace", config.workspace_path / "schedules"),
+    ]:
+        if not base_dir.is_dir():
+            continue
+        for path in sorted(base_dir.glob("*.md")):
+            task = parse_schedule_file(path)
+            if task is None:
+                continue
+            task.source = source
+            # Admin takes precedence
+            if task.name not in tasks_by_name or source == "admin":
+                tasks_by_name[task.name] = task
+
+    return list(tasks_by_name.values())
+
+
+# -- Last-run tracking --------------------------------------------------------
+
+
+def _safe_task_name(task_name: str) -> str:
+    """Sanitize task name for use in filesystem paths."""
+    import re
+    # Strip path separators and dots, keep alphanumeric + hyphens + underscores
+    safe = re.sub(r"[^a-zA-Z0-9_-]", "_", task_name)
+    if not safe or safe in (".", ".."):
+        safe = "_invalid_"
+    return safe
+
+
+def _last_run_path(config, task_name: str) -> Path:
+    base = config.workspace_path / ".schedule_last_run"
+    path = (base / _safe_task_name(task_name)).resolve()
+    # Verify path stays under the base directory
+    if not str(path).startswith(str(base.resolve())):
+        raise ValueError(f"Task name resolves outside last-run directory: {task_name!r}")
+    return path
+
+
+def read_last_run(config, task_name: str) -> float:
+    """Read last-run timestamp. Returns 0 if never run."""
+    path = _last_run_path(config, task_name)
+    try:
+        if path.exists():
+            return float(path.read_text().strip())
+    except (ValueError, OSError):
+        pass
+    return 0
+
+
+def write_last_run(config, task_name: str, timestamp: float | None = None) -> None:
+    """Write last-run timestamp (defaults to now)."""
+    path = _last_run_path(config, task_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(time.time() if timestamp is None else timestamp))
+
+
+def is_due(config, task: ScheduleTask) -> bool:
+    """Check if a scheduled task is due to run."""
+    last_run = read_last_run(config, task.name)
+    if last_run == 0:
+        return True  # never run before
+
+    cron = croniter(task.schedule, datetime.fromtimestamp(last_run))
+    next_fire = cron.get_next(float)
+    return time.time() >= next_fire
+
+
+# -- Task execution -----------------------------------------------------------
+
+
+async def run_schedule_task(config, event_bus, task: ScheduleTask) -> dict:
+    """Run a single scheduled task as an agent turn.
+
+    Returns {"task_name", "channel", "response", "is_ok", "context_id"}.
+    """
+    from .agent import run_agent_turn
+    from .context import Context
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    ctx = Context(config=config, event_bus=event_bus)
+    ctx.user_id = f"schedule-{task.source}"
+    ctx.channel_id = task.channel or f"schedule:{task.name}"
+    ctx.channel_name = task.channel or f"schedule:{task.name}"
+    ctx.conv_id = f"schedule-{task.name}-{timestamp}"
+    ctx.effort = task.effort
+
+    if task.allowed_tools:
+        ctx.allowed_tools = set(task.allowed_tools)
+
+    # Pre-activate required skills
+    if task.required_skills:
+        discovered = getattr(config, "discovered_skills", [])
+        skill_map = {s.name: s for s in discovered}
+        from .tools.skill_tools import activate_skill_internal
+        for skill_name in task.required_skills:
+            skill_info = skill_map.get(skill_name)
+            if skill_info:
+                try:
+                    await activate_skill_internal(ctx, skill_info)
+                except Exception as e:
+                    log.error(f"Failed to activate skill '{skill_name}' "
+                              f"for task '{task.name}': {e}")
+
+    preamble = (
+        f'You are running a scheduled task: "{task.name}".\n'
+        "Execute the following task and report your findings.\n"
+        "If there is nothing to report, respond with HEARTBEAT_OK.\n"
+        "Prefer workspace tools (workspace_read, workspace_write, "
+        "workspace_list) over shell commands.\n\n"
+    )
+    prompt = preamble + task.body
+
+    try:
+        result = await run_agent_turn(ctx, prompt, history=[])
+        response = result.text or "(no response)"
+        from .heartbeat import is_heartbeat_ok
+        ok = is_heartbeat_ok(response)
+        return {
+            "task_name": task.name,
+            "channel": task.channel,
+            "response": response,
+            "is_ok": ok,
+            "context_id": ctx.context_id,
+        }
+    except Exception as e:
+        log.error(f"Scheduled task '{task.name}' failed: {e}", exc_info=True)
+        return {
+            "task_name": task.name,
+            "channel": task.channel,
+            "response": f"[error: scheduled task failed: {e}]",
+            "is_ok": False,
+            "context_id": None,
+        }
+
+
+# -- Timer loop ---------------------------------------------------------------
+
+
+_SCHEDULE_POLL_INTERVAL = 60
+
+
+async def run_schedule_timer(config, event_bus, shutdown_event,
+                              on_result=None, poll_interval=None):
+    """Run the schedule timer loop.
+
+    Discovers schedule files, checks if tasks are due, and runs them.
+    """
+    interval = poll_interval or _SCHEDULE_POLL_INTERVAL
+    running_tasks: set[str] = set()
+    in_flight: set[asyncio.Task] = set()
+
+    log.info("Schedule timer starting")
+
+    try:
+        while not shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
+                break
+            except asyncio.TimeoutError:
+                pass
+
+            if shutdown_event.is_set():
+                break
+
+            tasks = discover_schedules(config)
+            if not tasks:
+                continue
+
+            for task in tasks:
+                if not task.enabled:
+                    continue
+                if task.name in running_tasks:
+                    log.debug(f"Schedule '{task.name}' still running, skipping")
+                    continue
+                if not is_due(config, task):
+                    continue
+
+                log.info(f"Schedule '{task.name}' is due, executing")
+                running_tasks.add(task.name)
+
+                async def _run(t=task):
+                    try:
+                        write_last_run(config, t.name)
+                        result = await run_schedule_task(config, event_bus, t)
+                        if on_result:
+                            try:
+                                await on_result(result)
+                            except Exception as e:
+                                log.error(f"Schedule result callback failed: {e}")
+                        elif result["is_ok"]:
+                            log.info(f"Schedule '{t.name}': HEARTBEAT_OK")
+                        else:
+                            log.info(f"Schedule '{t.name}' response: "
+                                     f"{result['response'][:200]}")
+                    except Exception as e:
+                        log.error(f"Schedule '{t.name}' execution failed: {e}")
+                    finally:
+                        running_tasks.discard(t.name)
+
+                t = asyncio.create_task(_run())
+                in_flight.add(t)
+                t.add_done_callback(in_flight.discard)
+    finally:
+        # Await in-flight tasks on shutdown
+        if in_flight:
+            log.info(f"Waiting for {len(in_flight)} in-flight scheduled task(s)")
+            await asyncio.gather(*in_flight, return_exceptions=True)
+
+    log.info("Schedule timer stopped")

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -153,6 +153,54 @@ def get_embeddings_data(config) -> dict:
     return {"total": total, "memory": memory, "conversation": conversation}
 
 
+def get_schedule_data(config) -> dict:
+    """Return scheduled task stats as a dict."""
+    from ..schedules import discover_schedules, read_last_run
+
+    tasks = discover_schedules(config)
+    admin = sum(1 for t in tasks if t.source == "admin")
+    workspace = sum(1 for t in tasks if t.source == "workspace")
+    enabled = sum(1 for t in tasks if t.enabled)
+
+    from datetime import datetime, timezone
+
+    from croniter import croniter
+
+    task_list = []
+    for t in tasks:
+        last_run = read_last_run(config, t.name)
+        entry: dict = {
+            "name": t.name,
+            "schedule": t.schedule,
+            "source": t.source,
+            "enabled": t.enabled,
+        }
+        if last_run > 0:
+            entry["last_run"] = datetime.fromtimestamp(
+                last_run, tz=timezone.utc).isoformat()
+        else:
+            entry["last_run"] = None
+
+        # Next run: based on last_run or now if never run
+        try:
+            base = datetime.fromtimestamp(last_run if last_run > 0 else time.time())
+            cron = croniter(t.schedule, base)
+            next_fire = cron.get_next(datetime)
+            entry["next_run"] = next_fire.astimezone(timezone.utc).isoformat()
+        except Exception:
+            entry["next_run"] = None
+
+        task_list.append(entry)
+
+    return {
+        "total": len(tasks),
+        "admin": admin,
+        "workspace": workspace,
+        "enabled": enabled,
+        "tasks": task_list,
+    }
+
+
 def get_health_data(config) -> dict:
     """Gather all health data as a JSON-serializable dict.
 
@@ -189,6 +237,13 @@ def get_health_data(config) -> dict:
         log.exception("Failed to gather embeddings health data")
         data["embeddings"] = None
         errors.append(f"embeddings: {exc}")
+
+    try:
+        data["schedules"] = get_schedule_data(config)
+    except Exception as exc:
+        log.exception("Failed to gather schedule health data")
+        data["schedules"] = None
+        errors.append(f"schedules: {exc}")
 
     if errors:
         data["status"] = "degraded"
@@ -305,6 +360,25 @@ def _embeddings_section(config) -> list[str]:
     ]
 
 
+def _schedule_section(config) -> list[str]:
+    """Gather scheduled task stats."""
+    data = get_schedule_data(config)
+    if data["total"] == 0:
+        return ["### Scheduled Tasks", "No scheduled tasks found."]
+
+    lines = [
+        "### Scheduled Tasks",
+        f"- **Total:** {data['total']} ({data['enabled']} enabled)",
+        f"- **Admin:** {data['admin']} | **Workspace:** {data['workspace']}",
+    ]
+    for t in data["tasks"]:
+        status = "enabled" if t["enabled"] else "disabled"
+        last = t["last_run"] or "never"
+        next_run = t.get("next_run") or "unknown"
+        lines.append(f"- `{t['name']}` ({t['schedule']}) — {status}, last: {last}, next: {next_run}")
+    return lines
+
+
 async def tool_health_status(ctx) -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
@@ -353,6 +427,14 @@ async def tool_health_status(ctx) -> str:
         sections.extend(_embeddings_section(ctx.config))
     except Exception as e:
         sections.append(f"### Embeddings\n- [error: {e}]")
+
+    sections.append("")
+
+    # Schedules
+    try:
+        sections.extend(_schedule_section(ctx.config))
+    except Exception as e:
+        sections.append(f"### Scheduled Tasks\n- [error: {e}]")
 
     return "\n".join(sections)
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -1,0 +1,323 @@
+"""Tests for scheduled task parsing, discovery, and execution."""
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from decafclaw.events import EventBus
+from decafclaw.schedules import (
+    ScheduleTask,
+    discover_schedules,
+    is_due,
+    parse_schedule_file,
+    read_last_run,
+    run_schedule_task,
+    run_schedule_timer,
+    write_last_run,
+)
+
+# -- Parsing -------------------------------------------------------------------
+
+
+class TestParseScheduleFile:
+    def test_basic_parse(self, tmp_path):
+        f = tmp_path / "daily-summary.md"
+        f.write_text(
+            "---\n"
+            'schedule: "0 9 * * 1-5"\n'
+            'channel: "#reports"\n'
+            "---\n\n"
+            "Summarize the day.\n"
+        )
+        task = parse_schedule_file(f)
+        assert task is not None
+        assert task.name == "daily-summary"
+        assert task.schedule == "0 9 * * 1-5"
+        assert task.channel == "#reports"
+        assert task.enabled is True
+        assert task.effort == "default"
+        assert "Summarize the day." in task.body
+
+    def test_all_frontmatter_fields(self, tmp_path):
+        f = tmp_path / "check.md"
+        f.write_text(
+            "---\n"
+            'schedule: "*/15 * * * *"\n'
+            "enabled: false\n"
+            "effort: fast\n"
+            "allowed-tools:\n"
+            "  - workspace_read\n"
+            "  - workspace_list\n"
+            "required-skills:\n"
+            "  - tabstack\n"
+            "---\n\n"
+            "Check things.\n"
+        )
+        task = parse_schedule_file(f)
+        assert task is not None
+        assert task.enabled is False
+        assert task.effort == "fast"
+        assert task.allowed_tools == ["workspace_read", "workspace_list"]
+        assert task.required_skills == ["tabstack"]
+
+    def test_missing_schedule_returns_none(self, tmp_path):
+        f = tmp_path / "bad.md"
+        f.write_text("---\nchannel: '#foo'\n---\n\nNo schedule.\n")
+        assert parse_schedule_file(f) is None
+
+    def test_invalid_cron_returns_none(self, tmp_path):
+        f = tmp_path / "bad-cron.md"
+        f.write_text("---\nschedule: 'not a cron'\n---\n\nBad cron.\n")
+        assert parse_schedule_file(f) is None
+
+    def test_no_frontmatter_returns_none(self, tmp_path):
+        f = tmp_path / "plain.md"
+        f.write_text("Just a plain markdown file.\n")
+        assert parse_schedule_file(f) is None
+
+    def test_defaults(self, tmp_path):
+        f = tmp_path / "minimal.md"
+        f.write_text("---\nschedule: '* * * * *'\n---\nDo it.\n")
+        task = parse_schedule_file(f)
+        assert task is not None
+        assert task.channel == ""
+        assert task.enabled is True
+        assert task.effort == "default"
+        assert task.allowed_tools == []
+        assert task.required_skills == []
+
+
+# -- Discovery ----------------------------------------------------------------
+
+
+class TestDiscoverSchedules:
+    def test_discovers_from_both_dirs(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "admin-task.md").write_text(
+            "---\nschedule: '0 9 * * *'\n---\nAdmin task.\n"
+        )
+        workspace = config.workspace_path / "schedules"
+        workspace.mkdir(parents=True)
+        (workspace / "agent-task.md").write_text(
+            "---\nschedule: '0 12 * * *'\n---\nAgent task.\n"
+        )
+        tasks = discover_schedules(config)
+        names = {t.name for t in tasks}
+        assert "admin-task" in names
+        assert "agent-task" in names
+
+    def test_admin_takes_precedence_on_collision(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "task.md").write_text(
+            "---\nschedule: '0 9 * * *'\n---\nAdmin version.\n"
+        )
+        workspace = config.workspace_path / "schedules"
+        workspace.mkdir(parents=True)
+        (workspace / "task.md").write_text(
+            "---\nschedule: '0 12 * * *'\n---\nWorkspace version.\n"
+        )
+        tasks = discover_schedules(config)
+        matching = [t for t in tasks if t.name == "task"]
+        assert len(matching) == 1
+        assert matching[0].source == "admin"
+
+    def test_empty_dirs(self, config):
+        assert discover_schedules(config) == []
+
+    def test_skips_invalid_files(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "good.md").write_text(
+            "---\nschedule: '0 9 * * *'\n---\nGood.\n"
+        )
+        (admin / "bad.md").write_text("No frontmatter here.\n")
+        tasks = discover_schedules(config)
+        assert len(tasks) == 1
+        assert tasks[0].name == "good"
+
+
+# -- Last-run tracking --------------------------------------------------------
+
+
+class TestLastRun:
+    def test_read_no_file(self, config):
+        assert read_last_run(config, "nonexistent") == 0
+
+    def test_write_and_read(self, config):
+        write_last_run(config, "my-task", 1700000000.0)
+        assert read_last_run(config, "my-task") == 1700000000.0
+
+    def test_write_defaults_to_now(self, config):
+        before = time.time()
+        write_last_run(config, "now-task")
+        after = time.time()
+        ts = read_last_run(config, "now-task")
+        assert before <= ts <= after
+
+
+class TestIsDue:
+    def test_never_run_is_due(self, config):
+        task = ScheduleTask(
+            name="test", schedule="* * * * *", body="test",
+            source="admin", path=Path("/fake"),
+        )
+        assert is_due(config, task) is True
+
+    def test_recently_run_not_due(self, config):
+        task = ScheduleTask(
+            name="test", schedule="0 9 * * *", body="test",
+            source="admin", path=Path("/fake"),
+        )
+        write_last_run(config, "test", time.time())
+        assert is_due(config, task) is False
+
+    def test_overdue_is_due(self, config):
+        task = ScheduleTask(
+            name="test", schedule="* * * * *", body="test",
+            source="admin", path=Path("/fake"),
+        )
+        # Ran 2 minutes ago, every-minute cron → due
+        write_last_run(config, "test", time.time() - 120)
+        assert is_due(config, task) is True
+
+
+# -- Task execution -----------------------------------------------------------
+
+
+class TestRunScheduleTask:
+    @pytest.mark.asyncio
+    async def test_runs_agent_turn(self, config):
+        task = ScheduleTask(
+            name="test-task", schedule="* * * * *",
+            body="Do the thing.", source="admin", path=Path("/fake"),
+            effort="fast",
+        )
+        mock_response = MagicMock()
+        mock_response.text = "Done."
+
+        with patch("decafclaw.agent.run_agent_turn",
+                    new_callable=AsyncMock, return_value=mock_response):
+            result = await run_schedule_task(config, EventBus(), task)
+
+        assert result["response"] == "Done."
+        assert result["is_ok"] is False
+        assert result["task_name"] == "test-task"
+        assert result["channel"] == ""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ok_detected(self, config):
+        task = ScheduleTask(
+            name="test-task", schedule="* * * * *",
+            body="Check.", source="admin", path=Path("/fake"),
+        )
+        mock_response = MagicMock()
+        mock_response.text = "HEARTBEAT_OK — nothing to report."
+
+        with patch("decafclaw.agent.run_agent_turn",
+                    new_callable=AsyncMock, return_value=mock_response):
+            result = await run_schedule_task(config, EventBus(), task)
+
+        assert result["is_ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_handles_error(self, config):
+        task = ScheduleTask(
+            name="failing-task", schedule="* * * * *",
+            body="Fail.", source="admin", path=Path("/fake"),
+        )
+        with patch("decafclaw.agent.run_agent_turn",
+                    new_callable=AsyncMock, side_effect=Exception("boom")):
+            result = await run_schedule_task(config, EventBus(), task)
+
+        assert result["is_ok"] is False
+        assert "boom" in result["response"]
+
+    @pytest.mark.asyncio
+    async def test_channel_in_result(self, config):
+        task = ScheduleTask(
+            name="test", schedule="* * * * *",
+            body="Report.", source="admin", path=Path("/fake"),
+            channel="#reports",
+        )
+        mock_response = MagicMock()
+        mock_response.text = "Report done."
+
+        with patch("decafclaw.agent.run_agent_turn",
+                    new_callable=AsyncMock, return_value=mock_response):
+            result = await run_schedule_task(config, EventBus(), task)
+
+        assert result["channel"] == "#reports"
+
+
+# -- Timer loop ----------------------------------------------------------------
+
+
+class TestRunScheduleTimer:
+    @pytest.mark.asyncio
+    async def test_executes_due_task(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "test.md").write_text(
+            "---\nschedule: '* * * * *'\n---\nDo the thing.\n"
+        )
+
+        shutdown = asyncio.Event()
+        executed = []
+
+        async def fake_run(cfg, bus, task):
+            executed.append(task.name)
+            return {"task_name": task.name, "channel": "", "response": "ok",
+                    "is_ok": True, "context_id": None}
+
+        with patch("decafclaw.schedules.run_schedule_task", side_effect=fake_run):
+            async def stop_soon():
+                await asyncio.sleep(0.05)
+                shutdown.set()
+            asyncio.create_task(stop_soon())
+            await run_schedule_timer(config, EventBus(), shutdown,
+                                     poll_interval=0.02)
+
+        assert "test" in executed
+
+    @pytest.mark.asyncio
+    async def test_skips_disabled_task(self, config):
+        admin = config.agent_path / "schedules"
+        admin.mkdir(parents=True)
+        (admin / "disabled.md").write_text(
+            "---\nschedule: '* * * * *'\nenabled: false\n---\nSkip me.\n"
+        )
+
+        shutdown = asyncio.Event()
+        executed = []
+
+        async def fake_run(cfg, bus, task):
+            executed.append(task.name)
+            return {"task_name": task.name, "channel": "", "response": "ok",
+                    "is_ok": True, "context_id": None}
+
+        with patch("decafclaw.schedules.run_schedule_task", side_effect=fake_run):
+            async def stop_soon():
+                await asyncio.sleep(0.05)
+                shutdown.set()
+            asyncio.create_task(stop_soon())
+            await run_schedule_timer(config, EventBus(), shutdown,
+                                     poll_interval=0.02)
+
+        assert "disabled" not in executed
+
+    @pytest.mark.asyncio
+    async def test_no_tasks_no_crash(self, config):
+        """Timer runs fine with no schedule files."""
+        shutdown = asyncio.Event()
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            shutdown.set()
+        asyncio.create_task(stop_soon())
+        await run_schedule_timer(config, EventBus(), shutdown,
+                                 poll_interval=0.02)

--- a/uv.lock
+++ b/uv.lock
@@ -121,6 +121,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -179,6 +191,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-code-sdk" },
+    { name = "croniter" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "numpy" },
@@ -207,6 +220,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "claude-code-sdk", specifier = ">=0.0.25" },
+    { name = "croniter", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "numpy", specifier = ">=2.4.3" },
@@ -587,6 +601,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -755,6 +781,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `schedules.py` module: cron-style task files with YAML frontmatter (schedule, channel, effort, allowed-tools, required-skills)
- Schedule files discovered from `data/{agent_id}/schedules/` (admin) and `workspace/schedules/` (agent-writable), admin takes precedence on name collision
- Per-task last-run tracking via timestamp files in `workspace/.schedule_last_run/`
- `croniter` library for cron expression parsing and due-check
- Independent timer loop (`run_schedule_timer`) wired into `runner.py`, 60s poll interval
- Overlap protection: running tasks skipped on subsequent ticks
- Tasks execute as independent agent turns with configurable effort, tool restrictions, and pre-activated skills
- Health endpoint (`/health`) and agent tool include schedule status
- CLAUDE.md updated with key file and convention

Closes #8

## Deferred
- Mattermost channel-name-to-ID resolution for `#channel-name` format (currently expects channel IDs like heartbeat does)
- Web UI named channel support for viewing scheduled task output
- Agent self-scheduling tools (`create_schedule`, etc.)

## Test plan
- [x] 23 new tests: parsing, discovery, last-run, due-check, execution, timer
- [x] All 649 tests pass, lint + typecheck clean
- [x] Create a schedule file with `* * * * *` cron, verify it fires on next poll tick
- [x] Verify `enabled: false` skips execution
- [x] Verify health endpoint includes schedule data

🤖 Generated with [Claude Code](https://claude.com/claude-code)