### PR TITLE
fix: hide dotfolders from vault folder listing

### DIFF
--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -287,7 +287,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         # Build folder list from all child directories
         folders = []
         for child in sorted(target_dir.iterdir(), key=lambda c: c.name.lower()):
-            if child.is_dir():
+            if child.is_dir() and not child.name.startswith('.'):
                 rel = child.relative_to(vault_resolved)
                 folders.append({"name": child.name, "path": str(rel)})
 


### PR DESCRIPTION
One-liner: skip directories starting with `.` in the vault folder API (e.g. `.obsidian`, `.git`, `.trash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)