### PR TITLE
feat: Claude Code context injection and diff output

### DIFF
--- a/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/notes.md
+++ b/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/notes.md
@@ -1,0 +1,3 @@
+# Claude Code Subagent Phase 2 — Notes
+
+<!-- Session notes and final summary -->

--- a/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/plan.md
+++ b/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/plan.md
@@ -1,0 +1,297 @@
+# Claude Code Subagent Phase 2 — Plan
+
+## Overview
+
+Four steps, each building on the previous. Each step ends with lint + test + commit.
+
+---
+
+## Step 1: Context injection — Session.instructions + prompt assembly
+
+**What:** Add `instructions` field to Session, `instructions` param to `claude_code_start`, `context` param to `claude_code_send`, and prompt assembly logic. Update TOOL_DEFINITIONS.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/sessions.py` — add `instructions` field
+- `src/decafclaw/skills/claude_code/tools.py` — add params, prompt assembly helper, wire into send
+
+**Details:**
+
+1. In `sessions.py`, add `instructions: str = ""` to the `Session` dataclass after `approved`.
+
+2. In `tools.py`, add a helper function to assemble the prompt:
+   ```python
+   def _assemble_prompt(prompt: str, instructions: str = "", context: str = "") -> str:
+       parts = []
+       if instructions:
+           parts.append(f"<instructions>\n{instructions}\n</instructions>")
+       if context:
+           parts.append(f"<context>\n{context}\n</context>")
+       parts.append(prompt)
+       return "\n\n".join(parts)
+   ```
+
+3. Add `instructions: str = ""` parameter to `tool_claude_code_start`. Pass it through to `manager.create()`, which needs to accept and store it on the Session.
+
+4. Update `SessionManager.create()` in `sessions.py` to accept `instructions` and pass it to the Session constructor.
+
+5. Add `context: str = ""` parameter to `tool_claude_code_send`.
+
+6. In `tool_claude_code_send`, replace the raw `prompt` with `_assemble_prompt(prompt, session.instructions, context)` when building the prompt stream.
+
+7. Update TOOL_DEFINITIONS:
+   - `claude_code_start`: add `instructions` property
+   - `claude_code_send`: add `context` property
+
+8. Write tests for `_assemble_prompt` (all combinations of empty/non-empty instructions and context).
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/sessions.py`:
+> 1. Add `instructions: str = ""` to the `Session` dataclass, after the `approved` field.
+> 2. Update `SessionManager.create()` to accept `instructions: str = ""` parameter and pass it to the Session constructor.
+>
+> In `src/decafclaw/skills/claude_code/tools.py`:
+> 1. Add a module-level helper before `tool_claude_code_start`:
+>    ```python
+>    def _assemble_prompt(prompt: str, instructions: str = "", context: str = "") -> str:
+>        """Build the full prompt with optional instructions and context preamble."""
+>        parts = []
+>        if instructions:
+>            parts.append(f"<instructions>\n{instructions}\n</instructions>")
+>        if context:
+>            parts.append(f"<context>\n{context}\n</context>")
+>        parts.append(prompt)
+>        return "\n\n".join(parts)
+>    ```
+>
+> 2. Add `instructions: str = ""` parameter to `tool_claude_code_start` (after `setup_command`). Pass it to `manager.create(instructions=instructions)`.
+>
+> 3. Add `context: str = ""` parameter to `tool_claude_code_send` (after `prompt`).
+>
+> 4. In `tool_claude_code_send`, where the prompt_stream is built (around line 350), replace the raw `prompt` with `_assemble_prompt(prompt, session.instructions, context)`:
+>    ```python
+>    full_prompt = _assemble_prompt(prompt, session.instructions, context)
+>    async def prompt_stream():
+>        yield {
+>            "type": "user",
+>            "message": {"role": "user", "content": full_prompt},
+>            ...
+>        }
+>    ```
+>
+> 5. Update `claude_code_start` TOOL_DEFINITIONS to add:
+>    ```python
+>    "instructions": {
+>        "type": "string",
+>        "description": (
+>            "Persistent instructions prepended to every send in this session. "
+>            "Use for project conventions, coding style, constraints."
+>        ),
+>    },
+>    ```
+>
+> 6. Update `claude_code_send` TOOL_DEFINITIONS to add:
+>    ```python
+>    "context": {
+>        "type": "string",
+>        "description": (
+>            "Per-task context prepended to this send only. "
+>            "Use for relevant specs, vault pages, conversation excerpts."
+>        ),
+>    },
+>    ```
+>
+> 7. Write tests in `tests/test_claude_code_context.py`:
+>    - `test_assemble_prompt_both`: instructions + context + prompt → correct XML tags and ordering
+>    - `test_assemble_prompt_instructions_only`: just instructions + prompt
+>    - `test_assemble_prompt_context_only`: just context + prompt
+>    - `test_assemble_prompt_neither`: prompt only → no tags, prompt unchanged
+>    - `test_session_stores_instructions`: create session with instructions, verify field is set
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 2: Diff capture helper
+
+**What:** Add an async helper function that captures git diff in a session's cwd. Self-contained, tested independently before wiring into send.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — add `_capture_git_diff` helper
+
+**Details:**
+
+1. Add `async def _capture_git_diff(cwd: str, baseline_ref: str | None) -> str | None`:
+   - If `baseline_ref` is None, return None (not a git repo or no commits)
+   - Run `git diff <baseline_ref>` in cwd — catches committed changes since baseline
+   - Run `git diff` in cwd — catches unstaged changes to tracked files
+   - Run `git ls-files --others --exclude-standard` in cwd — catches new untracked files
+   - Combine results: committed diff + unstaged diff + untracked file list
+   - For untracked files, append a section: `\nNew untracked files:\n  path/to/file1\n  path/to/file2`
+   - If all three are empty, return empty string (no changes)
+   - On any git command failure, log warning and return None
+   - Whole function wrapped in try/except for robustness
+
+2. Add `async def _get_git_head(cwd: str) -> str | None`:
+   - Run `git rev-parse HEAD` in cwd
+   - Return the hash string on success, None on failure (not a repo, empty repo, etc.)
+
+3. Write tests:
+   - Test `_get_git_head` in a real tmp git repo (init, commit, verify hash)
+   - Test `_get_git_head` in a non-git directory (returns None)
+   - Test `_capture_git_diff` with a modified file (shows diff)
+   - Test `_capture_git_diff` with a new untracked file (listed)
+   - Test `_capture_git_diff` with a committed change (shows diff from baseline)
+   - Test `_capture_git_diff` with None baseline (returns None)
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/tools.py`, add two helper functions after the existing `_run_setup_command`:
+>
+> 1. `async def _get_git_head(cwd: str) -> str | None`:
+>    - Run `git -C {cwd} rev-parse HEAD` via `asyncio.create_subprocess_exec`
+>    - On success (returncode 0), return stdout stripped
+>    - On failure, return None (not a git repo, empty repo, etc.)
+>
+> 2. `async def _capture_git_diff(cwd: str, baseline_ref: str | None) -> str | None`:
+>    - If `baseline_ref` is None, return None
+>    - Run three git commands in the cwd, all via `asyncio.create_subprocess_exec`:
+>      a. `git diff <baseline_ref>` — committed changes since baseline
+>      b. `git diff` — unstaged changes to tracked files
+>      c. `git ls-files --others --exclude-standard` — new untracked files
+>    - For each, capture stdout as string. If a command fails, log warning and treat as empty.
+>    - Build the result:
+>      - Start with committed diff (if non-empty)
+>      - Append unstaged diff (if non-empty and different from committed diff)
+>      - If untracked files exist, append `\nNew untracked files:\n` followed by each path indented with two spaces
+>    - If everything is empty, return "" (no changes detected)
+>    - Wrap the entire function in try/except, returning None on unexpected errors
+>
+> Write tests in `tests/test_claude_code_diff.py`:
+> - `test_get_git_head_returns_hash(tmp_path)`: init a git repo, make a commit, verify `_get_git_head` returns a 40-char hex string
+> - `test_get_git_head_not_a_repo(tmp_path)`: verify returns None for a plain directory
+> - `test_capture_diff_modified_file(tmp_path)`: init repo, commit a file, modify it, verify diff contains the change
+> - `test_capture_diff_new_untracked_file(tmp_path)`: init repo, commit, create a new file (don't add), verify "New untracked files" section
+> - `test_capture_diff_committed_change(tmp_path)`: init repo, commit file, save head, make another commit, verify diff from baseline shows the change
+> - `test_capture_diff_no_baseline(tmp_path)`: verify returns None when baseline_ref is None
+> - `test_capture_diff_no_changes(tmp_path)`: init repo, commit, verify returns "" when nothing changed
+>
+> All tests should use real git repos in tmp_path (via `git init`, `git add`, `git commit` subprocess calls).
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 3: Wire diff capture into claude_code_send
+
+**What:** Call `_get_git_head` before SDK streaming and `_capture_git_diff` after. Add `include_diff` parameter. Pass diff to `build_data()`.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — wire into send flow
+- `src/decafclaw/skills/claude_code/output.py` — add `diff` param to `build_data()`
+
+**Details:**
+
+1. In `output.py`, add `diff: str | None = None` parameter to `build_data()`. Include it in the returned dict.
+
+2. In `tools.py`, add `include_diff: bool = True` parameter to `tool_claude_code_send`.
+
+3. Before the SDK streaming starts (before the `prompt_stream` definition), capture baseline:
+   ```python
+   baseline_ref = None
+   if include_diff:
+       baseline_ref = await _get_git_head(session.cwd)
+   ```
+
+4. After SDK streaming completes (after `session.send_count += 1`), capture diff:
+   ```python
+   diff = None
+   if include_diff:
+       diff = await _capture_git_diff(session.cwd, baseline_ref)
+   ```
+
+5. Pass `diff=diff` to `logger.build_data()`.
+
+6. Also add `diff=None` to the `_send_error_data` helper.
+
+7. Update `claude_code_send` TOOL_DEFINITIONS to add:
+   ```python
+   "include_diff": {
+       "type": "boolean",
+       "description": "Capture git diff of changes made during this send (default true)",
+   },
+   ```
+
+**Prompt:**
+
+> 1. In `src/decafclaw/skills/claude_code/output.py`, modify `build_data()`:
+>    - Add `diff: str | None = None` parameter
+>    - Add `"diff": diff` to the returned dict
+>
+> 2. In `src/decafclaw/skills/claude_code/tools.py`:
+>    - Add `include_diff: bool = True` parameter to `tool_claude_code_send` (after `context`)
+>    - Before the `prompt_stream` definition (around line 348), add:
+>      ```python
+>      baseline_ref = None
+>      if include_diff:
+>          baseline_ref = await _get_git_head(session.cwd)
+>      ```
+>    - After `manager.touch(session_id)` (around line 398), add:
+>      ```python
+>      diff = None
+>      if include_diff:
+>          diff = await _capture_git_diff(session.cwd, baseline_ref)
+>      ```
+>    - Pass `diff=diff` to the `logger.build_data()` call
+>    - Add `"diff": None` to the `_send_error_data` helper function
+>    - Update `claude_code_send` TOOL_DEFINITIONS to add:
+>      ```python
+>      "include_diff": {
+>          "type": "boolean",
+>          "description": "Capture git diff of changes made during this send (default true)",
+>      },
+>      ```
+>
+> 3. Update `tests/test_claude_code_output.py`:
+>    - Update `test_build_data_shape` to pass `diff="some diff"` and verify it appears in the result
+>    - Update `test_build_data_defaults` to verify `diff` is None by default
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 4: Update SKILL.md + docs
+
+**What:** Update skill documentation with new parameters, diff output, git guidance, and context injection workflow.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/SKILL.md`
+- `CLAUDE.md` (if conventions need noting)
+
+**Prompt:**
+
+> Update `src/decafclaw/skills/claude_code/SKILL.md`:
+>
+> 1. Update `claude_code_start` tool section:
+>    - Add `instructions` parameter description
+>    - Note that instructions are prepended to every send in the session
+>
+> 2. Update `claude_code_send` tool section:
+>    - Add `context` parameter description
+>    - Add `include_diff` parameter description (default true)
+>    - Document the `diff` field in the structured result
+>    - Note the diff mechanism: captures committed changes, unstaged edits, and lists new untracked files
+>
+> 3. Add a "Git Best Practice" section or note advising:
+>    - Always use git-initialized working directories for Claude Code sessions
+>    - This ensures reliable diff capture and change tracking
+>    - The parent agent should consider running `git init` via `claude_code_exec` if the cwd isn't already a repo
+>
+> 4. Update the workflow section to show context injection:
+>    ```
+>    start (with instructions) → send (with context + include_diff) → review diff → send (fix) → exec (verify) → stop
+>    ```
+>
+> 5. Check `CLAUDE.md` for any conventions worth noting. Context injection and diff capture are feature additions, not new conventions — likely no CLAUDE.md changes needed.
+>
+> Run `make check` one final time.

