### PR TITLE
Proactive memory context retrieval

### DIFF
--- a/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/notes.md
+++ b/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/notes.md
@@ -1,0 +1,5 @@
+# Proactive Memory Retrieval — Notes
+
+## Session Log
+
+- 2026-03-24: Session started. Issue #89 reframed from "selective memory loading" to "proactive memory retrieval as context injection." Original issue incorrectly assumed memories were bulk-loaded into system prompt — they're actually tool-based (save/search/recent). The real gap is that the agent only accesses memories when it explicitly chooses to call tools.

--- a/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/plan.md
+++ b/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/plan.md
@@ -1,0 +1,92 @@
+# Proactive Memory Retrieval — Plan
+
+## Step 1: Config dataclass and wiring
+
+**Context:** We need a `MemoryContextConfig` dataclass and it needs to be wired into the main `Config`.
+
+**What to do:**
+- Add `MemoryContextConfig` dataclass to `config_types.py` with fields: `enabled` (bool, default True), `similarity_threshold` (float, default 0.3), `max_results` (int, default 5), `max_tokens` (int, default 500), `show_in_ui` (bool, default True)
+- Add `memory_context: MemoryContextConfig` field to the main `Config` dataclass in `config.py`
+- Add `skip_memory_context: bool = False` to `Context.__init__` in `context.py`
+- Verify: `make check` passes
+
+## Step 2: Set skip flags in non-interactive callers
+
+**Context:** After step 1, the flag exists but nothing sets it. Mirror the `skip_reflection` pattern.
+
+**What to do:**
+- In `heartbeat.py`: set `ctx.skip_memory_context = True` (same place as `skip_reflection`)
+- In `schedules.py`: set `ctx.skip_memory_context = True` (same place as `skip_reflection`)
+- In `tools/delegate.py`: set `child_ctx.skip_memory_context = True` (same place as `skip_reflection`)
+- Verify: `make check` passes
+
+## Step 3: Core retrieval function
+
+**Context:** Steps 1-2 gave us config and skip flags. Now build the retrieval logic as a standalone async function.
+
+**What to do:**
+- Create `src/decafclaw/memory_context.py` with an async function `retrieve_memory_context(config, user_message) -> list[dict]` that:
+  - Returns empty list if `config.memory_context.enabled` is False
+  - Returns empty list if `config.embedding.model` is not set
+  - Calls `embeddings.search_similar(config, user_message, top_k=max_results * 2)` with `source_type=None` to search all types (wiki, memory, conversation). Note: wiki results already get a 1.2x similarity boost in `search_similar_sync`, so no additional source-type sorting needed — just use results as-returned by similarity
+  - Filters by `similarity_threshold`
+  - Trims to `max_results` and `max_tokens` budget (using `len(text) // 4`)
+  - Returns list of result dicts with `entry_text`, `source_type`, `similarity`
+  - **Fail-open:** Entire function wrapped in try/except — any error (embedding API down, DB issue, etc.) logs a warning and returns empty list. Must never crash the agent turn.
+  - **No reindex trigger:** If the embedding index is empty, return empty results. Do not call `reindex_all` — avoid adding latency to the hot path. The agent's explicit `memory_search` tool handles reindexing. This means we should call `embeddings.embed_text` + `embeddings.search_similar_sync` directly instead of `search_similar` (which auto-reindexes).
+- Add a `format_memory_context(results) -> str` function that formats the results into a single string with the framing prefix and source labels
+- Write a test in `tests/test_memory_context.py` covering: empty results, threshold filtering, token budget trimming, disabled config, no embedding model, error handling (fail-open)
+- Verify: `make test` and `make check` pass
+
+## Step 4: Inject into agent turn
+
+**Context:** Step 3 gives us a retrieval function. Now wire it into `run_agent_turn` in `agent.py`.
+
+**What to do:**
+- In `agent.py`, after the user message is appended to history (line ~451) and before building the messages array (line ~456):
+  - Check `ctx.skip_memory_context` — if True, skip
+  - Call `retrieve_memory_context(config, user_message)`
+  - If results are non-empty, call `format_memory_context(results)` to get the text
+  - Create a message dict with `role: "memory_context"` and the formatted content
+  - Append to `history` (before the user message — insert at `len(history) - 1`)
+  - Archive the message via `_archive(ctx, memory_context_msg)`
+- Do **not** add `"memory_context"` to `LLM_ROLES` — it needs role remapping, not passthrough
+- Update the `llm_history` builder in `agent.py` to remap `"memory_context"` → `"user"`:
+  ```python
+  # Role remapping for non-standard roles that should appear in LLM context
+  ROLE_REMAP = {"memory_context": "user"}
+
+  for m in history:
+      role = m.get("role")
+      if role in LLM_ROLES:
+          llm_history.append(m)
+      elif role in ROLE_REMAP:
+          llm_history.append({**m, "role": ROLE_REMAP[role]})
+  ```
+- Verify: `make check` passes
+
+## Step 5: UI event emission
+
+**Context:** Step 4 handles retrieval and injection. Now add visibility.
+
+**What to do:**
+- In `agent.py`, right after injecting the memory context message, emit an event:
+  ```python
+  if config.memory_context.show_in_ui:
+      await ctx.publish("memory_context", results=results, text=formatted_text)
+  ```
+- In `mattermost.py` `_subscribe_progress`, add a handler for `"memory_context"` events that calls `conv_display.on_tool_status("memory_context", text)` — format as an expandable block showing source types and snippets
+- In `web/websocket.py`, handle the `"memory_context"` event similarly if needed (check if tool_status events already flow through to the web UI generically)
+- Verify: `make check` passes
+
+## Step 6: Docs and cleanup
+
+**Context:** Feature is functional. Update docs.
+
+**What to do:**
+- Create `docs/memory-context.md` documenting the feature: what it does, config options, how to disable, silent skip when no embedding model
+- Update `CLAUDE.md`: add `memory_context.py` to key files, add convention note about `skip_memory_context` flag
+- Update `README.md`: add config options to the config table if one exists
+- Update `docs/index.md` with link to new doc
+- Verify: `make check` passes
+- Commit everything

