### PR TITLE
feat: chat folder organization and REST conversation management

### DIFF
--- a/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/notes.md
+++ b/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/notes.md
@@ -1,0 +1,3 @@
+# Chat Folders and REST Conversations — Notes
+
+_Session notes will be captured here during development._

--- a/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/plan.md
+++ b/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/plan.md
@@ -1,0 +1,414 @@
+# Chat Folders and REST Conversations — Plan
+
+_Implementation plan for GitHub issues #184, #187, plus user-defined chat folders_
+
+## Overview
+
+Seven phases, each building on the previous. The dependency chain:
+
+1. **Folder Index Backend** — data model foundation
+2. **REST Listing Endpoints** — folder-aware conversation listing
+3. **REST Action Endpoints** — conversation + folder mutations
+4. **Frontend Store Migration** — ConversationStore switches from WebSocket to REST
+5. **Sidebar Folder Navigation** — file-browser UI replacing collapsible sections
+6. **Folder Management UI** — create/rename/delete folders, move conversations
+7. **WebSocket Cleanup** — remove dead WebSocket conversation handlers
+
+---
+
+## Phase 1: Folder Index Backend
+
+**Goal:** Create the `ConversationFolderIndex` class that manages `conversation_folders.json` per user.
+
+**Files to create/modify:**
+- Create `src/decafclaw/web/conversation_folders.py`
+
+### Prompt 1
+
+```
+Read src/decafclaw/web/conversations.py for context on how ConversationIndex works (file I/O patterns, path conventions, locking).
+
+Create a new file src/decafclaw/web/conversation_folders.py with a ConversationFolderIndex class:
+
+Data file location: data/{agent_id}/web/users/{username}/conversation_folders.json
+
+JSON structure:
+{
+  "folders": ["projects", "projects/bot-redesign", "research"],
+  "assignments": {
+    "web-les-abc123": "projects/bot-redesign"
+  }
+}
+
+Methods needed:
+- __init__(self, config, username: str) — resolve file path, load or create empty
+- _load() -> dict — read JSON, return default if missing
+- _save(data: dict) -> None — atomic write (write to tmp, rename)
+- list_folders(parent: str = "") -> list[str] — immediate child folder names under parent
+- create_folder(path: str) -> bool — add to folders list, auto-create parents, reject "_" prefix, return success
+- delete_folder(path: str) -> bool — remove if empty (no conversations assigned, no child folders), return success
+- rename_folder(old_path: str, new_path: str) -> bool — update folder list + all assignments under old_path. If new_path exists, merge (combine conversations). Reject "_" prefix on new_path.
+- get_folder(conv_id: str) -> str — return folder path or "" for top-level
+- set_folder(conv_id: str, folder: str) -> bool — assign conversation to folder (folder must exist or be "")
+- remove_assignment(conv_id: str) -> None — remove from assignments dict
+- list_conversations_in_folder(folder: str = "") -> list[str] — return conv_ids assigned to this exact folder
+
+Path validation: reject paths containing "..", leading "/", or starting with "_". Use a _validate_path() helper.
+
+Use asyncio.Lock for thread safety on reads/writes. Follow the project convention of simple file-based storage.
+
+Write tests in tests/test_conversation_folders.py covering:
+- Create/delete/rename folders
+- Assign/move/remove conversations
+- Parent auto-creation
+- "_" prefix rejection
+- Merge on rename collision
+- Empty folder deletion guard
+- Path traversal rejection
+```
+
+**Verify:** `make test` passes, `make check` passes.
+
+---
+
+## Phase 2: REST Listing Endpoints
+
+**Goal:** Add folder-aware listing endpoints that mirror the vault pattern, using the folder index.
+
+**Files to modify:**
+- `src/decafclaw/http_server.py` — add/update routes
+- `src/decafclaw/web/conversations.py` — may need minor adjustments to list methods
+
+### Prompt 2
+
+```
+Read these files for context:
+- src/decafclaw/http_server.py (especially vault_list around line 243 for the folder listing pattern)
+- src/decafclaw/web/conversations.py (ConversationIndex.list_for_user)
+- src/decafclaw/web/conversation_folders.py (the folder index from Phase 1)
+
+Update GET /api/conversations to support folder-aware listing:
+
+1. Accept ?folder= query parameter (default: "" for top-level)
+2. Load ConversationFolderIndex for the authenticated user
+3. Get all conversations for the user via ConversationIndex.list_for_user()
+4. Filter to only conversations assigned to the requested folder (or unassigned for top-level)
+5. Get immediate child folders from the folder index
+6. At top level, append virtual folders: {"name": "Archived", "path": "_archived", "virtual": true} and {"name": "System", "path": "_system", "virtual": true}
+7. Return: { "folder": str, "folders": [...], "conversations": [...] }
+
+Add GET /api/conversations/archived:
+1. Accept ?folder= query parameter
+2. List archived conversations (ConversationIndex.list_for_user with include_archived=True, filter archived=True)
+3. Filter by folder assignment from the folder index
+4. Return same shape as /api/conversations — child folders derived from assignments of archived conversations
+
+Add GET /api/conversations/system:
+1. Accept ?folder= query parameter
+2. Use existing list_system_conversations() function
+3. At top level, return sub-folders: heartbeat, scheduled, delegated
+4. With ?folder=heartbeat (etc.), filter by conv_type
+5. Return same response shape
+
+All endpoints require @_authenticated. Follow the vault_list pattern for path validation.
+
+Write tests for the new/updated endpoints.
+```
+
+**Verify:** `make test` passes, `make check` passes. Manually test with `curl`.
+
+---
+
+## Phase 3: REST Action Endpoints
+
+**Goal:** Add REST endpoints for all conversation mutations: rename+move, unarchive, folder CRUD, and update create to accept folder.
+
+**Files to modify:**
+- `src/decafclaw/http_server.py`
+
+### Prompt 3
+
+```
+Read src/decafclaw/http_server.py for existing route patterns.
+
+Add/update these REST endpoints:
+
+1. Update PUT or PATCH /api/conversations/{conv_id}:
+   - Accept body: { "title": "...", "folder": "..." } (both optional)
+   - If title provided: call ConversationIndex.rename()
+   - If folder provided: call ConversationFolderIndex.set_folder() (validate folder exists or is "")
+   - Return updated conversation dict + folder
+   - Note: there's already a PATCH route — update it to also handle folder changes
+
+2. Add POST /api/conversations/{conv_id}/unarchive:
+   - Call ConversationIndex.unarchive()
+   - Return {"ok": true}
+
+3. Update POST /api/conversations:
+   - Accept optional "folder" and "effort" in body
+   - After creating, assign to folder via ConversationFolderIndex if provided
+   - If effort provided (and not "default"), append effort message to archive (same logic as _handle_create_conv in websocket.py)
+
+4. Add POST /api/conversations/folders:
+   - Body: { "path": "projects/new-folder" }
+   - Call ConversationFolderIndex.create_folder()
+   - Return {"ok": true, "path": "..."} or 400/409 on error
+
+5. Add DELETE /api/conversations/folders/{path:path}:
+   - Call ConversationFolderIndex.delete_folder()
+   - Return {"ok": true} or 409 if not empty
+
+6. Add PUT /api/conversations/folders/{path:path}:
+   - Body: { "path": "new/path" }
+   - Call ConversationFolderIndex.rename_folder()
+   - Return {"ok": true} or 400 on error
+
+All endpoints require @_authenticated. Include proper error responses (400, 404, 409).
+
+Write tests for each new endpoint.
+```
+
+**Verify:** `make test` passes, `make check` passes.
+
+---
+
+## Phase 4: Frontend Store Migration
+
+**Goal:** Convert ConversationStore from WebSocket to REST for all conversation management operations. Keep WebSocket for real-time chat streaming and `conv_created` signal.
+
+**Files to modify:**
+- `src/decafclaw/web/static/lib/conversation-store.js`
+
+### Prompt 4
+
+```
+Read these files:
+- src/decafclaw/web/static/lib/conversation-store.js (full file — the store to migrate)
+- src/decafclaw/web/static/lib/auth-client.js (REST call pattern to follow)
+- src/decafclaw/web/static/components/conversation-sidebar.js (to understand what the store consumers expect)
+
+Convert ConversationStore methods from WebSocket sends to REST calls:
+
+1. listConversations(folder = '') → GET /api/conversations?folder=
+   - Store response: _conversations, _folders, _currentFolder
+   - Add new properties: _folders (array), _currentFolder (string)
+   - Add getter: get folders(), get currentFolder()
+
+2. listArchivedConversations(folder = '') → GET /api/conversations/archived?folder=
+   - Store response: _archivedConversations, _archivedFolders, _archivedCurrentFolder
+
+3. listSystemConversations(folder = '') → GET /api/conversations/system?folder=
+   - Store response: _systemConversations, _systemFolders, _systemCurrentFolder
+
+4. createConversation(title, effort, folder) → POST /api/conversations
+   - Body: { title, effort, folder }
+   - On success, re-fetch current folder listing
+
+5. renameConversation(convId, title) → PATCH /api/conversations/{convId}
+   - Body: { title }
+   - On success, re-fetch current listing
+
+6. moveConversation(convId, folder) → PATCH /api/conversations/{convId}
+   - Body: { folder }
+   - On success, re-fetch current listing
+
+7. archiveConversation(convId) → POST /api/conversations/{convId}/archive
+   - On success, re-fetch current listing
+
+8. unarchiveConversation(convId) → POST /api/conversations/{convId}/unarchive
+   - On success, re-fetch current listing
+
+9. Folder management methods (new):
+   - createFolder(path) → POST /api/conversations/folders
+   - deleteFolder(path) → DELETE /api/conversations/folders/{path}
+   - renameFolder(oldPath, newPath) → PUT /api/conversations/folders/{path}
+   - Each re-fetches current listing on success
+
+Remove WebSocket message handling for: conv_list, archived_list, system_conv_list, conv_renamed, conv_archived, conv_unarchived.
+
+Keep WebSocket handling for: all chat streaming messages (chunk, message_complete, tool_start, tool_end, tool_status, turn_start, turn_end, etc.), conv_selected, conv_history, effort_changed, confirm_request, error.
+
+On WebSocket open, call listConversations() via REST instead of sending list_convs message.
+
+Use async/await with fetch(). Follow auth-client.js pattern for error handling.
+
+Each method should call #emitChange() after updating state.
+```
+
+**Verify:** `make check-js` passes. Manually test in browser — sidebar should still load conversations.
+
+---
+
+## Phase 5: Sidebar Folder Navigation
+
+**Goal:** Replace collapsible Archived/System sections with file-browser navigation matching the vault tab pattern. Add breadcrumbs, folder listing, virtual folder support.
+
+**Files to modify:**
+- `src/decafclaw/web/static/components/conversation-sidebar.js`
+
+### Prompt 5
+
+```
+Read src/decafclaw/web/static/components/conversation-sidebar.js — study the vault tab's folder navigation pattern (#renderVaultBreadcrumbs, #navigateToFolder, #fetchWikiPages, #renderVaultTab) as the template.
+
+Refactor the Chats tab to use the same file-browser navigation pattern:
+
+1. Remove collapsible _showArchived / _showSystem sections and their toggle logic.
+
+2. Add navigation state:
+   - _chatSection: '' (active), '_archived', '_system' — which section we're in
+   - _chatFolder: '' — current folder path within the section
+   - These map to the REST endpoints: '' → /api/conversations, '_archived' → /api/conversations/archived, '_system' → /api/conversations/system
+
+3. Add #navigateChatFolder(section, folder) method:
+   - Updates _chatSection and _chatFolder
+   - Calls the appropriate store method: store.listConversations(folder), store.listArchivedConversations(folder), or store.listSystemConversations(folder)
+
+4. Add #renderChatBreadcrumbs() method (mirror #renderVaultBreadcrumbs):
+   - When at top level (_chatSection = '', _chatFolder = ''): no breadcrumbs needed
+   - When in Archived/System: show "Chats / Archived / subfolder / ..." with clickable segments
+   - When in a user folder: show "Chats / folder / subfolder / ..." with clickable segments
+   - Root "Chats" segment always navigates back to top level
+
+5. Update #renderChatsTab() (currently #renderConversationList or similar):
+   - Render breadcrumbs at top
+   - List folders first (from store.folders), then conversations
+   - Folders render with folder icon, click navigates into them
+   - Virtual folders (Archived, System) render with folder icon but no rename/delete
+   - User folders render with folder icon (rename/delete controls come in Phase 6)
+   - Conversations render with existing item renderer
+   - In Archived section: show unarchive button instead of archive button
+   - In System section: no archive/unarchive buttons, show type badge
+
+6. "+" button behavior:
+   - Creates new conversation in the current folder (pass folder to createConversation)
+   - Only show in active section, not in Archived or System
+
+7. When a conversation is selected that's in a different folder, navigate to that folder.
+
+8. Preserve scroll position and selected state across folder navigation.
+
+Keep all existing vault tab code unchanged.
+```
+
+**Verify:** `make check-js` passes. Test in browser: navigate folders, breadcrumbs work, Archived/System as virtual folders, creating conversations in folders.
+
+---
+
+## Phase 6: Folder Management UI
+
+**Goal:** Add UI for creating, renaming, deleting user-defined folders, and moving conversations between folders.
+
+**Files to modify:**
+- `src/decafclaw/web/static/components/conversation-sidebar.js`
+
+### Prompt 6
+
+```
+Read src/decafclaw/web/static/components/conversation-sidebar.js — study how the vault tab handles folder creation (+ Folder button), page rename (inline input), and page delete (delete button with confirm).
+
+Add folder management to the Chats tab:
+
+1. "+ Folder" button next to "+ Chat" in the sidebar header:
+   - Shows inline input field (like vault's folder creation)
+   - On submit, calls store.createFolder(currentPath + '/' + name) or store.createFolder(name) at top level
+   - Validates: no "_" prefix, no empty name
+   - Re-fetches listing on success
+
+2. Folder rename (inline):
+   - Double-click on a user-created folder name → editable input (same pattern as conversation rename)
+   - On submit, calls store.renameFolder(oldPath, newPath)
+   - Not available on virtual folders (Archived, System)
+
+3. Folder delete:
+   - Small delete button on user-created folders (hidden on hover, like vault)
+   - Confirmation before delete
+   - Calls store.deleteFolder(path)
+   - Shows error if folder is not empty
+   - Not available on virtual folders
+
+4. Move conversation:
+   - When renaming a conversation, support path syntax: "folder/New Title"
+   - Parse the path to extract folder + title
+   - Call store.moveConversation(convId, folder) + store.renameConversation(convId, title)
+   - Alternative: add a "Move to..." action that shows a folder picker (simpler UX, could defer)
+
+5. Accessibility:
+   - Focus management on inline inputs
+   - Keyboard support (Enter to confirm, Escape to cancel)
+   - aria-labels on icon-only buttons
+   - :focus-visible styles
+
+Match the vault tab's visual style for consistency.
+```
+
+**Verify:** `make check-js` passes. Test in browser: create folders, rename, delete, move conversations.
+
+---
+
+## Phase 7: WebSocket Cleanup
+
+**Goal:** Remove dead WebSocket conversation management handlers from backend and frontend.
+
+**Files to modify:**
+- `src/decafclaw/web/websocket.py`
+- `src/decafclaw/web/static/lib/conversation-store.js`
+
+### Prompt 7
+
+```
+Read:
+- src/decafclaw/web/websocket.py
+- src/decafclaw/web/static/lib/conversation-store.js
+
+Remove WebSocket handlers that are now replaced by REST:
+
+Backend (websocket.py):
+- Remove _handle_list_convs and the "list_convs" dispatch entry
+- Remove _handle_list_archived and the "list_archived" dispatch entry
+- Remove _handle_list_system_convs and the "list_system_convs" dispatch entry
+- Remove _handle_archive_conv and the "archive_conv" dispatch entry
+- Remove _handle_unarchive_conv and the "unarchive_conv" dispatch entry
+- Remove _handle_rename_conv and the "rename_conv" dispatch entry
+- Remove _handle_create_conv and the "create_conv" dispatch entry (creation is now REST-only via POST /api/conversations)
+- Keep: _handle_send, _handle_select_conv, _handle_load_history, _handle_set_effort, _handle_cancel_turn, _handle_confirm_response
+
+Frontend (conversation-store.js):
+- Remove WebSocket message handlers for: conv_list, archived_list, system_conv_list, conv_renamed, conv_archived, conv_unarchived
+- Remove conv_created handler (creation is now REST-only)
+- Keep handlers for: conv_selected, conv_history, chunk, message_complete, tool_start, tool_end, tool_status, error, turn_start, turn_end, reflection, compaction_start, compaction_end, effort_changed, confirm_request
+
+Verify no remaining references to removed message types in either file.
+
+Run make check and make test to confirm nothing is broken.
+```
+
+**Verify:** `make test` passes, `make check` passes. Full browser test of conversation flow.
+
+---
+
+## Final Verification Checklist
+
+After all phases:
+- [ ] Conversation list loads via REST (not WebSocket) — #184
+- [ ] Archived/System shown as navigable folders with breadcrumbs — #187
+- [ ] System sub-folders: heartbeat, scheduled, delegated
+- [ ] User-defined folders: create, rename, delete, navigate
+- [ ] Conversations can be moved between folders
+- [ ] Archive preserves folder assignment
+- [ ] Unarchive restores to original folder
+- [ ] New conversations created in current folder
+- [ ] Virtual folders (Archived, System) are read-only
+- [ ] "_" prefix reserved for virtual folders
+- [ ] Folder rename with collision merges
+- [ ] WebSocket only used for real-time chat streaming
+- [ ] No dead WebSocket handlers remain
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] Browser smoke test: full conversation lifecycle
+
+## Docs to Update
+
+- `docs/` — web UI docs, API docs (if they exist)
+- `CLAUDE.md` — key files list (conversation_folders.py), conventions (REST-only conversation management)
+- `README.md` — if API surface is documented there

