### PR TITLE
feat: relevance scoring, graph expansion, and vault frontmatter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,10 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/config_types.py` — Config sub-dataclasses (LlmConfig, MattermostConfig, etc.)
 - `src/decafclaw/config_cli.py` — CLI tool for config show/get/set
 - `src/decafclaw/context.py` — Forkable runtime context with sub-objects: TokenUsage, ToolState, SkillState, ComposerState
-- `src/decafclaw/context_composer.py` — Context composer: unified context assembly for agent turns (system prompt, history, memory, wiki, tools)
+- `src/decafclaw/context_composer.py` — Context composer: unified context assembly, relevance scoring, dynamic budget allocation
+- `src/decafclaw/frontmatter.py` — YAML frontmatter parsing/serialization for vault pages (summary, keywords, tags, importance)
 - `src/decafclaw/events.py` — In-process pub/sub event bus
-- `src/decafclaw/memory_context.py` — Proactive memory retrieval: auto-inject relevant context per turn
+- `src/decafclaw/memory_context.py` — Proactive memory retrieval: embedding search, graph expansion, metadata enrichment
 - `src/decafclaw/archive.py` — Conversation archive (JSONL per conversation)
 - `src/decafclaw/compaction.py` — History compaction via summarization
 - `src/decafclaw/embeddings.py` — Semantic search index (sqlite-vec cosine similarity)
@@ -147,6 +148,9 @@ Session docs live in `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`, `
 - **Skill schedule frontmatter.** Skills can declare `schedule: "cron expression"` in SKILL.md to run as scheduled tasks. Only bundled and admin-level skills are honored (workspace skills cannot self-schedule). File-based schedules override skill schedules on name collision. Skills with both `schedule` and `user-invocable: true` serve as both scheduled tasks and on-demand commands.
 - **Self-reflection is fail-open.** The reflection judge evaluates responses before delivery, but errors (network, parse, etc.) always pass through the response as-is. Retries consume `max_tool_iterations` budget. Skipped for child agents, cancelled turns, and empty responses.
 - **Context assembly via ContextComposer.** All context for an LLM turn is assembled by `ContextComposer.compose()` in `context_composer.py`. This produces a `ComposedContext` with messages, tools, deferred tools, token estimates, and per-source diagnostics. The composer is stateful per-conversation (via `ComposerState` on `ctx.composer`), tracking what was included and actual token usage across turns. Mode-aware: `INTERACTIVE`, `HEARTBEAT`, `SCHEDULED`, `CHILD_AGENT` control which sources are included. Tool assembly in the iteration loop still uses `_build_tool_list()` since fetched tools change mid-turn.
+- **Relevance scoring for memory context.** Retrieval candidates are scored by `composite_score = w_similarity * similarity + w_recency * recency + w_importance * importance`. Weights configurable via `RelevanceConfig`. Candidates ranked by score; dynamic budget allocation fills from top until budget exhausted. Fixed costs (system prompt, history, tools, explicit `@[[Page]]` refs) reserved first.
+- **Vault page frontmatter.** Vault pages support optional YAML frontmatter with `summary`, `keywords`, `tags`, `importance` fields. Parsed by `frontmatter.py`. Composite embeddings prepend metadata to body for richer semantic search. Frontmatter is LLM-generated (Phase B) and human-editable.
+- **Wiki-link graph expansion.** Memory context retrieval follows `[[wiki-links]]` one hop from top embedding hits to expand the candidate pool. Linked pages get discounted similarity and compete on composite score. Configurable via `RelevanceConfig.graph_expansion_enabled`.
 - **Proactive memory context is fail-open.** Before each interactive turn, relevant memories/wiki are auto-injected as context via the ContextComposer. Errors silently return empty results. Skipped for heartbeat, scheduled tasks, and child agents. Requires an embedding model to be configured — silently disabled otherwise.
 - **Vault chat context.** Users can share vault pages into conversations via `@[[PageName]]` mentions (all channels) or by having a page open in the web UI sidebar. Pages are injected once per conversation as `wiki_context` role messages, tracked by scanning history. Parsing happens in the ContextComposer via helpers in `agent.py`. Page resolution uses vault root, not a fixed wiki directory.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).

--- a/docs/dev-sessions/2026-04-01-1403-context-composer/notes.md
+++ b/docs/dev-sessions/2026-04-01-1403-context-composer/notes.md
@@ -2,40 +2,59 @@
 
 ## Session summary
 
