### PR TITLE
feat: Claude Code subagent structured results, env probe, exec tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Session docs live in `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`, `
 - **Prefer clarity over abstraction.** This is an exploration project — we try to keep things simple but aren't afraid to explore complexity when a feature calls for it. Readability matters more than cleverness.
 - **Files on disk, human-readable.** All agent state uses files you can read, edit, and inspect: markdown for memories and to-dos, JSONL for conversation archives, SQLite for embeddings. No opaque databases. Crash-recoverable by design.
 - **Tool error returns use `ToolResult`.** Error returns should use `ToolResult(text="[error: ...]")` rather than bare strings, for consistency across all tool modules.
+- **`ToolResult.data` for structured results.** Tools can return `ToolResult(text=..., data={...})` to provide machine-readable structured data alongside the human-readable text. The agent loop auto-appends a fenced JSON block to the tool result content when `data` is set. Use for tools where the caller needs to branch programmatically on the result.
 - **Use `asyncio.Lock` for concurrency guards.** Prefer `asyncio.Lock` over boolean flags — locks auto-release on exception, preventing stuck state.
 - **Conversation state in `ConversationState` dataclass.** Per-conversation state (history, skill state, busy flag, etc.) is tracked via `ConversationState` in mattermost.py, not parallel dicts.
 - **Tools receive `ctx` as first param.** All tool functions take a runtime context, even if they don't use it yet.

--- a/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/notes.md
+++ b/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/notes.md
@@ -1,0 +1,3 @@
+# Claude Code Subagent Improvements — Notes
+
+<!-- Session notes and final summary -->

--- a/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/plan.md
+++ b/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/plan.md
@@ -1,0 +1,409 @@
+# Claude Code Subagent Improvements — Plan
+
+## Overview
+
+Six steps, each building on the previous. Each step ends with lint + test + commit.
+
+---
+
+## Step 1: Add `data` field to ToolResult + agent loop serialization
+
+**What:** Add `data: dict | None = None` to `ToolResult` dataclass. Wire the agent loop to append a fenced JSON block to tool result content when `data` is present.
+
+**Files:**
+- `src/decafclaw/media.py` — add field
+- `src/decafclaw/agent.py` — serialize `data` in `_execute_single_tool_call()` at line 492
+
+**Details:**
+
+1. In `media.py`, add `data: dict | None = None` field to `ToolResult` after `display_short_text`.
+
+2. In `agent.py`, in `_execute_single_tool_call()`, change the tool_msg content construction (around line 489-492):
+   ```python
+   content = result.text
+   if result.data is not None:
+       import json
+       content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+   tool_msg = {
+       "role": "tool",
+       "tool_call_id": tool_call_id,
+       "content": content,
+   }
+   ```
+
+3. Add a test in `tests/` that verifies:
+   - `ToolResult(text="hello", data={"key": "val"})` produces a tool message with JSON block appended
+   - `ToolResult(text="hello")` (no data) produces unchanged content
+   - `ToolResult(text="hello", data=None)` also unchanged
+
+**Prompt:**
+
+> In `src/decafclaw/media.py`, add a `data: dict | None = None` field to the `ToolResult` dataclass, after the `display_short_text` field.
+>
+> In `src/decafclaw/agent.py`, in the `_execute_single_tool_call()` function, modify the tool_msg construction (around line 489-492). When `result.data` is not None, append a fenced JSON block to the content string: `"\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"`. Import `json` at the top of the file if not already imported.
+>
+> Write a test in `tests/test_tool_result_data.py` that:
+> - Creates a `ToolResult` with `data={"exit_status": "success", "cost": 1.23}` and verifies the field is accessible
+> - Tests that `data=None` is the default
+> - Tests the JSON serialization logic: given a `ToolResult` with text="hello" and data={"k": "v"}, verify that combining them produces `"hello\n\n```json\n...\n```"` with valid JSON in the block
+>
+> Run `make lint` and `make test` and fix any issues.
+
+---
+
+## Step 2: Add `approved` flag to Session + `build_data()` to SessionLogger
+
+**What:** Add the `approved: bool` field to `Session`. Add `build_data()` method to `SessionLogger` that returns the structured dict.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/sessions.py` — add `approved` field
+- `src/decafclaw/skills/claude_code/output.py` — add `build_data()` method
+
+**Details:**
+
+1. In `sessions.py`, add `approved: bool = False` to the `Session` dataclass.
+
+2. In `output.py`, add a `build_data()` method to `SessionLogger`:
+   ```python
+   def build_data(self, session_id: str = "", exit_status: str = "success",
+                  sdk_session_id: str | None = None, send_count: int = 0) -> dict:
+       """Return structured result dict with JSON-safe types only."""
+       from collections import Counter
+       tool_counts = dict(Counter(self.tools_used))
+       unique_files = list(dict.fromkeys(self.files_changed))
+       errors = [{"message": e} for e in self.errors[:10]]
+       return {
+           "exit_status": exit_status,
+           "files_changed": unique_files,
+           "tools_used": tool_counts,
+           "errors": errors,
+           "cost_usd": self.total_cost_usd,
+           "duration_ms": self.duration_ms,
+           "send_count": send_count,
+           "num_turns": self.num_turns,
+           "result_text": self.result_text,
+           "sdk_session_id": sdk_session_id or "",
+           "log_path": str(self.path),
+       }
+   ```
+
+3. Write tests for `build_data()` output shape and JSON serializability.
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/sessions.py`, add `approved: bool = False` to the `Session` dataclass, after the `send_count` field.
+>
+> In `src/decafclaw/skills/claude_code/output.py`, add a `build_data()` method to `SessionLogger`. It should accept `session_id: str = ""`, `exit_status: str = "success"`, `sdk_session_id: str | None = None`, and `send_count: int = 0`. It returns a dict with these fields:
+> - `exit_status`: the passed-in value
+> - `files_changed`: deduplicated list from `self.files_changed`
+> - `tools_used`: dict of tool_name → count (use `collections.Counter` on `self.tools_used`)
+> - `errors`: list of `{"message": str}` dicts from `self.errors` (limit 10)
+> - `cost_usd`: `self.total_cost_usd`
+> - `duration_ms`: `self.duration_ms`
+> - `send_count`: passed-in value
+> - `num_turns`: `self.num_turns`
+> - `result_text`: `self.result_text`
+> - `sdk_session_id`: passed-in value or ""
+> - `log_path`: `str(self.path)`
+>
+> All values must be JSON-safe (str, int, float, bool, None, list, dict). No Path objects.
+>
+> Write a test in `tests/test_session_logger.py` that creates a `SessionLogger`, manually sets some metrics (files_changed, tools_used, errors, etc.), calls `build_data()`, and verifies:
+> - The return value is a dict with the expected keys
+> - `json.dumps()` succeeds on the result (no serialization errors)
+> - `tools_used` is a count dict (e.g., `{"Edit": 2, "Read": 3}`)
+> - `files_changed` is deduplicated
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 3: Wire structured results into `claude_code_send`
+
+**What:** Change `claude_code_send` to return `ToolResult(text=summary, data=structured_dict)`. Set the `approved` flag on confirmation. Determine `exit_status` from send outcomes.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — modify `tool_claude_code_send`
+
+**Details:**
+
+1. Import `ToolResult` from `decafclaw.media`.
+
+2. After the confirmation block succeeds, set `session.approved = True`.
+
+3. For early returns (error, budget exhausted, cancelled), return `ToolResult` with appropriate `data`:
+   - Denied: `ToolResult(text="[error: ...]", data={"exit_status": "cancelled"})`
+   - Budget: `ToolResult(text="[error: ...]", data={"exit_status": "budget_exhausted", "cost_usd": session.total_cost_usd})`
+
+4. After the SDK streaming completes, build both summary and data:
+   ```python
+   summary = logger.build_summary(session_id)
+   data = logger.build_data(
+       session_id=session_id,
+       exit_status="error" if logger.errors else "success",
+       sdk_session_id=session.sdk_session_id,
+       send_count=session.send_count,
+   )
+   return ToolResult(text=summary, data=data)
+   ```
+
+5. For the SDK exception case, return `ToolResult` with `exit_status="error"`.
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/tools.py`, modify `tool_claude_code_send` to return `ToolResult` instead of plain strings.
+>
+> 1. Add `from decafclaw.media import ToolResult` at the top of the file.
+>
+> 2. After the confirmation block succeeds (after the `if not confirm.get("approved")` check, around line 136-140), add `session.approved = True`.
+>
+> 3. Change the return type annotation from `-> str` to `-> ToolResult`.
+>
+> 4. For the denied-by-user case (line 137), return:
+>    `ToolResult(text="[error: Claude Code task was denied by user]", data={"exit_status": "cancelled"})`
+>
+> 5. For the budget-exhausted case (lines 143-148), return:
+>    `ToolResult(text=<existing error string>, data={"exit_status": "budget_exhausted", "cost_usd": session.total_cost_usd, "budget_usd": session.budget_usd})`
+>
+> 6. For the SDK exception case (line 218), return:
+>    `ToolResult(text=f"[error: Claude Code failed: {e}]", data={"exit_status": "error", "errors": [{"message": str(e)}]})`
+>
+> 7. At the end of the function (replacing line 226), build and return structured result:
+>    ```python
+>    summary = logger.build_summary(session_id)
+>    data = logger.build_data(
+>        session_id=session_id,
+>        exit_status="error" if logger.errors else "success",
+>        sdk_session_id=session.sdk_session_id,
+>        send_count=session.send_count,
+>    )
+>    return ToolResult(text=summary, data=data)
+>    ```
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 4: Environment probe for `claude_code_start`
+
+**What:** Add environment probing and optional setup command to `claude_code_start`. Return `ToolResult` with structured data.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — modify `tool_claude_code_start`, add probe helper
+
+**Details:**
+
+1. Add an `async def _probe_environment(cwd: str) -> dict` helper that:
+   - Runs a single shell script via `asyncio.create_subprocess_shell` to batch-check tools on PATH
+   - The script: `for cmd in python3 node go uv pip npm pnpm make git cargo rustc; do which $cmd >/dev/null 2>&1 && echo $cmd; done`
+   - Checks for project files: scan cwd for known filenames (`Makefile`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `CLAUDE.md`, `README.md`, `.env`)
+   - If `.git` exists in cwd, runs `git -C <cwd> branch --show-current` and `git -C <cwd> status --porcelain` to get branch and clean/dirty
+   - Whole probe has 5-second timeout via `asyncio.wait_for`
+   - Returns the structured dict: `{"tools_available": [...], "project_files": [...], "git": {"branch": "...", "clean": true} | None}`
+
+2. Add an `async def _run_setup_command(cwd: str, command: str) -> dict` helper that:
+   - Runs the command via `asyncio.create_subprocess_shell` in the cwd
+   - Captures stdout/stderr
+   - Returns `{"command": command, "exit_code": int, "stdout": str, "stderr": str, "status": "success"|"error"}`
+
+3. Add `setup_command: str = ""` parameter to `tool_claude_code_start`.
+
+4. After session creation, run the probe. If `setup_command` is provided, check confirmation (allowlist or request), then run it. Set `session.approved = True` if confirmed.
+
+5. Return `ToolResult` with text summary and structured data.
+
+6. Update `TOOL_DEFINITIONS` for `claude_code_start` to include the new `setup_command` parameter.
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/tools.py`:
+>
+> 1. Add two helper functions before `tool_claude_code_start`:
+>
+>    `async def _probe_environment(cwd: str) -> dict`:
+>    - Run a shell script via `asyncio.create_subprocess_shell` in the given cwd:
+>      `for cmd in python3 node go uv pip npm pnpm make git cargo rustc; do which $cmd >/dev/null 2>&1 && echo $cmd; done`
+>    - Parse stdout lines as `tools_available` list
+>    - Scan cwd directory for project files: `Makefile`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `CLAUDE.md`, `README.md`, `.env` — check with `Path(cwd, name).exists()` for each
+>    - If `Path(cwd, ".git").exists()`, run `git -C {cwd} branch --show-current` and `git -C {cwd} status --porcelain` to get branch name and whether the working tree is clean
+>    - Wrap the entire probe in `asyncio.wait_for(..., timeout=5.0)`. On timeout, return partial results with what succeeded
+>    - Return `{"tools_available": list[str], "project_files": list[str], "git": {"branch": str, "clean": bool} | None}`
+>
+>    `async def _run_setup_command(cwd: str, command: str) -> dict`:
+>    - Run `command` via `asyncio.create_subprocess_shell` with `cwd=cwd`, capturing stdout and stderr
+>    - Return `{"command": command, "exit_code": proc.returncode, "stdout": stdout_str, "stderr": stderr_str, "status": "success" if returncode == 0 else "error"}`
+>
+> 2. Modify `tool_claude_code_start` to accept `setup_command: str = ""` parameter.
+>
+> 3. After session creation (after the try/except ValueError block), run `_probe_environment(cwd)`.
+>
+> 4. If `setup_command` is non-empty:
+>    - Check the allowlist for "claude_code_setup" pattern. If not matched, request confirmation with the command as the message. If confirmed, set `session.approved = True`. If "always", save the pattern. If denied, skip setup but still return the session (note the skip in the result).
+>    - If approved (or allowlisted), run `_run_setup_command(cwd, setup_command)`.
+>
+> 5. Build structured data dict:
+>    ```python
+>    data = {
+>        "session_id": session.session_id,
+>        "cwd": session.cwd,
+>        "model": session.model or (_skill_config.model if _skill_config else "") or "(SDK default)",
+>        "budget_usd": session.budget_usd,
+>        "environment": env_info,
+>        "setup": setup_result,  # None if no setup_command
+>    }
+>    ```
+>
+> 6. Build text summary including environment info (tools available, project files, git branch) and setup result if applicable.
+>
+> 7. Return `ToolResult(text=text_summary, data=data)`. Change the return type annotation to `-> ToolResult`. Change the error returns to also use `ToolResult`.
+>
+> 8. Update the `claude_code_start` entry in `TOOL_DEFINITIONS` to add the `setup_command` property:
+>    ```python
+>    "setup_command": {
+>        "type": "string",
+>        "description": "Shell command to run for setup before the session is ready (e.g., 'uv sync', 'npm install')",
+>    },
+>    ```
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 5: Add `claude_code_exec` tool
+
+**What:** New tool for running shell commands in a session's cwd without an LLM turn. Structured results, session logging, inherited confirmation.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — add tool function and definition
+- `src/decafclaw/skills/claude_code/output.py` — add exec logging method
+
+**Details:**
+
+1. In `output.py`, add a `log_exec()` method to `SessionLogger`:
+   ```python
+   def log_exec(self, command: str, exit_code: int | None,
+                stdout: str, stderr: str, duration_ms: int) -> None:
+       record = {
+           "type": "exec",
+           "command": command,
+           "exit_code": exit_code,
+           "stdout": stdout,
+           "stderr": stderr,
+           "duration_ms": duration_ms,
+           "timestamp": datetime.utcnow().isoformat(),
+       }
+       with open(self.path, "a") as f:
+           f.write(json.dumps(record) + "\n")
+   ```
+
+2. In `tools.py`, add `tool_claude_code_exec`:
+   - Look up session via manager (return error if not found/expired)
+   - Check `session.approved` — if not approved, request confirmation. If approved, set flag. If denied, return error.
+   - Run command via `asyncio.create_subprocess_shell` with `cwd=session.cwd`
+   - Use `asyncio.wait_for` with the timeout parameter (default 30s, capped at 120s)
+   - On timeout: kill process, capture partial output, set status to "timeout"
+   - Log via `SessionLogger.log_exec()`
+   - Touch session (update last_active)
+   - Return `ToolResult(text=formatted_output, data=structured_dict)`
+
+3. Add to `TOOLS` dict and `TOOL_DEFINITIONS` list.
+
+**Prompt:**
+
+> 1. In `src/decafclaw/skills/claude_code/output.py`, add a `log_exec()` method to `SessionLogger`:
+>    - Parameters: `command: str`, `exit_code: int | None`, `stdout: str`, `stderr: str`, `duration_ms: int`
+>    - Writes a JSON record to the session's JSONL log file with fields: `type` ("exec"), `command`, `exit_code`, `stdout`, `stderr`, `duration_ms`, `timestamp` (UTC ISO format)
+>    - Import `datetime` from the standard library at the top
+>
+> 2. In `src/decafclaw/skills/claude_code/tools.py`, add `async def tool_claude_code_exec(ctx, session_id: str, command: str, timeout: int = 30) -> ToolResult`:
+>    - Look up session via `_get_manager().get(session_id)`. Return `ToolResult(text="[error: session not found...]", data={"exit_status": "error"})` if not found.
+>    - **Confirmation**: If `session.approved` is False, load allowlist and check for "claude_code_exec". If not matched, request confirmation with the command. If confirmed, set `session.approved = True`. If "always", save pattern. If denied, return error ToolResult.
+>    - Clamp timeout to range [1, 120].
+>    - Record start time with `time.monotonic()`.
+>    - Run `command` via `asyncio.create_subprocess_shell(command, cwd=session.cwd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)`.
+>    - Use `asyncio.wait_for(proc.communicate(), timeout=timeout)` to get stdout/stderr.
+>    - On `asyncio.TimeoutError`: call `proc.kill()`, `await proc.wait()`, read any partial output, set exit_code=None and status="timeout".
+>    - Calculate `duration_ms = int((time.monotonic() - start) * 1000)`.
+>    - Decode stdout/stderr as UTF-8 (errors='replace').
+>    - Determine status: "timeout" if timed out, "success" if exit_code == 0, "error" otherwise.
+>    - Log via `SessionLogger(log_dir, session_id).log_exec(command, exit_code, stdout, stderr, duration_ms)` where log_dir is `_config.workspace_path / "claude-code-logs"`.
+>    - Call `_get_manager().touch(session_id)`.
+>    - Build text summary: command, exit code, stdout (if any), stderr (if any).
+>    - Build data dict: `{"exit_code": exit_code, "stdout": stdout, "stderr": stderr, "status": status, "duration_ms": duration_ms, "command": command}`
+>    - Return `ToolResult(text=text, data=data)`.
+>
+> 3. Add `"claude_code_exec": tool_claude_code_exec` to the `TOOLS` dict.
+>
+> 4. Add the tool definition to `TOOL_DEFINITIONS`:
+>    ```python
+>    {
+>        "type": "function",
+>        "function": {
+>            "name": "claude_code_exec",
+>            "description": (
+>                "Run a shell command in an active Claude Code session's working directory. "
+>                "No LLM turn — direct subprocess execution. Use for quick verification "
+>                "(make test, git status, etc.) between claude_code_send calls."
+>            ),
+>            "parameters": {
+>                "type": "object",
+>                "properties": {
+>                    "session_id": {
+>                        "type": "string",
+>                        "description": "Session ID from claude_code_start",
+>                    },
+>                    "command": {
+>                        "type": "string",
+>                        "description": "Shell command to run",
+>                    },
+>                    "timeout": {
+>                        "type": "integer",
+>                        "description": "Timeout in seconds (default 30, max 120)",
+>                    },
+>                },
+>                "required": ["session_id", "command"],
+>            },
+>        },
+>    }
+>    ```
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 6: Update SKILL.md + docs
+
+**What:** Update skill documentation with new tool, updated parameters, structured result formats, and the verify loop workflow pattern.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/SKILL.md`
+- `CLAUDE.md` (if key files list needs updating)
+
+**Prompt:**
+
+> Update `src/decafclaw/skills/claude_code/SKILL.md`:
+>
+> 1. Update the `claude_code_start` tool section:
+>    - Add `setup_command` parameter description
+>    - Document the environment probe output (tools available, project files, git info)
+>    - Note that it returns structured data with session info and environment diagnostics
+>
+> 2. Update the `claude_code_send` tool section:
+>    - Document that it returns structured data alongside the text summary
+>    - List the structured fields: exit_status, files_changed, tools_used, errors, cost_usd, duration_ms, send_count, num_turns, result_text, sdk_session_id, log_path
+>    - Note the exit_status values: success, error, budget_exhausted, timeout, cancelled
+>
+> 3. Add a new `claude_code_exec` tool section:
+>    - Description: run a shell command directly in a session's cwd, no LLM turn
+>    - Parameters: session_id (required), command (required), timeout (optional, default 30, max 120)
+>    - Document structured result: exit_code, stdout, stderr, status, duration_ms, command
+>    - Note confirmation model: inherits from session approval
+>
+> 4. Update the workflow section to show the verify loop pattern:
+>    ```
+>    start → send (implement) → exec (make test) → send (fix failures) → exec (verify) → stop
+>    ```
+>
+> 5. Read the current `CLAUDE.md` and check if any key files or conventions need updating for this work. The `ToolResult.data` field is a new convention worth noting.
+>
+> Run `make lint` and `make test` one final time. Then `make check` if available.