--- a/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/spec.md
+++ b/.claude/dev-sessions/2026-03-24-1532-proactive-memory-retrieval/spec.md
@@ -1,0 +1,83 @@
+# Proactive Memory Retrieval — Spec
+
+*Session for GitHub issue #89*
+
+## Problem
+
+The agent only accesses memories when it explicitly chooses to call `memory_search` or `memory_recent`. It doesn't proactively surface relevant memories for the current conversation turn. This means the agent often misses relevant context it already knows — the user has to prompt it to search, or the agent has to think to do so.
+
+## Solution
+
+A lightweight pre-pass before each agent turn that automatically retrieves relevant memories/wiki/conversation entries and injects them as context the LLM can use.
+
+## Design
+
+### Retrieval
+
+1. **Input:** The user's current message text (just the current message, not conversation history)
+2. **Search:** Run semantic search against the embeddings index
+3. **Source priority:** Wiki > Memory > Conversation — run a single search across all source types, then sort by (source_type_priority, similarity_score) descending
+4. **Threshold:** Only include results above a minimum similarity score (default `0.3`)
+5. **Budget:** Cap results at max count (default `5`) and max tokens (default `500`, estimated via `len(text) // 4` — consistent with the rest of the codebase)
+
+### Injection
+
+- Stored in history with role `"memory_context"` for identification and archival
+- When building the LLM `messages` array, mapped to `"user"` role (to avoid prompt injection risks of `"system"`)
+- Content framed with a clear prefix (e.g., `"[Automatically retrieved context — not from the user]:\n\n..."`)
+- Positioned between the previous message and the current user message in the `messages` array
+- **Kept in LLM context** on subsequent turns — compaction handles accumulation naturally
+- Add `"memory_context"` to `LLM_ROLES` mapping so it's included in `llm_history` (mapped to `"user"`)
+- **Empty results:** If no results pass the similarity threshold, inject nothing and emit no event
+
+### UI Indicator
+
+- Emit a `memory_context` event via `ctx.publish()` with the retrieved entries
+- Progress subscriber renders via `conv_display.on_tool_status("memory_context", text)` — follows the reflection pattern
+- Gated by `memory_context.show_in_ui` config flag (default: `true`)
+- Shows as an expandable block in the conversation, similar to tool calls
+
+### Skip Conditions
+
+Add `skip_memory_context` flag to context (mirrors `skip_reflection`). Skip retrieval for:
+- Delegated subtasks (child agents)
+- Heartbeat turns
+- Scheduled tasks
+- Compaction/internal turns
+- Any turn where `ctx.skip_memory_context` is `True`
+
+Only run for interactive user conversations (Mattermost direct messages, web UI, terminal).
+
+### Configuration
+
+New `memory_context` config section:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable the feature (silently skipped if no embedding model configured) |
+| `similarity_threshold` | float | `0.3` | Minimum similarity score to include a result |
+| `max_results` | int | `5` | Maximum number of entries to inject |
+| `max_tokens` | int | `500` | Token budget for injected context |
+| `show_in_ui` | bool | `true` | Show retrieval indicator in chat UI |
+
+### Silent Skip (No Embedding Model)
+
+If `config.embedding.model` is not configured, the feature silently does nothing — no error, no log, no UI indicator. Documented in docs.
+
+## Non-Goals
+
+- Replacing the existing memory tools — the agent can still explicitly search/save
+- Complex RAG pipeline — just semantic similarity
+- Memory summarization or compaction — separate concern
+- Custom ranking algorithms — source type priority + similarity score is enough for now
+
+## Acceptance Criteria
+
+- [ ] Relevant memories/wiki entries appear in LLM context without the agent explicitly searching
+- [ ] Results respect similarity threshold, max results, and token budget
+- [ ] UI shows expandable indicator of what was retrieved (when `show_in_ui` is true)
+- [ ] Retrieved context is archived with `memory_context` role
+- [ ] Feature silently disabled when no embedding model is configured
+- [ ] Skipped for non-interactive turns (heartbeat, scheduled, delegated, compaction)
+- [ ] All config options respected
+- [ ] Docs updated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ A minimal AI agent for learning how agent frameworks work. Connects to Mattermos
 - `src/decafclaw/context.py` — Forkable runtime context
 - `src/decafclaw/events.py` — In-process pub/sub event bus
 - `src/decafclaw/memory.py` — Memory file read/write operations
+- `src/decafclaw/memory_context.py` — Proactive memory retrieval: auto-inject relevant context per turn
 - `src/decafclaw/archive.py` — Conversation archive (JSONL per conversation)
 - `src/decafclaw/compaction.py` — History compaction via summarization
 - `src/decafclaw/embeddings.py` — Semantic search index (SQLite + cosine similarity)
@@ -138,6 +139,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Scheduled tasks via cron-style files.** Markdown files with YAML frontmatter in `data/{agent_id}/schedules/` (admin) and `workspace/schedules/` (agent-writable). Frontmatter fields: `schedule` (5-field cron), `channel` (Mattermost channel **ID** — `#name` resolution not yet implemented), `enabled`, `effort`, `allowed-tools`, `required-skills`. Independent timer loop (60s poll), per-task last-run tracking in `workspace/.schedule_last_run/`. Uses `croniter` for cron evaluation. Mattermost channel reporting not yet wired — results currently go to agent log.
 - **Skill schedule frontmatter.** Skills can declare `schedule: "cron expression"` in SKILL.md to run as scheduled tasks. Only bundled and admin-level skills are honored (workspace skills cannot self-schedule). File-based schedules override skill schedules on name collision. Skills with both `schedule` and `user-invocable: true` serve as both scheduled tasks and on-demand commands.
 - **Self-reflection is fail-open.** The reflection judge evaluates responses before delivery, but errors (network, parse, etc.) always pass through the response as-is. Retries consume `max_tool_iterations` budget. Skipped for child agents, cancelled turns, and empty responses.