--- a/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/spec.md
+++ b/.claude/dev-sessions/2026-04-01-0919-chat-folders-and-rest-conversations/spec.md
@@ -1,0 +1,183 @@
+# Chat Folders and REST Conversations — Spec
+
+_Session for GitHub issues #184, #187, plus general chat folder organization_
+
+## Issues
+
+- **#184** — Load conversation list via REST API instead of WebSocket
+- **#187** — Chat sidebar: folder-style navigation for archived and system conversations
+- **General** — User-defined folder organization for conversations
+
+## Summary
+
+Replace all WebSocket-based conversation management (list, archive, rename) with REST endpoints. Add folder-style navigation to the chat sidebar — matching the vault tab's file-browser pattern — with three virtual folder sections (active, archived, system) plus user-defined folders. Conversations are organized via a per-user folder index file; actual JSONL archive files stay in place (no filesystem moves).
+
+## Decisions
+
+- **REST-only conversation management.** All list/archive/rename/folder operations go through REST. WebSocket stays focused on real-time chat streaming only.
+- **Remove WebSocket conversation ops.** Delete `list_convs`, `list_archived`, `list_system_convs`, `archive`, `unarchive`, `rename` message handlers. No deprecation period — the web UI is the only client.
+- **Folder index file, not per-conversation metadata.** A flat JSON file per user tracks folder structure and conversation-to-folder assignments. Conversations not in the index default to top-level. Avoids scanning all conversations on every list request.
+- **Metadata-only folders.** Conversation files stay in their current filesystem location. Folders are a UI/API concept tracked in the index file, not filesystem directories.
+- **Archive preserves folder structure.** Archiving a conversation in `projects/bot-redesign` keeps that folder assignment. The Archived section mirrors the user's folder structure. Unarchiving restores the conversation to its original folder.
+- **System sub-folders by type.** System conversations are grouped into sub-folders: heartbeat, schedule, delegated.
+- **Virtual folders are read-only.** Archived and System (and their sub-folders) support navigation but not rename or delete.
+
+## Data Model
+
+### Folder Index File
+
+Location: `data/{agent_id}/web/users/{username}/conversation_folders.json`
+
+```json
+{
+  "folders": ["projects", "projects/bot-redesign", "research"],
+  "assignments": {
+    "web-les-abc123": "projects/bot-redesign",
+    "web-les-def456": "research"
+  }
+}
+```
+
+- `folders`: explicit list of user-created folders (supports empty folders)
+- `assignments`: maps conv_id → folder path. Absent conv_ids are top-level.
+- Flat structure — no tree nesting. Arbitrary depth supported.
+- Folder names starting with `_` are reserved for virtual folders (`_archived`, `_system`). User-created folders with `_` prefix are rejected.
+
+### ConversationMeta
+
+No changes to the dataclass. Folder assignment lives in the index file, not on the conversation metadata.
+
+## REST API
+
+### Conversation Listing
+
+**`GET /api/conversations?folder=`**
+- Returns conversations + subfolders in the given folder (default: top-level)
+- Top-level also includes virtual folder entries for "Archived" and "System"
+- Response mirrors vault pattern:
+
+```json
+{
+  "folder": "projects",
+  "folders": [
+    { "name": "bot-redesign", "path": "projects/bot-redesign" }
+  ],
+  "conversations": [
+    {
+      "conv_id": "web-les-abc123",
+      "title": "Chat about tools",
+      "created_at": "2026-03-31T10:00:00+00:00",
+      "updated_at": "2026-03-31T10:00:00+00:00"
+    }
+  ]
+}
+```
+
+- Top-level response includes additional virtual folders:
+
+```json
+{
+  "folder": "",
+  "folders": [
+    { "name": "projects", "path": "projects" },
+    { "name": "Archived", "path": "_archived", "virtual": true },
+    { "name": "System", "path": "_system", "virtual": true }
+  ],
+  "conversations": [ ... ]
+}
+```
+
+**`GET /api/conversations/archived?folder=`**
+- Same shape, scoped to archived conversations
+- Folder structure mirrors the user's folders (archive preserves folder assignment)
+
+**`GET /api/conversations/system?folder=`**
+- Same shape, with sub-folders for conversation types: `heartbeat`, `schedule`, `delegated`
+
+### Conversation Actions
+
+**`PUT /api/conversations/{conv_id}`**
+- Rename and/or move a conversation
+- Request body: `{ "title": "New Title", "folder": "projects/bot-redesign" }`
+- Either field optional; both can change at once
+- Moving updates the folder index; renaming updates ConversationMeta
+
+**`POST /api/conversations/{conv_id}/archive`**
+- Archives the conversation, preserving its folder assignment
+
+**`POST /api/conversations/{conv_id}/unarchive`**
+- Restores the conversation to its original folder
+
+**`POST /api/conversations`**
+- Create a new conversation
+- Request body: `{ "folder": "projects" }` (optional — defaults to top-level)
+
+### Folder Management
+
+**`POST /api/conversations/folders`**
+- Create a folder
+- Request body: `{ "path": "projects/new-folder" }`
+- Auto-creates parent folders if needed
+
+**`DELETE /api/conversations/folders/{path}`**
+- Delete an empty folder
+- Returns 409 if folder contains conversations
+
+**`PUT /api/conversations/folders/{path}`**
+- Rename/move a folder
+- Request body: `{ "path": "new/path" }`
+- Updates all conversation assignments under the old path
+- If the target path already exists, merge: conversations from both folders end up in the target, sub-folders are combined
+
+## Sidebar UI
+
+### File-Browser Navigation (matching vault pattern)
+
+- **Top level** shows: user-created folders, active conversations not in any folder, plus virtual folder entries for Archived and System
+- **Clicking a folder** replaces the list with that folder's contents + breadcrumbs
+- **Breadcrumbs** at top — each segment clickable to navigate up
+- **Folders listed first** (alphabetically), then conversations (by updated_at descending)
+
+### Virtual Folders
+
+- **Archived** — navigable with folder structure mirroring user folders. Conversations show unarchive action.
+- **System** — navigable with sub-folders (heartbeat, schedule, delegated). No archive/unarchive actions.
+- Virtual folders display with folder icon but no rename/delete controls.
+
+### Conversation Actions in Sidebar
+
+- **Select** — click to open
+- **Rename/Move** — inline rename (like vault), path change moves between folders
+- **Archive** — button on active conversations
+- **Unarchive** — button on archived conversations
+- **New Conversation** — creates in the currently viewed folder
+
+### Folder Actions in Sidebar
+
+- **Create folder** — button in sidebar (like vault's "+ Folder")
+- **Rename/Move folder** — inline rename
+- **Delete folder** — only if empty
+
+## WebSocket Cleanup
+
+Remove these message handlers from `websocket.py`:
+- `list_convs` / `conv_list`
+- `list_archived` / `archived_list`
+- `list_system_convs` / `system_conv_list`
+- `archive_conv` / `conv_archived`
+- `unarchive_conv` / `conv_unarchived`
+- `rename_conv` / `conv_renamed`
+
+Remove corresponding methods from `ConversationStore` on the frontend.
+
+Retain WebSocket for:
+- Real-time chat messages (send/receive streaming)
+- Conversation selection and history loading (session state)
+- Effort level changes, turn cancellation, confirmation requests
+- Any other real-time streaming events
+
+## Deferred (Future Issues)
+
+- **Filesystem path hashing** — hash-based subdirectories for conversation JSONL files to avoid large flat directories
+- **Archive date-based organization** — pagination or date grouping for the archived conversations list
+- **Drag-and-drop** — moving conversations between folders via drag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/commands.py` — User-invokable commands: trigger parsing, argument substitution, execution (fork/inline)
 - `src/decafclaw/tools/confirmation.py` — Shared confirmation request helper (event-bus-based user approval)
 - `src/decafclaw/runner.py` — Top-level orchestrator: manages MCP, HTTP server, Mattermost, heartbeat as parallel tasks
-- `src/decafclaw/web/` — Web gateway: auth, conversations, WebSocket chat handler
+- `src/decafclaw/web/` — Web gateway: auth, conversations, conversation folders, WebSocket chat handler
+- `src/decafclaw/web/conversation_folders.py` — Per-user conversation folder index (JSON file, metadata-only)
 - `src/decafclaw/web/static/` — Frontend: Lit web components, service layer (AuthClient, WebSocketClient, ConversationStore, MessageStore, ToolStatusStore, markdown, utils)
 
 ## Running
@@ -114,6 +115,7 @@ Session docs live in `.claude/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`
 - **Tool calls run concurrently.** When the model emits multiple tool calls in one response, they execute via `asyncio.gather` with a semaphore (`max_concurrent_tools`, default 5). Each call gets a forked ctx with its own `current_tool_call_id`. All tool events carry `tool_call_id` for UI correlation.
 - **Tool deferral.** When tool definitions exceed `tool_context_budget_pct` (default 10%) of `compaction_max_tokens`, non-essential tools are deferred behind `tool_search`. The model sees a name+description list and fetches full schemas on demand. Always-loaded tools configured via `ALWAYS_LOADED_TOOLS` env var. Fetched tools persist for the conversation.
 - **Events for progress.** Tools publish `tool_status` events via `ctx.publish()`. The agent loop publishes `llm_start/end` and `tool_start/end`. Subscribers (Mattermost, terminal) handle display.
+- **Web UI conversation management is REST-only.** All conversation listing, creation, renaming, archiving, folder management uses REST endpoints. WebSocket is only for real-time chat streaming, conversation selection/history loading, effort changes, and turn cancellation. Conversation folders are metadata-only (per-user JSON index file); archive files stay in place.
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholder management, threading logic — all in `MattermostClient`.
 - **Mattermost PATCH API quirks.** Omitting `props` from a PATCH preserves existing props (including attachments). To strip attachments, you must explicitly send `props: {"attachments": []}`. However, sending a PATCH with only `props` and no `message` field clears the message text, showing "(message deleted)". Always include the message text when patching props — fetch it first if needed.
 - **Config via defaults → config.json → env vars.** Config is resolved in priority order: dataclass defaults → `data/{agent_id}/config.json` → env vars. Env vars are highest priority. Dataclass defaults in `config.py`, sub-dataclasses in `config_types.py`.

--- a/docs/conversations.md
+++ b/docs/conversations.md
@@ -71,6 +71,57 @@ Place a `COMPACTION.md` file at `data/{agent_id}/COMPACTION.md` to customize the
 - **`conversation_compact`** — manually trigger compaction without waiting for the token budget to be exceeded
 - **`conversation_search`** — search past conversations using semantic search (across all archived conversations, not just the current one)
 
+## Web UI Conversations
+
+Web conversations are managed through a REST API. The web UI sidebar shows conversations organized into folders.
+
+### Conversation Folders
+
+Users can organize conversations into nested folders. Folder structure is tracked in a per-user JSON index file — conversation archive files stay in place (no filesystem moves).
+
+**Index file:** `data/{agent_id}/web/users/{username}/conversation_folders.json`
+
+```json
+{
+  "folders": ["projects", "projects/bot-redesign", "research"],
+  "assignments": {
+    "web-les-abc123": "projects/bot-redesign",
+    "web-les-def456": "research"
+  }
+}
+```
+
+- Conversations not in the index default to the top level
+- Folder names starting with `_` are reserved for virtual folders
+- Archiving preserves folder assignment; unarchiving restores it
+- Renaming a folder to an existing name merges them
+
+### Virtual Folders
+
+The sidebar shows two virtual folders at the top level:
+
+- **Archived** — archived conversations, preserving their folder structure
+- **System** — system conversations grouped into sub-folders by type (heartbeat, schedule, delegated)
+
+Virtual folders are navigable but not renamable or deletable.
+
+### REST API
+
+All conversation management uses REST (WebSocket is only for real-time chat streaming):
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/conversations?folder=` | List conversations + subfolders in a folder |
+| `GET` | `/api/conversations/archived?folder=` | List archived conversations by folder |
+| `GET` | `/api/conversations/system?folder=` | List system conversations by type |
+| `POST` | `/api/conversations` | Create conversation (optional: folder, effort) |
+| `PATCH` | `/api/conversations/{id}` | Rename and/or move to a folder |
+| `POST` | `/api/conversations/{id}/archive` | Archive a conversation |
+| `POST` | `/api/conversations/{id}/unarchive` | Unarchive a conversation |
+| `POST` | `/api/conversations/folders` | Create a folder |
+| `DELETE` | `/api/conversations/folders/{path}` | Delete an empty folder |
+| `PUT` | `/api/conversations/folders/{path}` | Rename/move a folder (merges on collision) |
+
 ## Files on disk
 
 ```
@@ -78,6 +129,9 @@ data/{agent_id}/workspace/
   conversations/
     {conv_id}.jsonl          # Append-only archive per conversation
   embeddings.db              # Semantic search index (includes conversation messages)
+data/{agent_id}/web/
+  users/{username}/
+    conversation_folders.json # Per-user folder index
 ```
 
-All files are human-readable (JSONL) and crash-recoverable (append-only writes).
+All files are human-readable (JSON/JSONL) and crash-recoverable (append-only writes, atomic folder index updates).

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -129,6 +129,17 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
     # -- Conversation routes ---------------------------------------------------
 
+    def _validate_folder_param(folder_param: str) -> str | None:
+        """Validate a folder query parameter. Returns error message or None."""
+        if not folder_param:
+            return None
+        if folder_param.startswith("/"):
+            return "invalid folder path"
+        segments = folder_param.split("/")
+        if any(not seg or seg == ".." for seg in segments):
+            return "invalid folder path"
+        return None
+
     def _require_auth(request):
         """Helper: get username from cookie or None."""
         from .web.auth import get_current_user
@@ -146,20 +157,160 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
     @_authenticated
     async def list_conversations(request: Request, username: str) -> JSONResponse:
-        """List conversations for the authenticated user."""
+        """List conversations and subfolders for a specific folder.
+
+        Query params:
+            folder — folder path (default: top-level)
+
+        Returns ``{folder, folders, conversations}`` mirroring vault_list pattern.
+        """
+        from .web.conversation_folders import ConversationFolderIndex
         from .web.conversations import ConversationIndex
+        folder_param = request.query_params.get("folder", "").strip()
+        err = _validate_folder_param(folder_param)
+        if err:
+            return JSONResponse({"error": err}, status_code=400)
         index = ConversationIndex(config)
+        folder_index = ConversationFolderIndex(config, username)
         convs = index.list_for_user(username)
-        return JSONResponse([c.to_dict() for c in convs])
+        assignments = await folder_index.get_all_assignments()
+        # Filter conversations to requested folder
+        filtered = [
+            c for c in convs
+            if assignments.get(c.conv_id, "") == folder_param
+        ]
+        # Get child folders
+        child_names = await folder_index.list_folders(folder_param)
+        folders: list[dict] = [
+            {"name": name, "path": f"{folder_param}/{name}" if folder_param else name}
+            for name in child_names
+        ]
+        # At top level, append virtual folders
+        if not folder_param:
+            folders.append({"name": "Archived", "path": "_archived", "virtual": True})
+            folders.append({"name": "System", "path": "_system", "virtual": True})
+        return JSONResponse({
+            "folder": folder_param,
+            "folders": folders,
+            "conversations": [c.to_dict() for c in filtered],
+        })
+
+    @_authenticated
+    async def list_archived_conversations(request: Request, username: str) -> JSONResponse:
+        """List archived conversations, optionally filtered by folder.
+
+        Query params:
+            folder — folder path (default: top-level)
+        """
+        from .web.conversation_folders import ConversationFolderIndex
+        from .web.conversations import ConversationIndex
+        folder_param = request.query_params.get("folder", "").strip()
+        err = _validate_folder_param(folder_param)
+        if err:
+            return JSONResponse({"error": err}, status_code=400)
+        index = ConversationIndex(config)
+        folder_index = ConversationFolderIndex(config, username)
+        convs = index.list_for_user(username, include_archived=True)
+        archived = [c for c in convs if c.archived]
+        assignments = await folder_index.get_all_assignments()
+        # Filter to requested folder
+        filtered = [
+            c for c in archived
+            if assignments.get(c.conv_id, "") == folder_param
+        ]
+        # Derive child folders from archived conversation assignments.
+        # Extract the immediate child segment — e.g. if folder_param="" and a
+        # conversation is in "projects/bot-redesign", emit "projects".
+        prefix = f"{folder_param}/" if folder_param else ""
+        child_names = set()
+        for c in archived:
+            folder = assignments.get(c.conv_id, "")
+            if not folder:
+                continue
+            if folder_param == "":
+                # Top level: extract first segment
+                child_names.add(folder.split("/")[0])
+            elif folder.startswith(prefix):
+                rest = folder[len(prefix):]
+                if rest:
+                    child_names.add(rest.split("/")[0])
+        folders = [
+            {"name": name, "path": f"{folder_param}/{name}" if folder_param else name}
+            for name in sorted(child_names)
+        ]
+        return JSONResponse({
+            "folder": folder_param,
+            "folders": folders,
+            "conversations": [c.to_dict() for c in filtered],
+        })
+
+    @_authenticated
+    async def list_system_conversations(request: Request, username: str) -> JSONResponse:
+        """List system conversations, grouped by type sub-folders.
+
+        Query params:
+            folder — sub-folder type: heartbeat, schedule, delegated (default: top-level)
+        """
+        from .web.conversations import list_system_conversations as list_sys
+        folder_param = request.query_params.get("folder", "").strip()
+        all_sys = list_sys(config, username=username)
+        if not folder_param:
+            # Top level: show type sub-folders, no conversations
+            folders = [
+                {"name": "Heartbeat", "path": "heartbeat"},
+                {"name": "Schedule", "path": "schedule"},
+                {"name": "Delegated", "path": "delegated"},
+            ]
+            return JSONResponse({
+                "folder": "",
+                "folders": folders,
+                "conversations": [],
+            })
+        # Filter by conv_type
+        valid_types = {"heartbeat", "schedule", "delegated"}
+        if folder_param not in valid_types:
+            return JSONResponse({"error": "invalid system folder"}, status_code=400)
+        filtered = [c for c in all_sys if c.get("conv_type") == folder_param]
+        return JSONResponse({
+            "folder": folder_param,
+            "folders": [],
+            "conversations": filtered,
+        })
 
     @_authenticated
     async def create_conversation(request: Request, username: str) -> JSONResponse:
-        """Create a new conversation."""
+        """Create a new conversation, optionally in a folder with an effort level."""
         body = await request.json()
+        folder = str(body.get("folder", "")).strip()
+        effort = str(body.get("effort", "")).strip()
+        # Validate effort level
+        if effort:
+            from .config import EFFORT_LEVELS
+            if effort not in EFFORT_LEVELS:
+                return JSONResponse({"error": f"Unknown effort level: {effort}"}, status_code=400)
+        # Validate folder exists before creating conversation
+        if folder:
+            from .web.conversation_folders import ConversationFolderIndex
+            folder_index = ConversationFolderIndex(config, username)
+            if not await folder_index.folder_exists(folder):
+                return JSONResponse({"error": "Folder does not exist"}, status_code=400)
         from .web.conversations import ConversationIndex
         index = ConversationIndex(config)
         conv = index.create(username, title=body.get("title", ""))
-        return JSONResponse(conv.to_dict(), status_code=201)
+        # Assign to folder
+        if folder:
+            await folder_index.set_folder(conv.conv_id, folder)
+        # Record initial effort level
+        if effort and effort != "default":
+            from .archive import append_message
+            append_message(config, conv.conv_id,
+                           {"role": "effort", "content": effort})
+        result = conv.to_dict()
+        if folder:
+            result["folder"] = folder
+        if effort:
+            result["effort"] = effort
+        return JSONResponse(result, status_code=201)
 
     @_authenticated
     async def get_conversation(request: Request, username: str) -> JSONResponse:
@@ -174,7 +325,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
     @_authenticated
     async def rename_conversation(request: Request, username: str) -> JSONResponse:
-        """Rename a conversation."""
+        """Rename and/or move a conversation to a different folder."""
         conv_id = request.path_params["id"]
         body = await request.json()
         from .web.conversations import ConversationIndex
@@ -182,10 +333,31 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         conv = index.get(conv_id)
         if not conv or conv.user_id != username:
             return JSONResponse({"error": "not found"}, status_code=404)
-        updated = index.rename(conv_id, body.get("title", ""))
-        if not updated:
-            return JSONResponse({"error": "not found"}, status_code=404)
-        return JSONResponse(updated.to_dict())
+        # Validate folder before applying any changes
+        folder = body.get("folder")
+        if folder is not None:
+            folder = str(folder).strip()
+            from .web.conversation_folders import ConversationFolderIndex
+            folder_index = ConversationFolderIndex(config, username)
+            if folder != "":
+                if not await folder_index.folder_exists(folder):
+                    return JSONResponse({"error": "Folder does not exist"}, status_code=400)
+        # Rename title if provided
+        title = body.get("title")
+        if title is not None:
+            updated = index.rename(conv_id, title)
+            if not updated:
+                return JSONResponse({"error": "not found"}, status_code=404)
+            conv = updated
+        # Move to folder if provided (already validated above)
+        if folder is not None:
+            ok, err = await folder_index.set_folder(conv_id, folder)
+            if not ok:
+                return JSONResponse({"error": err}, status_code=400)
+        result = conv.to_dict()
+        if folder is not None:
+            result["folder"] = folder
+        return JSONResponse(result)
 
     @_authenticated
     async def get_conversation_history(request: Request, username: str) -> JSONResponse:
@@ -580,6 +752,67 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         index.archive(conv_id)
         return JSONResponse({"ok": True})
 
+    @_authenticated
+    async def unarchive_conversation(request: Request, username: str) -> JSONResponse:
+        """Unarchive a conversation (restore to active list)."""
+        conv_id = request.path_params["id"]
+        from .web.conversations import ConversationIndex
+        index = ConversationIndex(config)
+        conv = index.get(conv_id)
+        if not conv or conv.user_id != username:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        index.unarchive(conv_id)
+        return JSONResponse({"ok": True})
+
+    # -- Conversation folder routes -----------------------------------------------
+
+    @_authenticated
+    async def create_conv_folder(request: Request, username: str) -> JSONResponse:
+        """Create a conversation folder."""
+        body = await request.json()
+        path = body.get("path", "")
+        if not path or not isinstance(path, str):
+            return JSONResponse({"error": "path (string) required"}, status_code=400)
+        from .web.conversation_folders import ConversationFolderIndex
+        folder_index = ConversationFolderIndex(config, username)
+        ok, err = await folder_index.create_folder(path.strip())
+        if not ok:
+            status = 409 if "already exists" in err else 400
+            return JSONResponse({"error": err}, status_code=status)
+        return JSONResponse({"ok": True, "path": path.strip()})
+
+    @_authenticated
+    async def delete_conv_folder(request: Request, username: str) -> JSONResponse:
+        """Delete an empty conversation folder."""
+        path = request.path_params.get("path", "")
+        if not path:
+            return JSONResponse({"error": "path required"}, status_code=400)
+        from .web.conversation_folders import ConversationFolderIndex
+        folder_index = ConversationFolderIndex(config, username)
+        ok, err = await folder_index.delete_folder(path)
+        if not ok:
+            status = 409 if "contains" in err else 404
+            return JSONResponse({"error": err}, status_code=status)
+        return JSONResponse({"ok": True})
+
+    @_authenticated
+    async def rename_conv_folder(request: Request, username: str) -> JSONResponse:
+        """Rename/move a conversation folder. Merges if target exists."""
+        old_path = request.path_params.get("path", "")
+        if not old_path:
+            return JSONResponse({"error": "path required"}, status_code=400)
+        body = await request.json()
+        new_path = body.get("path", "")
+        if not new_path or not isinstance(new_path, str):
+            return JSONResponse({"error": "path (string) required in body"}, status_code=400)
+        from .web.conversation_folders import ConversationFolderIndex
+        folder_index = ConversationFolderIndex(config, username)
+        ok, err = await folder_index.rename_folder(old_path, new_path.strip())
+        if not ok:
+            status = 404 if "not found" in err else 400
+            return JSONResponse({"error": err}, status_code=status)
+        return JSONResponse({"ok": True})
+
     # -- Config file routes ----------------------------------------------------
 
     def _resolve_config_path(path_str: str) -> tuple:
@@ -736,11 +969,17 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         Route("/api/auth/logout", auth_logout, methods=["POST"]),
         Route("/api/auth/me", auth_me, methods=["GET"]),
         Route("/api/conversations", list_conversations, methods=["GET"]),
+        Route("/api/conversations/archived", list_archived_conversations, methods=["GET"]),
+        Route("/api/conversations/system", list_system_conversations, methods=["GET"]),
         Route("/api/conversations", create_conversation, methods=["POST"]),
         Route("/api/conversations/{id}", get_conversation, methods=["GET"]),
         Route("/api/conversations/{id}", rename_conversation, methods=["PATCH"]),
         Route("/api/conversations/{id}/history", get_conversation_history, methods=["GET"]),
+        Route("/api/conversations/folders", create_conv_folder, methods=["POST"]),
+        Route("/api/conversations/folders/{path:path}", delete_conv_folder, methods=["DELETE"]),
+        Route("/api/conversations/folders/{path:path}", rename_conv_folder, methods=["PUT"]),
         Route("/api/conversations/{id}/archive", archive_conversation, methods=["POST"]),
+        Route("/api/conversations/{id}/unarchive", unarchive_conversation, methods=["POST"]),
         Route("/api/upload/{conv_id}", handle_upload, methods=["POST"]),
         Route("/api/workspace/{path:path}", serve_workspace_file, methods=["GET"]),
         Route("/api/config/files", config_list_files, methods=["GET"]),

--- a/src/decafclaw/web/conversation_folders.py
+++ b/src/decafclaw/web/conversation_folders.py
@@ -1,0 +1,228 @@
+"""Conversation folder index — per-user folder structure for organizing conversations."""
+
+import asyncio
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _validate_path(path: str) -> str | None:
+    """Validate a folder path. Returns error message or None if valid."""
+    if not path:
+        return "Path cannot be empty"
+    if ".." in path.split("/"):
+        return "Path cannot contain '..'"
+    if path.startswith("/"):
+        return "Path cannot start with '/'"
+    if path.startswith("_") or any(
+        seg.startswith("_") for seg in path.split("/")
+    ):
+        return "Path segments starting with '_' are reserved"
+    if any(seg == "" for seg in path.split("/")):
+        return "Path cannot contain empty segments"
+    return None
+
+
+class ConversationFolderIndex:
+    """Manages per-user conversation folder structure and assignments.
+
+    Backed by a JSON file at data/{agent_id}/web/users/{username}/conversation_folders.json.
+
+    JSON structure:
+    {
+        "folders": ["projects", "projects/bot-redesign", "research"],
+        "assignments": {
+            "web-les-abc123": "projects/bot-redesign"
+        }
+    }
+    """
+
+    def __init__(self, config, username: str):
+        self._path = (
+            config.agent_path / "web" / "users" / username
+            / "conversation_folders.json"
+        )
+        self._lock = asyncio.Lock()
+
+    def _load(self) -> dict:
+        if not self._path.exists():
+            return {"folders": [], "assignments": {}}
+        try:
+            data = json.loads(self._path.read_text())
+            # Ensure expected shape
+            if not isinstance(data.get("folders"), list):
+                data["folders"] = []
+            if not isinstance(data.get("assignments"), dict):
+                data["assignments"] = {}
+            return data
+        except (json.JSONDecodeError, OSError) as e:
+            log.warning(f"Could not read folder index: {e}")
+            return {"folders": [], "assignments": {}}
+
+    def _save(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(data, indent=2) + "\n"
+        # Atomic write via temp file + rename
+        fd, tmp = tempfile.mkstemp(
+            dir=self._path.parent, suffix=".tmp"
+        )
+        try:
+            with open(fd, "w") as f:
+                f.write(content)
+            Path(tmp).replace(self._path)
+        except Exception:
+            Path(tmp).unlink(missing_ok=True)
+            raise
+
+    async def list_folders(self, parent: str = "") -> list[str]:
+        """Return immediate child folder names under parent."""
+        async with self._lock:
+            data = self._load()
+        prefix = f"{parent}/" if parent else ""
+        result = set()
+        for folder in data["folders"]:
+            if parent == "":
+                # Top-level: folders with no "/" in them
+                if "/" not in folder:
+                    result.add(folder)
+            elif folder.startswith(prefix):
+                rest = folder[len(prefix):]
+                if rest and "/" not in rest:
+                    result.add(rest)
+        return sorted(result)
+
+    async def create_folder(self, path: str) -> tuple[bool, str]:
+        """Create a folder (and parents). Returns (success, error_message)."""
+        err = _validate_path(path)
+        if err:
+            return False, err
+        async with self._lock:
+            data = self._load()
+            if path in data["folders"]:
+                return False, "Folder already exists"
+            # Auto-create parent folders
+            parts = path.split("/")
+            for i in range(1, len(parts) + 1):
+                ancestor = "/".join(parts[:i])
+                if ancestor not in data["folders"]:
+                    data["folders"].append(ancestor)
+            self._save(data)
+        return True, ""
+
+    async def delete_folder(self, path: str) -> tuple[bool, str]:
+        """Delete an empty folder. Returns (success, error_message)."""
+        async with self._lock:
+            data = self._load()
+            if path not in data["folders"]:
+                return False, "Folder not found"
+            # Check for conversations in this folder
+            for folder in data["assignments"].values():
+                if folder == path:
+                    return False, "Folder contains conversations"
+            # Check for child folders
+            prefix = f"{path}/"
+            for folder in data["folders"]:
+                if folder.startswith(prefix):
+                    return False, "Folder contains subfolders"
+            data["folders"].remove(path)
+            self._save(data)
+        return True, ""
+
+    async def rename_folder(
+        self, old_path: str, new_path: str
+    ) -> tuple[bool, str]:
+        """Rename/move a folder. Merges if target exists. Returns (success, error_message)."""
+        err = _validate_path(new_path)
+        if err:
+            return False, err
+        async with self._lock:
+            data = self._load()
+            if old_path not in data["folders"]:
+                return False, "Folder not found"
+            old_prefix = f"{old_path}/"
+            # Collect all folders to rename (old_path + children)
+            to_rename = [f for f in data["folders"] if f == old_path or f.startswith(old_prefix)]
+            # Remove old folders, add new ones
+            for old_f in to_rename:
+                data["folders"].remove(old_f)
+                if old_f == old_path:
+                    new_f = new_path
+                else:
+                    new_f = new_path + old_f[len(old_path):]
+                if new_f not in data["folders"]:
+                    data["folders"].append(new_f)
+            # Update assignments
+            for conv_id, folder in list(data["assignments"].items()):
+                if folder == old_path:
+                    data["assignments"][conv_id] = new_path
+                elif folder.startswith(old_prefix):
+                    data["assignments"][conv_id] = new_path + folder[len(old_path):]
+            self._save(data)
+        return True, ""
+
+    async def folder_exists(self, path: str) -> bool:
+        """Check if a folder exists."""
+        err = _validate_path(path)
+        if err:
+            return False
+        async with self._lock:
+            data = self._load()
+        return path in data["folders"]
+
+    async def get_folder(self, conv_id: str) -> str:
+        """Return folder path for a conversation, or '' for top-level."""
+        async with self._lock:
+            data = self._load()
+        return data["assignments"].get(conv_id, "")
+
+    async def set_folder(
+        self, conv_id: str, folder: str
+    ) -> tuple[bool, str]:
+        """Assign a conversation to a folder. Returns (success, error_message)."""
+        if folder == "":
+            # Move to top-level: just remove assignment
+            async with self._lock:
+                data = self._load()
+                data["assignments"].pop(conv_id, None)
+                self._save(data)
+            return True, ""
+        err = _validate_path(folder)
+        if err:
+            return False, err
+        async with self._lock:
+            data = self._load()
+            if folder not in data["folders"]:
+                return False, "Folder does not exist"
+            data["assignments"][conv_id] = folder
+            self._save(data)
+        return True, ""
+
+    async def remove_assignment(self, conv_id: str) -> None:
+        """Remove a conversation's folder assignment."""
+        async with self._lock:
+            data = self._load()
+            if conv_id in data["assignments"]:
+                del data["assignments"][conv_id]
+                self._save(data)
+
+    async def list_conversations_in_folder(
+        self, folder: str = ""
+    ) -> list[str]:
+        """Return conv_ids assigned to this exact folder."""
+        async with self._lock:
+            data = self._load()
+        if folder == "":
+            # Top-level: caller must filter by checking assignments
+            return []
+        return [
+            cid for cid, f in data["assignments"].items() if f == folder
+        ]
+
+    async def get_all_assignments(self) -> dict[str, str]:
+        """Return all conv_id → folder assignments."""
+        async with self._lock:
+            data = self._load()
+        return dict(data["assignments"])

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -5,15 +5,14 @@ export class ConversationSidebar extends LitElement {
     store: { type: Object, attribute: false },
     authClient: { type: Object, attribute: false },
     _conversations: { type: Array, state: true },
-    _archived: { type: Array, state: true },
+    _chatFolders: { type: Array, state: true },
+    _chatSection: { type: String, state: true },
+    _chatFolder: { type: String, state: true },
     _activeId: { type: String, state: true },
-    _showArchived: { type: Boolean, state: true },
     _contextUsage: { type: Number, state: true },
     _contextLimit: { type: Number, state: true },
     _currentEffort: { type: String, state: true },
     _effortModel: { type: String, state: true },
-    _systemConversations: { type: Array, state: true },
-    _showSystem: { type: Boolean, state: true },
     _collapsed: { type: Boolean, state: true },
     _mobileOpen: { type: Boolean, state: true },
     _sidebarTab: { type: String, state: true },
@@ -31,15 +30,17 @@ export class ConversationSidebar extends LitElement {
     this.store = null;
     this.authClient = null;
     this._conversations = [];
-    this._archived = [];
+    /** @type {Array<{name: string, path: string, virtual?: boolean}>} */
+    this._chatFolders = [];
+    /** @type {string} which section: '' (active), '_archived', '_system' */
+    this._chatSection = '';
+    /** @type {string} folder path within the section */
+    this._chatFolder = '';
     this._activeId = null;
-    this._showArchived = false;
     this._contextUsage = 0;
     this._contextLimit = 0;
     this._currentEffort = 'default';
     this._effortModel = '';
-    this._systemConversations = [];
-    this._showSystem = false;
     this._collapsed = localStorage.getItem('sidebar-collapsed') === 'true';
     this._mobileOpen = false;
     this._sidebarTab = 'conversations';
@@ -64,14 +65,22 @@ export class ConversationSidebar extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this._onStoreChange = () => {
-      this._conversations = this.store?.conversations || [];
-      this._archived = this.store?.archivedConversations || [];
       this._activeId = this.store?.currentConvId;
       this._contextUsage = this.store?.contextUsage || 0;
       this._contextLimit = this.store?.contextLimit || 0;
       this._currentEffort = this.store?.currentEffort || 'default';
       this._effortModel = this.store?.effortModel || '';
-      this._systemConversations = this.store?.systemConversations || [];
+      // Update conversation list and folders based on current section
+      if (this._chatSection === '_archived') {
+        this._conversations = this.store?.archivedConversations || [];
+        this._chatFolders = this.store?.archivedFolders || [];
+      } else if (this._chatSection === '_system') {
+        this._conversations = this.store?.systemConversations || [];
+        this._chatFolders = this.store?.systemFolders || [];
+      } else {
+        this._conversations = this.store?.conversations || [];
+        this._chatFolders = this.store?.folders || [];
+      }
     };
   }
 
@@ -189,7 +198,114 @@ export class ConversationSidebar extends LitElement {
   }
 
   #handleNew() {
-    this.store?.createConversation();
+    // Create in current folder (only in active section)
+    const folder = this._chatSection === '' ? this._chatFolder : '';
+    this.store?.createConversation('', '', folder);
+  }
+
+  async #createChatFolder() {
+    const name = prompt('New folder name:');
+    if (!name || !name.trim()) return;
+    if (name.trim().startsWith('_')) {
+      alert('Folder names starting with "_" are reserved.');
+      return;
+    }
+    const path = this._chatFolder
+      ? `${this._chatFolder}/${name.trim()}`
+      : name.trim();
+    const ok = await this.store?.createFolder(path);
+    if (!ok) alert('Failed to create folder.');
+  }
+
+  /**
+   * @param {string} folderPath
+   * @param {string} folderName
+   */
+  async #renameChatFolder(folderPath, folderName) {
+    const newName = prompt('Rename folder:', folderName);
+    if (!newName || !newName.trim() || newName.trim() === folderName) return;
+    if (newName.trim().startsWith('_')) {
+      alert('Folder names starting with "_" are reserved.');
+      return;
+    }
+    // Build new path: replace last segment
+    const parts = folderPath.split('/');
+    parts[parts.length - 1] = newName.trim();
+    const newPath = parts.join('/');
+    const ok = await this.store?.renameFolder(folderPath, newPath);
+    if (!ok) alert('Failed to rename folder.');
+  }
+
+  /** @param {string} folderPath */
+  async #deleteChatFolder(folderPath) {
+    if (!confirm(`Delete folder "${folderPath}"? It must be empty.`)) return;
+    const ok = await this.store?.deleteFolder(folderPath);
+    if (!ok) alert('Failed to delete folder. It may not be empty.');
+  }
+
+  #renderChatBreadcrumbs() {
+    // Build breadcrumb path based on section and folder
+    const section = this._chatSection;
+    const folder = this._chatFolder;
+
+    // At the very top level — no breadcrumbs needed
+    if (!section && !folder) return nothing;
+
+    const crumbs = [];
+
+    // Root "Chats" segment — always navigates to top level
+    crumbs.push(html`
+      <button type="button" class="vault-breadcrumb-segment"
+        @click=${() => this.#navigateChatFolder('', '')}>Chats</button>
+    `);
+
+    // Section segment (Archived or System)
+    if (section === '_archived') {
+      if (folder) {
+        crumbs.push(html`
+          <span class="vault-breadcrumb-sep">/</span>
+          <button type="button" class="vault-breadcrumb-segment"
+            @click=${() => this.#navigateChatFolder('_archived', '')}>Archived</button>
+        `);
+      } else {
+        crumbs.push(html`
+          <span class="vault-breadcrumb-sep">/</span>
+          <span class="vault-breadcrumb-segment active">Archived</span>
+        `);
+      }
+    } else if (section === '_system') {
+      if (folder) {
+        crumbs.push(html`
+          <span class="vault-breadcrumb-sep">/</span>
+          <button type="button" class="vault-breadcrumb-segment"
+            @click=${() => this.#navigateChatFolder('_system', '')}>System</button>
+        `);
+      } else {
+        crumbs.push(html`
+          <span class="vault-breadcrumb-sep">/</span>
+          <span class="vault-breadcrumb-segment active">System</span>
+        `);
+      }
+    }
+
+    // Folder path segments
+    if (folder) {
+      const segments = folder.split('/');
+      segments.forEach((seg, i) => {
+        const path = segments.slice(0, i + 1).join('/');
+        const isLast = i === segments.length - 1;
+        crumbs.push(html`
+          <span class="vault-breadcrumb-sep">/</span>
+          ${isLast
+            ? html`<span class="vault-breadcrumb-segment active">${seg}</span>`
+            : html`<button type="button" class="vault-breadcrumb-segment"
+                @click=${() => this.#navigateChatFolder(section, path)}>${seg}</button>`
+          }
+        `);
+      });
+    }
+
+    return html`<div class="vault-breadcrumbs">${crumbs}</div>`;
   }
 
   /** @param {string} convId */
@@ -279,17 +395,20 @@ export class ConversationSidebar extends LitElement {
     `;
   }
 
-  #toggleArchived() {
-    this._showArchived = !this._showArchived;
-    if (this._showArchived) {
-      this.store?.listArchivedConversations();
-    }
-  }
-
-  #toggleSystem() {
-    this._showSystem = !this._showSystem;
-    if (this._showSystem) {
-      this.store?.listSystemConversations();
+  /**
+   * Navigate the chat sidebar to a section and folder.
+   * @param {string} section — '' (active), '_archived', '_system'
+   * @param {string} folder — folder path within the section
+   */
+  #navigateChatFolder(section, folder) {
+    this._chatSection = section;
+    this._chatFolder = folder;
+    if (section === '_archived') {
+      this.store?.listArchivedConversations(folder);
+    } else if (section === '_system') {
+      this.store?.listSystemConversations(folder);
+    } else {
+      this.store?.listConversations(folder);
     }
   }
 
@@ -426,55 +545,63 @@ export class ConversationSidebar extends LitElement {
       </div>
       ${this._sidebarTab === 'wiki' ? this.#renderWikiTab() : nothing}
       <div class="conv-list" style="${this._sidebarTab !== 'conversations' ? 'display:none' : ''}">
-        <button class="new-conv-btn outline" @click=${this.#handleNew} title="New chat (⌘K)">+ Chat</button>
-        ${this._conversations.length === 0
-          ? nothing
-          : this._conversations.map(c => this.#renderConversationItem(c, {
-              isActive: c.conv_id === this._activeId,
-              actionLabel: '\u00d7',
-              actionTitle: 'Archive conversation',
-              onAction: (id) => this.#handleArchive(id),
-              onDblClick: (/** @type {Event} */ e) => { e.stopPropagation(); this.#handleRename(c.conv_id, c.title); },
-            }))
-        }
-
-        <div
-          class="archived-toggle"
-          @click=${this.#toggleArchived}
-        >
-          <span>${this._showArchived ? '\u25bc' : '\u25b6'} Archived</span>
-        </div>
-
-        ${this._showArchived ? html`
-          ${this._archived.length === 0
-            ? html`<p style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color); font-size: 0.85rem;">No archived conversations</p>`
-            : this._archived.map(c => this.#renderConversationItem(c, {
-                extraClass: 'archived',
-                actionLabel: '\u21a9',
-                actionTitle: 'Unarchive conversation',
-                onAction: (id) => this.#handleUnarchive(id),
-              }))
-          }
+        ${this._chatSection === '' ? html`
+          <div class="vault-action-btns">
+            <button class="new-conv-btn outline" @click=${this.#handleNew} title="New chat (⌘K)">+ Chat</button>
+            <button class="wiki-new-folder-btn outline" @click=${() => this.#createChatFolder()}>+ Folder</button>
+          </div>
         ` : nothing}
-
-        <div
-          class="archived-toggle"
-          @click=${this.#toggleSystem}
-        >
-          <span>${this._showSystem ? '\u25bc' : '\u25b6'} System</span>
-        </div>
-
-        ${this._showSystem ? html`
-          ${this._systemConversations.length === 0
-            ? html`<p style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color); font-size: 0.85rem;">No system conversations</p>`
-            : this._systemConversations.map(c => this.#renderConversationItem(c, {
+        ${this.#renderChatBreadcrumbs()}
+        ${this._chatFolders.map(f => {
+          const isVirtual = f.virtual || f.path === '_archived' || f.path === '_system' || this._chatSection !== '';
+          return html`
+            <div class="conv-item wiki-item wiki-folder-item"
+              @click=${() => {
+                if (f.path === '_archived') {
+                  this.#navigateChatFolder('_archived', '');
+                } else if (f.path === '_system') {
+                  this.#navigateChatFolder('_system', '');
+                } else {
+                  this.#navigateChatFolder(this._chatSection, f.path);
+                }
+              }}
+              @dblclick=${!isVirtual ? (/** @type {Event} */ e) => { e.stopPropagation(); this.#renameChatFolder(f.path, f.name); } : nothing}
+              title=${f.path}>
+              <span class="conv-title">\u{1F4C1} ${f.name}</span>
+              ${!isVirtual ? html`
+                <button class="conv-archive" aria-label="Delete folder"
+                  @click=${(/** @type {Event} */ e) => { e.stopPropagation(); this.#deleteChatFolder(f.path); }}
+                  title="Delete folder">\u00d7</button>
+              ` : nothing}
+            </div>
+          `;
+        })}
+        ${this._conversations.length === 0 && this._chatFolders.length === 0
+          ? html`<p style="padding: 0.5rem 0.75rem; color: var(--pico-muted-color); font-size: 0.85rem;">No conversations</p>`
+          : nothing
+        }
+        ${this._chatSection === '_archived'
+          ? this._conversations.map(c => this.#renderConversationItem(c, {
+              extraClass: 'archived',
+              actionLabel: '\u21a9',
+              actionTitle: 'Unarchive conversation',
+              onAction: (id) => this.#handleUnarchive(id),
+            }))
+          : this._chatSection === '_system'
+            ? this._conversations.map(c => this.#renderConversationItem(c, {
                 isActive: c.conv_id === this._activeId,
                 extraClass: 'system',
                 badge: c.conv_type,
                 titleSuffix: c.conv_type,
               }))
-          }
-        ` : nothing}
+            : this._conversations.map(c => this.#renderConversationItem(c, {
+                isActive: c.conv_id === this._activeId,
+                actionLabel: '\u00d7',
+                actionTitle: 'Archive conversation',
+                onAction: (id) => this.#handleArchive(id),
+                onDblClick: (/** @type {Event} */ e) => { e.stopPropagation(); this.#handleRename(c.conv_id, c.title); },
+              }))
+        }
       </div>
       <div class="effort-picker" title="${this._effortModel ? `Model: ${this._effortModel}` : ''}">
         <div class="effort-picker-label">Effort</div>

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -29,17 +29,23 @@
  * @property {string} message
  */
 
+/**
+ * @typedef {object} FolderEntry
+ * @property {string} name
+ * @property {string} path
+ * @property {boolean} [virtual]
+ */
+
 import { uploadFile } from './upload-client.js';
+import { encodePagePath } from './utils.js';
 import { MessageStore } from './message-store.js';
 import { ToolStatusStore } from './tool-status-store.js';
 import { WebSocketClient } from './websocket-client.js';
 
 /**
  * Central state store for conversations.
- * Talks to the server via WebSocketClient, holds all UI state,
- * and emits 'change' events for components to re-render.
- *
- * Message and tool-status state are delegated to sub-stores.
+ * Conversation management (list, create, rename, archive, folders) uses REST.
+ * Real-time chat streaming uses WebSocket.
  *
  * @fires ConversationStore#change
  */
@@ -50,14 +56,36 @@ export class ConversationStore extends EventTarget {
   #messageStore;
   /** @type {ToolStatusStore} */
   #toolStatusStore;
+
+  // -- Active conversations state --
   /** @type {ConversationMeta[]} */
   #conversations = [];
+  /** @type {FolderEntry[]} */
+  #folders = [];
+  /** @type {string} */
+  #currentFolder = '';
+
+  // -- Archived conversations state --
+  /** @type {ConversationMeta[]} */
+  #archivedConversations = [];
+  /** @type {FolderEntry[]} */
+  #archivedFolders = [];
+  /** @type {string} */
+  #archivedCurrentFolder = '';
+
+  // -- System conversations state --
+  /** @type {object[]} */
+  #systemConversations = [];
+  /** @type {FolderEntry[]} */
+  #systemFolders = [];
+  /** @type {string} */
+  #systemCurrentFolder = '';
+
+  // -- Current conversation state --
   /** @type {string|null} */
   #currentConvId = null;
   /** @type {boolean} */
   #busy = false;
-  /** @type {ConversationMeta[]} */
-  #archivedConversations = [];
   /** @type {number} prompt tokens used in the last completed turn */
   #contextUsage = 0;
   /** @type {number} effective context limit (compaction threshold) */
@@ -66,8 +94,6 @@ export class ConversationStore extends EventTarget {
   #currentEffort = 'default';
   /** @type {string} resolved model name for the current effort level */
   #effortModel = '';
-  /** @type {object[]} system conversations (schedule, heartbeat, etc.) */
-  #systemConversations = [];
   /** @type {boolean} whether the current conversation is read-only */
   #readOnly = false;
   /** @type {string|null} message queued while creating a conversation */
@@ -90,6 +116,10 @@ export class ConversationStore extends EventTarget {
 
   /** @returns {ConversationMeta[]} sorted by updated_at desc */
   get conversations() { return this.#conversations; }
+  /** @returns {FolderEntry[]} */
+  get folders() { return this.#folders; }
+  /** @returns {string} */
+  get currentFolder() { return this.#currentFolder; }
   /** @returns {string|null} */
   get currentConvId() { return this.#currentConvId; }
   /** @returns {ChatMessage[]} */
@@ -106,6 +136,10 @@ export class ConversationStore extends EventTarget {
   get toolStatus() { return this.#toolStatusStore.toolStatus; }
   /** @returns {ConversationMeta[]} */
   get archivedConversations() { return this.#archivedConversations; }
+  /** @returns {FolderEntry[]} */
+  get archivedFolders() { return this.#archivedFolders; }
+  /** @returns {string} */
+  get archivedCurrentFolder() { return this.#archivedCurrentFolder; }
   /** @returns {number} */
   get contextUsage() { return this.#contextUsage; }
   /** @returns {number} */
@@ -116,21 +150,236 @@ export class ConversationStore extends EventTarget {
   get effortModel() { return this.#effortModel; }
   /** @returns {object[]} */
   get systemConversations() { return this.#systemConversations; }
+  /** @returns {FolderEntry[]} */
+  get systemFolders() { return this.#systemFolders; }
+  /** @returns {string} */
+  get systemCurrentFolder() { return this.#systemCurrentFolder; }
   /** @returns {boolean} */
   get isReadOnly() { return this.#readOnly; }
 
-  // -- Actions (called by components) -----------------------------------------
+  // -- REST-based conversation management ------------------------------------
 
-  listConversations() {
-    this.#ws.send({ type: 'list_convs' });
+  /** @param {string} [folder] */
+  async listConversations(folder = '') {
+    try {
+      const url = folder
+        ? `/api/conversations?folder=${encodeURIComponent(folder)}`
+        : '/api/conversations';
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      this.#conversations = data.conversations || [];
+      this.#folders = data.folders || [];
+      this.#currentFolder = data.folder || '';
+      this.#emitChange();
+    } catch (err) {
+      console.error('Failed to list conversations:', err);
+    }
   }
 
-  /** @param {string} [title] @param {string} [effort] */
-  createConversation(title = '', effort = '') {
-    const msg = { type: 'create_conv', title };
-    if (effort) msg.effort = effort;
-    this.#ws.send(msg);
+  /** @param {string} [folder] */
+  async listArchivedConversations(folder = '') {
+    try {
+      const url = folder
+        ? `/api/conversations/archived?folder=${encodeURIComponent(folder)}`
+        : '/api/conversations/archived';
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      this.#archivedConversations = data.conversations || [];
+      this.#archivedFolders = data.folders || [];
+      this.#archivedCurrentFolder = data.folder || '';
+      this.#emitChange();
+    } catch (err) {
+      console.error('Failed to list archived conversations:', err);
+    }
   }
+
+  /** @param {string} [folder] */
+  async listSystemConversations(folder = '') {
+    try {
+      const url = folder
+        ? `/api/conversations/system?folder=${encodeURIComponent(folder)}`
+        : '/api/conversations/system';
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      this.#systemConversations = data.conversations || [];
+      this.#systemFolders = data.folders || [];
+      this.#systemCurrentFolder = data.folder || '';
+      this.#emitChange();
+    } catch (err) {
+      console.error('Failed to list system conversations:', err);
+    }
+  }
+
+  /**
+   * @param {string} [title]
+   * @param {string} [effort]
+   * @param {string} [folder]
+   */
+  async createConversation(title = '', effort = '', folder = '') {
+    try {
+      /** @type {Record<string, string>} */
+      const body = { title };
+      if (effort) body.effort = effort;
+      if (folder) body.folder = folder;
+      const resp = await fetch('/api/conversations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) return;
+      const conv = await resp.json();
+      // Insert into local list and select
+      this.#conversations.unshift(conv);
+      if (conv.effort) this.#currentEffort = conv.effort;
+      this.selectConversation(conv.conv_id);
+      // Flush any message queued while the conversation was being created
+      if (this.#pendingMessage) {
+        const text = this.#pendingMessage;
+        const atts = this.#pendingAttachments;
+        this.#pendingMessage = null;
+        this.#pendingAttachments = [];
+        this.#uploadAndSend(conv.conv_id, text, atts);
+      }
+    } catch (err) {
+      console.error('Failed to create conversation:', err);
+    }
+  }
+
+  /** @param {string} convId @param {string} title */
+  async renameConversation(convId, title) {
+    try {
+      const resp = await fetch(`/api/conversations/${convId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      });
+      if (!resp.ok) return;
+      const updated = await resp.json();
+      this.#conversations = this.#conversations.map(c =>
+        c.conv_id === convId ? { ...c, ...updated } : c
+      );
+      this.#emitChange();
+    } catch (err) {
+      console.error('Failed to rename conversation:', err);
+    }
+  }
+
+  /** @param {string} convId @param {string} folder */
+  async moveConversation(convId, folder) {
+    try {
+      const resp = await fetch(`/api/conversations/${convId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ folder }),
+      });
+      if (!resp.ok) return;
+      // Re-fetch current folder listing
+      await this.listConversations(this.#currentFolder);
+    } catch (err) {
+      console.error('Failed to move conversation:', err);
+    }
+  }
+
+  /** @param {string} convId */
+  async archiveConversation(convId) {
+    try {
+      const resp = await fetch(`/api/conversations/${convId}/archive`, {
+        method: 'POST',
+      });
+      if (!resp.ok) return;
+      // If we're viewing the archived conversation, deselect it
+      if (this.#currentConvId === convId) {
+        this.#currentConvId = null;
+        this.#messageStore.clear();
+      }
+      // Re-fetch current folder listing
+      await this.listConversations(this.#currentFolder);
+    } catch (err) {
+      console.error('Failed to archive conversation:', err);
+    }
+  }
+
+  /** @param {string} convId */
+  async unarchiveConversation(convId) {
+    try {
+      const resp = await fetch(`/api/conversations/${convId}/unarchive`, {
+        method: 'POST',
+      });
+      if (!resp.ok) return;
+      // Re-fetch archived listing
+      await this.listArchivedConversations(this.#archivedCurrentFolder);
+    } catch (err) {
+      console.error('Failed to unarchive conversation:', err);
+    }
+  }
+
+  // -- Folder management (REST) -----------------------------------------------
+
+  /** @param {string} path */
+  async createFolder(path) {
+    try {
+      const resp = await fetch('/api/conversations/folders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json();
+        console.error('Failed to create folder:', data.error);
+        return false;
+      }
+      await this.listConversations(this.#currentFolder);
+      return true;
+    } catch (err) {
+      console.error('Failed to create folder:', err);
+      return false;
+    }
+  }
+
+  /** @param {string} path */
+  async deleteFolder(path) {
+    try {
+      const resp = await fetch(`/api/conversations/folders/${encodePagePath(path)}`, {
+        method: 'DELETE',
+      });
+      if (!resp.ok) {
+        const data = await resp.json();
+        console.error('Failed to delete folder:', data.error);
+        return false;
+      }
+      await this.listConversations(this.#currentFolder);
+      return true;
+    } catch (err) {
+      console.error('Failed to delete folder:', err);
+      return false;
+    }
+  }
+
+  /** @param {string} oldPath @param {string} newPath */
+  async renameFolder(oldPath, newPath) {
+    try {
+      const resp = await fetch(`/api/conversations/folders/${encodePagePath(oldPath)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: newPath }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json();
+        console.error('Failed to rename folder:', data.error);
+        return false;
+      }
+      await this.listConversations(this.#currentFolder);
+      return true;
+    } catch (err) {
+      console.error('Failed to rename folder:', err);
+      return false;
+    }
+  }
+
+  // -- WebSocket-based actions (chat streaming) --------------------------------
 
   /** @param {string} convId */
   selectConversation(convId) {
@@ -147,35 +396,6 @@ export class ConversationStore extends EventTarget {
     this.#emitChange();
   }
 
-  /** @param {string} convId @param {string} title */
-  renameConversation(convId, title) {
-    this.#ws.send({ type: 'rename_conv', conv_id: convId, title });
-  }
-
-  listArchivedConversations() {
-    this.#ws.send({ type: 'list_archived' });
-  }
-
-  listSystemConversations() {
-    this.#ws.send({ type: 'list_system_convs' });
-  }
-
-  /** @param {string} convId */
-  unarchiveConversation(convId) {
-    this.#ws.send({ type: 'unarchive_conv', conv_id: convId });
-  }
-
-  /** @param {string} convId */
-  archiveConversation(convId) {
-    this.#ws.send({ type: 'archive_conv', conv_id: convId });
-    // If we're viewing the archived conversation, deselect it
-    if (this.#currentConvId === convId) {
-      this.#currentConvId = null;
-      this.#messageStore.clear();
-      this.#emitChange();
-    }
-  }
-
   /**
    * @param {string} text
    * @param {{filename: string, path: string, mime_type: string}[]} [attachments]
@@ -187,7 +407,7 @@ export class ConversationStore extends EventTarget {
       this.#pendingMessage = text;
       this.#pendingAttachments = attachments;
       const effort = this.#currentEffort !== 'default' ? this.#currentEffort : '';
-      this.createConversation('', effort);
+      this.createConversation('', effort, this.#currentFolder);
       return;
     }
     // Optimistically add user message
@@ -207,7 +427,6 @@ export class ConversationStore extends EventTarget {
 
   /**
    * Upload any pending File objects, then send the message.
-   * Used when a conversation was just created and files need uploading.
    * @param {string} convId
    * @param {string} text
    * @param {object[]} attachments
@@ -258,7 +477,7 @@ export class ConversationStore extends EventTarget {
     this.#toolStatusStore.respondToConfirm(contextId, tool, toolCallId, approved, extra);
   }
 
-  // -- Message handling (from WebSocket) --------------------------------------
+  // -- WebSocket message handling (chat streaming) ----------------------------
 
   /** @param {object} msg */
   #handleMessage(msg) {
@@ -278,7 +497,7 @@ export class ConversationStore extends EventTarget {
           this.#busy = false;
           if (msg.usage?.prompt_tokens) this.#contextUsage = msg.usage.prompt_tokens;
           if (msg.context_limit) this.#contextLimit = msg.context_limit;
-          this.listConversations();
+          this.listConversations(this.#currentFolder);
         }
       }
       this.#emitChange();
@@ -292,59 +511,8 @@ export class ConversationStore extends EventTarget {
 
     // Messages handled directly by ConversationStore
     switch (msg.type) {
-      case 'conv_list':
-        this.#conversations = msg.conversations || [];
-        break;
-
-      case 'conv_created':
-        this.#conversations.unshift(msg);
-        if (msg.effort) this.#currentEffort = msg.effort;
-        this.selectConversation(msg.conv_id);
-        // Flush any message queued while the conversation was being created
-        if (this.#pendingMessage) {
-          const text = this.#pendingMessage;
-          const atts = this.#pendingAttachments;
-          this.#pendingMessage = null;
-          this.#pendingAttachments = [];
-          this.#uploadAndSend(msg.conv_id, text, atts);
-        }
-        break;
-
       case 'conv_selected':
         if (msg.read_only) this.#readOnly = true;
-        break;
-
-      case 'system_conv_list':
-        this.#systemConversations = msg.conversations || [];
-        break;
-
-      case 'conv_archived':
-        this.#conversations = this.#conversations.filter(c => c.conv_id !== msg.conv_id);
-        if (this.#currentConvId === msg.conv_id) {
-          this.#currentConvId = null;
-          this.#messageStore.clear();
-        }
-        this.#archivedConversations = [
-          { conv_id: msg.conv_id, title: msg.title,
-            created_at: msg.created_at, updated_at: msg.updated_at },
-          ...this.#archivedConversations,
-        ];
-        break;
-
-      case 'archived_list':
-        this.#archivedConversations = msg.conversations || [];
-        break;
-
-      case 'conv_unarchived':
-        this.#archivedConversations = this.#archivedConversations.filter(
-          c => c.conv_id !== msg.conv_id
-        );
-        break;
-
-      case 'conv_renamed':
-        this.#conversations = this.#conversations.map(c =>
-          c.conv_id === msg.conv_id ? { ...c, title: msg.title } : c
-        );
         break;
 
       case 'turn_start':

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -21,59 +21,6 @@ def _is_safe_conv_id(conv_id: str) -> bool:
 # -- WebSocket message handlers ------------------------------------------------
 
 
-async def _handle_list_convs(ws_send, index, username, msg, state):
-    convs = index.list_for_user(username)
-    await ws_send({"type": "conv_list", "conversations": [c.to_dict() for c in convs]})
-
-
-async def _handle_list_archived(ws_send, index, username, msg, state):
-    convs = index.list_for_user(username, include_archived=True)
-    archived = [c for c in convs if c.archived]
-    await ws_send({"type": "archived_list", "conversations": [c.to_dict() for c in archived]})
-
-
-async def _handle_unarchive_conv(ws_send, index, username, msg, state):
-    conv_id = msg.get("conv_id", "")
-    conv = index.get(conv_id)
-    if conv and conv.user_id == username:
-        index.unarchive(conv_id)
-        await ws_send({"type": "conv_unarchived", "conv_id": conv_id})
-        active = index.list_for_user(username)
-        await ws_send({"type": "conv_list", "conversations": [c.to_dict() for c in active]})
-        all_convs = index.list_for_user(username, include_archived=True)
-        archived = [c for c in all_convs if c.archived]
-        await ws_send({"type": "archived_list", "conversations": [c.to_dict() for c in archived]})
-    else:
-        await ws_send({"type": "error", "message": "Conversation not found"})
-
-
-async def _handle_list_system_convs(ws_send, index, username, msg, state):
-    from .conversations import list_system_conversations
-    try:
-        limit = min(max(1, int(msg.get("limit", 100))), 500)
-    except (TypeError, ValueError):
-        limit = 100
-    convs = list_system_conversations(state["config"], username=username,
-                                      limit=limit)
-    await ws_send({"type": "system_conv_list", "conversations": convs})
-
-
-async def _handle_create_conv(ws_send, index, username, msg, state):
-    title = msg.get("title", "")
-    conv = index.create(username, title=title)
-
-    # Record initial effort level if specified
-    effort = msg.get("effort", "")
-    if effort:
-        from ..config import EFFORT_LEVELS
-        if effort in EFFORT_LEVELS and effort != "default":
-            from ..archive import append_message
-            append_message(state["config"], conv.conv_id,
-                           {"role": "effort", "content": effort})
-
-    await ws_send({"type": "conv_created", **conv.to_dict(),
-                   **({"effort": effort} if effort else {})})
-
 
 async def _handle_select_conv(ws_send, index, username, msg, state):
     conv_id = msg.get("conv_id", "")
@@ -171,30 +118,6 @@ async def _handle_load_history(ws_send, index, username, msg, state):
         response["effort_model"] = resolved_model
     await ws_send(response)
 
-
-async def _handle_rename_conv(ws_send, index, username, msg, state):
-    conv_id = msg.get("conv_id", "")
-    title = msg.get("title", "")
-    conv = index.get(conv_id)
-    if conv and conv.user_id == username:
-        updated = index.rename(conv_id, title)
-        if updated:
-            await ws_send({"type": "conv_renamed", "conv_id": conv_id, "title": updated.title})
-    else:
-        await ws_send({"type": "error", "message": "Conversation not found"})
-
-
-async def _handle_archive_conv(ws_send, index, username, msg, state):
-    conv_id = msg.get("conv_id", "")
-    conv = index.get(conv_id)
-    if conv and conv.user_id == username:
-        index.archive(conv_id)
-
-        await ws_send({"type": "conv_archived", **conv.to_dict()})
-        convs = index.list_for_user(username)
-        await ws_send({"type": "conv_list", "conversations": [c.to_dict() for c in convs]})
-    else:
-        await ws_send({"type": "error", "message": "Conversation not found"})
 
 
 async def _handle_send(ws_send, index, username, msg, state):
@@ -370,15 +293,8 @@ async def _handle_confirm_response(ws_send, index, username, msg, state):
 
 
 _HANDLERS = {
-    "list_convs": _handle_list_convs,
-    "list_archived": _handle_list_archived,
-    "list_system_convs": _handle_list_system_convs,
-    "unarchive_conv": _handle_unarchive_conv,
-    "create_conv": _handle_create_conv,
     "select_conv": _handle_select_conv,
     "load_history": _handle_load_history,
-    "rename_conv": _handle_rename_conv,
-    "archive_conv": _handle_archive_conv,
     "send": _handle_send,
     "cancel_turn": _handle_cancel_turn,
     "set_effort": _handle_set_effort,

--- a/tests/test_conversation_folders.py
+++ b/tests/test_conversation_folders.py
@@ -1,0 +1,246 @@
+"""Tests for ConversationFolderIndex."""
+
+import pytest
+
+from decafclaw.web.conversation_folders import ConversationFolderIndex
+
+
+@pytest.fixture
+def folder_index(config):
+    return ConversationFolderIndex(config, "testuser")
+
+
+class TestCreateFolder:
+    @pytest.mark.asyncio
+    async def test_create_folder(self, folder_index):
+        ok, err = await folder_index.create_folder("projects")
+        assert ok
+        assert err == ""
+        folders = await folder_index.list_folders()
+        assert "projects" in folders
+
+    @pytest.mark.asyncio
+    async def test_create_nested_folder_auto_creates_parents(self, folder_index):
+        ok, err = await folder_index.create_folder("projects/bot-redesign")
+        assert ok
+        # Parent should exist too
+        folders = await folder_index.list_folders()
+        assert "projects" in folders
+        nested = await folder_index.list_folders("projects")
+        assert "bot-redesign" in nested
+
+    @pytest.mark.asyncio
+    async def test_create_duplicate_folder_fails(self, folder_index):
+        await folder_index.create_folder("projects")
+        ok, err = await folder_index.create_folder("projects")
+        assert not ok
+        assert "already exists" in err
+
+    @pytest.mark.asyncio
+    async def test_reject_underscore_prefix(self, folder_index):
+        ok, err = await folder_index.create_folder("_system")
+        assert not ok
+        assert "reserved" in err
+
+    @pytest.mark.asyncio
+    async def test_reject_underscore_prefix_nested(self, folder_index):
+        ok, err = await folder_index.create_folder("projects/_hidden")
+        assert not ok
+        assert "reserved" in err
+
+    @pytest.mark.asyncio
+    async def test_reject_path_traversal(self, folder_index):
+        ok, err = await folder_index.create_folder("../escape")
+        assert not ok
+        assert ".." in err
+
+    @pytest.mark.asyncio
+    async def test_reject_leading_slash(self, folder_index):
+        ok, err = await folder_index.create_folder("/absolute")
+        assert not ok
+
+    @pytest.mark.asyncio
+    async def test_reject_empty_segments(self, folder_index):
+        ok, err = await folder_index.create_folder("projects//nested")
+        assert not ok
+        assert "empty" in err
+
+
+class TestDeleteFolder:
+    @pytest.mark.asyncio
+    async def test_delete_empty_folder(self, folder_index):
+        await folder_index.create_folder("empty")
+        ok, err = await folder_index.delete_folder("empty")
+        assert ok
+        folders = await folder_index.list_folders()
+        assert "empty" not in folders
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_folder(self, folder_index):
+        ok, err = await folder_index.delete_folder("nope")
+        assert not ok
+        assert "not found" in err
+
+    @pytest.mark.asyncio
+    async def test_delete_folder_with_conversations(self, folder_index):
+        await folder_index.create_folder("active")
+        await folder_index.set_folder("conv-1", "active")
+        ok, err = await folder_index.delete_folder("active")
+        assert not ok
+        assert "contains conversations" in err
+
+    @pytest.mark.asyncio
+    async def test_delete_folder_with_subfolders(self, folder_index):
+        await folder_index.create_folder("parent/child")
+        ok, err = await folder_index.delete_folder("parent")
+        assert not ok
+        assert "contains subfolders" in err
+
+
+class TestRenameFolder:
+    @pytest.mark.asyncio
+    async def test_rename_folder(self, folder_index):
+        await folder_index.create_folder("old")
+        await folder_index.set_folder("conv-1", "old")
+        ok, err = await folder_index.rename_folder("old", "new")
+        assert ok
+        folders = await folder_index.list_folders()
+        assert "new" in folders
+        assert "old" not in folders
+        assert await folder_index.get_folder("conv-1") == "new"
+
+    @pytest.mark.asyncio
+    async def test_rename_folder_with_children(self, folder_index):
+        await folder_index.create_folder("old/child")
+        await folder_index.set_folder("conv-1", "old/child")
+        ok, err = await folder_index.rename_folder("old", "new")
+        assert ok
+        folders = await folder_index.list_folders()
+        assert "new" in folders
+        nested = await folder_index.list_folders("new")
+        assert "child" in nested
+        assert await folder_index.get_folder("conv-1") == "new/child"
+
+    @pytest.mark.asyncio
+    async def test_rename_nonexistent_folder(self, folder_index):
+        ok, err = await folder_index.rename_folder("nope", "new")
+        assert not ok
+        assert "not found" in err
+
+    @pytest.mark.asyncio
+    async def test_rename_to_reserved_prefix(self, folder_index):
+        await folder_index.create_folder("old")
+        ok, err = await folder_index.rename_folder("old", "_reserved")
+        assert not ok
+        assert "reserved" in err
+
+    @pytest.mark.asyncio
+    async def test_rename_merge_on_collision(self, folder_index):
+        await folder_index.create_folder("src")
+        await folder_index.create_folder("dst")
+        await folder_index.set_folder("conv-1", "src")
+        await folder_index.set_folder("conv-2", "dst")
+        ok, err = await folder_index.rename_folder("src", "dst")
+        assert ok
+        # Both conversations should be in dst
+        assert await folder_index.get_folder("conv-1") == "dst"
+        assert await folder_index.get_folder("conv-2") == "dst"
+        folders = await folder_index.list_folders()
+        assert "dst" in folders
+        assert "src" not in folders
+
+
+class TestAssignments:
+    @pytest.mark.asyncio
+    async def test_set_and_get_folder(self, folder_index):
+        await folder_index.create_folder("projects")
+        ok, err = await folder_index.set_folder("conv-1", "projects")
+        assert ok
+        assert await folder_index.get_folder("conv-1") == "projects"
+
+    @pytest.mark.asyncio
+    async def test_set_to_nonexistent_folder(self, folder_index):
+        ok, err = await folder_index.set_folder("conv-1", "nope")
+        assert not ok
+        assert "does not exist" in err
+
+    @pytest.mark.asyncio
+    async def test_set_to_top_level(self, folder_index):
+        await folder_index.create_folder("projects")
+        await folder_index.set_folder("conv-1", "projects")
+        ok, err = await folder_index.set_folder("conv-1", "")
+        assert ok
+        assert await folder_index.get_folder("conv-1") == ""
+
+    @pytest.mark.asyncio
+    async def test_remove_assignment(self, folder_index):
+        await folder_index.create_folder("projects")
+        await folder_index.set_folder("conv-1", "projects")
+        await folder_index.remove_assignment("conv-1")
+        assert await folder_index.get_folder("conv-1") == ""
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_assignment(self, folder_index):
+        # Should not raise
+        await folder_index.remove_assignment("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_get_unassigned_conversation(self, folder_index):
+        assert await folder_index.get_folder("nonexistent") == ""
+
+    @pytest.mark.asyncio
+    async def test_list_conversations_in_folder(self, folder_index):
+        await folder_index.create_folder("projects")
+        await folder_index.set_folder("conv-1", "projects")
+        await folder_index.set_folder("conv-2", "projects")
+        convs = await folder_index.list_conversations_in_folder("projects")
+        assert set(convs) == {"conv-1", "conv-2"}
+
+    @pytest.mark.asyncio
+    async def test_get_all_assignments(self, folder_index):
+        await folder_index.create_folder("a")
+        await folder_index.create_folder("b")
+        await folder_index.set_folder("conv-1", "a")
+        await folder_index.set_folder("conv-2", "b")
+        assignments = await folder_index.get_all_assignments()
+        assert assignments == {"conv-1": "a", "conv-2": "b"}
+
+
+class TestListFolders:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, folder_index):
+        folders = await folder_index.list_folders()
+        assert folders == []
+
+    @pytest.mark.asyncio
+    async def test_list_top_level(self, folder_index):
+        await folder_index.create_folder("alpha")
+        await folder_index.create_folder("beta")
+        await folder_index.create_folder("alpha/child")
+        folders = await folder_index.list_folders()
+        assert folders == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_list_nested(self, folder_index):
+        await folder_index.create_folder("parent/child1")
+        await folder_index.create_folder("parent/child2")
+        folders = await folder_index.list_folders("parent")
+        assert folders == ["child1", "child2"]
+
+    @pytest.mark.asyncio
+    async def test_list_nonexistent_parent(self, folder_index):
+        folders = await folder_index.list_folders("nope")
+        assert folders == []
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_data_persists_across_instances(self, config):
+        idx1 = ConversationFolderIndex(config, "testuser")
+        await idx1.create_folder("projects")
+        await idx1.set_folder("conv-1", "projects")
+
+        idx2 = ConversationFolderIndex(config, "testuser")
+        assert await idx2.get_folder("conv-1") == "projects"
+        folders = await idx2.list_folders()
+        assert "projects" in folders

--- a/tests/test_web_conversations.py
+++ b/tests/test_web_conversations.py
@@ -193,7 +193,15 @@ async def test_list_convs_route(authed_client):
 
     resp = await authed_client.get("/api/conversations")
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    data = resp.json()
+    assert data["folder"] == ""
+    assert len(data["conversations"]) == 2
+    # Virtual folders at top level
+    virtual = [f for f in data["folders"] if f.get("virtual")]
+    assert len(virtual) == 2
+    paths = {f["path"] for f in virtual}
+    assert "_archived" in paths
+    assert "_system" in paths
 
 
 @pytest.mark.asyncio
@@ -248,3 +256,308 @@ async def test_history_route(authed_client, http_config):
     data = resp.json()
     assert len(data["messages"]) == 3
     assert data["has_more"] is False
+
+
+# -- Folder-aware listing tests -----------------------------------------------
+
+
+@pytest.fixture
+async def folder_index(http_config):
+    """Create a folder index for testuser."""
+    from decafclaw.web.conversation_folders import ConversationFolderIndex
+    return ConversationFolderIndex(http_config, "testuser")
+
+
+@pytest.mark.asyncio
+async def test_list_convs_with_folder(authed_client, folder_index):
+    """Conversations in a folder only appear when that folder is requested."""
+    # Create folder and conversations
+    await folder_index.create_folder("projects")
+    r1 = await authed_client.post("/api/conversations", json={"title": "In folder"})
+    await authed_client.post("/api/conversations", json={"title": "Top level"})
+    conv_in_folder = r1.json()["conv_id"]
+    await folder_index.set_folder(conv_in_folder, "projects")
+
+    # Top level should only have "Top level"
+    resp = await authed_client.get("/api/conversations")
+    data = resp.json()
+    titles = [c["title"] for c in data["conversations"]]
+    assert "Top level" in titles
+    assert "In folder" not in titles
+    # Should have "projects" user folder + virtual folders
+    folder_names = [f["name"] for f in data["folders"]]
+    assert "projects" in folder_names
+
+    # Folder listing should have "In folder"
+    resp = await authed_client.get("/api/conversations?folder=projects")
+    data = resp.json()
+    assert data["folder"] == "projects"
+    titles = [c["title"] for c in data["conversations"]]
+    assert "In folder" in titles
+    assert "Top level" not in titles
+
+
+@pytest.mark.asyncio
+async def test_list_archived_convs(authed_client, http_config):
+    """Archived conversations appear in /archived endpoint."""
+    r = await authed_client.post("/api/conversations", json={"title": "To archive"})
+    conv_id = r.json()["conv_id"]
+    await authed_client.post(f"/api/conversations/{conv_id}/archive")
+
+    resp = await authed_client.get("/api/conversations/archived")
+    assert resp.status_code == 200
+    data = resp.json()
+    titles = [c["title"] for c in data["conversations"]]
+    assert "To archive" in titles
+
+    # Should not appear in active list
+    resp = await authed_client.get("/api/conversations")
+    active_titles = [c["title"] for c in resp.json()["conversations"]]
+    assert "To archive" not in active_titles
+
+
+@pytest.mark.asyncio
+async def test_list_archived_with_folder(authed_client, folder_index, http_config):
+    """Archived conversations preserve folder assignment."""
+    await folder_index.create_folder("projects")
+    r = await authed_client.post("/api/conversations", json={"title": "Archived in folder"})
+    conv_id = r.json()["conv_id"]
+    await folder_index.set_folder(conv_id, "projects")
+    await authed_client.post(f"/api/conversations/{conv_id}/archive")
+
+    # Top-level archived should not have it
+    resp = await authed_client.get("/api/conversations/archived")
+    data = resp.json()
+    top_titles = [c["title"] for c in data["conversations"]]
+    assert "Archived in folder" not in top_titles
+    # But should show "projects" as a child folder
+    folder_names = [f["name"] for f in data["folders"]]
+    assert "projects" in folder_names
+
+    # Folder-level archived should have it
+    resp = await authed_client.get("/api/conversations/archived?folder=projects")
+    data = resp.json()
+    titles = [c["title"] for c in data["conversations"]]
+    assert "Archived in folder" in titles
+
+
+@pytest.mark.asyncio
+async def test_list_system_convs(authed_client, http_config):
+    """System conversations appear in /system endpoint with type sub-folders."""
+    # Create some system conversation archive files
+    conv_dir = http_config.workspace_path / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    (conv_dir / "heartbeat-20260401-100000-0.jsonl").write_text("{}\n")
+    (conv_dir / "schedule-daily-20260401-090000.jsonl").write_text("{}\n")
+
+    # Top level should show sub-folder types, no conversations
+    resp = await authed_client.get("/api/conversations/system")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["conversations"] == []
+    folder_names = [f["name"] for f in data["folders"]]
+    assert "Heartbeat" in folder_names
+    assert "Schedule" in folder_names
+    assert "Delegated" in folder_names
+
+    # Filter by heartbeat
+    resp = await authed_client.get("/api/conversations/system?folder=heartbeat")
+    data = resp.json()
+    assert len(data["conversations"]) == 1
+    assert data["conversations"][0]["conv_type"] == "heartbeat"
+
+    # Filter by schedule
+    resp = await authed_client.get("/api/conversations/system?folder=schedule")
+    data = resp.json()
+    assert len(data["conversations"]) == 1
+    assert data["conversations"][0]["conv_type"] == "schedule"
+
+
+@pytest.mark.asyncio
+async def test_list_convs_invalid_folder(authed_client):
+    """Path traversal in folder param is rejected."""
+    resp = await authed_client.get("/api/conversations?folder=../escape")
+    assert resp.status_code == 400
+
+    resp = await authed_client.get("/api/conversations?folder=/absolute")
+    assert resp.status_code == 400
+
+    resp = await authed_client.get("/api/conversations?folder=a//b")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_folder_with_dots_in_name(authed_client, folder_index):
+    """Folder names containing dots (not as path segments) should be allowed."""
+    await folder_index.create_folder("foo..bar")
+    resp = await authed_client.get("/api/conversations?folder=foo..bar")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_archived_nested_folder_ancestors(authed_client, folder_index, http_config):
+    """Archived conversations in nested folders should expose ancestor folders."""
+    await folder_index.create_folder("projects/bot-redesign")
+    r = await authed_client.post("/api/conversations", json={"title": "Deep"})
+    conv_id = r.json()["conv_id"]
+    await folder_index.set_folder(conv_id, "projects/bot-redesign")
+    await authed_client.post(f"/api/conversations/{conv_id}/archive")
+
+    # Top-level archived should show "projects" as a child folder
+    resp = await authed_client.get("/api/conversations/archived")
+    data = resp.json()
+    folder_names = [f["name"] for f in data["folders"]]
+    assert "projects" in folder_names
+
+    # Navigate into "projects" should show "bot-redesign"
+    resp = await authed_client.get("/api/conversations/archived?folder=projects")
+    data = resp.json()
+    folder_names = [f["name"] for f in data["folders"]]
+    assert "bot-redesign" in folder_names
+
+
+@pytest.mark.asyncio
+async def test_list_system_invalid_folder(authed_client):
+    resp = await authed_client.get("/api/conversations/system?folder=invalid")
+    assert resp.status_code == 400
+
+
+# -- Action endpoint tests ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unarchive_conv(authed_client):
+    r = await authed_client.post("/api/conversations", json={"title": "Test"})
+    conv_id = r.json()["conv_id"]
+    await authed_client.post(f"/api/conversations/{conv_id}/archive")
+
+    resp = await authed_client.post(f"/api/conversations/{conv_id}/unarchive")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # Should be back in active list
+    resp = await authed_client.get("/api/conversations")
+    titles = [c["title"] for c in resp.json()["conversations"]]
+    assert "Test" in titles
+
+
+@pytest.mark.asyncio
+async def test_rename_and_move_conv(authed_client, folder_index):
+    await folder_index.create_folder("target")
+    r = await authed_client.post("/api/conversations", json={"title": "Original"})
+    conv_id = r.json()["conv_id"]
+
+    resp = await authed_client.patch(
+        f"/api/conversations/{conv_id}",
+        json={"title": "Renamed", "folder": "target"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Renamed"
+    assert resp.json()["folder"] == "target"
+
+    # Should appear in target folder
+    resp = await authed_client.get("/api/conversations?folder=target")
+    titles = [c["title"] for c in resp.json()["conversations"]]
+    assert "Renamed" in titles
+
+
+@pytest.mark.asyncio
+async def test_move_conv_to_top_level(authed_client, folder_index):
+    await folder_index.create_folder("source")
+    r = await authed_client.post("/api/conversations", json={"title": "Movable"})
+    conv_id = r.json()["conv_id"]
+    await folder_index.set_folder(conv_id, "source")
+
+    resp = await authed_client.patch(
+        f"/api/conversations/{conv_id}", json={"folder": ""}
+    )
+    assert resp.status_code == 200
+
+    # Should be at top level now
+    resp = await authed_client.get("/api/conversations")
+    titles = [c["title"] for c in resp.json()["conversations"]]
+    assert "Movable" in titles
+
+
+@pytest.mark.asyncio
+async def test_create_conv_in_folder(authed_client, folder_index):
+    await folder_index.create_folder("projects")
+    r = await authed_client.post(
+        "/api/conversations", json={"title": "In folder", "folder": "projects"}
+    )
+    assert r.status_code == 201
+    assert r.json()["folder"] == "projects"
+
+    resp = await authed_client.get("/api/conversations?folder=projects")
+    titles = [c["title"] for c in resp.json()["conversations"]]
+    assert "In folder" in titles
+
+
+@pytest.mark.asyncio
+async def test_create_conv_with_effort(authed_client, http_config):
+    http_config.workspace_path.mkdir(parents=True, exist_ok=True)
+    r = await authed_client.post(
+        "/api/conversations", json={"title": "Strong", "effort": "strong"}
+    )
+    assert r.status_code == 201
+    assert r.json()["effort"] == "strong"
+
+
+# -- Folder CRUD endpoint tests -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_conv_folder_route(authed_client):
+    resp = await authed_client.post(
+        "/api/conversations/folders", json={"path": "projects"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # Should appear in listing
+    resp = await authed_client.get("/api/conversations")
+    folder_names = [f["name"] for f in resp.json()["folders"] if not f.get("virtual")]
+    assert "projects" in folder_names
+
+
+@pytest.mark.asyncio
+async def test_delete_conv_folder_route(authed_client):
+    await authed_client.post("/api/conversations/folders", json={"path": "empty"})
+    resp = await authed_client.delete("/api/conversations/folders/empty")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_nonempty_conv_folder(authed_client, folder_index):
+    await folder_index.create_folder("notempty")
+    r = await authed_client.post("/api/conversations", json={"title": "Blocking"})
+    await folder_index.set_folder(r.json()["conv_id"], "notempty")
+
+    resp = await authed_client.delete("/api/conversations/folders/notempty")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_rename_conv_folder_route(authed_client, folder_index):
+    await folder_index.create_folder("old-name")
+    await folder_index.set_folder("dummy-conv", "old-name")
+
+    resp = await authed_client.put(
+        "/api/conversations/folders/old-name", json={"path": "new-name"}
+    )
+    assert resp.status_code == 200
+
+    # Check that the folder was renamed
+    resp = await authed_client.get("/api/conversations")
+    folder_names = [f["name"] for f in resp.json()["folders"] if not f.get("virtual")]
+    assert "new-name" in folder_names
+    assert "old-name" not in folder_names
+
+
+@pytest.mark.asyncio
+async def test_create_conv_folder_reserved_prefix(authed_client):
+    resp = await authed_client.post(
+        "/api/conversations/folders", json={"path": "_reserved"}
+    )
+    assert resp.status_code == 400

--- a/tests/test_ws_effort.py
+++ b/tests/test_ws_effort.py
@@ -8,7 +8,6 @@ from decafclaw.archive import append_message, read_archive
 from decafclaw.events import EventBus
 from decafclaw.web.conversations import ConversationIndex
 from decafclaw.web.websocket import (
-    _handle_create_conv,
     _handle_load_history,
     _handle_set_effort,
 )
@@ -166,47 +165,8 @@ class TestLoadHistoryEffort:
 
 
 class TestCreateConvEffort:
-    @pytest.mark.asyncio
-    async def test_create_with_effort(self, ws_state, index):
-        """Creating a conversation with effort should persist it in archive."""
-        ws_send = AsyncMock()
-        await _handle_create_conv(ws_send, index, "testuser",
-                                  {"title": "Test", "effort": "strong"}, ws_state)
+    """Tests for effort level on conversation creation (now via REST)."""
 
-        msg = ws_send.call_args[0][0]
-        assert msg["type"] == "conv_created"
-        conv_id = msg["conv_id"]
-
-        # Verify effort was recorded
-        messages = read_archive(ws_state["config"], conv_id)
-        effort_msgs = [m for m in messages if m.get("role") == "effort"]
-        assert len(effort_msgs) == 1
-        assert effort_msgs[0]["content"] == "strong"
-
-    @pytest.mark.asyncio
-    async def test_create_without_effort(self, ws_state, index):
-        """Creating a conversation without effort should not record effort."""
-        ws_send = AsyncMock()
-        await _handle_create_conv(ws_send, index, "testuser",
-                                  {"title": "Test"}, ws_state)
-
-        msg = ws_send.call_args[0][0]
-        conv_id = msg["conv_id"]
-
-        messages = read_archive(ws_state["config"], conv_id)
-        effort_msgs = [m for m in messages if m.get("role") == "effort"]
-        assert len(effort_msgs) == 0
-
-    @pytest.mark.asyncio
-    async def test_create_with_default_effort_no_record(self, ws_state, index):
-        """Creating with effort='default' should not record (it's the default)."""
-        ws_send = AsyncMock()
-        await _handle_create_conv(ws_send, index, "testuser",
-                                  {"title": "Test", "effort": "default"}, ws_state)
-
-        msg = ws_send.call_args[0][0]
-        conv_id = msg["conv_id"]
-
-        messages = read_archive(ws_state["config"], conv_id)
-        effort_msgs = [m for m in messages if m.get("role") == "effort"]
-        assert len(effort_msgs) == 0
+    # These tests are in test_web_conversations.py (test_create_conv_with_effort)
+    # since conversation creation moved from WebSocket to REST.
+    pass


### PR DESCRIPTION
## Summary

- **Conversation folders**: user-defined folder hierarchy for organizing web UI conversations, tracked via per-user JSON index file (metadata-only, no filesystem moves)
- **REST API migration**: all conversation management (list, create, rename, archive, unarchive, folders) moved from WebSocket to REST endpoints, mirroring the vault API pattern
- **Folder navigation UI**: sidebar uses file-browser navigation with breadcrumbs (matching vault tab), replacing collapsible Archived/System sections
- **Virtual folders**: Archived (preserves folder structure) and System (heartbeat/schedule/delegated sub-folders) as navigable read-only folders
- **WebSocket cleanup**: removed 7 dead handlers, WebSocket retained only for real-time chat streaming

Closes #184, closes #187

## New REST endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/conversations?folder=` | Folder-aware conversation listing |
| `GET` | `/api/conversations/archived?folder=` | Archived conversations by folder |
| `GET` | `/api/conversations/system?folder=` | System conversations by type |
| `POST` | `/api/conversations/{id}/unarchive` | Unarchive |
| `POST/DELETE/PUT` | `/api/conversations/folders/...` | Folder CRUD |

## Test plan

- [ ] `make check` passes (lint + pyright + tsc)
- [ ] `make test` passes (950 tests including 62 new)
- [ ] Browser smoke test: create folders, navigate, create conversation in folder, archive/unarchive, rename, system conversations
- [ ] Verify breadcrumb navigation works for nested folders
- [ ] Verify virtual folders (Archived, System) are not renameable/deletable

🤖 Generated with [Claude Code](https://claude.com/claude-code)