### PR TITLE
fix: reflection judge summarizes tool results instead of truncating

### DIFF
--- a/docs/dev-sessions/2026-04-02-1755-fix-reflection/notes.md
+++ b/docs/dev-sessions/2026-04-02-1755-fix-reflection/notes.md
@@ -1,0 +1,2 @@
+# Fix Reflection Truncation — Notes
+

--- a/docs/dev-sessions/2026-04-02-1755-fix-reflection/plan.md
+++ b/docs/dev-sessions/2026-04-02-1755-fix-reflection/plan.md
@@ -1,0 +1,3 @@
+# Fix Reflection Truncation — Plan
+
+Targeted fix, no brainstorm needed.

--- a/docs/dev-sessions/2026-04-02-1755-fix-reflection/spec.md
+++ b/docs/dev-sessions/2026-04-02-1755-fix-reflection/spec.md
@@ -1,0 +1,66 @@
+# Fix Reflection Truncation — Spec
+
+## Related issue
+
+GitHub issue #200 — Reflection judge incorrectly flags tool results as hallucinations due to truncation
+
+## Problem
+
+The reflection judge truncates tool results to `max_tool_result_len` (default 2000 chars) before evaluating responses. When tools like `vault_search` return large results (full page content, 20k+ chars), the judge sees only a tiny snippet and incorrectly concludes the agent hallucinated details that were actually present in the full results.
+
+This causes the agent to retract correct answers, which is worse than no reflection at all.
+
+## Root cause
+
+`_extract_tool_lines()` in `reflection.py` truncates each tool result to `max_result_len`:
+```python
+if len(content) > max_result_len:
+    content = content[:max_result_len] + "..."
+```
+
+For `vault_search` returning 10 pages, only the first result's partial text is visible to the judge. The judge sees "3 result(s)" in the header but can't see results 2-10.
+
+## Fix approach
+
+Rather than just increasing the truncation limit (which burns tokens), we should **summarize** what was returned instead of truncating. The judge doesn't need the full page content — it needs to know:
+
+1. What tool was called and with what args
+2. How many results were returned
+3. What the results contained (titles, key identifiers) — enough to verify the agent's response isn't fabricated
+
+For vault_search specifically: "vault_search('creative writing') returned 10 results: [Comparison of Short Stories, There was no minimum safe size, Rays of a Distant Sun, When the Halloween invite, ...]"
+
+This gives the judge enough to say "the agent mentioned these stories, and they were in the search results" without needing 20k chars of full content.
+
+## Design
+
+### Smart result summarization
+
+Replace blind truncation with structured summarization in `_extract_tool_lines()`:
+
+1. For each tool result, extract a **summary** rather than truncating raw text:
+   - Parse the result content for structure (headings, tl;dr lines, result counts)
+   - Extract key identifiers (page names, titles, file paths)
+   - Include the result count and first-line summaries
+
+2. Keep the truncation as a fallback for unstructured results.
+
+3. Make the summary strategy pluggable — different tools may benefit from different summarization. Start with vault_search and vault_read as the high-value targets.
+
+### Specific patterns to extract
+
+- **vault_search results**: Parse "Found N result(s)" header, extract page titles from `# Title` or `> tl;dr:` lines
+- **vault_read**: Extract page title and tl;dr
+- **web_fetch**: Extract URL and page title
+- **Generic**: First N lines or first paragraph
+
+### Config
+
+Keep `max_tool_result_len` but use it as the budget for the *summarized* output, not for raw truncation. Default can stay at 2000 since summaries are much more compact.
+
+## Success criteria
+
+1. Reflection judge sees enough context to verify tool-based responses
+2. The creative writing scenario from #200 passes reflection without false flagging
+3. Token usage for reflection calls doesn't significantly increase
+4. All existing tests pass

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -69,6 +69,67 @@ def _format_tool_args(fn: dict) -> str:
     return f"Tool: {name}({key_args})"
 
 