+- **Proactive memory context is fail-open.** Before each interactive turn, relevant memories/wiki are auto-injected as context. Errors silently return empty results. Skipped for heartbeat, scheduled tasks, and child agents (`skip_memory_context` flag on ctx). Requires an embedding model to be configured — silently disabled otherwise.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 
 ## Keeping docs current

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@
 - [Skills System](skills.md) — Agent Skills standard, portable skill packages, native Python + shell-based tools
 - [MCP Server Support](mcp-servers.md) — Connect external MCP servers as tool providers (stdio + HTTP)
 - [Memory](memory.md) — Persistent memory with tags, substring and semantic search
+- [Proactive Memory Context](memory-context.md) — Automatically surface relevant memories/wiki per turn
 - [Knowledge Base (Wiki)](wiki.md) — Obsidian-compatible wiki for curated, evolving knowledge
 - [Dream Consolidation](dream-consolidation.md) — Periodic memory review and wiki gardening
 - [Conversations](conversations.md) — Archive, resume, and compaction of conversation history

--- a/docs/memory-context.md
+++ b/docs/memory-context.md
@@ -1,0 +1,81 @@
+# Proactive Memory Context
+
+Automatically surfaces relevant memories, wiki entries, and conversation snippets before each agent turn — without the agent needing to explicitly search.
+
+## How it works
+
+Before each turn, the agent:
+
+1. Embeds the user's current message
+2. Runs semantic search across all indexed content (wiki, memory, conversation)
+3. Filters results by similarity threshold
+4. Injects matching entries as a context message before the user's message
+
+The LLM sees this context alongside the conversation and can use it naturally. The context message is archived for auditability and persists in the conversation history.
+
+## Configuration
+
+All settings live under the `memory_context` section in `config.json`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Enable/disable the feature |
+| `similarity_threshold` | float | `0.3` | Minimum similarity score to include a result |
+| `max_results` | int | `5` | Maximum number of entries to inject |
+| `max_tokens` | int | `500` | Token budget for injected context |
+| `show_in_ui` | bool | `true` | Show retrieval indicator in chat UI |
+
+Environment variable prefix: `MEMORY_CONTEXT_` (e.g., `MEMORY_CONTEXT_ENABLED=false`).
+
+### Example config.json
+
+```json
+{
+  "memory_context": {
+    "enabled": true,
+    "similarity_threshold": 0.4,
+    "max_results": 3,
+    "max_tokens": 300,
+    "show_in_ui": true
+  }
+}
+```
+
+## Requirements
+
+- An embedding model must be configured (`embedding.model`). If not set, the feature silently does nothing.
+- The embedding index should be populated (run `make reindex` if starting fresh).
+
+## Skip conditions
+
+Memory context retrieval is skipped for non-interactive turns:
+
+- Heartbeat cycles
+- Scheduled tasks
+- Delegated subtasks (child agents)
+- Any turn with `skip_memory_context` set on the context
+
+Only interactive conversations (Mattermost, web UI, terminal) trigger retrieval.
+
+## UI indicator
+
+When `show_in_ui` is true:
+
+- **Web UI**: An expandable block shows the full retrieved context with source types and relevance scores. Visible both live and on conversation reload.
+- **Mattermost**: A concise summary post shows the count of retrieved items by source type (e.g., "🧠 Retrieved 1 wiki, 3 conversation"). Full text is not shown since Mattermost posts can't collapse.
+
+Note: `show_in_ui` gates the live progress event. The `memory_context` message is always archived for auditability and will appear on web UI history reload regardless of this setting. To fully suppress, disable the feature with `enabled: false`.
+
+## Source priority
+
+Wiki entries receive a 1.2x similarity boost (configured in the embeddings layer), so curated wiki content naturally ranks above raw memory entries at equal semantic distance.
+
+## Disabling
+
+Set `memory_context.enabled` to `false` in config, or set `MEMORY_CONTEXT_ENABLED=false` in the environment.
+
+## Related
+
+- [Memory](memory.md) — The memory save/search tools (still available for explicit use)
+- [Knowledge Base (Wiki)](wiki.md) — Wiki entries are included in retrieval
+- [Semantic Search](semantic-search.md) — The underlying embedding index

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -273,6 +273,7 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
             await call_ctx.publish("tool_end", tool=fn_name,
                                    result_text=result.text,
                                    display_text=getattr(result, "display_text", None),
+                                   display_short_text=getattr(result, "display_short_text", None),
                                    media=result.media or [],
                                    tool_call_id=tool_call_id)
 
@@ -281,6 +282,8 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
         "tool_call_id": tool_call_id,
         "content": result.text,
     }
+    if result.display_short_text:
+        tool_msg["display_short_text"] = result.display_short_text
     _archive(call_ctx, tool_msg)
     return tool_msg, result.media or []
 
