### PR TITLE
feat: Mattermost inbound file attachments

### DIFF
--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -241,7 +241,8 @@ class MattermostClient:
 
         channel_type = data.get("channel_type", "")
         message = post.get("message", "").strip()
-        if not message:
+        post_file_ids = post.get("file_ids") or []
+        if not message and not post_file_ids:
             return
 
         # Strip bot @mention and track whether it was present
@@ -260,6 +261,12 @@ class MattermostClient:
         if self.require_mention and not is_dm and not mentioned and not in_thread:
             return
 
+        # Extract file metadata from post for attachment processing
+        file_metadata = {}
+        for finfo in (post.get("metadata") or {}).get("files") or []:
+            if isinstance(finfo, dict) and finfo.get("id"):
+                file_metadata[finfo["id"]] = finfo
+
         on_message({
             "text": message,
             "channel_id": channel_id,
@@ -269,6 +276,8 @@ class MattermostClient:
             "sender_name": data.get("sender_name", ""),
             "channel_type": channel_type,
             "mentioned": mentioned,
+            "file_ids": post_file_ids,
+            "file_metadata": file_metadata,
         })
 
     # -- Conversation processing -----------------------------------------------
@@ -408,6 +417,45 @@ class MattermostClient:
                     channel_id, "", file_ids, root_id=root_id
                 )
 
+    async def _download_attachments(self, msgs, conv_id, config):
+        """Download user-uploaded files from Mattermost and save as conversation attachments.
+
+        Returns a list of attachment metadata dicts (same format as web UI uploads).
+        """
+        from .attachments import save_attachment
+
+        max_bytes = getattr(getattr(config, "http", None), "max_upload_bytes", None)
+
+        attachments = []
+        for msg in msgs:
+            file_ids = msg.get("file_ids") or []
+            file_metadata = msg.get("file_metadata") or {}
+            for fid in file_ids:
+                try:
+                    # Download file content
+                    resp = await self._http.get(f"/files/{fid}")
+                    resp.raise_for_status()
+                    data = resp.content
+
+                    # Enforce size limit (same as web UI uploads)
+                    if max_bytes and len(data) > max_bytes:
+                        log.warning(f"Mattermost file {fid} too large: "
+                                    f"{len(data)} bytes > {max_bytes} limit, skipping")
+                        continue
+
+                    # Get filename and MIME type from metadata or file info
+                    fmeta = file_metadata.get(fid, {})
+                    filename = fmeta.get("name", f"file-{fid}")
+                    mime_type = fmeta.get("mime_type", "application/octet-stream")
+
+                    # Save to conversation uploads
+                    att = save_attachment(config, conv_id, filename, data, mime_type)
+                    attachments.append(att)
+                    log.info(f"Saved Mattermost attachment: {att['filename']} ({mime_type})")
+                except Exception as e:
+                    log.warning(f"Failed to download Mattermost file {fid}: {e}")
+        return attachments
+
     async def _process_conversation(self, conv_id, channel_id, msgs,
                                     app_ctx, conversations):
         """Process accumulated messages for a conversation."""
@@ -497,10 +545,15 @@ class MattermostClient:
             req_ctx.extra_tools.update(cmd_ctx.extra_tools)
             req_ctx.extra_tool_definitions.extend(cmd_ctx.extra_tool_definitions)
 
+        # Download user-uploaded files and store as conversation attachments
+        attachments = await self._download_attachments(
+            msgs, conv_id, app_ctx.config)
+
         conv.busy = True
         try:
             response = await run_agent_turn(
-                req_ctx, combined_text, history, archive_text=archive_text)
+                req_ctx, combined_text, history, archive_text=archive_text,
+                attachments=attachments or None)
         except BaseException as e:
             log.error(f"Agent turn failed: {e}")
             from .media import ToolResult

