### PR TITLE
feat: unified media storage and web UI agent media delivery

### DIFF
--- a/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/notes.md
+++ b/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/notes.md
@@ -1,0 +1,17 @@
+# Session Notes
+
+## Log
+
+- Session started 2026-03-27
+- Addresses #141 (web UI agent media delivery) and #135 (unify media storage)
+- Phase 1: Added MediaSaveResult, save_media() to all handlers — commit 7270842
+- Phase 2: Per-tool-call media processing, removed pending_media — commit 34e2908
+- Phase 3: Wired handlers on all channels (web, terminal, mattermost) — commit 4fe0aea
+- Phase 4: Frontend workspace:// link rewriting for images and links — commit 91418be
+- Phase 5: Cleanup — removed process_media_for_terminal, workspace/media/ refs
+
+## Key Decisions
+
+- **Critical gap found during plan review**: `extract_workspace_media` strips `workspace://` refs from agent text. For web UI this is harmful — the frontend needs those refs to render. Fixed by making extraction conditional via `strips_workspace_refs` flag on MediaHandler.
+- **Mattermost media attachment**: Changed from batching media at end-of-turn to per-tool-call via `tool_media_uploaded` event. Mattermost subscriber posts file_ids as thread replies.
+- **Terminal simplification**: Terminal no longer saves to `workspace/media/`. Uses same `save_attachment()` path as web. Raw workspace:// refs shown in terminal output.

