### PR TITLE
feat: wiki page context injection for chat

### DIFF
--- a/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/notes.md
+++ b/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/notes.md
@@ -1,0 +1,34 @@
+# Wiki Chat Context — Notes
+
+## Implementation Summary
+
+All 6 steps complete. Two commits on `feat/wiki-chat-context`:
+
+1. `0bb6c57` — feat: wiki page context injection (core implementation)
+2. `9a60e92` — test: add wiki context injection tests (15 tests)
+
+### Files Changed
+
+- `src/decafclaw/context.py` — added `wiki_page` field
+- `src/decafclaw/agent.py` — `_resolve_wiki_references()`, `_get_already_injected_pages()`, injection in `_prepare_messages()`, `wiki_context` in `ROLE_REMAP`
+- `src/decafclaw/web/static/app.js` — `window.getOpenWikiPage()` function
+- `src/decafclaw/web/static/lib/conversation-store.js` — sends `wiki_page` in WebSocket `send` messages
+- `src/decafclaw/web/websocket.py` — threads `wiki_page` through handler → agent, forwards `wiki_context` events
+- `src/decafclaw/prompts/AGENT.md` — wiki context annotation docs for agent
+- `tests/test_wiki_context.py` — 15 tests
+
+### Design Decisions
+
+- `@[[PageName]]` parsing is in `agent.py` (channel-agnostic) — works in web, Mattermost, terminal
+- Open wiki page (`ctx.wiki_page`) is web-only, set by WebSocket handler
+- Already-injected tracking uses history scan (no separate state) — survives restarts, works with compaction (re-injects after compaction, which is desirable since content was lost)
+- `wiki_context` role messages carry a `wiki_page` metadata field for reliable page name extraction
+
+### Manual Testing Checklist
+
+- [ ] Web: Open wiki page, send message → page content appears as context
+- [ ] Web: Send another message with same page open → no re-injection
+- [ ] Web: Navigate to different page, send message → new page injected
+- [ ] Any channel: Type `@[[PageName]]` → page content injected
+- [ ] Any channel: Type `@[[NonExistent]]` → error note injected
+- [ ] Web: Refresh browser, send message with same page → no re-injection

