### PR TITLE
Add required-skills frontmatter for forked commands

### DIFF
--- a/src/decafclaw/commands.py
+++ b/src/decafclaw/commands.py
@@ -91,6 +91,26 @@ async def execute_command(ctx, skill: SkillInfo, arguments: str) -> tuple[str, s
     ctx.preapproved_tools = set(skill.allowed_tools)
 
     if skill.context == "fork":
+        # Pre-activate required skills so the child inherits their tools
+        if skill.requires_skills:
+            discovered = getattr(ctx.config, "discovered_skills", [])
+            skill_map = {s.name: s for s in discovered}
+            for req_name in skill.requires_skills:
+                if req_name in ctx.activated_skills:
+                    continue
+                req_info = skill_map.get(req_name)
+                if req_info:
+                    try:
+                        result = await activate_skill_internal(ctx, req_info)
+                        if isinstance(result, _ToolResult):
+                            log.error(f"Failed to activate required skill "
+                                      f"'{req_name}' for command '{skill.name}': "
+                                      f"{result.text}")
+                            return "error", result.text
+                    except Exception as e:
+                        log.error(f"Failed to activate required skill "
+                                  f"'{req_name}' for command '{skill.name}': {e}")
+
         from .tools.delegate import _run_child_turn
         response = await _run_child_turn(ctx, body, effort=skill.effort or "")
         return "fork", response

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -28,6 +28,7 @@ class SkillInfo:
     context: str = "inline"  # "inline" or "fork"
     argument_hint: str = ""
     effort: str = ""  # empty = inherit conversation effort
+    requires_skills: list[str] = field(default_factory=list)
 
 
 def parse_skill_md(path: Path) -> SkillInfo | None:
@@ -84,7 +85,17 @@ def parse_skill_md(path: Path) -> SkillInfo | None:
         context=meta.get("context", "inline"),
         argument_hint=meta.get("argument-hint", ""),
         effort=meta.get("effort", ""),
+        requires_skills=_coerce_str_list(meta.get("required-skills", [])),
     )
+
+
+def _coerce_str_list(value) -> list[str]:
+    """Coerce a YAML value to a list of strings (handles scalar or None)."""
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return [str(value)]
 
 
 def _split_frontmatter(text: str) -> tuple[dict | None, str]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -191,3 +191,48 @@ class TestExecuteCommand:
         # Should not error even though activation logic isn't called
         mode, result = await execute_command(ctx, skill, "")
         assert mode == "inline"
+
+    @pytest.mark.asyncio
+    async def test_fork_required_skills_activated(self, ctx):
+        """Fork commands pre-activate required-skills before spawning child."""
+        dep_skill = SkillInfo(
+            name="markdown_vault", description="Vault", location=Path("."),
+            has_native_tools=True,
+        )
+        ctx.config.discovered_skills = [dep_skill]
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do stuff", context="fork",
+            requires_skills=["markdown_vault"],
+        )
+        with patch("decafclaw.tools.skill_tools.activate_skill_internal",
+                    new_callable=AsyncMock, return_value="activated") as mock_activate, \
+             patch("decafclaw.tools.delegate._run_child_turn",
+                    new_callable=AsyncMock, return_value="child result"):
+            mode, result = await execute_command(ctx, skill, "")
+
+        assert mode == "fork"
+        mock_activate.assert_called_once_with(ctx, dep_skill)
+
+    @pytest.mark.asyncio
+    async def test_fork_required_skills_already_active(self, ctx):
+        """Already-activated skills are not re-activated."""
+        dep_skill = SkillInfo(
+            name="markdown_vault", description="Vault", location=Path("."),
+        )
+        ctx.config.discovered_skills = [dep_skill]
+        ctx.activated_skills.add("markdown_vault")
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do stuff", context="fork",
+            requires_skills=["markdown_vault"],
+        )
+        with patch("decafclaw.tools.skill_tools.activate_skill_internal",
+                    new_callable=AsyncMock) as mock_activate, \
+             patch("decafclaw.tools.delegate._run_child_turn",
+                    new_callable=AsyncMock, return_value="done"):
+            await execute_command(ctx, skill, "")
+
+        mock_activate.assert_not_called()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -137,6 +137,21 @@ def test_parse_command_frontmatter_defaults(tmp_path):
     assert info.allowed_tools == []
     assert info.context == "inline"
     assert info.argument_hint == ""
+    assert info.requires_skills == []
+
+
+def test_parse_required_skills(tmp_path):
+    """Parse required-skills list from frontmatter."""
+    skill_dir = tmp_path / "migrate"
+    _write_skill(
+        skill_dir,
+        'name: migrate\ndescription: "Migrate"\n'
+        'context: fork\n'
+        'required-skills:\n  - markdown_vault\n  - tabstack',
+    )
+    info = parse_skill_md(skill_dir / "SKILL.md")
+    assert info is not None
+    assert info.requires_skills == ["markdown_vault", "tabstack"]
 
 
 # -- find_command / list_commands tests --


### PR DESCRIPTION
## Summary
- New `required-skills` frontmatter field in SKILL.md for forked commands
- Listed skills are pre-activated before spawning the child turn, so the child inherits their tools
- Already-active skills are skipped (no double-activation)
- Uses the same field name as scheduled tasks (`required-skills`) for consistency
- 3 new tests: parsing, pre-activation, skip-if-already-active

Closes #101

## Example

```yaml
---
name: daily-todo-migration
context: fork
required-skills:
  - markdown_vault
---

Migrate yesterday's incomplete todos to today's file.
```

## Test plan
- [x] Frontmatter parsing test
- [x] Fork pre-activation test (mock verifies activate_skill_internal called)
- [x] Already-active skill skipped test
- [x] All 652 tests pass, lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)