### PR TITLE
feat: Claude Code richer progress reporting

### DIFF
--- a/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/notes.md
+++ b/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/notes.md
@@ -1,0 +1,3 @@
+# Claude Code Subagent Phase 3 — Notes
+
+<!-- Session notes and final summary -->

--- a/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/plan.md
+++ b/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/plan.md
@@ -1,0 +1,199 @@
+# Claude Code Subagent Phase 3 — Plan
+
+## Overview
+
+Two steps. This is a focused change — all logic is in the streaming loop of `tool_claude_code_send`.
+
+---
+
+## Step 1: Enrich the streaming loop with counts, cost, budget warnings, and error snippets
+
+**What:** Add per-send state tracking and richer progress events to the SDK message streaming loop. Extract budget warning logic into a testable helper.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — modify streaming loop, add budget warning helper
+
+**Details:**
+
+1. Add a helper function for budget warning checks:
+   ```python
+   _BUDGET_THRESHOLDS = [0.5, 0.75, 0.9]
+
+   def _check_budget_warnings(cost: float, budget: float, fired: set) -> list[str]:
+       """Return list of budget warning messages for newly crossed thresholds."""
+       warnings = []
+       for threshold in _BUDGET_THRESHOLDS:
+           if threshold not in fired and budget > 0 and cost >= budget * threshold:
+               pct = int(threshold * 100)
+               warnings.append(
+                   f"Budget warning: {pct}% used (${cost:.2f} of ${budget:.2f})"
+               )
+               fired.add(threshold)
+       return warnings
+   ```
+
+2. Before the streaming loop (after `logger = SessionLogger(...)`, around line 444), initialize per-send state:
+   ```python
+   tool_call_count = 0
+   tool_id_to_name: dict[str, str] = {}
+   warnings_fired: set[float] = set()
+   ```
+
+3. In the `AssistantMessage` branch, for each `ToolUseBlock`:
+   - Increment `tool_call_count`
+   - Record `tool_id_to_name[block.id] = block.name`
+   - Publish: `f"Tool call {tool_call_count}: Using {block.name}..."`
+
+4. Add a `UserMessage` branch (currently not handled in the loop). Import `UserMessage` and `ToolResultBlock` (already imported in output.py but need to check tools.py imports). For each `ToolResultBlock` with `is_error`:
+   - Look up tool name via `tool_id_to_name.get(block.tool_use_id, "unknown tool")`
+   - Get error snippet: first 100 chars of content
+   - Publish: `f"{tool_name} failed — {snippet}"`
+
+5. In the `ResultMessage` branch, after updating cost:
+   - Publish cost: `f"Session cost: ${session.total_cost_usd:.2f} of ${session.budget_usd:.2f} budget"`
+   - Check budget warnings: `for warning in _check_budget_warnings(session.total_cost_usd, session.budget_usd, warnings_fired): await ctx.publish("tool_status", tool="claude_code", message=warning)`
+
+6. Write tests:
+   - `test_check_budget_warnings_fires_at_thresholds`: verify 50/75/90 fire at correct points
+   - `test_check_budget_warnings_no_duplicates`: verify same threshold doesn't fire twice
+   - `test_check_budget_warnings_skips_crossed`: verify jumping from 0% to 80% fires both 50% and 75%
+   - `test_check_budget_warnings_zero_budget`: verify no warnings when budget is 0
+
+**Prompt:**
+
+> In `src/decafclaw/skills/claude_code/tools.py`:
+>
+> 1. Add imports if not present: `UserMessage` and `ToolResultBlock` from `claude_code_sdk`.
+>
+> 2. Add a module-level constant and helper after `_assemble_prompt`:
+>    ```python
+>    _BUDGET_THRESHOLDS = [0.5, 0.75, 0.9]
+>
+>    def _check_budget_warnings(cost: float, budget: float, fired: set) -> list[str]:
+>        """Return list of budget warning messages for newly crossed thresholds."""
+>        warnings = []
+>        for threshold in _BUDGET_THRESHOLDS:
+>            if threshold not in fired and budget > 0 and cost >= budget * threshold:
+>                pct = int(threshold * 100)
+>                warnings.append(
+>                    f"Budget warning: {pct}% used (${cost:.2f} of ${budget:.2f})"
+>                )
+>                fired.add(threshold)
+>        return warnings
+>    ```
+>
+> 3. Before the streaming try block (after `logger = SessionLogger(...)`, around line 444), add:
+>    ```python
+>    tool_call_count = 0
+>    tool_id_to_name: dict[str, str] = {}
+>    warnings_fired: set[float] = set()
+>    ```
+>
+> 4. Replace the current `AssistantMessage` ToolUseBlock handling:
+>    ```python
+>    # Old:
+>    elif isinstance(block, ToolUseBlock):
+>        await ctx.publish("tool_status", tool="claude_code",
+>                          message=f"Using {block.name}...")
+>
+>    # New:
+>    elif isinstance(block, ToolUseBlock):
+>        tool_call_count += 1
+>        tool_id_to_name[block.id] = block.name
+>        await ctx.publish(
+>            "tool_status", tool="claude_code",
+>            message=f"Tool call {tool_call_count}: Using {block.name}..."
+>        )
+>    ```
+>
+> 5. Add a `UserMessage` branch after the `AssistantMessage` block (before `elif isinstance(message, ResultMessage)`):
+>    ```python
+>    elif isinstance(message, UserMessage):
+>        for block in getattr(message, "content", []):
+>            if isinstance(block, ToolResultBlock) and block.is_error:
+>                tool_name = tool_id_to_name.get(block.tool_use_id, "unknown tool")
+>                snippet = (block.content if isinstance(block.content, str)
+>                           else str(block.content))[:100]
+>                await ctx.publish(
+>                    "tool_status", tool="claude_code",
+>                    message=f"{tool_name} failed — {snippet}"
+>                )
+>    ```
+>
+> 6. In the `ResultMessage` branch, after the cost update (`session.total_cost_usd = message.total_cost_usd`), add:
+>    ```python
+>    # Publish cost progress
+>    await ctx.publish(
+>        "tool_status", tool="claude_code",
+>        message=f"Session cost: ${session.total_cost_usd:.2f} of ${session.budget_usd:.2f} budget"
+>    )
+>    # Check budget warnings
+>    for warning in _check_budget_warnings(
+>        session.total_cost_usd, session.budget_usd, warnings_fired
+>    ):
+>        await ctx.publish("tool_status", tool="claude_code", message=warning)
+>    ```
+>
+> 7. Write tests in `tests/test_claude_code_progress.py`:
+>    ```python
+>    from decafclaw.skills.claude_code.tools import _check_budget_warnings
+>
+>    def test_fires_at_thresholds():
+>        fired = set()
+>        # At 50%
+>        warnings = _check_budget_warnings(1.0, 2.0, fired)
+>        assert len(warnings) == 1
+>        assert "50%" in warnings[0]
+>        # At 75%
+>        warnings = _check_budget_warnings(1.5, 2.0, fired)
+>        assert len(warnings) == 1
+>        assert "75%" in warnings[0]
+>        # At 90%
+>        warnings = _check_budget_warnings(1.8, 2.0, fired)
+>        assert len(warnings) == 1
+>        assert "90%" in warnings[0]
+>
+>    def test_no_duplicates():
+>        fired = set()
+>        _check_budget_warnings(1.0, 2.0, fired)
+>        warnings = _check_budget_warnings(1.0, 2.0, fired)
+>        assert len(warnings) == 0
+>
+>    def test_jumps_fire_multiple():
+>        fired = set()
+>        warnings = _check_budget_warnings(1.6, 2.0, fired)
+>        assert len(warnings) == 2  # 50% and 75%
+>        assert "50%" in warnings[0]
+>        assert "75%" in warnings[1]
+>
+>    def test_zero_budget():
+>        fired = set()
+>        warnings = _check_budget_warnings(1.0, 0, fired)
+>        assert len(warnings) == 0
+>    ```
+>
+> Run `make lint` and `make test`.
+
+---
+
+## Step 2: Update SKILL.md + docs
+
+**What:** Document the richer progress events in SKILL.md.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/SKILL.md`
+
+**Prompt:**
+
+> Update `src/decafclaw/skills/claude_code/SKILL.md`:
+>
+> 1. Add a "Progress Reporting" section (after "Permission Model") documenting:
+>    - Tool call count: each tool use is numbered ("Tool call 5: Using Edit...")
+>    - Error snippets: tool failures are reported with the first 100 chars of error text
+>    - Running cost: session cost updates published on each ResultMessage
+>    - Budget warnings: published when cost crosses 50%, 75%, 90% of session budget
+>    - All events use the `tool_status` event type
+>
+> 2. Note that cost is session-total (cumulative across sends), not per-send.
+>
+> Run `make check` one final time.

--- a/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/spec.md
+++ b/docs/dev-sessions/2026-04-05-1228-claude-code-subagent-phase3/spec.md
@@ -1,0 +1,80 @@
+# Claude Code Subagent Phase 3 — Spec
+
+## Goal
+
+Enrich progress reporting during `claude_code_send` so the parent agent and Mattermost display have better situational awareness. Currently progress events are coarse ("Using Edit..."). This adds tool call counts, running cost, budget warnings, and error snippets.
+
+Covers issue: #212 (richer progress reporting). Part of umbrella #213.
+
+Note: #210 (structured error classification) was closed as not planned — the parent LLM can classify errors from raw messages better than any rule-based system.
+
+## 1. Enriched progress events (#212)
+
+### Tool call count
+
+Track a per-send tool call counter (resets each `claude_code_send`). Include it in progress messages:
+
+- On tool use: `"Tool call 5: Using Edit..."`
+- On tool error: `"Edit failed — ModuleNotFoundError: No module named 'foo'"` (no count prefix — the tool name identifies which tool failed)
+
+Counter increments for each `ToolUseBlock` seen in `AssistantMessage`.
+
+### Tool result snippets
+
+When a `UserMessage` contains `ToolResultBlock` entries with `is_error=True`, publish a progress event with the error snippet (first 100 chars). This gives the parent agent signal that things are going wrong without waiting for the send to complete.
+
+### Running cost
+
+When a `ResultMessage` arrives with cost data, publish a progress event:
+
+- `"Session cost: $0.45 of $2.00 budget"`
+
+### Budget warnings
+
+When cost crosses threshold percentages of the session budget, publish a warning:
+
+- 50%: `"Budget warning: 50% used ($1.00 of $2.00)"`
+- 75%: `"Budget warning: 75% used ($1.50 of $2.00)"`
+- 90%: `"Budget warning: 90% used ($1.80 of $2.00)"`
+
+Track which thresholds have been crossed per-send to avoid duplicate warnings (e.g., if cost jumps from 40% to 80%, fire both 50% and 75% warnings).
+
+### Event type
+
+All progress events use the existing `tool_status` event type with richer message text. No new event types needed.
+
+## 2. Edge cases and constraints
+
+### Tool name lookup for error snippets
+
+`ToolResultBlock` carries `tool_use_id` but not the tool name. To show `"Tool call 5: Edit failed — ..."`, we need a mapping from tool_use_id → tool_name built during the loop as we see `ToolUseBlock` entries. If the id isn't found (shouldn't happen, but defensive), fall back to `"unknown tool"`.
+
+### Multiple ResultMessages
+
+The SDK may yield multiple `ResultMessage`s with updated cost. The budget threshold tracking (`warnings_fired` set) handles this correctly — thresholds already fired won't fire again.
+
+### Cost is session-total, not per-send
+
+`ResultMessage.total_cost_usd` is the cumulative session cost. Progress messages should say `"Session cost: $0.45 of $2.00 budget"` (not just "Cost:") to avoid confusion with per-send cost.
+
+## 3. Implementation approach
+
+All changes are in the SDK message streaming loop inside `tool_claude_code_send` in `tools.py`. The loop already iterates over `AssistantMessage`, `UserMessage`, and `ResultMessage` — we just enrich what's published.
+
+State needed during the loop:
+- `tool_call_count: int = 0` — increments per ToolUseBlock
+- `tool_id_to_name: dict[str, str]` — maps ToolUseBlock.id → name for error snippet lookup
+- `warnings_fired: set` — tracks which budget thresholds (0.5, 0.75, 0.9) have been published
+
+## 4. Files changed
+
+- `src/decafclaw/skills/claude_code/tools.py` — enrich the streaming loop in `tool_claude_code_send`
+- `src/decafclaw/skills/claude_code/SKILL.md` — document richer progress events
+- Tests for budget warning threshold logic
+
+## 5. Out of scope
+
+- Phase detection (reading/writing/testing/stuck) — too heuristic, parent LLM can infer
+- Structured error classification (#210) — closed as not planned
+- New event types — reuse tool_status
+- File staging (#211) — next phase

--- a/src/decafclaw/skills/claude_code/SKILL.md
+++ b/src/decafclaw/skills/claude_code/SKILL.md
@@ -139,3 +139,12 @@ Each Claude Code interaction costs money (Anthropic API usage). The structured r
 ## Permission Model
 
 Claude Code tools require confirmation before executing. The first `claude_code_send` or `claude_code_exec` in a session requires user approval (via Mattermost reactions or web UI). Once approved, subsequent calls in the same session are auto-approved. Setup commands also require confirmation.
+
+## Progress Reporting
+
+During `claude_code_send`, the skill publishes `tool_status` events with richer detail:
+
+- **Tool call count**: Each tool use is numbered — `"Tool call 5: Using Edit..."`. Counter resets per send.
+- **Error snippets**: Tool failures include the tool name and first 100 chars of error text — `"Edit failed — SyntaxError: unexpected indent"`. Published as they happen, before the send completes.
+- **Running cost**: Session cost updated on each SDK result — `"Session cost: $0.45 of $2.00 budget"`. Note: this is cumulative session cost, not per-send.
+- **Budget warnings**: Published when session cost crosses 50%, 75%, and 90% of the session budget. Each threshold fires at most once per send.

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -11,7 +11,9 @@ from claude_code_sdk import (
     ClaudeCodeOptions,
     ResultMessage,
     TextBlock,
+    ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
     query,
 )
 
@@ -79,6 +81,24 @@ def _assemble_prompt(prompt: str, instructions: str = "", context: str = "") -> 
         parts.append(f"<context>\n{context}\n</context>")
     parts.append(prompt)
     return "\n\n".join(parts)
+
+
+_BUDGET_THRESHOLDS = [0.5, 0.75, 0.9]
+
+
+def _check_budget_warnings(cost: float, budget: float, fired: set[float]) -> list[str]:
+    """Return list of budget warning messages for newly crossed thresholds."""
+    warnings = []
+    for threshold in _BUDGET_THRESHOLDS:
+        if threshold not in fired and budget > 0 and cost >= budget * threshold:
+            pct = int(threshold * 100)
+            actual_pct = (cost / budget) * 100
+            warnings.append(
+                f"Budget warning: exceeded {pct}% threshold "
+                f"({actual_pct:.0f}% used, ${cost:.2f} of ${budget:.2f})"
+            )
+            fired.add(threshold)
+    return warnings
 
 
 async def _probe_environment(cwd: str) -> dict:
@@ -443,6 +463,11 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
     # Set up logger (log_dir already created above for stderr)
     logger = SessionLogger(log_dir, session.session_id)
 
+    # Per-send progress tracking
+    tool_call_count = 0
+    tool_id_to_name: dict[str, str] = {}
+    warnings_fired: set[float] = set()
+
     # Capture git baseline for diff (before any changes)
     baseline_ref = None
     if include_diff:
@@ -477,9 +502,23 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                         # Don't publish every text chunk — just tool usage
                         pass
                     elif isinstance(block, ToolUseBlock):
+                        tool_call_count += 1
+                        tool_id_to_name[block.id] = block.name
                         await ctx.publish(
                             "tool_status", tool="claude_code",
-                            message=f"Using {block.name}..."
+                            message=f"Tool call {tool_call_count}: Using {block.name}..."
+                        )
+
+            elif isinstance(message, UserMessage):
+                for block in getattr(message, "content", []):
+                    if isinstance(block, ToolResultBlock) and block.is_error:
+                        tool_name = tool_id_to_name.get(
+                            block.tool_use_id, "unknown tool")
+                        snippet = (block.content if isinstance(block.content, str)
+                                   else str(block.content))[:100]
+                        await ctx.publish(
+                            "tool_status", tool="claude_code",
+                            message=f"{tool_name} failed — {snippet}"
                         )
 
             elif isinstance(message, ResultMessage):
@@ -489,6 +528,19 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                 # Update cost tracking
                 if message.total_cost_usd is not None:
                     session.total_cost_usd = message.total_cost_usd
+                    await ctx.publish(
+                        "tool_status", tool="claude_code",
+                        message=(f"Session cost: ${session.total_cost_usd:.2f} "
+                                 f"of ${session.budget_usd:.2f} budget")
+                    )
+                    for warning in _check_budget_warnings(
+                        session.total_cost_usd, session.budget_usd,
+                        warnings_fired
+                    ):
+                        await ctx.publish(
+                            "tool_status", tool="claude_code",
+                            message=warning
+                        )
 
     except Exception as e:
         log.error(f"Claude Code SDK error: {e}", exc_info=True)

--- a/tests/test_claude_code_progress.py
+++ b/tests/test_claude_code_progress.py
@@ -1,0 +1,64 @@
+"""Tests for Claude Code budget warning threshold logic."""
+
+from decafclaw.skills.claude_code.tools import _check_budget_warnings
+
+
+def test_fires_at_thresholds():
+    """Warnings fire at 50%, 75%, 90% thresholds."""
+    fired = set()
+    # At 50%
+    warnings = _check_budget_warnings(1.0, 2.0, fired)
+    assert len(warnings) == 1
+    assert "50%" in warnings[0]
+    assert "$1.00" in warnings[0]
+    # At 75%
+    warnings = _check_budget_warnings(1.5, 2.0, fired)
+    assert len(warnings) == 1
+    assert "75%" in warnings[0]
+    # At 90%
+    warnings = _check_budget_warnings(1.8, 2.0, fired)
+    assert len(warnings) == 1
+    assert "90%" in warnings[0]
+
+
+def test_no_duplicates():
+    """Same threshold doesn't fire twice."""
+    fired = set()
+    _check_budget_warnings(1.0, 2.0, fired)
+    assert 0.5 in fired
+    warnings = _check_budget_warnings(1.0, 2.0, fired)
+    assert len(warnings) == 0
+
+
+def test_jumps_fire_multiple():
+    """Jumping from 0% to 80% fires both 50% and 75% with actual percentage."""
+    fired = set()
+    warnings = _check_budget_warnings(1.6, 2.0, fired)
+    assert len(warnings) == 2
+    assert "exceeded 50%" in warnings[0]
+    assert "80% used" in warnings[0]  # actual percentage, not threshold
+    assert "exceeded 75%" in warnings[1]
+
+
+def test_zero_budget():
+    """No warnings when budget is 0 (avoids division issues)."""
+    fired = set()
+    warnings = _check_budget_warnings(1.0, 0, fired)
+    assert len(warnings) == 0
+
+
+def test_below_threshold():
+    """No warnings when cost is below 50%."""
+    fired = set()
+    warnings = _check_budget_warnings(0.5, 2.0, fired)
+    assert len(warnings) == 0
+
+
+def test_all_thresholds_at_once():
+    """Cost at 100% fires all three thresholds."""
+    fired = set()
+    warnings = _check_budget_warnings(2.0, 2.0, fired)
+    assert len(warnings) == 3
+    assert "50%" in warnings[0]
+    assert "75%" in warnings[1]
+    assert "90%" in warnings[2]


### PR DESCRIPTION
## Summary

- **Tool call counts**: Each tool use numbered per-send — `"Tool call 5: Using Edit..."`
- **Error snippets**: Tool failures published with tool name and first 100 chars — `"Edit failed — SyntaxError: unexpected indent"`
- **Running cost**: Session cost published on each SDK result — `"Session cost: $0.45 of $2.00 budget"`
- **Budget warnings**: Published when session cost crosses 50%, 75%, 90% of budget. Each threshold fires at most once per send.

All events use existing `tool_status` type. No new event types.

Also closed #210 (structured error classification) as not planned — the parent LLM classifies errors better than any rule-based system.

Part of the Claude Code subagent improvement initiative (#213).

Closes #212.

## Test plan

- [x] `_check_budget_warnings`: threshold firing, no duplicates, jump scenarios, zero budget, below threshold, all-at-once (6 tests)
- [x] All 1084 tests pass
- [x] `make check` clean (lint + pyright + tsc)
- [ ] Live test: send a task, verify numbered tool calls in Mattermost progress
- [ ] Live test: trigger a tool error, verify error snippet appears
- [ ] Live test: run an expensive task, verify cost and budget warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)