--- a/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/plan.md
+++ b/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/plan.md
@@ -1,0 +1,275 @@
+# Plan: Web UI Agent Media & Unified Media Storage
+
+## Phase 1: MediaHandler Interface — `save_media()` and `MediaSaveResult`
+
+Extend the `MediaHandler` base class with the new unified method, without changing any existing behavior yet.
+
+### Step 1.1: Add `MediaSaveResult` and `save_media()` to base class
+
+**Prompt:**
+In `src/decafclaw/media.py`, add a `MediaSaveResult` dataclass and a default `save_media()` method to `MediaHandler`:
+
+```python
+@dataclass
+class MediaSaveResult:
+    workspace_ref: str | None = None  # workspace:// path for text injection
+    file_id: str | None = None        # platform file ID (Mattermost)
+    saved_filename: str | None = None # actual filename after dedup
+```
+
+Add to `MediaHandler`:
+```python
+async def save_media(self, conv_id, filename, data, content_type) -> MediaSaveResult:
+    """Save media and return a result describing where it went.
+    Subclasses implement channel-specific behavior."""
+    raise NotImplementedError
+```
+
+Keep all existing methods (`upload_file`, `send_with_media`, etc.) unchanged.
+
+Add tests:
+- `MediaSaveResult` fields default to None
+- Base `save_media()` raises NotImplementedError
+
+### Step 1.2: Implement `save_media()` on `TerminalMediaHandler`
+
+**Prompt:**
+Update `TerminalMediaHandler` in `src/decafclaw/media.py`. It currently stores `workspace_path`. Add `config` to its constructor (needed for `save_attachment()`).
+
+Implement `save_media()`:
+1. Call `save_attachment(self.config, conv_id, filename, data, content_type)`
+2. The return dict has `path` (workspace-relative) and `filename` (actual saved name)
+3. Return `MediaSaveResult(workspace_ref="workspace://" + path, saved_filename=filename)`
+
+Update the call site in `agent.py` where `TerminalMediaHandler` is constructed (~line 792) to pass `config`.
+
+Add tests:
+- `save_media()` saves file to `workspace/conversations/{conv_id}/uploads/`
+- Returned `workspace_ref` contains correct path
+- Returned `saved_filename` may differ from input (timestamp dedup)
+
+### Step 1.3: Create `WebMediaHandler` with `save_media()`
+
+**Prompt:**
+Add a `WebMediaHandler` class in `src/decafclaw/media.py`. It needs `config` in its constructor.
+
+Implement `save_media()` identically to `TerminalMediaHandler` — both save via `save_attachment()` and return `workspace_ref`. (They could share a base, but keep it simple — they're small.)
+
+Implement `upload_file()` and `send_with_media()` as no-ops for now (the old interface won't be used for web).
+
+Add tests mirroring the terminal handler tests.
+
+### Step 1.4: Implement `save_media()` on `MattermostMediaHandler`
+
+**Prompt:**
+Update `MattermostMediaHandler` in `src/decafclaw/media.py`. It currently stores `_http` (the httpx client). Add `channel_id` to its constructor — Mattermost needs this for uploads.
+
+Implement `save_media()`:
+1. Call the existing `upload_file(self.channel_id, filename, data, content_type)` to upload to Mattermost
+2. Return `MediaSaveResult(file_id=file_id)`
+
+Update the call site in `mattermost.py` (~line 332) where `MattermostMediaHandler` is constructed to pass `channel_id`.
+
+Add tests:
+- `save_media()` calls `upload_file()` and returns `file_id`
+
+---
+
+## Phase 2: Per-Tool-Call Media Processing in Agent Loop
+
+Replace the `pending_media` accumulation pattern with per-tool-call processing.
+
+### Step 2.1: Add `_process_tool_media()` helper
+
+**Prompt:**
+In `src/decafclaw/agent.py`, add a new async function:
+
+```python
+async def _process_tool_media(ctx, result: ToolResult) -> None:
+```
+
+This function:
+1. If `result.media` is empty, return immediately
+2. If `ctx.media_handler` is None, log a warning ("No media handler — {len(result.media)} media item(s) not delivered") and return
+3. Get `conv_id` from `ctx.conv_id or ctx.channel_id or "unknown"`
+4. For each item in `result.media`:
+   a. Call `await ctx.media_handler.save_media(conv_id, item["filename"], item["data"], item["content_type"])`
+   b. If result has `workspace_ref`:
+      - Find the placeholder text in `result.text` matching the item's filename (pattern: `[file attached: {filename}` — match up to the closing `]`)
+      - If content_type starts with `image/`: replace with `![{filename}]({workspace_ref})`
+      - Otherwise: replace with `[{filename}]({workspace_ref})`
+   c. If result has `file_id`: store on a list for the caller (we'll wire this to Mattermost's tool post attachment later)
+   d. On exception: log warning, leave placeholder unchanged (fail-open)
+5. Clear `result.media` after processing
+
+Add tests:
+- Workspace ref replacement for image content type
+- Workspace ref replacement for non-image content type
+- Missing media handler logs warning, leaves text unchanged
+- Failed save logs warning, leaves placeholder unchanged
+- Multiple media items in one result all get processed
+
+### Step 2.2: Wire `_process_tool_media()` into `_execute_single_tool`
+
+**Prompt:**
+In `src/decafclaw/agent.py`, modify `_execute_single_tool()` (~line 293).
+
+After `result = await execute_tool(call_ctx, fn_name, fn_args)` (line 313) and before the `finally` block publishes `tool_end`, add:
+
+```python
+await _process_tool_media(call_ctx, result)
+```
+
+This processes media before the tool_end event fires, so by the time Mattermost's subscriber sees `tool_end`, the media has already been handled.
+
+Update the return value: `_execute_single_tool` currently returns `(tool_msg, result.media or [])`. Since media is now processed in-place and cleared, this will return an empty list. That's fine — we'll clean up `pending_media` in the next step.
+
+Update existing tests to verify:
+- Tool results with media get processed before tool_end event
+- The tool message `content` field reflects the updated text (workspace refs, not placeholders)
+
+### Step 2.3: Remove `pending_media` accumulation
+
+**Prompt:**
+In `src/decafclaw/agent.py`, remove the `pending_media` pattern:
+
+1. In `run_agent_turn()` (~line 488): remove `pending_media = []`
+2. In `_execute_tool_calls()` signature and body: remove `pending_media` parameter. Remove the `pending_media.extend(media)` line (~line 408). The `_execute_single_tool` return value for media can be simplified — it no longer needs to return media since it's processed in-place.
+3. At end of turn (~line 747-754): make `extract_workspace_media()` **conditional**. Add a `strips_workspace_refs` property to `MediaHandler` (default `True`). `WebMediaHandler` and `TerminalMediaHandler` set it to `False` — their workspace:// refs render in-place (web via frontend, terminal as visible paths). `MattermostMediaHandler` keeps `True` — it needs extraction + upload. Only call `extract_workspace_media()` when `ctx.media_handler` is None or `ctx.media_handler.strips_workspace_refs` is True.
+4. Update all call sites of `_execute_tool_calls()` to not pass `pending_media`.
+
+**Why conditional**: `extract_workspace_media` strips `![](workspace://...)` refs from the agent's final text. Per-tool-call processing injects those refs into tool results; the LLM may repeat them in its response. If we strip them for web UI, the frontend can't render them and the media has nowhere to go. Mattermost still needs extraction to upload the referenced files.
+
+Update tests to verify:
+- `pending_media` is no longer accumulated
+- `extract_workspace_media()` only runs when handler has `strips_workspace_refs=True`
+- Web/terminal handlers preserve workspace:// refs in final text
+
+---
+
+## Phase 3: Wire Up Media Handlers on All Channels
+
+### Step 3.1: Set `WebMediaHandler` on web UI context
+
+**Prompt:**
+In `src/decafclaw/web/websocket.py`, in `_run_agent_turn()` (~line 459), after creating the context:
+
+```python
+from ..media import WebMediaHandler
+ctx.media_handler = WebMediaHandler(config)
+```
+
+This is the key fix for #141 — the web UI now has a media handler that saves to conversation uploads.
+
+Add an integration-style test:
+- Mock a tool returning media in a web context
+- Verify media is saved to conversation uploads dir
+- Verify tool result text contains workspace:// refs
+
+### Step 3.2: Update `TerminalMediaHandler` construction
+
+**Prompt:**
+In `src/decafclaw/agent.py` (~line 792), the terminal handler is constructed as `TerminalMediaHandler(config.workspace_path)`. Update to `TerminalMediaHandler(config)` (per Step 1.2).
+
+Also remove `process_media_for_terminal()` from `media.py` — it's the old path that saved to `workspace/media/`. Check all call sites:
+- `agent.py` ~line 925 uses it for terminal display. Replace with just using `result.text` directly since media is now processed per-tool-call (text already has workspace refs).
+
+Update tests.
+
+### Step 3.3: Update `MattermostMediaHandler` construction
+
+**Prompt:**
+In `src/decafclaw/mattermost.py` (~line 332), the handler is constructed as `MattermostMediaHandler(self._http)`. Update to `MattermostMediaHandler(self._http, channel_id)` where `channel_id` is the conversation's channel.
+
+Also in `mattermost.py` `on_tool_end()` (~line 1062-1076): this block currently creates a *new* `MattermostMediaHandler` and calls `upload_and_collect()` to handle tool media. With per-tool-call processing, `result.media` is already empty by the time `tool_end` fires. Remove this media-handling block from `on_tool_end()` — it's no longer needed.
+
+The `tool_end` event still carries a `media` field but it will be empty. The file_ids from `save_media()` need to be attached to the tool post. Two options:
+- Pass file_ids via the `tool_end` event (add a `file_ids` field)
+- Or have the `_process_tool_media` step publish its own event
+
+The simpler approach: in `_process_tool_media`, when `save_media()` returns `file_id`s, publish a `tool_media_uploaded` event with the file_ids and tool_call_id. The Mattermost subscriber handles attaching them to the tool post.
+
+Add tests:
+- `tool_end` no longer triggers media upload
+- `tool_media_uploaded` event carries file_ids
+- Mattermost subscriber attaches file_ids to tool post
+
+---
+
+## Phase 4: Frontend — `workspace://` Link Rewriting
+
+### Step 4.1: Add `renderer.link` override in `assistant-message.js`
+
+**Prompt:**
+In `src/decafclaw/web/static/components/messages/assistant-message.js`, add a link renderer override alongside the existing image renderer (~line 8):
+
+```javascript
+const originalLink = renderer.link.bind(renderer);
+renderer.link = function(token) {
+  let href = token.href || '';
+  if (href.startsWith('workspace://')) {
+    href = '/api/workspace/' + href.slice('workspace://'.length);
+    token = { ...token, href };
+  }
+  return originalLink(token);
+};
+```
+
+Also update the existing `renderer.image` to specifically check for `workspace://` prefix (currently it rewrites all non-http, non-absolute paths — tighten to `workspace://` for consistency):
+
+```javascript
+renderer.image = function(token) {
+  let href = token.href || '';
+  if (href.startsWith('workspace://')) {
+    href = '/api/workspace/' + href.slice('workspace://'.length);
+    token = { ...token, href };
+  }
+  return originalImage(token);
+};
+```
+
+Test manually:
+- Agent response with `![img](workspace://conversations/abc/uploads/test.png)` renders as image with `/api/workspace/conversations/abc/uploads/test.png` src
+- Agent response with `[file.pdf](workspace://conversations/abc/uploads/file.pdf)` renders as download link with correct href
+
+Run `make check-js` to verify.
+
+---
+
+## Phase 5: Cleanup and Polish
+
+### Step 5.1: Remove `workspace/media/` references
+
+**Prompt:**
+Search the codebase for remaining references to `workspace/media/`:
+- Remove `process_media_for_terminal()` if not already removed in Step 3.2
+- Remove `TerminalMediaHandler.upload_file()` — `save_media()` replaces it. Keep the method as a no-op or raise `NotImplementedError` if the base class requires it.
+- Clean up any tests that reference `workspace/media/`
+
+The `upload_and_collect()` utility in `media.py` — check if it's still used anywhere after the Mattermost `on_tool_end` cleanup. If not, remove it.
+
+### Step 5.2: Lint, test, documentation
+
+**Prompt:**
+- Run `make check` (lint + typecheck + JS check) and fix any issues
+- Run `make test` and fix any failures
+- Update `CLAUDE.md`:
+  - Key files: note `WebMediaHandler` in `media.py`
+  - Conventions: note unified media storage in conversation uploads
+  - Remove any references to `workspace/media/`
+- Update `docs/` if there's a media-related doc page
+- Update `README.md` if media handling is mentioned
+
+---
+
+## Review: Critical Gaps
+
+1. **Placeholder regex matching**: The `_process_tool_media()` function needs to match `[file attached: {filename} ...]` in `result.text`. The exact pattern from `mcp_client.py` is `[file attached: {filename} ({mime_type}) — will appear as an attachment on your reply]`. Use a regex like `\[file attached: {re.escape(filename)}[^\]]*\]` to match flexibly.
+
+2. **Mattermost file_id attachment to tool post**: Step 3.3 proposes a `tool_media_uploaded` event. This requires the Mattermost subscriber to PATCH the tool post with file_ids. Mattermost's PATCH API quirk: must include `message` when patching `props`/`file_ids`. Fetch existing message first.
+
+3. **`extract_workspace_media` must be conditional**: At end-of-turn, this function strips `![](workspace://...)` from the agent's text. For web UI this is **harmful** — it removes refs the frontend would render, and the extracted media has nowhere to go. Fixed in Step 2.3: add `strips_workspace_refs` flag to `MediaHandler`, only run extraction when True (Mattermost). Web and Terminal set False.
+
+4. **Terminal mode `conv_id`**: Terminal uses `conv_id="interactive"`. The `save_attachment()` call will create `workspace/conversations/interactive/uploads/`. This is fine and consistent.
+
+5. **`WebMediaHandler` for non-web-turn contexts**: Heartbeat turns, scheduled tasks, and child agents may not have a conv_id. The `_process_tool_media()` check for `ctx.media_handler is None` handles this — those contexts won't have a handler set, so media falls through with a warning. This is acceptable.

--- a/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/spec.md
+++ b/.claude/dev-sessions/2026-03-27-0942-web-ui-agent-media/spec.md
@@ -1,0 +1,97 @@
+# Spec: Web UI Agent Media & Unified Media Storage
+
+Addresses #141 (web UI agent media delivery) and #135 (unify media storage).
+
+## Problem
+
+When a tool returns a `ToolResult` with media (MCP binary resources, images, audio, Tabstack screenshots), the media is silently dropped in the web UI. Mattermost and terminal handle it, but the web UI never sets a `ctx.media_handler` and the websocket handler ignores `result.media`.
+
+Additionally, agent-generated media uses a separate `workspace/media/` path from user uploads (`workspace/conversations/{conv_id}/uploads/`), creating inconsistency.
+
+## Design Decisions
+
+### Storage: conversation-scoped uploads
+
+All agent-generated media saves to `workspace/conversations/{conv_id}/uploads/` via the existing `save_attachment()` function. This unifies agent and user media in one location per conversation. Terminal mode uses `conv_id="interactive"`.
+
+The `workspace/media/` path is retired. No migration of existing files.
+
+### MediaHandler interface: single `save_media()` method
+
+Add a new unified method for per-tool-call media handling:
+
+```python
+@dataclass
+class MediaSaveResult:
+    workspace_ref: str | None = None  # workspace:// path for text injection
+    file_id: str | None = None        # platform file ID (Mattermost)
+    saved_filename: str | None = None # actual filename after dedup
+
+class MediaHandler:
+    async def save_media(self, conv_id, filename, data, content_type) -> MediaSaveResult:
+        ...
+```
+
+Each channel implements differently:
+- **Web/Terminal**: save via `save_attachment()`, return `workspace_ref` with the actual saved path
+- **Mattermost**: upload to Mattermost API via channel_id (stored on handler at construction), return `file_id`
+
+Note: The existing `upload_file()` and `send_with_media()` methods are retained for the `extract_workspace_media` end-of-turn flow in Mattermost (which still needs to upload workspace refs from the agent's final response text). They can be removed in a future cleanup once that flow is also migrated.
+
+### Per-tool-call media processing
+
+Media is handled immediately during tool execution, not accumulated to end-of-turn. This replaces the `pending_media` accumulation pattern.
+
+Post-processing step in `execute_tool` (agent.py), after tool function returns:
+
+1. If `result.media` is empty, skip
+2. If `ctx.media_handler` is None, log warning, leave placeholder text as-is
+3. For each media item, call `ctx.media_handler.save_media()`
+4. Based on result:
+   - If `workspace_ref`: replace placeholder text in `result.text` with markdown ref
+   - If `file_id`: attach to current post (Mattermost tool status message)
+5. Clear `result.media` after processing
+
+### Text injection format
+
+Placeholder text like `[file attached: mcp-resource-1.png (image/png) — will appear as an attachment on your reply]` gets replaced with markdown refs.
+
+**Matching**: Each media item has a `filename` field. The post-processor finds the placeholder containing that filename in `result.text` and replaces it. `save_attachment()` may return a different filename (timestamp dedup) — the `workspace_ref` in `MediaSaveResult` contains the actual saved path.
+
+**Replacement format** (based on content_type):
+- **Images** (`image/*`): `![mcp-resource-1.png](workspace://conversations/{conv_id}/uploads/20260327-094200-mcp-resource-1.png)`
+- **Non-image files**: `[mcp-resource-1.bin](workspace://conversations/{conv_id}/uploads/20260327-094200-mcp-resource-1.bin)`
+
+Full `workspace://` paths from workspace root. No short aliases.
+
+### Concurrency
+
+Tool calls execute concurrently via `asyncio.gather`. Each tool gets its own `ToolResult`, so per-tool placeholder replacement is safe. `save_attachment()` uses timestamp-based filenames, so concurrent saves don't collide.
+
+### Mattermost behavior unchanged
+
+Mattermost keeps its current upload-to-API approach. Per-tool-call means files attach to the tool status progress post rather than batching onto the final response.
+
+`extract_workspace_media()` is now **conditional** — only runs when the media handler has `strips_workspace_refs=True` (Mattermost). Web and Terminal set this to False because their workspace:// refs render in-place. Running extraction on web UI would strip the refs the frontend needs to render, and the extracted media would have nowhere to go.
+
+### Frontend changes
+
+Add `renderer.link` override in `assistant-message.js` to rewrite `workspace://` hrefs to `/api/workspace/` URLs, matching the existing `renderer.image` pattern. DOMPurify already allows `<a>` tags.
+
+### Error handling
+
+- No media handler on ctx → log warning, leave placeholder text unchanged
+- Save/upload failure → log warning, leave placeholder text unchanged (fail-open)
+
+## Out of scope (follow-up issues)
+
+- Inline audio/video players in web UI (file as follow-up issue)
+- Web UI autocomplete for commands and resources (#139)
+
+## Channels affected
+
+| Channel | Media handler | Behavior |
+|---------|--------------|----------|
+| Web UI | New `WebMediaHandler` | Save to conversation uploads, inject `workspace://` refs |
+| Terminal | Updated `TerminalMediaHandler` | Save to conversation uploads (conv_id=interactive), inject `workspace://` refs |
+| Mattermost | Updated `MattermostMediaHandler` | Upload to Mattermost API, attach to tool status post |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/mcp_client.py` — MCP client: config, registry, server connections, auto-restart
 - `src/decafclaw/heartbeat.py` — Heartbeat: periodic wake-up, section parsing, timer, cycle runner
 - `src/decafclaw/schedules.py` — Scheduled tasks: cron-style task files, discovery, execution, timer loop
-- `src/decafclaw/media.py` — Media handling: ToolResult, MediaHandler interface, workspace ref scanning
+- `src/decafclaw/media.py` — Media handling: ToolResult, MediaSaveResult, MediaHandler interface (Web/Terminal/Mattermost), workspace ref scanning
 - `src/decafclaw/tools/` — Tool registry: core, memory, todo, workspace, file_share, shell, conversation, skill activation, MCP status, health, delegation
 - `src/decafclaw/tools/health.py` — Health/diagnostic status tool: uptime, MCP, heartbeat, tools, embeddings
 - `src/decafclaw/tools/effort_tools.py` — Effort level tool: `set_effort` for conversation model switching

--- a/scripts/test-image-mcp.py
+++ b/scripts/test-image-mcp.py
@@ -64,12 +64,55 @@ def main():
                 "id": msg_id,
                 "result": {
                     "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}},
+                    "capabilities": {"tools": {}, "resources": {}},
                     "serverInfo": {"name": "test-image-mcp", "version": "0.1.0"},
                 },
             })
         elif method == "notifications/initialized":
             pass  # no response needed
+        elif method == "resources/list":
+            send({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {
+                    "resources": [
+                        {
+                            "uri": "test://gradient.png",
+                            "name": "Test gradient image",
+                            "description": "A 200x200 red-blue gradient PNG for testing",
+                            "mimeType": "image/png",
+                        },
+                    ],
+                },
+            })
+        elif method == "resources/templates/list":
+            send({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "result": {"resourceTemplates": []},
+            })
+        elif method == "resources/read":
+            uri = msg.get("params", {}).get("uri", "")
+            if uri == "test://gradient.png":
+                send({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "result": {
+                        "contents": [
+                            {
+                                "uri": "test://gradient.png",
+                                "mimeType": "image/png",
+                                "blob": TEST_PNG,
+                            },
+                        ],
+                    },
+                })
+            else:
+                send({
+                    "jsonrpc": "2.0",
+                    "id": msg_id,
+                    "error": {"code": -32602, "message": f"Unknown resource: {uri}"},
+                })
         elif method == "tools/list":
             send({
                 "jsonrpc": "2.0",

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re as _re
 from dataclasses import replace
 from pathlib import Path
 
@@ -289,11 +290,76 @@ async def _call_llm_with_events(ctx, config, messages, tools,
     return response
 
 
+# Matches placeholder text: [file attached: filename (mime) — ...]
+_MEDIA_PLACEHOLDER_RE_CACHE: dict[str, _re.Pattern] = {}
+
+
+def _media_placeholder_pattern(filename: str) -> _re.Pattern:
+    """Build (and cache) a regex to find the placeholder for a given filename."""
+    if filename not in _MEDIA_PLACEHOLDER_RE_CACHE:
+        _MEDIA_PLACEHOLDER_RE_CACHE[filename] = _re.compile(
+            r"\[file attached: " + _re.escape(filename) + r"[^\]]*\]"
+        )
+    return _MEDIA_PLACEHOLDER_RE_CACHE[filename]
+
+
+async def _process_tool_media(ctx, result: ToolResult) -> list[str]:
+    """Process media items on a tool result — save/upload and replace placeholders.
+
+    For handlers returning workspace_ref: replaces placeholder text with markdown refs.
+    For handlers returning file_id: collects file_ids for caller to attach.
+
+    Returns list of file_ids (for Mattermost attachment), empty for other channels.
+    Clears result.media after processing.
+    """
+    if not result.media:
+        return []
+
+    handler = ctx.media_handler
+    if handler is None:
+        log.warning(f"No media handler — {len(result.media)} media item(s) not delivered")
+        result.media.clear()
+        return []
+
+    conv_id = ctx.conv_id or ctx.channel_id or "unknown"
+    file_ids = []
+
+    for item in result.media:
+        filename = item.get("filename", "unknown")
+        content_type = item.get("content_type", "application/octet-stream")
+        data = item.get("data", b"")
+
+        try:
+            save_result = await handler.save_media(conv_id, filename, data, content_type)
+        except Exception as e:
+            log.warning(f"Failed to save media {filename}: {e}")
+            continue
+
+        if save_result.workspace_ref:
+            pattern = _media_placeholder_pattern(filename)
+            if content_type.startswith("image/"):
+                replacement = f"![{filename}]({save_result.workspace_ref})"
+            else:
+                replacement = f"[{filename}]({save_result.workspace_ref})"
+            new_text, count = pattern.subn(replacement, result.text, count=1)
+            if count > 0:
+                result.text = new_text
+            else:
+                # No placeholder — append ref so the media is discoverable
+                result.text = result.text.rstrip() + "\n" + replacement
+        if save_result.file_id:
+            file_ids.append(save_result.file_id)
+
+    result.media.clear()
+    return file_ids
+
+
 async def _execute_single_tool(call_ctx, tc, semaphore):
-    """Execute one tool call. Returns (tool_msg, media_list).
+    """Execute one tool call. Returns tool_msg dict.
 
     Designed to run concurrently — uses its own forked ctx so
     current_tool_call_id doesn't race with other calls.
+    Media is processed per-tool-call via _process_tool_media().
     """
     tool_call_id = tc["id"]
     fn_name = tc["function"]["name"]
@@ -312,6 +378,14 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
                                    tool_call_id=tool_call_id)
             result = await execute_tool(call_ctx, fn_name, fn_args)
             log.debug(f"Tool result [{fn_name}]: {result.text[:200]}...")
+
+            # Process media per-tool-call (save/upload, replace placeholders)
+            file_ids = await _process_tool_media(call_ctx, result)
+            if file_ids:
+                await call_ctx.publish("tool_media_uploaded",
+                                       tool=fn_name,
+                                       file_ids=file_ids,
+                                       tool_call_id=tool_call_id)
         except asyncio.CancelledError:
             result = ToolResult(text=f"[cancelled: {fn_name}]")
         except Exception as e:
@@ -333,10 +407,10 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
     if result.display_short_text:
         tool_msg["display_short_text"] = result.display_short_text
     _archive(call_ctx, tool_msg)
-    return tool_msg, result.media or []
+    return tool_msg
 
 
-async def _execute_tool_calls(ctx, tool_calls, history, messages, pending_media):
+async def _execute_tool_calls(ctx, tool_calls, history, messages):
     """Execute tool calls concurrently, add results to history.
 
     Returns ToolResult if cancelled, None otherwise.
@@ -401,11 +475,9 @@ async def _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
             messages.append(tool_msg)
             _archive(ctx, tool_msg)
         else:
-            tool_msg, media = result  # type: ignore[misc]
+            tool_msg = result
             history.append(tool_msg)
             messages.append(tool_msg)
-            if media:
-                pending_media.extend(media)
 
     return None
 
@@ -484,8 +556,6 @@ async def run_agent_turn(ctx, user_message: str, history: list,
             "llm_api_key": effort_llm.api_key,
         }
     log.info(f"Agent turn: effort={ctx.effort}, model={effort_llm.model}")
-
-    pending_media = []
 
     try:
         # Add user message to history
@@ -611,7 +681,7 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                     await ctx.publish("text_before_tools", text=iter_content)
 
                 cancelled = await _execute_tool_calls(
-                    ctx, tool_calls, history, messages, pending_media
+                    ctx, tool_calls, history, messages
                 )
                 if cancelled:
                     return cancelled
@@ -744,14 +814,16 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
             await _maybe_compact(ctx, config, history, prompt_tokens)
 
-            # Scan for workspace image references and combine with tool media
-            cleaned_text, workspace_media = extract_workspace_media(
-                content or "", config.workspace_path
-            )
-            all_media = pending_media + workspace_media
-
-            if all_media:
-                return ToolResult(text=cleaned_text, media=all_media)
+            # Extract workspace:// refs only for channels that need it
+            # (Mattermost strips refs and uploads files; web/terminal render them in-place)
+            handler = ctx.media_handler
+            should_extract = (handler is None or handler.strips_workspace_refs)
+            if should_extract:
+                cleaned_text, workspace_media = extract_workspace_media(
+                    content or "", config.workspace_path
+                )
+                if workspace_media:
+                    return ToolResult(text=cleaned_text, media=workspace_media)
             return ToolResult(text=content or "")
 
         # Hit max iterations — preserve accumulated text from tool-call iterations
@@ -789,7 +861,7 @@ def _setup_interactive_context(ctx) -> None:
     ctx.channel_name = ctx.channel_name or "interactive"
     ctx.thread_id = ctx.thread_id or ""
     ctx.conv_id = "interactive"
-    ctx.media_handler = TerminalMediaHandler(config.workspace_path)
+    ctx.media_handler = TerminalMediaHandler(config)
 
     if config.llm.streaming:
         async def _terminal_stream_chunk(chunk_type, data):
@@ -922,21 +994,11 @@ async def run_interactive(ctx):
                 break
 
             result = await run_agent_turn(ctx, user_input, history)
-            from .media import process_media_for_terminal
 
             if config.llm.streaming:
-                # Text was already printed token-by-token; handle media only
-                if result.media:
-                    output = process_media_for_terminal(result, config.workspace_path)
-                    # Print just the media lines (text was already streamed)
-                    media_lines = [line for line in output.split("\n")
-                                   if line.startswith("[file saved:") or line.startswith("[image:")]
-                    if media_lines:
-                        print("\n" + "\n".join(media_lines))
                 print()  # final newline after streamed text
             else:
-                output = process_media_for_terminal(result, config.workspace_path)
-                print(f"\nagent> {output}\n")
+                print(f"\nagent> {result.text}\n")
     finally:
         shutdown_event.set()
         heartbeat_task.cancel()

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -329,7 +329,7 @@ class MattermostClient:
             thread_id=root_id or "",
             conv_id=conv_id,
         )
-        req_ctx.media_handler = MattermostMediaHandler(self._http)
+        req_ctx.media_handler = MattermostMediaHandler(self._http, channel_id=channel_id)
 
         # Restore per-conversation skill state from previous turns
         if conv.skill_state:
@@ -399,7 +399,7 @@ class MattermostClient:
 
         if response_media:
             from .media import MattermostMediaHandler, upload_and_collect
-            handler = MattermostMediaHandler(self._http)
+            handler = MattermostMediaHandler(self._http, channel_id=channel_id)
             file_ids = await upload_and_collect(
                 handler, channel_id, response_media
             )
@@ -675,6 +675,11 @@ class MattermostClient:
                     event.get("media", []),
                     tool_call_id=event.get("tool_call_id", ""),
                     display_short_text=event.get("display_short_text"),
+                )
+            elif event_type == "tool_media_uploaded" and conv_display:
+                await conv_display.on_tool_media_uploaded(
+                    event.get("file_ids", []),
+                    tool_call_id=event.get("tool_call_id", ""),
                 )
             elif event_type == "tool_confirm_request" and conv_display:
                 await conv_display.on_confirm_request(
@@ -1059,26 +1064,23 @@ class ConversationDisplay:
             except Exception:
                 pass
 
-            # Attach media to the tool call message
-            if media:
-                try:
-                    from .media import MattermostMediaHandler, upload_and_collect
-                    handler = MattermostMediaHandler(self.client._http)
-                    file_ids = await upload_and_collect(
-                        handler, self._channel_id, media,
-                    )
-                    if file_ids:
-                        await handler.send_with_media(
-                            self._channel_id, "", file_ids,
-                            root_id=self._root_id,
-                        )
-                except Exception as e:
-                    log.debug(f"Failed to attach tool media: {e}")
-
         # Reset tool state when all concurrent tools are done
         if not self._tool_posts:
             self._current_type = None
             self._tools_text_finalized = False
+
+    async def on_tool_media_uploaded(self, file_ids, tool_call_id=""):
+        """Tool media was uploaded — post files as a thread reply."""
+        if not file_ids:
+            return
+        try:
+            from .media import MattermostMediaHandler
+            handler = MattermostMediaHandler(self.client._http, channel_id=self._channel_id)
+            await handler.send_with_media(
+                self._channel_id, "", file_ids, root_id=self._root_id,
+            )
+        except Exception as e:
+            log.debug(f"Failed to post tool media: {e}")
 
     # -- Confirmation ----------------------------------------------------------
 

--- a/src/decafclaw/media.py
+++ b/src/decafclaw/media.py
@@ -27,11 +27,35 @@ class ToolResult:
         return cls(text=text)
 
 
+@dataclass
+class MediaSaveResult:
+    """Result from saving a media item via a MediaHandler."""
+
+    workspace_ref: str | None = None   # workspace:// path for text injection
+    file_id: str | None = None         # platform file ID (Mattermost)
+    saved_filename: str | None = None  # actual filename after dedup
+
+
 class MediaHandler:
     """Interface for channel-specific media operations.
 
-    Subclass for each channel type (Mattermost, terminal, etc.).
+    Subclass for each channel type (Mattermost, terminal, web, etc.).
     """
+
+    # Whether extract_workspace_media() should strip workspace:// refs from
+    # the agent's final text. Mattermost sets True (needs extraction + upload).
+    # Web and Terminal set False (refs render in-place).
+    strips_workspace_refs: bool = True
+
+    async def save_media(self, conv_id: str, filename: str,
+                         data: bytes, content_type: str) -> MediaSaveResult:
+        """Save media and return a result describing where it went.
+
+        Subclasses implement channel-specific behavior:
+        - Web/Terminal: save to conversation uploads, return workspace_ref
+        - Mattermost: upload to API, return file_id
+        """
+        raise NotImplementedError
 
     async def upload_file(self, channel_id: str, filename: str,
                           data: bytes, content_type: str) -> str:
@@ -104,47 +128,61 @@ def extract_workspace_media(text: str, workspace_path: Path) -> tuple[str, list[
 
 
 class TerminalMediaHandler(MediaHandler):
-    """Media handler for interactive terminal mode — saves files to workspace."""
+    """Media handler for interactive terminal mode — saves to conversation uploads."""
 
-    def __init__(self, workspace_path: Path):
-        self.workspace_path = workspace_path
+    strips_workspace_refs = False
+
+    def __init__(self, config):
+        self.config = config
+
+    async def save_media(self, conv_id, filename, data, content_type):
+        """Save media to conversation uploads, return workspace ref."""
+        import asyncio
+
+        from .attachments import save_attachment
+        result = await asyncio.to_thread(
+            save_attachment, self.config, conv_id, filename, data, content_type)
+        return MediaSaveResult(
+            workspace_ref="workspace://" + result["path"],
+            saved_filename=result["filename"],
+        )
 
     async def upload_file(self, channel_id, filename, data, content_type):
-        """Save file to workspace/media/ directory, return the path."""
-        media_dir = self.workspace_path / "media"
-        media_dir.mkdir(parents=True, exist_ok=True)
-        path = media_dir / filename
-        path.write_bytes(data)
-        return str(path.relative_to(self.workspace_path))
+        """Legacy — not used with per-tool-call processing."""
+        raise NotImplementedError
 
     async def send_with_media(self, channel_id, message, media_refs, root_id=None):
         """Not applicable in terminal mode."""
         return ""
 
 
-def process_media_for_terminal(result: ToolResult, workspace_path: Path) -> str:
-    """Process a ToolResult for terminal display.
+class WebMediaHandler(MediaHandler):
+    """Media handler for web UI — saves to conversation uploads."""
 
-    Saves file media to workspace/media/, appends paths to text.
-    URL media items get appended as text references.
-    """
-    if not result.media:
-        return result.text
+    strips_workspace_refs = False
 
-    lines = [result.text] if result.text else []
-    media_dir = workspace_path / "media"
-    media_dir.mkdir(parents=True, exist_ok=True)
+    def __init__(self, config):
+        self.config = config
 
-    for item in result.media:
-        if item.get("type") == "file":
-            filename = item["filename"]
-            path = media_dir / filename
-            path.write_bytes(item["data"])
-            lines.append(f"[file saved: media/{filename}]")
-        elif item.get("type") == "url":
-            lines.append(f"[image: {item['url']}]")
+    async def save_media(self, conv_id, filename, data, content_type):
+        """Save media to conversation uploads, return workspace ref."""
+        import asyncio
 
-    return "\n".join(lines)
+        from .attachments import save_attachment
+        result = await asyncio.to_thread(
+            save_attachment, self.config, conv_id, filename, data, content_type)
+        return MediaSaveResult(
+            workspace_ref="workspace://" + result["path"],
+            saved_filename=result["filename"],
+        )
+
+    async def upload_file(self, channel_id, filename, data, content_type):
+        """Legacy — not used with per-tool-call processing."""
+        raise NotImplementedError
+
+    async def send_with_media(self, channel_id, message, media_refs, root_id=None):
+        """Not applicable in web mode."""
+        return ""
 
 
 # -- Mattermost media handler -------------------------------------------------
@@ -155,8 +193,17 @@ MAX_FILES_PER_POST = 10
 class MattermostMediaHandler(MediaHandler):
     """Media handler for Mattermost — uploads files via API, attaches to posts."""
 
-    def __init__(self, http_client):
+    strips_workspace_refs = True
+
+    def __init__(self, http_client, channel_id: str = ""):
         self._http = http_client
+        self._channel_id = channel_id
+
+    async def save_media(self, conv_id, filename, data, content_type):
+        """Upload media to Mattermost, return file_id."""
+        file_id = await self.upload_file(
+            self._channel_id, filename, data, content_type)
+        return MediaSaveResult(file_id=file_id)
 
     async def upload_file(self, channel_id, filename, data, content_type):
         """Upload a file to Mattermost, return the file_id."""

--- a/src/decafclaw/web/static/components/messages/assistant-message.js
+++ b/src/decafclaw/web/static/components/messages/assistant-message.js
@@ -3,17 +3,29 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 
-// Custom marked renderer to rewrite workspace image paths
+// Custom marked renderer to rewrite workspace:// paths to /api/workspace/ URLs
 const renderer = new marked.Renderer();
+
 const originalImage = renderer.image.bind(renderer);
 /** @type {(token: {href: string, title: string|null, text: string}) => string} */
 renderer.image = function(token) {
   let href = token.href || '';
-  if (href && !href.startsWith('http') && !href.startsWith('/')) {
-    href = '/api/workspace/' + href;
+  if (href.startsWith('workspace://')) {
+    href = '/api/workspace/' + href.slice('workspace://'.length);
     token = { ...token, href };
   }
   return originalImage(token);
+};
+
+const originalLink = renderer.link.bind(renderer);
+/** @type {(token: {href: string, title?: string|null, tokens: object[]}) => string} */
+renderer.link = function(token) {
+  let href = token.href || '';
+  if (href.startsWith('workspace://')) {
+    href = '/api/workspace/' + href.slice('workspace://'.length);
+    token = { ...token, href };
+  }
+  return originalLink(token);
 };
 
 /**

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -456,12 +456,14 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
             pass
 
     # Fork a request context for this turn
+    from ..media import WebMediaHandler
     ctx = Context(config=config, event_bus=event_bus)
     ctx.user_id = username
     ctx.channel_id = conv_id
     ctx.channel_name = "web"
     ctx.thread_id = ""
     ctx.conv_id = conv_id
+    ctx.media_handler = WebMediaHandler(config)
     # Apply pre-configured command state (set by dispatch_command)
     if command_ctx:
         ctx.preapproved_tools = command_ctx.preapproved_tools

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -106,9 +106,7 @@ async def test_execute_tool_calls_runs_tools(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
-
-    result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+    result = await _execute_tool_calls(ctx, tool_calls, history, messages)
     assert result is None  # not cancelled
     assert len(history) == 1
     assert history[0]["role"] == "tool"
@@ -128,10 +126,9 @@ async def test_execute_tool_calls_handles_malformed_json(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
 
     # Should not raise — handles JSONDecodeError gracefully
-    result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+    result = await _execute_tool_calls(ctx, tool_calls, history, messages)
     assert result is None
     assert len(history) == 1
 
@@ -149,9 +146,7 @@ async def test_execute_tool_calls_cancellation(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
-
-    result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+    result = await _execute_tool_calls(ctx, tool_calls, history, messages)
     assert result is not None
     assert "cancelled" in result.text
 
@@ -182,10 +177,10 @@ async def test_execute_tool_calls_concurrent(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
+
 
     with patch("decafclaw.agent.execute_tool", side_effect=_concurrent_tool):
-        result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+        result = await _execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert result is None
     assert len(history) == 3
@@ -214,10 +209,10 @@ async def test_execute_tool_calls_semaphore_limits(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
+
 
     with patch("decafclaw.agent.execute_tool", side_effect=_tracked_tool):
-        await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+        await _execute_tool_calls(ctx, tool_calls, history, messages)
 
     # With semaphore=1, max concurrency should be exactly 1
     assert concurrency_high_water == 1
@@ -239,10 +234,10 @@ async def test_execute_tool_calls_one_fails_others_succeed(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
+
 
     with patch("decafclaw.agent.execute_tool", side_effect=_maybe_fail):
-        result = await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+        result = await _execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert result is None
     assert len(history) == 3
@@ -264,10 +259,10 @@ async def test_execute_tool_calls_preserves_order(ctx):
     ]
     history = []
     messages = []
-    pending_media = []
+
 
     with patch("decafclaw.agent.execute_tool", side_effect=_variable_speed):
-        await _execute_tool_calls(ctx, tool_calls, history, messages, pending_media)
+        await _execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert history[0]["tool_call_id"] == "tc0"
     assert history[1]["tool_call_id"] == "tc1"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,5 +1,6 @@
-"""Tests for media handling — ToolResult, workspace image scanning."""
+"""Tests for media handling — ToolResult, workspace image scanning, save_media."""
 
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -7,10 +8,12 @@ import pytest
 
 from decafclaw.media import (
     MattermostMediaHandler,
+    MediaHandler,
+    MediaSaveResult,
     TerminalMediaHandler,
     ToolResult,
+    WebMediaHandler,
     extract_workspace_media,
-    process_media_for_terminal,
     upload_and_collect,
 )
 
@@ -99,38 +102,100 @@ def test_extract_workspace_media_no_refs(tmp_path):
     assert media == []
 
 
-# -- TerminalMediaHandler tests --
+# -- MediaSaveResult tests --
+
+
+def test_media_save_result_defaults():
+    r = MediaSaveResult()
+    assert r.workspace_ref is None
+    assert r.file_id is None
+    assert r.saved_filename is None
+
+
+def test_media_save_result_workspace():
+    r = MediaSaveResult(workspace_ref="workspace://path/file.png",
+                        saved_filename="file-20260327.png")
+    assert r.workspace_ref == "workspace://path/file.png"
+    assert r.saved_filename == "file-20260327.png"
+
+
+def test_media_save_result_file_id():
+    r = MediaSaveResult(file_id="abc123")
+    assert r.file_id == "abc123"
+
+
+# -- Base MediaHandler tests --
 
 
 @pytest.mark.asyncio
-async def test_terminal_handler_upload(tmp_path):
-    handler = TerminalMediaHandler(tmp_path)
-    path = await handler.upload_file("ch", "test.png", b"data", "image/png")
-    assert (tmp_path / "media" / "test.png").exists()
-    assert path == "media/test.png"
+async def test_base_handler_save_media_raises():
+    handler = MediaHandler()
+    with pytest.raises(NotImplementedError):
+        await handler.save_media("conv1", "file.png", b"data", "image/png")
 
 
-def test_process_media_for_terminal(tmp_path):
-    result = ToolResult(text="Here's the image", media=[
-        {"type": "file", "filename": "pic.png", "data": b"png-data", "content_type": "image/png"},
-    ])
-    output = process_media_for_terminal(result, tmp_path)
-    assert "[file saved: media/pic.png]" in output
-    assert (tmp_path / "media" / "pic.png").exists()
+def test_base_handler_strips_workspace_refs_default():
+    handler = MediaHandler()
+    assert handler.strips_workspace_refs is True
 
 
-def test_process_media_for_terminal_url():
-    result = ToolResult(text="Check this", media=[
-        {"type": "url", "url": "https://example.com/img.png", "alt": "image"},
-    ])
-    output = process_media_for_terminal(result, Path("/tmp"))
-    assert "[image: https://example.com/img.png]" in output
+# -- Helper: fake config for save_attachment --
 
 
-def test_process_media_for_terminal_no_media():
-    result = ToolResult(text="plain text")
-    output = process_media_for_terminal(result, Path("/tmp"))
-    assert output == "plain text"
+@dataclass
+class _FakeConfig:
+    workspace_path: Path
+
+
+# -- TerminalMediaHandler tests --
+
+
+def test_terminal_handler_strips_workspace_refs():
+    assert TerminalMediaHandler.strips_workspace_refs is False
+
+
+@pytest.mark.asyncio
+async def test_terminal_handler_save_media(tmp_path):
+    config = _FakeConfig(workspace_path=tmp_path)
+    handler = TerminalMediaHandler(config)
+    result = await handler.save_media("conv1", "test.png", b"png-data", "image/png")
+    assert result.workspace_ref is not None
+    assert result.workspace_ref.startswith("workspace://conversations/conv1/uploads/")
+    assert result.saved_filename is not None
+    assert "test" in result.saved_filename
+    # Verify file was actually saved
+    saved_path = tmp_path / result.workspace_ref.replace("workspace://", "")
+    assert saved_path.exists()
+    assert saved_path.read_bytes() == b"png-data"
+
+
+@pytest.mark.asyncio
+async def test_terminal_handler_upload_legacy_raises(tmp_path):
+    config = _FakeConfig(workspace_path=tmp_path)
+    handler = TerminalMediaHandler(config)
+    with pytest.raises(NotImplementedError):
+        await handler.upload_file("ch", "test.png", b"data", "image/png")
+
+
+# -- WebMediaHandler tests --
+
+
+def test_web_handler_strips_workspace_refs():
+    assert WebMediaHandler.strips_workspace_refs is False
+
+
+@pytest.mark.asyncio
+async def test_web_handler_save_media(tmp_path):
+    config = _FakeConfig(workspace_path=tmp_path)
+    handler = WebMediaHandler(config)
+    result = await handler.save_media("conv-abc", "doc.pdf", b"pdf-data", "application/pdf")
+    assert result.workspace_ref is not None
+    assert result.workspace_ref.startswith("workspace://conversations/conv-abc/uploads/")
+    assert result.saved_filename is not None
+    # Verify file was actually saved
+    saved_path = tmp_path / result.workspace_ref.replace("workspace://", "")
+    assert saved_path.exists()
+    assert saved_path.read_bytes() == b"pdf-data"
 
 
 # -- MattermostMediaHandler tests --
@@ -149,10 +214,23 @@ def _make_mock_http():
     return http
 
 
+def test_mattermost_handler_strips_workspace_refs():
+    assert MattermostMediaHandler.strips_workspace_refs is True
+
+
+@pytest.mark.asyncio
+async def test_mattermost_save_media():
+    http = _make_mock_http()
+    handler = MattermostMediaHandler(http, channel_id="ch1")
+    result = await handler.save_media("conv1", "test.png", b"data", "image/png")
+    assert result.file_id == "file-id-123"
+    assert result.workspace_ref is None
+
+
 @pytest.mark.asyncio
 async def test_mattermost_upload_file():
     http = _make_mock_http()
-    handler = MattermostMediaHandler(http)
+    handler = MattermostMediaHandler(http, channel_id="ch1")
     file_id = await handler.upload_file("ch1", "test.png", b"data", "image/png")
     assert file_id == "file-id-123"
     # Verify the upload was called with correct params
@@ -168,7 +246,7 @@ async def test_mattermost_send_with_media_single_batch():
     post_resp.raise_for_status = MagicMock()
     http.post.return_value = post_resp
 
-    handler = MattermostMediaHandler(http)
+    handler = MattermostMediaHandler(http, channel_id="ch1")
     post_id = await handler.send_with_media("ch1", "Hello", ["f1", "f2"])
     assert post_id == "post-123"
     # Should be a single post call
@@ -186,7 +264,7 @@ async def test_mattermost_send_with_media_overflow():
     post_resp.raise_for_status = MagicMock()
     http.post.return_value = post_resp
 
-    handler = MattermostMediaHandler(http)
+    handler = MattermostMediaHandler(http, channel_id="ch1")
     file_ids = [f"f{i}" for i in range(15)]  # 15 files, needs 2 posts
     await handler.send_with_media("ch1", "Many files", file_ids)
     assert http.post.call_count == 2  # first 10 + remaining 5
@@ -208,7 +286,7 @@ async def test_upload_and_collect():
 
 
 def test_mattermost_format_attachment_card():
-    handler = MattermostMediaHandler(None)
+    handler = MattermostMediaHandler(None, channel_id="")
     card = handler.format_attachment_card("Title", "Body", image_url="https://img.png")
     assert card["title"] == "Title"
     assert card["text"] == "Body"

--- a/tests/test_process_tool_media.py
+++ b/tests/test_process_tool_media.py
@@ -1,0 +1,193 @@
+"""Tests for _process_tool_media — per-tool-call media save and placeholder replacement."""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from decafclaw.agent import _process_tool_media
+from decafclaw.media import MediaSaveResult, ToolResult
+
+
+@dataclass
+class _FakeCtx:
+    conv_id: str = "conv1"
+    channel_id: str = ""
+    media_handler: object = None
+
+
+def _make_handler(workspace_ref=None, file_id=None, saved_filename=None):
+    handler = AsyncMock()
+    handler.save_media = AsyncMock(return_value=MediaSaveResult(
+        workspace_ref=workspace_ref,
+        file_id=file_id,
+        saved_filename=saved_filename,
+    ))
+    return handler
+
+
+# -- Workspace ref replacement --
+
+
+@pytest.mark.asyncio
+async def test_image_placeholder_replaced_with_markdown_image():
+    handler = _make_handler(
+        workspace_ref="workspace://conversations/conv1/uploads/img-20260327.png",
+        saved_filename="img-20260327.png",
+    )
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == []
+    assert "![img.png](workspace://conversations/conv1/uploads/img-20260327.png)" in result.text
+    assert "[file attached:" not in result.text
+    assert result.media == []
+
+
+@pytest.mark.asyncio
+async def test_non_image_placeholder_replaced_with_markdown_link():
+    handler = _make_handler(
+        workspace_ref="workspace://conversations/conv1/uploads/doc-20260327.pdf",
+        saved_filename="doc-20260327.pdf",
+    )
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text="[file attached: doc.pdf (application/pdf) — will appear as an attachment on your reply]",
+        media=[{"type": "file", "filename": "doc.pdf", "data": b"pdf", "content_type": "application/pdf"}],
+    )
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == []
+    assert "[doc.pdf](workspace://conversations/conv1/uploads/doc-20260327.pdf)" in result.text
+    assert "![" not in result.text  # not an image ref
+
+
+# -- Mattermost file_id --
+
+
+@pytest.mark.asyncio
+async def test_file_id_collected():
+    handler = _make_handler(file_id="mm-file-123")
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == ["mm-file-123"]
+    assert result.media == []
+
+
+# -- No media handler --
+
+
+@pytest.mark.asyncio
+async def test_no_handler_logs_warning_leaves_text(caplog):
+    ctx = _FakeCtx(media_handler=None)
+    result = ToolResult(
+        text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == []
+    assert "[file attached:" in result.text
+    assert "No media handler" in caplog.text
+
+
+# -- Failed save --
+
+
+@pytest.mark.asyncio
+async def test_failed_save_logs_warning_preserves_placeholder(caplog):
+    handler = AsyncMock()
+    handler.save_media = AsyncMock(side_effect=RuntimeError("upload failed"))
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == []
+    assert "[file attached:" in result.text
+    assert "Failed to save media" in caplog.text
+    assert result.media == []
+
+
+# -- Multiple media items --
+
+
+@pytest.mark.asyncio
+async def test_multiple_media_items():
+    call_count = 0
+
+    async def _save(conv_id, filename, data, content_type):
+        nonlocal call_count
+        call_count += 1
+        return MediaSaveResult(
+            workspace_ref=f"workspace://uploads/{filename.replace('.', f'-{call_count}.')}",
+            saved_filename=f"{filename.replace('.', f'-{call_count}.')}",
+        )
+
+    handler = MagicMock()
+    handler.save_media = _save
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text=(
+            "[file attached: a.png (image/png) — will appear as an attachment on your reply]\n"
+            "[file attached: b.txt (text/plain) — will appear as an attachment on your reply]"
+        ),
+        media=[
+            {"type": "file", "filename": "a.png", "data": b"a", "content_type": "image/png"},
+            {"type": "file", "filename": "b.txt", "data": b"b", "content_type": "text/plain"},
+        ],
+    )
+    await _process_tool_media(ctx, result)
+    assert "![a.png](workspace://uploads/a-1.png)" in result.text
+    assert "[b.txt](workspace://uploads/b-2.txt)" in result.text
+    assert "[file attached:" not in result.text
+    assert result.media == []
+
+
+# -- No placeholder — append ref --
+
+
+@pytest.mark.asyncio
+async def test_no_placeholder_appends_ref():
+    handler = _make_handler(
+        workspace_ref="workspace://conversations/conv1/uploads/img-20260327.png",
+        saved_filename="img-20260327.png",
+    )
+    ctx = _FakeCtx(media_handler=handler)
+    result = ToolResult(
+        text="Here's a test image (200x200 gradient):",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    await _process_tool_media(ctx, result)
+    assert "Here's a test image" in result.text
+    assert "![img.png](workspace://conversations/conv1/uploads/img-20260327.png)" in result.text
+    assert result.media == []
+
+
+@pytest.mark.asyncio
+async def test_no_handler_clears_media():
+    ctx = _FakeCtx(media_handler=None)
+    result = ToolResult(
+        text="some text",
+        media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
+    )
+    await _process_tool_media(ctx, result)
+    assert result.media == []
+
+
+# -- Empty media --
+
+
+@pytest.mark.asyncio
+async def test_empty_media_noop():
+    ctx = _FakeCtx(media_handler=None)
+    result = ToolResult(text="no media here")
+    file_ids = await _process_tool_media(ctx, result)
+    assert file_ids == []
+    assert result.text == "no media here"


### PR DESCRIPTION
## Summary

- **Per-tool-call media processing**: Replaces the `pending_media` accumulation pattern. Media is saved/uploaded immediately during tool execution, and placeholder text is replaced with `workspace://` markdown refs (images) or links (other files).
- **Unified storage**: Agent-generated media now saves to `workspace/conversations/{conv_id}/uploads/` via `save_attachment()`, same as user uploads. Retires the `workspace/media/` path.
- **Web UI delivery (#141)**: New `WebMediaHandler` saves media to conversation uploads. Frontend `assistant-message.js` rewrites `workspace://` hrefs in both images and links to `/api/workspace/` URLs.
- **MediaHandler interface**: New `save_media()` method + `MediaSaveResult` dataclass on all handlers. `strips_workspace_refs` flag controls whether `extract_workspace_media()` runs at end-of-turn (Mattermost=yes, Web/Terminal=no).
- **Mattermost**: Per-tool-call upload via `tool_media_uploaded` event, attached as thread replies. End-of-turn workspace ref extraction still works for refs in final response text.
- **Terminal**: Updated to save via `save_attachment()` with `conv_id="interactive"`. Workspace refs shown as text paths.

Closes #141, closes #135

## Test plan

- [x] 800 tests pass (`make test`)
- [x] Lint clean (`make check`)
- [x] Type check clean (`make typecheck`, `make check-js`)
- [x] Live test: web UI — ask bot to fetch MCP binary resource, verify image renders / file links work
- [x] Live test: Mattermost — verify tool media still uploads and attaches to posts
- [x] Live test: terminal — verify workspace:// refs appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)