--- a/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/plan.md
+++ b/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/plan.md
@@ -1,0 +1,154 @@
+# Wiki Chat Context — Plan
+
+GitHub Issue: #168
+
+## Architecture Overview
+
+The feature adds wiki page content injection into chat conversations via two mechanisms:
+
+1. **Auto-context**: Web client sends `wiki_page` field with `send` messages when a wiki page is open. Passed to agent via `ctx.wiki_page`.
+2. **@[[PageName]]**: Agent parses `@[[...]]` patterns from user message text — works across all channels (web, Mattermost, terminal).
+
+Both are handled in `agent.py` `_prepare_messages()`, sharing the same injection mechanism. Already-injected pages are detected by scanning conversation history for existing `wiki_context` role messages — no separate tracking state needed.
+
+### Data Flow
+
+```
+Any channel sends user message
+         ↓
+agent.py: _prepare_messages()
+  1. Parse @[[...]] from user message text
+  2. Check ctx.wiki_page for open page (web only)
+  3. Scan history for existing wiki_context messages → already-injected set
+  4. Filter out already-injected pages
+  5. Resolve remaining pages via _resolve_page()
+  6. Inject wiki_context role messages into history
+  7. Publish wiki_context events for UI display
+         ↓
+ROLE_REMAP: wiki_context → "user" for LLM
+```
+
+---
+
+## Step 1: Wiki context injection in agent.py
+
+**Goal**: Add `@[[PageName]]` parsing and wiki context injection to `_prepare_messages()`, following the `memory_context` pattern. This is the core feature and works across all channels.
+
+### Prompt
+
+In `src/decafclaw/agent.py`, add wiki page context injection to `_prepare_messages()`:
+
+1. Add a helper function `_resolve_wiki_references(config, user_message, wiki_page=None)`:
+   - Parse `@[[...]]` patterns from `user_message` using regex `r'@\[\[([^\]]+)\]\]'`.
+   - Collect page names from matches. If `wiki_page` is provided and not already in the list, add it.
+   - For each unique page name, call `_resolve_page(config, page)` from `decafclaw.skills.wiki.tools` to resolve the path, then read the file content.
+   - Return a list of dicts: `{"page": name, "content": content_or_None, "source": "mention"|"open_page"}`.
+
+2. Add a helper function `_get_already_injected_pages(history)`:
+   - Scan `history` for messages with `role: "wiki_context"`.
+   - Extract page names from these messages (parse from the formatted text or store in a `wiki_page` field on the message dict).
+   - Return a `set` of page names.
+
+3. In `_prepare_messages()`, before the memory context block (around line 690):
+   - Call `_resolve_wiki_references(config, user_message, ctx.wiki_page)` if the wiki skill is available (check that wiki dir exists).
+   - Call `_get_already_injected_pages(history)` to get the set of already-injected pages.
+   - Filter out pages that are already injected.
+   - For each remaining page, create a message with `role: "wiki_context"` and a `wiki_page` metadata field:
+     - For `source: "open_page"`: format as `[Currently viewing wiki page: {page}]\n\n{content}`
+     - For `source: "mention"`: format as `[Referenced wiki page: {page}]\n\n{content}`
+     - For missing pages (content is None): format as `[Wiki page '{page}' not found]`
+   - Append each to `history` and archive it.
+   - Publish a `wiki_context` event for UI display.
+
+4. Add `"wiki_context"` to `ROLE_REMAP` dict so it gets remapped to `"user"` for the LLM.
+
+5. Add `wiki_page: str | None = None` field to `Context` in `src/decafclaw/context.py`.
+
+---
+
+## Step 2: Client sends wiki_page with messages
+
+**Goal**: The web UI includes the currently open wiki page name in chat messages. Other channels don't need changes — `@[[PageName]]` works automatically.
+
+### Prompt
+
+In the web UI frontend, include the open wiki page name when sending chat messages:
+
+1. In `src/decafclaw/web/static/app.js`:
+   - Add a `getOpenWikiPage()` function that returns the current wiki page name from the `?wiki=` URL param (or `null` if no wiki page is open). Export or attach to `window` so the conversation store can access it.
+
+2. In `src/decafclaw/web/static/lib/conversation-store.js`:
+   - In `sendMessage()`, call the function to get the open wiki page name.
+   - If a page is open, add `wiki_page: pageName` to the WebSocket `send` message object.
+   - Same for the pending-message flow (when creating a new conversation then sending).
+
+---
+
+## Step 3: Server passes wiki_page through to agent context
+
+**Goal**: The WebSocket handler reads `wiki_page` from the client message and sets it on the agent context.
+
+### Prompt
+
+In `src/decafclaw/web/websocket.py`:
+
+1. In `_handle_send()`, extract `wiki_page` from the incoming message: `wiki_page = msg.get("wiki_page")`.
+2. Pass `wiki_page` through `_start_agent_turn()` and `_run_agent_turn()` as a new parameter.
+3. In `_run_agent_turn()`, set `ctx.wiki_page = wiki_page` on the context before calling `run_agent_turn()`.
+
+---
+
+## Step 4: Forward wiki_context events to WebSocket
+
+**Goal**: Wiki context injection events appear in the web UI as status messages.
+
+### Prompt
+
+In `src/decafclaw/web/websocket.py`, in the `_run_agent_turn()` event forwarding:
+
+1. In the `_forward` function within `on_turn_event`, add handling for `wiki_context` events.
+2. Forward them as `tool_status` messages to the WebSocket: `{"type": "tool_status", "conv_id": conv_id, "tool": "wiki_context", "message": event["text"], "tool_call_id": ""}`.
+3. Follow the same pattern used for `memory_context` events (around line 549-557).
+
+---
+
+## Step 5: System prompt addition
+
+**Goal**: Add a brief note to the system prompt so the agent understands wiki context annotations.
+
+### Prompt
+
+Add wiki context documentation to the agent's system prompt:
+
+1. In `src/decafclaw/prompts/AGENT.md`, add a section explaining:
+   - Messages with role `wiki_context` contain wiki page content injected into the conversation.
+   - `[Currently viewing wiki page: PageName]` means the user has that page open in the UI.
+   - `[Referenced wiki page: PageName]` means the user used `@[[PageName]]` syntax.
+   - `[Wiki page 'PageName' not found]` means the referenced page doesn't exist.
+   - The agent can use wiki tools to edit pages or search for related content.
+   - Users can use `@[[PageName]]` from any channel (web, Mattermost, terminal).
+
+---
+
+## Step 6: Lint, test, and manual verification
+
+**Goal**: Ensure everything works end-to-end.
+
+### Prompt
+
+Verify the wiki chat context feature:
+
+1. Run `make check` (lint + typecheck for Python and JS).
+2. Run `make test` to ensure no regressions.
+3. Write tests for:
+   - `_resolve_wiki_references()` — given message text with `@[[PageName]]` patterns, returns correct page dicts.
+   - `_get_already_injected_pages()` — given history with wiki_context messages, returns correct set.
+   - Wiki context injection in `_prepare_messages()` — verify messages are added to history with correct formatting, and already-injected pages are skipped.
+4. Manual testing checklist (for Les):
+   - **Web**: Open a wiki page, send a message → page content appears as context
+   - **Web**: Send another message with same page open → no re-injection
+   - **Web**: Navigate to different page, send message → new page injected
+   - **Any channel**: Type `@[[PageName]]` in message → page content injected
+   - **Any channel**: Type `@[[NonExistent]]` → error note injected
+   - **Web**: Refresh browser, send message with same page → no re-injection (history-based tracking)
+   - **Mattermost**: Send message with `@[[PageName]]` → works without web UI