--- a/tests/test_mattermost_attachments.py
+++ b/tests/test_mattermost_attachments.py
@@ -1,0 +1,264 @@
+"""Tests for Mattermost inbound file attachment handling."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from decafclaw.mattermost import MattermostClient
+
+
+@dataclass
+class _FakeConfig:
+    workspace_path: Path
+
+
+def _make_client(http_mock=None):
+    """Create a MattermostClient with mocked internals for testing."""
+    client = MattermostClient.__new__(MattermostClient)
+    client._http = http_mock or AsyncMock()
+    client.bot_user_id = "bot123"
+    client.bot_username = "testbot"
+    client.ignore_bots = True
+    client.ignore_webhooks = True
+    client.require_mention = False
+    client.channel_blocklist = set()
+    return client
+
+
+# -- _handle_posted: file_ids extraction --
+
+
+def test_handle_posted_extracts_file_ids():
+    """file_ids and file_metadata are passed through in the message dict."""
+    client = _make_client()
+    captured = []
+
+    post = {
+        "id": "post1",
+        "message": "check this out",
+        "channel_id": "ch1",
+        "user_id": "user1",
+        "root_id": "",
+        "type": "",
+        "props": {},
+        "file_ids": ["fid1", "fid2"],
+        "metadata": {
+            "files": [
+                {"id": "fid1", "name": "photo.jpg", "mime_type": "image/jpeg"},
+                {"id": "fid2", "name": "doc.pdf", "mime_type": "application/pdf"},
+            ],
+        },
+    }
+    import json
+    evt = {
+        "data": {
+            "post": json.dumps(post),
+            "sender_name": "user",
+            "channel_type": "D",
+        },
+    }
+    client._handle_posted(evt, lambda msg: captured.append(msg))
+
+    assert len(captured) == 1
+    msg = captured[0]
+    assert msg["file_ids"] == ["fid1", "fid2"]
+    assert msg["file_metadata"]["fid1"]["name"] == "photo.jpg"
+    assert msg["file_metadata"]["fid2"]["mime_type"] == "application/pdf"
+
+
+def test_handle_posted_file_only_message():
+    """A message with files but no text should still be processed."""
+    client = _make_client()
+    captured = []
+
+    post = {
+        "id": "post1",
+        "message": "",
+        "channel_id": "ch1",
+        "user_id": "user1",
+        "root_id": "",
+        "type": "",
+        "props": {},
+        "file_ids": ["fid1"],
+        "metadata": {
+            "files": [{"id": "fid1", "name": "image.png", "mime_type": "image/png"}],
+        },
+    }
+    import json
+    evt = {
+        "data": {
+            "post": json.dumps(post),
+            "sender_name": "user",
+            "channel_type": "D",
+        },
+    }
+    client._handle_posted(evt, lambda msg: captured.append(msg))
+
+    assert len(captured) == 1
+    assert captured[0]["text"] == ""
+    assert captured[0]["file_ids"] == ["fid1"]
+
+
+def test_handle_posted_no_text_no_files_ignored():
+    """A message with no text and no files should be ignored."""
+    client = _make_client()
+    captured = []
+
+    post = {
+        "id": "post1",
+        "message": "",
+        "channel_id": "ch1",
+        "user_id": "user1",
+        "root_id": "",
+        "type": "",
+        "props": {},
+    }
+    import json
+    evt = {
+        "data": {
+            "post": json.dumps(post),
+            "sender_name": "user",
+            "channel_type": "D",
+        },
+    }
+    client._handle_posted(evt, lambda msg: captured.append(msg))
+
+    assert len(captured) == 0
+
+
+# -- _download_attachments --
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_saves_files(tmp_path):
+    """Files are downloaded from Mattermost API and saved to conversation uploads."""
+    http = AsyncMock()
+    resp = MagicMock()
+    resp.content = b"fake-image-data"
+    resp.raise_for_status = MagicMock()
+    http.get.return_value = resp
+
+    client = _make_client(http)
+    config = _FakeConfig(workspace_path=tmp_path)
+
+    msgs = [{
+        "text": "check this",
+        "file_ids": ["fid1"],
+        "file_metadata": {
+            "fid1": {"name": "photo.jpg", "mime_type": "image/jpeg"},
+        },
+    }]
+
+    attachments = await client._download_attachments(msgs, "conv1", config)
+
+    assert len(attachments) == 1
+    assert attachments[0]["mime_type"] == "image/jpeg"
+    assert "photo" in attachments[0]["filename"]
+    # Verify file was saved
+    saved = tmp_path / attachments[0]["path"]
+    assert saved.exists()
+    assert saved.read_bytes() == b"fake-image-data"
+    # Verify API was called correctly
+    http.get.assert_called_once_with("/files/fid1")
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_multiple_files(tmp_path):
+    """Multiple files across messages are all downloaded."""
+    http = AsyncMock()
+    resp = MagicMock()
+    resp.content = b"data"
+    resp.raise_for_status = MagicMock()
+    http.get.return_value = resp
+
+    client = _make_client(http)
+    config = _FakeConfig(workspace_path=tmp_path)
+
+    msgs = [
+        {
+            "text": "msg1",
+            "file_ids": ["fid1"],
+            "file_metadata": {"fid1": {"name": "a.png", "mime_type": "image/png"}},
+        },
+        {
+            "text": "msg2",
+            "file_ids": ["fid2", "fid3"],
+            "file_metadata": {
+                "fid2": {"name": "b.jpg", "mime_type": "image/jpeg"},
+                "fid3": {"name": "c.txt", "mime_type": "text/plain"},
+            },
+        },
+    ]
+
+    attachments = await client._download_attachments(msgs, "conv2", config)
+
+    assert len(attachments) == 3
+    assert http.get.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_failure_continues(tmp_path):
+    """Failed downloads are logged but don't block other files."""
+    http = AsyncMock()
+    # First call fails, second succeeds
+    fail_resp = MagicMock()
+    fail_resp.raise_for_status.side_effect = RuntimeError("download failed")
+    ok_resp = MagicMock()
+    ok_resp.content = b"ok-data"
+    ok_resp.raise_for_status = MagicMock()
+    http.get.side_effect = [fail_resp, ok_resp]
+
+    client = _make_client(http)
+    config = _FakeConfig(workspace_path=tmp_path)
+
+    msgs = [{
+        "text": "files",
+        "file_ids": ["bad", "good"],
+        "file_metadata": {
+            "bad": {"name": "fail.bin", "mime_type": "application/octet-stream"},
+            "good": {"name": "ok.png", "mime_type": "image/png"},
+        },
+    }]
+
+    attachments = await client._download_attachments(msgs, "conv3", config)
+
+    assert len(attachments) == 1
+    assert "ok" in attachments[0]["filename"]
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_no_files(tmp_path):
+    """Messages without file_ids return empty list."""
+    client = _make_client()
+    config = _FakeConfig(workspace_path=tmp_path)
+
+    msgs = [{"text": "no files"}]
+    attachments = await client._download_attachments(msgs, "conv4", config)
+
+    assert attachments == []
+
+
+@pytest.mark.asyncio
+async def test_download_attachments_missing_metadata(tmp_path):
+    """Files without metadata use fallback filename and MIME type."""
+    http = AsyncMock()
+    resp = MagicMock()
+    resp.content = b"mystery-data"
+    resp.raise_for_status = MagicMock()
+    http.get.return_value = resp
+
+    client = _make_client(http)
+    config = _FakeConfig(workspace_path=tmp_path)
+
+    msgs = [{
+        "text": "mysterious file",
+        "file_ids": ["fid1"],
+        "file_metadata": {},  # no metadata for this file
+    }]
+
+    attachments = await client._download_attachments(msgs, "conv5", config)
+
+    assert len(attachments) == 1
+    assert attachments[0]["mime_type"] == "application/octet-stream"


### PR DESCRIPTION
## Summary

- Extract `file_ids` and file metadata from incoming Mattermost posts in `_handle_posted()`
- Download file content via Mattermost Files API (`GET /files/{file_id}`)
- Save to conversation uploads via `save_attachment()` — same storage as web UI
- Pass attachment metadata to `run_agent_turn()` — the existing `_resolve_attachments()` pipeline handles LLM multimodal construction (base64 images, text placeholders for non-images)
- Allow file-only messages (no text) to be processed

Closes #134

## Test plan

- [x] 810 tests pass (`make test`)
- [x] Lint clean (`make check`)
- [x] Type check clean (`make typecheck`, `make check-js`)
- [x] Live test: upload an image in Mattermost DM, verify bot describes it
- [x] Live test: upload a non-image file, verify bot acknowledges it
- [x] Live test: upload image with no text caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)