--- a/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/spec.md
+++ b/docs/dev-sessions/2026-04-05-0940-claude-code-subagent-phase2/spec.md
@@ -1,0 +1,124 @@
+# Claude Code Subagent Phase 2 — Spec
+
+## Goal
+
+Add context injection and diff output to the Claude Code skill. Context injection lets the parent agent share project conventions, vault knowledge, and per-task context with Claude Code. Diff output lets the parent agent review what changed without separately reading files.
+
+Covers issues: #207 (context injection), #209 (diff output). Part of umbrella #213.
+
+## 1. Context injection (#207)
+
+### Session-level instructions
+
+Add `instructions: str = ""` parameter to `claude_code_start`. Stored on the `Session` dataclass. Set once, immutable for the session lifetime.
+
+Purpose: persistent context prepended to every `claude_code_send` in the session — project conventions, coding style, user preferences.
+
+### Per-send context
+
+Add `context: str = ""` parameter to `claude_code_send`. Ephemeral, applies only to that send.
+
+Purpose: task-specific context — relevant vault pages, specs, conversation excerpts.
+
+### Prompt assembly
+
+When building the prompt for the Claude Code SDK, prepend instructions and context using XML-style tags:
+
+```
+<instructions>
+{session.instructions}
+</instructions>
+
+<context>
+{per_send_context}
+</context>
+
+{actual_prompt}
+```
+
+- If `instructions` is empty, omit the `<instructions>` block entirely
+- If `context` is empty, omit the `<context>` block entirely
+- If both are empty, the prompt is sent as-is (no change from current behavior)
+
+### Responsibility model
+
+The skill is dumb — it accepts plain strings. The parent agent is responsible for assembling context from vault pages, conversation history, user preferences, etc. No coupling between the skill and vault internals.
+
+### Not on claude_code_exec
+
+Context injection only applies to `claude_code_send` (which involves an LLM). `claude_code_exec` is direct shell execution — no LLM to receive context.
+
+## 2. Diff output (#209)
+
+### Auto git-diff after sends
+
+After `claude_code_send` completes, automatically capture a git diff of what changed during the send.
+
+### Mechanism
+
+1. **Before** SDK streaming starts: capture the current HEAD via `git rev-parse HEAD` (may fail in empty repos — handle gracefully)
+2. **After** streaming completes, capture three categories of changes:
+   - `git diff <saved_head>` — catches committed changes (if Claude Code made commits)
+   - `git diff` — catches unstaged changes to tracked files
+   - `git ls-files --others --exclude-standard` — catches new untracked files
+3. Combine into a single diff string. For untracked files, generate a pseudo-diff by reading their content (`git diff --no-index /dev/null <file>` for each, or just list them with a header)
+
+**Simplified approach:** Rather than combining three commands, use a two-step strategy:
+1. Before: `git rev-parse HEAD` to save the baseline
+2. After: `git add -A --dry-run` to see what would be staged (without mutating), then `git diff <saved_head>` for committed changes, plus `git diff` for working tree changes. For untracked files, just list them in the diff field with a `[new file]` marker — the parent can use `claude_code_exec` to read them if needed.
+
+**Even simpler:** Just run `git diff <saved_head>` (for commits) concatenated with `git diff` (for unstaged edits) and append a list of new untracked files. Three commands, no index mutation.
+
+If the cwd is not a git repo, or `git rev-parse HEAD` fails (empty repo, not initialized), skip the diff entirely (return `None`).
+
+### Parameter
+
+Add `include_diff: bool = True` parameter to `claude_code_send`. Defaults to `True` — the parent agent gets diffs by default and can opt out if not needed.
+
+### Result placement
+
+The diff goes in the structured `data` dict as a `diff` string field (or `None` if not a git repo or diff capture failed). It is NOT duplicated in the text summary — the text summary already lists changed files, and the LLM can read the diff from the JSON block.
+
+### No output capping
+
+No size limit on the diff. The parent agent can advise the subagent to keep changes small if diffs are too large.
+
+### SKILL.md guidance
+
+Update the skill documentation to advise the parent agent to use git whenever possible when starting a coding project. This ensures reliable diff capture.
+
+## 3. Edge cases and constraints
+
+### Diff capture failures
+
+- **Not a git repo:** `diff` field is `None`, no error
+- **Empty repo (no commits):** `git rev-parse HEAD` fails — skip diff, `diff` field is `None`
+- **Git command errors:** Log warning, return `None` — diff is best-effort, never blocks the send result
+- **Claude Code committed during send:** `git diff <saved_head>` catches the committed changes; `git diff` catches any remaining unstaged changes
+
+### Untracked files in diff
+
+New files created by Claude Code that aren't git-added won't appear in `git diff`. These are listed separately at the end of the diff string with a `New untracked files:` header. The parent can use `claude_code_exec` to inspect their contents if needed.
+
+### TOOL_DEFINITIONS updates
+
+Both `claude_code_start` and `claude_code_send` TOOL_DEFINITIONS need new parameter entries:
+- `claude_code_start`: add `instructions` property
+- `claude_code_send`: add `context` and `include_diff` properties
+
+## 4. Files changed
+
+- `src/decafclaw/skills/claude_code/sessions.py` — add `instructions: str` field to `Session`
+- `src/decafclaw/skills/claude_code/tools.py` — add parameters, prompt assembly, diff capture
+- `src/decafclaw/skills/claude_code/output.py` — add `diff` field to `build_data()` return
+- `src/decafclaw/skills/claude_code/SKILL.md` — update tool docs, add git guidance
+- Tests for context injection and diff capture
+
+## 5. Out of scope
+
+- Smart context assembly (pulling vault pages, formatting conventions) — parent agent's job
+- Diff from tracked SDK edits (fragile, incomplete for Write/new files)
+- Diff output capping
+- Error classification (#210) — next phase
+- File staging (#211) — next phase
+- Progress reporting (#212) — next phase

--- a/src/decafclaw/skills/claude_code/SKILL.md
+++ b/src/decafclaw/skills/claude_code/SKILL.md
@@ -22,6 +22,7 @@ Creates a new Claude Code session for a specific working directory. Probes the e
 - `model` (optional) — override the Claude model
 - `budget_usd` (optional) — per-session cost limit
 - `setup_command` (optional) — shell command to run for environment setup (e.g., `uv sync`, `npm install`). Requires user confirmation.
+- `instructions` (optional) — persistent instructions prepended to every `claude_code_send` in this session. Use for project conventions, coding style, constraints. Set once at start.
 
 Only one session per working directory. Use `claude_code_sessions` to check active sessions.
 
@@ -41,6 +42,10 @@ Sends a prompt to an active Claude Code session. The session maintains context a
 **Parameters:**
 - `session_id` (required) — which session to use
 - `prompt` (required) — the coding task or follow-up
+- `context` (optional) — per-task context prepended to this send only. Use for relevant specs, vault pages, conversation excerpts.
+- `include_diff` (optional, default true) — capture git diff of changes made during this send. Requires the cwd to be a git repo.
+
+Context injection: if the session has `instructions` (from start) and/or this send has `context`, they are prepended to the prompt using XML-style `<instructions>` and `<context>` tags. The LLM sees them as structured preamble before the task.
 
 **Returns structured data alongside a text summary:**
 - `exit_status` — `success`, `error`, `budget_exhausted`, `timeout`, or `cancelled`
@@ -51,9 +56,12 @@ Sends a prompt to an active Claude Code session. The session maintains context a
 - `duration_ms` — wall time for this send
 - `send_count` — total sends in this session
 - `num_turns` — LLM turns in this send
-- `result_text` — final text from Claude Code
+- `result_text` — final text from Claude Code (truncated to 500 chars)
 - `sdk_session_id` — for debugging
 - `log_path` — path to JSONL log file
+- `diff` — git diff of changes made during this send (`null` if not a git repo or diff capture failed; `""` if no changes were made)
+
+The `diff` field captures three categories: committed changes (if Claude Code made commits), unstaged edits to tracked files, and a list of new untracked files. Use it to review what changed without separately reading files.
 
 Use `exit_status` to branch programmatically: if `success`, move on; if `error`, send a fix prompt or run `claude_code_exec` to diagnose.
 
@@ -91,6 +99,14 @@ Shows all active sessions with ID, working directory, age, and cost so far.
 2. **Send** tasks with `claude_code_send` — iterate as needed
 3. **Stop** when done with `claude_code_stop`
 
+### With context and review
+1. **Start** → `claude_code_start` with `instructions` for project conventions
+2. **Send** → `claude_code_send` with `context` (specs, vault pages) and `include_diff=true`
+3. **Review** → inspect the `diff` field in the structured result
+4. **Fix** → if changes need adjustment, `claude_code_send` with feedback
+5. **Verify** → `claude_code_exec` to run tests
+6. **Stop** → `claude_code_stop` when satisfied
+
 ### Verify loop (TDD-style)
 1. **Start** → `claude_code_start` with optional `setup_command`
 2. **Implement** → `claude_code_send` with the coding task
@@ -102,6 +118,15 @@ Shows all active sessions with ID, working directory, age, and cost so far.
 The exec tool makes the verify steps cheap (no LLM cost, no latency). Use this pattern for iterative development.
 
 Sessions expire after 30 minutes of inactivity. If a session expires, start a new one and restate the context.
+
+## Git Best Practice
+
+**Always use git-initialized working directories for Claude Code sessions.** This enables:
+- Reliable diff capture after each send (`include_diff=true`)
+- Change tracking and rollback if needed
+- The parent agent can review exactly what changed
+
+If the cwd isn't already a git repo, consider running `claude_code_exec` with `git init && git add -A && git commit -m "initial"` before sending coding tasks.
 
 ## Cost Awareness
 

--- a/src/decafclaw/skills/claude_code/output.py
+++ b/src/decafclaw/skills/claude_code/output.py
@@ -108,7 +108,8 @@ class SessionLogger:
         return "\n".join(parts)
 
     def build_data(self, session_id: str = "", exit_status: str = "success",
-                   sdk_session_id: str | None = None, send_count: int = 0) -> dict:
+                   sdk_session_id: str | None = None, send_count: int = 0,
+                   diff: str | None = None) -> dict:
         """Return structured result dict with JSON-safe types only."""
         from collections import Counter
         tool_counts = dict(Counter(self.tools_used))
@@ -127,6 +128,7 @@ class SessionLogger:
             "result_text_truncated": len(self.result_text) > 500,
             "sdk_session_id": sdk_session_id or "",
             "log_path": str(self.path),
+            "diff": diff,
         }
 
     def log_exec(self, command: str, exit_code: int | None,

--- a/src/decafclaw/skills/claude_code/sessions.py
+++ b/src/decafclaw/skills/claude_code/sessions.py
@@ -22,6 +22,7 @@ class Session:
     total_cost_usd: float = 0
     send_count: int = 0
     approved: bool = False
+    instructions: str = ""
 
 
 class SessionManager:
@@ -35,7 +36,8 @@ class SessionManager:
         self.budget_max = budget_max
 
     def create(self, cwd: str, description: str = "",
-               model: str | None = None, budget_usd: float | None = None) -> Session:
+               model: str | None = None, budget_usd: float | None = None,
+               instructions: str = "") -> Session:
         """Create a new session. Raises ValueError if cwd already has an active session."""
         # Resolve and normalize path
         cwd = str(cwd).rstrip("/")
@@ -63,6 +65,7 @@ class SessionManager:
             budget_usd=budget,
             created_at=now,
             last_active=now,
+            instructions=instructions,
         )
         self.sessions[session.session_id] = session
         self.cwd_to_session[cwd] = session.session_id

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -70,6 +70,17 @@ _PROBE_FILES = ["Makefile", "pyproject.toml", "package.json", "go.mod", "Cargo.t
                 "CLAUDE.md", "README.md", ".env"]
 
 