--- a/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/spec.md
+++ b/.claude/dev-sessions/2026-03-30-1040-wiki-chat-context/spec.md
@@ -1,0 +1,57 @@
+# Wiki Chat Context — Spec
+
+GitHub Issue: #168
+
+## Overview
+
+When a user is viewing a wiki page in the web UI side panel, or references a wiki page with `@[[PageName]]` syntax in their message, automatically inject that page's content into the conversation context so the agent can discuss it.
+
+## Feature 1: Auto-context from open wiki page
+
+When the user sends a chat message while a wiki page is open in the side panel, the page content is injected into the conversation as context.
+
+- The web UI includes an optional `wiki_page` field in the WebSocket `send` message, set to the currently open page name (or omitted if no page is open).
+- The server checks whether that page has already been injected for this conversation. If not, it injects the page content as a one-time context message.
+- If the user navigates to a different wiki page and sends another message, the new page is also injected (since it hasn't been seen before).
+- Pages that have already been injected are skipped — no repeated injection even if the page is still open.
+
+## Feature 2: @[[PageName]] inline references
+
+Users can reference wiki pages in their message text using `@[[PageName]]` syntax. The page content is injected as context, similar to the auto-context feature.
+
+- The `@[[PageName]]` text is left as-is in the user's message — the agent sees the literal reference.
+- The server parses `@[[...]]` patterns from the message text and resolves each page.
+- Page content is injected as a one-time context message, using the same tracking as auto-context (shared "already injected" set per conversation).
+- If a referenced page does not exist, an error note is injected: `[Wiki page 'PageName' not found]`.
+
+## Injection mechanism
+
+- **`@[[PageName]]` parsing happens in `agent.py`**, not in any channel-specific handler. This means it works across all channels: web, Mattermost, terminal.
+- Context messages use a role similar to `memory_context` — a separate message injected before the user's turn, remapped to "user" role for the LLM.
+- Tracking of which pages have been injected is determined by scanning conversation history for existing `wiki_context` role messages. No separate state dict needed — history is the source of truth.
+- No token budget or truncation for now — full page content is injected. Address if it becomes a problem.
+
+## System prompt
+
+A brief note is added to the system prompt explaining:
+- `@[[PageName]]` references mean the user is referencing a wiki page whose content has been provided.
+- `[Currently viewing wiki page: PageName]` means the user has that page open in the side panel.
+
+This helps the agent understand and respond to these annotations.
+
+## Channel-specific changes
+
+- **Web UI**: `conversation-store` includes `wiki_page` field in `send` messages when a wiki page is open. WebSocket handler passes it through to agent via `ctx`.
+- **Mattermost / Terminal**: No changes needed — `@[[PageName]]` parsing in the agent works automatically.
+- No autocomplete UI for `@[[...]]` in this iteration.
+
+## Agent changes (channel-agnostic)
+
+- `agent.py` `_prepare_messages()`: parse `@[[...]]` from user message text, resolve pages via wiki skill's `_resolve_page`, plus handle optional `wiki_page` from ctx.
+- Scan conversation history for existing `wiki_context` messages to determine already-injected pages.
+- Inject `wiki_context` role messages for new pages only.
+
+## Deferred
+
+- Autocomplete for `@[[...]]` (and workspace file references) — future issue.
+- Token budget / truncation for large pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Skill schedule frontmatter.** Skills can declare `schedule: "cron expression"` in SKILL.md to run as scheduled tasks. Only bundled and admin-level skills are honored (workspace skills cannot self-schedule). File-based schedules override skill schedules on name collision. Skills with both `schedule` and `user-invocable: true` serve as both scheduled tasks and on-demand commands.
 - **Self-reflection is fail-open.** The reflection judge evaluates responses before delivery, but errors (network, parse, etc.) always pass through the response as-is. Retries consume `max_tool_iterations` budget. Skipped for child agents, cancelled turns, and empty responses.
 - **Proactive memory context is fail-open.** Before each interactive turn, relevant memories/wiki are auto-injected as context. Errors silently return empty results. Skipped for heartbeat, scheduled tasks, and child agents (`skip_memory_context` flag on ctx). Requires an embedding model to be configured — silently disabled otherwise.
+- **Wiki chat context.** Users can share wiki pages into conversations via `@[[PageName]]` mentions (all channels) or by having a page open in the web UI sidebar. Pages are injected once per conversation as `wiki_context` role messages, tracked by scanning history. Parsing happens in `agent.py` `_prepare_messages()`, not in channel handlers.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 
 ## Keeping docs current

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -61,6 +61,19 @@ The agent follows these principles (encoded in the skill's system prompt):
 - **Split when large** — break big pages into sub-pages with a summary parent
 - **Update over duplicate** — edit existing pages rather than creating new ones
 
+## Chat Context Integration
+
+Users can share wiki pages directly into conversation context:
+
+- **Open page in UI**: When a wiki page is open in the web UI side panel and the user sends a message, the page content is automatically injected as context. The agent sees `[Currently viewing wiki page: PageName]` followed by the page content.
+- **@[[PageName]] mentions**: Users can reference wiki pages in their message text using `@[[PageName]]` syntax. This works across all channels (web, Mattermost, terminal). The agent sees `[Referenced wiki page: PageName]` followed by the page content.
+
+Each page is injected **once per conversation** — subsequent messages with the same page open or mentioned will not re-inject. This is tracked by scanning conversation history for existing `wiki_context` role messages.
+
+If a referenced page doesn't exist, the agent sees `[Wiki page 'PageName' not found]`.
+
+Wiki context messages use the `wiki_context` role internally, remapped to `user` for the LLM. They carry a `wiki_page` metadata field for tracking.
+
 ## Semantic Search
 
 Wiki pages are indexed in the embeddings database as `source_type: "wiki"`. They receive a 1.2x score boost over memory and conversation results, since curated knowledge is higher signal.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -657,6 +657,63 @@ async def _setup_turn_state(ctx, config, history) -> dict[str, str]:
     return effort_overrides
 
 
+# -- Wiki context helpers ------------------------------------------------------
+
+_WIKI_MENTION_RE = _re.compile(r'@\[\[([^\]]+)\]\]')
+
+
+def _parse_wiki_references(
+    user_message: str, wiki_page: str | None = None,
+) -> list[dict]:
+    """Parse @[[PageName]] mentions and optional open wiki page.
+
+    Returns a list of dicts: {"page": name, "source": "mention"|"open_page"}.
+    Does NOT resolve or read pages — caller filters against already-injected
+    pages first, then resolves only the ones needed.
+    """
+    seen: set[str] = set()
+    results: list[dict] = []
+
+    # Parse @[[...]] mentions from message text
+    for match in _WIKI_MENTION_RE.finditer(user_message):
+        page_name = match.group(1).strip()
+        if page_name and page_name not in seen:
+            seen.add(page_name)
+            results.append({"page": page_name, "source": "mention"})
+
+    # Add open wiki page from web UI (if not already mentioned)
+    if wiki_page and wiki_page not in seen:
+        results.append({"page": wiki_page, "source": "open_page"})
+
+    return results
+
+
+def _read_wiki_page(config, page_name: str) -> str | None:
+    """Resolve and read a wiki page. Returns content or None. Fail-open."""
+    from .skills.wiki.tools import resolve_page
+
+    resolved = resolve_page(config, page_name)
+    if not resolved:
+        return None
+    try:
+        return resolved.read_text()
+    except (OSError, UnicodeError):
+        log.warning("Failed to read wiki page %s at %s", page_name, resolved,
+                     exc_info=True)
+        return None
+
+
+def _get_already_injected_pages(history: list) -> set[str]:
+    """Scan history for wiki_context messages and return set of page names."""
+    pages: set[str] = set()
+    for msg in history:
+        if msg.get("role") == "wiki_context":
+            page = msg.get("wiki_page")
+            if page:
+                pages.add(page)
+    return pages
+
+
 async def _prepare_messages(
     ctx, config, user_message: str, history: list,
     archive_text: str = "",
@@ -687,6 +744,30 @@ async def _prepare_messages(
     if attachments:
         user_msg["attachments"] = attachments
 
+    # Wiki context — inject referenced/open wiki pages before user message
+    wiki_dir = config.workspace_path / "wiki"
+    wiki_refs = _parse_wiki_references(user_message, ctx.wiki_page) if wiki_dir.exists() else []
+    if wiki_refs:
+        already_injected = _get_already_injected_pages(history)
+        for ref in wiki_refs:
+            if ref["page"] in already_injected:
+                continue
+            content = _read_wiki_page(config, ref["page"])
+            if content is None:
+                text = f"[Wiki page '{ref['page']}' not found]"
+            elif ref["source"] == "open_page":
+                text = f"[Currently viewing wiki page: {ref['page']}]\n\n{content}"
+            else:
+                text = f"[Referenced wiki page: {ref['page']}]\n\n{content}"
+            wc_msg: dict = {
+                "role": "wiki_context",
+                "content": text,
+                "wiki_page": ref["page"],
+            }
+            history.append(wc_msg)
+            _archive(ctx, wc_msg)
+            await ctx.publish("wiki_context", text=text, page=ref["page"])
+
     # Proactive memory context — inject before user message
     retrieved_context_text = ""
     if not ctx.skip_memory_context:
@@ -715,7 +796,7 @@ async def _prepare_messages(
     # Build the messages array: system prompt + history
     # Filter out metadata roles (effort, reflection) that aren't valid LLM messages
     # Remap non-standard roles that should appear in LLM context
-    ROLE_REMAP = {"memory_context": "user"}
+    ROLE_REMAP = {"memory_context": "user", "wiki_context": "user"}
     from .archive import LLM_ROLES
     llm_history = []
     for m in history:

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -66,6 +66,7 @@ class Context:
         self.is_child: bool = False
         self.skip_reflection: bool = False
         self.skip_memory_context: bool = False
+        self.wiki_page: str | None = None  # open wiki page from web UI
         self.effort: str = "default"
 
     @classmethod
@@ -147,6 +148,7 @@ class Context:
         child.is_child = self.is_child
         child.skip_reflection = self.skip_reflection
         child.skip_memory_context = self.skip_memory_context
+        child.wiki_page = self.wiki_page
         child.effort = self.effort
         # Share tools + skills (concurrent tool calls read but don't mutate)
         child.tools = self.tools

--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -64,3 +64,12 @@ When reading files, workspace_read returns line numbers. Use start_line/end_line
 to read just the section you need — large files are automatically capped at 200
 lines with a prompt to use line ranges. The line numbers from workspace_read can
 be used directly with workspace_insert and workspace_replace_lines.
+
+Users can share wiki pages as conversation context in two ways:
+- Opening a wiki page in the UI side panel — you'll see a message prefixed with
+  `[Currently viewing wiki page: PageName]` followed by the page content.
+- Using `@[[PageName]]` in their message — you'll see a message prefixed with
+  `[Referenced wiki page: PageName]` followed by the page content.
+- If a referenced page doesn't exist, you'll see `[Wiki page 'PageName' not found]`.
+These pages are injected once per conversation. You can use wiki tools to edit
+or search for related pages as needed.

--- a/src/decafclaw/skills/wiki/tools.py
+++ b/src/decafclaw/skills/wiki/tools.py
@@ -15,7 +15,7 @@ def _wiki_dir(config) -> Path:
     return config.workspace_path / "wiki"
 
 
-def _resolve_page(config, page: str) -> Path | None:
+def resolve_page(config, page: str) -> Path | None:
     """Resolve a page name to a file path, searching subdirectories.
 
     Returns None if the page doesn't exist or the name is invalid.
@@ -51,7 +51,7 @@ def _safe_write_path(config, page: str) -> Path | None:
 async def tool_wiki_read(ctx, page: str) -> str | ToolResult:
     """Read a wiki page by name."""
     log.info(f"[tool:wiki_read] page={page}")
-    path = _resolve_page(ctx.config, page)
+    path = resolve_page(ctx.config, page)
     if path is None:
         return ToolResult(text=f"[error: wiki page '{page}' not found]")
     return ToolResult(text=path.read_text(), display_short_text=page)

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -132,6 +132,14 @@ function showWikiPage(page, { replace = false } = {}) {
   }
 }
 
+/** Get the currently open wiki page name, or null if none.
+ * @type {() => string | null} */
+// @ts-ignore — global function accessed from conversation-store.js
+window.getOpenWikiPage = function() {
+  const params = new URLSearchParams(location.search);
+  return params.get('wiki') || null;
+};
+
 /** Hide the wiki view. */
 function hideWikiView() {
   wikiMainEl?.classList.add('hidden');

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -50,6 +50,10 @@ export class ChatMessage extends LitElement {
       return html`<tool-message .tool=${'memory_context'} .content=${this.content} .icon=${'\u{1f9e0}'}></tool-message>`;
     }
 
+    if (this.role === 'wiki_context') {
+      return html`<tool-message .tool=${'wiki_context'} .content=${this.content} .icon=${'\u{1f4d6}'}></tool-message>`;
+    }
+
     if (this.role === 'tool_call') {
       return html`<tool-call-message variant="tool_call" .content=${this.content}></tool-call-message>`;
     }

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -199,6 +199,8 @@ export class ConversationStore extends EventTarget {
     this.#toolStatusStore.clearToolStatus();
     const wsMsg = { type: 'send', conv_id: this.#currentConvId, text };
     if (attachments.length) wsMsg.attachments = attachments;
+    const wikiPage = /** @type {any} */ (window).getOpenWikiPage?.();
+    if (wikiPage) wsMsg.wiki_page = wikiPage;
     this.#ws.send(wsMsg);
     this.#emitChange();
   }

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -98,9 +98,9 @@ export class ToolStatusStore {
       case 'tool_status':
         this.#toolStatus = `${msg.tool}: ${msg.message}`;
         if (msg.conv_id === currentConvId) {
-          if (msg.tool === 'memory_context') {
+          if (msg.tool === 'memory_context' || msg.tool === 'wiki_context') {
             this.#messageStore.insertBeforeLastUser({
-              role: 'memory_context',
+              role: msg.tool,
               content: msg.message,
               timestamp: new Date().toISOString(),
             });

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -201,6 +201,7 @@ async def _handle_send(ws_send, index, username, msg, state):
     conv_id = msg.get("conv_id", "")
     text = msg.get("text", "").strip()
     attachments = msg.get("attachments") or None
+    wiki_page = msg.get("wiki_page") or None
     if not conv_id or (not text and not attachments):
         await ws_send({"type": "error", "message": "conv_id and text (or attachments) required"})
         return
@@ -259,16 +260,18 @@ async def _handle_send(ws_send, index, username, msg, state):
             log.info(f"WS: queuing message for busy conversation {conv_id}")
         pending_queue.setdefault(conv_id, []).append(
             {"text": text, "command_ctx": command_ctx,
-             "command_display": command_display, "attachments": attachments})
+             "command_display": command_display, "attachments": attachments,
+             "wiki_page": wiki_page})
         return
 
     _start_agent_turn(state, index, conv_id, username, text, ws_send,
                       command_ctx=command_ctx, archive_text=command_display,
-                      attachments=attachments)
+                      attachments=attachments, wiki_page=wiki_page)
 
 
 def _start_agent_turn(state, index, conv_id, username, text, ws_send,
-                      command_ctx=None, archive_text="", attachments=None):
+                      command_ctx=None, archive_text="", attachments=None,
+                      wiki_page=None):
     """Launch an agent turn task with queue drain on completion."""
     busy_convs = state.setdefault("busy_convs", set())
     pending_queue = state.setdefault("pending_msgs", {})
@@ -282,7 +285,7 @@ def _start_agent_turn(state, index, conv_id, username, text, ws_send,
             state["websocket"], state["app_ctx"], state["config"], state["event_bus"],
             index, conv_id, username, text, cancel_event,
             command_ctx=command_ctx, archive_text=archive_text,
-            attachments=attachments,
+            attachments=attachments, wiki_page=wiki_page,
         )
     )
     state["agent_tasks"].add(task)
@@ -308,11 +311,15 @@ def _start_agent_turn(state, index, conv_id, username, text, ws_send,
             for q in queued:
                 if q.get("attachments"):
                     all_attachments.extend(q["attachments"])
+            # Use last wiki_page — it reflects what's currently open.
+            # Earlier pages from queued messages are still available via @[[...]] syntax.
+            last_wiki_page = queued[-1].get("wiki_page")
             combined = "\n".join(texts)
             log.info(f"WS: draining {len(queued)} queued message(s) for {cid}")
             _start_agent_turn(state, index, cid, username, combined, ws_send,
                               command_ctx=last_ctx, archive_text=last_display,
-                              attachments=all_attachments or None)
+                              attachments=all_attachments or None,
+                              wiki_page=last_wiki_page)
 
     task.add_done_callback(_on_task_done)
 
@@ -442,7 +449,8 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx):
 
 async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                           index, conv_id, username, text, cancel_event=None,
-                          command_ctx=None, archive_text="", attachments=None):
+                          command_ctx=None, archive_text="", attachments=None,
+                          wiki_page=None):
     """Run an agent turn for a web conversation, streaming events to WebSocket."""
     from ..agent import run_agent_turn  # deferred: circular dep
     from ..archive import read_archive
@@ -464,6 +472,7 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
     ctx.thread_id = ""
     ctx.conv_id = conv_id
     ctx.media_handler = LocalFileMediaHandler(config)
+    ctx.wiki_page = wiki_page
     # Apply pre-configured command state (set by dispatch_command)
     if command_ctx:
         ctx.tools.preapproved = command_ctx.tools.preapproved
@@ -552,6 +561,16 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     await ws_send({
                         "type": "tool_status", "conv_id": conv_id,
                         "tool": "memory_context",
+                        "message": text,
+                        "tool_call_id": "",
+                    })
+
+            elif event_type == "wiki_context":
+                text = event.get("text", "")
+                if text:
+                    await ws_send({
+                        "type": "tool_status", "conv_id": conv_id,
+                        "tool": "wiki_context",
                         "message": text,
                         "tool_call_id": "",
                     })

--- a/tests/test_wiki_context.py
+++ b/tests/test_wiki_context.py
@@ -1,0 +1,197 @@
+"""Tests for wiki context injection — @[[PageName]] and open wiki page."""
+
+import pytest
+
+from decafclaw.agent import (
+    _get_already_injected_pages,
+    _parse_wiki_references,
+    _read_wiki_page,
+)
+
+# -- _parse_wiki_references ---------------------------------------------------
+
+
+def test_parse_no_mentions_no_page():
+    """No @[[...]] and no wiki_page → empty list."""
+    result = _parse_wiki_references("hello world")
+    assert result == []
+
+
+def test_parse_mention():
+    """@[[TestPage]] is parsed."""
+    result = _parse_wiki_references("check @[[TestPage]] please")
+    assert len(result) == 1
+    assert result[0]["page"] == "TestPage"
+    assert result[0]["source"] == "mention"
+
+
+def test_parse_open_page():
+    """wiki_page param appears as open_page source."""
+    result = _parse_wiki_references("hello", wiki_page="OpenPage")
+    assert len(result) == 1
+    assert result[0]["page"] == "OpenPage"
+    assert result[0]["source"] == "open_page"
+
+
+def test_parse_dedup_mention_and_open_page():
+    """If @[[X]] and wiki_page=X, only one entry (mention wins)."""
+    result = _parse_wiki_references("@[[Page]]", wiki_page="Page")
+    assert len(result) == 1
+    assert result[0]["source"] == "mention"
+
+
+def test_parse_multiple_mentions():
+    """Multiple @[[...]] in one message all parse."""
+    result = _parse_wiki_references("see @[[A]] and @[[B]]")
+    assert len(result) == 2
+    pages = {r["page"] for r in result}
+    assert pages == {"A", "B"}
+
+
+def test_parse_duplicate_mention():
+    """Same page mentioned twice → only one entry."""
+    result = _parse_wiki_references("@[[X]] and @[[X]]")
+    assert len(result) == 1
+
+
+# -- _read_wiki_page ----------------------------------------------------------
+
+
+def test_read_wiki_page_found(config):
+    """Existing page returns content."""
+    wiki_dir = config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "TestPage.md").write_text("# Test\nHello")
+    assert _read_wiki_page(config, "TestPage") == "# Test\nHello"
+
+
+def test_read_wiki_page_not_found(config):
+    """Missing page returns None."""
+    wiki_dir = config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    assert _read_wiki_page(config, "Missing") is None
+
+
+def test_read_wiki_page_no_wiki_dir(config):
+    """No wiki directory → None (no crash)."""
+    assert _read_wiki_page(config, "Anything") is None
+
+
+# -- _get_already_injected_pages -----------------------------------------------
+
+
+def test_already_injected_empty():
+    assert _get_already_injected_pages([]) == set()
+
+
+def test_already_injected_finds_wiki_context():
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "wiki_context", "content": "...", "wiki_page": "Page1"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "wiki_context", "content": "...", "wiki_page": "Page2"},
+    ]
+    assert _get_already_injected_pages(history) == {"Page1", "Page2"}
+
+
+def test_already_injected_ignores_other_roles():
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "memory_context", "content": "..."},
+    ]
+    assert _get_already_injected_pages(history) == set()
+
+
+# -- Integration: injection in _prepare_messages --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_messages_injects_wiki_context(ctx):
+    """Wiki context messages are injected into history."""
+    from decafclaw.agent import _prepare_messages
+
+    wiki_dir = ctx.config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "TestPage.md").write_text("wiki content here")
+    ctx.config.system_prompt = "system"
+    ctx.skip_memory_context = True
+
+    history = []
+    messages, _ = await _prepare_messages(
+        ctx, ctx.config, "tell me about @[[TestPage]]", history,
+    )
+
+    # Check that wiki_context was injected into history
+    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    assert len(wiki_msgs) == 1
+    assert "wiki content here" in wiki_msgs[0]["content"]
+    assert wiki_msgs[0]["wiki_page"] == "TestPage"
+
+    # Check that wiki_context is remapped to "user" in LLM messages
+    user_msgs = [m for m in messages if m["role"] == "user"]
+    assert any("wiki content here" in m["content"] for m in user_msgs)
+
+
+@pytest.mark.asyncio
+async def test_prepare_messages_skips_already_injected(ctx):
+    """Pages already in history are not re-injected."""
+    from decafclaw.agent import _prepare_messages
+
+    wiki_dir = ctx.config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "TestPage.md").write_text("wiki content")
+    ctx.config.system_prompt = "system"
+    ctx.skip_memory_context = True
+
+    history = [
+        {"role": "wiki_context", "content": "[Referenced wiki page: TestPage]\n\nwiki content",
+         "wiki_page": "TestPage"},
+    ]
+    messages, _ = await _prepare_messages(
+        ctx, ctx.config, "tell me more about @[[TestPage]]", history,
+    )
+
+    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    assert len(wiki_msgs) == 1  # still just the original, no duplicate
+
+
+@pytest.mark.asyncio
+async def test_prepare_messages_injects_open_page(ctx):
+    """Open wiki page from ctx.wiki_page is injected."""
+    from decafclaw.agent import _prepare_messages
+
+    wiki_dir = ctx.config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    (wiki_dir / "OpenPage.md").write_text("open page content")
+    ctx.config.system_prompt = "system"
+    ctx.skip_memory_context = True
+    ctx.wiki_page = "OpenPage"
+
+    history = []
+    messages, _ = await _prepare_messages(
+        ctx, ctx.config, "hello", history,
+    )
+
+    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    assert len(wiki_msgs) == 1
+    assert "[Currently viewing wiki page: OpenPage]" in wiki_msgs[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_messages_missing_page_error(ctx):
+    """Missing @[[PageName]] injects error note."""
+    from decafclaw.agent import _prepare_messages
+
+    wiki_dir = ctx.config.workspace_path / "wiki"
+    wiki_dir.mkdir(parents=True)
+    ctx.config.system_prompt = "system"
+    ctx.skip_memory_context = True
+
+    history = []
+    messages, _ = await _prepare_messages(
+        ctx, ctx.config, "see @[[NonExistent]]", history,
+    )
+
+    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    assert len(wiki_msgs) == 1
+    assert "[Wiki page 'NonExistent' not found]" in wiki_msgs[0]["content"]


### PR DESCRIPTION
## Summary

- Add `@[[PageName]]` syntax to reference wiki pages inline in chat messages — works across all channels (web, Mattermost, terminal)
- Auto-inject open wiki page content when sending messages from the web UI sidebar
- Pages injected once per conversation as `wiki_context` role messages, displayed in chat with a book icon

## Details

- Parsing happens in `agent.py` `_prepare_messages()` (channel-agnostic)
- Web UI sends `wiki_page` field with WebSocket messages when a page is open
- Already-injected tracking via history scan (no separate state needed)
- Missing pages get `[Wiki page 'X' not found]` error notes
- System prompt updated so the agent understands the annotations
- 15 tests covering parsing, dedup, injection, and edge cases

## Test plan

- [x] Web: Open wiki page, send message → page content appears as context with book icon
- [x] Web: Send another message with same page open → no re-injection
- [x] Web: Navigate to different page, send message → new page injected
- [x] Any channel: Type `@[[PageName]]` → page content injected
- [x] Any channel: Type `@[[NonExistent]]` → error note injected
- [x] Web: Refresh browser → wiki context messages persist in history

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)