### PR TITLE
feat: context inspector — waffle chart popover and diagnostics sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/web/` — Web gateway: auth, conversations, conversation folders, WebSocket chat handler
 - `src/decafclaw/web/conversation_folders.py` — Per-user conversation folder index (JSON file, metadata-only)
 - `src/decafclaw/web/static/` — Frontend: Lit web components, service layer (AuthClient, WebSocketClient, ConversationStore, MessageStore, ToolStatusStore, markdown, utils)
+- `src/decafclaw/web/static/components/context-inspector.js` — Context inspection popover: waffle chart, source breakdown, memory candidates
 
 ## Running
 
@@ -153,6 +154,7 @@ Session docs live in `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`, `
 - **Wiki-link graph expansion.** Memory context retrieval follows `[[wiki-links]]` one hop from top embedding hits to expand the candidate pool. Linked pages get discounted similarity and compete on composite score. Configurable via `RelevanceConfig.graph_expansion_enabled`.
 - **Proactive memory context is fail-open.** Before each interactive turn, relevant memories/wiki are auto-injected as context via the ContextComposer. Errors silently return empty results. Skipped for heartbeat, scheduled tasks, and child agents. Requires an embedding model to be configured — silently disabled otherwise.
 - **Vault chat context.** Users can share vault pages into conversations via `@[[PageName]]` mentions (all channels) or by having a page open in the web UI sidebar. Pages are injected once per conversation as `wiki_context` role messages, tracked by scanning history. Parsing happens in the ContextComposer via helpers in `agent.py`. Page resolution uses vault root, not a fixed wiki directory.
+- **Context diagnostics sidecar.** After each turn, the agent loop writes `workspace/conversations/{conv_id}.context.json` with per-source token estimates, scoring details, and memory candidate breakdowns. REST endpoint `GET /api/conversations/{id}/context` returns this data. Web UI popover with waffle chart visualization triggered by clicking the context bar.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 
 ## Keeping docs current

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -67,11 +67,21 @@ Each context source produces a `SourceEntry` with token estimates, item counts, 
 
 The agent loop (`run_agent_turn`) creates a `ContextComposer` at the start of each turn and calls `compose()` once. The iteration loop still uses `_build_tool_list()` per-iteration because fetched tools change mid-turn as the model calls `tool_search`. After each LLM response, `record_actuals()` stores the real token counts for future calibration.
 
+## Context Inspection
+
+After each turn, the agent writes a diagnostics sidecar file (`workspace/conversations/{conv_id}.context.json`) with per-source token estimates, scoring details, and memory candidate breakdowns.
+
+**REST endpoint:** `GET /api/conversations/{id}/context` returns the sidecar data.
+
+**Web UI:** Click the context usage bar in the sidebar to open a popover with:
+- Waffle chart (grid map) showing token allocation by source
+- Summary stats (estimated vs actual tokens, window size, compaction threshold)
+- Source breakdown table with token counts and item details
+- Memory candidates with composite scores, score breakdowns, and graph expansion provenance
+
 ## Future work (deferred)
 
-- Relevance scoring (recency + importance + similarity)
-- Dynamic budget allocation across sources
-- Budget-aware truncation/summarization
-- Context stats command for surfacing diagnostics
 - Calibrating estimates from actuals
 - Model switching as alternative to compaction
+- Mattermost `!context` command (uses REST endpoint)
+- Agent self-inspection tool

--- a/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/notes.md
+++ b/docs/dev-sessions/2026-04-02-0952-context-composer-relevance/notes.md
@@ -1,2 +1,50 @@
 # Context Composer Phase 2: Relevance Scoring & A-MEM Concepts — Notes
 
