### PR TITLE
Obsidian-compatible wiki knowledge base

### DIFF
--- a/.claude/dev-sessions/2026-03-23-1647-knowledge-base/notes.md
+++ b/.claude/dev-sessions/2026-03-23-1647-knowledge-base/notes.md
@@ -1,0 +1,11 @@
+# Session Notes — Knowledge Base
+
+## Session started: 2026-03-23
+
+### Context
+- Issue #15: Knowledge base (Obsidian-style wiki)
+- Structured knowledge alongside episodic memory
+- Key motivation: give dream memory consolidation (#81) a place to record
+  distilled facts, rather than only append-only memory files
+- Memory = episodic ("Les said X on March 13")
+- Wiki = curated truth ("Les's drink preferences: Boulevardier, Old Fashioned")

--- a/.claude/dev-sessions/2026-03-23-1647-knowledge-base/plan.md
+++ b/.claude/dev-sessions/2026-03-23-1647-knowledge-base/plan.md
@@ -1,0 +1,435 @@
+# Knowledge Base (Wiki) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Obsidian-compatible wiki as a bundled always-loaded skill. The agent can create, read, search, and maintain wiki pages as curated knowledge alongside episodic memory. Wiki pages are indexed in semantic search with a score boost.
+
+**Architecture:** Wiki lives at `workspace/wiki/`. A native skill (`skills/wiki/`) provides tools and gardening guidance. A new `always-loaded: true` frontmatter field auto-activates the skill at startup. Wiki pages are indexed as `source_type: "wiki"` in the embeddings DB with a configurable score boost.
+
+**Tech Stack:** Python, existing skills/embeddings/prompts patterns.
+
+**Key integration points:**
+- `skills/__init__.py` — parse `always-loaded` field on SkillInfo
+- `prompts/__init__.py` — auto-activate always-loaded skills in system prompt
+- `tools/tool_registry.py` — exempt always-loaded skill tools from deferral
+- `embeddings.py` — add wiki indexing, score boost for wiki source_type
+- `agent.py` — register always-loaded skill tools at turn start
+
+---
+
+### Task 1: Add `always-loaded` field to SkillInfo and parsing
+
+**Files:**
+- Modify: `src/decafclaw/skills/__init__.py` — add field, parse from frontmatter
+- Modify: `tests/test_skills.py` — parsing tests
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_parse_always_loaded(tmp_path):
+    """Parse always-loaded field from frontmatter."""
+    skill_dir = tmp_path / "wiki"
+    _write_skill(skill_dir,
+        'name: wiki\ndescription: "Knowledge base"\nalways-loaded: true')
+    info = parse_skill_md(skill_dir / "SKILL.md")
+    assert info is not None
+    assert info.always_loaded is True
+
+def test_parse_always_loaded_default(tmp_path):
+    """always-loaded defaults to False."""
+    skill_dir = tmp_path / "basic"
+    _write_skill(skill_dir, 'name: basic\ndescription: "Basic"')
+    info = parse_skill_md(skill_dir / "SKILL.md")
+    assert info.always_loaded is False
+```
+
+- [ ] **Step 2: Add `always_loaded` field to SkillInfo**
+
+In `skills/__init__.py`, add to the SkillInfo dataclass:
+```python
+always_loaded: bool = False
+```
+
+In `parse_skill_md()`, add:
+```python
+always_loaded=bool(meta.get("always-loaded", False)),
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `make check && make test`
+
+- [ ] **Step 4: Commit**
+
+```
+feat: add always-loaded field to SkillInfo frontmatter
+```
+
+---
+
+### Task 2: Auto-activate always-loaded skills in system prompt and agent loop
+
+**Files:**
+- Modify: `src/decafclaw/prompts/__init__.py` — append always-loaded skill bodies to system prompt
+- Modify: `src/decafclaw/agent.py` — register always-loaded skill tools at turn start
+- Modify: `src/decafclaw/tools/tool_registry.py` — exempt always-loaded skill tools from deferral
+- Create: `tests/test_always_loaded.py` — integration tests
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_always_loaded_skills_in_system_prompt(config, tmp_path):
+    """Always-loaded skills have their body appended to the system prompt."""
+    # Create a skill dir with always-loaded: true and a body
+    # Call load_system_prompt, verify body appears in the prompt
+
+def test_always_loaded_skill_tools_registered(ctx):
+    """Always-loaded skill tools are available without activate_skill."""
+    # Verify that tools from always-loaded skills appear in ctx
+```
+
+- [ ] **Step 2: Modify `load_system_prompt` to collect always-loaded skills**
+
+In `prompts/__init__.py`, after discovering skills:
+```python
+# Auto-activate always-loaded skills
+always_loaded_bodies = []
+always_loaded_skill_names = []
+for skill in skills:
+    if skill.always_loaded and skill.body:
+        always_loaded_bodies.append(skill.body)
+        always_loaded_skill_names.append(skill.name)
+
+if always_loaded_bodies:
+    sections.append("\n\n".join(always_loaded_bodies))
+    log.info(f"Always-loaded skills: {', '.join(always_loaded_skill_names)}")
+```
+
+Return `always_loaded_skill_names` alongside `skills` so the agent loop knows which skills to auto-register tools for.
+
+- [ ] **Step 3: Register always-loaded skill tools in agent turn startup**
+
+In `agent.py`, at the start of `run_agent_turn`, after skill restoration:
+- Check `config.always_loaded_skill_names` (set during prompt assembly)
+- For each, load native tools via `_load_native_tools` and register on ctx
+- Add their tool names to the always-loaded set so they're exempt from deferral
+
+- [ ] **Step 4: Update `tool_registry.py`**
+
+In `get_always_loaded_names()`, include tool names from always-loaded skills:
+```python
+# Add tools from always-loaded skills
+for name in getattr(config, "always_loaded_skill_names", []):
+    skill_map = {s.name: s for s in getattr(config, "discovered_skills", [])}
+    skill = skill_map.get(name)
+    if skill and skill.has_native_tools:
+        # Tool names will be added when the skill is loaded
+        pass  # handled by agent.py registration
+```
+
+Actually simpler: store the tool names on config when registering them, and include in `get_always_loaded_names`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `make check && make test`
+
+- [ ] **Step 6: Commit**
+
+```
+feat: auto-activate always-loaded skills in system prompt and agent loop
+```
+
+---
+
+### Task 3: Wiki tools — `wiki_read`, `wiki_write`, `wiki_list`
+
+**Files:**
+- Create: `src/decafclaw/skills/wiki/tools.py` — tool implementations
+- Create: `tests/test_wiki_tools.py` — tool tests
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+class TestWikiRead:
+    def test_read_existing_page(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Test Page.md").write_text("# Test Page\n\nContent here.")
+        result = wiki_read(config, "Test Page")
+        assert "Content here." in result
+
+    def test_read_nonexistent(self, config):
+        result = wiki_read(config, "Nope")
+        assert "not found" in result.lower() or "error" in result.lower()
+
+    def test_read_finds_in_subdirectory(self, config):
+        wiki_dir = config.workspace_path / "wiki" / "people"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Alice.md").write_text("# Alice\n\nA person.")
+        result = wiki_read(config, "Alice")
+        assert "A person." in result
+
+class TestWikiWrite:
+    def test_create_new_page(self, config):
+        wiki_write(config, "New Page", "# New Page\n\nFresh content.")
+        path = config.workspace_path / "wiki" / "New Page.md"
+        assert path.exists()
+        assert "Fresh content." in path.read_text()
+
+    def test_overwrite_existing(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Existing.md").write_text("Old content.")
+        wiki_write(config, "Existing", "New content.")
+        assert "New content." in (wiki_dir / "Existing.md").read_text()
+
+    def test_rejects_path_traversal(self, config):
+        result = wiki_write(config, "../../../etc/passwd", "hack")
+        assert "error" in result.lower()
+
+class TestWikiList:
+    def test_list_pages(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Alpha.md").write_text("# Alpha")
+        (wiki_dir / "Beta.md").write_text("# Beta")
+        result = wiki_list(config)
+        assert "Alpha" in result
+        assert "Beta" in result
+
+    def test_empty_wiki(self, config):
+        result = wiki_list(config)
+        assert "no pages" in result.lower() or "empty" in result.lower()
+```
+
+- [ ] **Step 2: Implement `wiki_read`, `wiki_write`, `wiki_list`**
+
+In `skills/wiki/tools.py`:
+
+- `wiki_read(ctx, page)` — resolve page name to file path (search wiki root + subdirs), return content or error
+- `wiki_write(ctx, page, content)` — validate path stays within wiki root, create dirs if needed, write file
+- `wiki_list(ctx, pattern="")` — glob wiki dir for `*.md` files, return names with last-modified dates
+
+Path safety: resolve the full path and verify it starts with the wiki root.
+
+- [ ] **Step 3: Define TOOLS dict and TOOL_DEFINITIONS list**
+
+Standard skill tools pattern: `TOOLS = {"wiki_read": ..., "wiki_write": ..., "wiki_list": ...}` and matching `TOOL_DEFINITIONS`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `make check && pytest tests/test_wiki_tools.py -v`
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add wiki_read, wiki_write, wiki_list tools
+```
+
+---
+
+### Task 4: Wiki tools — `wiki_search` and `wiki_backlinks`
+
+**Files:**
+- Modify: `src/decafclaw/skills/wiki/tools.py` — add search and backlinks
+- Modify: `tests/test_wiki_tools.py` — tests
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+class TestWikiSearch:
+    def test_search_by_content(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Drinks.md").write_text("# Drinks\n\nBoulevardier, Old Fashioned")
+        (wiki_dir / "Food.md").write_text("# Food\n\nPizza, Tacos")
+        result = wiki_search(config, "Boulevardier")
+        assert "Drinks" in result
+        assert "Food" not in result
+
+    def test_search_by_title(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "DecafClaw.md").write_text("# DecafClaw\n\nAn agent.")
+        result = wiki_search(config, "DecafClaw")
+        assert "DecafClaw" in result
+
+    def test_search_no_results(self, config):
+        result = wiki_search(config, "nonexistent")
+        assert "no" in result.lower()
+
+class TestWikiBacklinks:
+    def test_finds_backlinks(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "DecafClaw.md").write_text("# DecafClaw\n\nAn agent.")
+        (wiki_dir / "Les Orchard.md").write_text("# Les\n\nWorks on [[DecafClaw]].")
+        (wiki_dir / "Blog.md").write_text("# Blog\n\nNo links here.")
+        result = wiki_backlinks(config, "DecafClaw")
+        assert "Les Orchard" in result
+        assert "Blog" not in result
+
+    def test_no_backlinks(self, config):
+        wiki_dir = config.workspace_path / "wiki"
+        wiki_dir.mkdir(parents=True)
+        (wiki_dir / "Orphan.md").write_text("# Orphan\n\nNobody links here.")
+        result = wiki_backlinks(config, "Orphan")
+        assert "no" in result.lower()
+```
+
+- [ ] **Step 2: Implement `wiki_search` and `wiki_backlinks`**
+
+- `wiki_search(ctx, query)` — scan all `*.md` files in wiki root (recursive), match query against filename and file content (case-insensitive substring), return page names with excerpts
+- `wiki_backlinks(ctx, page)` — scan all `*.md` files for `[[page]]` pattern (case-insensitive), return linking pages with context lines
+
+- [ ] **Step 3: Add to TOOLS and TOOL_DEFINITIONS**
+
+- [ ] **Step 4: Run tests**
+
+Run: `make check && pytest tests/test_wiki_tools.py -v`
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add wiki_search and wiki_backlinks tools
+```
+
+---
+
+### Task 5: SKILL.md — wiki gardening guidance
+
+**Files:**
+- Create: `src/decafclaw/skills/wiki/SKILL.md` — skill definition with always-loaded flag and gardening guidance
+
+- [ ] **Step 1: Write SKILL.md**
+
+```yaml
+---
+name: wiki
+description: Obsidian-compatible knowledge base for curated, evolving knowledge
+always-loaded: true
+---
+```
+
+Body contains the wiki gardening principles from the spec: search before create, revise and rewrite, link liberally, sources section, entity pages, merge related content, split when large, update over duplicate. Also include the memory boundary rule (wiki tools only modify files in workspace/wiki/).
+
+- [ ] **Step 2: Verify skill discovery picks it up**
+
+Run: `make check && make test`
+Verify the wiki skill appears in discovered skills and its `always_loaded` flag is True.
+
+- [ ] **Step 3: Commit**
+
+```
+feat: add wiki SKILL.md with gardening guidance
+```
+
+---
+
+### Task 6: Semantic search integration — wiki indexing
+
+**Files:**
+- Modify: `src/decafclaw/embeddings.py` — add wiki reindexing, score boost
+- Modify: `src/decafclaw/skills/wiki/tools.py` — index on wiki_write
+- Modify: `tests/test_wiki_tools.py` — indexing tests
+
+- [ ] **Step 1: Add `reindex_wiki` to embeddings.py**
+
+Similar pattern to `reindex_all` (memories) and `reindex_conversations`:
+```python
+async def reindex_wiki(config):
+    """Index all wiki pages into the embeddings database."""
+    wiki_dir = config.workspace_path / "wiki"
+    if not wiki_dir.is_dir():
+        return
+    for path in wiki_dir.rglob("*.md"):
+        text = path.read_text().strip()
+        if text:
+            rel_path = str(path.relative_to(config.workspace_path))
+            await index_entry(config, rel_path, text, source_type="wiki")
+```
+
+Call it from the `reindex_cli` function alongside the existing memory/conversation reindexing.
+
+- [ ] **Step 2: Add score boost for wiki results in `search_similar_sync`**
+
+In the search ranking, apply a multiplier to wiki results:
+```python
+# After computing similarity scores
+WIKI_BOOST = 1.2
+if row_source_type == "wiki":
+    similarity *= WIKI_BOOST
+```
+
+This requires the search to also fetch `source_type` from the DB.
+
+- [ ] **Step 3: Index on `wiki_write`**
+
+In `wiki_write`, after writing the file, call:
+```python
+await index_entry(config, rel_path, content, source_type="wiki")
+```
+
+- [ ] **Step 4: Write tests**
+
+```python
+class TestWikiEmbeddings:
+    @pytest.mark.asyncio
+    async def test_wiki_write_indexes(self, config):
+        """wiki_write should create an embeddings entry."""
+        ...
+
+    def test_wiki_boost_applied(self, config):
+        """Wiki results should have boosted scores."""
+        ...
+```
+
+- [ ] **Step 5: Update `make reindex` / reindex_cli**
+
+Add `await reindex_wiki(config)` to the reindex pipeline.
+
+- [ ] **Step 6: Run tests**
+
+Run: `make check && make test`
+
+- [ ] **Step 7: Commit**
+
+```
+feat: add wiki pages to semantic search with score boost
+```
+
+---
+
+### Task 7: Docs and CLAUDE.md update
+
+**Files:**
+- Create: `docs/wiki.md` — feature documentation
+- Modify: `docs/index.md` — add wiki to feature list
+- Modify: `CLAUDE.md` — key files, conventions
+
+- [ ] **Step 1: Create `docs/wiki.md`**
+
+Full feature doc: storage layout, Obsidian compatibility, tools, gardening guidance, semantic search integration, linking to memories, always-loaded skills concept.
+
+- [ ] **Step 2: Update `docs/index.md`**
+
+Add wiki to the Features section.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Add to key files:
+- `src/decafclaw/skills/wiki/` — Bundled wiki skill: Obsidian-compatible knowledge base, always-loaded
+
+Add to conventions:
+- "Always-loaded skills." Skills with `always-loaded: true` in SKILL.md are auto-activated at startup — their body is in the system prompt and tools are always available. No permission check. Wiki is the first.
+- "Wiki is curated knowledge, memory is episodic." Memory is append-only daily entries. Wiki pages are living documents revised over time. The agent should use wiki for distilled facts and memory for timestamped observations.
+
+- [ ] **Step 4: Run checks**
+
+Run: `make check && make test`
+
+- [ ] **Step 5: Commit**
+
+```
+docs: add wiki knowledge base documentation
+```

--- a/.claude/dev-sessions/2026-03-23-1647-knowledge-base/spec.md
+++ b/.claude/dev-sessions/2026-03-23-1647-knowledge-base/spec.md
@@ -1,0 +1,174 @@
+# Knowledge Base (Obsidian-style Wiki)
+
+## Overview
+
+Add an Obsidian-compatible wiki as a structured knowledge base alongside episodic memory. The wiki stores curated, evolving knowledge — facts, preferences, project context, entity profiles — that the agent actively maintains through wiki gardening practices.
+
+Unlike memory (append-only, timestamped entries), wiki pages are living documents the agent revises, restructures, and condenses as understanding evolves.
+
+## References
+
+- Issue: https://github.com/lmorchard/decafclaw/issues/15
+- Related: #81 (Dream memory consolidation — needs a destination for distilled facts)
+- Related: #89 (Selective memory loading — wiki pages as another context source)
+
+## Storage
+
+### Location
+
+`workspace/wiki/` — inside the agent's workspace, writable by the agent.
+
+### Obsidian Compatibility
+
+The wiki directory should work as an Obsidian vault that the user can open and edit manually:
+
+- **Filenames are page titles** — `Les Orchard.md`, not `les-orchard.md`. Obsidian uses the filename as the display name.
+- **`[[wiki-links]]`** — standard Obsidian-style links. `[[Les Orchard]]` resolves to `Les Orchard.md`.
+- **Flat structure to start** — all pages in `workspace/wiki/`. Subdirectories are not forbidden but should emerge organically as the wiki grows. Obsidian resolves `[[links]]` across subdirectories by default.
+
+### Page Format
+
+Free-form markdown. Some pages will be entity-oriented (people, projects) with consistent sections, but there's no enforced template. Pages should include a `## Sources` section at the bottom linking to conversations/dates where information originated.
+
+Example:
+
+```markdown
+# Les Orchard
+
+Software engineer. Owner and primary user of this DecafClaw instance.
+
+## Preferences
+
+- Drinks: Boulevardier, Old Fashioned
+- Editor: VS Code
+- Prefers pragmatic solutions over clever ones
+
+## Projects
+
+- [[DecafClaw]] — AI agent project (this bot)
+- [[Blog]] — personal blog, weeknotes
+
+## Sources
+
+- 2026-03-15 conversation: mentioned drink preferences
+- 2026-03-20 conversation: discussed editor setup
+```
+
+## Skill Implementation
+
+### Native Skill
+
+The wiki is implemented as a bundled native skill at `src/decafclaw/skills/wiki/`:
+
+- `SKILL.md` — wiki gardening guidance and tool descriptions
+- `tools.py` — Python tool implementations
+
+### Always-Loaded Skill
+
+This introduces a new concept: **always-loaded skills**. The wiki skill's tools and SKILL.md prompt are injected at startup without needing `activate_skill`. This ensures the agent always has wiki awareness and can proactively reference/update knowledge.
+
+Implementation:
+- New frontmatter field `always-loaded: true` in SKILL.md
+- During skill discovery, skills with `always-loaded: true` are collected separately
+- At system prompt assembly time (not per-conversation), these skills are auto-activated: their SKILL.md body is appended to the system prompt and their tools are registered globally
+- **No permission check** — always-loaded skills are bundled and admin-trusted
+- **Tool budget exemption** — always-loaded skill tools count as always-loaded tools (like `set_effort`, `health_status`), not deferred
+- This is a general mechanism — wiki is the first user, but other skills could use it later
+
+## Tools
+
+### `wiki_read(page)`
+
+Read a wiki page by name. Returns the page content, or an error if the page doesn't exist.
+
+- `page`: Page name (filename without `.md`)
+- Searches `workspace/wiki/` and subdirectories for the file
+- If multiple files match (same name in different subdirs), return the first match and log a warning. Obsidian has the same behavior.
+
+### `wiki_write(page, content)`
+
+Create or overwrite a wiki page. The agent should use this for both new pages and revisions.
+
+- `page`: Page name (becomes the filename)
+- `content`: Full markdown content of the page
+- Creates `workspace/wiki/{page}.md`
+- If the page exists, overwrites it entirely (the agent should read first to preserve what it wants to keep)
+
+### `wiki_search(query)`
+
+Search wiki page titles and contents using substring matching (case-insensitive). Critical for the "search before create" gardening practice.
+
+- `query`: Search term
+- Returns matching page names and relevant excerpts
+- Also searches page titles (filenames)
+- This is distinct from `semantic_search`: `wiki_search` is exact substring matching for finding specific pages by name/content (the gardening tool). `semantic_search` finds conceptually related content across wiki, memories, and conversations (the retrieval tool).
+
+### `wiki_list()`
+
+List all wiki pages. Helps the agent discover what exists.
+
+- Returns page names, optionally with last-modified dates
+- Supports an optional `pattern` parameter for filtering (glob-style)
+
+### `wiki_backlinks(page)`
+
+Find all pages that link to the given page via `[[wiki-links]]`.
+
+- `page`: Page name to find backlinks for
+- Scans all wiki files for `[[page]]` references
+- Returns list of linking page names with the context line
+
+## SKILL.md Guidance
+
+The SKILL.md body contains wiki gardening guidance that's always in the agent's system prompt:
+
+### Core Principles
+
+- **Search before create** — always `wiki_search` before making a new page. Look for existing pages to add to rather than creating duplicates.
+- **Revise and rewrite** — wiki pages are living documents. Don't just append — restructure, condense, and rewrite as understanding evolves. New information should improve the whole page, not just pile up at the bottom.
+- **Link liberally** — use `[[Page Name]]` to connect related concepts. Links are how the knowledge graph grows.
+- **Sources section** — include a `## Sources` section at the bottom of pages noting where information came from (conversation dates, memory entries).
+- **Entity pages** — for people, projects, and recurring topics, create dedicated pages that accumulate facts over time.
+- **Merge related content** — when you find scattered information about a topic across multiple pages, consolidate into one well-organized page.
+- **Split when large** — when a page grows unwieldy, break it into sub-pages with a summary parent page that links to them.
+- **Update over duplicate** — if new information contradicts or updates existing wiki content, edit the existing page. The wiki should reflect current understanding, not a history of changes.
+
+## Linking to Memories
+
+Wiki pages can reference memory files using relative paths from the wiki root:
+
+```markdown
+## Sources
+
+- [2026-03-15 conversation](../memories/2026/2026-03-15.md) — mentioned drink preferences
+- [2026-03-20 conversation](../memories/2026/2026-03-20.md) — discussed editor setup
+```
+
+Since `workspace/wiki/` and `workspace/memories/` are siblings, `../memories/...` paths resolve correctly — and work in Obsidian too (Obsidian supports relative links).
+
+**Important boundary**: wiki tools must only create/edit files within `workspace/wiki/`. Memory files are read-only context — the agent should never modify them through wiki operations. The SKILL.md guidance and `wiki_write` tool should enforce this (reject paths that resolve outside the wiki root).
+
+## Semantic Search Integration
+
+Wiki pages are indexed in the embeddings database alongside memories and conversations.
+
+- **Source type**: `"wiki"` (new, alongside existing `"memory"` and `"conversation"`)
+- **Higher weight**: wiki results should rank higher than memory/conversation results in semantic search, since they represent curated knowledge. Implementation: apply a score multiplier (e.g. 1.2x) to wiki results when ranking search output. This is a tunable parameter — start with a modest boost and adjust based on experience.
+- **Reindexing**: the `make reindex` pipeline should scan `workspace/wiki/` for pages to index
+- **Incremental updates**: when a wiki page is written via `wiki_write`, update its embeddings entry
+
+## Configuration
+
+No new config initially. The wiki is always available once the skill is loaded.
+
+Future enhancements:
+- `wiki_path` config override (default: `workspace/wiki/`)
+- Max page size warnings
+
+## What's NOT in Scope (v1)
+
+- **Git-backed version control** — the workspace is inside a git repo, so git history is naturally available. A formal `wiki_history(page)` tool or auto-commit-on-write is deferred.
+- **`wiki_append` tool** — the agent can `wiki_read` + `wiki_write` to achieve the same thing. Add if the read-modify-write pattern proves too expensive.
+- **Templates/schemas** — no enforced page structure. Entity pages will develop consistent patterns organically through the SKILL.md guidance.
+- **Wiki-specific UI** — no Obsidian-like viewer in the web UI. The user opens the directory in Obsidian (or any markdown editor) for browsing. The agent uses tools.
+- **Cross-wiki links** — only one wiki per agent instance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/skills/tabstack/` — Bundled Tabstack skill (SKILL.md + tools.py)
 - `src/decafclaw/http_server.py` — HTTP server (Starlette/uvicorn): interactive button callbacks, health check
 - `src/decafclaw/skills/health/` — Bundled `!health` command: agent diagnostic status
+- `src/decafclaw/skills/wiki/` — Bundled wiki skill: Obsidian-compatible knowledge base, always-loaded
 - `src/decafclaw/skills/claude_code/` — Claude Code subagent skill (sessions, permissions, output logging)
 - `src/decafclaw/eval/` — Eval harness (YAML tests, failure reflection)
 - `src/decafclaw/mcp_client.py` — MCP client: config, registry, server connections, auto-restart
@@ -122,7 +123,8 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Memory lives in `data/{agent_id}/workspace/memories/`.** Daily markdown files, append-only. Tools read context from ctx, not config.
 - **Agent data at `data/{agent_id}/`.** Admin files (SOUL.md, AGENT.md, USER.md, COMPACTION.md, config.yaml) live at the root — read-only to the agent. Agent read/write files live in `workspace/` subdirectory.
 - **System prompt from files.** SOUL.md + AGENT.md bundled in code, overridable at `data/{agent_id}/`. USER.md is workspace-only.
-- **Skills are lazy-loaded.** Skill catalog (name + description) is in the system prompt. Full content and tools only load when the agent calls `activate_skill`. Per-conversation activation via `ctx.extra_tools`.
+- **Skills are lazy-loaded (unless always-loaded).** Skill catalog (name + description) is in the system prompt. Full content and tools only load when the agent calls `activate_skill`. Per-conversation activation via `ctx.extra_tools`. Exception: skills with `always-loaded: true` in SKILL.md are auto-activated at startup — body in system prompt, tools always available, exempt from deferral.
+- **Wiki is curated knowledge, memory is episodic.** Memory is append-only daily entries ("Les said X on March 13"). Wiki pages (`workspace/wiki/`) are living documents revised over time ("Les's drink preferences: Boulevardier, Old Fashioned"). The agent uses wiki for distilled facts, memory for timestamped observations. Wiki pages are Obsidian-compatible — filenames are page titles, `[[wiki-links]]` work.
 - **User-invokable commands.** Skills with `user-invocable: true` can be triggered by `!name` (Mattermost) or `/name` (web UI). Supports `$ARGUMENTS`/`$0`/`$1` substitution, `context: fork` for isolated execution, and `allowed-tools` for tool pre-approval. `!help`/`/help` lists available commands.
 - **Skill permissions at agent level.** `data/{agent_id}/skill_permissions.json` — outside the workspace, so the agent can't grant itself permission. User confirms activation with yes/no/always.
 - **Bundled skills in `src/decafclaw/skills/`.** Each skill has SKILL.md (required) + tools.py (optional for native Python tools). Skill scan order: workspace > agent-level > bundled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 - [Skills System](skills.md) — Agent Skills standard, portable skill packages, native Python + shell-based tools
 - [MCP Server Support](mcp-servers.md) — Connect external MCP servers as tool providers (stdio + HTTP)
 - [Memory](memory.md) — Persistent memory with tags, substring and semantic search
+- [Knowledge Base (Wiki)](wiki.md) — Obsidian-compatible wiki for curated, evolving knowledge
 - [Conversations](conversations.md) — Archive, resume, and compaction of conversation history
 - [Semantic Search](semantic-search.md) — Embedding-based search over memories and conversations
 - [Eval Loop](eval-loop.md) — Test prompts and tools with real LLM calls

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -1,0 +1,105 @@
+# Knowledge Base (Wiki)
+
+DecafClaw includes an Obsidian-compatible wiki for storing curated, evolving knowledge. Unlike [memory](memory.md) (append-only, timestamped entries), wiki pages are living documents the agent revises and improves over time.
+
+The wiki directory works as an Obsidian vault — you can open it in Obsidian (or any markdown editor) and edit pages alongside the agent.
+
+## Storage
+
+Wiki pages live at `workspace/wiki/`. Each page is a markdown file where the filename is the page title (e.g. `Les Orchard.md`).
+
+The directory starts flat. Subdirectories can be created as the wiki grows — Obsidian resolves `[[links]]` across subdirectories by default.
+
+## Wiki Links
+
+Use standard Obsidian `[[wiki-links]]` to connect pages:
+
+```markdown
+Works on [[DecafClaw]] and maintains a [[Blog]].
+```
+
+`[[DecafClaw]]` resolves to `DecafClaw.md` in the wiki directory (or any subdirectory).
+
+### Linking to Memories
+
+Wiki pages can reference memory files using relative paths:
+
+```markdown
+## Sources
+
+- [2026-03-15 conversation](../memories/2026/2026-03-15.md) — mentioned drink preferences
+```
+
+Since `workspace/wiki/` and `workspace/memories/` are siblings, `../memories/...` paths resolve correctly in Obsidian too.
+
+## Tools
+
+The wiki skill is **always loaded** — its tools are available in every conversation without activation.
+
+| Tool | Description |
+|------|-------------|
+| `wiki_read(page)` | Read a page by name. Searches subdirectories. |
+| `wiki_write(page, content)` | Create or overwrite a page. Indexes in semantic search. |
+| `wiki_search(query)` | Substring search across page titles and content. |
+| `wiki_list(pattern?)` | List all pages with last-modified dates. Optional filter. |
+| `wiki_backlinks(page)` | Find pages linking to this page via `[[wiki-links]]`. |
+
+### Path Safety
+
+Both `wiki_read` and `wiki_write` validate that paths stay within `workspace/wiki/`. Path traversal attempts (e.g. `../../../etc/passwd`) are rejected.
+
+## Wiki Gardening
+
+The agent follows these principles (encoded in the skill's system prompt):
+
+- **Search before create** — always search for existing pages before making new ones
+- **Revise and rewrite** — restructure pages as understanding evolves, don't just append
+- **Link liberally** — `[[Page Name]]` connects knowledge
+- **Include sources** — `## Sources` section at the bottom of each page
+- **Entity pages** — dedicated pages for people, projects, recurring topics
+- **Merge related content** — consolidate scattered info into one page
+- **Split when large** — break big pages into sub-pages with a summary parent
+- **Update over duplicate** — edit existing pages rather than creating new ones
+
+## Semantic Search
+
+Wiki pages are indexed in the embeddings database as `source_type: "wiki"`. They receive a 1.2x score boost over memory and conversation results, since curated knowledge is higher signal.
+
+- Pages are indexed incrementally when written via `wiki_write`
+- `make reindex` rebuilds the full index including wiki pages
+- `memory_search` (with embeddings enabled) and `conversation_search` return wiki content alongside memories and conversations
+
+## Always-Loaded Skills
+
+The wiki uses a new concept: **always-loaded skills**. Skills with `always-loaded: true` in their SKILL.md frontmatter are auto-activated at startup:
+
+- Their SKILL.md body is appended to the system prompt (always in context)
+- Their tools are registered globally (no `activate_skill` needed)
+- Their tools are exempt from deferral (always available, not behind `tool_search`)
+- No permission check — always-loaded skills are bundled and admin-trusted
+
+The wiki is the first always-loaded skill. Other skills can use this mechanism by adding `always-loaded: true` to their frontmatter.
+
+## Example Page
+
+```markdown
+# Les Orchard
+
+Software engineer. Owner and primary user of this DecafClaw instance.
+
+## Preferences
+
+- Drinks: Boulevardier, Old Fashioned
+- Editor: VS Code
+- Prefers pragmatic solutions over clever ones
+
+## Projects
+
+- [[DecafClaw]] — AI agent project (this bot)
+- [[Blog]] — personal blog, weeknotes
+
+## Sources
+
+- [2026-03-15 conversation](../memories/2026/2026-03-15.md) — drink preferences
+- [2026-03-20 conversation](../memories/2026/2026-03-20.md) — editor setup
+```

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 from dataclasses import replace
+from pathlib import Path
 
 from .archive import append_message
 from .compaction import compact_history
@@ -390,6 +391,22 @@ async def run_agent_turn(ctx, user_message: str, history: list) -> "ToolResult":
         existing_data = ctx.skill_data
         ctx.skill_data = {**persisted_data, **existing_data}
     await restore_skills(ctx)
+
+    # Auto-activate always-loaded skills (bundled only — trust boundary)
+    from .skills import _BUNDLED_SKILLS_DIR
+    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
+    discovered = getattr(config, "discovered_skills", [])
+    for skill_info in discovered:
+        if not skill_info.always_loaded or skill_info.name in ctx.activated_skills:
+            continue
+        if not Path(skill_info.location).resolve().is_relative_to(bundled_dir):
+            continue  # only bundled skills can be always-loaded
+        from .tools.skill_tools import activate_skill_internal
+        try:
+            await activate_skill_internal(ctx, skill_info)
+            log.debug(f"Auto-activated always-loaded skill '{skill_info.name}'")
+        except Exception as e:
+            log.error(f"Failed to auto-activate skill '{skill_info.name}': {e}")
 
     # Restore effort level from archive (scan for last effort event)
     if ctx.effort == "default" and conv_id:

--- a/src/decafclaw/embeddings.py
+++ b/src/decafclaw/embeddings.py
@@ -142,6 +142,40 @@ def index_entry_sync(config, file_path: str, entry_text: str, embedding: list[fl
         conn.commit()
 
 
+def delete_entries(config, file_path: str, source_type: str | None = None) -> int:
+    """Delete embeddings entries by file_path (and optionally source_type).
+
+    Returns the number of rows deleted.
+    """
+    with _open_db(config) as conn:
+        if source_type:
+            cursor = conn.execute(
+                "DELETE FROM memory_embeddings WHERE file_path = ? AND source_type = ?",
+                (file_path, source_type),
+            )
+        else:
+            cursor = conn.execute(
+                "DELETE FROM memory_embeddings WHERE file_path = ?",
+                (file_path,),
+            )
+        conn.commit()
+        return cursor.rowcount
+
+
+def delete_by_source_type(config, source_type: str) -> int:
+    """Delete all embeddings entries for a given source type.
+
+    Returns the number of rows deleted.
+    """
+    with _open_db(config) as conn:
+        cursor = conn.execute(
+            "DELETE FROM memory_embeddings WHERE source_type = ?",
+            (source_type,),
+        )
+        conn.commit()
+        return cursor.rowcount
+
+
 def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
                         source_type: str | None = None) -> list[dict]:
     """Find the top K most similar entries by cosine similarity (sync).
@@ -152,12 +186,12 @@ def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
         _check_model(config, conn)
         if source_type:
             rows = conn.execute(
-                "SELECT entry_text, file_path, embedding FROM memory_embeddings WHERE source_type = ?",
+                "SELECT entry_text, file_path, embedding, source_type FROM memory_embeddings WHERE source_type = ?",
                 (source_type,),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT entry_text, file_path, embedding FROM memory_embeddings"
+                "SELECT entry_text, file_path, embedding, source_type FROM memory_embeddings"
             ).fetchall()
 
     if not rows:
@@ -168,17 +202,23 @@ def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
     if query_norm == 0:
         return []
 
+    # Score boost for curated wiki content
+    WIKI_BOOST = 1.2
+
     results = []
-    for entry_text, file_path, embedding_blob in rows:
+    for entry_text, file_path, embedding_blob, row_source_type in rows:
         entry_vec = _deserialize_embedding(embedding_blob)
         entry_norm = np.linalg.norm(entry_vec)
         if entry_norm == 0:
             continue
         similarity = float(np.dot(query_vec, entry_vec) / (query_norm * entry_norm))
+        if row_source_type == "wiki":
+            similarity *= WIKI_BOOST
         results.append({
             "entry_text": entry_text,
             "file_path": file_path,
             "similarity": similarity,
+            "source_type": row_source_type,
         })
 
     results.sort(key=lambda x: x["similarity"], reverse=True)
@@ -276,12 +316,47 @@ async def reindex_conversations(config):
     return count
 
 
+async def reindex_wiki(config):
+    """Rebuild wiki page embeddings."""
+    wiki_dir = config.workspace_path / "wiki"
+    if not wiki_dir.is_dir():
+        log.info("No wiki directory found, nothing to index")
+        return 0
+
+    # Clear existing wiki entries to avoid stale rows
+    deleted = delete_by_source_type(config, "wiki")
+    if deleted:
+        log.info(f"Cleared {deleted} existing wiki embedding(s)")
+
+    md_files = sorted(wiki_dir.rglob("*.md"))
+    count = 0
+    for fi, filepath in enumerate(md_files):
+        text = filepath.read_text().strip()
+        if not text:
+            continue
+        rel_path = str(filepath.relative_to(config.workspace_path))
+        await index_entry(config, rel_path, text, source_type="wiki")
+        count += 1
+        if count % 10 == 0:
+            print(f"  wiki: {count} pages ({fi + 1}/{len(md_files)} files)...", flush=True)
+
+    log.info(f"Reindexed {count} wiki pages from {len(md_files)} files")
+    return count
+
+
 def reindex_cli():
-    """CLI entry point: rebuild the embedding index from all sources."""
+    """CLI entry point: rebuild the embedding index from all sources (or a specific source)."""
+    import argparse
     import asyncio
     import logging
 
     from .config import load_config
+
+    parser = argparse.ArgumentParser(description="Rebuild DecafClaw embedding index")
+    parser.add_argument("--wiki", action="store_true", help="Reindex only wiki pages")
+    parser.add_argument("--memory", action="store_true", help="Reindex only memories")
+    parser.add_argument("--conversations", action="store_true", help="Reindex only conversations")
+    args = parser.parse_args()
 
     logging.basicConfig(
         level=logging.INFO,
@@ -290,21 +365,29 @@ def reindex_cli():
 
     config = load_config()
     db_path = _db_path(config)
+    subset = args.wiki or args.memory or args.conversations
 
-    # Delete existing DB to force full rebuild
-    if db_path.exists():
-        db_path.unlink()
-        print(f"Deleted existing index: {db_path}")
+    # Full rebuild: delete existing DB
+    if not subset:
+        if db_path.exists():
+            db_path.unlink()
+            print(f"Deleted existing index: {db_path}")
 
     print(f"Embedding model: {config.embedding.model}")
 
-    async def _reindex_all():
-        mem_count = await reindex_all(config)
-        conv_count = await reindex_conversations(config)
-        return mem_count, conv_count
+    async def _run():
+        counts = {}
+        if args.wiki or not subset:
+            counts["wiki"] = await reindex_wiki(config)
+        if args.memory or not subset:
+            counts["memory"] = await reindex_all(config)
+        if args.conversations or not subset:
+            counts["conversations"] = await reindex_conversations(config)
+        return counts
 
-    mem_count, conv_count = asyncio.run(_reindex_all())
-    print(f"Done: {mem_count} memory entries + {conv_count} conversation messages → {db_path}")
+    counts = asyncio.run(_run())
+    parts = [f"{v} {k}" for k, v in counts.items()]
+    print(f"Done: {' + '.join(parts)} → {db_path}")
 
 
 def search_cli():

--- a/src/decafclaw/prompts/__init__.py
+++ b/src/decafclaw/prompts/__init__.py
@@ -63,4 +63,17 @@ def load_system_prompt(config):
     if catalog:
         sections.append(catalog)
 
+    # Append always-loaded skill bodies to system prompt (bundled only — trust boundary)
+    from ..skills import _BUNDLED_SKILLS_DIR
+    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
+    for skill in skills:
+        if not skill.always_loaded or not skill.body:
+            continue
+        if not Path(skill.location).resolve().is_relative_to(bundled_dir):
+            log.warning(f"Ignoring always-loaded on non-bundled skill '{skill.name}' "
+                        f"at {skill.location}")
+            continue
+        sections.append(skill.body)
+        log.info(f"Always-loaded skill '{skill.name}' body appended to system prompt")
+
     return "\n\n".join(sections), skills

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -29,6 +29,7 @@ class SkillInfo:
     argument_hint: str = ""
     effort: str = ""  # empty = inherit conversation effort
     requires_skills: list[str] = field(default_factory=list)
+    always_loaded: bool = False
 
 
 def parse_skill_md(path: Path) -> SkillInfo | None:
@@ -86,6 +87,7 @@ def parse_skill_md(path: Path) -> SkillInfo | None:
         argument_hint=meta.get("argument-hint", ""),
         effort=meta.get("effort", ""),
         requires_skills=_coerce_str_list(meta.get("required-skills", [])),
+        always_loaded=bool(meta.get("always-loaded", False)),
     )
 
 
@@ -186,15 +188,38 @@ def build_catalog_text(skills: list[SkillInfo]) -> str:
     if not skills:
         return ""
 
-    lines = [
-        "## Available Skills",
-        "",
-        "The following skills can be activated. Their tools are NOT available until you "
-        "call activate_skill first. You MUST activate a skill before using any of its tools.",
-        "",
+    # Separate always-loaded (bundled only) from on-demand skills
+    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
+    always_loaded = [
+        s for s in skills
+        if s.always_loaded and Path(s.location).resolve().is_relative_to(bundled_dir)
     ]
-    for skill in skills:
-        lines.append(f"- **{skill.name}**: {skill.description}")
+    always_loaded_names = {s.name for s in always_loaded}
+    on_demand = [s for s in skills if s.name not in always_loaded_names]
+
+    lines = []
+
+    if always_loaded:
+        lines.extend([
+            "## Active Skills",
+            "",
+            "The following skills are always active — their tools are available now.",
+            "",
+        ])
+        for skill in always_loaded:
+            lines.append(f"- **{skill.name}**: {skill.description}")
+        lines.append("")
+
+    if on_demand:
+        lines.extend([
+            "## Available Skills",
+            "",
+            "The following skills can be activated. Their tools are NOT available until you "
+            "call activate_skill first. You MUST activate a skill before using any of its tools.",
+            "",
+        ])
+        for skill in on_demand:
+            lines.append(f"- **{skill.name}**: {skill.description}")
 
     return "\n".join(lines)
 

--- a/src/decafclaw/skills/wiki/SKILL.md
+++ b/src/decafclaw/skills/wiki/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: wiki
+description: Obsidian-compatible knowledge base for curated, evolving knowledge
+always-loaded: true
+---
+
+# Knowledge Base (Wiki)
+
+You have a wiki at `workspace/wiki/` for storing curated knowledge. Unlike memories (append-only, timestamped), wiki pages are **living documents** you revise and improve over time.
+
+The wiki is Obsidian-compatible — the user may also edit pages directly.
+
+## Wiki Gardening Rules
+
+**Search before create.** ALWAYS use `wiki_search` before making a new page. Look for existing pages to add to rather than creating duplicates.
+
+**Revise and rewrite.** Don't just append facts to the bottom of a page. Restructure, condense, and rewrite as understanding evolves. New information should improve the whole page.
+
+**Link liberally.** Use `[[Page Name]]` to connect related concepts. Links are how the knowledge graph grows.
+
+**Include sources.** Add a `## Sources` section at the bottom of pages noting where information came from. Link to memory files with relative paths: `[2026-03-15](../memories/2026/2026-03-15.md)`.
+
+**Create entity pages.** For people, projects, and recurring topics, create dedicated pages that accumulate facts over time.
+
+**Merge related content.** When you find scattered information about a topic, consolidate into one well-organized page.
+
+**Split when large.** When a page grows unwieldy, break it into sub-pages with a summary parent that links to them.
+
+**Update over duplicate.** If new information contradicts existing wiki content, edit the existing page. The wiki should reflect current understanding, not a history of changes.
+
+## Boundaries
+
+- Wiki tools only modify files in `workspace/wiki/`. Never use wiki tools to edit memory files.
+- Memories are read-only context. Reference them in Sources sections but don't modify them.
+- Use `wiki_read` before `wiki_write` when updating existing pages — `wiki_write` overwrites the entire page.
+
+## Navigating the Knowledge Graph
+
+**Follow links.** When you read a wiki page, note any `[[wiki-links]]` in the content. If the linked pages are relevant to your current task, read them too — context builds through connections.
+
+**Check backlinks.** After reading a page, use `wiki_backlinks` to see what other pages reference it. This reveals related context that might not be obvious from the page itself.
+
+**Explore before answering.** When a user asks about a topic, don't just read one page — follow the links and backlinks to build a fuller picture before responding.
+
+## When to Consult the Wiki
+
+- A user asks about a person, project, or topic → `wiki_search` first, then `wiki_read` matching pages
+- You need context for a task → check if there's a wiki page with relevant background
+- You're about to give advice or make a decision → see if the wiki has recorded preferences or prior decisions
+- You're unsure about something the user told you before → the wiki may have the curated answer
+- Don't rely solely on conversation history — the wiki may have information from past conversations you don't have in context
+
+## When to Update the Wiki
+
+- Someone tells you a fact, preference, or decision worth remembering long-term → wiki page
+- You notice scattered information about a topic across conversations → consolidate into a wiki page
+- A project or person comes up repeatedly → create an entity page
+- You learn something that corrects or updates existing knowledge → revise the wiki page

--- a/src/decafclaw/skills/wiki/tools.py
+++ b/src/decafclaw/skills/wiki/tools.py
@@ -1,0 +1,283 @@
+"""Wiki tools — Obsidian-compatible knowledge base operations."""
+
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from decafclaw.media import ToolResult
+
+log = logging.getLogger(__name__)
+
+
+def _wiki_dir(config) -> Path:
+    """Return the wiki directory path."""
+    return config.workspace_path / "wiki"
+
+
+def _resolve_page(config, page: str) -> Path | None:
+    """Resolve a page name to a file path, searching subdirectories.
+
+    Returns None if the page doesn't exist or the name is invalid.
+    """
+    if ".." in page or page.startswith("/"):
+        return None
+    wiki_root = _wiki_dir(config).resolve()
+    # Try direct path first
+    direct = (wiki_root / f"{page}.md").resolve()
+    if direct.is_relative_to(wiki_root) and direct.exists():
+        return direct
+    # Search subdirectories by comparing stems (avoids glob metachar issues)
+    for path in wiki_root.rglob("*.md"):
+        if path.stem == page and path.resolve().is_relative_to(wiki_root):
+            return path
+    return None
+
+
+def _safe_write_path(config, page: str) -> Path | None:
+    """Validate and return a safe write path within the wiki root.
+
+    Returns None if the path would escape the wiki directory.
+    """
+    if ".." in page or page.startswith("/"):
+        return None
+    wiki_root = _wiki_dir(config).resolve()
+    path = (wiki_root / f"{page}.md").resolve()
+    if not path.is_relative_to(wiki_root):
+        return None
+    return path
+
+
+async def tool_wiki_read(ctx, page: str) -> str | ToolResult:
+    """Read a wiki page by name."""
+    log.info(f"[tool:wiki_read] page={page}")
+    path = _resolve_page(ctx.config, page)
+    if path is None:
+        return ToolResult(text=f"[error: wiki page '{page}' not found]")
+    return path.read_text()
+
+
+async def tool_wiki_write(ctx, page: str, content: str) -> str | ToolResult:
+    """Create or overwrite a wiki page."""
+    log.info(f"[tool:wiki_write] page={page}")
+    path = _safe_write_path(ctx.config, page)
+    if path is None:
+        return ToolResult(
+            text=f"[error: invalid page name '{page}' — must be within wiki directory]")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+    # Update semantic search index (replace old entry for this page)
+    try:
+        from decafclaw.embeddings import delete_entries, index_entry
+        rel_path = str(path.resolve().relative_to(ctx.config.workspace_path.resolve()))
+        delete_entries(ctx.config, rel_path, source_type="wiki")
+        await index_entry(ctx.config, rel_path, content, source_type="wiki")
+    except Exception as e:
+        log.warning(f"Failed to index wiki page '{page}': {e}")
+
+    return f"Wiki page '{page}' saved."
+
+
+async def tool_wiki_search(ctx, query: str) -> str:
+    """Search wiki pages by title and content (substring match)."""
+    log.info(f"[tool:wiki_search] query={query}")
+    wiki = _wiki_dir(ctx.config)
+    if not wiki.is_dir():
+        return "No wiki pages found."
+
+    query_lower = query.lower()
+    results = []
+
+    for path in sorted(wiki.rglob("*.md")):
+        name = path.stem
+        text = path.read_text()
+        name_match = query_lower in name.lower()
+        content_match = query_lower in text.lower()
+
+        if name_match or content_match:
+            # Extract a relevant excerpt
+            excerpt = ""
+            if content_match:
+                for line in text.splitlines():
+                    if query_lower in line.lower():
+                        excerpt = line.strip()[:200]
+                        break
+            results.append(f"- **{name}**" + (f": {excerpt}" if excerpt else ""))
+
+    if not results:
+        return f"No wiki pages matching '{query}'."
+
+    return f"Found {len(results)} page(s):\n\n" + "\n".join(results)
+
+
+async def tool_wiki_list(ctx, pattern: str = "") -> str:
+    """List all wiki pages."""
+    log.info(f"[tool:wiki_list] pattern={pattern}")
+    wiki = _wiki_dir(ctx.config)
+    if not wiki.is_dir():
+        return "No wiki pages found (wiki directory does not exist)."
+
+    glob_pattern = f"*{pattern}*.md" if pattern else "*.md"
+    pages = []
+
+    for path in sorted(wiki.rglob(glob_pattern)):
+        name = path.stem
+        rel = path.relative_to(wiki)
+        mtime = datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+        # Show subdir prefix if not in root
+        display = str(rel.parent / name) if rel.parent != Path(".") else name
+        pages.append(f"- {display} (modified: {mtime})")
+
+    if not pages:
+        return "No wiki pages found." + (f" (pattern: {pattern})" if pattern else "")
+
+    return f"{len(pages)} page(s):\n\n" + "\n".join(pages)
+
+
+_WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+async def tool_wiki_backlinks(ctx, page: str) -> str:
+    """Find all pages that link to the given page via [[wiki-links]]."""
+    log.info(f"[tool:wiki_backlinks] page={page}")
+    wiki = _wiki_dir(ctx.config)
+    if not wiki.is_dir():
+        return f"No backlinks to '{page}' (wiki directory does not exist)."
+
+    page_lower = page.lower()
+    results = []
+
+    for path in sorted(wiki.rglob("*.md")):
+        if path.stem.lower() == page_lower:
+            continue  # skip the page itself
+        text = path.read_text()
+        for match in _WIKI_LINK_RE.finditer(text):
+            if match.group(1).lower() == page_lower:
+                # Find the line containing the match for context
+                line_no = text[:match.start()].count("\n")
+                lines = text.splitlines()
+                context_line = lines[line_no].strip()[:200] if line_no < len(lines) else ""
+                results.append(f"- **{path.stem}**: {context_line}")
+                break  # one backlink per page is enough
+
+    if not results:
+        return f"No pages link to '{page}'."
+
+    return f"{len(results)} page(s) link to '{page}':\n\n" + "\n".join(results)
+
+
+TOOLS = {
+    "wiki_read": tool_wiki_read,
+    "wiki_write": tool_wiki_write,
+    "wiki_search": tool_wiki_search,
+    "wiki_list": tool_wiki_list,
+    "wiki_backlinks": tool_wiki_backlinks,
+}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "wiki_read",
+            "description": (
+                "Read a wiki page by name. Returns the full page content. "
+                "Use to check existing content before writing updates."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": "Page name (e.g. 'Les Orchard', 'DecafClaw')",
+                    },
+                },
+                "required": ["page"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "wiki_write",
+            "description": (
+                "Create or overwrite a wiki page. ALWAYS wiki_read first if updating "
+                "an existing page to preserve content you want to keep. Use [[Page Name]] "
+                "syntax to link to other wiki pages. Include a ## Sources section."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": "Page name (becomes the filename, e.g. 'Les Orchard')",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Full markdown content of the page",
+                    },
+                },
+                "required": ["page", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "wiki_search",
+            "description": (
+                "Search wiki pages by title and content (substring match). "
+                "ALWAYS search before creating a new page — add to existing pages "
+                "rather than creating duplicates."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search term",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "wiki_list",
+            "description": "List all wiki pages with last-modified dates.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Optional filter pattern (e.g. 'project' to match pages with 'project' in the name)",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "wiki_backlinks",
+            "description": (
+                "Find all wiki pages that link to the given page via [[wiki-links]]. "
+                "Useful for understanding how a topic connects to other knowledge."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": "Page name to find backlinks for",
+                    },
+                },
+                "required": ["page"],
+            },
+        },
+    },
+]

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -137,20 +137,22 @@ def get_embeddings_data(config) -> dict:
                 SELECT
                     COUNT(*) AS total,
                     SUM(CASE WHEN source_type = 'memory' THEN 1 ELSE 0 END),
-                    SUM(CASE WHEN source_type = 'conversation' THEN 1 ELSE 0 END)
+                    SUM(CASE WHEN source_type = 'conversation' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN source_type = 'wiki' THEN 1 ELSE 0 END)
                 FROM memory_embeddings
                 """
             ).fetchone()
-            total, memory, conversation = row
+            total, memory, conversation, wiki = row
             memory = memory or 0
             conversation = conversation or 0
+            wiki = wiki or 0
         finally:
             conn.close()
     except sqlite3.Error as exc:
         log.exception("Failed to read embeddings database at %s", db_path)
-        return {"total": 0, "memory": 0, "conversation": 0, "error": str(exc)}
+        return {"total": 0, "memory": 0, "conversation": 0, "wiki": 0, "error": str(exc)}
 
-    return {"total": total, "memory": memory, "conversation": conversation}
+    return {"total": total, "memory": memory, "conversation": conversation, "wiki": wiki}
 
 
 def get_schedule_data(config) -> dict:
@@ -356,7 +358,7 @@ def _embeddings_section(config) -> list[str]:
     return [
         "### Embeddings",
         f"- **Total entries:** {data['total']}",
-        f"- **Memory:** {data['memory']} | **Conversation:** {data['conversation']}",
+        f"- **Memory:** {data['memory']} | **Conversation:** {data['conversation']} | **Wiki:** {data['wiki']}",
     ]
 
 

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -183,6 +183,13 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
                     ctx._skill_shutdown_hooks = {}
                 ctx._skill_shutdown_hooks[name] = shutdown_fn
             log.info(f"Activated native skill '{name}' with tools: {tool_names}")
+
+            # Cache tool names for always-loaded skills so tool_registry
+            # can exempt them from deferral
+            if getattr(skill_info, "always_loaded", False):
+                cached = getattr(ctx.config, "_always_loaded_skill_tools", set())
+                ctx.config._always_loaded_skill_tools = cached | set(tool_names)
+
         except Exception as e:
             log.error(f"Failed to load skill '{name}' tools: {e}")
             return ToolResult(text=f"[error: failed to load skill '{name}': {e}]")

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -19,8 +19,17 @@ def estimate_tool_tokens(tool_defs: list[dict]) -> int:
 
 
 def get_always_loaded_names(config) -> set[str]:
-    """Return the set of tool names that should always be loaded."""
+    """Return the set of tool names that should always be loaded.
+
+    Includes tools from always-loaded skills (e.g. wiki).
+    """
     extra = set(config.agent.always_loaded_tools)
+    # Include tool names from always-loaded skills
+    for skill in getattr(config, "discovered_skills", []):
+        if skill.always_loaded and skill.has_native_tools:
+            # Tool names aren't known until loaded, but we store them on config
+            # after first activation. Check the cached set.
+            extra |= set(getattr(config, "_always_loaded_skill_tools", []))
     return DEFAULT_ALWAYS_LOADED | extra
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -154,6 +154,26 @@ def test_parse_required_skills(tmp_path):
     assert info.requires_skills == ["markdown_vault", "tabstack"]
 
 
+def test_parse_always_loaded(tmp_path):
+    """Parse always-loaded field from frontmatter."""
+    skill_dir = tmp_path / "wiki"
+    _write_skill(
+        skill_dir,
+        'name: wiki\ndescription: "Knowledge base"\nalways-loaded: true',
+    )
+    info = parse_skill_md(skill_dir / "SKILL.md")
+    assert info is not None
+    assert info.always_loaded is True
+
+
+def test_parse_always_loaded_default(tmp_path):
+    """always-loaded defaults to False."""
+    skill_dir = tmp_path / "basic"
+    _write_skill(skill_dir, 'name: basic\ndescription: "Basic"')
+    info = parse_skill_md(skill_dir / "SKILL.md")
+    assert info.always_loaded is False
+
+
 # -- find_command / list_commands tests --
 
 

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -1,0 +1,163 @@
+"""Tests for wiki tools."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.skills.wiki.tools import (
+    tool_wiki_backlinks,
+    tool_wiki_list,
+    tool_wiki_read,
+    tool_wiki_search,
+    tool_wiki_write,
+)
+
+
+@pytest.fixture
+def wiki_dir(config):
+    """Create the wiki directory."""
+    d = config.workspace_path / "wiki"
+    d.mkdir(parents=True)
+    return d
+
+
+class TestWikiRead:
+    @pytest.mark.asyncio
+    async def test_read_existing_page(self, ctx, wiki_dir):
+        (wiki_dir / "Test Page.md").write_text("# Test Page\n\nContent here.")
+        result = await tool_wiki_read(ctx, "Test Page")
+        assert "Content here." in result
+
+    @pytest.mark.asyncio
+    async def test_read_nonexistent(self, ctx, wiki_dir):
+        result = await tool_wiki_read(ctx, "Nope")
+        assert "not found" in result.text
+
+    @pytest.mark.asyncio
+    async def test_read_rejects_path_traversal(self, ctx, wiki_dir, config):
+        memories = config.workspace_path / "memories"
+        memories.mkdir(parents=True)
+        (memories / "secret.md").write_text("super secret")
+        result = await tool_wiki_read(ctx, "../memories/secret")
+        assert "not found" in result.text
+        assert "super secret" not in getattr(result, "text", "")
+
+    @pytest.mark.asyncio
+    async def test_read_rejects_absolute_path(self, ctx, wiki_dir):
+        result = await tool_wiki_read(ctx, "/etc/passwd")
+        assert "not found" in result.text
+
+    @pytest.mark.asyncio
+    async def test_read_in_subdirectory(self, ctx, wiki_dir):
+        sub = wiki_dir / "people"
+        sub.mkdir()
+        (sub / "Alice.md").write_text("# Alice\n\nA person.")
+        result = await tool_wiki_read(ctx, "Alice")
+        assert "A person." in result
+
+
+class TestWikiWrite:
+    @pytest.mark.asyncio
+    async def test_create_new_page(self, ctx, wiki_dir):
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            result = await tool_wiki_write(ctx, "New Page", "# New Page\n\nFresh.")
+        assert "saved" in result.lower()
+        assert (wiki_dir / "New Page.md").exists()
+        assert "Fresh." in (wiki_dir / "New Page.md").read_text()
+
+    @pytest.mark.asyncio
+    async def test_overwrite_existing(self, ctx, wiki_dir):
+        (wiki_dir / "Existing.md").write_text("Old content.")
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_wiki_write(ctx, "Existing", "New content.")
+        assert "New content." in (wiki_dir / "Existing.md").read_text()
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, ctx, wiki_dir):
+        result = await tool_wiki_write(ctx, "../../../etc/passwd", "hack")
+        assert "error" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_dotdot_in_name(self, ctx, wiki_dir):
+        result = await tool_wiki_write(ctx, "foo/../bar", "hack")
+        assert "error" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_creates_subdirectory(self, ctx, wiki_dir):
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_wiki_write(ctx, "people/Alice", "# Alice")
+        assert (wiki_dir / "people" / "Alice.md").exists()
+
+
+class TestWikiSearch:
+    @pytest.mark.asyncio
+    async def test_search_by_content(self, ctx, wiki_dir):
+        (wiki_dir / "Drinks.md").write_text("# Drinks\n\nBoulevardier, Old Fashioned")
+        (wiki_dir / "Food.md").write_text("# Food\n\nPizza, Tacos")
+        result = await tool_wiki_search(ctx, "Boulevardier")
+        assert "Drinks" in result
+        assert "Food" not in result
+
+    @pytest.mark.asyncio
+    async def test_search_by_title(self, ctx, wiki_dir):
+        (wiki_dir / "DecafClaw.md").write_text("# DecafClaw\n\nAn agent.")
+        result = await tool_wiki_search(ctx, "DecafClaw")
+        assert "DecafClaw" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_results(self, ctx, wiki_dir):
+        result = await tool_wiki_search(ctx, "nonexistent")
+        assert "no" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_search_empty_wiki(self, ctx, config):
+        result = await tool_wiki_search(ctx, "anything")
+        assert "no" in result.lower()
+
+
+class TestWikiList:
+    @pytest.mark.asyncio
+    async def test_list_pages(self, ctx, wiki_dir):
+        (wiki_dir / "Alpha.md").write_text("# Alpha")
+        (wiki_dir / "Beta.md").write_text("# Beta")
+        result = await tool_wiki_list(ctx)
+        assert "Alpha" in result
+        assert "Beta" in result
+        assert "2 page" in result
+
+    @pytest.mark.asyncio
+    async def test_list_with_pattern(self, ctx, wiki_dir):
+        (wiki_dir / "Alpha.md").write_text("# Alpha")
+        (wiki_dir / "Beta.md").write_text("# Beta")
+        result = await tool_wiki_list(ctx, pattern="Alpha")
+        assert "Alpha" in result
+        assert "Beta" not in result
+
+    @pytest.mark.asyncio
+    async def test_empty_wiki(self, ctx, config):
+        result = await tool_wiki_list(ctx)
+        assert "no" in result.lower()
+
+
+class TestWikiBacklinks:
+    @pytest.mark.asyncio
+    async def test_finds_backlinks(self, ctx, wiki_dir):
+        (wiki_dir / "DecafClaw.md").write_text("# DecafClaw\n\nAn agent.")
+        (wiki_dir / "Les Orchard.md").write_text("# Les\n\nWorks on [[DecafClaw]].")
+        (wiki_dir / "Blog.md").write_text("# Blog\n\nNo links here.")
+        result = await tool_wiki_backlinks(ctx, "DecafClaw")
+        assert "Les Orchard" in result
+        assert "Blog" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_backlinks(self, ctx, wiki_dir):
+        (wiki_dir / "Orphan.md").write_text("# Orphan\n\nNobody links here.")
+        result = await tool_wiki_backlinks(ctx, "Orphan")
+        assert "No pages" in result
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive(self, ctx, wiki_dir):
+        (wiki_dir / "Target.md").write_text("# Target")
+        (wiki_dir / "Linker.md").write_text("See [[target]] for details.")
+        result = await tool_wiki_backlinks(ctx, "Target")
+        assert "Linker" in result


### PR DESCRIPTION
## Summary

New always-loaded wiki skill providing an Obsidian-compatible knowledge base for curated, evolving knowledge.

**New concept: always-loaded skills** — skills with `always-loaded: true` in SKILL.md are auto-activated at startup. Their body is in the system prompt, tools are always available, and tools are exempt from deferral. Wiki is the first.

**Wiki features:**
- 5 tools: `wiki_read`, `wiki_write`, `wiki_search`, `wiki_list`, `wiki_backlinks`
- Obsidian-compatible: filenames are page titles, `[[wiki-links]]` work, directory works as a vault
- Path traversal protection on `wiki_write`
- Wiki gardening guidance always in system prompt (search before create, revise and rewrite, link liberally, sources sections)
- Semantic search integration with 1.2x score boost for wiki results
- `make reindex` includes wiki pages
- Incremental indexing on `wiki_write`

Closes #15

## Test plan
- [x] 18 new wiki tool tests (read, write, search, list, backlinks, path safety)
- [x] 2 new always-loaded parsing tests
- [x] All 672 tests pass, lint + typecheck clean
- [x] Create a wiki page via chat, verify it appears in `workspace/wiki/`
- [x] Open wiki directory in Obsidian, verify pages and links work
- [x] Verify `wiki_search` finds existing pages before agent creates duplicates
- [x] Verify `semantic_search` returns wiki results with boost

🤖 Generated with [Claude Code](https://claude.com/claude-code)