-Extracted scattered context assembly logic into a unified `ContextComposer` class (issue #182, phases 1-3).
+Extracted scattered context assembly logic into a unified `ContextComposer` class (issue #182, phases 1-3). PR #195.
 
-### What was done
+## Key actions
 
-1. **Skeleton** — Created `context_composer.py` with `SourceEntry`, `ComposedContext`, `ComposerMode`, `ComposerState` dataclasses and `ContextComposer` class. Added `ComposerState` to `Context`. Added `context_window_size` to `LlmConfig`.
+1. **Brainstormed spec** — 10 Q&A rounds covering ownership/lifecycle, scope, structured result, token budget model, mode awareness, compaction relationship, success criteria.
+2. **Planned 6 steps** — skeleton → system prompt → memory/wiki → tools → full compose() → agent loop integration.
+3. **Executed all 6 steps** — each with lint + test + commit. 966 → 988 tests.
+4. **Opened PR #195**, got Copilot review comments.
+5. **Post-PR review fixes** (4 additional commits):
+   - Moved archiving out of composer (Les caught this)
+   - Fixed token double-counting (Copilot caught this)
+   - Decoupled skip_memory_context from HEARTBEAT mode (Copilot caught this)
+   - Aligned history diagnostics items_included (Copilot caught this)
+   - Added deprecation/safety/future-use documentation
+6. **Filed #196** for wiki/memory → vault naming cleanup.
 
-2. **System prompt** — Added `_compose_system_prompt()` wrapping `config.system_prompt` with token estimation. Added `_get_context_window_size()` with fallback from `context_window_size` to `compaction_max_tokens`.
+## Divergences from plan
 
-3. **Memory + wiki** — Added `_compose_memory_context()` (async, fail-open, mode-aware) and `_compose_wiki_context()` (page dedup, not-found handling). Both produce `SourceEntry` diagnostics.
+- **Archiving pulled out of composer** — the plan had compose() handling archiving (since `_prepare_messages()` did). Les questioned this during PR review. The cleaner separation: composer decides what goes in, caller persists it. Added `messages_to_archive` field to `ComposedContext`.
+- **`skip_memory_context` mode mapping changed** — plan mapped it to HEARTBEAT mode, but this incorrectly skipped wiki context too. Fixed to keep INTERACTIVE mode and let the composer check the flag directly.
+- **System prompt simpler than planned** — discovered during implementation that skill bodies aren't injected into the system prompt per-conversation. They come back as tool results. So `_compose_system_prompt` just wraps the cached `config.system_prompt`.
+- **`_prepare_messages()` kept as deprecated** — plan said to remove it, but wiki context tests still exercise it directly. Marked deprecated instead; full removal is a follow-up.
 
-4. **Tool assembly** — Added `_compose_tools()` replicating `_build_tool_list()` logic with diagnostics tracking active/deferred counts.
+## Insights and lessons learned
 
-5. **Full compose()** — Implemented the complete orchestration: truncation, system prompt, wiki injection, memory injection, history filtering/remapping, tool classification, event publishing. Returns `ComposedContext`.
+- **Extraction refactors reveal design assumptions.** Moving code into a new module forces you to think about what's a responsibility vs a side effect. Archiving looked like it belonged in the composer until you questioned it.
+- **Copilot review caught real bugs.** The token double-counting and mode mapping issues were subtle — both passed all tests but would have produced incorrect diagnostics and changed wiki behavior for heartbeat/scheduled tasks.
+- **Mode enums need callers, not just definitions.** HEARTBEAT/SCHEDULED modes were defined but never wired. The `skip_memory_context` flag was doing double duty. Worth being more deliberate about when to use enums vs flags.
+- **Review feedback loop is a recurring pattern.** We do "push PR → check comments → fix → push" a lot. Worth considering a command to streamline this.
 
-6. **Agent loop integration** — Replaced `_prepare_messages()` call with `composer.compose()` in `run_agent_turn()`. Added `record_actuals()` after LLM response. Initialized deferred message tracking from compose result. Updated CLAUDE.md and docs.
+## What's deferred
 
-### Design decisions during implementation
-
-- **System prompt is simpler than planned**: `config.system_prompt` already includes always-loaded skill bodies. Per-conversation activated skills get their body as `activate_skill` tool response, not system prompt injection. So `_compose_system_prompt` just wraps the cached value.
-
-- **Memory context returns raw results**: Changed `_compose_memory_context` to return 4-tuple (msgs, formatted_text, raw_results, entry) so compose() can publish the raw results in the memory_context event for UI rendering.
-
-- **Tool iteration stays in agent loop**: The iteration loop still calls `_build_tool_list()` per-iteration since fetched tools change mid-turn. The composer handles initial assembly and diagnostics only. Full tool lifecycle in the composer is a follow-up.
-
-- **Deferred message handoff**: compose() may insert a deferred tool list as `messages[1]`. The agent loop detects this and initializes `deferred_msg` from it so subsequent iterations can update/remove it correctly.
-
-### What's deferred
-
-- Relevance scoring, dynamic budget allocation, budget-aware truncation
+- Relevance scoring (recency + importance + similarity)
+- Dynamic budget allocation across sources
+- Budget-aware truncation/summarization
 - Context stats command for surfacing diagnostics
 - Token estimate calibration from actuals
 - Model switching as alternative to compaction
 - Full tool lifecycle in composer (per-iteration tool assembly)
+- Remove deprecated `_prepare_messages()` and migrate its tests
+- Wiki/memory → vault naming cleanup (#196)
 
-### Test count
+## Stats
 
-Started at 966 tests, ended at 988 tests (22 new tests for context composer).
+- **Commits:** 10 (6 planned steps + 4 review fixes)
+- **Files changed:** 11 (+1539 / -11 lines)
+- **New files:** `context_composer.py`, `test_context_composer.py`, `docs/context-composer.md`
+- **Tests:** 966 → 988 (36 new, but also removed the NotImplementedError test = net +22)
+- **Conversation turns:** ~35
+- **Session duration:** ~2 hours (brainstorm + plan + execute + PR + review)
+
+## Process observations
+
+- **6-step incremental plan worked well.** Each step was testable and commitable independently. Steps 1-5 were additive (no existing behavior changes), step 6 was the swap. This meant regressions were easy to bisect.
+- **Copilot review as a second pair of eyes.** Caught issues we missed — token double-counting and mode/flag conflation. Worth always checking PR comments before considering a PR done.
+- **Brainstorm → plan → execute flow is solid.** The brainstorm surfaced the right design decisions (stateful vs stateless, mode awareness, compaction relationship). The plan mapped cleanly to implementation.

--- a/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/notes.md
+++ b/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/notes.md
@@ -1,0 +1,2 @@
+# Context Composer Phase 2: Relevance Scoring & A-MEM Concepts — Notes
+

--- a/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/plan.md
+++ b/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/plan.md
@@ -1,0 +1,385 @@
+# Context Composer Phase 2: Relevance Scoring & A-MEM Concepts — Plan
+
+## Overview
+
+Build on the Phase 1 ContextComposer to add frontmatter parsing, composite embeddings, wiki-link graph expansion, relevance scoring, and dynamic budget allocation. 7 steps, each building on the previous.
+
+The key files we're modifying:
+- `config_types.py` — new `RelevanceConfig` dataclass
+- `config.py` — wire `RelevanceConfig` into `Config`
+- `embeddings.py` — composite embedding text, frontmatter-aware indexing
+- `memory_context.py` — graph expansion, return richer metadata
+- `context_composer.py` — relevance scoring, budget allocation
+- `skills/vault/tools.py` — frontmatter-aware read/write
+
+New files:
+- `src/decafclaw/frontmatter.py` — YAML frontmatter parse/serialize utilities
+
+---
+
+## Step 1: Frontmatter parsing utilities
+
+Create a `frontmatter.py` module with pure functions for parsing and serializing YAML frontmatter. No integration yet — just the utilities and tests.
+
+### Prompt
+
+```
+Create `src/decafclaw/frontmatter.py` with utilities for YAML frontmatter
+(Jekyll/Obsidian-compatible). These are pure functions, no dependencies on
+the rest of the codebase.
+
+1. `parse_frontmatter(text: str) -> tuple[dict, str]`:
+   - Splits markdown text into (frontmatter_dict, body_content)
+   - Frontmatter is YAML between opening `---\n` and closing `\n---\n`
+   - Must be at the very start of the file
+   - Returns ({}, text) if no frontmatter found
+   - Use `yaml.safe_load` for parsing
+   - Handle edge cases: empty frontmatter, malformed YAML (log warning, return empty dict)
+
+2. `serialize_frontmatter(metadata: dict, body: str) -> str`:
+   - Combines a metadata dict and body text into frontmatter + markdown
+   - Uses `yaml.dump` with `default_flow_style=False`
+   - Omits frontmatter block entirely if metadata is empty
+   - Preserves body content exactly (no trailing newline changes)
+
+3. `get_frontmatter_field(metadata: dict, field: str, default=None)`:
+   - Type-safe getter. For `importance`, clamp to [0, 1] float.
+   - For `keywords` and `tags`, ensure list of strings.
+   - For `summary`, ensure string.
+
+4. `build_composite_text(metadata: dict, body: str) -> str`:
+   - Builds the composite text for embedding indexing:
+     `{summary}\n{keywords joined by ', '}\n{tags joined by ', '}\n{body}`
+   - If no frontmatter fields, returns body as-is (backward compatible)
+
+Add `pyyaml` to project dependencies if not already present.
+
+Write tests in `tests/test_frontmatter.py`:
+- parse_frontmatter with valid frontmatter
+- parse_frontmatter with no frontmatter (plain markdown)
+- parse_frontmatter with empty frontmatter block
+- parse_frontmatter with malformed YAML (returns empty dict, body intact)
+- serialize_frontmatter round-trips with parse_frontmatter
+- serialize_frontmatter with empty dict omits frontmatter block
+- get_frontmatter_field clamps importance to [0, 1]
+- get_frontmatter_field returns list for keywords/tags
+- build_composite_text with full frontmatter
+- build_composite_text with no frontmatter (returns body)
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 2: RelevanceConfig and configuration
+
+Add `RelevanceConfig` dataclass and wire it into the config system.
+
+### Prompt
+
+```
+Step 2: Add RelevanceConfig to the configuration system.
+
+In `config_types.py`, add:
+
+```python
+@dataclass
+class RelevanceConfig:
+    w_similarity: float = 0.5
+    w_recency: float = 0.3
+    w_importance: float = 0.2
+    recency_decay_rate: float = 0.99  # per-hour exponential decay
+    graph_expansion_enabled: bool = True
+    graph_expansion_similarity_discount: float = 0.7
+```
+
+In `config.py`, add `relevance: RelevanceConfig` to the `Config` dataclass,
+following the existing pattern for sub-configs. Wire it into the config
+loading (env vars, config.json, defaults).
+
+Write tests:
+- Test default values
+- Test config loading with custom relevance values
+- Test that env var overrides work (e.g. RELEVANCE_W_SIMILARITY=0.8)
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 3: Frontmatter-aware vault tools and embeddings
+
+Integrate frontmatter parsing into vault read/write and the embedding index.
+
+### Prompt
+
+```
+Step 3: Integrate frontmatter into vault tools and embedding index.
+
+In `skills/vault/tools.py`:
+- `tool_vault_write`: when writing a page, use `build_composite_text()`
+  for the embedding index instead of raw content. Parse the content with
+  `parse_frontmatter()` to extract metadata, then build the composite.
+  The full content (including frontmatter) is written to disk as-is.
+- `tool_vault_read`: no changes needed — reads the raw file including
+  frontmatter. The agent sees the full page.
+
+In `embeddings.py`:
+- `_iter_vault_pages()`: when yielding entries for reindex, parse
+  frontmatter from each page and use `build_composite_text()` for the
+  entry_text field. This enriches the embedding with metadata.
+- `index_entry()`: no changes — callers are responsible for passing
+  composite text when appropriate.
+
+Import from the new `frontmatter.py` module.
+
+Write tests:
+- Test that vault_write indexes composite text (mock index_entry, verify
+  the text passed includes frontmatter fields)
+- Test that _iter_vault_pages yields composite text for pages with
+  frontmatter
+- Test that pages without frontmatter yield plain content (backward compat)
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 4: Enrich retrieval results with metadata
+
+Modify `memory_context.py` and `embeddings.py` to return richer metadata
+with each retrieval result: file modification time and frontmatter fields.
+
+### Prompt
+
+```
+Step 4: Return richer metadata from retrieval results.
+
+The composer needs timestamp and importance to score candidates. Currently
+`search_similar_sync` returns {entry_text, file_path, similarity, source_type}.
+We need to add metadata without breaking existing callers.
+
+Important design choice: do NOT read vault files inside search_similar_sync.
+That function returns many results (over-fetches 3x) before threshold
+filtering. File I/O for all of them would be wasteful. Instead:
+
+In `embeddings.py`:
+- `search_similar_sync()`: add `created_at` from the DB to each result
+  dict. This is already in the query — just include it in the result.
+  No file I/O needed.
+
+In `memory_context.py`:
+- Add a helper `_enrich_results(config, results: list[dict]) -> list[dict]`:
+  - Called AFTER threshold filtering and max_results trimming (on the
+    small, final candidate set)
+  - For each result with a file_path, resolve against vault_root
+  - Read file modification time via os.path.getmtime → `modified_at` (ISO)
+  - For page/user source types: parse frontmatter, extract importance
+  - For journal entries: importance = 0.5 (default)
+  - If file not found, fall back to created_at and default importance
+  - Fail-open: any error on a single result logs warning, uses defaults
+- Call `_enrich_results()` in `retrieve_memory_context()` after filtering
+
+This keeps the hot path (DB query) fast and only does file I/O on the
+small set of candidates that will actually be scored.
+
+Write tests:
+- Test _enrich_results adds modified_at and importance
+- Test _enrich_results defaults importance to 0.5 without frontmatter
+- Test _enrich_results reads importance from frontmatter
+- Test _enrich_results is fail-open (missing file → defaults)
+- Test search_similar_sync includes created_at in results
+- Test retrieve_memory_context results have enriched metadata
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 5: Wiki-link graph expansion
+
+Add one-hop wiki-link graph expansion to `memory_context.py`. When
+embedding search returns top hits, follow `[[wiki-links]]` from those
+pages to expand the candidate pool.
+
+### Prompt
+
+```
+Step 5: Add wiki-link graph expansion to memory context retrieval.
+
+In `memory_context.py`, add a function:
+
+`_expand_graph_links(config, results: list[dict], max_hops: int = 1) -> list[dict]`:
+  - For each result in the top hits, read the page content from the vault
+    (using file_path to resolve against vault_root)
+  - Parse `[[PageName]]` and `[[PageName|display]]` links from the content
+    (reuse the regex pattern from agent.py or frontmatter.py)
+  - For each linked page:
+    - Skip if already in results (by file_path)
+    - Read the page, parse frontmatter for importance
+    - Get file modification time for recency
+    - Assign discounted similarity: parent_result["similarity"] * discount_factor
+    - Add to results with source_type="graph_expansion" and
+      linked_from=parent_page_name
+  - Return the expanded results list (originals + linked pages)
+
+In `retrieve_memory_context()`:
+  - After the initial search and filtering, call `_expand_graph_links()`
+    if graph expansion is enabled in config
+  - Pass config.relevance.graph_expansion_enabled and
+    config.relevance.graph_expansion_similarity_discount
+  - The expanded results are returned to the composer for scoring
+
+Add a wiki-link regex: `r'\[\[([^\]|]+)(?:\|[^\]]+)?\]\]'` — extracts
+the page name, handles `[[target|display]]` format.
+
+Write tests:
+- Test _expand_graph_links finds and resolves wiki-links
+- Test _expand_graph_links skips already-present results (dedup)
+- Test linked pages get discounted similarity
+- Test linked pages have source_type="graph_expansion"
+- Test graph expansion is skipped when disabled in config
+- Test wiki-link regex handles both [[Page]] and [[Page|display]] formats
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 6: Relevance scoring in the composer
+
+Add three-factor relevance scoring to the composer's memory context
+handling. Replace the fixed token budget with scored ranking.
+
+### Prompt
+
+```
+Step 6: Add relevance scoring to the ContextComposer.
+
+In `context_composer.py`, add a method:
+
+`_score_candidates(self, candidates: list[dict], config) -> list[dict]`:
+  - For each candidate, compute a composite score:
+    score = w_similarity * similarity + w_recency * recency + w_importance * importance
+  - Similarity: already in candidate["similarity"], normalized [0, 1]
+  - Recency: exponential decay based on candidate["modified_at"] timestamp.
+    `recency = decay_rate ^ hours_since_modification`. Clamp to [0, 1].
+    If modified_at is missing, use 0.5 (neutral).
+  - Importance: from candidate["importance"], default 0.5. Already [0, 1].
+  - Weights from config.relevance (w_similarity, w_recency, w_importance)
+  - Add "composite_score" to each candidate dict
+  - Sort by composite_score descending
+  - Return sorted candidates
+
+Modify `_compose_memory_context()`:
+  - After retrieving candidates (which now include graph-expanded results),
+    call `_score_candidates()` to rank them
+  - Instead of using the fixed max_tokens budget from MemoryContextConfig,
+    the composer will use dynamic budget allocation (next step). For now,
+    still use max_tokens but select candidates by score instead of by
+    similarity order.
+  - Update the SourceEntry details to include scoring info:
+    details={"top_score": ..., "min_score": ..., "candidates_considered": ...}
+
+Write tests:
+- Test _score_candidates produces correct composite scores
+- Test candidates are sorted by score descending
+- Test recency decay: recent items score higher than old items
+- Test importance influences score
+- Test missing modified_at defaults to 0.5 recency
+- Test _compose_memory_context uses scored ordering
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 7: Dynamic budget allocation
+
+Replace fixed memory token budget with dynamic allocation in the composer.
+Fixed costs are reserved first, scored candidates fill the remainder.
+
+### Prompt
+
+```
+Step 7: Implement dynamic budget allocation in the composer.
+
+Modify `compose()` in `context_composer.py`:
+
+The current flow assembles all sources independently. The new flow:
+
+1. Compute fixed costs first (unchanged from current code):
+   - System prompt tokens (from _compose_system_prompt)
+   - Tool tokens (from _compose_tools)
+   - Wiki context for explicit @[[Page]] references (from _compose_wiki_context —
+     these are fixed costs, always included)
+   - History tokens estimate (from existing history, before new messages)
+
+2. Calculate remaining budget:
+   `remaining = _get_context_window_size(config) - fixed_costs - response_reserve`
+   where response_reserve is a configurable margin (e.g. 4096 tokens) for
+   the model's response. Use compaction_max_tokens as the budget ceiling
+   if context_window_size is not set.
+
+3. Score and select memory candidates:
+   - Retrieve candidates via _compose_memory_context (which now includes
+     graph-expanded results)
+   - Score via _score_candidates
+   - Fill from the top until remaining budget is exhausted
+   - Candidates that don't fit are counted as items_truncated
+
+4. The MemoryContextConfig.max_tokens field becomes a fallback: if
+   context_window_size is 0 and compaction_max_tokens is the default,
+   fall back to the fixed budget. This preserves backward compatibility
+   for deployments that haven't configured window sizes.
+
+Update the SourceEntry for memory to reflect:
+- items_included: candidates that made the cut
+- items_truncated: candidates scored but excluded by budget
+- tokens_estimated: actual tokens of included candidates
+- details: scoring stats, budget info
+
+Write tests:
+- Test that fixed costs are reserved before memory candidates
+- Test that scored candidates fill remaining budget in score order
+- Test that candidates exceeding budget are truncated
+- Test backward compatibility: when context_window_size is 0, falls back
+  to max_tokens fixed budget
+- Test explicit @[[Page]] references are not scored (always included as
+  fixed costs)
+
+Run `make check && make test`.
+
+After this step, update CLAUDE.md:
+- Add frontmatter.py to key files list
+- Update memory context convention to mention relevance scoring
+- Add relevance scoring convention note
+- Update context composer convention to mention budget allocation
+
+Update docs/context-composer.md with the new scoring and budget model.
+Create docs/relevance-scoring.md documenting the formula, weights, and
+graph expansion.
+Update docs/index.md with the new doc page.
+```
+
+---
+
+## Summary of changes per step
+
+| Step | New/Modified Files | Tests |
+|------|-------------------|-------|
+| 1 | `frontmatter.py` (new) | `test_frontmatter.py` (new) |
+| 2 | `config_types.py`, `config.py` | `test_config.py` |
+| 3 | `skills/vault/tools.py`, `embeddings.py` | `test_vault_tools.py`, `test_embeddings.py` |
+| 4 | `embeddings.py`, `memory_context.py` | `test_embeddings.py`, `test_memory_context.py` |
+| 5 | `memory_context.py` | `test_memory_context.py` |
+| 6 | `context_composer.py` | `test_context_composer.py` |
+| 7 | `context_composer.py`, `CLAUDE.md`, `docs/` | `test_context_composer.py` |
+
+## Risk notes
+
+- **Step 3 changes embedding content** — existing indexes won't have composite text until reindex. Pages without frontmatter are backward compatible (body-only, same as before). A reindex is needed to benefit from frontmatter enrichment.
+- **Step 4 adds I/O per candidate** — reading frontmatter from files, but only on the post-filtered candidate set (typically 5-10 files), not the full search results. Acceptable cost.
+- **Step 5 graph expansion** — could significantly increase candidate count. The budget allocation in step 7 prevents this from bloating context, but the retrieval I/O increases.
+- **Step 7 is the riskiest** — changes how memory budget works. Backward compatibility fallback is critical for deployments without `context_window_size` configured.
+- **YAML dependency** — `pyyaml` already in project dependencies (6.0.3). No action needed.

--- a/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/spec.md
+++ b/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/spec.md
@@ -1,0 +1,161 @@
+# Context Composer Phase 2: Relevance Scoring & A-MEM Concepts — Spec
+
+## Related issue
+
+GitHub issue #182 — Context composer (phases 4-6)
+
+## Goal
+
+Enhance the context composer's retrieval and selection pipeline with relevance scoring, wiki-link graph expansion, and structured vault page frontmatter. This builds on the Phase 1 extraction/refactor (PR #195) to make context selection intentional rather than ad-hoc.
+
+Inspired by research from A-MEM (Zettelkasten-inspired agentic memory), Generative Agents (three-factor relevance scoring), and the context rot findings (lean context > big context).
+
+## Background
+
+### Current state
+
+- Memory context retrieval (`memory_context.py`) uses embedding cosine similarity with a fixed threshold and fixed token budget (500 tokens)
+- No relevance scoring beyond raw similarity
+- Vault pages are plain markdown with no structured metadata
+- Wiki-links (`[[page]]`) exist in pages but aren't used for retrieval
+- The composer (Phase 1) assembles context but doesn't score or rank sources
+- Dream process distills journal → pages every 3 hours
+- Garden process does structural maintenance weekly
+
+### Research inputs
+
+- **A-MEM** — Zettelkasten-inspired: each memory gets keywords, tags, summary, and dynamic links. New info refines existing memories. Graph traversal at retrieval time follows links beyond pure vector search.
+- **Generative Agents** — Three-factor scoring: `score = w1*recency + w2*importance + w3*similarity`. All normalized to [0,1].
+- **Context Rot** (Chroma) — Every token added degrades retrieval quality. Lean, relevant context beats dumping everything in.
+
+## Design
+
+### 1. Vault page frontmatter
+
+Pages support optional YAML frontmatter (Jekyll/Obsidian-compatible):
+
+```markdown
+---
+summary: "One-line description of the page's purpose"
+keywords: [term1, term2, term3]
+tags: [category1, category2]
+importance: 0.5
+---
+
+# Page Title
+...content...
+```
+
+**Fields:**
+- `summary` — one-line description. Replaces the informal `tl;dr` convention. Used in composite embeddings.
+- `keywords` — salient terms ordered by importance. Enriches embedding search.
+- `tags` — broad categorical labels. Compatible with Obsidian tags.
+- `importance` — float [0, 1], default 0.5 (neutral). Adjusted by garden process in Phase B.
+
+**Rules:**
+- Frontmatter is optional — pages without it work fine (defaults applied).
+- LLM-generated when pages are created/updated (Phase B dream integration). 
+- Human-editable — manually set values are respected; LLM fills gaps but doesn't overwrite explicit values.
+- Parsing on read, preservation on write. Vault tools (`vault_write`, `vault_read`) handle frontmatter transparently.
+
+### 2. Composite embeddings
+
+The embedding index stores a composite document per page:
+
+```
+{summary}\n{keywords joined by ', '}\n{tags joined by ', '}\n{content}
+```
+
+This enriches semantic search with structured metadata. Requires reindex when frontmatter is added or updated (`make reindex` already handles this).
+
+Pages without frontmatter embed as content-only (current behavior).
+
+### 3. Wiki-link graph expansion
+
+When `memory_context.py` retrieves top-k results via embedding search, it expands the candidate set by following `[[wiki-links]]` from the top hits:
+
+- **One hop only** — if hit A links to page B, page B is added to the candidate pool.
+- **Linked pages are marked** — `{"source_type": "graph_expansion", "linked_from": "PageName"}` so the composer can see provenance.
+- **No cap on expansion** — all linked pages enter the candidate pool, but they compete on score like everything else. The composer's budget allocation handles the rest.
+- **Link parsing** — extract `[[PageName]]` and `[[PageName|display]]` from page content. Resolve against vault root.
+- **Scoring graph-expanded pages** — linked pages don't have their own cosine similarity from embedding search. They inherit a discounted similarity from the parent hit (e.g., `parent_similarity * 0.7`). Their recency and importance use their own metadata as normal.
+
+This happens in `memory_context.py` — the composer just sees a bigger, annotated candidate pool.
+
+### 4. Relevance scoring
+
+The composer scores all retrieval candidates using three factors, each normalized to [0, 1]:
+
+**`score = w_similarity * similarity + w_recency * recency + w_importance * importance`**
+
+**Factors:**
+- **Similarity** — cosine similarity from embedding search (already normalized [0, 1]).
+- **Recency** — exponential decay based on page modification time or journal entry timestamp. More recent = higher score. Decay rate configurable.
+- **Importance** — from frontmatter field (default 0.5 if absent). Neutral until dream/garden adjusts it in Phase B.
+
+**Default weights** (configurable in `config.json`):
+- `w_similarity: 0.5` — similarity dominates
+- `w_recency: 0.3` — recency is secondary
+- `w_importance: 0.2` — importance has less influence until actively tuned
+
+**Where it lives:**
+- `memory_context.py` retrieves candidates with raw metadata (similarity, timestamp, importance from frontmatter).
+- The composer applies the scoring formula and makes selection/budget decisions.
+
+### 5. Budget allocation
+
+The composer uses a priority-tier model:
+
+1. **Fixed costs** (always included, not negotiable):
+   - System prompt
+   - Conversation history
+   - Tool definitions (active + deferred list)
+   - Explicitly referenced vault pages (`@[[Page]]` mentions and open web UI page) — user intent, not scored
+
+2. **Scored candidates** (compete for remaining budget):
+   - Memory/journal entries from retrieval
+   - Vault pages from retrieval (not explicitly referenced)
+   - Graph-expanded pages (linked from retrieval hits)
+
+After fixed costs are reserved, remaining token budget goes to scored candidates. Candidates are ranked by composite score; the composer fills from the top until the budget is exhausted.
+
+The fixed token budget for memory context (currently 500 tokens) is replaced by this dynamic allocation.
+
+### 6. Configuration
+
+New config fields in `MemoryContextConfig` (or a new `RelevanceConfig`):
+
+```python
+@dataclass
+class RelevanceConfig:
+    w_similarity: float = 0.5
+    w_recency: float = 0.3
+    w_importance: float = 0.2
+    recency_decay_rate: float = 0.99  # per-hour decay
+    graph_expansion_enabled: bool = True
+```
+
+## Success criteria
+
+1. **Vault pages with frontmatter** — parse on read, preserve on write, composite embedding on index
+2. **Graph expansion** — retrieval follows one hop of wiki-links, linked pages in candidate pool
+3. **Relevance scoring** — candidates scored by recency + importance + similarity with configurable weights
+4. **Budget allocation** — fixed costs reserved, scored candidates fill remainder
+5. **All existing tests pass** — no regressions
+6. **Configurable** — weights, decay rate, graph expansion toggle in config
+
+## Out of scope (Phase B — follow-up issue)
+
+- Dream process generates/updates frontmatter on pages it creates/revises
+- Dream process suggests new wiki-links (A-MEM "strengthen" operation)
+- Garden process adjusts importance scores across all pages (retrieval frequency, link count, reference frequency)
+- Garden process validates/repairs frontmatter consistency
+- Backfill frontmatter on existing pages
+- Reindex existing pages with composite embeddings
+- Micro-evolution on journal append (lighter than dream, more responsive)
+
+## Relationship to other issues
+
+- #182 — Context composer parent issue (this is phases 4-6)
+- #196 — Wiki/memory → vault naming cleanup
+- #175 — Vault unification

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@
 - [MCP Server Support](mcp-servers.md) — Connect external MCP servers as tool providers (stdio + HTTP)
 - [Vault](vault.md) — Unified knowledge base: curated pages, journal entries, user notes
 - [Proactive Memory Context](memory-context.md) — Automatically surface relevant vault content per turn
+- [Relevance Scoring](relevance-scoring.md) — Three-factor scoring, graph expansion, dynamic budget allocation
 - [Dream Consolidation](dream-consolidation.md) — Periodic journal review and vault page gardening
 - [Conversations](conversations.md) — Archive, resume, and compaction of conversation history
 - [Semantic Search](semantic-search.md) — Embedding-based search over memories and conversations

--- a/docs/relevance-scoring.md
+++ b/docs/relevance-scoring.md
@@ -1,0 +1,114 @@
+# Relevance Scoring & Graph Expansion
+
+Memory context retrieval uses a three-factor relevance scoring system inspired by Generative Agents and A-MEM research.
+
+## Scoring Formula
+
+```
+composite_score = w_similarity * similarity + w_recency * recency + w_importance * importance
+```
+
+All factors are normalized to [0, 1].
+
+### Factors
+
+| Factor | Source | Description |
+|--------|--------|-------------|
+| **Similarity** | Embedding cosine similarity | How semantically close the entry is to the user's message |
+| **Recency** | File modification time | Exponential decay: `decay_rate ^ hours_since_modification` |
+| **Importance** | Frontmatter field | Page significance, default 0.5. Adjusted by garden process. |
+
+### Default Weights
+
+| Weight | Default | Rationale |
+|--------|---------|-----------|
+| `w_similarity` | 0.5 | Similarity dominates — relevance to the query matters most |
+| `w_recency` | 0.3 | Recent content is more likely to be useful |
+| `w_importance` | 0.2 | Lower weight until dream/garden actively tune importance |
+
+Configurable via `RelevanceConfig` in `config.json` or environment variables.
+
+## Wiki-Link Graph Expansion
+
+After embedding search returns top-k results, the system follows `[[wiki-links]]` one hop from each hit:
+
+1. Parse `[[PageName]]` links from top hit content
+2. Resolve each link against the vault
+3. Add linked pages to the candidate pool with:
+   - Discounted similarity: `parent_similarity * 0.7` (configurable)
+   - Their own recency (file mtime) and importance (frontmatter)
+   - `source_type: "graph_expansion"` and `linked_from: parent_page`
+4. All candidates (original + expanded) compete on composite score
+
+This captures conceptual relationships that pure embedding similarity might miss — if a page about "deployment" links to a page about "systemd services," both may be relevant even if only one matches the query embedding.
+
+## Dynamic Budget Allocation
+
+The composer uses a priority-tier model:
+
+### Fixed Costs (always included)
+- System prompt
+- Conversation history
+- Tool definitions
+- Explicitly referenced vault pages (`@[[Page]]` mentions, open web UI page)
+
+### Scored Candidates (compete for remaining budget)
+After fixed costs are reserved, remaining tokens go to scored candidates:
+- Memory/journal entries from embedding retrieval
+- Vault pages from retrieval
+- Graph-expanded pages
+
+Candidates fill in composite_score order until the budget is exhausted.
+
+The budget is derived from `context_window_size` (or `compaction_max_tokens` as fallback) minus fixed costs minus a response reserve (4096 tokens). Falls back to the fixed `max_tokens` budget if the dynamic budget is unavailable.
+
+## Vault Page Frontmatter
+
+Pages support optional YAML frontmatter:
+
+```markdown
+---
+summary: "One-line description"
+keywords: [term1, term2, term3]
+tags: [category1, category2]
+importance: 0.5
+---
+
+# Page Content
+...
+```
+
+### Composite Embeddings
+
+The embedding index stores a composite document:
+```
+{summary}
+{keywords joined by ', '}
+{tags joined by ', '}
+{body content}
+```
+
+This enriches semantic search with structured metadata. Pages without frontmatter embed as body-only (backward compatible).
+
+### Future: Automated Frontmatter (Phase B)
+
+- Dream process will generate/update frontmatter when creating or revising pages
+- Garden process will adjust importance scores across all pages
+- See issue #197 for details
+
+## Configuration
+
+```json
+{
+  "relevance": {
+    "w_similarity": 0.5,
+    "w_recency": 0.3,
+    "w_importance": 0.2,
+    "recency_decay_rate": 0.99,
+    "graph_expansion_enabled": true,
+    "graph_expansion_similarity_discount": 0.7
+  }
+}
+```
+
+Environment variables: `RELEVANCE_W_SIMILARITY`, `RELEVANCE_W_RECENCY`, etc.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -120,6 +120,9 @@ async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
                  f"triggering compaction")
         try:
             await compact_history(ctx, history)
+            # After compaction, summarized content replaces originals —
+            # allow previously-injected pages to be re-injected if relevant.
+            ctx.composer.injected_paths.clear()
         except Exception as e:
             log.error(f"Compaction failed: {e}")
 

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -26,6 +26,7 @@ from .config_types import (
     MattermostConfig,
     MemoryContextConfig,
     ReflectionConfig,
+    RelevanceConfig,
     VaultConfig,
 )
 
@@ -143,6 +144,7 @@ class Config:
     models: dict[str, dict[str, str]] = field(default_factory=dict)
     reflection: ReflectionConfig = field(default_factory=ReflectionConfig)
     memory_context: MemoryContextConfig = field(default_factory=MemoryContextConfig)
+    relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
 
     # Custom environment variables from config.json "env" section
@@ -337,6 +339,9 @@ def load_config() -> Config:
     memory_context = load_sub_config(
         MemoryContextConfig, file_data.get("memory_context", {}), "MEMORY_CONTEXT")
 
+    relevance = load_sub_config(
+        RelevanceConfig, file_data.get("relevance", {}), "RELEVANCE")
+
     vault = load_sub_config(
         VaultConfig, file_data.get("vault", {}), "VAULT")
 
@@ -360,6 +365,7 @@ def load_config() -> Config:
         models=models,
         reflection=reflection,
         memory_context=memory_context,
+        relevance=relevance,
         vault=vault,
         env=env_vars,
         system_prompt=system_prompt,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -143,6 +143,17 @@ class MemoryContextConfig:
     show_in_ui: bool = True
 
 
+@dataclass
+class RelevanceConfig:
+    w_similarity: float = 0.5
+    w_recency: float = 0.3
+    w_importance: float = 0.2
+    recency_decay_rate: float = 0.99  # per-hour exponential decay
+    min_composite_score: float = 0.65  # candidates below this are dropped
+    graph_expansion_enabled: bool = True
+    graph_expansion_similarity_discount: float = 0.7
+
+
 def is_secret(dc_class: type, field_name: str) -> bool:
     """Check if a dataclass field is marked as secret."""
     for f in dc_fields(dc_class):

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -78,7 +78,7 @@ class ComposerState:
     last_total_tokens_estimated: int = 0
     last_prompt_tokens_actual: int = 0
     last_completion_tokens_actual: int = 0
-    recent_memory_ids: list[str] = field(default_factory=list)
+    injected_paths: set[str] = field(default_factory=set)  # file_paths already in context; cleared on compaction
 
 
 # -- Composer -----------------------------------------------------------------
@@ -137,6 +137,7 @@ class ContextComposer:
         sources.append(system_entry)
 
         # -- Wiki context (injected before user message in history) --
+        # Explicit @[[Page]] references are fixed costs — always included.
         wiki_msgs, wiki_entry = self._compose_wiki_context(
             ctx, config, user_message, history, mode,
         )
@@ -147,9 +148,48 @@ class ContextComposer:
         if wiki_entry:
             sources.append(wiki_entry)
 
+        # -- Tools (compute before budget so we have actual token cost) --
+        active_tools, deferred_tools, deferred_text, tools_entry = self._compose_tools(ctx, config)
+        sources.append(tools_entry)
+
+        # -- Compute fixed costs for dynamic budget allocation --
+        # Fixed costs: system prompt + wiki refs + tools + existing history
+        fixed_tokens = system_entry.tokens_estimated
+        if wiki_entry:
+            fixed_tokens += wiki_entry.tokens_estimated
+        # Estimate existing history (before this turn's additions)
+        # Only exclude wiki messages injected THIS turn (wiki_msgs);
+        # prior turns' memory/wiki are already in history and sent to the LLM.
+        injected_wiki_ids = {id(wm) for wm in wiki_msgs}
+        existing_history_tokens = sum(
+            estimate_tokens(str(m.get("content", "")))
+            for m in history
+            if id(m) not in injected_wiki_ids
+        )
+        fixed_tokens += existing_history_tokens
+        # User message
+        fixed_tokens += estimate_tokens(user_message)
+        # Tools (actual token cost, not estimate)
+        fixed_tokens += tools_entry.tokens_estimated
+
+        # Response reserve (leave room for the model's response)
+        response_reserve = 4096
+
+        # Dynamic budget for scored candidates
+        window_size = self._get_context_window_size(config)
+        remaining_budget = max(0, window_size - fixed_tokens - response_reserve)
+
+        # Fall back to fixed max_tokens if remaining budget is unreasonable
+        # (e.g. context_window_size not configured)
+        memory_budget: int | None = None
+        if remaining_budget > 0:
+            memory_budget = remaining_budget
+        # else: None → _compose_memory_context falls back to max_tokens
+
         # -- Memory context (injected before user message in history) --
         memory_msgs, retrieved_context_text, mc_results, memory_entry = await self._compose_memory_context(
             ctx, config, user_message, mode,
+            token_budget=memory_budget,
         )
         for mm in memory_msgs:
             history.append(mm)
@@ -192,10 +232,6 @@ class ContextComposer:
             details={"total_llm_messages": len(llm_history)},
         )
         sources.append(history_entry)
-
-        # -- Tools --
-        active_tools, deferred_tools, deferred_text, tools_entry = self._compose_tools(ctx, config)
-        sources.append(tools_entry)
 
         # -- Assemble final messages --
         messages = [{"role": "system", "content": system_text}]
@@ -244,12 +280,56 @@ class ContextComposer:
         )
         return text, entry
 
