### PR TITLE
fix: exclude conversation entries from memory context and search

### DIFF
--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -37,6 +37,9 @@ async def retrieve_memory_context(config, user_message: str) -> list[dict]:
             config, query_embedding, top_k=mc.max_results * 2
         )
 
+        # Exclude conversation entries — they add noise (see #133)
+        results = [r for r in results if r["source_type"] != "conversation"]
+
         # Filter by similarity threshold
         results = [r for r in results if r["similarity"] >= mc.similarity_threshold]
 

--- a/src/decafclaw/tools/memory_tools.py
+++ b/src/decafclaw/tools/memory_tools.py
@@ -41,15 +41,18 @@ async def tool_memory_save(ctx, tags: list[str], content: str) -> str:
     return result
 
 
-async def tool_memory_search(ctx, query: str) -> str:
+async def tool_memory_search(ctx, query: str, include_conversations: bool = False) -> str:
     """Search memories."""
-    log.info(f"[tool:memory_search] query={query} strategy={ctx.config.embedding.search_strategy}")
+    log.info(f"[tool:memory_search] query={query} include_conversations={include_conversations} strategy={ctx.config.embedding.search_strategy}")
 
     if ctx.config.embedding.search_strategy == "semantic":
         try:
             from .. import embeddings
             # Ensure index exists (reindex on first search if needed)
             results = await embeddings.search_similar(ctx.config, query, top_k=5)
+            # Exclude conversation entries by default — they add noise (see #133)
+            if not include_conversations:
+                results = [r for r in results if r["source_type"] != "conversation"]
             if results:
                 lines = [f"Found {len(results)} matching memories (ranked by relevance):\n"]
                 for i, r in enumerate(results):
@@ -143,6 +146,14 @@ MEMORY_TOOL_DEFINITIONS = [
                     "query": {
                         "type": "string",
                         "description": "Text to search for (case-insensitive substring match)",
+                    },
+                    "include_conversations": {
+                        "type": "boolean",
+                        "description": (
+                            "Include past conversation entries in results. Default false — "
+                            "set true only when explicitly looking for something said in a "
+                            "prior conversation."
+                        ),
                     },
                 },
                 "required": ["query"],


### PR DESCRIPTION
## Summary

- Filter out `source_type="conversation"` from `memory_context` auto-injection (proactive context per turn)
- Filter out conversation entries from `memory_search` tool by default
- Add `include_conversations` boolean param to `memory_search` so the agent can opt in when explicitly searching prior conversations

Closes #133

## Test plan

- [ ] Verify `memory_search` no longer returns conversation entries by default
- [ ] Verify `memory_search` with `include_conversations: true` still returns them
- [ ] Verify `memory_context` auto-injection no longer includes conversation hits
- [ ] Test in Mattermost with a query that previously returned noisy conversation results

🤖 Generated with [Claude Code](https://claude.com/claude-code)