@@ -448,6 +451,22 @@ async def run_agent_turn(ctx, user_message: str, history: list,
             log.warning(f"User message truncated: {original_len:,} -> {max_len:,} chars")
 
         user_msg = {"role": "user", "content": user_message}
+
+        # Proactive memory context — inject before user message
+        retrieved_context_text = ""
+        if not ctx.skip_memory_context:
+            from .memory_context import format_memory_context, retrieve_memory_context
+            mc_results = await retrieve_memory_context(config, user_message)
+            if mc_results:
+                retrieved_context_text = format_memory_context(mc_results)
+                mc_msg = {"role": "memory_context", "content": retrieved_context_text}
+                history.append(mc_msg)
+                _archive(ctx, mc_msg)
+                if config.memory_context.show_in_ui:
+                    await ctx.publish("memory_context",
+                                      text=retrieved_context_text,
+                                      results=mc_results)
+
         history.append(user_msg)
         # Archive the display version for inline commands (short), full text for normal messages
         archive_msg = {"role": "user", "content": archive_text} if archive_text else user_msg
@@ -455,8 +474,16 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
         # Build the messages array: system prompt + history
         # Filter out metadata roles (effort, reflection) that aren't valid LLM messages
+        # Remap non-standard roles that should appear in LLM context
+        ROLE_REMAP = {"memory_context": "user"}
         from .archive import LLM_ROLES
-        llm_history = [m for m in history if m.get("role") in LLM_ROLES]
+        llm_history = []
+        for m in history:
+            role = m.get("role")
+            if role in LLM_ROLES:
+                llm_history.append(m)
+            elif role in ROLE_REMAP:
+                llm_history.append({**m, "role": ROLE_REMAP[role]})
         messages = [{"role": "system", "content": config.system_prompt}] + llm_history
         ctx.messages = messages
 
@@ -559,7 +586,8 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
                 tool_summary = build_tool_summary(history, turn_start_index)
                 result = await evaluate_response(
-                    config, user_message, content, tool_summary)
+                    config, user_message, content, tool_summary,
+                    retrieved_context=retrieved_context_text)
 
                 last_reflection = result
                 log.info("Reflection result: passed=%s, critique=%s, error=%s",

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -59,13 +59,16 @@ def _extract_previous_summary(config, conv_id: str) -> tuple[str | None, str | N
 def _split_into_turns(messages: list[dict]) -> list[list[dict]]:
     """Split a flat message list into turns.
 
-    A turn starts with a user message and includes everything until
-    the next user message.
+    A turn starts with a user or memory_context message and includes
+    everything until the next turn boundary. memory_context is treated
+    as a turn start because it's injected before the user message it
+    belongs to.
     """
     turns = []
     current_turn = []
     for msg in messages:
-        if msg.get("role") == "user" and current_turn:
+        role = msg.get("role")
+        if role in ("user", "memory_context") and current_turn:
             turns.append(current_turn)
             current_turn = []
         current_turn.append(msg)

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -24,6 +24,7 @@ from .config_types import (
     HttpConfig,
     LlmConfig,
     MattermostConfig,
+    MemoryContextConfig,
     ReflectionConfig,
 )
 
@@ -140,6 +141,7 @@ class Config:
     skills: dict[str, dict[str, Any]] = field(default_factory=dict)
     models: dict[str, dict[str, str]] = field(default_factory=dict)
     reflection: ReflectionConfig = field(default_factory=ReflectionConfig)
+    memory_context: MemoryContextConfig = field(default_factory=MemoryContextConfig)
 
     # Custom environment variables from config.json "env" section
     env: dict[str, str] = field(default_factory=dict)
@@ -308,6 +310,9 @@ def load_config() -> Config:
     reflection = load_sub_config(
         ReflectionConfig, file_data.get("reflection", {}), "REFLECTION")
 
+    memory_context = load_sub_config(
+        MemoryContextConfig, file_data.get("memory_context", {}), "MEMORY_CONTEXT")
+
     # Custom env vars from config file
     env_vars: dict[str, str] = {
         str(k): str(v) for k, v in file_data.get("env", {}).items()
@@ -327,6 +332,7 @@ def load_config() -> Config:
         skills=skills,
         models=models,
         reflection=reflection,
+        memory_context=memory_context,
         env=env_vars,
         system_prompt=system_prompt,
     )

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -124,6 +124,15 @@ class ReflectionConfig:
 
 
 
+@dataclass
+class MemoryContextConfig:
+    enabled: bool = True
+    similarity_threshold: float = 0.3
+    max_results: int = 5
+    max_tokens: int = 500
+    show_in_ui: bool = True
+
+
 def is_secret(dc_class: type, field_name: str) -> bool:
     """Check if a dataclass field is marked as secret."""
     for f in dc_fields(dc_class):

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -41,6 +41,7 @@ class Context:
         self._current_iteration: int = 1
         self.is_child: bool = False
         self.skip_reflection: bool = False
+        self.skip_memory_context: bool = False
         self.effort: str = "default"
 
     def fork(self, **overrides) -> "Context":

--- a/src/decafclaw/heartbeat.py
+++ b/src/decafclaw/heartbeat.py
@@ -159,6 +159,7 @@ async def run_section_turn(
         ctx.thread_id = ""
         ctx.conv_id = f"heartbeat-{timestamp}-{index}"
         ctx.skip_reflection = True
+        ctx.skip_memory_context = True
 
         prompt = build_section_prompt(section)
         result = await run_agent_turn(ctx, prompt, history=[])

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -674,6 +674,7 @@ class MattermostClient:
                     event.get("display_text"),
                     event.get("media", []),
                     tool_call_id=event.get("tool_call_id", ""),
+                    display_short_text=event.get("display_short_text"),
                 )
             elif event_type == "tool_confirm_request" and conv_display:
                 await conv_display.on_confirm_request(
@@ -705,6 +706,21 @@ class MattermostClient:
                         text = (f"\U0001f50d Reflection retry {retry_num}: "
                                 f"{critique}")
                         await conv_display.on_tool_status("reflection", text)
+            elif event_type == "memory_context" and conv_display:
+                results = event.get("results") or []
+                if results:
+                    source_counts: dict[str, int] = {}
+                    for item in results:
+                        st = item.get("source_type", "unknown")
+                        source_counts[st] = source_counts.get(st, 0) + 1
+                    parts = []
+                    for st in ("wiki", "memory", "conversation"):
+                        if source_counts.get(st):
+                            parts.append(f"{source_counts[st]} {st}")
+                    summary = ", ".join(parts) or "context"
+                    await conv_display.on_tool_status(
+                        "memory_context",
+                        f"\U0001f9e0 Retrieved {summary}")
             # Compaction stays as-is (separate message)
             elif event_type == "compaction_start" and channel_id:
                 import time as _time
@@ -996,7 +1012,11 @@ class ConversationDisplay:
         self._current_type = "tool"
 
     async def on_tool_status(self, tool_name, message, tool_call_id=""):
-        """Tool status update — edit the tool call's progress message."""
+        """Tool status update — edit the tool call's progress message.
+
+        If no existing tool post is found (e.g., memory_context or reflection
+        events that arrive without a preceding tool_start), create a standalone post.
+        """
         post_id = self._tool_posts.get(tool_call_id)
         if not post_id and self._tool_posts:
             # Fallback: use most recent post if tool_call_id not found
@@ -1009,12 +1029,22 @@ class ConversationDisplay:
                 )
             except Exception:
                 pass
+        else:
+            # Standalone status (no preceding tool_start) — create a new post
+            try:
+                await self.client.send(
+                    self._channel_id, message, root_id=self._root_id,
+                )
+            except Exception:
+                pass
 
     async def on_tool_end(self, tool_name, result_text, display_text, media,
-                          tool_call_id=""):
+                          tool_call_id="", display_short_text=None):
         """Tool finished — edit tool call message with result, handle media."""
         if display_text:
             msg = display_text
+        elif display_short_text:
+            msg = f"\U0001f527 {tool_name}: {display_short_text} \u2714\ufe0f"
         else:
             msg = f"\U0001f527 {tool_name} \u2714\ufe0f"
 

--- a/src/decafclaw/media.py
+++ b/src/decafclaw/media.py
@@ -19,6 +19,7 @@ class ToolResult:
     text: str
     media: list[dict] = field(default_factory=list)
     display_text: str | None = None
+    display_short_text: str | None = None
 
     @classmethod
     def from_text(cls, text: str) -> "ToolResult":

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -1,0 +1,76 @@
+"""Proactive memory retrieval — automatically surface relevant context per turn."""
+
+import logging
+
+from .embeddings import embed_text, search_similar_sync
+
+log = logging.getLogger(__name__)
+
+# Source type labels for display
+SOURCE_LABELS = {
+    "wiki": "Wiki",
+    "memory": "Memory",
+    "conversation": "Conversation",
+}
+
+
+async def retrieve_memory_context(config, user_message: str) -> list[dict]:
+    """Retrieve relevant memory/wiki/conversation entries for a user message.
+
+    Returns a list of result dicts with entry_text, source_type, similarity.
+    Fail-open: any error logs a warning and returns empty list.
+    """
+    try:
+        mc = config.memory_context
+        if not mc.enabled:
+            return []
+        if not config.embedding.model:
+            return []
+
+        # Embed the query — skip reindexing (hot path, avoid latency)
+        query_embedding = await embed_text(config, user_message)
+        if not query_embedding:
+            return []
+
+        # Search all source types, fetch extra to allow for threshold filtering
+        results = search_similar_sync(
+            config, query_embedding, top_k=mc.max_results * 2
+        )
+
+        # Filter by similarity threshold
+        results = [r for r in results if r["similarity"] >= mc.similarity_threshold]
+
+        # Trim to max_results
+        results = results[:mc.max_results]
+
+        # Trim to token budget
+        results = _trim_to_token_budget(results, mc.max_tokens)
+
+        return results
+
+    except Exception:
+        log.warning("Memory context retrieval failed", exc_info=True)
+        return []
+
+
+def _trim_to_token_budget(results: list[dict], max_tokens: int) -> list[dict]:
+    """Trim results to fit within a token budget (len // 4 estimate)."""
+    trimmed = []
+    total_tokens = 0
+    for r in results:
+        entry_tokens = len(r["entry_text"]) // 4
+        if total_tokens + entry_tokens > max_tokens and trimmed:
+            break
+        trimmed.append(r)
+        total_tokens += entry_tokens
+    return trimmed
+
+
+def format_memory_context(results: list[dict]) -> str:
+    """Format retrieval results into a context message for injection."""
+    parts = ["[Automatically retrieved context — not from the user]\n"]
+    for r in results:
+        label = SOURCE_LABELS.get(r["source_type"], r["source_type"])
+        sim = f"{r['similarity']:.2f}"
+        parts.append(f"--- {label} (relevance: {sim}) ---\n{r['entry_text']}")
+    return "\n\n".join(parts)

--- a/src/decafclaw/prompts/REFLECTION.md
+++ b/src/decafclaw/prompts/REFLECTION.md
@@ -24,6 +24,8 @@ the response meaningfully misses what the user asked for.
 
 ---
 
+{retrieved_context}
+
 User: {user_message}
 
 {tool_results_summary}

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -149,6 +149,7 @@ async def evaluate_response(
     user_message: str,
     agent_response: str,
     tool_summary: str,
+    retrieved_context: str = "",
 ) -> ReflectionResult:
     """Run the judge LLM to evaluate the agent's response.
 
@@ -156,10 +157,18 @@ async def evaluate_response(
     """
     try:
         prompt_template = load_reflection_prompt(config)
+        if retrieved_context:
+            context_block = (
+                "Retrieved context (automatically injected before the user's message):\n"
+                + retrieved_context
+            )
+        else:
+            context_block = ""
         prompt = prompt_template.format(
             user_message=user_message,
             tool_results_summary=tool_summary or "(no tools used)",
             agent_response=agent_response,
+            retrieved_context=context_block,
         )
 
         rc = config.reflection.resolved(config)

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -213,6 +213,7 @@ async def run_schedule_task(config, event_bus, task: ScheduleTask) -> dict:
     ctx.conv_id = f"schedule-{task.name}-{timestamp}"
     ctx.effort = task.effort
     ctx.skip_reflection = True
+    ctx.skip_memory_context = True
 
     if task.allowed_tools:
         ctx.allowed_tools = set(task.allowed_tools)

--- a/src/decafclaw/skills/wiki/tools.py
+++ b/src/decafclaw/skills/wiki/tools.py
@@ -54,7 +54,7 @@ async def tool_wiki_read(ctx, page: str) -> str | ToolResult:
     path = _resolve_page(ctx.config, page)
     if path is None:
         return ToolResult(text=f"[error: wiki page '{page}' not found]")
-    return path.read_text()
+    return ToolResult(text=path.read_text(), display_short_text=page)
 
 
 async def tool_wiki_write(ctx, page: str, content: str) -> str | ToolResult:
@@ -81,12 +81,13 @@ async def tool_wiki_write(ctx, page: str, content: str) -> str | ToolResult:
     return f"Wiki page '{page}' saved."
 
 
-async def tool_wiki_search(ctx, query: str) -> str:
+async def tool_wiki_search(ctx, query: str) -> str | ToolResult:
     """Search wiki pages by title and content (substring match)."""
     log.info(f"[tool:wiki_search] query={query}")
     wiki = _wiki_dir(ctx.config)
     if not wiki.is_dir():
-        return "No wiki pages found."
+        return ToolResult(text="No wiki pages found.",
+                          display_short_text=f"'{query}' — no pages")
 
     query_lower = query.lower()
     results = []
@@ -108,9 +109,12 @@ async def tool_wiki_search(ctx, query: str) -> str:
             results.append(f"- **{name}**" + (f": {excerpt}" if excerpt else ""))
 
     if not results:
-        return f"No wiki pages matching '{query}'."
+        return ToolResult(text=f"No wiki pages matching '{query}'.",
+                          display_short_text=f"'{query}' — no matches")
 
-    return f"Found {len(results)} page(s):\n\n" + "\n".join(results)
+    text = f"Found {len(results)} page(s):\n\n" + "\n".join(results)
+    return ToolResult(text=text,
+                      display_short_text=f"'{query}' — {len(results)} match(es)")
 
 
 async def tool_wiki_list(ctx, pattern: str = "") -> str:

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -84,6 +84,7 @@ async def _run_child_turn(parent_ctx, task, effort: str = "",
     child_ctx.on_stream_chunk = None
     child_ctx.is_child = True
     child_ctx.skip_reflection = True
+    child_ctx.skip_memory_context = True
 
     # Set effort level: explicit override > parent's level > default
     child_ctx.effort = effort if effort else getattr(parent_ctx, "effort", "default")

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -10,6 +10,7 @@ export class ChatMessage extends LitElement {
     content: { type: String },
     streaming: { type: Boolean },
     tool: { type: String },
+    display_short_text: { type: String, attribute: false },
     toolCalls: { type: Array, attribute: false },
     toolCallId: { type: String, attribute: false },
     usage: { type: Object, attribute: false },
@@ -24,6 +25,7 @@ export class ChatMessage extends LitElement {
     this.content = '';
     this.streaming = false;
     this.tool = '';
+    this.display_short_text = '';
     /** @type {Array|null} */
     this.toolCalls = null;
     this.toolCallId = '';
@@ -41,12 +43,16 @@ export class ChatMessage extends LitElement {
       return html`<tool-message .tool=${this.tool || 'reflection'} .content=${this.content} .icon=${'\u{1f441}'}></tool-message>`;
     }
 
+    if (this.role === 'memory_context') {
+      return html`<tool-message .tool=${'memory_context'} .content=${this.content} .icon=${'\u{1f9e0}'}></tool-message>`;
+    }
+
     if (this.role === 'tool_call') {
       return html`<tool-call-message variant="tool_call" .content=${this.content}></tool-call-message>`;
     }
 
     if (this.role === 'tool') {
-      return html`<tool-message .tool=${this.tool} .content=${this.content} .timestamp=${this.timestamp}></tool-message>`;
+      return html`<tool-message .tool=${this.tool} .content=${this.content} .display_short_text=${this.display_short_text || ''} .timestamp=${this.timestamp}></tool-message>`;
     }
 
     if (this.role === 'assistant' && this.toolCalls?.length) {

--- a/src/decafclaw/web/static/components/chat-view.js
+++ b/src/decafclaw/web/static/components/chat-view.js
@@ -130,6 +130,7 @@ export class ChatView extends LitElement {
           .role=${m.role}
           .content=${m.content || ''}
           .tool=${m.tool || ''}
+          .display_short_text=${m.display_short_text || ''}
           .toolCalls=${m.tool_calls || null}
           .toolCallId=${m.tool_call_id || ''}
           .usage=${m.usage || null}

--- a/src/decafclaw/web/static/components/messages/tool-message.js
+++ b/src/decafclaw/web/static/components/messages/tool-message.js
@@ -6,6 +6,7 @@ export class ToolMessage extends LitElement {
     tool: { type: String },
     content: { type: String },
     icon: { type: String },
+    display_short_text: { type: String },
     _expanded: { type: Boolean, state: true },
   };
 
@@ -16,6 +17,7 @@ export class ToolMessage extends LitElement {
     this.tool = '';
     this.content = '';
     this.icon = '\u{1f527}';
+    this.display_short_text = '';
     this._expanded = false;
   }
 
@@ -37,7 +39,7 @@ export class ToolMessage extends LitElement {
           <span class="tool-icon">${this.icon}</span>
           <span class="tool-name">${this.tool}</span>
           ${hasContent ? html`
-            <span class="tool-preview">${this.#truncate(this.content)}</span>
+            <span class="tool-preview">${this.display_short_text || this.#truncate(this.content)}</span>
             <span class="expand-toggle">${this._expanded ? '\u25b2' : '\u25bc'}</span>
           ` : nothing}
         </div>

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -13,6 +13,7 @@
  * @property {string} [timestamp]
  * @property {string} [tool]
  * @property {string} [tool_call_id]
+ * @property {string} [display_short_text]
  * @property {object[]} [tool_calls]
  * @property {boolean} [_merged]
  * @property {{prompt_tokens: number, completion_tokens: number, total_tokens: number}|null} [usage]
@@ -319,11 +320,30 @@ export class ConversationStore extends EventTarget {
 
       case 'tool_status':
         this.#toolStatus = `${msg.tool}: ${msg.message}`;
-        // Update the last tool_call message if it exists
         if (msg.conv_id === this.#currentConvId) {
-          const last = this.#currentMessages[this.#currentMessages.length - 1];
-          if (last?.role === 'tool_call') {
-            last.content = `${msg.tool}: ${msg.message}`;
+          // memory_context arrives without a preceding tool_start — insert before user message
+          if (msg.tool === 'memory_context') {
+            const mcMsg = {
+              role: 'memory_context',
+              content: msg.message,
+              timestamp: new Date().toISOString(),
+            };
+            // Insert before the last user message (memory context precedes the user's turn)
+            let lastUserIdx = -1;
+            for (let i = this.#currentMessages.length - 1; i >= 0; i--) {
+              if (this.#currentMessages[i].role === 'user') { lastUserIdx = i; break; }
+            }
+            if (lastUserIdx >= 0) {
+              this.#currentMessages.splice(lastUserIdx, 0, mcMsg);
+            } else {
+              this.#currentMessages.push(mcMsg);
+            }
+          } else {
+            // Update the last tool_call message if it exists
+            const last = this.#currentMessages[this.#currentMessages.length - 1];
+            if (last?.role === 'tool_call') {
+              last.content = `${msg.tool}: ${msg.message}`;
+            }
           }
         }
         break;
@@ -338,6 +358,7 @@ export class ConversationStore extends EventTarget {
               role: 'tool',
               content: msg.result_text || '',
               tool: msg.tool,
+              display_short_text: msg.display_short_text || '',
               timestamp: new Date().toISOString(),
             };
           }
@@ -420,9 +441,11 @@ export class ConversationStore extends EventTarget {
           const tcId = tc.id;
           // Look ahead for matching tool result
           let resultContent = '';
+          let resultShortText = '';
           for (let j = i + 1; j < messages.length; j++) {
             if (messages[j].role === 'tool' && messages[j].tool_call_id === tcId) {
               resultContent = messages[j].content || '';
+              resultShortText = messages[j].display_short_text || '';
               messages[j]._merged = true; // mark as consumed
               break;
             }
@@ -431,6 +454,7 @@ export class ConversationStore extends EventTarget {
             role: 'tool',
             tool: toolName,
             content: resultContent,
+            display_short_text: resultShortText,
             timestamp: msg.timestamp,
           });
         }

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -409,12 +409,26 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                 })
 
             elif event_type == "tool_end":
-                await ws_send({
+                payload = {
                     "type": "tool_end", "conv_id": conv_id,
                     "tool": event.get("tool", ""),
                     "result_text": event.get("result_text", ""),
                     "tool_call_id": event.get("tool_call_id", ""),
-                })
+                }
+                short = event.get("display_short_text")
+                if short:
+                    payload["display_short_text"] = short
+                await ws_send(payload)
+
+            elif event_type == "memory_context":
+                text = event.get("text", "")
+                if text:
+                    await ws_send({
+                        "type": "tool_status", "conv_id": conv_id,
+                        "tool": "memory_context",
+                        "message": text,
+                        "tool_call_id": "",
+                    })
 
             elif event_type == "tool_confirm_request":
                 log.info(f"Forwarding confirm request to web UI: {event.get('tool')}")

--- a/tests/test_memory_context.py
+++ b/tests/test_memory_context.py
@@ -1,0 +1,127 @@
+"""Tests for proactive memory context retrieval."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.config_types import MemoryContextConfig
+from decafclaw.memory_context import (
+    _trim_to_token_budget,
+    format_memory_context,
+    retrieve_memory_context,
+)
+
+
+def _make_result(text="entry", source_type="memory", similarity=0.5):
+    return {"entry_text": text, "source_type": source_type, "similarity": similarity}
+
+
+class TestTrimToTokenBudget:
+    def test_empty(self):
+        assert _trim_to_token_budget([], 500) == []
+
+    def test_within_budget(self):
+        results = [_make_result(text="a" * 100)]  # 25 tokens
+        assert len(_trim_to_token_budget(results, 500)) == 1
+
+    def test_exceeds_budget(self):
+        results = [
+            _make_result(text="a" * 400),  # 100 tokens
+            _make_result(text="b" * 400),  # 100 tokens
+            _make_result(text="c" * 400),  # 100 tokens
+        ]
+        trimmed = _trim_to_token_budget(results, 200)
+        assert len(trimmed) == 2
+
+    def test_first_entry_always_included(self):
+        """Even if the first entry exceeds the budget, include it."""
+        results = [_make_result(text="a" * 4000)]  # 1000 tokens
+        trimmed = _trim_to_token_budget(results, 500)
+        assert len(trimmed) == 1
+
+
+class TestFormatMemoryContext:
+    def test_basic_format(self):
+        results = [
+            _make_result(text="Les likes Boulevardiers", source_type="wiki", similarity=0.85),
+            _make_result(text="Discussed project timeline", source_type="memory", similarity=0.6),
+        ]
+        text = format_memory_context(results)
+        assert "[Automatically retrieved context" in text
+        assert "Wiki (relevance: 0.85)" in text
+        assert "Memory (relevance: 0.60)" in text
+        assert "Les likes Boulevardiers" in text
+
+    def test_empty_results(self):
+        text = format_memory_context([])
+        assert "[Automatically retrieved context" in text
+
+
+class TestRetrieveMemoryContext:
+    @pytest.mark.asyncio
+    async def test_disabled(self, config):
+        from dataclasses import replace
+        cfg = replace(config, memory_context=MemoryContextConfig(enabled=False))
+        results = await retrieve_memory_context(cfg, "hello")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_no_embedding_model(self, config):
+        from dataclasses import replace
+
+        from decafclaw.config_types import EmbeddingConfig
+        cfg = replace(config, embedding=EmbeddingConfig(model=""))
+        results = await retrieve_memory_context(cfg, "hello")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_embed_failure_returns_empty(self, config):
+        with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=None):
+            results = await retrieve_memory_context(config, "hello")
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_threshold(self, config):
+        fake_embedding = [1.0] * 768
+        search_results = [
+            _make_result(text="high", similarity=0.8),
+            _make_result(text="low", similarity=0.1),
+        ]
+        with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=fake_embedding), \
+             patch("decafclaw.memory_context.search_similar_sync", return_value=search_results):
+            results = await retrieve_memory_context(config, "hello")
+            assert len(results) == 1
+            assert results[0]["entry_text"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_respects_max_results(self, config):
+        from dataclasses import replace
+        cfg = replace(config, memory_context=MemoryContextConfig(max_results=2))
+        fake_embedding = [1.0] * 768
+        search_results = [_make_result(similarity=0.8) for _ in range(5)]
+        with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=fake_embedding), \
+             patch("decafclaw.memory_context.search_similar_sync", return_value=search_results):
+            results = await retrieve_memory_context(cfg, "hello")
+            assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_exception(self, config):
+        with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            results = await retrieve_memory_context(config, "hello")
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_respects_token_budget(self, config):
+        from dataclasses import replace
+        cfg = replace(config, memory_context=MemoryContextConfig(max_tokens=100))
+        fake_embedding = [1.0] * 768
+        # Each entry is 400 chars = 100 tokens
+        search_results = [
+            _make_result(text="a" * 400, similarity=0.8),
+            _make_result(text="b" * 400, similarity=0.7),
+            _make_result(text="c" * 400, similarity=0.6),
+        ]
+        with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=fake_embedding), \
+             patch("decafclaw.memory_context.search_similar_sync", return_value=search_results):
+            results = await retrieve_memory_context(cfg, "hello")
+            assert len(results) == 1

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -26,7 +26,7 @@ class TestWikiRead:
     async def test_read_existing_page(self, ctx, wiki_dir):
         (wiki_dir / "Test Page.md").write_text("# Test Page\n\nContent here.")
         result = await tool_wiki_read(ctx, "Test Page")
-        assert "Content here." in result
+        assert "Content here." in result.text
 
     @pytest.mark.asyncio
     async def test_read_nonexistent(self, ctx, wiki_dir):
@@ -53,7 +53,7 @@ class TestWikiRead:
         sub.mkdir()
         (sub / "Alice.md").write_text("# Alice\n\nA person.")
         result = await tool_wiki_read(ctx, "Alice")
-        assert "A person." in result
+        assert "A person." in result.text
 
 
 class TestWikiWrite:
@@ -95,24 +95,24 @@ class TestWikiSearch:
         (wiki_dir / "Drinks.md").write_text("# Drinks\n\nBoulevardier, Old Fashioned")
         (wiki_dir / "Food.md").write_text("# Food\n\nPizza, Tacos")
         result = await tool_wiki_search(ctx, "Boulevardier")
-        assert "Drinks" in result
-        assert "Food" not in result
+        assert "Drinks" in result.text
+        assert "Food" not in result.text
 
     @pytest.mark.asyncio
     async def test_search_by_title(self, ctx, wiki_dir):
         (wiki_dir / "DecafClaw.md").write_text("# DecafClaw\n\nAn agent.")
         result = await tool_wiki_search(ctx, "DecafClaw")
-        assert "DecafClaw" in result
+        assert "DecafClaw" in result.text
 
     @pytest.mark.asyncio
     async def test_search_no_results(self, ctx, wiki_dir):
         result = await tool_wiki_search(ctx, "nonexistent")
-        assert "no" in result.lower()
+        assert "no" in result.text.lower()
 
     @pytest.mark.asyncio
     async def test_search_empty_wiki(self, ctx, config):
         result = await tool_wiki_search(ctx, "anything")
-        assert "no" in result.lower()
+        assert "no" in result.text.lower()
 
 
 class TestWikiList:


### PR DESCRIPTION
## Summary

- Automatically surfaces relevant memories, wiki entries, and conversation snippets before each agent turn using semantic search
- Injected as a context message (role `memory_context`, mapped to `user` for the LLM) positioned before the user's message
- Fail-open design: errors silently return empty results, never crash the agent turn
- Skipped for non-interactive turns (heartbeat, scheduled tasks, delegated subtasks)
- Requires an embedding model — silently disabled otherwise
- UI indicator in both Mattermost and web UI (expandable status block)
- Configurable: threshold, max results, token budget, UI visibility, on/off toggle

## Test plan

- [x] 13 unit tests covering retrieval, filtering, token budget, fail-open, config gating
- [x] 695 total tests passing, 0 lint/type errors
- [x] Live test in Mattermost: verify memory context appears in conversations
- [x] Live test in web UI: verify expandable status block renders
- [x] Verify no context injection for heartbeat/scheduled/delegated turns
- [x] Verify silent skip when embedding model is not configured
- [x] Tune similarity_threshold if results are too noisy or too sparse

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)