+    def _score_candidates(self, candidates: list[dict], config) -> list[dict]:
+        """Score retrieval candidates using recency + importance + similarity.
+
+        Each candidate gets a composite_score field. Returns sorted descending.
+        """
+        from datetime import datetime
+
+        relevance = config.relevance
+        now = datetime.now()
+
+        for c in candidates:
+            similarity = min(1.0, max(0.0, c.get("similarity", 0.0)))
+
+            # Recency: exponential decay based on hours since modification
+            modified_at = c.get("modified_at", "")
+            if modified_at:
+                try:
+                    mod_time = datetime.fromisoformat(modified_at)
+                    hours = max(0.0, (now - mod_time).total_seconds() / 3600)
+                    recency = relevance.recency_decay_rate ** hours
+                    recency = min(1.0, max(0.0, recency))
+                except (ValueError, TypeError):
+                    recency = 0.5
+            else:
+                recency = 0.5
+
+            importance = min(1.0, max(0.0, c.get("importance", 0.5)))
+
+            c["composite_score"] = (
+                relevance.w_similarity * similarity
+                + relevance.w_recency * recency
+                + relevance.w_importance * importance
+            )
+
+        candidates.sort(key=lambda c: c.get("composite_score", 0), reverse=True)
+        return candidates
+
     async def _compose_memory_context(
         self, ctx, config, user_message: str, mode: ComposerMode,
+        token_budget: int | None = None,
     ) -> tuple[list[dict], str, list[dict], SourceEntry | None]:
         """Retrieve and format memory context for injection.
 
+        Args:
+            token_budget: Dynamic budget from composer. If None, falls back
+                to config.memory_context.max_tokens for backward compatibility.
+
         Returns (messages_to_inject, formatted_text, raw_results, source_entry).
+        Retrieval candidates are scored by composite relevance and selected
+        by score order within the token budget.
         Fail-open: exceptions log a warning and return empty results.
         """
         from .util import estimate_tokens
