### PR TITLE
refactor: code quality round 2 — store boundaries, listener leaks, test coverage

### DIFF
--- a/.claude/dev-sessions/2026-03-29-0926-code-quality-round2/plan.md
+++ b/.claude/dev-sessions/2026-03-29-0926-code-quality-round2/plan.md
@@ -1,0 +1,281 @@
+# Code Quality Round 2 — Implementation Plan
+
+**Branch:** `refactor/code-quality-round2`
+**Spec:** `spec.md`
+**Approach:** 3 phases. Commit after each phase.
+
+---
+
+## Phase 1: Quick Fixes
+
+All independent, low-risk changes. Can be done in parallel.
+
+---
+
+### Step 1.1: Type hints on context sub-objects
+
+**Prompt:**
+
+> Read `src/decafclaw/context.py`. Update the `ToolState`, `SkillState`, and `TokenUsage` dataclass fields to use parameterized type hints:
+>
+> ```python
+> # ToolState
+> extra: dict[str, Any] = field(default_factory=dict)
+> extra_definitions: list[dict] = field(default_factory=list)
+> deferred_pool: list[dict] = field(default_factory=list)
+> preapproved: set[str] = field(default_factory=set)
+> preapproved_shell_patterns: list[str]  # already typed
+> allowed: set[str] | None = None
+>
+> # SkillState
+> activated: set[str] = field(default_factory=set)
+> data: dict[str, Any] = field(default_factory=dict)
+> ```
+>
+> Add `from typing import Any` if not present. Run `make check`.
+
+---
+
+### Step 1.2: Remove dead empty listener in app.js
+
+**Prompt:**
+
+> Read `src/decafclaw/web/static/app.js`. Find the empty event listener `store.addEventListener('change', () => {})` and remove it. Run `make check-js`.
+
+---
+
+### Step 1.3: Fix duplicate store listener in chat-view.js
+
+**Prompt:**
+
+> Read `src/decafclaw/web/static/components/chat-view.js`.
+>
+> The `updated()` method (line ~99) adds a store listener without removing the old one. Fix by:
+> 1. In `updated()`, when `store` changes, remove the old listener first, then add the new one:
+>    ```js
+>    updated(changedProps) {
+>      if (changedProps.has('store')) {
+>        const oldStore = changedProps.get('store');
+>        if (oldStore) oldStore.removeEventListener('change', this._onStoreChange);
+>        if (this.store) {
+>          this.store.addEventListener('change', this._onStoreChange);
+>          this._onStoreChange();
+>        }
+>      }
+>    }
+>    ```
+> 2. Remove the `this.store?.addEventListener('change', this._onStoreChange)` from `connectedCallback` — let `updated()` handle it (it fires after first render with all properties).
+>
+> Run `make check-js`.
+
+---
+
+### Step 1.4: Fix duplicate store listener in conversation-sidebar.js
+
+**Prompt:**
+
+> Read `src/decafclaw/web/static/components/conversation-sidebar.js`.
+>
+> Same pattern as chat-view.js. Fix `updated()` to remove old listener before adding new one. Remove the listener add from `connectedCallback`. Keep `disconnectedCallback` as-is (it removes the current listener).
+>
+> Run `make check-js`.
+
+---
+
+### Step 1.5: Commit Phase 1
+
+> Run `make check && make test`. Commit with message:
+> "refactor: quick fixes — context type hints, dead code, listener leaks"
+
+---
+
+## Phase 2: JS Store Boundary Fix
+
+---
+
+### Step 2.1: Refactor ToolStatusStore to not mutate MessageStore's array
+
+**Context:** `ToolStatusStore.handleMessage()` receives `currentMessages` (MessageStore's array) and directly pushes/splices into it. This breaks encapsulation.
+
+**Prompt:**
+
+> Read `src/decafclaw/web/static/lib/tool-status-store.js`, `src/decafclaw/web/static/lib/message-store.js`, and `src/decafclaw/web/static/lib/conversation-store.js`.
+>
+> Refactor so ToolStatusStore never touches MessageStore's array directly:
+>
+> 1. Add methods to MessageStore for the mutations ToolStatusStore needs:
+>    - `pushMessage(msg)` — already exists
+>    - `updateLastToolCall(content)` — update last `tool_call` message's content
+>    - `replaceLastToolCall(msg)` — replace last `tool_call` message (for tool_end)
+>    - `insertBeforeLastUser(msg)` — insert message before the last user message (for memory_context)
+>
+> 2. Change ToolStatusStore constructor to accept a message store reference instead of raw array:
+>    ```js
+>    constructor(onChange, ws, messageStore)
+>    ```
+>
+> 3. Update `handleMessage()` to call MessageStore methods instead of direct array mutation:
+>    - `tool_start`: `this.#messageStore.pushMessage({...})`
+>    - `tool_status` (memory_context): `this.#messageStore.insertBeforeLastUser({...})`
+>    - `tool_status` (other): `this.#messageStore.updateLastToolCall(content)`
+>    - `tool_end`: `this.#messageStore.replaceLastToolCall({...})`
+>    - `reflection_result`: `this.#messageStore.pushMessage({...})`
+>
+> 4. Remove the `currentMessages` parameter from `handleMessage()`. Update ConversationStore to pass the messageStore reference instead.
+>
+> 5. Update ConversationStore's `#handleMessage()` to no longer pass `this.#messages.currentMessages` to ToolStatusStore.
+>
+> Run `make check-js`.
+
+---
+
+### Step 2.2: Commit Phase 2
+
+> Run `make check && make test`. Commit with message:
+> "refactor: fix JS store boundary — ToolStatusStore uses MessageStore API instead of direct mutation"
+
+---
+
+## Phase 3: Test Coverage
+
+Each test file is independent. Can be written in parallel.
+
+---
+
+### Step 3.1: Tests for `util.py`
+
+**Prompt:**
+
+> Create `tests/test_util.py` with tests for `estimate_tokens()`:
+> - Empty string returns 0
+> - Short string: `estimate_tokens("abcd")` returns 1
+> - Longer string: `estimate_tokens("a" * 100)` returns 25
+> - Whitespace is counted: `estimate_tokens("    ")` returns 1
+>
+> Run `make test -k test_util`.
+
+---
+
+### Step 3.2: Tests for `polling.py`
+
+**Prompt:**
+
+> Create `tests/test_polling.py` with async tests for:
+>
+> 1. `build_task_preamble("heartbeat check")` — returns string containing "heartbeat check"
+> 2. `build_task_preamble("scheduled task", "my-task")` — returns string containing "my-task"
+> 3. `run_polling_loop()` — calls `on_tick` when interval elapses, then exits on shutdown:
+>    ```python
+>    async def test_polling_loop_calls_tick():
+>        shutdown = asyncio.Event()
+>        calls = []
+>        async def tick():
+>            calls.append(1)
+>            shutdown.set()  # stop after first tick
+>        await run_polling_loop(0.01, shutdown, tick, label="test")
+>        assert len(calls) == 1
+>    ```
+> 4. `run_polling_loop()` continues after tick failure:
+>    ```python
+>    async def test_polling_loop_survives_tick_error():
+>        shutdown = asyncio.Event()
+>        calls = []
+>        async def bad_tick():
+>            calls.append(1)
+>            if len(calls) == 1:
+>                raise ValueError("boom")
+>            shutdown.set()
+>        await run_polling_loop(0.01, shutdown, bad_tick, label="test")
+>        assert len(calls) == 2  # continued after first failure
+>    ```
+> 5. `run_polling_loop()` exits immediately if shutdown already set.
+>
+> Run `make test -k test_polling`.
+
+---
+
+### Step 3.3: Tests for `archive.py:restore_history()`
+
+**Prompt:**
+
+> Read `src/decafclaw/archive.py` — the `restore_history()` function.
+>
+> Add tests to `tests/test_archive.py` (or create new file `tests/test_restore_history.py`):
+>
+> 1. `test_restore_history_no_archive` — returns None when no files exist
+> 2. `test_restore_history_archive_only` — returns full archive when no compacted sidecar
+> 3. `test_restore_history_compacted_only` — returns compacted when no newer archive entries
+> 4. `test_restore_history_compacted_plus_newer` — returns compacted + archive entries newer than last compacted timestamp
+> 5. `test_restore_history_ignores_corrupt_lines` — verifies JSONL corruption is handled (from Phase 1 fix)
+>
+> Use `tmp_path` fixture with a fake config that has `workspace_path = tmp_path`.
+>
+> Run `make test -k test_restore`.
+
+---
+
+### Step 3.4: Tests for `mattermost_display.py`
+
+**Prompt:**
+
+> Read `src/decafclaw/mattermost_display.py`.
+>
+> Create `tests/test_mattermost_display.py` testing `ConversationDisplay` with a mock Mattermost client. The mock client should record calls to `send()`, `edit_message()`, `delete_message()`, `send_typing()`.
+>
+> Test cases:
+>
+> 1. `test_on_llm_start_sends_thinking` — first call edits placeholder with thinking indicator
+> 2. `test_on_llm_start_iteration_2_sends_new_post` — second iteration posts a new thinking message
+> 3. `test_on_text_complete_non_streaming` — posts complete text as new message
+> 4. `test_on_tool_start_posts_tool_message` — posts a tool call indicator
+> 5. `test_on_tool_end_edits_tool_message` — edits the tool message with result
+> 6. `test_on_tool_end_truncates_long_result` — long results are truncated
+> 7. `test_finalize_strips_thinking` — finalize removes thinking suffix from last message
+> 8. `test_finalize_deletes_empty_placeholder` — deletes placeholder if no content was posted
+>
+> Use `AsyncMock` for the client. Set `throttle_ms=0` in tests to avoid timing issues.
+>
+> Run `make test -k test_mattermost_display`.
+
+---
+
+### Step 3.5: Tests for priority tool functions
+
+**Prompt:**
+
+> Create `tests/test_core_tools.py` testing the tool functions in `src/decafclaw/tools/core.py`:
+>
+> 1. `test_tool_think_returns_input` — `tool_think(ctx, thought="hello")` returns "hello"
+> 2. `test_tool_current_time_returns_iso` — `tool_current_time(ctx)` returns a parseable ISO datetime
+> 3. `test_tool_context_stats_format` — `tool_context_stats(ctx)` returns a string with "System prompt", "Tools", "History" sections (mock ctx with messages and config)
+>
+> Create `tests/test_todo_tools.py` testing `src/decafclaw/tools/todo_tools.py`:
+>
+> 1. `test_todo_add_creates_item` — adds an item and verifies it appears in list
+> 2. `test_todo_complete_checks_item` — marks item complete
+> 3. `test_todo_list_shows_items` — lists items with status
+> 4. `test_todo_remove_deletes_item` — removes an item
+>
+> Use `tmp_path` for workspace. Create minimal ctx with `config.workspace_path` and `conv_id`.
+>
+> Create `tests/test_memory_tools.py` testing `src/decafclaw/tools/memory_tools.py`:
+>
+> 1. `test_memory_save_creates_file` — saves a memory entry and verifies file exists
+> 2. `test_memory_recent_returns_entries` — after saving, recent returns the entry
+>
+> Use `tmp_path` for workspace. Skip semantic search tests (require embedding model).
+>
+> Run `make test -k "test_core_tools or test_todo_tools or test_memory_tools"`.
+
+---
+
+### Step 3.6: Commit Phase 3
+
+> Run `make check && make test`. Commit with message:
+> "test: add coverage for polling, util, restore_history, mattermost_display, core/todo/memory tools"
+
+---
+
+## Final Step
+
+> Run full `make check && make test`. Push branch, create PR.

--- a/.claude/dev-sessions/2026-03-29-0926-code-quality-round2/spec.md
+++ b/.claude/dev-sessions/2026-03-29-0926-code-quality-round2/spec.md
@@ -1,0 +1,133 @@
+# Code Quality Review — Round 2
+
+**Branch:** `refactor/code-quality-round2`
+**Date:** 2026-03-29
+**Goal:** Address 5 focused areas from the second-pass code review: test coverage, JS store boundaries, listener leaks, dead code, and type hints on new dataclasses.
+
+---
+
+## 1. Test Coverage for New/Critical Modules
+
+### 1.1 `polling.py` — zero tests
+- **File:** `src/decafclaw/polling.py` (~50 lines)
+- **Functions:** `run_polling_loop()`, `build_task_preamble()`
+- **What to test:**
+  - `build_task_preamble()` output format with/without task name
+  - `run_polling_loop()` calls `on_tick` at intervals
+  - `run_polling_loop()` exits cleanly on shutdown_event
+  - `run_polling_loop()` continues after tick failure (logs error)
+
+### 1.2 `util.py` — zero tests
+- **File:** `src/decafclaw/util.py` (~7 lines)
+- **Function:** `estimate_tokens()`
+- **What to test:**
+  - Basic estimation: `estimate_tokens("hello world")` returns ~2-3
+  - Empty string returns 0
+  - None-safe (empty string case)
+
+### 1.3 `archive.py:restore_history()` — extracted but untested
+- **File:** `src/decafclaw/archive.py`
+- **Function:** `restore_history(config, conv_id)`
+- **What to test:**
+  - Returns compacted history when available
+  - Falls back to full archive when no compacted sidecar
+  - Returns None when no archive exists
+  - Merges compacted + newer archive entries correctly
+
+### 1.4 `mattermost_display.py` — zero tests, 383 lines
+- **File:** `src/decafclaw/mattermost_display.py`
+- **Class:** `ConversationDisplay` with 15 async methods
+- **What to test (focused on core logic, not HTTP calls):**
+  - `on_llm_start()` sends thinking indicator
+  - `on_text_chunk()` buffers and throttles edits
+  - `on_tool_start()` posts tool message
+  - `on_tool_end()` edits tool message with result
+  - `finalize()` cleans up thinking placeholder and stop button
+  - Throttling behavior (`_throttled_edit` respects timing)
+
+### 1.5 Tool functions — 44 functions across 10 untested modules
+- **Priority tools to test (highest impact):**
+  - `tools/core.py` — `tool_web_fetch`, `tool_think`, `tool_context_stats`
+  - `tools/conversation_tools.py` — `tool_conversation_search`, `tool_conversation_compact`
+  - `tools/memory_tools.py` — `tool_memory_save`, `tool_memory_search`
+  - `tools/todo_tools.py` — `tool_todo_add`, `tool_todo_complete`, `tool_todo_list`
+  - `tools/effort_tools.py` — `tool_set_effort`
+- **Lower priority (complex integration, hard to unit test):**
+  - `tools/shell_tools.py` — subprocess execution with confirmation
+  - `tools/mcp_tools.py` — MCP server delegation
+  - `tools/heartbeat_tools.py` — Mattermost HTTP posting
+
+---
+
+## 2. JS Store Boundary Violation
+
+### 2.1 ToolStatusStore directly mutates MessageStore's array
+- **File:** `src/decafclaw/web/static/lib/tool-status-store.js`
+- **Problem:** Lines 85, 111, 113, 159 — `currentMessages.push()` and `currentMessages.splice()` directly mutate an array owned by MessageStore.
+- **Fix:** Replace direct mutation with a callback. ToolStatusStore constructor should accept an `onAddMessage(msg)` and `onInsertMessage(msg, beforeRole)` callback that MessageStore provides. MessageStore owns all mutations of its array.
+
+---
+
+## 3. Duplicate Store Listener Registration (Memory Leak)
+
+### 3.1 chat-view.js adds store listener twice
+- **File:** `src/decafclaw/web/static/components/chat-view.js`
+- **Problem:** Store listener added in `connectedCallback` AND again in `updated()` when store property changes. Old listener not removed.
+- **Fix:** Only register listener in `connectedCallback` / remove in `disconnectedCallback`. Remove the listener setup from `updated()`, or properly remove-then-add when store changes.
+
+### 3.2 conversation-sidebar.js same pattern
+- **File:** `src/decafclaw/web/static/components/conversation-sidebar.js`
+- **Problem:** Same duplicate listener pattern as chat-view.
+- **Fix:** Same approach — register only in lifecycle callbacks.
+
+---
+
+## 4. Dead Code Cleanup
+
+### 4.1 Empty event listener in app.js
+- **File:** `src/decafclaw/web/static/app.js`
+- **Problem:** `store.addEventListener('change', () => {})` — empty handler, serves no purpose.
+- **Fix:** Remove it.
+
+---
+
+## 5. Type Hints on Context Sub-Objects
+
+### 5.1 ToolState/SkillState/TokenUsage fields need parameterized types
+- **File:** `src/decafclaw/context.py`
+- **Current:**
+  ```python
+  extra: dict = field(default_factory=dict)
+  extra_definitions: list = field(default_factory=list)
+  deferred_pool: list = field(default_factory=list)
+  activated: set = field(default_factory=set)
+  data: dict = field(default_factory=dict)
+  ```
+- **Fix:**
+  ```python
+  extra: dict[str, Any] = field(default_factory=dict)
+  extra_definitions: list[dict] = field(default_factory=list)
+  deferred_pool: list[dict] = field(default_factory=list)
+  activated: set[str] = field(default_factory=set)
+  data: dict[str, Any] = field(default_factory=dict)
+  ```
+
+---
+
+## Proposed Phases
+
+### Phase 1: Quick Fixes (low risk)
+- [ ] Type hints on context sub-objects (5.1)
+- [ ] Dead code: remove empty listener in app.js (4.1)
+- [ ] Fix duplicate store listeners in chat-view.js (3.1)
+- [ ] Fix duplicate store listeners in conversation-sidebar.js (3.2)
+
+### Phase 2: JS Store Boundary Fix (medium risk)
+- [ ] Refactor ToolStatusStore to use callbacks instead of direct array mutation (2.1)
+
+### Phase 3: Test Coverage (low risk, high value)
+- [ ] Tests for `polling.py` (1.1)
+- [ ] Tests for `util.py` (1.2)
+- [ ] Tests for `archive.py:restore_history()` (1.3)
+- [ ] Tests for `mattermost_display.py` (1.4)
+- [ ] Tests for priority tool functions (1.5)

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -19,11 +19,11 @@ class TokenUsage:
 @dataclass
 class ToolState:
     """Tool-related state for the current conversation."""
-    extra: dict = field(default_factory=dict)
-    extra_definitions: list = field(default_factory=list)
-    deferred_pool: list = field(default_factory=list)
-    allowed: set | None = None
-    preapproved: set = field(default_factory=set)
+    extra: dict[str, Any] = field(default_factory=dict)
+    extra_definitions: list[dict] = field(default_factory=list)
+    deferred_pool: list[dict] = field(default_factory=list)
+    allowed: set[str] | None = None
+    preapproved: set[str] = field(default_factory=set)
     preapproved_shell_patterns: list[str] = field(default_factory=list)
     current_call_id: str = ""
 
@@ -31,8 +31,8 @@ class ToolState:
 @dataclass
 class SkillState:
     """Skill activation state for the current conversation."""
-    activated: set = field(default_factory=set)
-    data: dict = field(default_factory=dict)
+    activated: set[str] = field(default_factory=set)
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 class Context:

--- a/src/decafclaw/polling.py
+++ b/src/decafclaw/polling.py
@@ -7,7 +7,7 @@ log = logging.getLogger(__name__)
 
 
 async def run_polling_loop(
-    interval: int,
+    interval: int | float,
     shutdown_event,
     on_tick,
     label: str = "poll",

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -262,7 +262,6 @@ sidebarBackdrop?.addEventListener('click', () => {
 });
 
 // Keep backdrop in sync with sidebar mobile state
-store.addEventListener('change', () => {});  // ensure sidebar re-renders
 if (sidebar) {
   const observer = new MutationObserver(() => {
     const isOpen = sidebar.hasAttribute('mobile-open');

--- a/src/decafclaw/web/static/components/chat-view.js
+++ b/src/decafclaw/web/static/components/chat-view.js
@@ -81,7 +81,6 @@ export class ChatView extends LitElement {
         this._showScrollBtn = true;
       }
     };
-    this.store?.addEventListener('change', this._onStoreChange);
     // Track scroll position + auto-load older messages
     this.addEventListener('scroll', () => {
       this._showScrollBtn = !this.#isNearBottom();
@@ -97,9 +96,13 @@ export class ChatView extends LitElement {
   }
 
   updated(changedProps) {
-    if (changedProps.has('store') && this.store) {
-      this.store.addEventListener('change', this._onStoreChange);
-      this._onStoreChange();
+    if (changedProps.has('store')) {
+      const oldStore = changedProps.get('store');
+      if (oldStore) oldStore.removeEventListener('change', this._onStoreChange);
+      if (this.store) {
+        this.store.addEventListener('change', this._onStoreChange);
+        this._onStoreChange();
+      }
     }
   }
 

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -65,7 +65,6 @@ export class ConversationSidebar extends LitElement {
       this._effortModel = this.store?.effortModel || '';
       this._systemConversations = this.store?.systemConversations || [];
     };
-    this.store?.addEventListener('change', this._onStoreChange);
   }
 
   disconnectedCallback() {
@@ -75,9 +74,13 @@ export class ConversationSidebar extends LitElement {
 
   /** @param {Map} changedProps */
   updated(changedProps) {
-    if (changedProps.has('store') && this.store) {
-      this.store.addEventListener('change', this._onStoreChange);
-      this._onStoreChange();
+    if (changedProps.has('store')) {
+      const oldStore = changedProps.get('store');
+      if (oldStore) oldStore.removeEventListener('change', this._onStoreChange);
+      if (this.store) {
+        this.store.addEventListener('change', this._onStoreChange);
+        this._onStoreChange();
+      }
     }
     this.toggleAttribute('collapsed', this._collapsed);
     this.toggleAttribute('mobile-open', this._mobileOpen);

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -81,7 +81,7 @@ export class ConversationStore extends EventTarget {
     this.#ws = wsClient;
     const onChange = () => this.#emitChange();
     this.#messageStore = new MessageStore(onChange);
-    this.#toolStatusStore = new ToolStatusStore(onChange, wsClient);
+    this.#toolStatusStore = new ToolStatusStore(onChange, wsClient, this.#messageStore);
     this.#ws.addEventListener('message', (e) => this.#handleMessage(/** @type {CustomEvent} */(e).detail));
     this.#ws.addEventListener('open', () => this.listConversations());
   }
@@ -283,7 +283,7 @@ export class ConversationStore extends EventTarget {
       return;
     }
 
-    if (this.#toolStatusStore.handleMessage(msg, this.#currentConvId, this.#messageStore.currentMessages)) {
+    if (this.#toolStatusStore.handleMessage(msg, this.#currentConvId)) {
       this.#emitChange();
       return;
     }

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -43,6 +43,35 @@ export class MessageStore {
     this.#currentMessages.push(msg);
   }
 
+  /** Update the content of the last tool_call message (for status updates). */
+  updateLastToolCall(/** @type {string} */ content) {
+    const last = this.#currentMessages[this.#currentMessages.length - 1];
+    if (last?.role === 'tool_call') {
+      last.content = content;
+    }
+  }
+
+  /** Replace the last tool_call message with a completed tool result. */
+  replaceLastToolCall(/** @type {ChatMessage} */ msg) {
+    const idx = this.#currentMessages.findLastIndex(m => m.role === 'tool_call');
+    if (idx >= 0) {
+      this.#currentMessages[idx] = msg;
+    }
+  }
+
+  /** Insert a message before the last user message (for memory context). */
+  insertBeforeLastUser(/** @type {ChatMessage} */ msg) {
+    let lastUserIdx = -1;
+    for (let i = this.#currentMessages.length - 1; i >= 0; i--) {
+      if (this.#currentMessages[i].role === 'user') { lastUserIdx = i; break; }
+    }
+    if (lastUserIdx >= 0) {
+      this.#currentMessages.splice(lastUserIdx, 0, msg);
+    } else {
+      this.#currentMessages.push(msg);
+    }
+  }
+
   clearStreamingText() {
     this.#streamingText = '';
   }

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -2,6 +2,7 @@
  * @typedef {import('./conversation-store.js').ChatMessage} ChatMessage
  * @typedef {import('./conversation-store.js').PendingConfirm} PendingConfirm
  * @typedef {import('./websocket-client.js').WebSocketClient} WebSocketClient
+ * @typedef {import('./message-store.js').MessageStore} MessageStore
  */
 
 /**
@@ -16,14 +17,18 @@ export class ToolStatusStore {
   #onChange;
   /** @type {WebSocketClient} */
   #ws;
+  /** @type {MessageStore} */
+  #messageStore;
 
   /**
    * @param {() => void} onChange
    * @param {WebSocketClient} ws
+   * @param {MessageStore} messageStore
    */
-  constructor(onChange, ws) {
+  constructor(onChange, ws, messageStore) {
     this.#onChange = onChange;
     this.#ws = ws;
+    this.#messageStore = messageStore;
   }
 
   // -- Getters ----------------------------------------------------------------
@@ -74,15 +79,14 @@ export class ToolStatusStore {
    * Handle a WebSocket message if it's tool-related.
    * @param {object} msg
    * @param {string|null} currentConvId
-   * @param {ChatMessage[]} currentMessages - direct reference to message array for in-place updates
    * @returns {boolean} true if handled
    */
-  handleMessage(msg, currentConvId, currentMessages) {
+  handleMessage(msg, currentConvId) {
     switch (msg.type) {
       case 'tool_start':
         this.#toolStatus = `Running ${msg.tool}...`;
         if (msg.conv_id === currentConvId) {
-          currentMessages.push({
+          this.#messageStore.pushMessage({
             role: 'tool_call',
             content: `Running ${msg.tool}...`,
             tool: msg.tool,
@@ -94,30 +98,14 @@ export class ToolStatusStore {
       case 'tool_status':
         this.#toolStatus = `${msg.tool}: ${msg.message}`;
         if (msg.conv_id === currentConvId) {
-          // memory_context arrives without a preceding tool_start — insert before user message
           if (msg.tool === 'memory_context') {
-            /** @type {ChatMessage} */
-            const mcMsg = {
+            this.#messageStore.insertBeforeLastUser({
               role: 'memory_context',
               content: msg.message,
               timestamp: new Date().toISOString(),
-            };
-            // Insert before the last user message (memory context precedes the user's turn)
-            let lastUserIdx = -1;
-            for (let i = currentMessages.length - 1; i >= 0; i--) {
-              if (currentMessages[i].role === 'user') { lastUserIdx = i; break; }
-            }
-            if (lastUserIdx >= 0) {
-              currentMessages.splice(lastUserIdx, 0, mcMsg);
-            } else {
-              currentMessages.push(mcMsg);
-            }
+            });
           } else {
-            // Update the last tool_call message if it exists
-            const last = currentMessages[currentMessages.length - 1];
-            if (last?.role === 'tool_call') {
-              last.content = `${msg.tool}: ${msg.message}`;
-            }
+            this.#messageStore.updateLastToolCall(`${msg.tool}: ${msg.message}`);
           }
         }
         return true;
@@ -125,16 +113,13 @@ export class ToolStatusStore {
       case 'tool_end':
         this.#toolStatus = null;
         if (msg.conv_id === currentConvId) {
-          const idx = currentMessages.findLastIndex(m => m.role === 'tool_call');
-          if (idx >= 0) {
-            currentMessages[idx] = {
-              role: 'tool',
-              content: msg.result_text || '',
-              tool: msg.tool,
-              display_short_text: msg.display_short_text || '',
-              timestamp: new Date().toISOString(),
-            };
-          }
+          this.#messageStore.replaceLastToolCall({
+            role: 'tool',
+            content: msg.result_text || '',
+            tool: msg.tool,
+            display_short_text: msg.display_short_text || '',
+            timestamp: new Date().toISOString(),
+          });
         }
         return true;
 
@@ -156,7 +141,7 @@ export class ToolStatusStore {
           const raw = msg.raw_response || '';
           const retryNum = msg.retry_number || 0;
           const detail = raw || critique || (passed ? 'Response passed evaluation' : 'No details');
-          currentMessages.push({
+          this.#messageStore.pushMessage({
             role: 'reflection',
             tool: passed ? 'reflection: PASS' : `reflection: retry ${retryNum}`,
             content: detail,

--- a/tests/test_core_tools.py
+++ b/tests/test_core_tools.py
@@ -5,14 +5,14 @@ from datetime import datetime
 from decafclaw.tools.core import tool_current_time, tool_think
 
 
-def test_tool_think_returns_input(ctx):
-    """tool_think returns 'OK' (content is logged but not echoed)."""
+def test_tool_think_returns_ok(ctx):
+    """tool_think returns the constant string 'OK' (content is logged but not echoed)."""
     result = tool_think(ctx, content="hello")
     assert result == "OK"
 
 
-def test_tool_current_time_returns_iso(ctx):
-    """tool_current_time returns a string containing a parseable date."""
+def test_tool_current_time_returns_parseable_datetime(ctx):
+    """tool_current_time returns a parseable datetime string."""
     result = tool_current_time(ctx)
     # Format is "YYYY-MM-DD HH:MM:SS (Weekday)" — extract the datetime part
     date_part = result.split("(")[0].strip()
@@ -20,8 +20,8 @@ def test_tool_current_time_returns_iso(ctx):
     assert parsed.year >= 2024
 
 
-def test_tool_current_time_includes_timezone(ctx):
-    """The output includes day-of-week info (the parenthetical weekday name)."""
+def test_tool_current_time_includes_weekday(ctx):
+    """The output includes a parenthetical weekday name."""
     result = tool_current_time(ctx)
     # The format includes a weekday name in parens, e.g. "(Saturday)"
     assert "(" in result and ")" in result

--- a/tests/test_core_tools.py
+++ b/tests/test_core_tools.py
@@ -1,0 +1,31 @@
+"""Tests for core tools — think, current_time."""
+
+from datetime import datetime
+
+from decafclaw.tools.core import tool_current_time, tool_think
+
+
+def test_tool_think_returns_input(ctx):
+    """tool_think returns 'OK' (content is logged but not echoed)."""
+    result = tool_think(ctx, content="hello")
+    assert result == "OK"
+
+
+def test_tool_current_time_returns_iso(ctx):
+    """tool_current_time returns a string containing a parseable date."""
+    result = tool_current_time(ctx)
+    # Format is "YYYY-MM-DD HH:MM:SS (Weekday)" — extract the datetime part
+    date_part = result.split("(")[0].strip()
+    parsed = datetime.strptime(date_part, "%Y-%m-%d %H:%M:%S")
+    assert parsed.year >= 2024
+
+
+def test_tool_current_time_includes_timezone(ctx):
+    """The output includes day-of-week info (the parenthetical weekday name)."""
+    result = tool_current_time(ctx)
+    # The format includes a weekday name in parens, e.g. "(Saturday)"
+    assert "(" in result and ")" in result
+    # Extract the weekday and verify it's a real day name
+    weekday = result.split("(")[1].rstrip(")")
+    valid_days = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+    assert weekday in valid_days

--- a/tests/test_mattermost_display.py
+++ b/tests/test_mattermost_display.py
@@ -1,0 +1,204 @@
+"""Tests for ConversationDisplay message sequencing."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from decafclaw.mattermost_display import (
+    THINKING_INDICATOR,
+    THINKING_SUFFIX,
+    ConversationDisplay,
+)
+
+
+def make_mock_client():
+    client = AsyncMock()
+    client.send = AsyncMock(return_value="post-id-1")
+    client.edit_message = AsyncMock()
+    client.delete_message = AsyncMock()
+    client.send_typing = AsyncMock()
+    return client
+
+
+def make_display(client, initial_post_id=None):
+    return ConversationDisplay(
+        client=client,
+        channel_id="ch1",
+        root_id="root1",
+        throttle_ms=0,
+        initial_post_id=initial_post_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_llm_start_edits_placeholder():
+    """When initial_post_id is set, first on_llm_start keeps it as thinking placeholder."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+
+    await display.on_llm_start(iteration=1)
+
+    # First iteration reuses the initial post — no send or edit yet
+    assert display._current_post_id == "placeholder-id"
+    assert display._current_type == "thinking"
+    client.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_llm_start_no_placeholder_sends_new():
+    """When no initial_post_id and iteration > 1, sends a new thinking post."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id=None)
+
+    # Simulate iteration 2 (after tool calls)
+    await display.on_llm_start(iteration=2)
+
+    client.send.assert_awaited_once_with(
+        "ch1", THINKING_INDICATOR, root_id="root1", attachments=None,
+    )
+    assert display._current_post_id == "post-id-1"
+    assert display._current_type == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_on_text_complete_sends_text():
+    """on_text_complete sends text as a new message when no current post."""
+    client = make_mock_client()
+    display = make_display(client)
+
+    await display.on_text_complete("Hello world")
+
+    client.send.assert_awaited_once_with(
+        "ch1", "Hello world", root_id="root1", attachments=None,
+    )
+    assert display._text_buffer == "Hello world"
+    assert display._text_has_content is True
+
+
+@pytest.mark.asyncio
+async def test_on_text_complete_edits_thinking_placeholder():
+    """on_text_complete edits existing thinking placeholder instead of sending new."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+    await display.on_llm_start(iteration=1)
+
+    await display.on_text_complete("Hello world")
+
+    client.edit_message.assert_awaited_with("placeholder-id", "Hello world")
+    client.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_tool_start_sends_tool_message():
+    """on_tool_start sends a tool indicator message."""
+    client = make_mock_client()
+    display = make_display(client)
+
+    await display.on_tool_start("web_search", {"query": "test"}, tool_call_id="tc1")
+
+    client.send.assert_awaited_once_with(
+        "ch1", "\U0001f527 web_search...", root_id="root1",
+        attachments=None,
+    )
+    assert "tc1" in display._tool_posts
+
+
+@pytest.mark.asyncio
+async def test_on_tool_start_reuses_thinking_placeholder():
+    """First tool_start reuses the thinking placeholder instead of sending new."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+    await display.on_llm_start(iteration=1)
+
+    await display.on_tool_start("web_search", {}, tool_call_id="tc1")
+
+    # Should edit the placeholder, not send a new message
+    client.edit_message.assert_awaited_with(
+        "placeholder-id", "\U0001f527 web_search...",
+    )
+    assert display._tool_posts["tc1"] == "placeholder-id"
+    client.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_tool_end_edits_tool_message():
+    """After tool_start, on_tool_end edits the tool message with a checkmark."""
+    client = make_mock_client()
+    display = make_display(client)
+
+    await display.on_tool_start("web_search", {"q": "test"}, tool_call_id="tc1")
+    client.edit_message.reset_mock()
+
+    await display.on_tool_end(
+        "web_search", "result text", display_text=None, media=[],
+        tool_call_id="tc1",
+    )
+
+    client.edit_message.assert_awaited_once_with(
+        "post-id-1", "\U0001f527 web_search \u2714\ufe0f",
+        props={"attachments": []},
+    )
+    assert "tc1" not in display._tool_posts
+
+
+@pytest.mark.asyncio
+async def test_on_tool_end_uses_display_text():
+    """on_tool_end uses display_text when provided."""
+    client = make_mock_client()
+    display = make_display(client)
+
+    await display.on_tool_start("web_search", {}, tool_call_id="tc1")
+    client.edit_message.reset_mock()
+
+    await display.on_tool_end(
+        "web_search", "raw result", display_text="Custom display", media=[],
+        tool_call_id="tc1",
+    )
+
+    client.edit_message.assert_awaited_once_with(
+        "post-id-1", "Custom display", props={"attachments": []},
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_deletes_empty_placeholder():
+    """If only a thinking placeholder exists with no real content, finalize deletes it."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+    await display.on_llm_start(iteration=1)
+
+    await display.finalize()
+
+    client.delete_message.assert_awaited_once_with("placeholder-id")
+
+
+@pytest.mark.asyncio
+async def test_finalize_strips_thinking_suffix():
+    """If text was posted with thinking suffix, finalize strips it."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+    await display.on_llm_start(iteration=1)
+
+    # Simulate streaming text (adds THINKING_SUFFIX via throttled edit)
+    await display.on_text_chunk("Hello ")
+    await display.on_text_chunk("world")
+    client.edit_message.reset_mock()
+
+    await display.finalize()
+
+    # Final edit should have clean text without thinking suffix
+    client.edit_message.assert_awaited_with("placeholder-id", "Hello world")
+
+
+@pytest.mark.asyncio
+async def test_finalize_is_idempotent():
+    """Calling finalize twice does not double-delete or double-edit."""
+    client = make_mock_client()
+    display = make_display(client, initial_post_id="placeholder-id")
+    await display.on_llm_start(iteration=1)
+
+    await display.finalize()
+    client.delete_message.reset_mock()
+
+    await display.finalize()
+    client.delete_message.assert_not_called()

--- a/tests/test_memory_tools.py
+++ b/tests/test_memory_tools.py
@@ -1,0 +1,40 @@
+"""Tests for memory tools — save and recent recall."""
+
+import pytest
+
+from decafclaw.memory import memory_dir
+from decafclaw.tools.memory_tools import tool_memory_recent, tool_memory_save
+
+
+@pytest.mark.asyncio
+async def test_memory_save_creates_file(ctx):
+    """Saving a memory creates a file in the workspace memories directory."""
+    # Default search_strategy is "substring", so no embedding indexing occurs.
+    result = await tool_memory_save(
+        ctx,
+        tags=["test", "unit"],
+        content="This is a test memory.",
+    )
+
+    assert "Saved memory" in result
+    assert "test, unit" in result
+
+    # Verify the file was created on disk
+    mem_base = memory_dir(ctx.config)
+    md_files = list(mem_base.rglob("*.md"))
+    assert len(md_files) == 1
+    contents = md_files[0].read_text()
+    assert "This is a test memory." in contents
+
+
+@pytest.mark.asyncio
+async def test_memory_recent_returns_entries(ctx):
+    """After saving, tool_memory_recent returns the saved entry."""
+    await tool_memory_save(
+        ctx,
+        tags=["recall"],
+        content="Remember this fact.",
+    )
+
+    result = tool_memory_recent(ctx, n=5)
+    assert "Remember this fact." in result

--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,0 +1,59 @@
+"""Tests for decafclaw.polling."""
+
+import asyncio
+
+import pytest
+
+from decafclaw.polling import build_task_preamble, run_polling_loop
+
+
+def test_build_task_preamble_heartbeat():
+    result = build_task_preamble("heartbeat check")
+    assert "heartbeat check" in result
+    assert "HEARTBEAT_OK" in result
+
+
+def test_build_task_preamble_with_task_name():
+    result = build_task_preamble("scheduled task", "my-task")
+    assert "my-task" in result
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_calls_tick():
+    shutdown = asyncio.Event()
+    calls = []
+
+    async def tick():
+        calls.append(1)
+        shutdown.set()
+
+    await run_polling_loop(0.01, shutdown, tick, label="test")
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_survives_tick_error():
+    shutdown = asyncio.Event()
+    calls = []
+
+    async def bad_tick():
+        calls.append(1)
+        if len(calls) == 1:
+            raise ValueError("boom")
+        shutdown.set()
+
+    await run_polling_loop(0.01, shutdown, bad_tick, label="test")
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_exits_immediately_if_shutdown_set():
+    shutdown = asyncio.Event()
+    shutdown.set()
+    calls = []
+
+    async def tick():
+        calls.append(1)
+
+    await run_polling_loop(0.01, shutdown, tick, label="test")
+    assert len(calls) == 0

--- a/tests/test_restore_history.py
+++ b/tests/test_restore_history.py
@@ -1,0 +1,86 @@
+"""Tests for archive.restore_history and its helpers."""
+
+import json
+
+from decafclaw.archive import restore_history
+
+CONV_ID = "test-conv-123"
+
+
+def _write_jsonl(path, messages):
+    """Write a list of dicts as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for msg in messages:
+            f.write(json.dumps(msg) + "\n")
+
+
+def _conv_dir(config):
+    return config.workspace_path / "conversations"
+
+
+def test_restore_history_no_archive(config):
+    """Returns None when no archive or compacted files exist."""
+    result = restore_history(config, CONV_ID)
+    assert result is None
+
+
+def test_restore_history_archive_only(config):
+    """Returns full archive messages when no compacted sidecar exists."""
+    messages = [
+        {"role": "user", "content": "hello", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "hi", "timestamp": "2026-01-01T00:00:01"},
+    ]
+    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", messages)
+
+    result = restore_history(config, CONV_ID)
+    assert result == messages
+
+
+def test_restore_history_compacted_only(config):
+    """Returns compacted history when sidecar exists, even if archive also exists."""
+    archive_msgs = [
+        {"role": "user", "content": "old msg", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "old reply", "timestamp": "2026-01-01T00:00:01"},
+    ]
+    compacted_msgs = [
+        {"role": "assistant", "content": "summary of conversation", "timestamp": "2026-01-01T00:00:01"},
+    ]
+    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", archive_msgs)
+    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.compacted.jsonl", compacted_msgs)
+
+    result = restore_history(config, CONV_ID)
+    # Should return only the compacted messages (no newer archive entries)
+    assert result == compacted_msgs
+
+
+def test_restore_history_compacted_plus_newer(config):
+    """Returns compacted messages plus archive entries newer than the last compacted timestamp."""
+    compacted_msgs = [
+        {"role": "assistant", "content": "summary", "timestamp": "2026-01-01T00:00:05"},
+    ]
+    archive_msgs = [
+        {"role": "user", "content": "old msg", "timestamp": "2026-01-01T00:00:00"},
+        {"role": "assistant", "content": "old reply", "timestamp": "2026-01-01T00:00:03"},
+        {"role": "user", "content": "new msg", "timestamp": "2026-01-01T00:00:06"},
+        {"role": "assistant", "content": "new reply", "timestamp": "2026-01-01T00:00:07"},
+    ]
+    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", archive_msgs)
+    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.compacted.jsonl", compacted_msgs)
+
+    result = restore_history(config, CONV_ID)
+    assert result == [
+        {"role": "assistant", "content": "summary", "timestamp": "2026-01-01T00:00:05"},
+        {"role": "user", "content": "new msg", "timestamp": "2026-01-01T00:00:06"},
+        {"role": "assistant", "content": "new reply", "timestamp": "2026-01-01T00:00:07"},
+    ]
+
+
+def test_restore_history_empty_archive(config):
+    """Returns None when archive file exists but is empty."""
+    path = _conv_dir(config) / f"{CONV_ID}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+
+    result = restore_history(config, CONV_ID)
+    assert result is None

--- a/tests/test_todo_tools.py
+++ b/tests/test_todo_tools.py
@@ -1,0 +1,45 @@
+"""Tests for to-do list tools."""
+
+from decafclaw.tools.todo_tools import (
+    tool_todo_add,
+    tool_todo_clear,
+    tool_todo_complete,
+    tool_todo_list,
+)
+
+
+def test_todo_add_creates_item(ctx):
+    """Adding an item reports success and shows up in the list."""
+    result = tool_todo_add(ctx, item="Buy milk")
+    assert "Buy milk" in result
+    assert "1 total" in result
+
+
+def test_todo_complete_checks_item(ctx):
+    """Marking an item complete changes its status."""
+    tool_todo_add(ctx, item="Write tests")
+    result = tool_todo_complete(ctx, index=1)
+    assert "Completed" in result
+    assert "Write tests" in result
+    # Verify it shows as checked in the list
+    listing = tool_todo_list(ctx)
+    assert "[x]" in listing
+
+
+def test_todo_list_shows_items(ctx):
+    """Listing items returns correct format with numbering and checkboxes."""
+    tool_todo_add(ctx, item="First task")
+    tool_todo_add(ctx, item="Second task")
+    listing = tool_todo_list(ctx)
+    assert "1. [ ] First task" in listing
+    assert "2. [ ] Second task" in listing
+    assert "0/2 complete" in listing
+
+
+def test_todo_remove_deletes_item(ctx):
+    """Clearing the list removes all items."""
+    tool_todo_add(ctx, item="Temporary task")
+    result = tool_todo_clear(ctx)
+    assert "cleared" in result.lower()
+    listing = tool_todo_list(ctx)
+    assert "No to-do items" in listing

--- a/tests/test_todo_tools.py
+++ b/tests/test_todo_tools.py
@@ -36,8 +36,8 @@ def test_todo_list_shows_items(ctx):
     assert "0/2 complete" in listing
 
 
-def test_todo_remove_deletes_item(ctx):
-    """Clearing the list removes all items."""
+def test_todo_clear_removes_all(ctx):
+    """tool_todo_clear removes all items from the list."""
     tool_todo_add(ctx, item="Temporary task")
     result = tool_todo_clear(ctx)
     assert "cleared" in result.lower()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,19 @@
+"""Tests for decafclaw.util."""
+
+from decafclaw.util import estimate_tokens
+
+
+def test_empty_string_returns_zero():
+    assert estimate_tokens("") == 0
+
+
+def test_short_string():
+    assert estimate_tokens("abcd") == 1
+
+
+def test_longer_string():
+    assert estimate_tokens("a" * 100) == 25
+
+
+def test_whitespace_is_counted():
+    assert estimate_tokens("    ") == 1


### PR DESCRIPTION
## Summary

Follow-up to #161. Addresses findings from a second-pass code review:

- **Fix JS store boundary violation** — ToolStatusStore was directly mutating MessageStore's `currentMessages` array via `push()`/`splice()`. Now uses proper MessageStore API methods (`pushMessage`, `updateLastToolCall`, `replaceLastToolCall`, `insertBeforeLastUser`)
- **Fix duplicate store listener registration** — `chat-view.js` and `conversation-sidebar.js` were adding store listeners in both `connectedCallback` and `updated()` without removing old ones. Now only registered via `updated()` with proper old-listener cleanup
- **Remove dead code** — empty `store.addEventListener('change', () => {})` in `app.js`
- **Add parameterized type hints** to `ToolState`, `SkillState` dataclass fields in `context.py`
- **34 new tests** across 7 files: `polling.py`, `util.py`, `restore_history()`, `ConversationDisplay`, `tool_think`, `tool_current_time`, todo tools, memory tools

**833 → 867 tests passing, 0 errors, 0 warnings.**

## Test plan

- [x] `make check` — 0 errors, 0 warnings
- [x] `make test` — 867 passed
- [ ] Manual test web UI (verify store listeners don't double-fire, tool status updates render correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)