### PR TITLE
fix: propagate allowed-tools from skill schedules to ScheduleTask

### DIFF
--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -137,6 +137,7 @@ def discover_schedules(config) -> list[ScheduleTask]:
                 path=skill_md,
                 enabled=skill.enabled,
                 effort=skill.effort or "default",
+                allowed_tools=skill.allowed_tools,
                 required_skills=skill.requires_skills,
             )
 

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -193,6 +193,20 @@ class TestDiscoverSchedules:
         assert task.source == "admin"
         assert task.effort == "fast"
 
+    def test_skill_allowed_tools_propagated(self, config):
+        """Skill allowed-tools are propagated to the ScheduleTask."""
+        skill_dir = config.agent_path / "skills" / "ingest-job"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: ingest-job\ndescription: Ingest job\n"
+            "schedule: '0 */4 * * *'\n"
+            "allowed-tools: shell, wiki_read, wiki_write\n"
+            "---\nRun the ingest.\n"
+        )
+        tasks = discover_schedules(config)
+        task = [t for t in tasks if t.name == "ingest-job"][0]
+        assert task.allowed_tools == ["shell", "wiki_read", "wiki_write"]
+
     def test_disabled_skill_schedule(self, config):
         """Skills with enabled: false are discovered but marked disabled."""
         skill_dir = config.agent_path / "skills" / "paused-job"


### PR DESCRIPTION
## Summary

- When `discover_schedules()` creates `ScheduleTask` entries from skill SKILL.md frontmatter, `allowed_tools` was not being passed through — a missing field in the constructor call
- This caused scheduled skills (like `mastodon-ingest` and `linkding-ingest`) to request confirmation for shell commands, which timed out unattended, despite having `allowed-tools: shell` in their SKILL.md
- One-line fix + regression test

## Test plan

- [x] New test `test_skill_allowed_tools_propagated` verifies allowed-tools from skill frontmatter appear on the discovered ScheduleTask
- [x] All 722 tests pass
- [x] Lint + typecheck clean
- [ ] Deploy and verify scheduled mastodon-ingest/linkding-ingest run without confirmation prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)