### PR TITLE
fix: update contrib skills for vault unification

### DIFF
--- a/contrib/skills/daily-todo-migration/SKILL.md
+++ b/contrib/skills/daily-todo-migration/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 
 To perform the daily to-do migration, you MUST follow these steps in order:
 
-1.  **Activate Skill**: Activate the `markdown_vault` skill.
+1.  **Activate Skill**: Activate the `vault` skill.
 2.  **Confirm Vault Path**: Search memory for the user's vault `base_path`. If not found, ask the user for it and save it. A common default is `obsidian/main`.
 3.  **Get Paths**: Call `vault_daily_path` for both yesterday (`offset=-1`) and today.
 4.  **Check for Today's Note**: Use `workspace_list` on the directory of today's note to check if the file exists.

--- a/contrib/skills/linkding-ingest/SKILL.md
+++ b/contrib/skills/linkding-ingest/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: linkding-ingest
-description: Fetch recent Linkding bookmarks, read their content, and record insights to the wiki
+description: Fetch recent Linkding bookmarks, read their content, and record insights to the vault
 schedule: "45 */4 * * *"
 effort: default
 required-skills:
-  - wiki
   - tabstack
-allowed-tools: shell($SKILL_DIR/fetch.sh), wiki_read, wiki_write, wiki_search, wiki_list, wiki_backlinks, tabstack_extract_markdown, memory_recent, memory_search, current_time, delegate_task
+allowed-tools: shell($SKILL_DIR/fetch.sh), vault_read, vault_write, vault_search, vault_list, vault_backlinks, tabstack_extract_markdown, vault_journal_append, current_time, delegate_task
 user-invocable: true
 ---
 
 # Linkding Bookmark Ingestion
 
-Fetch recent bookmarks from Linkding, then delegate each bookmark to a child agent for content extraction and wiki integration.
+Fetch recent bookmarks from Linkding, then delegate each bookmark to a child agent for content extraction and vault integration.
+
+## Output Folder
+
+Write all bookmark-derived pages into `agent/pages/bookmarks/`. Use sub-organization by topic when it makes sense (e.g. `agent/pages/bookmarks/programming/`, `agent/pages/bookmarks/tools/`). Include `[[wiki-links]]` back to related pages elsewhere in the vault.
 
 ## Configuration
 
@@ -54,20 +57,20 @@ Description: {bookmark_description}
 
 You have these tools available:
 - tabstack_extract_markdown(url) — fetch full article content
-- wiki_search(query) — search wiki pages by name/content
-- wiki_read(page) — read a wiki page (parameter is "page", not "path")
-- wiki_write(page, content) — create or overwrite a wiki page (parameters are "page" and "content")
-- wiki_backlinks(page) — find pages linking to a page
+- vault_search(query) — search vault pages by name/content
+- vault_read(page) — read a vault page (parameter is "page", not "path")
+- vault_write(page, content) — create or overwrite a vault page (parameters are "page" and "content")
+- vault_backlinks(page) — find pages linking to a page
 
 Instructions:
 1. Use tabstack_extract_markdown(url="{bookmark_url}") to fetch the full content. If it fails (paywall, dead link), work with just the title, tags, and description above.
 2. Analyze the content for key facts, insights, technologies, people, projects, or concepts.
-3. Use wiki_search(query="relevant topic") to find existing wiki pages.
-4. If a relevant page exists: wiki_read(page="Page Name") to get it, revise with new info, wiki_write(page="Page Name", content="...") to save.
-5. If no relevant page exists and the topic is substantial: wiki_write(page="New Page", content="...") with [[wiki-links]] and a ## Sources section.
+3. Use vault_search(query="relevant topic") to find existing vault pages.
+4. If a relevant page exists: vault_read(page="Page Name") to get it, revise with new info, vault_write(page="Page Name", content="...") to save.
+5. If no relevant page exists and the topic is substantial: vault_write(page="agent/pages/bookmarks/New Page", content="...") with [[wiki-links]] and a ## Sources section.
 6. Include the original URL and {bookmark_date} in ## Sources.
 7. Extract knowledge — "X uses Y approach for Z problem" is better than "bookmarked an article about X".