@@ -265,19 +345,64 @@ class ContextComposer:
             if not results:
                 return [], "", [], None
 
+            # Filter out candidates already injected in this conversation
+            # (they're already in history — re-injecting wastes tokens)
+            if self.state.injected_paths:
+                before = len(results)
+                results = [r for r in results if r.get("file_path", "") not in self.state.injected_paths]
+                suppressed = before - len(results)
+                if suppressed:
+                    log.debug("Memory context: suppressed %d already-injected candidates", suppressed)
+
+            if not results:
+                return [], "", [], None
+
+            # Score and rank candidates
+            total_candidates = len(results)
+            results = self._score_candidates(results, config)
+
+            # Drop candidates below minimum score threshold
+            score_threshold = config.relevance.min_composite_score
+            results = [r for r in results if r.get("composite_score", 0) >= score_threshold]
+
+            # Select by token budget (score order replaces similarity order)
+            budget = token_budget if token_budget is not None else config.memory_context.max_tokens
+            log.debug("Memory context: %d candidates, budget=%d tokens (%s)",
+                      total_candidates, budget,
+                      "dynamic" if token_budget is not None else "fixed")
+            from .memory_context import _trim_to_token_budget
+            results = _trim_to_token_budget(results, budget)
+            if results:
+                log.debug("Memory context: selected %d/%d candidates (scores %.3f–%.3f)",
+                          len(results), total_candidates,
+                          results[0].get("composite_score", 0),
+                          results[-1].get("composite_score", 0))
+
             formatted = format_memory_context(results)
             msg = {"role": "memory_context", "content": formatted}
 