+## Session summary
+
+Built on Phase 1 (PR #195) to add relevance scoring, wiki-link graph expansion, vault frontmatter, and dynamic budget allocation. PR #198, also closes #121.
+
+## Key actions
+
+1. **Researched A-MEM** — background agent fetched the GitHub repo and paper. Key takeaways: structured metadata per memory, graph traversal at retrieval, continuous evolution.
+2. **Brainstormed spec** — 10 Q&A rounds covering frontmatter fields, graph expansion depth, scoring formula, budget tiers, dream/garden split, configuration.
+3. **Filed #197** for Phase B (dream/garden frontmatter generation, importance tuning).
+4. **Planned 7 steps** — frontmatter → config → vault tools → enrichment → graph expansion → scoring → budget allocation.
+5. **Executed all 7 steps** with lint + test + commit each.
+6. **Live debugging** — graph expansion not working (vault_root not resolved), candidates pre-trimmed before composer saw them.
+7. **Tuning** — min_composite_score threshold (0.4 → 0.55 → 0.65), injection suppression for already-injected pages.
+8. **Two rounds of PR review** — Copilot caught 12 issues total across two reviews. All fixed.
+9. **Squash + rebase** — squashed lost prior fixes, had to re-apply. Lesson: squash AFTER all fixes.
+
+## Divergences from plan
+
+- **Token budget trimming moved** — `retrieve_memory_context` no longer trims to `max_tokens`. The composer handles all budget decisions. This wasn't in the plan but was necessary for graph-expanded candidates to survive to the scoring stage.
+- **Injection suppression added** — not in original spec. Tracks injected file_paths per conversation, suppresses re-injection until compaction clears the set.
+- **min_composite_score threshold added** — not in spec. Needed to cut the long tail of marginally relevant graph-expanded pages.
+- **Tool composition moved before budget calculation** — plan had tools computed after budget. Review comment pointed out we were using a threshold estimate instead of actual token cost.
+- **format_memory_context shows composite score** — switched from raw similarity to composite_score for clearer display.
+
+## Bugs found and fixed during session
+
+1. **vault_root not resolved** — `_expand_graph_links` compared resolved paths against unresolved vault_root. All linked pages appeared "outside vault root."
+2. **Candidates pre-trimmed** — `retrieve_memory_context` trimmed to 500 tokens before the composer could score. Graph-expanded candidates were lost.
+3. **SOURCE_LABELS missing graph_expansion** — displayed as raw string instead of "Linked page."
+4. **build_composite_text didn't normalize scalar keywords/tags** — `keywords: "single"` was silently dropped.
+5. **_iter_vault_pages strip() before parse** — could mangle frontmatter detection.
+6. **resolve_page missing from_page** — graph expansion didn't prefer closest match.
+
+## Insights
+
+- **Live testing finds what unit tests miss.** The vault_root resolution bug and pre-trimming bug both passed all tests but failed in production. The tests mocked the vault, avoiding the real path resolution.
+- **Squash timing matters.** Squashing before all review fixes means the fixes get lost on rebase. Squash last.
+- **Copilot review is consistently useful.** Caught real bugs across two review rounds — format inconsistencies, uninitialized variables, budget miscalculation, config not wired.
+- **Thresholds need live tuning.** Started at 0.4, ended at 0.65 based on actual score distributions. Can't predict the right value from theory alone.
+
+## Stats
+
+- **Commits:** squashed to 1 (was ~20 during development)
+- **Files changed:** 18 (+1551 / -56 lines)
+- **New files:** `frontmatter.py`, `test_frontmatter.py`, `docs/relevance-scoring.md`
+- **Tests:** 988 → 1034 (46 new)
+- **Issues closed:** #121 (temporal decay), #182 partially (phases 4-6)
+- **Issues filed:** #197 (Phase B vault evolution)

--- a/docs/dev-sessions/2026-04-02-1650-context-inspection/notes.md
+++ b/docs/dev-sessions/2026-04-02-1650-context-inspection/notes.md
@@ -1,0 +1,2 @@
+# Context Inspection — Notes
+

--- a/docs/dev-sessions/2026-04-02-1650-context-inspection/plan.md
+++ b/docs/dev-sessions/2026-04-02-1650-context-inspection/plan.md
@@ -1,0 +1,270 @@
+# Context Inspection — Plan
+
+## Overview
+
+Surface context composer diagnostics through a sidecar file, REST endpoint, and web UI popover with a waffle chart visualization. 5 steps, each building on the previous.
+
+Key files we're modifying/creating:
+- `src/decafclaw/context_composer.py` — store recency + per-candidate tokens during scoring
+- `src/decafclaw/agent.py` — write sidecar after each turn
+- `src/decafclaw/http_server.py` — REST endpoint for context diagnostics
+- `src/decafclaw/web/static/components/context-inspector.js` — new Lit component
+- `src/decafclaw/web/static/components/conversation-sidebar.js` — click handler on context bar
+- `src/decafclaw/web/static/styles/context-inspector.css` — styles
+
+---
+
+## Step 1: Enrich scoring data and write sidecar file
+
+Store `recency` and per-candidate `tokens_estimated` during scoring. Write a JSON sidecar file after each turn with the full diagnostics.
+
+### Prompt
+
+```
+Step 1: Enrich candidate scoring data and write context diagnostics sidecar.
+
+In `context_composer.py`, modify `_score_candidates()`:
+- Store `recency` on each candidate dict (alongside `composite_score`)
+- After scoring in `_compose_memory_context`, compute per-candidate
+  `tokens_estimated` using `estimate_tokens(r.get("entry_text", ""))`
+  on each selected result
+
+Add a method `_build_diagnostics(self, config, composed: ComposedContext) -> dict`:
+- Build the full diagnostics dict matching the spec's JSON schema:
+  - timestamp (ISO format)
+  - total_tokens_estimated (from composed)
+  - total_tokens_actual (from state.last_prompt_tokens_actual)
+  - context_window_size (from _get_context_window_size)
+  - compaction_threshold (from config.compaction.max_tokens)
+  - sources (from composed.sources, serialized as list of dicts)
+  - memory_candidates (from composed.memory_results, each with
+    file_path, source_type, composite_score, similarity, recency,
+    importance, modified_at, linked_from, tokens_estimated)
+
+Add a module-level function `write_context_sidecar(config, conv_id: str, diagnostics: dict)`:
+- Write to `workspace/conversations/{conv_id}.context.json`
+- Use the same directory as archive_path
+- Fail-open: log warning on error, never raise
+
+In `agent.py`, after the LLM response and `record_actuals()`, call:
+```python
+diagnostics = composer._build_diagnostics(config, composed)
+write_context_sidecar(config, conv_id, diagnostics)
+```
+
+Also add a `read_context_sidecar(config, conv_id: str) -> dict | None`:
+- Read and parse the JSON file. Return None if missing or malformed.
+
+Write tests:
+- Test _build_diagnostics produces valid dict with all expected keys
+- Test write_context_sidecar creates file with correct content
+- Test read_context_sidecar reads it back
+- Test read_context_sidecar returns None for missing file
+- Test write_context_sidecar is fail-open (mock open to raise)
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 2: REST endpoint
+
+Add a GET endpoint that returns the sidecar diagnostics for a conversation.
+
+### Prompt
+
+```
+Step 2: Add REST endpoint for context diagnostics.
+
+In `http_server.py`, add a new route handler:
+
+```python
+@_authenticated
+async def get_context_diagnostics(request: Request, username: str) -> JSONResponse:
+    conv_id = request.path_params["id"]
+    from .context_composer import read_context_sidecar
+    data = read_context_sidecar(config, conv_id)
+    if data is None:
+        return JSONResponse({"error": "no context data"}, status_code=404)
+    return JSONResponse(data)
+```
+
+Add the route:
+```python
+Route("/api/conversations/{id}/context", get_context_diagnostics, methods=["GET"]),
+```
+
+Place it near the other `/api/conversations/{id}/*` routes.
+
+Write tests:
+- Test endpoint returns 200 with diagnostics when sidecar exists
+- Test endpoint returns 404 when no sidecar
+- Test endpoint returns 401 when not authenticated
+
+Run `make check && make test`.
+```
+
+---
+
+## Step 3: Web UI popover component — waffle chart and source breakdown
+
+Create the context-inspector Lit component with the waffle chart visualization and source breakdown table.
+
+### Prompt
+
+```
+Step 3: Create the context-inspector web component.
+
+Create `src/decafclaw/web/static/components/context-inspector.js`:
+
+A Lit component that fetches and displays context diagnostics.
+
+Properties:
+- convId: String — the conversation ID to fetch diagnostics for
+- open: Boolean — whether the popover is visible
+
+Methods:
+- async fetchData() — fetch `/api/conversations/${this.convId}/context`,
+  store result in internal state
+- _renderWaffleChart(sources, contextWindowSize) — render the grid
+- _renderSourceTable(sources) — render the breakdown table
+- _renderMemoryCandidates(candidates) — render the candidates list
+
+Waffle chart:
+- Calculate total cells = Math.ceil(contextWindowSize / tokensPerCell)
+  where tokensPerCell is chosen to keep the grid reasonable (e.g.
+  aim for ~200-400 cells: tokensPerCell = Math.ceil(contextWindowSize / 300))
+- For each source, fill cells proportional to tokens_estimated
+- Remaining cells are "unused" capacity
+- Each cell is a small colored div (8x8px or similar)
+- Colors: system_prompt=#4A90D9, history=#888, tools=#9B59B6,
+  wiki=#27AE60, memory=#E67E22, unused=#eee
+- Grid wraps via CSS flexbox
+- Tooltip on hover showing source name + token count
+
+Source breakdown table:
+- Row per source: color swatch, name, tokens, items included/truncated
+- For memory source: show score range and candidates considered
+- For tools: show deferred mode status
+
+Memory candidates list:
+- Only shown if memory_candidates array is non-empty
+- Each entry: truncated file_path, source type label, composite score
+- Score breakdown as small colored inline bars:
+  similarity (blue), recency (green), importance (orange)
+  proportional to their contribution (weight * value)
+- Graph expansion provenance ("← linked from X") if linked_from present
+
+Popover positioning:
+- Absolutely positioned, anchored near the context bar
+- Dismiss on click outside (use a backdrop or document click listener)
+- Max height with overflow scroll for long candidate lists
+
+Create `src/decafclaw/web/static/styles/context-inspector.css` with styles.
+
+No tests needed for the component (visual, tested manually).
+
+Run `make check` (including check-js for type checking).
+```
+
+---
+
+## Step 4: Wire popover into sidebar
+
+Connect the context bar click to open the inspector popover.
+
+### Prompt
+
+```
+Step 4: Wire the context inspector into the conversation sidebar.
+
+In `conversation-sidebar.js`:
+
+1. Import the context-inspector component (dynamic import or static)
+
+2. Add a click handler on the context-usage div:
+   ```javascript
+   @click=${() => this.#toggleContextInspector()}
+   ```
+
+3. Add a `#toggleContextInspector()` method:
+   - If inspector is open, close it
+   - If closed, open it with the current conversation ID
+   - The conversation ID comes from the conversation store's current selection
+
+4. Add the context-inspector element to the sidebar template,
+   positioned near the context bar:
+   ```html
+   <context-inspector
+     .convId=${this._currentConvId}
+     .open=${this._contextInspectorOpen}
+     @close=${() => this._contextInspectorOpen = false}
+   ></context-inspector>
+   ```
+
+5. Add state property: `_contextInspectorOpen: { type: Boolean, state: true }`
+
+6. Style the context-usage bar with `cursor: pointer` to indicate clickability
+
+7. The inspector should dismiss when:
+   - User clicks outside it
+   - User clicks the context bar again (toggle)
+   - User switches conversations
+
+Run `make check` (check-js).
+Test manually in the browser.
+```
+
+---
+
+## Step 5: Documentation and polish
+
+Update docs, CLAUDE.md, handle edge cases.
+
+### Prompt
+
+```
+Step 5: Documentation and edge case handling.
+
+Edge cases to handle:
+- No context data yet (first message not sent) — show "No context data
+  yet" in the popover instead of the chart
+- Context data from a previous session (conv loaded from archive) —
+  stale data is fine, show timestamp so user knows when it's from
+- Very small context windows — ensure waffle chart still renders
+  reasonably with few cells
+
+In `context-inspector.js`:
+- Show loading state while fetching
+- Show error state if fetch fails
+- Show "No context data" if 404
+
+Update CLAUDE.md:
+- Add context-inspector.js to key files
+- Add convention note about context diagnostics sidecar
+
+Update docs/context-composer.md with the new inspection feature.
+Update docs/index.md if needed.
+
+Run `make check && make test`.
+Commit all remaining changes.
+```
+
+---
+
+## Summary of changes per step
+
+| Step | New/Modified Files | Tests |
+|------|-------------------|-------|
+| 1 | `context_composer.py`, `agent.py` | `test_context_composer.py` |
+| 2 | `http_server.py` | `test_http_server.py` or inline |
+| 3 | `context-inspector.js` (new), `context-inspector.css` (new) | Manual browser testing |
+| 4 | `conversation-sidebar.js` | Manual browser testing |
+| 5 | `CLAUDE.md`, `docs/`, edge case fixes | Existing tests |
+
+## Risk notes
+
+- **Step 1 is the only backend change** — enriching scoring data and writing the sidecar. Low risk since it's additive and fail-open.
+- **Step 3 is the largest** — the waffle chart component. Pure frontend, no backend risk. The visual design will need iteration.
+- **Sidecar file size** — typically <5KB, written once per turn. Negligible I/O.
+- **No auth bypass risk** — the REST endpoint uses the same `_authenticated` decorator as all other conversation endpoints.

--- a/docs/dev-sessions/2026-04-02-1650-context-inspection/spec.md
+++ b/docs/dev-sessions/2026-04-02-1650-context-inspection/spec.md
@@ -1,0 +1,199 @@
+# Context Inspection — Spec
+
+## Related issue
+
+GitHub issue #159 — Improved context inspection
+
+## Goal
+
+Surface the context composer's per-source diagnostics through a REST endpoint and a web UI popover, giving users a visual breakdown of what's in context and why. Inspired by Claude Code's context usage display.
+
+## Background
+
+The context composer (PR #195, #198) already tracks per-source token estimates, scoring details, and budget allocation in `ComposerState`. This data is currently invisible — only accessible via `LOG_LEVEL=DEBUG`. This feature makes it inspectable on demand.
+
+## Design
+
+### 1. Sidecar file for diagnostics
+
+After each turn, persist the latest composer diagnostics to a JSON sidecar file alongside the conversation archive:
+
+```
+workspace/conversations/{conv_id}.context.json
+```
+
+(Same directory as the conversation archive JSONL files.)
+
+Contents:
+
+```json
+{
+  "timestamp": "2026-04-02T14:58:39Z",
+  "total_tokens_estimated": 12500,
+  "total_tokens_actual": 13200,
+  "context_window_size": 100000,
+  "compaction_threshold": 100000,
+  "sources": [
+    {
+      "source": "system_prompt",
+      "tokens_estimated": 3200,
+      "items_included": 1,
+      "items_truncated": 0,
+      "details": {}
+    },
+    {
+      "source": "history",
+      "tokens_estimated": 5400,
+      "items_included": 22,
+      "items_truncated": 0,
+      "details": {"total_llm_messages": 24}
+    },
+    {
+      "source": "tools",
+      "tokens_estimated": 2100,
+      "items_included": 15,
+      "items_truncated": 90,
+      "details": {"deferred_mode": true}
+    },
+    {
+      "source": "wiki",
+      "tokens_estimated": 800,
+      "items_included": 1,
+      "items_truncated": 0,
+      "details": {}
+    },
+    {
+      "source": "memory",
+      "tokens_estimated": 1000,
+      "items_included": 5,
+      "items_truncated": 13,
+      "details": {
+        "top_score": 0.761,
+        "min_score": 0.573,
+        "candidates_considered": 18,
+        "token_budget": 82827,
+        "budget_source": "dynamic"
+      }
+    }
+  ],
+  "memory_candidates": [
+    {
+      "file_path": "agent/pages/AI Agents.md",
+      "source_type": "page",
+      "composite_score": 0.761,
+      "similarity": 0.84,
+      "recency": 0.92,
+      "importance": 0.5,
+      "modified_at": "2026-04-01T12:00:00",
+      "tokens_estimated": 250
+    },
+    {
+      "file_path": "agent/pages/Claw Projects.md",
+      "source_type": "graph_expansion",
+      "composite_score": 0.65,
+      "similarity": 0.59,
+      "recency": 0.88,
+      "importance": 0.5,
+      "modified_at": "2026-03-31T08:00:00",
+      "linked_from": "agent/pages/AI Agents.md",
+      "tokens_estimated": 180
+    }
+  ]
+}
+```
+
+**Rules:**
+- Written after each turn by the agent loop (after `compose()` and the LLM response)
+- Overwrites on each turn (only latest state, not a history)
+- Fail-open: write errors are logged, never block the turn
+- File is small (typically <5KB)
+
+**Data enrichment needed:**
+- `_score_candidates` must store `recency` on each candidate dict (currently only stores `composite_score`)
+- Per-candidate `tokens_estimated` must be computed during scoring or sidecar write (currently only aggregate exists on SourceEntry)
+- The `memory_candidates` list in the sidecar is built from the `ComposedContext.memory_results` field
+
+### 2. REST endpoint
+
+`GET /api/conversations/{conv_id}/context`
+
+Returns the sidecar JSON file contents. 404 if no context data exists for that conversation.
+
+Authentication: same as other conversation endpoints (session cookie).
+
+Reusable by:
+- Web UI popover (fetch on click)
+- Mattermost `!context` command (future)
+- Agent self-inspection tool (future)
+
+### 3. Web UI popover
+
+Triggered by clicking the context usage bar in the sidebar. Displays:
+
+#### Waffle chart / grid map
+
+A grid of small colored cells where each cell represents a chunk of tokens (e.g., 100 tokens per cell). Cells colored by source type:
+
+| Source | Color |
+|--------|-------|
+| System prompt | blue |
+| History | gray |
+| Tools | purple |
+| Wiki (explicit refs) | green |
+| Memory (retrieved) | amber/orange |
+| Unused capacity | very light gray / empty |
+
+The grid gives a visceral sense of how much of the context window each source occupies.
+
+#### Summary stats
+
+Below the grid:
+- Total tokens: estimated vs actual
+- Context window size
+- Compaction threshold
+- Budget source (dynamic vs fixed)
+
+#### Source breakdown table
+
+Per-source rows:
+- Source name + color swatch
+- Token count
+- Items included / truncated
+- Key details (deferred mode for tools, score range for memory)
+
+#### Memory candidates list
+
+For each included memory entry:
+- File path (truncated)
+- Source type label (Agent page, Linked page, Journal, etc.)
+- Composite score
+- Score breakdown (similarity, recency, importance) as small inline bars or numbers
+- Graph expansion provenance ("linked from X") if applicable
+
+#### Interaction
+
+- Click context bar → fetch REST endpoint → show popover
+- Click outside or X → dismiss
+- Popover positioned anchored to the context bar, expanding toward the center of the screen
+- No live updates — snapshot at time of click
+
+### 4. Mattermost command (future)
+
+Not in this session's scope, but the REST endpoint enables a future `!context` command that would format the diagnostics as a Mattermost message (text table or attachment).
+
+## Success criteria
+
+1. **Sidecar file written** after each turn with full diagnostics
+2. **REST endpoint** returns context diagnostics for a conversation
+3. **Waffle chart** renders proportional grid colored by source
+4. **Source breakdown** table with token counts and details
+5. **Memory candidates** listed with scores and provenance
+6. **Popover** triggered by clicking context bar, dismissed on click-outside
+7. **All existing tests pass** — no regressions
+
+## Out of scope
+
+- Mattermost `!context` command (future, uses same REST endpoint)
+- Agent self-inspection tool (future)
+- Historical context snapshots (only latest turn)
+- Live-updating popover during a turn

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -831,6 +831,9 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
     conv_id = ctx.conv_id or ctx.channel_id
 
+    composed = None
+    composer = None
+
     try:
         # Determine composer mode from context flags.
         # Note: skip_memory_context is handled directly by the composer,
@@ -1018,6 +1021,15 @@ async def run_agent_turn(ctx, user_message: str, history: list,
         return ToolResult(text=msg)
 
     finally:
+        # Write context diagnostics on any exit path
+        if composed is not None and composer is not None and conv_id:
+            try:
+                from .context_composer import write_context_sidecar
+                diagnostics = composer.build_diagnostics(config, composed)
+                write_context_sidecar(config, conv_id, diagnostics)
+            except Exception:
+                pass
+
         # Persist activated skills and skill_data after every turn
         if conv_id:
             activated = ctx.skills.activated

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -8,8 +8,10 @@ Tracks per-turn diagnostics (what was included, token estimates, actuals).
 from __future__ import annotations
 
 import enum
+import json
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +63,7 @@ class ComposedContext:
     sources: list[SourceEntry]
     messages_to_archive: list[dict] = field(default_factory=list)
     retrieved_context_text: str = ""
+    memory_results: list[dict] = field(default_factory=list)
 
 
 # -- Per-conversation state ---------------------------------------------------
@@ -79,6 +82,43 @@ class ComposerState:
     last_prompt_tokens_actual: int = 0
     last_completion_tokens_actual: int = 0
     injected_paths: set[str] = field(default_factory=set)  # file_paths already in context; cleared on compaction
+
+
+# -- Sidecar persistence ------------------------------------------------------
+
+
+def _context_sidecar_path(config, conv_id: str) -> Path:
+    """Path to the context diagnostics sidecar file."""
+    base_dir = (config.workspace_path / "conversations").resolve()
+    safe_name = conv_id.replace("/", "").replace("\\", "").replace("..", "")
+    if not safe_name:
+        return base_dir / "_invalid.context.json"
+    path = (base_dir / f"{safe_name}.context.json").resolve()
+    if not path.is_relative_to(base_dir):
+        return base_dir / "_invalid.context.json"
+    return path
+
+
+def write_context_sidecar(config, conv_id: str, diagnostics: dict) -> None:
+    """Write context diagnostics to the sidecar file. Fail-open."""
+    try:
+        path = _context_sidecar_path(config, conv_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(diagnostics, indent=2, default=str))
+    except Exception:
+        log.warning("Failed to write context sidecar for %s", conv_id, exc_info=True)
+
+
+def read_context_sidecar(config, conv_id: str) -> dict | None:
+    """Read context diagnostics from the sidecar file. Returns None if missing."""
+    try:
+        path = _context_sidecar_path(config, conv_id)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+    except Exception:
+        log.warning("Failed to read context sidecar for %s", conv_id, exc_info=True)
+        return None
 
 
 # -- Composer -----------------------------------------------------------------
@@ -260,6 +300,7 @@ class ContextComposer:
             sources=sources,
             messages_to_archive=to_archive,
             retrieved_context_text=retrieved_context_text,
+            memory_results=mc_results,
         )
 
     def _compose_system_prompt(self, config) -> tuple[str, SourceEntry]:
@@ -308,6 +349,7 @@ class ContextComposer:
 
             importance = min(1.0, max(0.0, c.get("importance", 0.5)))
 
+            c["recency"] = recency
             c["composite_score"] = (
                 relevance.w_similarity * similarity
                 + relevance.w_recency * recency
@@ -377,6 +419,10 @@ class ContextComposer:
                           len(results), total_candidates,
                           results[0].get("composite_score", 0),
                           results[-1].get("composite_score", 0))
+
+            # Compute per-candidate token estimates for diagnostics
+            for r in results:
+                r["tokens_estimated"] = estimate_tokens(r.get("entry_text", ""))
 
             formatted = format_memory_context(results)
             msg = {"role": "memory_context", "content": formatted}
@@ -530,3 +576,43 @@ class ContextComposer:
         """Record actual token usage from the LLM response."""
         self.state.last_prompt_tokens_actual = prompt_tokens
         self.state.last_completion_tokens_actual = completion_tokens
+
+    def build_diagnostics(self, config, composed: ComposedContext) -> dict:
+        """Build the full diagnostics dict for the context sidecar file."""
+        from datetime import datetime, timezone
+
+        candidates = []
+        for r in composed.memory_results:
+            entry = {
+                "file_path": r.get("file_path", ""),
+                "source_type": r.get("source_type", ""),
+                "composite_score": round(r.get("composite_score", 0), 3),
+                "similarity": round(r.get("similarity", 0), 3),
+                "recency": round(r.get("recency", 0.5), 3),
+                "importance": round(r.get("importance", 0.5), 3),
+                "modified_at": r.get("modified_at", ""),
+                "tokens_estimated": r.get("tokens_estimated", 0),
+            }
+            if r.get("linked_from"):
+                entry["linked_from"] = r["linked_from"]
+            candidates.append(entry)
+
+        sources = []
+        for s in composed.sources:
+            sources.append({
+                "source": s.source,
+                "tokens_estimated": s.tokens_estimated,
+                "items_included": s.items_included,
+                "items_truncated": s.items_truncated,
+                "details": s.details,
+            })
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "total_tokens_estimated": composed.total_tokens_estimated,
+            "total_tokens_actual": self.state.last_prompt_tokens_actual,
+            "context_window_size": self._get_context_window_size(config),
+            "compaction_threshold": config.compaction.max_tokens,
+            "sources": sources,
+            "memory_candidates": candidates,
+        }

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -374,6 +374,21 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         return JSONResponse({"messages": messages, "has_more": has_more})
 
     @_authenticated
+    async def get_context_diagnostics(request: Request, username: str) -> JSONResponse:
+        """Return context composer diagnostics for a conversation."""
+        conv_id = request.path_params["id"]
+        from .web.conversations import ConversationIndex
+        index = ConversationIndex(config)
+        conv = index.get(conv_id)
+        if not conv or conv.user_id != username:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        from .context_composer import read_context_sidecar
+        data = read_context_sidecar(config, conv_id)
+        if data is None:
+            return JSONResponse({"error": "no context data"}, status_code=404)
+        return JSONResponse(data)
+
+    @_authenticated
     async def serve_workspace_file(request: Request, username: str):
         """Serve a file from the agent workspace (authenticated, read-only)."""
         file_path = request.path_params.get("path", "")
@@ -975,6 +990,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         Route("/api/conversations/{id}", get_conversation, methods=["GET"]),
         Route("/api/conversations/{id}", rename_conversation, methods=["PATCH"]),
         Route("/api/conversations/{id}/history", get_conversation_history, methods=["GET"]),
+        Route("/api/conversations/{id}/context", get_context_diagnostics, methods=["GET"]),
         Route("/api/conversations/folders", create_conv_folder, methods=["POST"]),
         Route("/api/conversations/folders/{path:path}", delete_conv_folder, methods=["DELETE"]),
         Route("/api/conversations/folders/{path:path}", rename_conv_folder, methods=["PUT"]),

--- a/src/decafclaw/web/static/components/context-inspector.js
+++ b/src/decafclaw/web/static/components/context-inspector.js
@@ -1,0 +1,258 @@
+import { LitElement, html, nothing } from 'lit';
+
+const SOURCE_COLORS = {
+  system_prompt: '#4A90D9',
+  history: '#888888',
+  tools: '#9B59B6',
+  wiki: '#27AE60',
+  memory: '#E67E22',
+};
+
+const SOURCE_LABELS = {
+  system_prompt: 'System Prompt',
+  history: 'History',
+  tools: 'Tools',
+  wiki: 'Wiki Pages',
+  memory: 'Memory',
+};
+
+const TYPE_LABELS = {
+  page: 'Agent page',
+  user: 'User page',
+  journal: 'Journal',
+  graph_expansion: 'Linked page',
+};
+
+export class ContextInspector extends LitElement {
+  static properties = {
+    convId: { type: String },
+    open: { type: Boolean, reflect: true },
+    contextVersion: { type: Number },  // bumped by parent when context changes
+    _data: { type: Object, state: true },
+    _loading: { type: Boolean, state: true },
+    _error: { type: String, state: true },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    this.convId = '';
+    this.open = false;
+    this.contextVersion = 0;
+    this._data = null;
+    this._loading = false;
+    this._error = '';
+  }
+
+  updated(changed) {
+    if (changed.has('open') && this.open && this.convId) {
+      this.#fetchData();
+    }
+    if (changed.has('open')) {
+      if (this.open) {
+        // Defer so the current click doesn't immediately close
+        requestAnimationFrame(() => {
+          this._onDocClick = (e) => {
+            if (!this.contains(e.target)) {
+              this.dispatchEvent(new Event('close'));
+            }
+          };
+          document.addEventListener('click', this._onDocClick, true);
+        });
+      } else {
+        this.#removeDocClickListener();
+      }
+    }
+    // Re-fetch when context changes while inspector is open
+    if (changed.has('contextVersion') && this.open && this.convId && !this._loading) {
+      this.#fetchData();
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#removeDocClickListener();
+  }
+
+  #removeDocClickListener() {
+    if (this._onDocClick) {
+      document.removeEventListener('click', this._onDocClick, true);
+      this._onDocClick = null;
+    }
+  }
+
+  async #fetchData() {
+    if (!this.convId) return;
+    this._loading = true;
+    this._error = '';
+    this._data = null;
+    try {
+      const res = await fetch(`/api/conversations/${encodeURIComponent(this.convId)}/context`);
+      if (res.status === 404) {
+        this._data = null;
+        this._loading = false;
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      this._data = await res.json();
+    } catch (e) {
+      this._error = e.message || 'Failed to load';
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  #renderWaffle(sources, windowSize) {
+    if (!windowSize || !sources?.length) return nothing;
+
+    // Aim for ~300 cells
+    const tokensPerCell = Math.max(1, Math.ceil(windowSize / 300));
+    const totalCells = Math.ceil(windowSize / tokensPerCell);
+
+    const cells = [];
+    for (const s of sources) {
+      const count = Math.max(1, Math.round(s.tokens_estimated / tokensPerCell));
+      const color = SOURCE_COLORS[s.source] || '#ccc';
+      for (let i = 0; i < count && cells.length < totalCells; i++) {
+        cells.push(color);
+      }
+    }
+    // Fill remaining with unused
+    while (cells.length < totalCells) {
+      cells.push('var(--pico-muted-border-color, #eee)');
+    }
+
+    return html`
+      <div class="waffle">
+        ${cells.map(c => html`<div class="waffle-cell" style="background:${c}"></div>`)}
+      </div>
+      <div class="legend">
+        ${Object.entries(SOURCE_COLORS).map(([key, color]) => html`
+          <span class="legend-item">
+            <span class="legend-swatch" style="background:${color}"></span>
+            ${SOURCE_LABELS[key] || key}
+          </span>
+        `)}
+        <span class="legend-item">
+          <span class="legend-swatch" style="background:var(--pico-muted-border-color, #eee)"></span>
+          Unused
+        </span>
+      </div>
+    `;
+  }
+
+  #renderStats(data) {
+    return html`
+      <dl class="stats">
+        <dt>Estimated</dt>
+        <dd>${data.total_tokens_estimated?.toLocaleString() || '—'}</dd>
+        <dt>Actual</dt>
+        <dd>${data.total_tokens_actual?.toLocaleString() || '—'}</dd>
+        <dt>Window</dt>
+        <dd>${data.context_window_size?.toLocaleString() || '—'}</dd>
+        <dt>Compact at</dt>
+        <dd>${data.compaction_threshold?.toLocaleString() || '—'}</dd>
+      </dl>
+    `;
+  }
+
+  #renderSourceTable(sources) {
+    if (!sources?.length) return nothing;
+    return html`
+      <table class="source-table">
+        <thead>
+          <tr><th>Source</th><th>Tokens</th><th>Items</th><th>Detail</th></tr>
+        </thead>
+        <tbody>
+          ${sources.map(s => html`
+            <tr>
+              <td>
+                <span class="source-swatch" style="background:${SOURCE_COLORS[s.source] || '#ccc'}"></span>
+                ${SOURCE_LABELS[s.source] || s.source}
+              </td>
+              <td>${s.tokens_estimated?.toLocaleString()}</td>
+              <td>${s.items_included}${s.items_truncated ? html` <span style="color:var(--pico-muted-color)">(+${s.items_truncated} dropped)</span>` : ''}</td>
+              <td>${this.#sourceDetail(s)}</td>
+            </tr>
+          `)}
+        </tbody>
+      </table>
+    `;
+  }
+
+  #sourceDetail(s) {
+    if (s.source === 'memory' && s.details) {
+      const d = s.details;
+      return html`scores ${d.top_score ?? '—'}–${d.min_score ?? '—'}, ${d.budget_source || ''} budget`;
+    }
+    if (s.source === 'tools' && s.details?.deferred_mode) {
+      return 'deferred mode';
+    }
+    return '';
+  }
+
+  #renderCandidates(candidates) {
+    if (!candidates?.length) return nothing;
+
+    const maxBarWidth = 40; // px
+
+    return html`
+      <div class="candidates-header">Memory Candidates (${candidates.length})</div>
+      ${candidates.map(c => {
+        const path = c.file_path?.replace(/^agent\/pages\//, '') || '?';
+        const typeLabel = TYPE_LABELS[c.source_type] || c.source_type;
+        return html`
+          <div class="candidate">
+            <div class="candidate-path">${path}</div>
+            <div class="candidate-meta">
+              <span>${typeLabel}</span>
+              <span>score: ${c.composite_score?.toFixed(2)}</span>
+              <span>~${c.tokens_estimated?.toLocaleString() || '?'} tok</span>
+            </div>
+            <div class="score-bars" title="sim=${c.similarity?.toFixed(2)} rec=${c.recency?.toFixed(2)} imp=${c.importance?.toFixed(2)}">
+              <div class="score-bar" style="width:${(c.similarity || 0) * maxBarWidth}px;background:#4A90D9"></div>
+              <div class="score-bar" style="width:${(c.recency || 0) * maxBarWidth}px;background:#27AE60"></div>
+              <div class="score-bar" style="width:${(c.importance || 0) * maxBarWidth}px;background:#E67E22"></div>
+              <span class="score-label">s/r/i</span>
+            </div>
+            ${c.linked_from ? html`<div class="candidate-provenance">\u2190 linked from ${c.linked_from.replace(/^agent\/pages\//, '')}</div>` : ''}
+          </div>
+        `;
+      })}
+    `;
+  }
+
+  render() {
+    if (!this.open) return nothing;
+
+    let content;
+    if (this._loading) {
+      content = html`<div class="loading">Loading...</div>`;
+    } else if (this._error) {
+      content = html`<div class="error-msg">Error: ${this._error}</div>`;
+    } else if (!this._data) {
+      content = html`<div class="empty-msg">No context data yet</div>`;
+    } else {
+      const d = this._data;
+      content = html`
+        ${this.#renderWaffle(d.sources, d.context_window_size)}
+        ${this.#renderStats(d)}
+        ${this.#renderSourceTable(d.sources)}
+        ${this.#renderCandidates(d.memory_candidates)}
+      `;
+    }
+
+    return html`
+      <div class="inspector">
+        <div class="inspector-header">
+          <h3>Context Inspector</h3>
+          <button class="close-btn" @click=${() => this.dispatchEvent(new Event('close'))}>&times;</button>
+        </div>
+        ${content}
+      </div>
+    `;
+  }
+}
+
+customElements.define('context-inspector', ContextInspector);

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -1,4 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
+import './context-inspector.js';
 
 export class ConversationSidebar extends LitElement {
   static properties = {
@@ -21,6 +22,8 @@ export class ConversationSidebar extends LitElement {
     _vaultFolder: { type: String, state: true },
     _vaultFolders: { type: Array, state: true },
     _openWikiPage: { type: String, state: true },
+    _contextInspectorOpen: { type: Boolean, state: true },
+    _contextVersion: { type: Number, state: true },
   };
 
   createRenderRoot() { return this; }
@@ -52,6 +55,8 @@ export class ConversationSidebar extends LitElement {
     this._vaultFolders = [];
     /** @type {string|null} */
     this._openWikiPage = null;
+    this._contextInspectorOpen = false;
+    this._contextVersion = 0;
   }
 
   openMobile() {
@@ -65,8 +70,12 @@ export class ConversationSidebar extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this._onStoreChange = () => {
-      this._activeId = this.store?.currentConvId;
-      this._contextUsage = this.store?.contextUsage || 0;
+      const newId = this.store?.currentConvId;
+      if (newId !== this._activeId) this._contextInspectorOpen = false;
+      this._activeId = newId;
+      const newUsage = this.store?.contextUsage || 0;
+      if (newUsage !== this._contextUsage) this._contextVersion++;
+      this._contextUsage = newUsage;
       this._contextLimit = this.store?.contextLimit || 0;
       this._currentEffort = this.store?.currentEffort || 'default';
       this._effortModel = this.store?.effortModel || '';
@@ -619,7 +628,12 @@ export class ConversationSidebar extends LitElement {
           const pct = Math.round(this._contextUsage / this._contextLimit * 100);
           const cls = pct >= 100 ? 'full' : pct >= 80 ? 'warn' : '';
           return html`
-            <div class="context-usage ${cls}" title="${this._contextUsage.toLocaleString()} / ${this._contextLimit.toLocaleString()} tokens">
+            <div class="context-usage ${cls}" title="Click for details"
+                 style="cursor:pointer;position:relative"
+                 role="button" tabindex="0"
+                 aria-expanded=${this._contextInspectorOpen}
+                 @click=${() => { this._contextInspectorOpen = !this._contextInspectorOpen; }}
+                 @keydown=${(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); this._contextInspectorOpen = !this._contextInspectorOpen; }}}>
               <div class="context-usage-label">
                 <span>Context</span>
                 <span>${pct}%</span>
@@ -627,6 +641,12 @@ export class ConversationSidebar extends LitElement {
               <div class="context-usage-bar">
                 <div class="context-usage-fill" style="width: ${Math.min(100, pct)}%"></div>
               </div>
+              <context-inspector
+                .convId=${this._activeId || ''}
+                .open=${this._contextInspectorOpen}
+                .contextVersion=${this._contextVersion}
+                @close=${() => { this._contextInspectorOpen = false; }}
+              ></context-inspector>
             </div>
           `;
         })()}

--- a/src/decafclaw/web/static/style.css
+++ b/src/decafclaw/web/static/style.css
@@ -2,6 +2,7 @@
 @import './styles/layout.css';
 @import './styles/login.css';
 @import './styles/sidebar.css';
+@import './styles/context-inspector.css';
 @import './styles/chat.css';
 @import './styles/chat-input.css';
 @import './styles/wiki.css';

--- a/src/decafclaw/web/static/styles/context-inspector.css
+++ b/src/decafclaw/web/static/styles/context-inspector.css
@@ -1,0 +1,197 @@
+/* Context inspector popover — light DOM styles */
+
+context-inspector {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  margin-bottom: 4px;
+}
+
+context-inspector[open] {
+  display: block;
+}
+
+context-inspector .inspector {
+  background: var(--pico-card-background-color, #fff);
+  border: 1px solid var(--pico-muted-border-color, #ddd);
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+  padding: 1rem;
+  max-height: 70vh;
+  overflow-y: auto;
+  font-size: 0.8rem;
+  color: var(--pico-color, #333);
+}
+
+context-inspector .inspector-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+context-inspector .inspector-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+context-inspector .close-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--pico-muted-color);
+  padding: 0 0.25rem;
+}
+
+/* Waffle chart */
+context-inspector .waffle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  margin-bottom: 0.75rem;
+  padding: 4px;
+  background: var(--pico-muted-border-color, #eee);
+  border-radius: 4px;
+}
+
+context-inspector .waffle-cell {
+  width: 6px;
+  height: 6px;
+  border-radius: 1px;
+}
+
+/* Legend */
+context-inspector .legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+context-inspector .legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  color: var(--pico-muted-color);
+}
+
+context-inspector .legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+/* Summary stats */
+context-inspector .stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.25rem 1rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
+}
+
+context-inspector .stats dt {
+  color: var(--pico-muted-color);
+}
+
+context-inspector .stats dd {
+  margin: 0;
+  text-align: right;
+}
+
+/* Source breakdown */
+context-inspector .source-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
+}
+
+context-inspector .source-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--pico-muted-border-color);
+  color: var(--pico-muted-color);
+}
+
+context-inspector .source-table td {
+  padding: 0.25rem 0.5rem;
+}
+
+context-inspector .source-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  margin-right: 0.3rem;
+  vertical-align: middle;
+}
+
+/* Memory candidates */
+context-inspector .candidates-header {
+  font-weight: 600;
+  font-size: 0.75rem;
+  margin-bottom: 0.4rem;
+  color: var(--pico-muted-color);
+}
+
+context-inspector .candidate {
+  padding: 0.3rem 0;
+  border-bottom: 1px solid var(--pico-muted-border-color, #eee);
+}
+
+context-inspector .candidate:last-child {
+  border-bottom: none;
+}
+
+context-inspector .candidate-path {
+  font-weight: 500;
+  font-size: 0.75rem;
+}
+
+context-inspector .candidate-meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--pico-muted-color);
+  margin-top: 0.15rem;
+}
+
+context-inspector .candidate-provenance {
+  font-size: 0.65rem;
+  color: var(--pico-muted-color);
+  font-style: italic;
+}
+
+context-inspector .score-bars {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  margin-top: 0.15rem;
+}
+
+context-inspector .score-bar {
+  height: 4px;
+  border-radius: 2px;
+  min-width: 2px;
+}
+
+context-inspector .score-label {
+  font-size: 0.6rem;
+  color: var(--pico-muted-color);
+  margin-left: 0.25rem;
+}
+
+context-inspector .loading,
+context-inspector .error-msg,
+context-inspector .empty-msg {
+  text-align: center;
+  padding: 1rem;
+  color: var(--pico-muted-color);
+}

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -534,6 +534,89 @@ class TestScoreCandidates:
 
 
 
+# -- Diagnostics and sidecar ---------------------------------------------------
+
+
+class TestBuildDiagnostics:
+    def test_produces_valid_dict(self, config):
+        config.system_prompt = "System."
+        composed = ComposedContext(
+            messages=[{"role": "system", "content": "System."}],
+            tools=[], deferred_tools=[],
+            total_tokens_estimated=5000,
+            sources=[
+                SourceEntry(source="system_prompt", tokens_estimated=800, items_included=1),
+                SourceEntry(source="history", tokens_estimated=3000, items_included=10),
+            ],
+            memory_results=[
+                {"file_path": "page.md", "source_type": "page",
+                 "composite_score": 0.75, "similarity": 0.9,
+                 "recency": 0.8, "importance": 0.5,
+                 "modified_at": "2026-04-01T12:00:00",
+                 "tokens_estimated": 200},
+            ],
+        )
+        composer = ContextComposer()
+        composer.record_actuals(5200, 300)
+        diag = composer.build_diagnostics(config, composed)
+        assert "timestamp" in diag
+        assert diag["total_tokens_estimated"] == 5000
+        assert diag["total_tokens_actual"] == 5200
+        assert len(diag["sources"]) == 2
+        assert len(diag["memory_candidates"]) == 1
+        assert diag["memory_candidates"][0]["composite_score"] == 0.75
+        assert diag["memory_candidates"][0]["recency"] == 0.8
+
+    def test_handles_empty_memory(self, config):
+        config.system_prompt = "System."
+        composed = ComposedContext(
+            messages=[], tools=[], deferred_tools=[],
+            total_tokens_estimated=100, sources=[], memory_results=[],
+        )
+        composer = ContextComposer()
+        diag = composer.build_diagnostics(config, composed)
+        assert diag["memory_candidates"] == []
+
+    def test_includes_linked_from(self, config):
+        config.system_prompt = "System."
+        composed = ComposedContext(
+            messages=[], tools=[], deferred_tools=[],
+            total_tokens_estimated=100, sources=[],
+            memory_results=[
+                {"file_path": "linked.md", "source_type": "graph_expansion",
+                 "composite_score": 0.6, "similarity": 0.5,
+                 "recency": 0.7, "importance": 0.5,
+                 "modified_at": "", "tokens_estimated": 100,
+                 "linked_from": "parent.md"},
+            ],
+        )
+        composer = ContextComposer()
+        diag = composer.build_diagnostics(config, composed)
+        assert diag["memory_candidates"][0]["linked_from"] == "parent.md"
+
+
+class TestContextSidecar:
+    def test_write_and_read(self, config):
+        from decafclaw.context_composer import read_context_sidecar, write_context_sidecar
+        data = {"timestamp": "2026-04-02T12:00:00", "sources": [], "total_tokens_estimated": 100}
+        write_context_sidecar(config, "test-conv", data)
+        result = read_context_sidecar(config, "test-conv")
+        assert result is not None
+        assert result["total_tokens_estimated"] == 100
+
+    def test_read_missing_returns_none(self, config):
+        from decafclaw.context_composer import read_context_sidecar
+        result = read_context_sidecar(config, "nonexistent-conv")
+        assert result is None
+
+    def test_write_fail_open(self, config):
+        from decafclaw.context_composer import write_context_sidecar
+        # Should not raise even with bad data
+        with patch("decafclaw.context_composer.Path.write_text", side_effect=OSError("fail")):
+            write_context_sidecar(config, "test-conv", {"data": True})
+            # No exception raised
+
+
 class TestContextComposerOnContext:
     def test_ctx_has_composer_state(self, ctx):
         assert isinstance(ctx.composer, ComposerState)


### PR DESCRIPTION
## Summary

Surfaces the context composer's per-source diagnostics through a REST endpoint and web UI popover with a waffle chart visualization. Closes #159.

- **Diagnostics sidecar** — `workspace/conversations/{conv_id}.context.json` written after each turn with per-source token estimates, scoring details, and memory candidate breakdowns
- **REST endpoint** — `GET /api/conversations/{id}/context` returns the sidecar data (authenticated)
- **Context inspector popover** — click the context usage bar in the sidebar to see:
  - Waffle chart (grid map) showing token allocation by source with color coding
  - Summary stats (estimated vs actual tokens, window size, compaction threshold)
  - Source breakdown table with token counts and item details
  - Memory candidates with composite scores, score breakdown bars (similarity/recency/importance), and graph expansion provenance
- **Scoring enrichment** — `recency` and per-candidate `tokens_estimated` now stored during scoring for diagnostics

### Reusable foundation for future work
- Mattermost `!context` command (reads same REST endpoint)
- Agent self-inspection tool

Closes #159

## Test plan

- [x] All 1040 tests pass (6 new diagnostics/sidecar tests)
- [x] Lint + type check clean (Python + JS)
- [x] Manual browser test of popover interaction
- [x] Live test with running agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)