### PR TITLE
feat: file staging between parent workspace and Claude Code sessions

### DIFF
--- a/docs/dev-sessions/2026-04-05-1747-file-staging/notes.md
+++ b/docs/dev-sessions/2026-04-05-1747-file-staging/notes.md
@@ -1,0 +1,3 @@
+# File Staging — Notes
+
+<!-- Session notes and final summary -->

--- a/docs/dev-sessions/2026-04-05-1747-file-staging/plan.md
+++ b/docs/dev-sessions/2026-04-05-1747-file-staging/plan.md
@@ -1,0 +1,49 @@
+# File Staging — Plan
+
+## Overview
+
+Two steps. Simple feature — two new tool functions following existing patterns.
+
+---
+
+## Step 1: Add push and pull tool functions + TOOL_DEFINITIONS
+
+**What:** Add `tool_claude_code_push_file` and `tool_claude_code_pull_file` functions, register in TOOLS dict and TOOL_DEFINITIONS.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/tools.py` — add `shutil` import, two tool functions, TOOLS entries, TOOL_DEFINITIONS entries
+- Tests for both tools
+
+**Details:**
+
+1. Add `import shutil` at the top of tools.py.
+
+2. Add `tool_claude_code_push_file(ctx, session_id, source_path, dest_name="")`:
+   - Look up session, return error if not found
+   - Resolve source_path relative to workspace, enforce sandbox with is_relative_to
+   - Check source exists and is a file (not directory)
+   - Resolve dest_name (default to basename of source_path) relative to session cwd, enforce sandbox
+   - Create parent dirs for dest if needed
+   - shutil.copy2(source, dest)
+   - Touch session
+   - Return ToolResult with status, source, dest, size_bytes
+
+3. Add `tool_claude_code_pull_file(ctx, session_id, source_name, dest_path="")`:
+   - Same pattern in reverse
+   - Resolve source_name relative to session cwd, enforce sandbox
+   - Check source exists and is a file
+   - Resolve dest_path (default to basename of source_name) relative to workspace, enforce sandbox
+   - Create parent dirs, copy, touch, return ToolResult
+
+4. Add both to TOOLS dict and TOOL_DEFINITIONS.
+
+5. Write tests using tmp_path fixtures — mock _config and _session_manager for sandbox testing.
+
+---
+
+## Step 2: Update SKILL.md + docs
+
+**What:** Document the new tools in SKILL.md.
+
+**Files:**
+- `src/decafclaw/skills/claude_code/SKILL.md`

--- a/docs/dev-sessions/2026-04-05-1747-file-staging/spec.md
+++ b/docs/dev-sessions/2026-04-05-1747-file-staging/spec.md
@@ -1,0 +1,101 @@
+# File Staging Between Parent and Child — Spec
+
+## Goal
+
+Add file transfer tools to the Claude Code skill so the parent agent can push files into a session's working directory and pull files back out. Reduces ad-hoc path juggling for multi-step workflows (specs in, artifacts out).
+
+Covers issue: #211 (file staging). Part of umbrella #213.
+
+## 1. New tools
+
+### `claude_code_push_file(session_id, source_path, dest_name)`
+
+Copy a file from the parent's workspace into the session's cwd.
+
+**Parameters:**
+- `session_id` (required) — active session
+- `source_path` (required) — path relative to the parent's workspace
+- `dest_name` (optional) — filename or relative path within the session's cwd. Defaults to the basename of `source_path`.
+
+**Behavior:**
+- Resolve `source_path` relative to the workspace, enforce sandbox (must be within workspace)
+- Resolve `dest_name` relative to the session's cwd
+- Create parent directories for `dest_name` if needed
+- Copy using `shutil.copy2` (preserves metadata, handles binary)
+- Touch session (update last_active)
+
+**Returns:** `ToolResult` with `data`:
+```python
+{
+    "status": "success",
+    "source": str,      # resolved source path
+    "dest": str,        # resolved dest path
+    "size_bytes": int,  # file size after copy
+}
+```
+
+### `claude_code_pull_file(session_id, source_name, dest_path)`
+
+Copy a file from the session's cwd to the parent's workspace.
+
+**Parameters:**
+- `session_id` (required) — active session
+- `source_name` (required) — filename or relative path within the session's cwd
+- `dest_path` (optional) — path relative to the parent's workspace. Defaults to the basename of `source_name`.
+
+**Behavior:**
+- Resolve `source_name` relative to the session's cwd
+- Resolve `dest_path` relative to the workspace, enforce sandbox (must be within workspace)
+- Create parent directories for `dest_path` if needed
+- Copy using `shutil.copy2`
+- Touch session (update last_active)
+
+**Returns:** `ToolResult` with `data`:
+```python
+{
+    "status": "success",
+    "source": str,      # resolved source path
+    "dest": str,        # resolved dest path
+    "size_bytes": int,  # file size after copy
+}
+```
+
+## 2. Design decisions
+
+### Confirmation model
+Auto-approved — no user confirmation needed. Both paths are sandboxed (workspace on one side, session cwd on the other), and the parent agent explicitly requests the copy.
+
+### File types
+Supports any file type (text, binary, images, build artifacts). Uses `shutil.copy2` which copies bytes transparently.
+
+### Scope
+Single files only. No directory support in initial implementation. The parent can push multiple files with multiple calls.
+
+### Path traversal protection
+Both push and pull enforce that resolved paths stay within their respective sandboxes:
+- Push: `source_path` must resolve within workspace, `dest_name` must resolve within session cwd
+- Pull: `source_name` must resolve within session cwd, `dest_path` must resolve within workspace
+Use `Path.is_relative_to()` for checks (same pattern as `claude_code_start`).
+
+### Overwrite behavior
+If the destination file already exists, it is silently overwritten. This matches standard `shutil.copy2` behavior.
+
+### Error handling
+- Session not found/expired → error ToolResult
+- Source file doesn't exist → error ToolResult
+- Source is a directory → error ToolResult (files only)
+- Path outside sandbox → error ToolResult
+- Copy failure (permissions, disk space) → error ToolResult with exception message
+
+## 3. Files changed
+
+- `src/decafclaw/skills/claude_code/tools.py` — add two tool functions, TOOLS dict entries, TOOL_DEFINITIONS
+- `src/decafclaw/skills/claude_code/SKILL.md` — document new tools
+- Tests for push and pull (sandbox enforcement, missing files, happy path)
+
+## 4. Out of scope
+
+- Directory push/pull (may add later if needed)
+- Streaming/chunked transfer for large files
+- File diffing or content inspection
+- Shared mount / symlink approach

--- a/src/decafclaw/skills/claude_code/SKILL.md
+++ b/src/decafclaw/skills/claude_code/SKILL.md
@@ -84,11 +84,45 @@ Runs a shell command directly in a session's working directory. No LLM involved 
 
 **Confirmation model:** Inherits from session approval. If the user has already approved a `claude_code_send` for this session, exec calls are auto-approved. Otherwise, requests its own confirmation.
 
-### 4. `claude_code_stop` — End a session
+### 4. `claude_code_push_file` — Push a file to the session
+
+Copies a file from the parent's workspace into the session's working directory. Use to provide specs, configs, or reference files to the coding session.
+
+**Parameters:**
+- `session_id` (required) — which session to use
+- `source_path` (required) — path to the file in the workspace (relative to workspace root)
+- `dest_name` (optional) — filename or relative path within the session's cwd. Defaults to the basename of source_path.
+
+**Returns structured data:**
+- `status` — `success` or `error`
+- `source` — resolved source path
+- `dest` — resolved dest path
+- `size_bytes` — file size after copy
+
+Auto-approved — no user confirmation needed. Supports any file type (text, binary). Single files only.
+
+### 5. `claude_code_pull_file` — Pull a file from the session
+
+Copies a file from the session's working directory to the parent's workspace. Use to retrieve build artifacts, generated code, or test results.
+
+**Parameters:**
+- `session_id` (required) — which session to use
+- `source_name` (required) — filename or relative path within the session's cwd
+- `dest_path` (optional) — path in the workspace to copy to (relative to workspace root). Defaults to the basename of source_name.
+
+**Returns structured data:**
+- `status` — `success` or `error`
+- `source` — resolved source path
+- `dest` — resolved dest path
+- `size_bytes` — file size after copy
+
+Auto-approved. Supports any file type. Single files only.
+
+### 6. `claude_code_stop` — End a session
 
 Closes a session and reports final cost.
 
-### 5. `claude_code_sessions` — List active sessions
+### 7. `claude_code_sessions` — List active sessions
 
 Shows all active sessions with ID, working directory, age, and cost so far.
 
@@ -139,6 +173,8 @@ Each Claude Code interaction costs money (Anthropic API usage). The structured r
 ## Permission Model
 
 Claude Code tools require confirmation before executing. The first `claude_code_send` or `claude_code_exec` in a session requires user approval (via Mattermost reactions or web UI). Once approved, subsequent calls in the same session are auto-approved. Setup commands also require confirmation.
+
+**Exceptions:** `claude_code_push_file` and `claude_code_pull_file` are auto-approved without user confirmation — they only copy files within sandboxed paths (workspace ↔ session cwd).
 
 ## Progress Reporting
 

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -685,6 +686,128 @@ async def tool_claude_code_exec(ctx, session_id: str, command: str,
     return ToolResult(text="\n".join(parts), data=data)
 
 
+async def tool_claude_code_push_file(ctx, session_id: str, source_path: str,
+                                     dest_name: str = "") -> ToolResult:
+    """Copy a file from the parent's workspace into the session's cwd."""
+    log.info(f"[tool:claude_code_push_file] session={session_id} source={source_path}")
+    manager = _get_manager()
+
+    session = manager.get(session_id)
+    if session is None:
+        return ToolResult(
+            text=(f"[error: session '{session_id}' not found or expired.]"),
+            data={"status": "error"},
+        )
+
+    # Resolve source relative to workspace, enforce sandbox
+    workspace = _config.workspace_path if _config else Path(".")
+    source = (workspace / source_path).resolve()
+    if not source.is_relative_to(workspace.resolve()):
+        return ToolResult(
+            text=f"[error: source path must be within the workspace ({workspace})]",
+            data={"status": "error"},
+        )
+    if not source.exists():
+        return ToolResult(
+            text=f"[error: source file not found: {source_path}]",
+            data={"status": "error"},
+        )
+    if not source.is_file():
+        return ToolResult(
+            text=f"[error: source is not a file (directories not supported): {source_path}]",
+            data={"status": "error"},
+        )
+
+    # Resolve dest relative to session cwd, enforce sandbox
+    if not dest_name:
+        dest_name = source.name
+    dest = Path(session.cwd, dest_name).resolve()
+    if not dest.is_relative_to(Path(session.cwd).resolve()):
+        return ToolResult(
+            text=f"[error: dest path must be within the session cwd ({session.cwd})]",
+            data={"status": "error"},
+        )
+
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+    except Exception as e:
+        return ToolResult(
+            text=f"[error: copy failed: {e}]",
+            data={"status": "error"},
+        )
+
+    manager.touch(session_id)
+    size = dest.stat().st_size
+
+    return ToolResult(
+        text=f"Pushed `{source_path}` → `{dest_name}` ({size} bytes)",
+        data={"status": "success", "source": str(source), "dest": str(dest),
+              "size_bytes": size},
+    )
+
+
+async def tool_claude_code_pull_file(ctx, session_id: str, source_name: str,
+                                     dest_path: str = "") -> ToolResult:
+    """Copy a file from the session's cwd to the parent's workspace."""
+    log.info(f"[tool:claude_code_pull_file] session={session_id} source={source_name}")
+    manager = _get_manager()
+
+    session = manager.get(session_id)
+    if session is None:
+        return ToolResult(
+            text=(f"[error: session '{session_id}' not found or expired.]"),
+            data={"status": "error"},
+        )
+
+    # Resolve source relative to session cwd, enforce sandbox
+    source = Path(session.cwd, source_name).resolve()
+    if not source.is_relative_to(Path(session.cwd).resolve()):
+        return ToolResult(
+            text=f"[error: source path must be within the session cwd ({session.cwd})]",
+            data={"status": "error"},
+        )
+    if not source.exists():
+        return ToolResult(
+            text=f"[error: source file not found: {source_name}]",
+            data={"status": "error"},
+        )
+    if not source.is_file():
+        return ToolResult(
+            text=f"[error: source is not a file (directories not supported): {source_name}]",
+            data={"status": "error"},
+        )
+
+    # Resolve dest relative to workspace, enforce sandbox
+    workspace = _config.workspace_path if _config else Path(".")
+    if not dest_path:
+        dest_path = source.name
+    dest = (workspace / dest_path).resolve()
+    if not dest.is_relative_to(workspace.resolve()):
+        return ToolResult(
+            text=f"[error: dest path must be within the workspace ({workspace})]",
+            data={"status": "error"},
+        )
+
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, dest)
+    except Exception as e:
+        return ToolResult(
+            text=f"[error: copy failed: {e}]",
+            data={"status": "error"},
+        )
+
+    manager.touch(session_id)
+    size = dest.stat().st_size
+
+    return ToolResult(
+        text=f"Pulled `{source_name}` → `{dest_path}` ({size} bytes)",
+        data={"status": "success", "source": str(source), "dest": str(dest),
+              "size_bytes": size},
+    )
+
+
 async def tool_claude_code_stop(ctx, session_id: str) -> str:
     """Stop a Claude Code session and clean up."""
     log.info(f"[tool:claude_code_stop] session={session_id}")
@@ -738,6 +861,8 @@ TOOLS = {
     "claude_code_start": tool_claude_code_start,
     "claude_code_send": tool_claude_code_send,
     "claude_code_exec": tool_claude_code_exec,
+    "claude_code_push_file": tool_claude_code_push_file,
+    "claude_code_pull_file": tool_claude_code_pull_file,
     "claude_code_stop": tool_claude_code_stop,
     "claude_code_sessions": tool_claude_code_sessions,
 }
@@ -855,6 +980,70 @@ TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["session_id", "command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "claude_code_push_file",
+            "description": (
+                "Copy a file from the parent's workspace into a Claude Code session's "
+                "working directory. Use to provide specs, configs, or other files to "
+                "the coding session."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID from claude_code_start",
+                    },
+                    "source_path": {
+                        "type": "string",
+                        "description": "Path to the file in the workspace (relative to workspace root)",
+                    },
+                    "dest_name": {
+                        "type": "string",
+                        "description": (
+                            "Filename or relative path within the session's cwd. "
+                            "Defaults to the basename of source_path."
+                        ),
+                    },
+                },
+                "required": ["session_id", "source_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "claude_code_pull_file",
+            "description": (
+                "Copy a file from a Claude Code session's working directory to the "
+                "parent's workspace. Use to retrieve build artifacts, generated code, "
+                "or test results."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {
+                        "type": "string",
+                        "description": "Session ID from claude_code_start",
+                    },
+                    "source_name": {
+                        "type": "string",
+                        "description": "Filename or relative path within the session's cwd",
+                    },
+                    "dest_path": {
+                        "type": "string",
+                        "description": (
+                            "Path in the workspace to copy to (relative to workspace root). "
+                            "Defaults to the basename of source_name."
+                        ),
+                    },
+                },
+                "required": ["session_id", "source_name"],
             },
         },
     },

--- a/tests/test_claude_code_file_staging.py
+++ b/tests/test_claude_code_file_staging.py
@@ -1,0 +1,256 @@
+"""Tests for Claude Code file staging — push and pull between workspace and session."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import decafclaw.skills.claude_code.tools as cc_tools
+from decafclaw.skills.claude_code.sessions import SessionManager
+
+
+@pytest.fixture
+def staging_env(tmp_path):
+    """Set up workspace, session cwd, and module state for file staging tests."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_cwd = tmp_path / "workspace" / "projects" / "myrepo"
+    session_cwd.mkdir(parents=True)
+
+    # Create a session manager and session
+    manager = SessionManager(timeout_sec=300, budget_default=2.0, budget_max=10.0)
+    session = manager.create(cwd=str(session_cwd))
+
+    # Mock module-level _config
+    config = MagicMock()
+    config.workspace_path = workspace
+
+    # Patch module state
+    old_config = cc_tools._config
+    old_manager = cc_tools._session_manager
+    cc_tools._config = config
+    cc_tools._session_manager = manager
+
+    yield {
+        "workspace": workspace,
+        "session_cwd": session_cwd,
+        "session": session,
+        "manager": manager,
+    }
+
+    cc_tools._config = old_config
+    cc_tools._session_manager = old_manager
+
+
+@pytest.fixture
+def ctx():
+    """Minimal context mock."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_push_file_happy_path(staging_env, ctx):
+    """Push a file from workspace to session cwd."""
+    workspace = staging_env["workspace"]
+    session = staging_env["session"]
+
+    # Create source file in workspace
+    (workspace / "spec.md").write_text("# My Spec\n")
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "spec.md"
+    )
+
+    assert result.data["status"] == "success"
+    assert result.data["size_bytes"] > 0
+    dest = Path(result.data["dest"])
+    assert dest.exists()
+    assert dest.read_text() == "# My Spec\n"
+    assert dest.name == "spec.md"
+
+
+@pytest.mark.asyncio
+async def test_push_file_custom_dest(staging_env, ctx):
+    """Push with a custom dest_name."""
+    workspace = staging_env["workspace"]
+    session = staging_env["session"]
+
+    (workspace / "spec.md").write_text("content")
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "spec.md", dest_name="docs/spec.md"
+    )
+
+    assert result.data["status"] == "success"
+    dest = Path(result.data["dest"])
+    assert dest.name == "spec.md"
+    assert "docs" in str(dest)
+    assert dest.read_text() == "content"
+
+
+@pytest.mark.asyncio
+async def test_push_file_source_not_found(staging_env, ctx):
+    """Error when source file doesn't exist."""
+    session = staging_env["session"]
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "nonexistent.txt"
+    )
+
+    assert result.data["status"] == "error"
+    assert "not found" in result.text
+
+
+@pytest.mark.asyncio
+async def test_push_file_source_is_directory(staging_env, ctx):
+    """Error when source is a directory."""
+    workspace = staging_env["workspace"]
+    session = staging_env["session"]
+
+    (workspace / "somedir").mkdir()
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "somedir"
+    )
+
+    assert result.data["status"] == "error"
+    assert "not a file" in result.text
+
+
+@pytest.mark.asyncio
+async def test_push_file_dest_traversal(staging_env, ctx):
+    """Error when dest_name tries to escape session cwd."""
+    workspace = staging_env["workspace"]
+    session = staging_env["session"]
+
+    (workspace / "spec.md").write_text("content")
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "spec.md", dest_name="../../../../etc/evil"
+    )
+
+    assert result.data["status"] == "error"
+    assert "must be within" in result.text
+
+
+@pytest.mark.asyncio
+async def test_push_file_session_not_found(staging_env, ctx):
+    """Error when session doesn't exist."""
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, "nonexistent", "spec.md"
+    )
+
+    assert result.data["status"] == "error"
+    assert "not found" in result.text
+
+
+@pytest.mark.asyncio
+async def test_pull_file_happy_path(staging_env, ctx):
+    """Pull a file from session cwd to workspace."""
+    session = staging_env["session"]
+    session_cwd = staging_env["session_cwd"]
+
+    # Create source file in session cwd
+    (session_cwd / "output.txt").write_text("build result\n")
+
+    result = await cc_tools.tool_claude_code_pull_file(
+        ctx, session.session_id, "output.txt"
+    )
+
+    assert result.data["status"] == "success"
+    assert result.data["size_bytes"] > 0
+    dest = Path(result.data["dest"])
+    assert dest.exists()
+    assert dest.read_text() == "build result\n"
+
+
+@pytest.mark.asyncio
+async def test_pull_file_custom_dest(staging_env, ctx):
+    """Pull with a custom dest_path."""
+    session = staging_env["session"]
+    session_cwd = staging_env["session_cwd"]
+
+    (session_cwd / "output.txt").write_text("content")
+
+    result = await cc_tools.tool_claude_code_pull_file(
+        ctx, session.session_id, "output.txt", dest_path="results/output.txt"
+    )
+
+    assert result.data["status"] == "success"
+    dest = Path(result.data["dest"])
+    assert dest.read_text() == "content"
+    assert "results" in str(dest)
+
+
+@pytest.mark.asyncio
+async def test_pull_file_source_not_found(staging_env, ctx):
+    """Error when source file doesn't exist in session."""
+    session = staging_env["session"]
+
+    result = await cc_tools.tool_claude_code_pull_file(
+        ctx, session.session_id, "nonexistent.txt"
+    )
+
+    assert result.data["status"] == "error"
+    assert "not found" in result.text
+
+
+@pytest.mark.asyncio
+async def test_pull_file_source_traversal(staging_env, ctx):
+    """Error when source_name tries to escape session cwd."""
+    session = staging_env["session"]
+
+    result = await cc_tools.tool_claude_code_pull_file(
+        ctx, session.session_id, "../../../../etc/passwd"
+    )
+
+    assert result.data["status"] == "error"
+    assert "must be within" in result.text
+
+
+@pytest.mark.asyncio
+async def test_push_file_source_traversal(staging_env, ctx):
+    """Error when source_path tries to escape workspace."""
+    session = staging_env["session"]
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "../../outside.txt"
+    )
+
+    assert result.data["status"] == "error"
+    assert "must be within" in result.text
+
+
+@pytest.mark.asyncio
+async def test_pull_file_dest_traversal(staging_env, ctx):
+    """Error when dest_path tries to escape workspace."""
+    session = staging_env["session"]
+    session_cwd = staging_env["session_cwd"]
+
+    (session_cwd / "output.txt").write_text("content")
+
+    result = await cc_tools.tool_claude_code_pull_file(
+        ctx, session.session_id, "output.txt", dest_path="../../outside.txt"
+    )
+
+    assert result.data["status"] == "error"
+    assert "must be within" in result.text
+
+
+@pytest.mark.asyncio
+async def test_push_binary_file(staging_env, ctx):
+    """Push handles binary files correctly."""
+    workspace = staging_env["workspace"]
+    session = staging_env["session"]
+
+    binary_data = bytes(range(256))
+    (workspace / "image.bin").write_bytes(binary_data)
+
+    result = await cc_tools.tool_claude_code_push_file(
+        ctx, session.session_id, "image.bin"
+    )
+
+    assert result.data["status"] == "success"
+    dest = Path(result.data["dest"])
+    assert dest.read_bytes() == binary_data


### PR DESCRIPTION
## Summary

- **`claude_code_push_file`** — copy a file from the parent workspace into a session's cwd (provide specs, configs)
- **`claude_code_pull_file`** — copy a file from a session's cwd to the workspace (retrieve artifacts, generated code)
- Sandbox enforced with `is_relative_to` on both sides (workspace and session cwd)
- Supports binary files via `shutil.copy2`
- Auto-approved — no user confirmation needed
- Single files only, returns structured `ToolResult` with status, paths, size_bytes

Part of the Claude Code subagent improvement initiative (#213).

Closes #211.

## Test plan

- [x] Push happy path — file copied, data correct
- [x] Push with custom dest_name — subdirectory created
- [x] Push source not found — error
- [x] Push source is directory — error
- [x] Push dest path traversal — blocked
- [x] Push session not found — error
- [x] Pull happy path — file copied back
- [x] Pull with custom dest_path — subdirectory created
- [x] Pull source not found — error
- [x] Pull source path traversal — blocked
- [x] Binary file push — bytes preserved
- [x] All 1095 tests pass
- [x] `make check` clean (lint + pyright + tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)