-            # Track recently injected entries
-            self.state.recent_memory_ids = [
-                r.get("entry_text", "")[:80] for r in results
-            ]
+            # Track injected paths so they're suppressed in future turns
+            # (cleared on compaction when the content is summarized away)
+            for r in results:
+                path = r.get("file_path", "")
+                if path:
+                    self.state.injected_paths.add(path)
 
             tokens = estimate_tokens(formatted)
+            top_score = results[0].get("composite_score", 0) if results else 0
+            min_score = results[-1].get("composite_score", 0) if results else 0
             entry = SourceEntry(
                 source="memory",
                 tokens_estimated=tokens,
                 items_included=len(results),
+                items_truncated=total_candidates - len(results),
+                details={
+                    "top_score": round(top_score, 3),
+                    "min_score": round(min_score, 3),
+                    "candidates_considered": total_candidates,
+                    "token_budget": budget,
+                    "budget_source": "dynamic" if token_budget is not None else "fixed",
+                },
             )
             return [msg], formatted, results, entry
 
@@ -394,7 +519,7 @@ class ContextComposer:
         Prefers the explicit context_window_size if set, otherwise falls back
         to compaction_max_tokens as a conservative proxy.
 
-        Not yet called — will be used by budget allocation in a future phase.
+        Used by compose() for dynamic budget allocation.
         """
         window = config.llm.context_window_size
         if window and window > 0:

--- a/src/decafclaw/embeddings.py
+++ b/src/decafclaw/embeddings.py
@@ -279,7 +279,7 @@ def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
         fetch_k = top_k * 3
 
         rows = conn.execute("""
-            SELECT m.entry_text, m.file_path, m.source_type, v.distance
+            SELECT m.entry_text, m.file_path, m.source_type, m.created_at, v.distance
             FROM (
                 SELECT rowid, distance
                 FROM embeddings_vec
@@ -303,7 +303,7 @@ def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
     }
 
     results = []
-    for entry_text, file_path, row_source_type, distance in rows:
+    for entry_text, file_path, row_source_type, created_at, distance in rows:
         if source_type and row_source_type != source_type:
             continue
         similarity = 1.0 - distance
@@ -313,6 +313,7 @@ def search_similar_sync(config, query_embedding: list[float], top_k: int = 5,
             "file_path": file_path,
             "similarity": similarity,
             "source_type": row_source_type,
+            "created_at": created_at,
         })
 
     results.sort(key=lambda x: x["similarity"], reverse=True)
@@ -429,7 +430,12 @@ def _iter_vault_pages(config):
 
     Indexes all non-journal vault pages (agent pages + user pages).
     Journal entries are indexed separately via _iter_journal_entries.