-8. Prefer adding to existing wiki pages over creating new ones.
+8. Prefer adding to existing vault pages over creating new ones.
 9. Do NOT use tool_search — it is not available. Use only the tools listed above.
 ```
 

--- a/contrib/skills/mastodon-ingest/SKILL.md
+++ b/contrib/skills/mastodon-ingest/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: mastodon-ingest
-description: Fetch recent Mastodon posts and record interesting content to the wiki
+description: Fetch recent Mastodon posts and record interesting content to the vault
 schedule: "30 */4 * * *"
 effort: default
-required-skills:
-  - wiki
-allowed-tools: shell($SKILL_DIR/fetch.sh), wiki_read, wiki_write, wiki_search, wiki_list, wiki_backlinks, memory_recent, memory_search, current_time
+allowed-tools: shell($SKILL_DIR/fetch.sh), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, current_time
 user-invocable: true
 ---
 
 # Mastodon Post Ingestion
 
-Fetch recent Mastodon posts and integrate interesting content into the wiki knowledge base.
+Fetch recent Mastodon posts and integrate interesting content into the vault knowledge base.
+
+## Output Folder
+
+Write all Mastodon-derived pages into `agent/pages/mastodon/`. Use sub-organization by topic when it makes sense. Include `[[wiki-links]]` back to related pages elsewhere in the vault.
 
 ## Configuration
 
@@ -43,7 +45,7 @@ If the script fails (missing env vars, binary not found), report the error and s
 ## Step 2: Review the output
 
 Read through the fetched posts. For each one, consider:
-- Is it about a topic that has (or should have) a wiki page?
+- Is it about a topic that has (or should have) a vault page?
 - Does it express a preference, opinion, or decision worth recording?
 - Does it mention a project, person, or recurring theme?
 
@@ -52,18 +54,18 @@ Skip boring posts — routine posts, casual replies, and low-signal content don'
 ## Step 3: Update the wiki
 
 For each interesting post:
-1. `wiki_search` to find existing relevant pages
-2. If a page exists: `wiki_read` it, revise with new context, `wiki_write` the updated page
+1. `vault_search` to find existing relevant pages
+2. If a page exists: `vault_read` it, revise with new context, `vault_write` the updated page
 3. If no page exists: create a new page with `[[wiki-links]]` and a `## Sources` section
 4. In Sources, note the Mastodon post date and include the post URL if available
 
 ## Step 4: Finish
 
-If you made wiki changes, summarize what you added/updated.
+If you made vault changes, summarize what you added/updated.
 If there was nothing interesting to ingest, respond with HEARTBEAT_OK.
 
 ## Rules
 
 - Only ingest the user's OWN posts — do not quote or reproduce other people's content without attribution
 - Convert relative dates ("yesterday", "last week") to absolute dates
-- Don't create wiki pages for throwaway posts — only for content revealing preferences, projects, or recurring interests
+- Don't create vault pages for throwaway posts — only for content revealing preferences, projects, or recurring interests


### PR DESCRIPTION
## Summary

Updates contrib skills to use vault tools instead of removed wiki/memory tools. Partial fix for #171.

- **linkding-ingest** — `wiki_*` → `vault_*`, `memory_*` → `vault_journal_append`, adds `agent/pages/bookmarks/` output folder guidance
- **mastodon-ingest** — same tool renames, adds `agent/pages/mastodon/` output folder guidance  
- **daily-todo-migration** — `markdown_vault` → `vault` skill reference

## Note

daily-todo-migration references tools (`vault_daily_path`, `md_create`, `md_show`, `md_move_lines`) that don't exist in the built-in vault skill — it likely depends on an external MCP server. That needs a separate look.

## Test plan

- [x] `make check` passes
- [ ] Verify linkding-ingest runs with updated tool names
- [ ] Verify mastodon-ingest runs with updated tool names

🤖 Generated with [Claude Code](https://claude.com/claude-code)