--- a/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/spec.md
+++ b/docs/dev-sessions/2026-04-03-2215-claude-code-subagent/spec.md
@@ -1,0 +1,227 @@
+# Claude Code Subagent Improvements — Spec
+
+## Goal
+
+Make the Claude Code skill a capable software development delegate by adding structured results, environment diagnostics, and lightweight shell execution. These three changes form the foundation for autonomous multi-step coding workflows.
+
+Covers issues: #206, #205, #208 (from umbrella #213).
+
+## 1. ToolResult.data field
+
+Add a `data: dict | None = None` field to the shared `ToolResult` dataclass in `media.py`.
+
+When `data` is present, the **agent loop** (in `agent.py`) appends a fenced JSON block to the tool result text before inserting it into conversation history. This happens in one place — tools don't format it themselves.
+
+Format appended to text:
+
+```
+\n\n```json\n{... serialized data ...}\n```
+```
+
+Tools that don't set `data` are unaffected (field defaults to `None`).
+
+## 2. Structured results from claude_code_send (#206)
+
+### Current behavior
+
+`claude_code_send` returns a markdown summary string built by `SessionLogger.build_summary()`. The parent agent parses prose to understand what happened.
+
+### New behavior
+
+`claude_code_send` returns a `ToolResult` with both `text` (markdown summary, same as today) and `data` (machine-readable dict).
+
+### Structured data shape
+
+```python
+{
+    "exit_status": str,       # "success" | "error" | "budget_exhausted" | "timeout" | "cancelled"
+    "files_changed": list[str],  # paths relative to session cwd
+    "tools_used": dict[str, int],  # tool_name → call count
+    "errors": list[dict],     # [{"message": str, "file": str | None, "line": int | None}]
+    "cost_usd": float,        # running total for the session
+    "duration_ms": int,       # wall time for this send
+    "send_count": int,        # how many sends in this session (including this one)
+    "num_turns": int,         # LLM turns in this send
+    "result_text": str,       # final text from Claude Code (may be long)
+    "sdk_session_id": str,    # for debugging / resume tracking
+    "log_path": str           # path to JSONL log file
+}
+```
+
+### Implementation
+
+- `SessionLogger.build_summary()` continues to produce the markdown text
+- Add `SessionLogger.build_data()` → returns the dict above
+- `claude_code_send` returns `ToolResult(text=summary, data=data_dict)`
+- `exit_status` derived from: SDK result (success/error), budget check (budget_exhausted), timeout, cancellation
+- Most fields already tracked by `SessionLogger` — just need to expose them as a dict instead of formatting into markdown
+
+## 3. Session environment setup and diagnostics (#205)
+
+### Current behavior
+
+`claude_code_start` creates a `Session` dataclass and returns a formatted string. No environment validation.
+
+### New behavior
+
+`claude_code_start` runs a quick environment probe in the session's cwd and optionally executes a setup command. Returns structured results.
+
+### New parameter
+
+- `setup_command: str | None` — optional shell command to run before the session is ready (e.g., `"uv sync"`, `"npm install"`, `"make deps"`)
+
+### Environment probe
+
+A lightweight subprocess that checks:
+
+- **Tools on PATH**: `python3`, `node`, `go`, `uv`, `pip`, `npm`, `pnpm`, `make`, `git`, `cargo`, `rustc` — just existence via `which`
+- **Project files present**: `Makefile`, `pyproject.toml`, `package.json`, `go.mod`, `Cargo.toml`, `CLAUDE.md`, `README.md`, `.env`
+- **Git info** (if repo): current branch, clean/dirty status
+
+The probe is generic — not language-specific. The parent agent interprets the results and makes project-specific decisions (e.g., "I see `pyproject.toml` and `uv` on PATH, so I'll pass `setup_command='uv sync'`").
+
+### Setup command
+
+If `setup_command` is provided:
+- Run it as a subprocess in the session cwd
+- Capture stdout, stderr, exit code
+- If it fails (non-zero exit), still create the session but report the failure — the parent agent decides whether to proceed or abort
+
+### Structured data shape
+
+```python
+{
+    "session_id": str,
+    "cwd": str,
+    "model": str,
+    "budget_usd": float,
+    "environment": {
+        "tools_available": list[str],    # names of tools found on PATH
+        "project_files": list[str],      # config/project files found in cwd
+        "git": {                         # null if not a git repo
+            "branch": str,
+            "clean": bool
+        }
+    },
+    "setup": {                           # null if no setup_command provided
+        "command": str,
+        "exit_code": int,
+        "stdout": str,
+        "stderr": str,
+        "status": str                    # "success" | "error"
+    }
+}
+```
+
+### Implementation
+
+- Add probe logic as a helper function in `tools.py` (or a new `environment.py` if it gets big)
+- Probe runs as `asyncio.create_subprocess_exec` calls (one per tool check) or a single shell script
+- Prefer a single shell script for speed — batch all `which` checks into one subprocess
+- `claude_code_start` becomes async (it already is since it's a tool function)
+- Return `ToolResult(text=formatted_summary, data=structured_dict)`
+
+## 4. Lightweight shell exec (#208)
+
+### New tool: `claude_code_exec`
+
+Runs a shell command directly in an active session's cwd. No LLM involved — just subprocess execution.
+
+### Parameters
+
+- `session_id: str` (required) — active session
+- `command: str` (required) — shell command to run
+- `timeout: int` (optional, default 30) — seconds before killing the process
+
+### Confirmation model
+
+Inherits from the session. If the user has already approved a `claude_code_send` for this session, execs are auto-approved. This avoids confirmation fatigue during tight verify loops (`exec make test` → `send "fix it"` → `exec make test`).
+
+Implementation: track an `approved: bool` flag on the `Session` dataclass. Set to `True` when a `claude_code_send` is confirmed (or the session itself is allowlisted). `claude_code_exec` checks this flag — if approved, skip confirmation; otherwise, request it.
+
+### Structured data shape
+
+```python
+{
+    "exit_code": int | None,   # None if timeout
+    "stdout": str,
+    "stderr": str,
+    "status": str,             # "success" | "error" | "timeout"
+    "duration_ms": int,
+    "command": str
+}
+```
+
+No output capping — the parent agent can advise the subagent to limit output if needed.
+
+### Logging
+
+Commands and results are logged to the session's JSONL log file (same file as `claude_code_send` logs). Log entry format:
+
+```json
+{"type": "exec", "command": "...", "exit_code": 0, "stdout": "...", "stderr": "...", "duration_ms": 1234, "timestamp": "..."}
+```
+
+### Implementation
+
+- Add `claude_code_exec` to `TOOLS` and `TOOL_DEFINITIONS` in `tools.py`
+- Subprocess via `asyncio.create_subprocess_shell` with the session's cwd
+- Timeout via `asyncio.wait_for` wrapping `process.communicate()`
+- On timeout: kill process, return partial output with `status: "timeout"`
+- Update SKILL.md with the new tool definition
+
+## 5. SKILL.md updates
+
+Update the skill documentation to reflect:
+- `claude_code_start` new `setup_command` parameter and environment probe output
+- `claude_code_send` structured result format
+- `claude_code_exec` new tool with full parameter and result documentation
+- Updated workflow section showing the verify loop pattern: start → send → exec (verify) → send (fix) → exec (verify) → stop
+
+## 6. Files changed
+
+- `src/decafclaw/media.py` — add `data: dict | None` field to `ToolResult`
+- `src/decafclaw/agent.py` — serialize `data` as JSON block when building tool result messages
+- `src/decafclaw/skills/claude_code/tools.py` — update `claude_code_start`, add `claude_code_exec`, update `claude_code_send` return
+- `src/decafclaw/skills/claude_code/output.py` — add `build_data()` method to `SessionLogger`
+- `src/decafclaw/skills/claude_code/sessions.py` — add `approved: bool` to `Session` dataclass
+- `src/decafclaw/skills/claude_code/SKILL.md` — update tool docs
+- Tests for new/changed functionality
+
+## 7. Edge cases and constraints
+
+### ToolResult return from tool functions
+
+`execute_tool` already handles `ToolResult` passthrough via `_to_tool_result()` in `tools/__init__.py` — if a tool returns a `ToolResult` directly, it's used as-is (no double-wrapping). So `claude_code_send`, `claude_code_start`, and `claude_code_exec` can safely return `ToolResult` objects.
+
+### Session approval flag lifecycle
+
+The `approved` flag on `Session` is set to `True` when:
+- A `claude_code_send` is confirmed by the user (or auto-approved via allowlist)
+- The flag persists for the session's lifetime
+
+If `claude_code_exec` is called on a session that hasn't been approved yet (e.g., user wants to `git status` before sending work), `exec` falls back to its own confirmation request. If the user approves, that also sets the `approved` flag.
+
+### Environment probe timeout
+
+The environment probe (tool checks, git info, project file scan) has a hard timeout of 5 seconds. If any subprocess hangs, it's killed and the probe returns partial results. The probe is best-effort — failures don't prevent session creation.
+
+### Setup command confirmation
+
+The `setup_command` runs arbitrary shell before any `claude_code_send` has been confirmed. It follows the same confirmation model: check the allowlist, otherwise request user confirmation. If confirmed, this also sets the session's `approved` flag.
+
+### JSON serialization safety
+
+`build_data()` and all structured result builders must return only JSON-safe types (str, int, float, bool, None, list, dict). No `Path` objects, datetimes, or custom types. The agent loop serializes `data` with `json.dumps()` — non-serializable values would crash the tool result.
+
+## 8. Out of scope
+
+- Test result parsing (language-specific, fragile)
+- Output capping for exec (let the agent manage it)
+- Context injection from parent (#207) — next session
+- Diff output (#209) — next session
+- Error classification (#210) — next session
+- File staging (#211) — next session
+- Progress reporting (#212) — next session
+- Background process management (#203) — separate concern
+- HTTP request tool (#204) — separate concern

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -486,10 +486,17 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
                                    media=result.media or [],
                                    tool_call_id=tool_call_id)
 
+    content = result.text
+    if result.data is not None:
+        try:
+            content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+        except (TypeError, ValueError) as e:
+            log.warning(f"Failed to serialize ToolResult.data for {fn_name}: {e}")
+            content += "\n\n[structured data omitted: serialization error]"
     tool_msg = {
         "role": "tool",
         "tool_call_id": tool_call_id,
-        "content": result.text,
+        "content": content,
     }
     if result.display_short_text:
         tool_msg["display_short_text"] = result.display_short_text

--- a/src/decafclaw/media.py
+++ b/src/decafclaw/media.py
@@ -20,6 +20,7 @@ class ToolResult:
     media: list[dict] = field(default_factory=list)
     display_text: str | None = None
     display_short_text: str | None = None
+    data: dict | None = None
 
     @classmethod
     def from_text(cls, text: str) -> "ToolResult":

--- a/src/decafclaw/skills/claude_code/SKILL.md
+++ b/src/decafclaw/skills/claude_code/SKILL.md
@@ -14,15 +14,25 @@ Claude Code is a powerful coding agent that can read, edit, and execute code in 
 
 ### 1. `claude_code_start` — Start a new coding session
 
-Creates a new Claude Code session for a specific working directory.
+Creates a new Claude Code session for a specific working directory. Probes the environment and optionally runs a setup command.
 
 **Parameters:**
 - `cwd` (required) — path to the project/repository
 - `description` (optional) — what this session is for
 - `model` (optional) — override the Claude model
 - `budget_usd` (optional) — per-session cost limit
+- `setup_command` (optional) — shell command to run for environment setup (e.g., `uv sync`, `npm install`). Requires user confirmation.
 
 Only one session per working directory. Use `claude_code_sessions` to check active sessions.
+
+**Returns structured data:**
+- `session_id`, `cwd`, `model`, `budget_usd` — session info
+- `environment.tools_available` — tools found on PATH (python3, node, go, uv, pip, npm, make, git, cargo, etc.)
+- `environment.project_files` — config files found in cwd (Makefile, pyproject.toml, package.json, etc.)
+- `environment.git` — branch name and clean/dirty status (null if not a git repo)
+- `setup` — setup command result (command, exit_code, stdout, stderr, status) or null
+
+Use the environment info to decide what setup command to run and how to structure tasks.
 
 ### 2. `claude_code_send` — Send a task to a session
 
@@ -32,31 +42,75 @@ Sends a prompt to an active Claude Code session. The session maintains context a
 - `session_id` (required) — which session to use
 - `prompt` (required) — the coding task or follow-up
 
-Returns a summary of what Claude Code did. Full logs are saved to disk.
+**Returns structured data alongside a text summary:**
+- `exit_status` — `success`, `error`, `budget_exhausted`, `timeout`, or `cancelled`
+- `files_changed` — list of file paths modified
+- `tools_used` — dict of tool name → call count
+- `errors` — list of `{message}` dicts
+- `cost_usd` — running session cost total
+- `duration_ms` — wall time for this send
+- `send_count` — total sends in this session
+- `num_turns` — LLM turns in this send
+- `result_text` — final text from Claude Code
+- `sdk_session_id` — for debugging
+- `log_path` — path to JSONL log file
 
-### 3. `claude_code_stop` — End a session
+Use `exit_status` to branch programmatically: if `success`, move on; if `error`, send a fix prompt or run `claude_code_exec` to diagnose.
+
+### 3. `claude_code_exec` — Run a shell command (no LLM turn)
+
+Runs a shell command directly in a session's working directory. No LLM involved — direct subprocess execution. Use for quick verification between `claude_code_send` calls.
+
+**Parameters:**
+- `session_id` (required) — which session to use
+- `command` (required) — shell command to run
+- `timeout` (optional) — seconds before killing the process (default 30, max 120)
+
+**Returns structured data:**
+- `exit_code` — process exit code (null if timed out)
+- `stdout` — captured standard output
+- `stderr` — captured standard error
+- `status` — `success`, `error`, or `timeout`
+- `duration_ms` — wall time
+- `command` — the command that was run
+
+**Confirmation model:** Inherits from session approval. If the user has already approved a `claude_code_send` for this session, exec calls are auto-approved. Otherwise, requests its own confirmation.
+
+### 4. `claude_code_stop` — End a session
 
 Closes a session and reports final cost.
 
-### 4. `claude_code_sessions` — List active sessions
+### 5. `claude_code_sessions` — List active sessions
 
 Shows all active sessions with ID, working directory, age, and cost so far.
 
 ## Workflow
 
+### Basic
 1. **Start** a session with `claude_code_start` pointing at the repo
 2. **Send** tasks with `claude_code_send` — iterate as needed
 3. **Stop** when done with `claude_code_stop`
+
+### Verify loop (TDD-style)
+1. **Start** → `claude_code_start` with optional `setup_command`
+2. **Implement** → `claude_code_send` with the coding task
+3. **Verify** → `claude_code_exec` to run tests (`make test`, `pytest`, etc.)
+4. **Fix** → if tests failed, `claude_code_send` with the failure output
+5. **Verify** → `claude_code_exec` again to confirm the fix
+6. **Stop** → `claude_code_stop` when satisfied
+
+The exec tool makes the verify steps cheap (no LLM cost, no latency). Use this pattern for iterative development.
 
 Sessions expire after 30 minutes of inactivity. If a session expires, start a new one and restate the context.
 
 ## Cost Awareness
 
-Each Claude Code interaction costs money (Anthropic API usage). The summary after each `claude_code_send` includes the cost. Be mindful of:
+Each Claude Code interaction costs money (Anthropic API usage). The structured result after each `claude_code_send` includes the cost. Be mindful of:
 - Keep tasks focused — one clear objective per send
+- Use `claude_code_exec` for verification instead of burning a full `claude_code_send`
 - Use `claude_code_stop` when done to free the session
 - Default budget limit applies per session
 
 ## Permission Model
 
-Claude Code tools require confirmation before executing. Read-only tools (Read, Glob, Grep) are auto-approved. File edits and shell commands need user approval via Mattermost reactions.
+Claude Code tools require confirmation before executing. The first `claude_code_send` or `claude_code_exec` in a session requires user approval (via Mattermost reactions or web UI). Once approved, subsequent calls in the same session are auto-approved. Setup commands also require confirmation.

--- a/src/decafclaw/skills/claude_code/output.py
+++ b/src/decafclaw/skills/claude_code/output.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from claude_code_sdk import (
@@ -105,6 +106,43 @@ class SessionLogger:
             parts.append(f"\n**Result:**\n{preview}")
 
         return "\n".join(parts)
+
+    def build_data(self, session_id: str = "", exit_status: str = "success",
+                   sdk_session_id: str | None = None, send_count: int = 0) -> dict:
+        """Return structured result dict with JSON-safe types only."""
+        from collections import Counter
+        tool_counts = dict(Counter(self.tools_used))
+        unique_files = list(dict.fromkeys(self.files_changed))
+        errors = [{"message": e} for e in self.errors[:10]]
+        return {
+            "exit_status": exit_status,
+            "files_changed": unique_files,
+            "tools_used": tool_counts,
+            "errors": errors,
+            "cost_usd": self.total_cost_usd,
+            "duration_ms": self.duration_ms,
+            "send_count": send_count,
+            "num_turns": self.num_turns,
+            "result_text": self.result_text[:500] if self.result_text else "",
+            "result_text_truncated": len(self.result_text) > 500,
+            "sdk_session_id": sdk_session_id or "",
+            "log_path": str(self.path),
+        }
+
+    def log_exec(self, command: str, exit_code: int | None,
+                 stdout: str, stderr: str, duration_ms: int) -> None:
+        """Log a claude_code_exec command to the session's JSONL log."""
+        record = {
+            "type": "exec",
+            "command": command,
+            "exit_code": exit_code,
+            "stdout": stdout,
+            "stderr": stderr,
+            "duration_ms": duration_ms,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        with open(self.path, "a") as f:
+            f.write(json.dumps(record) + "\n")
 
     def _track_file_change(self, tool_name: str, tool_input: dict) -> None:
         """Track file paths from Edit/Write tool calls."""

--- a/src/decafclaw/skills/claude_code/sessions.py
+++ b/src/decafclaw/skills/claude_code/sessions.py
@@ -21,6 +21,7 @@ class Session:
     last_active: float = field(default_factory=time.monotonic)
     total_cost_usd: float = 0
     send_count: int = 0
+    approved: bool = False
 
 
 class SessionManager:

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -1,5 +1,6 @@
 """Claude Code skill — delegate coding tasks to Claude Code as a subagent."""
 
+import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
@@ -14,8 +15,8 @@ from claude_code_sdk import (
     query,
 )
 
+from decafclaw.media import ToolResult
 from decafclaw.skills.claude_code.output import SessionLogger
-from decafclaw.skills.claude_code.permissions import make_permission_handler
 from decafclaw.skills.claude_code.sessions import SessionManager
 
 log = logging.getLogger(__name__)
@@ -64,8 +65,93 @@ def _get_manager() -> SessionManager:
     return _session_manager
 
 
+_PROBE_TOOLS = ["python3", "node", "go", "uv", "pip", "npm", "pnpm", "make", "git", "cargo", "rustc"]
+_PROBE_FILES = ["Makefile", "pyproject.toml", "package.json", "go.mod", "Cargo.toml",
+                "CLAUDE.md", "README.md", ".env"]
+
+
+async def _probe_environment(cwd: str) -> dict:
+    """Run a quick environment probe in cwd. Best-effort, 5s timeout."""
+    result: dict = {"tools_available": [], "project_files": [], "git": None}
+
+    async def _do_probe():
+        # Batch check tools on PATH
+        script = "; ".join(
+            f"which {cmd} >/dev/null 2>&1 && echo {cmd}" for cmd in _PROBE_TOOLS
+        )
+        proc = await asyncio.create_subprocess_shell(
+            script, cwd=cwd,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        result["tools_available"] = [
+            line for line in stdout.decode().strip().splitlines() if line
+        ]
+
+        # Check project files
+        cwd_path = Path(cwd)
+        result["project_files"] = [
+            name for name in _PROBE_FILES if (cwd_path / name).exists()
+        ]
+
+        # Git info
+        if (cwd_path / ".git").exists():
+            branch_proc = await asyncio.create_subprocess_exec(
+                "git", "-C", cwd, "branch", "--show-current",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            branch_out, _ = await branch_proc.communicate()
+            status_proc = await asyncio.create_subprocess_exec(
+                "git", "-C", cwd, "status", "--porcelain",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            status_out, _ = await status_proc.communicate()
+            result["git"] = {
+                "branch": branch_out.decode().strip(),
+                "clean": len(status_out.decode().strip()) == 0,
+            }
+
+    try:
+        await asyncio.wait_for(_do_probe(), timeout=5.0)
+    except asyncio.TimeoutError:
+        log.warning("Environment probe timed out after 5s, returning partial results")
+    except Exception as e:
+        log.warning(f"Environment probe error: {e}")
+
+    return result
+
+
+async def _run_setup_command(cwd: str, command: str, timeout: float = 30.0) -> dict:
+    """Run a setup command in cwd and return structured result."""
+    proc = await asyncio.create_subprocess_shell(
+        command, cwd=cwd,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        log.warning(f"Setup command timed out after {timeout}s: {command}")
+        proc.kill()
+        await proc.wait()
+        return {
+            "command": command,
+            "exit_code": None,
+            "stdout": "",
+            "stderr": "",
+            "status": "timeout",
+        }
+    return {
+        "command": command,
+        "exit_code": proc.returncode,
+        "stdout": stdout.decode(errors="replace"),
+        "stderr": stderr.decode(errors="replace"),
+        "status": "success" if proc.returncode == 0 else "error",
+    }
+
+
 async def tool_claude_code_start(ctx, cwd: str, description: str = "",
-                                  model: str = "", budget_usd: float = 0) -> str:
+                                  model: str = "", budget_usd: float = 0,
+                                  setup_command: str = "") -> ToolResult:
     """Start a new Claude Code session for a working directory within the workspace."""
     log.info(f"[tool:claude_code_start] cwd={cwd}")
     manager = _get_manager()
@@ -74,8 +160,8 @@ async def tool_claude_code_start(ctx, cwd: str, description: str = "",
     workspace = _config.workspace_path if _config else Path(".")
     resolved = (workspace / cwd).resolve()
     workspace_resolved = workspace.resolve()
-    if not str(resolved).startswith(str(workspace_resolved)):
-        return f"[error: path must be within the workspace ({workspace})]"
+    if not resolved.is_relative_to(workspace_resolved):
+        return ToolResult(text=f"[error: path must be within the workspace ({workspace})]")
     if not resolved.is_dir():
         resolved.mkdir(parents=True, exist_ok=True)
         log.info(f"Created workspace directory: {resolved}")
@@ -89,28 +175,124 @@ async def tool_claude_code_start(ctx, cwd: str, description: str = "",
             budget_usd=budget_usd if budget_usd > 0 else None,
         )
     except ValueError as e:
-        return f"[error: {e}]"
+        return ToolResult(text=f"[error: {e}]")
 
-    return (
-        f"Claude Code session started.\n"
-        f"- **Session ID:** `{session.session_id}`\n"
-        f"- **Working directory:** {session.cwd}\n"
-        f"- **Budget:** ${session.budget_usd:.2f}\n"
-        f"- **Model:** {session.model or (_skill_config and _skill_config.model) or '(SDK default)'}\n"
-        f"\nUse `claude_code_send` with this session ID to send tasks."
-    )
+    # Environment probe
+    env_info = await _probe_environment(cwd)
+
+    # Optional setup command
+    setup_result = None
+    if setup_command:
+        from decafclaw.skills.claude_code.permissions import load_allowlist, matches_allowlist
+        from decafclaw.tools.confirmation import request_confirmation
+
+        patterns = load_allowlist(_config) if _config else []
+        run_setup = False
+        if matches_allowlist("claude_code_setup", patterns):
+            session.approved = True
+            run_setup = True
+        else:
+            confirm = await request_confirmation(
+                ctx,
+                tool_name="claude_code_setup",
+                command=f"Setup: {setup_command}",
+                message=(
+                    f"**Claude Code** wants to run a setup command in `{cwd}`:\n"
+                    f"```\n{setup_command}\n```"
+                ),
+            )
+            if confirm.get("approved"):
+                session.approved = True
+                run_setup = True
+                if confirm.get("always"):
+                    from decafclaw.skills.claude_code.permissions import save_allowlist_entry
+                    save_allowlist_entry(_config, "claude_code_setup")
+
+        if run_setup:
+            try:
+                setup_result = await _run_setup_command(cwd, setup_command)
+            except Exception as e:
+                log.error(f"Setup command failed: {e}", exc_info=True)
+                setup_result = {"command": setup_command, "status": "error",
+                                "stdout": "", "stderr": str(e), "exit_code": None}
+        else:
+            setup_result = {"command": setup_command, "status": "skipped",
+                            "stdout": "", "stderr": "", "exit_code": None}
+
+    # Build model string
+    model_str = session.model or (_skill_config.model if _skill_config else "") or "(SDK default)"
+
+    # Structured data
+    data = {
+        "session_id": session.session_id,
+        "cwd": session.cwd,
+        "model": model_str,
+        "budget_usd": session.budget_usd,
+        "environment": env_info,
+        "setup": setup_result,
+    }
+
+    # Text summary
+    parts = [
+        "Claude Code session started.",
+        f"- **Session ID:** `{session.session_id}`",
+        f"- **Working directory:** {session.cwd}",
+        f"- **Budget:** ${session.budget_usd:.2f}",
+        f"- **Model:** {model_str}",
+    ]
+    if env_info["tools_available"]:
+        parts.append(f"- **Tools on PATH:** {', '.join(env_info['tools_available'])}")
+    if env_info["project_files"]:
+        parts.append(f"- **Project files:** {', '.join(env_info['project_files'])}")
+    if env_info["git"]:
+        git = env_info["git"]
+        git_status = "clean" if git["clean"] else "dirty"
+        parts.append(f"- **Git:** branch `{git['branch']}` ({git_status})")
+    if setup_result:
+        if setup_result["status"] == "success":
+            parts.append(f"- **Setup:** `{setup_command}` succeeded")
+        elif setup_result["status"] == "skipped":
+            parts.append(f"- **Setup:** `{setup_command}` skipped (not approved)")
+        elif setup_result["status"] == "timeout":
+            parts.append(f"- **Setup:** `{setup_command}` timed out")
+        else:
+            parts.append(f"- **Setup:** `{setup_command}` failed (exit {setup_result['exit_code']})")
+    parts.append("\nUse `claude_code_send` with this session ID to send tasks.")
+
+    return ToolResult(text="\n".join(parts), data=data)
 
 
-async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> str:
+def _send_error_data(exit_status: str, **extra) -> dict:
+    """Build a consistent structured data dict for send error paths."""
+    data = {
+        "exit_status": exit_status,
+        "files_changed": [],
+        "tools_used": {},
+        "errors": [],
+        "cost_usd": 0,
+        "duration_ms": 0,
+        "send_count": 0,
+        "num_turns": 0,
+        "result_text": "",
+        "result_text_truncated": False,
+        "sdk_session_id": "",
+        "log_path": "",
+    }
+    data.update(extra)
+    return data
+
+
+async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> ToolResult:
     """Send a prompt to an active Claude Code session."""
     log.info(f"[tool:claude_code_send] session={session_id}")
     manager = _get_manager()
 
     session = manager.get(session_id)
     if session is None:
-        return (
-            f"[error: session '{session_id}' not found or expired. "
-            f"Start a new session with claude_code_start.]"
+        return ToolResult(
+            text=(f"[error: session '{session_id}' not found or expired. "
+                  f"Start a new session with claude_code_start.]"),
+            data=_send_error_data("error"),
         )
 
     # Upfront confirmation — one approval per send, not per tool.
@@ -121,7 +303,9 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> str:
 
     # Skip confirmation if "claude_code_send" is in the allowlist
     patterns = load_allowlist(_config) if _config else []
-    if not matches_allowlist("claude_code_send", patterns):
+    if matches_allowlist("claude_code_send", patterns):
+        session.approved = True
+    else:
         prompt_preview = prompt[:200] + ("..." if len(prompt) > 200 else "")
         confirm = await request_confirmation(
             ctx,
@@ -134,17 +318,25 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> str:
             ),
         )
         if not confirm.get("approved"):
-            return "[error: Claude Code task was denied by user]"
+            return ToolResult(
+                text="[error: Claude Code task was denied by user]",
+                data=_send_error_data("cancelled"),
+            )
         if confirm.get("always"):
             from decafclaw.skills.claude_code.permissions import save_allowlist_entry
             save_allowlist_entry(_config, "claude_code_send")
+        session.approved = True
 
     # Check budget
     if session.total_cost_usd >= session.budget_usd:
-        return (
-            f"[error: session budget exhausted (${session.total_cost_usd:.2f} / "
-            f"${session.budget_usd:.2f}). Stop this session and start a new one "
-            f"with a higher budget if needed.]"
+        return ToolResult(
+            text=(
+                f"[error: session budget exhausted (${session.total_cost_usd:.2f} / "
+                f"${session.budget_usd:.2f}). Stop this session and start a new one "
+                f"with a higher budget if needed.]"
+            ),
+            data=_send_error_data("budget_exhausted",
+                                  cost_usd=session.total_cost_usd),
         )
 
     # Build options
@@ -215,7 +407,10 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> str:
 
     except Exception as e:
         log.error(f"Claude Code SDK error: {e}", exc_info=True)
-        return f"[error: Claude Code failed: {e}]"
+        return ToolResult(
+            text=f"[error: Claude Code failed: {e}]",
+            data=_send_error_data("error", errors=[{"message": str(e)}]),
+        )
     finally:
         stderr_file.close()
 
@@ -223,7 +418,128 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> str:
     session.send_count += 1
     manager.touch(session_id)
 
-    return logger.build_summary(session_id)
+    summary = logger.build_summary(session_id)
+    data = logger.build_data(
+        session_id=session_id,
+        exit_status="error" if logger.errors else "success",
+        sdk_session_id=session.sdk_session_id,
+        send_count=session.send_count,
+    )
+    return ToolResult(text=summary, data=data)
+
+
+async def tool_claude_code_exec(ctx, session_id: str, command: str,
+                                timeout: int = 30) -> ToolResult:
+    """Run a shell command in a session's cwd without an LLM turn."""
+    log.info(f"[tool:claude_code_exec] session={session_id} command={command[:80]}")
+    manager = _get_manager()
+
+    session = manager.get(session_id)
+    if session is None:
+        return ToolResult(
+            text=(f"[error: session '{session_id}' not found or expired. "
+                  f"Start a new session with claude_code_start.]"),
+            data={"status": "error", "exit_code": None, "stdout": "",
+                  "stderr": "", "duration_ms": 0, "command": command},
+        )
+
+    # Confirmation — inherit from session if already approved
+    if not session.approved:
+        from decafclaw.skills.claude_code.permissions import load_allowlist, matches_allowlist
+        from decafclaw.tools.confirmation import request_confirmation
+
+        patterns = load_allowlist(_config) if _config else []
+        if matches_allowlist("claude_code_exec", patterns):
+            session.approved = True
+        else:
+            confirm = await request_confirmation(
+                ctx,
+                tool_name="claude_code_exec",
+                command=f"Exec: {command}",
+                message=(
+                    f"**Claude Code** wants to run a command in `{session.cwd}`:\n"
+                    f"```\n{command}\n```"
+                ),
+            )
+            if not confirm.get("approved"):
+                return ToolResult(
+                    text="[error: command was denied by user]",
+                    data={"status": "cancelled", "exit_code": None, "stdout": "",
+                          "stderr": "", "duration_ms": 0, "command": command},
+                )
+            if confirm.get("always"):
+                from decafclaw.skills.claude_code.permissions import save_allowlist_entry
+                save_allowlist_entry(_config, "claude_code_exec")
+            session.approved = True
+
+    # Clamp timeout
+    timeout = max(1, min(timeout, 120))
+
+    start = time.monotonic()
+    exit_code = None
+    stdout_str = ""
+    stderr_str = ""
+    status = "success"
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command, cwd=session.cwd,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout,
+        )
+        exit_code = proc.returncode
+        stdout_str = stdout_bytes.decode(errors="replace")
+        stderr_str = stderr_bytes.decode(errors="replace")
+        status = "success" if exit_code == 0 else "error"
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        # Try to capture partial output
+        if proc.stdout:
+            partial = await proc.stdout.read()
+            stdout_str = partial.decode(errors="replace")
+        if proc.stderr:
+            partial = await proc.stderr.read()
+            stderr_str = partial.decode(errors="replace")
+        status = "timeout"
+    except Exception as e:
+        log.error(f"claude_code_exec subprocess error: {e}", exc_info=True)
+        stderr_str = str(e)
+        status = "error"
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    # Log to session JSONL
+    log_dir = _config.workspace_path / "claude-code-logs" if _config else Path("claude-code-logs")
+    logger = SessionLogger(log_dir, session.session_id)
+    logger.log_exec(command, exit_code, stdout_str, stderr_str, duration_ms)
+
+    # Touch session
+    manager.touch(session_id)
+
+    # Build text summary
+    parts = [f"**Exec** in `{session.cwd}`"]
+    parts.append(f"```\n$ {command}\n```")
+    if status == "timeout":
+        parts.append(f"**Timed out** after {timeout}s")
+    else:
+        parts.append(f"Exit code: {exit_code}")
+    if stdout_str:
+        parts.append(f"**stdout:**\n```\n{stdout_str}\n```")
+    if stderr_str:
+        parts.append(f"**stderr:**\n```\n{stderr_str}\n```")
+
+    data = {
+        "exit_code": exit_code,
+        "stdout": stdout_str,
+        "stderr": stderr_str,
+        "status": status,
+        "duration_ms": duration_ms,
+        "command": command,
+    }
+    return ToolResult(text="\n".join(parts), data=data)
 
 
 async def tool_claude_code_stop(ctx, session_id: str) -> str:
@@ -278,6 +594,7 @@ async def shutdown():
 TOOLS = {
     "claude_code_start": tool_claude_code_start,
     "claude_code_send": tool_claude_code_send,
+    "claude_code_exec": tool_claude_code_exec,
     "claude_code_stop": tool_claude_code_stop,
     "claude_code_sessions": tool_claude_code_sessions,
 }
@@ -311,6 +628,13 @@ TOOL_DEFINITIONS = [
                         "type": "number",
                         "description": "Per-session cost limit in USD (optional, 0 = default)",
                     },
+                    "setup_command": {
+                        "type": "string",
+                        "description": (
+                            "Shell command to run for environment setup before the session "
+                            "is ready (e.g., 'uv sync', 'npm install'). Requires confirmation."
+                        ),
+                    },
                 },
                 "required": ["cwd"],
             },
@@ -338,6 +662,35 @@ TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["session_id", "prompt"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "claude_code_exec",
+            "description": (
+                "Run a shell command in an active Claude Code session's working directory. "
+                "No LLM turn — direct subprocess execution. Use for quick verification "
+                "(make test, git status, etc.) between claude_code_send calls."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID from claude_code_start",
+                    },
+                    "command": {
+                        "type": "string",
+                        "description": "Shell command to run",
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Timeout in seconds (default 30, max 120)",
+                    },
+                },
+                "required": ["session_id", "command"],
             },
         },
     },

--- a/tests/test_claude_code_output.py
+++ b/tests/test_claude_code_output.py
@@ -153,6 +153,91 @@ def test_build_summary_empty(tmp_path):
     assert "No tool calls" in summary
 
 
+def test_build_data_shape(tmp_path):
+    """build_data() returns a dict with expected keys and JSON-safe values."""
+    logger = SessionLogger(tmp_path, "test-session")
+    logger.files_changed = ["src/foo.py", "src/bar.py", "src/foo.py"]
+    logger.tools_used = ["Read", "Edit", "Read", "Edit", "Edit"]
+    logger.errors = ["ImportError: no module named foo"]
+    logger.total_cost_usd = 0.45
+    logger.duration_ms = 5000
+    logger.num_turns = 3
+    logger.result_text = "Done"
+
+    data = logger.build_data(
+        session_id="abc123",
+        exit_status="success",
+        sdk_session_id="sdk-456",
+        send_count=2,
+    )
+
+    assert data["exit_status"] == "success"
+    assert data["files_changed"] == ["src/foo.py", "src/bar.py"]  # deduplicated
+    assert data["tools_used"] == {"Read": 2, "Edit": 3}
+    assert data["errors"] == [{"message": "ImportError: no module named foo"}]
+    assert data["cost_usd"] == 0.45
+    assert data["duration_ms"] == 5000
+    assert data["send_count"] == 2
+    assert data["num_turns"] == 3
+    assert data["result_text"] == "Done"
+    assert data["result_text_truncated"] is False
+    assert data["sdk_session_id"] == "sdk-456"
+    assert "test-session" in data["log_path"]
+
+    # Must be JSON-serializable
+    json_str = json.dumps(data)
+    assert json.loads(json_str) == data
+
+
+def test_build_data_defaults(tmp_path):
+    """build_data() works with no metrics set."""
+    logger = SessionLogger(tmp_path, "test-session")
+    data = logger.build_data()
+
+    assert data["exit_status"] == "success"
+    assert data["files_changed"] == []
+    assert data["tools_used"] == {}
+    assert data["errors"] == []
+    assert data["cost_usd"] == 0
+    assert data["sdk_session_id"] == ""
+
+    json.dumps(data)  # must not raise
+
+
+def test_log_exec(tmp_path):
+    """log_exec() writes a JSON record with exec type and all fields."""
+    logger = SessionLogger(tmp_path, "test-session")
+    logger.log_exec(
+        command="make test",
+        exit_code=0,
+        stdout="all passed\n",
+        stderr="",
+        duration_ms=1234,
+    )
+
+    assert logger.path.exists()
+    with open(logger.path) as f:
+        record = json.loads(f.readline())
+    assert record["type"] == "exec"
+    assert record["command"] == "make test"
+    assert record["exit_code"] == 0
+    assert record["stdout"] == "all passed\n"
+    assert record["stderr"] == ""
+    assert record["duration_ms"] == 1234
+    assert "timestamp" in record
+
+
+def test_log_exec_timeout(tmp_path):
+    """log_exec() handles None exit_code for timeouts."""
+    logger = SessionLogger(tmp_path, "test-session")
+    logger.log_exec("sleep 999", None, "", "killed", 30000)
+
+    with open(logger.path) as f:
+        record = json.loads(f.readline())
+    assert record["exit_code"] is None
+    assert record["stderr"] == "killed"
+
+
 def test_deduplicates_files_changed(tmp_path):
     logger = SessionLogger(tmp_path, "test-session")
     msg = AssistantMessage(

--- a/tests/test_tool_result_data.py
+++ b/tests/test_tool_result_data.py
@@ -1,0 +1,141 @@
+"""Tests for ToolResult.data field and JSON serialization in tool messages."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.media import ToolResult
+
+
+def test_data_field_accessible():
+    """ToolResult.data stores structured data dict."""
+    result = ToolResult(text="hello", data={"exit_status": "success", "cost": 1.23})
+    assert result.data == {"exit_status": "success", "cost": 1.23}
+
+
+def test_data_defaults_to_none():
+    """ToolResult.data is None by default."""
+    result = ToolResult(text="hello")
+    assert result.data is None
+
+
+def test_data_none_explicit():
+    """Explicit data=None is the same as default."""
+    result = ToolResult(text="hello", data=None)
+    assert result.data is None
+
+
+def test_json_block_appended_when_data_present():
+    """When data is set, a fenced JSON block should be appendable to text."""
+    result = ToolResult(text="hello", data={"k": "v"})
+    content = result.text
+    if result.data is not None:
+        content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+
+    assert content.startswith("hello")
+    assert "```json" in content
+    assert "```" in content
+
+    # Extract and validate the JSON block
+    json_start = content.index("```json\n") + len("```json\n")
+    json_end = content.index("\n```", json_start)
+    parsed = json.loads(content[json_start:json_end])
+    assert parsed == {"k": "v"}
+
+
+def test_no_json_block_when_data_is_none():
+    """When data is None, text should be unchanged."""
+    result = ToolResult(text="hello", data=None)
+    content = result.text
+    if result.data is not None:
+        content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+
+    assert content == "hello"
+
+
+def test_complex_data_serializes():
+    """Nested dicts and lists serialize correctly."""
+    data = {
+        "files_changed": ["src/foo.py", "tests/test_foo.py"],
+        "tools_used": {"Edit": 3, "Read": 5},
+        "errors": [{"message": "ImportError", "file": "src/bar.py"}],
+        "cost_usd": 0.45,
+        "exit_code": None,
+    }
+    result = ToolResult(text="done", data=data)
+    content = result.text + "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+
+    json_start = content.index("```json\n") + len("```json\n")
+    json_end = content.index("\n```", json_start)
+    parsed = json.loads(content[json_start:json_end])
+    assert parsed == data
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_appends_json_block(ctx):
+    """The actual agent loop appends a JSON block when ToolResult.data is set."""
+    from decafclaw.agent import _execute_single_tool
+
+    test_data = {"exit_status": "success", "cost_usd": 1.23}
+    mock_result = ToolResult(text="task completed", data=test_data)
+
+    tc = {
+        "id": "call_123",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+    semaphore = asyncio.Semaphore(1)
+
+    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg = await _execute_single_tool(ctx, tc, semaphore)
+
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["content"].startswith("task completed")
+    assert "```json" in tool_msg["content"]
+
+    # Extract and validate the JSON block
+    content = tool_msg["content"]
+    json_start = content.index("```json\n") + len("```json\n")
+    json_end = content.index("\n```", json_start)
+    parsed = json.loads(content[json_start:json_end])
+    assert parsed == test_data
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_no_json_block_without_data(ctx):
+    """No JSON block when ToolResult.data is None."""
+    from decafclaw.agent import _execute_single_tool
+
+    mock_result = ToolResult(text="plain result")
+    tc = {
+        "id": "call_456",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+    semaphore = asyncio.Semaphore(1)
+
+    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg = await _execute_single_tool(ctx, tc, semaphore)
+
+    assert tool_msg["content"] == "plain result"
+    assert "```json" not in tool_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_handles_unserializable_data(ctx):
+    """Non-serializable data doesn't crash the tool call."""
+    from decafclaw.agent import _execute_single_tool
+
+    mock_result = ToolResult(text="result", data={"bad": object()})
+    tc = {
+        "id": "call_789",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+    semaphore = asyncio.Semaphore(1)
+
+    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg = await _execute_single_tool(ctx, tc, semaphore)
+
+    assert "result" in tool_msg["content"]
+    assert "serialization error" in tool_msg["content"]
+    assert "```json" not in tool_msg["content"]


### PR DESCRIPTION
## Summary

Make the Claude Code skill a capable software development delegate with three foundational improvements:

- **Structured results from `claude_code_send`** (#206) — returns machine-readable `exit_status`, `files_changed`, `tools_used`, `errors`, `cost_usd`, etc. alongside the text summary. All return paths (success, error, budget_exhausted, cancelled) include structured data.
- **Environment probe + setup command for `claude_code_start`** (#205) — probes the session cwd for tools on PATH, project files, and git status. Optional `setup_command` parameter runs a shell command (e.g., `uv sync`) with user confirmation.
- **`claude_code_exec` tool** (#208) — runs shell commands directly in a session's cwd without an LLM turn. Enables cheap verification loops (`exec make test` → `send "fix it"` → `exec make test`). Inherits session approval so users don't re-confirm every exec.

### Infrastructure

- Added `data: dict | None` field to `ToolResult` — the agent loop auto-appends a fenced JSON block to tool result content when set. Any tool can now return structured data.
- Added `approved: bool` flag to `Session` for inherited confirmation model.

Part of the Claude Code subagent improvement initiative (#213).

Closes #206, closes #205, closes #208.

## Test plan

- [x] `ToolResult.data` field: unit tests for field access, default, JSON serialization
- [x] `SessionLogger.build_data()`: unit tests for shape, dedup, JSON safety
- [x] `SessionLogger.log_exec()`: unit tests for JSONL output, timeout handling
- [x] All 1060 tests pass
- [x] `make check` clean (lint + pyright + tsc)
- [ ] Live test: activate claude_code skill, start session, send task, verify structured data in response
- [ ] Live test: start session with `setup_command`, verify env probe output
- [ ] Live test: exec `make test` in session, verify structured stdout/stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)