+
+    If a page has YAML frontmatter, the embedding text is a composite of
+    summary + keywords + tags + body for richer semantic search.
     """
+    from .frontmatter import build_composite_text, parse_frontmatter
+
     vault = config.vault_root
     if not vault.is_dir():
         return
@@ -443,12 +449,15 @@ def _iter_vault_pages(config):
                 continue
         except (ValueError, OSError):
             pass
-        text = filepath.read_text().strip()
-        if not text:
+        raw_text = filepath.read_text()
+        if not raw_text.strip():
             continue
+        # Build composite embedding text from frontmatter + body
+        metadata, body = parse_frontmatter(raw_text)
+        embed_text = build_composite_text(metadata, body)
         rel_path = str(filepath.relative_to(vault))
         source_type = _source_type_for_vault_path(config, filepath)
-        yield rel_path, text, source_type, {}
+        yield rel_path, embed_text, source_type, {}
 
 
 async def reindex_journal(config, concurrency: int = 4):

--- a/src/decafclaw/frontmatter.py
+++ b/src/decafclaw/frontmatter.py
@@ -1,0 +1,112 @@
+"""YAML frontmatter parsing and serialization for vault pages.
+
+Supports Jekyll/Obsidian-compatible frontmatter: YAML between `---` delimiters
+at the start of a markdown file. Pure utility functions, no codebase dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Split markdown text into (frontmatter_dict, body_content).
+
+    Frontmatter must be at the very start of the file, between ``---`` delimiters.
+    Returns ({}, text) if no frontmatter found or on parse error.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}, text
+
+    yaml_text = match.group(1)
+    body = text[match.end():]
+
+    if not yaml_text.strip():
+        return {}, body
+
+    try:
+        metadata = yaml.safe_load(yaml_text)
+        if not isinstance(metadata, dict):
+            log.warning("Frontmatter YAML is not a dict, ignoring")
+            return {}, body
+        return metadata, body
+    except yaml.YAMLError as e:
+        log.warning("Malformed YAML frontmatter: %s", e)
+        return {}, body
+
+
+def serialize_frontmatter(metadata: dict, body: str) -> str:
+    """Combine a metadata dict and body text into frontmatter + markdown.
+
+    Omits the frontmatter block entirely if metadata is empty.
+    """
+    if not metadata:
+        return body
+
+    yaml_text = yaml.dump(metadata, default_flow_style=False, allow_unicode=True)
+    return f"---\n{yaml_text}---\n{body}"
+
+
+def get_frontmatter_field(metadata: dict, field: str, default=None):
+    """Type-safe getter for frontmatter fields.
+
+    - ``importance``: clamped to [0, 1] float.
+    - ``keywords``, ``tags``: ensured to be list of strings.
+    - ``summary``: ensured to be a string.
+    """
+    value = metadata.get(field, default)
+    if value is None:
+        return default
+
+    if field == "importance":
+        try:
+            return max(0.0, min(1.0, float(value)))
+        except (TypeError, ValueError):
+            return default if default is not None else 0.5
+
+    if field in ("keywords", "tags"):
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        if isinstance(value, str):
+            return [value]
+        return default if default is not None else []
+
+    if field == "summary":
+        return str(value)
+
+    return value
+
+
+def build_composite_text(metadata: dict, body: str) -> str:
+    """Build composite text for embedding indexing.
+
+    Prepends summary, keywords, and tags to body content for richer embeddings.
+    Returns body as-is if no relevant frontmatter fields are present.
+    """
+    parts: list[str] = []
+
+    summary = metadata.get("summary")
+    if summary:
+        parts.append(str(summary))
+
+    keywords = get_frontmatter_field(metadata, "keywords", [])
+    if isinstance(keywords, list) and keywords:
+        parts.append(", ".join(str(k) for k in keywords))
+
+    tags = get_frontmatter_field(metadata, "tags", [])
+    if isinstance(tags, list) and tags:
+        parts.append(", ".join(str(t) for t in tags))
+
+    if not parts:
+        return body
+
+    parts.append(body)
+    return "\n".join(parts)

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -1,17 +1,22 @@
 """Proactive memory retrieval — automatically surface relevant context per turn."""
 
 import logging
+import re
 
 from .embeddings import embed_text, search_similar_sync
 from .util import estimate_tokens
 
 log = logging.getLogger(__name__)
 