+def _assemble_prompt(prompt: str, instructions: str = "", context: str = "") -> str:
+    """Build the full prompt with optional instructions and context preamble."""
+    parts = []
+    if instructions:
+        parts.append(f"<instructions>\n{instructions}\n</instructions>")
+    if context:
+        parts.append(f"<context>\n{context}\n</context>")
+    parts.append(prompt)
+    return "\n\n".join(parts)
+
+
 async def _probe_environment(cwd: str) -> dict:
     """Run a quick environment probe in cwd. Best-effort, 5s timeout."""
     result: dict = {"tools_available": [], "project_files": [], "git": None}
@@ -149,9 +160,71 @@ async def _run_setup_command(cwd: str, command: str, timeout: float = 30.0) -> d
     }
 
 
+async def _get_git_head(cwd: str) -> str | None:
+    """Get the current git HEAD hash, or None if not a git repo / empty repo."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", cwd, "rev-parse", "HEAD",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode == 0:
+            return stdout.decode().strip()
+        return None
+    except Exception:
+        return None
+
+
+async def _capture_git_diff(cwd: str, baseline_ref: str | None) -> str | None:
+    """Capture git diff since baseline. Returns None if not applicable, "" if no changes."""
+    if baseline_ref is None:
+        return None
+
+    try:
+        parts = []
+
+        # 1. Committed changes since baseline (baseline..HEAD, excludes working tree)
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", cwd, "diff", f"{baseline_ref}..HEAD",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        committed_diff = stdout.decode(errors="replace").strip() if proc.returncode == 0 else ""
+        if committed_diff:
+            parts.append(committed_diff)
+
+        # 2. Unstaged changes to tracked files (working tree vs index)
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", cwd, "diff",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        unstaged_diff = stdout.decode(errors="replace").strip() if proc.returncode == 0 else ""
+        if unstaged_diff:
+            parts.append(unstaged_diff)
+
+        # 3. New untracked files
+        proc = await asyncio.create_subprocess_exec(
+            "git", "-C", cwd, "ls-files", "--others", "--exclude-standard",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        untracked = stdout.decode(errors="replace").strip() if proc.returncode == 0 else ""
+        if untracked:
+            file_list = "\n".join(f"  {f}" for f in untracked.splitlines() if f)
+            parts.append(f"New untracked files:\n{file_list}")
+
+        return "\n".join(parts) if parts else ""
+
+    except Exception as e:
+        log.warning(f"Git diff capture failed: {e}")
+        return None
+
+
 async def tool_claude_code_start(ctx, cwd: str, description: str = "",
                                   model: str = "", budget_usd: float = 0,
-                                  setup_command: str = "") -> ToolResult:
+                                  setup_command: str = "",
+                                  instructions: str = "") -> ToolResult:
     """Start a new Claude Code session for a working directory within the workspace."""
     log.info(f"[tool:claude_code_start] cwd={cwd}")
     manager = _get_manager()
@@ -173,6 +246,7 @@ async def tool_claude_code_start(ctx, cwd: str, description: str = "",
             description=description,
             model=model or None,
             budget_usd=budget_usd if budget_usd > 0 else None,
+            instructions=instructions,
         )
     except ValueError as e:
         return ToolResult(text=f"[error: {e}]")
@@ -277,12 +351,15 @@ def _send_error_data(exit_status: str, **extra) -> dict:
         "result_text_truncated": False,
         "sdk_session_id": "",
         "log_path": "",
+        "diff": None,
     }
     data.update(extra)
     return data
 
 
-async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> ToolResult:
+async def tool_claude_code_send(ctx, session_id: str, prompt: str,
+                                context: str = "",
+                                include_diff: bool = True) -> ToolResult:
     """Send a prompt to an active Claude Code session."""
     log.info(f"[tool:claude_code_send] session={session_id}")
     manager = _get_manager()
@@ -366,12 +443,20 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> ToolResult
     # Set up logger (log_dir already created above for stderr)
     logger = SessionLogger(log_dir, session.session_id)
 
+    # Capture git baseline for diff (before any changes)
+    baseline_ref = None
+    if include_diff:
+        baseline_ref = await _get_git_head(session.cwd)
+
+    # Assemble full prompt with session instructions and per-send context
+    full_prompt = _assemble_prompt(prompt, session.instructions, context)
+
     # Wrap prompt as async iterable (required when can_use_tool is set)
     # Format per SDK docs: type, message, parent_tool_use_id, session_id
     async def prompt_stream():
         yield {
             "type": "user",
-            "message": {"role": "user", "content": prompt},
+            "message": {"role": "user", "content": full_prompt},
             "parent_tool_use_id": None,
             "session_id": session.sdk_session_id or "default",
         }
@@ -418,12 +503,18 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str) -> ToolResult
     session.send_count += 1
     manager.touch(session_id)
 
+    # Capture git diff of changes made during this send
+    diff = None
+    if include_diff:
+        diff = await _capture_git_diff(session.cwd, baseline_ref)
+
     summary = logger.build_summary(session_id)
     data = logger.build_data(
         session_id=session_id,
         exit_status="error" if logger.errors else "success",
         sdk_session_id=session.sdk_session_id,
         send_count=session.send_count,
+        diff=diff,
     )
     return ToolResult(text=summary, data=data)
 
@@ -635,6 +726,13 @@ TOOL_DEFINITIONS = [
                             "is ready (e.g., 'uv sync', 'npm install'). Requires confirmation."
                         ),
                     },
+                    "instructions": {
+                        "type": "string",
+                        "description": (
+                            "Persistent instructions prepended to every send in this session. "
+                            "Use for project conventions, coding style, constraints."
+                        ),
+                    },
                 },
                 "required": ["cwd"],
             },
@@ -659,6 +757,20 @@ TOOL_DEFINITIONS = [
                     "prompt": {
                         "type": "string",
                         "description": "The coding task or follow-up message",
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": (
+                            "Per-task context prepended to this send only. "
+                            "Use for relevant specs, vault pages, conversation excerpts."
+                        ),
+                    },
+                    "include_diff": {
+                        "type": "boolean",
+                        "description": (
+                            "Capture git diff of changes made during this send (default true). "
+                            "Requires the cwd to be a git repo."
+                        ),
                     },
                 },
                 "required": ["session_id", "prompt"],

--- a/tests/test_claude_code_context.py
+++ b/tests/test_claude_code_context.py
@@ -1,0 +1,67 @@
+"""Tests for Claude Code context injection — prompt assembly and session instructions."""
+
+from decafclaw.skills.claude_code.sessions import Session, SessionManager
+from decafclaw.skills.claude_code.tools import _assemble_prompt
+
+
+def test_assemble_prompt_both():
+    """Instructions + context + prompt produces correct XML tags and ordering."""
+    result = _assemble_prompt(
+        prompt="Fix the bug",
+        instructions="Use pytest. Follow PEP 8.",
+        context="Here's the spec:\n- Must handle edge cases",
+    )
+    assert "<instructions>" in result
+    assert "Use pytest. Follow PEP 8." in result
+    assert "</instructions>" in result
+    assert "<context>" in result
+    assert "Here's the spec:" in result
+    assert "</context>" in result
+    assert "Fix the bug" in result
+    # Ordering: instructions before context before prompt
+    assert result.index("<instructions>") < result.index("<context>")
+    assert result.index("</context>") < result.index("Fix the bug")
+
+
+def test_assemble_prompt_instructions_only():
+    """Only instructions + prompt — no context tags."""
+    result = _assemble_prompt(prompt="Fix the bug", instructions="Use pytest.")
+    assert "<instructions>" in result
+    assert "Use pytest." in result
+    assert "</instructions>" in result
+    assert "<context>" not in result
+    assert "Fix the bug" in result
+
+
+def test_assemble_prompt_context_only():
+    """Only context + prompt — no instructions tags."""
+    result = _assemble_prompt(prompt="Fix the bug", context="The spec says...")
+    assert "<instructions>" not in result
+    assert "<context>" in result
+    assert "The spec says..." in result
+    assert "</context>" in result
+    assert "Fix the bug" in result
+
+
+def test_assemble_prompt_neither():
+    """No instructions or context — prompt unchanged."""
+    result = _assemble_prompt(prompt="Fix the bug")
+    assert result == "Fix the bug"
+    assert "<" not in result
+
+
+def test_session_stores_instructions():
+    """Session dataclass stores instructions field."""
+    manager = SessionManager(timeout_sec=300, budget_default=2.0, budget_max=10.0)
+    session = manager.create(
+        cwd="/tmp/test",
+        description="test",
+        instructions="Always use type hints.",
+    )
+    assert session.instructions == "Always use type hints."
+
+
+def test_session_default_instructions():
+    """Session instructions default to empty string."""
+    session = Session(session_id="abc", cwd="/tmp")
+    assert session.instructions == ""

--- a/tests/test_claude_code_diff.py
+++ b/tests/test_claude_code_diff.py
@@ -1,0 +1,132 @@
+"""Tests for git diff capture helpers — _get_git_head and _capture_git_diff."""
+
+import subprocess
+
+import pytest
+
+from decafclaw.skills.claude_code.tools import _capture_git_diff, _get_git_head
+
+
+def _git(cwd, *args):
+    """Run a git command in the given directory."""
+    subprocess.run(["git", "-C", str(cwd)] + list(args),
+                   check=True, capture_output=True)
+
+
+def _init_repo(tmp_path):
+    """Create a git repo with one initial commit."""
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "test@test.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "initial.txt").write_text("hello\n")
+    _git(tmp_path, "add", "initial.txt")
+    _git(tmp_path, "commit", "-m", "initial")
+
+
+@pytest.mark.asyncio
+async def test_get_git_head_returns_hash(tmp_path):
+    """Returns a 40-char hex hash for a repo with commits."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+    assert head is not None
+    assert len(head) == 40
+    assert all(c in "0123456789abcdef" for c in head)
+
+
+@pytest.mark.asyncio
+async def test_get_git_head_not_a_repo(tmp_path):
+    """Returns None for a plain directory."""
+    head = await _get_git_head(str(tmp_path))
+    assert head is None
+
+
+@pytest.mark.asyncio
+async def test_get_git_head_empty_repo(tmp_path):
+    """Returns None for a repo with no commits."""
+    _git(tmp_path, "init")
+    head = await _get_git_head(str(tmp_path))
+    assert head is None
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_modified_file(tmp_path):
+    """Captures diff for a modified tracked file."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+
+    (tmp_path / "initial.txt").write_text("changed\n")
+
+    diff = await _capture_git_diff(str(tmp_path), head)
+    assert diff is not None
+    assert "hello" in diff
+    assert "changed" in diff
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_new_untracked_file(tmp_path):
+    """Lists new untracked files."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+
+    (tmp_path / "newfile.py").write_text("print('hi')\n")
+
+    diff = await _capture_git_diff(str(tmp_path), head)
+    assert diff is not None
+    assert "New untracked files:" in diff
+    assert "newfile.py" in diff
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_committed_change(tmp_path):
+    """Captures diff for changes committed after baseline."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+
+    # Make a new commit after baseline
+    (tmp_path / "new.txt").write_text("new content\n")
+    _git(tmp_path, "add", "new.txt")
+    _git(tmp_path, "commit", "-m", "add new file")
+
+    diff = await _capture_git_diff(str(tmp_path), head)
+    assert diff is not None
+    assert "new content" in diff
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_no_baseline():
+    """Returns None when baseline_ref is None."""
+    diff = await _capture_git_diff("/tmp", None)
+    assert diff is None
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_no_changes(tmp_path):
+    """Returns empty string when nothing changed since baseline."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+
+    diff = await _capture_git_diff(str(tmp_path), head)
+    assert diff == ""
+
+
+@pytest.mark.asyncio
+async def test_capture_diff_committed_plus_unstaged(tmp_path):
+    """Committed change + unstaged edit shows both without duplication."""
+    _init_repo(tmp_path)
+    head = await _get_git_head(str(tmp_path))
+
+    # Make a commit after baseline
+    (tmp_path / "committed.txt").write_text("committed content\n")
+    _git(tmp_path, "add", "committed.txt")
+    _git(tmp_path, "commit", "-m", "add committed file")
+
+    # Also make an unstaged edit to the original file
+    (tmp_path / "initial.txt").write_text("unstaged edit\n")
+
+    diff = await _capture_git_diff(str(tmp_path), head)
+    assert diff is not None
+    # Both changes should appear
+    assert "committed content" in diff
+    assert "unstaged edit" in diff
+    # The committed content should appear exactly once (no duplication)
+    assert diff.count("committed content") == 1

