### PR TITLE
fix: preserve sidebar scroll when selecting a vault page

### DIFF
--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -162,8 +162,10 @@ export class ConversationSidebar extends LitElement {
     this._openWikiPage = pagePath;
     const lastSlash = pagePath.lastIndexOf('/');
     const folder = lastSlash >= 0 ? pagePath.substring(0, lastSlash) : '';
-    this._vaultFolder = folder;
-    this.#fetchWikiPages();
+    if (folder !== this._vaultFolder) {
+      this._vaultFolder = folder;
+      this.#fetchWikiPages();
+    }
   }
 
   /** Clear the open page highlight (called when wiki pane is closed). */


### PR DESCRIPTION
## Summary

Clicking a vault page in the sidebar was resetting the scroll position because `navigateToPageFolder` always re-fetched the page list, causing Lit to rebuild the DOM.

Now it only fetches when the folder changes. Same-folder clicks just update the active highlight via the reactive `_openWikiPage` property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)