+# Matches [[PageName]] and [[PageName|display text]] in vault page content
+_WIKI_LINK_RE = re.compile(r'\[\[([^\]|]+)(?:\|[^\]]+)?\]\]')
+
 # Source type labels for display
 SOURCE_LABELS = {
     "page": "Agent page",
     "user": "User page",
     "journal": "Journal",
+    "graph_expansion": "Linked page",
     # Legacy compat
     "wiki": "Wiki",
     "memory": "Memory",
@@ -52,9 +57,20 @@ async def retrieve_memory_context(config, user_message: str) -> list[dict]:
         # Trim to max_results
         results = results[:mc.max_results]
 
-        # Trim to token budget
-        results = _trim_to_token_budget(results, mc.max_tokens)
+        # Enrich with file metadata for relevance scoring
+        results = _enrich_results(config, results)
 
+        # Expand via wiki-link graph traversal (one hop)
+        relevance = getattr(config, "relevance", None)
+        if relevance and relevance.graph_expansion_enabled:
+            results = _expand_graph_links(
+                config, results,
+                similarity_discount=relevance.graph_expansion_similarity_discount,
+            )
+
+        # Token budget trimming is handled by the composer's dynamic budget
+        # allocation (_compose_memory_context). We return all candidates here
+        # so the composer can score and select with the full picture.
         return results
 
     except Exception:
@@ -75,11 +91,155 @@ def _trim_to_token_budget(results: list[dict], max_tokens: int) -> list[dict]:
     return trimmed
 
 
+def _enrich_results(config, results: list[dict]) -> list[dict]:
+    """Enrich retrieval results with file metadata for relevance scoring.
+
+    Adds modified_at (ISO timestamp) and importance (float) to each result.
+    Called after threshold filtering on the small candidate set.
+    Fail-open: errors on individual results log a warning and use defaults.
+    """
+    import os
+    from datetime import datetime
+
+    from .frontmatter import get_frontmatter_field, parse_frontmatter
+
+    vault_root = config.vault_root
+    for result in results:
+        try:
+            file_path = result.get("file_path", "")
+            source_type = result.get("source_type", "")
+
+            # Default values
+            result.setdefault("importance", 0.5)
+            result.setdefault("modified_at", result.get("created_at", ""))
+
+            # Try to get file modification time and frontmatter
+            if file_path:
+                full_path = vault_root / file_path
+                if full_path.exists():
+                    mtime = os.path.getmtime(full_path)
+                    result["modified_at"] = datetime.fromtimestamp(mtime).isoformat()
+
+                    # Parse frontmatter for importance (pages/user only, not journal)
+                    if source_type in ("page", "user"):
+                        text = full_path.read_text()
+                        metadata, _ = parse_frontmatter(text)
+                        if metadata:
+                            result["importance"] = get_frontmatter_field(
+                                metadata, "importance", 0.5,
+                            )
+        except Exception:
+            log.warning("Failed to enrich result %s", result.get("file_path", "?"),
+                        exc_info=True)
+
+    return results
+
+
+def _expand_graph_links(
+    config, results: list[dict], similarity_discount: float = 0.7,
+) -> list[dict]:
+    """Expand retrieval results by following [[wiki-links]] one hop.
+
+    For each result, parse wiki-links from the page content. Linked pages
+    are added to the candidate pool with discounted similarity and marked
+    as graph_expansion source type. Deduplicates by file_path.
+    """
+    import os
+    from datetime import datetime
+
+    from .frontmatter import build_composite_text, get_frontmatter_field, parse_frontmatter
+
+    vault_root = config.vault_root.resolve()
+    seen_paths = {r.get("file_path") for r in results}
+    expanded: list[dict] = []
+
+    for result in results:
+        file_path = result.get("file_path", "")
+        if not file_path:
+            continue
+        full_path = vault_root / file_path
+        if not full_path.exists():
+            continue
+
+        try:
+            text = full_path.read_text()
+        except (OSError, UnicodeError):
+            continue
+
+        # Parse wiki-links from page content
+        linked_pages = _WIKI_LINK_RE.findall(text)
+        if not linked_pages:
+            continue
+
+        log.debug("Graph expansion: %s has %d wiki-links", file_path, len(linked_pages))
+
+        parent_similarity = result.get("similarity", 0.5)
+        parent_page = file_path
+        added_count = 0
+
+        for page_name in linked_pages:
+            page_name = page_name.strip()
+            if not page_name:
+                continue
+
+            # Resolve the linked page against vault root
+            from .skills.vault.tools import resolve_page
+            linked_path = resolve_page(config, page_name, from_page=file_path)
+            if linked_path is None or not linked_path.exists():
+                log.debug("Graph expansion: link [[%s]] from %s — not found", page_name, file_path)
+                continue
+
+            try:
+                rel_path = str(linked_path.relative_to(vault_root))
+            except ValueError:
+                log.debug("Graph expansion: link [[%s]] — outside vault root", page_name)
+                continue
+
+            if rel_path in seen_paths:
+                log.debug("Graph expansion: link [[%s]] → %s — already in candidates", page_name, rel_path)
+                continue
+            seen_paths.add(rel_path)
+
+            # Read linked page for metadata
+            linked_text = ""
+            try:
+                linked_text = linked_path.read_text()
+                metadata, body = parse_frontmatter(linked_text)
+                importance = get_frontmatter_field(metadata, "importance", 0.5)
+                mtime = os.path.getmtime(linked_path)
+                modified_at = datetime.fromtimestamp(mtime).isoformat()
+                entry_text = build_composite_text(metadata, body)
+            except Exception:
+                importance = 0.5
+                modified_at = ""
+                entry_text = linked_text
+
+            expanded.append({
+                "entry_text": entry_text,
+                "file_path": rel_path,
+                "similarity": parent_similarity * similarity_discount,
+                "source_type": "graph_expansion",
+                "linked_from": parent_page,
+                "importance": importance,
+                "modified_at": modified_at,
+            })
+            added_count += 1
+
+        if added_count:
+            log.debug("Graph expansion from '%s': added %d new candidates", file_path, added_count)
+
+    if expanded:
+        log.info("Graph expansion: %d candidates added from %d source pages",
+                 len(expanded), sum(1 for r in results if r.get("file_path")))
+    return results + expanded
+
+
 def format_memory_context(results: list[dict]) -> str:
     """Format retrieval results into a context message for injection."""
     parts = ["[Automatically retrieved context — not from the user]\n"]
     for r in results:
         label = SOURCE_LABELS.get(r["source_type"], r["source_type"])
-        sim = f"{r['similarity']:.2f}"
-        parts.append(f"--- {label} (relevance: {sim}) ---\n{r['entry_text']}")
+        # Show composite score if available (from relevance scoring), else raw similarity
+        score = r.get("composite_score", r.get("similarity", 0))
+        parts.append(f"--- {label} (score: {score:.2f}) ---\n{r['entry_text']}")
     return "\n\n".join(parts)

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -158,13 +158,16 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
 
-    # Update semantic search index
+    # Update semantic search index with composite text (frontmatter-enriched)
     source_type = _source_type_for_path(ctx.config, path)
     try:
         from decafclaw.embeddings import delete_entries, index_entry
+        from decafclaw.frontmatter import build_composite_text, parse_frontmatter
         rel_path = str(path.resolve().relative_to(ctx.config.vault_root.resolve()))
         delete_entries(ctx.config, rel_path, source_type=source_type)
-        await index_entry(ctx.config, rel_path, content, source_type=source_type)
+        metadata, body = parse_frontmatter(content)
+        embed_text = build_composite_text(metadata, body)
+        await index_entry(ctx.config, rel_path, embed_text, source_type=source_type)
     except Exception as e:
         log.warning(f"Failed to index vault page '{page}': {e}")
 

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -80,7 +80,7 @@ class TestComposerState:
         assert state.last_total_tokens_estimated == 0
         assert state.last_prompt_tokens_actual == 0
         assert state.last_completion_tokens_actual == 0
-        assert state.recent_memory_ids == []
+        assert state.injected_paths == set()
 
 
 # -- ContextComposer ----------------------------------------------------------
@@ -214,10 +214,12 @@ class TestComposeMemoryContext:
             assert entry is None
 
     @pytest.mark.asyncio
-    async def test_tracks_recent_memory_ids(self, ctx, config):
+    async def test_tracks_injected_paths(self, ctx, config):
         mock_results = [
-            {"entry_text": "first memory entry", "source_type": "page", "similarity": 0.8},
-            {"entry_text": "second memory entry", "source_type": "journal", "similarity": 0.7},
+            {"entry_text": "first", "source_type": "page", "similarity": 0.9,
+             "file_path": "pages/first.md", "modified_at": "", "importance": 0.5},
+            {"entry_text": "second", "source_type": "journal", "similarity": 0.85,
+             "file_path": "journal/second.md", "modified_at": "", "importance": 0.5},
         ]
         with (
             patch("decafclaw.memory_context.retrieve_memory_context",
@@ -229,7 +231,32 @@ class TestComposeMemoryContext:
             await composer._compose_memory_context(
                 ctx, config, "hello", ComposerMode.INTERACTIVE,
             )
-            assert len(composer.state.recent_memory_ids) == 2
+            assert "pages/first.md" in composer.state.injected_paths
+            assert "journal/second.md" in composer.state.injected_paths
+
+    @pytest.mark.asyncio
+    async def test_suppresses_already_injected(self, ctx, config):
+        mock_results = [
+            {"entry_text": "first", "source_type": "page", "similarity": 0.8,
+             "file_path": "pages/first.md", "modified_at": "", "importance": 0.5},
+        ]
+        with (
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=mock_results),
+            patch("decafclaw.memory_context.format_memory_context",
+                  return_value="formatted"),
+        ):
+            composer = ContextComposer()
+            # First turn: injected
+            _, _, _, entry1 = await composer._compose_memory_context(
+                ctx, config, "hello", ComposerMode.INTERACTIVE,
+            )
+            assert entry1 is not None
+            # Second turn: suppressed (already in context)
+            _, _, _, entry2 = await composer._compose_memory_context(
+                ctx, config, "hello again", ComposerMode.INTERACTIVE,
+            )
+            assert entry2 is None  # no results after suppression
 
 
 # -- Wiki context --------------------------------------------------------------
@@ -447,6 +474,64 @@ class TestCompose:
             composer = ContextComposer()
             result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
             assert result.retrieved_context_text == "formatted memory"
+
+
+# -- Relevance scoring ---------------------------------------------------------
+
+
+class TestScoreCandidates:
+    def test_produces_composite_scores(self, config):
+        candidates = [
+            {"similarity": 0.8, "modified_at": "", "importance": 0.5},
+            {"similarity": 0.6, "modified_at": "", "importance": 0.5},
+        ]
+        composer = ContextComposer()
+        scored = composer._score_candidates(candidates, config)
+        assert all("composite_score" in c for c in scored)
+
+    def test_sorted_by_score_descending(self, config):
+        candidates = [
+            {"similarity": 0.3, "modified_at": "", "importance": 0.5},
+            {"similarity": 0.9, "modified_at": "", "importance": 0.5},
+            {"similarity": 0.6, "modified_at": "", "importance": 0.5},
+        ]
+        composer = ContextComposer()
+        scored = composer._score_candidates(candidates, config)
+        scores = [c["composite_score"] for c in scored]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_recency_favors_recent(self, config):
+        from datetime import datetime, timedelta
+        now = datetime.now()
+        recent = (now - timedelta(hours=1)).isoformat()
+        old = (now - timedelta(hours=1000)).isoformat()
+        candidates = [
+            {"similarity": 0.5, "modified_at": old, "importance": 0.5},
+            {"similarity": 0.5, "modified_at": recent, "importance": 0.5},
+        ]
+        composer = ContextComposer()
+        scored = composer._score_candidates(candidates, config)
+        # Recent item should score higher
+        assert scored[0]["modified_at"] == recent
+
+    def test_importance_influences_score(self, config):
+        candidates = [
+            {"similarity": 0.5, "modified_at": "", "importance": 0.1},
+            {"similarity": 0.5, "modified_at": "", "importance": 0.9},
+        ]
+        composer = ContextComposer()
+        scored = composer._score_candidates(candidates, config)
+        # Higher importance should score higher
+        assert scored[0]["importance"] == 0.9
+
+    def test_missing_modified_at_defaults_recency(self, config):
+        candidates = [
+            {"similarity": 0.8, "importance": 0.5},
+        ]
+        composer = ContextComposer()
+        scored = composer._score_candidates(candidates, config)
+        assert scored[0]["composite_score"] > 0
+
 
 
 class TestContextComposerOnContext:

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,161 @@
+"""Tests for YAML frontmatter parsing and serialization."""
+
+import pytest
+
+from decafclaw.frontmatter import (
+    build_composite_text,
+    get_frontmatter_field,
+    parse_frontmatter,
+    serialize_frontmatter,
+)
+
+# -- parse_frontmatter ---------------------------------------------------------
+
+
+class TestParseFrontmatter:
+    def test_valid_frontmatter(self):
+        text = "---\ntitle: Test\ntags: [a, b]\n---\n# Hello\nBody here."
+        meta, body = parse_frontmatter(text)
+        assert meta == {"title": "Test", "tags": ["a", "b"]}
+        assert body == "# Hello\nBody here."
+
+    def test_no_frontmatter(self):
+        text = "# Hello\nJust plain markdown."
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert body == text
+
+    def test_empty_frontmatter_block(self):
+        text = "---\n\n---\n# Hello"
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert body == "# Hello"
+
+    def test_malformed_yaml(self):
+        text = "---\n[invalid: yaml: stuff\n---\nBody"
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert body == "Body"
+
+    def test_non_dict_yaml(self):
+        text = "---\n- just\n- a list\n---\nBody"
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert body == "Body"
+
+    def test_frontmatter_not_at_start(self):
+        text = "Some text\n---\ntitle: Test\n---\nBody"
+        meta, body = parse_frontmatter(text)
+        assert meta == {}
+        assert body == text
+
+    def test_full_frontmatter(self):
+        text = (
+            "---\n"
+            "summary: A test page\n"
+            "keywords: [foo, bar, baz]\n"
+            "tags: [config, models]\n"
+            "importance: 0.8\n"
+            "---\n"
+            "# Content\nHere."
+        )
+        meta, body = parse_frontmatter(text)
+        assert meta["summary"] == "A test page"
+        assert meta["keywords"] == ["foo", "bar", "baz"]
+        assert meta["tags"] == ["config", "models"]
+        assert meta["importance"] == 0.8
+        assert body == "# Content\nHere."
+
+
+# -- serialize_frontmatter -----------------------------------------------------
+
+
+class TestSerializeFrontmatter:
+    def test_round_trip(self):
+        original_meta = {"summary": "Test", "tags": ["a", "b"]}
+        original_body = "# Hello\nBody."
+        text = serialize_frontmatter(original_meta, original_body)
+        meta, body = parse_frontmatter(text)
+        assert meta == original_meta
+        assert body == original_body
+
+    def test_empty_dict_omits_block(self):
+        body = "# Hello\nNo frontmatter."
+        text = serialize_frontmatter({}, body)
+        assert text == body
+        assert "---" not in text
+
+    def test_preserves_body_exactly(self):
+        body = "Line 1\nLine 2\n\nLine 4"
+        text = serialize_frontmatter({"key": "val"}, body)
+        _, parsed_body = parse_frontmatter(text)
+        assert parsed_body == body
+
+
+# -- get_frontmatter_field -----------------------------------------------------
+
+
+class TestGetFrontmatterField:
+    def test_importance_clamped_low(self):
+        assert get_frontmatter_field({"importance": -0.5}, "importance") == 0.0
+
+    def test_importance_clamped_high(self):
+        assert get_frontmatter_field({"importance": 1.5}, "importance") == 1.0
+
+    def test_importance_valid(self):
+        assert get_frontmatter_field({"importance": 0.7}, "importance") == pytest.approx(0.7)
+
+    def test_importance_string(self):
+        assert get_frontmatter_field({"importance": "0.3"}, "importance") == pytest.approx(0.3)
+
+    def test_importance_invalid(self):
+        assert get_frontmatter_field({"importance": "not a number"}, "importance") == 0.5
+
+    def test_importance_missing(self):
+        assert get_frontmatter_field({}, "importance", 0.5) == 0.5
+
+    def test_keywords_list(self):
+        assert get_frontmatter_field({"keywords": ["a", "b"]}, "keywords") == ["a", "b"]
+
+    def test_keywords_string(self):
+        assert get_frontmatter_field({"keywords": "single"}, "keywords") == ["single"]
+
+    def test_keywords_missing(self):
+        assert get_frontmatter_field({}, "keywords", []) == []
+
+    def test_tags_list(self):
+        assert get_frontmatter_field({"tags": ["x", "y"]}, "tags") == ["x", "y"]
+
+    def test_summary_string(self):
+        assert get_frontmatter_field({"summary": "A page"}, "summary") == "A page"
+
+    def test_summary_number(self):
+        assert get_frontmatter_field({"summary": 42}, "summary") == "42"
+
+
+# -- build_composite_text ------------------------------------------------------
+
+
+class TestBuildCompositeText:
+    def test_full_frontmatter(self):
+        meta = {"summary": "A test", "keywords": ["foo", "bar"], "tags": ["config"]}
+        body = "Content here."
+        result = build_composite_text(meta, body)
+        assert result == "A test\nfoo, bar\nconfig\nContent here."
+
+    def test_no_frontmatter(self):
+        body = "Just body content."
+        result = build_composite_text({}, body)
+        assert result == body
+
+    def test_partial_frontmatter(self):
+        meta = {"summary": "Just a summary"}
+        body = "Body."
+        result = build_composite_text(meta, body)
+        assert result == "Just a summary\nBody."
+
+    def test_keywords_only(self):
+        meta = {"keywords": ["alpha", "beta"]}
+        body = "Body."
+        result = build_composite_text(meta, body)
+        assert result == "alpha, beta\nBody."

--- a/tests/test_memory_context.py
+++ b/tests/test_memory_context.py
@@ -6,6 +6,9 @@ import pytest
 
 from decafclaw.config_types import MemoryContextConfig
 from decafclaw.memory_context import (
+    _WIKI_LINK_RE,
+    _enrich_results,
+    _expand_graph_links,
     _trim_to_token_budget,
     format_memory_context,
     retrieve_memory_context,
@@ -48,8 +51,8 @@ class TestFormatMemoryContext:
         ]
         text = format_memory_context(results)
         assert "[Automatically retrieved context" in text
-        assert "Wiki (relevance: 0.85)" in text
-        assert "Memory (relevance: 0.60)" in text
+        assert "Wiki (score: 0.85)" in text
+        assert "Memory (score: 0.60)" in text
         assert "Les likes Boulevardiers" in text
 
     def test_empty_results(self):
@@ -111,11 +114,12 @@ class TestRetrieveMemoryContext:
             assert results == []
 
     @pytest.mark.asyncio
-    async def test_respects_token_budget(self, config):
+    async def test_returns_all_candidates_for_composer(self, config):
+        """retrieve_memory_context returns all candidates — the composer handles budget trimming."""
         from dataclasses import replace
         cfg = replace(config, memory_context=MemoryContextConfig(max_tokens=100))
         fake_embedding = [1.0] * 768
-        # Each entry is 400 chars = 100 tokens
+        # Each entry is 400 chars = 100 tokens; all 3 should be returned
         search_results = [
             _make_result(text="a" * 400, similarity=0.8),
             _make_result(text="b" * 400, similarity=0.7),
@@ -124,4 +128,134 @@ class TestRetrieveMemoryContext:
         with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=fake_embedding), \
              patch("decafclaw.memory_context.search_similar_sync", return_value=search_results):
             results = await retrieve_memory_context(cfg, "hello")
-            assert len(results) == 1
+            assert len(results) == 3
+
+
+# -- Wiki-link regex -----------------------------------------------------------
+
+
+class TestWikiLinkRegex:
+    def test_simple_link(self):
+        assert _WIKI_LINK_RE.findall("See [[PageName]] for details") == ["PageName"]
+
+    def test_display_text(self):
+        assert _WIKI_LINK_RE.findall("See [[Target|display text]]") == ["Target"]
+
+    def test_multiple_links(self):
+        text = "Links: [[Alpha]], [[Beta|b]], and [[Gamma]]"
+        assert _WIKI_LINK_RE.findall(text) == ["Alpha", "Beta", "Gamma"]
+
+    def test_no_links(self):
+        assert _WIKI_LINK_RE.findall("No links here") == []
+
+    def test_nested_brackets(self):
+        # Should not match malformed syntax
+        assert _WIKI_LINK_RE.findall("Not a [[link") == []
+
+
+# -- Enrich results ------------------------------------------------------------
+
+
+class TestEnrichResults:
+    def test_adds_defaults(self, config):
+        results = [_make_result(text="entry", source_type="journal")]
+        enriched = _enrich_results(config, results)
+        assert enriched[0]["importance"] == 0.5
+        assert "modified_at" in enriched[0]
+
+    def test_reads_importance_from_frontmatter(self, config, tmp_path):
+        # Create a vault page with frontmatter
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        page = vault_dir / "test.md"
+        page.write_text("---\nimportance: 0.9\n---\n# Test")
+        config.vault.vault_path = str(vault_dir)
+        results = [{"entry_text": "test", "source_type": "page", "similarity": 0.8,
+                     "file_path": "test.md"}]
+        enriched = _enrich_results(config, results)
+        assert enriched[0]["importance"] == 0.9
+
+    def test_fail_open_on_missing_file(self, config):
+        results = [{"entry_text": "entry", "source_type": "page", "similarity": 0.5,
+                     "file_path": "nonexistent.md"}]
+        enriched = _enrich_results(config, results)
+        assert enriched[0]["importance"] == 0.5  # default
+
+
+# -- Graph expansion -----------------------------------------------------------
+
+
+class TestExpandGraphLinks:
+    def test_expands_wiki_links(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        # Source page with a link
+        source = vault_dir / "source.md"
+        source.write_text("# Source\nSee [[linked]] for more.")
+        # Linked page
+        linked = vault_dir / "linked.md"
+        linked.write_text("# Linked\nContent here.")
+        config.vault.vault_path = str(vault_dir)
+        results = [{"entry_text": "source content", "file_path": "source.md",
+                     "similarity": 0.8, "source_type": "page"}]
+        expanded = _expand_graph_links(config, results, similarity_discount=0.7)
+        assert len(expanded) == 2  # original + linked
+        linked_result = [r for r in expanded if r.get("source_type") == "graph_expansion"]
+        assert len(linked_result) == 1
+        assert linked_result[0]["linked_from"] == "source.md"
+        assert linked_result[0]["similarity"] == pytest.approx(0.56)  # 0.8 * 0.7
+
+    def test_resolves_with_unresolved_vault_root(self, config, tmp_path):
+        """Regression: vault_root must be resolved before relative_to comparison.
+
+        resolve_page returns resolved (absolute) paths. If vault_root is
+        relative, relative_to fails and all links appear "outside vault root".
+        """
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        source = vault_dir / "source.md"
+        source.write_text("See [[linked]]")
+        linked = vault_dir / "linked.md"
+        linked.write_text("# Linked page")
+        # Set vault_path as a relative-looking string (not pre-resolved)
+        config.vault.vault_path = str(vault_dir)
+        results = [{"entry_text": "source", "file_path": "source.md",
+                     "similarity": 0.8, "source_type": "page"}]
+        expanded = _expand_graph_links(config, results)
+        graph_results = [r for r in expanded if r.get("source_type") == "graph_expansion"]
+        assert len(graph_results) == 1, "linked page should be found despite unresolved vault_root"
+
+    def test_deduplicates(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        # Two pages that link to the same target
+        a = vault_dir / "a.md"
+        a.write_text("See [[target]]")
+        b = vault_dir / "b.md"
+        b.write_text("Also [[target]]")
+        target = vault_dir / "target.md"
+        target.write_text("# Target")
+        config.vault.vault_path = str(vault_dir)
+        results = [
+            {"entry_text": "a", "file_path": "a.md", "similarity": 0.8, "source_type": "page"},
+            {"entry_text": "b", "file_path": "b.md", "similarity": 0.7, "source_type": "page"},
+        ]
+        expanded = _expand_graph_links(config, results)
+        # target.md should appear only once
+        target_results = [r for r in expanded if "target.md" in r.get("file_path", "")]
+        assert len(target_results) == 1
+
+    def test_skips_dangling_links(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        source = vault_dir / "source.md"
+        source.write_text("See [[nonexistent]]")
+        config.vault.vault_path = str(vault_dir)
+        results = [{"entry_text": "source", "file_path": "source.md",
+                     "similarity": 0.8, "source_type": "page"}]
+        expanded = _expand_graph_links(config, results)
+        assert len(expanded) == 1  # only the original, no expansion
+
+    def test_empty_results(self, config):
+        expanded = _expand_graph_links(config, [])
+        assert expanded == []


### PR DESCRIPTION
## Summary

Phase 2 of the context composer (#182). Builds on Phase 1 (PR #195) to make context selection intentional with relevance scoring, wiki-link graph expansion, and structured vault page frontmatter. Inspired by A-MEM and Generative Agents research.

- **YAML frontmatter** for vault pages — `summary`, `keywords`, `tags`, `importance` fields. Parsed/preserved transparently. Composite embeddings prepend metadata to body for richer search.
- **Wiki-link graph expansion** — retrieval follows `[[wiki-links]]` one hop from top hits, expanding the candidate pool with discounted similarity
- **Three-factor relevance scoring** — `composite_score = w_similarity * similarity + w_recency * recency + w_importance * importance`, configurable weights via `RelevanceConfig`
- **Dynamic budget allocation** — fixed costs (system prompt, history, tools, explicit page refs) reserved first, scored candidates fill the remainder
- 31 new tests (26 frontmatter + 5 scoring), 1020 total passing

### Deferred to Phase B (#197)

- Dream process generates/updates frontmatter on pages
- Garden process adjusts importance scores across vault
- Backfill frontmatter on existing pages
- Micro-evolution on journal append

## Test plan

- [x] All 1020 tests pass (no regressions)
- [x] Lint (`ruff check`) clean
- [x] Type check (`pyright`) clean
- [x] Live test in Mattermost after merge
- [x] Reindex vault with `make reindex` to pick up composite embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)