--- a/tests/test_claude_code_output.py
+++ b/tests/test_claude_code_output.py
@@ -169,6 +169,7 @@ def test_build_data_shape(tmp_path):
         exit_status="success",
         sdk_session_id="sdk-456",
         send_count=2,
+        diff="--- a/foo.py\n+++ b/foo.py\n@@ changed @@",
     )
 
     assert data["exit_status"] == "success"
@@ -183,6 +184,7 @@ def test_build_data_shape(tmp_path):
     assert data["result_text_truncated"] is False
     assert data["sdk_session_id"] == "sdk-456"
     assert "test-session" in data["log_path"]
+    assert data["diff"] == "--- a/foo.py\n+++ b/foo.py\n@@ changed @@"
 
     # Must be JSON-serializable
     json_str = json.dumps(data)
@@ -200,6 +202,7 @@ def test_build_data_defaults(tmp_path):
     assert data["errors"] == []
     assert data["cost_usd"] == 0
     assert data["sdk_session_id"] == ""
+    assert data["diff"] is None
 
     json.dumps(data)  # must not raise
 


### PR DESCRIPTION
## Summary

- **Context injection (#207)** — session-level `instructions` (set on start, prepended to every send) and per-send `context` parameter. Uses XML-style `<instructions>` and `<context>` tags for clear LLM signal. Parent agent assembles context strings; skill is a dumb pipe.
- **Diff output (#209)** — auto git-diff after each `claude_code_send`. Captures committed changes, unstaged edits, and new untracked files. `include_diff=true` by default. Diff goes in structured `data.diff` field. Best-effort: gracefully returns `None` if not a git repo.
- **Git best practice** — SKILL.md now advises using git-initialized working directories for reliable diff capture.

Part of the Claude Code subagent improvement initiative (#213).

Closes #207, closes #209.

## Test plan

- [x] `_assemble_prompt`: all combinations of empty/non-empty instructions and context (6 tests)
- [x] `_get_git_head`: real git repo, non-repo, empty repo (3 tests)
- [x] `_capture_git_diff`: modified file, untracked file, committed change, no baseline, no changes (5 tests)
- [x] `build_data()` with diff parameter
- [x] All 1077 tests pass
- [x] `make check` clean (lint + pyright + tsc)
- [ ] Live test: start session with instructions, verify they appear in Claude Code's context
- [ ] Live test: send with context, verify per-task context appears
- [ ] Live test: send with include_diff, verify diff field in structured result

🤖 Generated with [Claude Code](https://claude.com/claude-code)