+def _summarize_tool_result(content: str, max_len: int) -> str:
+    """Summarize a tool result, preserving key structure.
+
+    Instead of blindly truncating, extract headings, tl;dr lines, and
+    result counts so the reflection judge can verify the agent's response
+    references real content. Non-structural body text fills remaining budget.
+    """
+    if len(content) <= max_len:
+        return content
+
+    lines = content.split("\n")
+
+    # First pass: collect all structural lines (headings, tl;dr, separators)
+    structural: list[str] = []
+    body: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        is_structural = (
+            stripped.startswith("# ")
+            or stripped.startswith("## ")
+            or stripped.startswith("> tl;dr:")
+            or (stripped.startswith("Found ") and "result" in stripped)
+            or stripped.startswith("--- ")
+        )
+        if is_structural:
+            structural.append(line)
+        else:
+            body.append(line)
+
+    # Build result: all structural lines first, then fill with body
+    # Reserve space for the omission note
+    omission_reserve = 60  # "[... NNNNN chars of detail omitted]"
+    budget = max_len - omission_reserve
+
+    result_parts = list(structural)
+    total_len = sum(len(s) + 1 for s in result_parts)
+
+    if budget > total_len:
+        for line in body:
+            remaining = budget - total_len
+            if remaining <= 0:
+                break
+            if len(line) + 1 <= remaining:
+                result_parts.append(line)
+                total_len += len(line) + 1
+            else:
+                # Truncate oversized body lines (e.g. minified JSON/HTML)
+                snippet = line[:max(0, remaining - 1)]
+                if snippet:
+                    result_parts.append(snippet)
+                    total_len += len(snippet) + 1
+                break
+
+    selected = "\n".join(result_parts)
+    if len(selected) >= len(content):
+        return selected
+
+    omitted = len(content) - len(selected)
+    return selected + f"\n[... {omitted} chars of detail omitted]"
+
+
 def _extract_tool_lines(messages: list, max_result_len: int) -> list[str]:
     """Extract tool call/result lines from a slice of history messages."""
     tool_lines: list[str] = []
@@ -78,8 +139,7 @@ def _extract_tool_lines(messages: list, max_result_len: int) -> list[str]:
                 tool_lines.append(_format_tool_args(tc.get("function", {})))
         if msg.get("role") == "tool":
             content = msg.get("content", "")
-            if len(content) > max_result_len:
-                content = content[:max_result_len] + "..."
+            content = _summarize_tool_result(content, max_result_len)
             tool_lines.append(f"Result: {content}")
     return tool_lines
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -10,6 +10,7 @@ from decafclaw.config_types import AgentConfig, LlmConfig, ReflectionConfig
 from decafclaw.reflection import (
     ReflectionResult,
     _parse_verdict,
+    _summarize_tool_result,
     build_prior_turn_summary,
     build_tool_summary,
     evaluate_response,
@@ -100,6 +101,129 @@ class TestBuildToolSummary:
         assert result == ""  # no tools in current turn
         result_old = build_tool_summary(history, 0)
         assert "old_tool" in result_old
+
+
+
+class TestSummarizeToolResult:
+    def test_short_content_unchanged(self):
+        content = "Short result"
+        assert _summarize_tool_result(content, 2000) == content
+
+    def test_preserves_headings(self):
+        content = "# Title\n" + "x" * 5000
+        result = _summarize_tool_result(content, 500)
+        assert "# Title" in result
+
+    def test_preserves_tldrs(self):
+        content = "x" * 3000 + "\n> tl;dr: Important summary.\n" + "y" * 3000
+        result = _summarize_tool_result(content, 500)
+        assert "Important summary" in result
+
+    def test_preserves_result_separators(self):
+        content = (
+            "--- Result 1 ---\n# Page A\nfoo\n"
+            + "x" * 5000 + "\n"
+            "--- Result 2 ---\n# Page B\nbar\n"
+            + "y" * 5000
+        )
+        result = _summarize_tool_result(content, 500)
+        assert "Result 1" in result
+        assert "Result 2" in result
+        assert "Page A" in result
+        assert "Page B" in result
+
+    def test_single_long_line_preserves_snippet(self):
+        """A single long line (e.g. minified JSON) should still produce a snippet."""
+        content = "x" * 10000
+        result = _summarize_tool_result(content, 500)
+        # Should have some content, not just the omission note
+        assert result.startswith("x")
+        assert "chars of detail omitted" in result
+
+    def test_result_within_max_len(self):
+        """Summary + omission note should fit within max_len."""
+        content = "# Title\n" + "x" * 10000
+        result = _summarize_tool_result(content, 500)
+        assert len(result) <= 600  # max_len + reasonable omission note
+
+    def test_includes_omission_note(self):
+        content = "x" * 10000
+        result = _summarize_tool_result(content, 500)
+        assert "chars of detail omitted" in result
+
+    def test_structural_lines_prioritized_over_body(self):
+        """Even with lots of body text, all structural lines should appear."""
+        content = ""
+        for i in range(10):
+            content += f"# Page {i}\n> tl;dr: Summary {i}\n" + "x" * 2000 + "\n"
+        result = _summarize_tool_result(content, 2000)
+        for i in range(10):
+            assert f"Page {i}" in result
+            assert f"Summary {i}" in result
+
+
+class TestBuildToolSummaryVaultSearch:
+    """Tests specifically for vault_search tool result summarization."""
+
+    def test_vault_search_preserves_page_titles(self):
+        """Regression: vault_search with large results should preserve page
+        titles/summaries so the judge can verify the agent's response references
+        real content, not hallucinations. Issue #200."""
+        # Simulate vault_search returning multiple pages — each page has a title
+        # and tl;dr that the agent references in its response. With raw truncation
+        # at 2000 chars, only the first result's partial text would be visible.
+        result_content = "Found 5 result(s):\n\n"
+        for i, title in enumerate([
+            "Comparison of Short Stories",
+            "There was no minimum safe size",
+            "Rays of a Distant Sun",
+            "When the Halloween invite",
+            "Les Orchard",
+        ]):
+            result_content += f"--- Result {i+1} ---\n# {title}\n\n> tl;dr: Summary of {title}.\n\n"
+            result_content += f"{'x' * 3000}\n\n"  # bulk content that makes it large
+
+        history = [
+            {"role": "user", "content": "What do you know about my stories?"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "vault_search",
+                    "arguments": json.dumps({"query": "stories"}),
+                }},
+            ]},
+            {"role": "tool", "content": result_content},
+            {"role": "assistant", "content": "You have written three stories..."},
+        ]
+        summary = build_tool_summary(history, 0, max_result_len=2000)
+        # All page titles should be visible to the judge, not just the first one
+        assert "Comparison of Short Stories" in summary
+        assert "There was no minimum safe size" in summary
+        assert "Rays of a Distant Sun" in summary
+        assert "When the Halloween invite" in summary
+        assert "Les Orchard" in summary
+
+    def test_vault_search_preserves_tldrs(self):
+        """tl;dr lines from vault_search results should survive summarization."""
+        result_content = (
+            "Found 2 result(s):\n\n"
+            "--- Result 1 ---\n# Page One\n\n> tl;dr: A story about robots.\n\n"
+            + "x" * 5000 + "\n\n"
+            "--- Result 2 ---\n# Page Two\n\n> tl;dr: A poem about cats.\n\n"
+            + "y" * 5000
+        )
+        history = [
+            {"role": "user", "content": "search"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "vault_search",
+                    "arguments": json.dumps({"query": "writing"}),
+                }},
+            ]},
+            {"role": "tool", "content": result_content},
+        ]
+        summary = build_tool_summary(history, 0, max_result_len=2000)
+        assert "A story about robots" in summary
+        assert "A poem about cats" in summary
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #200 — the reflection judge was incorrectly flagging tool-based responses as hallucinations because large tool results (e.g., vault_search returning full page content) were blindly truncated to 2000 chars, losing everything after the first result.

**Before:** `_extract_tool_lines` truncated raw content → judge saw first result's partial text → concluded agent hallucinated details from results 2-10

**After:** `_summarize_tool_result` extracts structural elements first (headings, tl;dr lines, result separators, result counts), then fills remaining budget with body text → judge sees all page titles and summaries → can verify agent's response references real content

The key insight: the judge doesn't need full page content to verify correctness — it needs to see *what was returned* (titles, summaries, structure). A 20k vault_search result can be faithfully represented in ~500 chars of structural summary.

## Changes

- New `_summarize_tool_result()` in `reflection.py` — two-pass extraction (structural lines first, body fills remainder)
- `_extract_tool_lines()` now calls `_summarize_tool_result()` instead of blind truncation
- 8 new tests covering the summarization logic and the specific vault_search failure scenario

## Test plan

- [x] All 1048 tests pass (8 new)
- [x] Lint + type check clean
- [x] Live test: reproduce the creative writing scenario from #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)