### PR TITLE
refactor: rename wiki_context/memory_context to vault_references/vault_retrieval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/context_composer.py` — Context composer: unified context assembly, relevance scoring, dynamic budget allocation
 - `src/decafclaw/frontmatter.py` — YAML frontmatter parsing/serialization for vault pages (summary, keywords, tags, importance)
 - `src/decafclaw/events.py` — In-process pub/sub event bus
-- `src/decafclaw/memory_context.py` — Proactive memory retrieval: embedding search, graph expansion, metadata enrichment
+- `src/decafclaw/memory_context.py` — Vault retrieval: embedding search, graph expansion, metadata enrichment
 - `src/decafclaw/archive.py` — Conversation archive (JSONL per conversation)
 - `src/decafclaw/compaction.py` — History compaction via summarization
 - `src/decafclaw/embeddings.py` — Semantic search index (sqlite-vec cosine similarity)
@@ -156,7 +156,7 @@ Session docs live in `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`, `
 - **Vault page frontmatter.** Vault pages support optional YAML frontmatter with `summary`, `keywords`, `tags`, `importance` fields. Parsed by `frontmatter.py`. Composite embeddings prepend metadata to body for richer semantic search. Frontmatter is LLM-generated (Phase B) and human-editable.
 - **Wiki-link graph expansion.** Memory context retrieval follows `[[wiki-links]]` one hop from top embedding hits to expand the candidate pool. Linked pages get discounted similarity and compete on composite score. Configurable via `RelevanceConfig.graph_expansion_enabled`.
 - **Proactive memory context is fail-open.** Before each interactive turn, relevant memories/wiki are auto-injected as context via the ContextComposer. Errors silently return empty results. Skipped for heartbeat, scheduled tasks, and child agents. Requires an embedding model to be configured — silently disabled otherwise.
-- **Vault chat context.** Users can share vault pages into conversations via `@[[PageName]]` mentions (all channels) or by having a page open in the web UI sidebar. Pages are injected once per conversation as `wiki_context` role messages, tracked by scanning history. Parsing happens in the ContextComposer via helpers in `agent.py`. Page resolution uses vault root, not a fixed wiki directory.
+- **Vault chat context.** Users can share vault pages into conversations via `@[[PageName]]` mentions (all channels) or by having a page open in the web UI sidebar. Pages are injected once per conversation as `vault_references` role messages, tracked by scanning history. Parsing happens in the ContextComposer via helpers in `agent.py`. Page resolution uses vault root, not a fixed wiki directory.
 - **Context diagnostics sidecar.** After each turn, the agent loop writes `workspace/conversations/{conv_id}.context.json` with per-source token estimates, scoring details, and memory candidate breakdowns. REST endpoint `GET /api/conversations/{id}/context` returns this data. Web UI popover with waffle chart visualization triggered by clicking the context bar.
 - **LOG_LEVEL env var.** Set `LOG_LEVEL=DEBUG` for verbose logging (default: INFO).
 

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -51,7 +51,7 @@ The composer is mode-aware via `ComposerMode`:
 | `SCHEDULED` | No | No | Full | Scheduled tasks (set via `ctx.task_mode="scheduled"`) |
 | `CHILD_AGENT` | No | No | Full | `delegate_task` sub-agents (set via `ctx.is_child`) |
 
-`skip_memory_context` on the context is an independent flag — it skips memory retrieval without affecting wiki injection or the composer mode.
+`skip_vault_retrieval` on the context is an independent flag — it skips vault retrieval without affecting vault references or the composer mode.
 
 ### Source diagnostics
 

--- a/docs/dev-sessions/2026-04-05-2221-vault-rename/notes.md
+++ b/docs/dev-sessions/2026-04-05-2221-vault-rename/notes.md
@@ -1,0 +1,1 @@
+# Vault Rename — Notes

--- a/docs/dev-sessions/2026-04-05-2221-vault-rename/plan.md
+++ b/docs/dev-sessions/2026-04-05-2221-vault-rename/plan.md
@@ -1,0 +1,3 @@
+# Vault Rename — Plan
+
+Mechanical rename. Find all occurrences, replace, lint, test.

--- a/docs/dev-sessions/2026-04-05-2221-vault-rename/spec.md
+++ b/docs/dev-sessions/2026-04-05-2221-vault-rename/spec.md
@@ -1,0 +1,10 @@
+# Vault Rename — Spec
+
+Mechanical rename of wiki/memory context terminology to vault_references/vault_retrieval.
+
+- `wiki_context` → `vault_references` (explicit page injection via @[[Page]] or sidebar)
+- `memory_context` → `vault_retrieval` (semantic search, auto-injected)
+
+Module file `memory_context.py` stays as-is (named for purpose, not the old terminology).
+
+Ripple: context_composer.py, agent.py, archive.py, compaction.py, events, web UI JS, mattermost display, config_types.py, CLAUDE.md, docs.

--- a/docs/memory-context.md
+++ b/docs/memory-context.md
@@ -1,13 +1,13 @@
-# Proactive Memory Context
+# Proactive Vault Retrieval
 
-Automatically surfaces relevant memories, wiki entries, and conversation snippets before each agent turn — without the agent needing to explicitly search.
+Automatically surfaces relevant vault entries (pages, journal, user notes, conversation snippets) before each agent turn — without the agent needing to explicitly search.
 
 ## How it works
 
 Before each turn, the agent:
 
 1. Embeds the user's current message
-2. Runs semantic search across all indexed content (wiki, memory, conversation)
+2. Runs semantic search across all indexed content (vault pages, journal, conversation)
 3. Filters results by similarity threshold
 4. Injects matching entries as a context message before the user's message
 
@@ -15,7 +15,7 @@ The LLM sees this context alongside the conversation and can use it naturally. T
 
 ## Configuration
 
-All settings live under the `memory_context` section in `config.json`:
+All settings live under the `vault_retrieval` section in `config.json`:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -25,13 +25,13 @@ All settings live under the `memory_context` section in `config.json`:
 | `max_tokens` | int | `500` | Token budget for injected context |
 | `show_in_ui` | bool | `true` | Show retrieval indicator in chat UI |
 
-Environment variable prefix: `MEMORY_CONTEXT_` (e.g., `MEMORY_CONTEXT_ENABLED=false`).
+Environment variable prefix: `VAULT_RETRIEVAL_` (e.g., `VAULT_RETRIEVAL_ENABLED=false`).
 
 ### Example config.json
 
 ```json
 {
-  "memory_context": {
+  "vault_retrieval": {
     "enabled": true,
     "similarity_threshold": 0.4,
     "max_results": 3,
@@ -48,12 +48,12 @@ Environment variable prefix: `MEMORY_CONTEXT_` (e.g., `MEMORY_CONTEXT_ENABLED=fa
 
 ## Skip conditions
 
-Memory context retrieval is skipped for non-interactive turns:
+Vault retrieval is skipped for non-interactive turns:
 
 - Heartbeat cycles
 - Scheduled tasks
 - Delegated subtasks (child agents)
-- Any turn with `skip_memory_context` set on the context
+- Any turn with `skip_vault_retrieval` set on the context
 
 Only interactive conversations (Mattermost, web UI, terminal) trigger retrieval.
 
@@ -62,20 +62,18 @@ Only interactive conversations (Mattermost, web UI, terminal) trigger retrieval.
 When `show_in_ui` is true:
 
 - **Web UI**: An expandable block shows the full retrieved context with source types and relevance scores. Visible both live and on conversation reload.
-- **Mattermost**: A concise summary post shows the count of retrieved items by source type (e.g., "🧠 Retrieved 1 wiki, 3 conversation"). Full text is not shown since Mattermost posts can't collapse.
+- **Mattermost**: A concise summary post shows the count of retrieved items by source type (e.g., "🧠 Retrieved 1 page, 3 conversation"). Full text is not shown since Mattermost posts can't collapse.
 
-Note: `show_in_ui` gates the live progress event. The `memory_context` message is always archived for auditability and will appear on web UI history reload regardless of this setting. To fully suppress, disable the feature with `enabled: false`.
+Note: `show_in_ui` gates the live progress event. The `vault_retrieval` message is always archived for auditability and will appear on web UI history reload regardless of this setting. To fully suppress, disable the feature with `enabled: false`.
 
 ## Source priority
 
-Wiki entries receive a 1.2x similarity boost (configured in the embeddings layer), so curated wiki content naturally ranks above raw memory entries at equal semantic distance.
+Wiki entries receive a 1.2x similarity boost (configured in the embeddings layer), so curated vault pages naturally rank above raw entries at equal semantic distance.
 
 ## Disabling
 
-Set `memory_context.enabled` to `false` in config, or set `MEMORY_CONTEXT_ENABLED=false` in the environment.
+Set `vault_retrieval.enabled` to `false` in config, or set `VAULT_RETRIEVAL_ENABLED=false` in the environment.
 
 ## Related
 
-- [Memory](memory.md) — The memory save/search tools (still available for explicit use)
-- [Knowledge Base (Wiki)](wiki.md) — Wiki entries are included in retrieval
 - [Semantic Search](semantic-search.md) — The underlying embedding index

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -695,10 +695,10 @@ def _read_wiki_page(config, page_name: str) -> str | None:
 
 
 def _get_already_injected_pages(history: list) -> set[str]:
-    """Scan history for wiki_context messages and return set of page names."""
+    """Scan history for vault_references messages and return set of page names."""
     pages: set[str] = set()
     for msg in history:
-        if msg.get("role") == "wiki_context":
+        if msg.get("role") == "vault_references":
             page = msg.get("wiki_page")
             if page:
                 pages.add(page)
@@ -755,24 +755,24 @@ async def _prepare_messages(
             else:
                 text = f"[Referenced wiki page: {ref['page']}]\n\n{content}"
             wc_msg: dict = {
-                "role": "wiki_context",
+                "role": "vault_references",
                 "content": text,
                 "wiki_page": ref["page"],
             }
             history.append(wc_msg)
             _archive(ctx, wc_msg)
-            await ctx.publish("wiki_context", text=text, page=ref["page"])
+            await ctx.publish("vault_references", text=text, page=ref["page"])
 
     # Proactive memory context — inject before user message in history
     # (but publish the UI event after the user message so it renders below)
     retrieved_context_text = ""
     mc_results = None
-    if not ctx.skip_memory_context:
+    if not ctx.skip_vault_retrieval:
         from .memory_context import format_memory_context, retrieve_memory_context
         mc_results = await retrieve_memory_context(config, user_message)
         if mc_results:
             retrieved_context_text = format_memory_context(mc_results)
-            mc_msg = {"role": "memory_context", "content": retrieved_context_text}
+            mc_msg = {"role": "vault_retrieval", "content": retrieved_context_text}
             history.append(mc_msg)
             _archive(ctx, mc_msg)
 
@@ -789,7 +789,7 @@ async def _prepare_messages(
     # Build the messages array: system prompt + history
     # Filter out metadata roles (effort, reflection) that aren't valid LLM messages
     # Remap non-standard roles that should appear in LLM context
-    ROLE_REMAP = {"memory_context": "user", "wiki_context": "user"}
+    ROLE_REMAP = {"vault_retrieval": "user", "vault_references": "user"}
     from .archive import LLM_ROLES
     llm_history = []
     for m in history:
@@ -804,8 +804,8 @@ async def _prepare_messages(
 
     # Publish memory context event after user message so it renders below
     # in the web UI (history ordering is already correct for the LLM)
-    if mc_results and config.memory_context.show_in_ui:
-        await ctx.publish("memory_context",
+    if mc_results and config.vault_retrieval.show_in_ui:
+        await ctx.publish("vault_retrieval",
                           text=retrieved_context_text,
                           results=mc_results)
 
@@ -843,7 +843,7 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
     try:
         # Determine composer mode from context flags.
-        # Note: skip_memory_context is handled directly by the composer,
+        # Note: skip_vault_retrieval is handled directly by the composer,
         # not via mode — HEARTBEAT/SCHEDULED skip wiki too, which isn't
         # always desired when only memory should be skipped.
         _task_mode_map = {

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -60,8 +60,8 @@ def _extract_previous_summary(config, conv_id: str) -> tuple[str | None, str | N
 def _split_into_turns(messages: list[dict]) -> list[list[dict]]:
     """Split a flat message list into turns.
 
-    A turn starts with a user or memory_context message and includes
-    everything until the next turn boundary. memory_context is treated
+    A turn starts with a user or vault_retrieval message and includes
+    everything until the next turn boundary. vault_retrieval is treated
     as a turn start because it's injected before the user message it
     belongs to.
     """
@@ -69,7 +69,7 @@ def _split_into_turns(messages: list[dict]) -> list[list[dict]]:
     current_turn = []
     for msg in messages:
         role = msg.get("role")
-        if role in ("user", "memory_context") and current_turn:
+        if role in ("user", "vault_retrieval") and current_turn:
             turns.append(current_turn)
             current_turn = []
         current_turn.append(msg)

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -24,10 +24,10 @@ from .config_types import (
     HttpConfig,
     LlmConfig,
     MattermostConfig,
-    MemoryContextConfig,
     ReflectionConfig,
     RelevanceConfig,
     VaultConfig,
+    VaultRetrievalConfig,
 )
 
 log = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class Config:
     skills: dict[str, dict[str, Any]] = field(default_factory=dict)
     models: dict[str, dict[str, str]] = field(default_factory=dict)
     reflection: ReflectionConfig = field(default_factory=ReflectionConfig)
-    memory_context: MemoryContextConfig = field(default_factory=MemoryContextConfig)
+    vault_retrieval: VaultRetrievalConfig = field(default_factory=VaultRetrievalConfig)
     relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
 
@@ -336,8 +336,8 @@ def load_config() -> Config:
     reflection = load_sub_config(
         ReflectionConfig, file_data.get("reflection", {}), "REFLECTION")
 
-    memory_context = load_sub_config(
-        MemoryContextConfig, file_data.get("memory_context", {}), "MEMORY_CONTEXT")
+    vault_retrieval = load_sub_config(
+        VaultRetrievalConfig, file_data.get("vault_retrieval", {}), "MEMORY_CONTEXT")
 
     relevance = load_sub_config(
         RelevanceConfig, file_data.get("relevance", {}), "RELEVANCE")
@@ -364,7 +364,7 @@ def load_config() -> Config:
         skills=skills,
         models=models,
         reflection=reflection,
-        memory_context=memory_context,
+        vault_retrieval=vault_retrieval,
         relevance=relevance,
         vault=vault,
         env=env_vars,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -135,7 +135,7 @@ class VaultConfig:
 
 
 @dataclass
-class MemoryContextConfig:
+class VaultRetrievalConfig:
     enabled: bool = True
     similarity_threshold: float = 0.3
     max_results: int = 5

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -68,7 +68,7 @@ class Context:
         self._current_iteration: int = 1
         self.is_child: bool = False
         self.skip_reflection: bool = False
-        self.skip_memory_context: bool = False
+        self.skip_vault_retrieval: bool = False
         self.wiki_page: str | None = None  # open wiki page from web UI
         self.effort: str = "default"
         self.task_mode: str = ""  # "heartbeat" | "scheduled" | "" (interactive)
@@ -86,7 +86,7 @@ class Context:
         effort: str = "default",
         task_mode: str = "",
         skip_reflection: bool = True,
-        skip_memory_context: bool = True,
+        skip_vault_retrieval: bool = True,
         allowed_tools: set | None = None,
         preapproved_tools: set | None = None,
         preapproved_shell_patterns: list[str] | None = None,
@@ -107,7 +107,7 @@ class Context:
         ctx.effort = effort
         ctx.task_mode = task_mode
         ctx.skip_reflection = skip_reflection
-        ctx.skip_memory_context = skip_memory_context
+        ctx.skip_vault_retrieval = skip_vault_retrieval
         if allowed_tools is not None:
             ctx.tools.allowed = allowed_tools
         if preapproved_tools is not None:
@@ -163,7 +163,7 @@ class Context:
         child._current_iteration = self._current_iteration
         child.is_child = self.is_child
         child.skip_reflection = self.skip_reflection
-        child.skip_memory_context = self.skip_memory_context
+        child.skip_vault_retrieval = self.skip_vault_retrieval
         child.wiki_page = self.wiki_page
         child.effort = self.effort
         # Share tools + skills + composer (concurrent tool calls read but don't mutate)

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -28,7 +28,7 @@ class ComposerMode(enum.Enum):
     - SCHEDULED — cron-style scheduled tasks (skips memory + wiki)
     - CHILD_AGENT — delegate_task sub-agents (skips memory + wiki)
 
-    ``skip_memory_context`` on the context is an independent flag that
+    ``skip_vault_retrieval`` on the context is an independent flag that
     skips memory retrieval without affecting wiki injection or mode.
     """
     INTERACTIVE = "interactive"
@@ -178,13 +178,13 @@ class ContextComposer:
 
         # -- Wiki context (injected before user message in history) --
         # Explicit @[[Page]] references are fixed costs — always included.
-        wiki_msgs, wiki_entry = self._compose_wiki_context(
+        wiki_msgs, wiki_entry = self._compose_vault_references(
             ctx, config, user_message, history, mode,
         )
         for wm in wiki_msgs:
             history.append(wm)
             to_archive.append(wm)
-            await ctx.publish("wiki_context", text=wm["content"], page=wm.get("wiki_page"))
+            await ctx.publish("vault_references", text=wm["content"], page=wm.get("wiki_page"))
         if wiki_entry:
             sources.append(wiki_entry)
 
@@ -224,10 +224,10 @@ class ContextComposer:
         memory_budget: int | None = None
         if remaining_budget > 0:
             memory_budget = remaining_budget
-        # else: None → _compose_memory_context falls back to max_tokens
+        # else: None → _compose_vault_retrieval falls back to max_tokens
 
         # -- Memory context (injected before user message in history) --
-        memory_msgs, retrieved_context_text, mc_results, memory_entry = await self._compose_memory_context(
+        memory_msgs, retrieved_context_text, mc_results, memory_entry = await self._compose_vault_retrieval(
             ctx, config, user_message, mode,
             token_budget=memory_budget,
         )
@@ -242,7 +242,7 @@ class ContextComposer:
         to_archive.append(user_msg)
 
         # -- Build LLM messages (filter + remap roles) --
-        role_remap = {"memory_context": "user", "wiki_context": "user"}
+        role_remap = {"vault_retrieval": "user", "vault_references": "user"}
         llm_history = []
         for m in history:
             role = m.get("role")
@@ -280,8 +280,8 @@ class ContextComposer:
         messages.extend(llm_history)
 
         # -- Publish memory context event (after user message for UI ordering) --
-        if mc_results and config.memory_context.show_in_ui:
-            await ctx.publish("memory_context",
+        if mc_results and config.vault_retrieval.show_in_ui:
+            await ctx.publish("vault_retrieval",
                               text=retrieved_context_text,
                               results=mc_results)
 
@@ -359,7 +359,7 @@ class ContextComposer:
         candidates.sort(key=lambda c: c.get("composite_score", 0), reverse=True)
         return candidates
 
-    async def _compose_memory_context(
+    async def _compose_vault_retrieval(
         self, ctx, config, user_message: str, mode: ComposerMode,
         token_budget: int | None = None,
     ) -> tuple[list[dict], str, list[dict], SourceEntry | None]:
@@ -367,7 +367,7 @@ class ContextComposer:
 
         Args:
             token_budget: Dynamic budget from composer. If None, falls back
-                to config.memory_context.max_tokens for backward compatibility.
+                to config.vault_retrieval.max_tokens for backward compatibility.
 
         Returns (messages_to_inject, formatted_text, raw_results, source_entry).
         Retrieval candidates are scored by composite relevance and selected
@@ -377,7 +377,7 @@ class ContextComposer:
         from .util import estimate_tokens
 
         skip_modes = {ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT}
-        if ctx.skip_memory_context or mode in skip_modes:
+        if ctx.skip_vault_retrieval or mode in skip_modes:
             return [], "", [], None
 
         try:
@@ -408,7 +408,7 @@ class ContextComposer:
             results = [r for r in results if r.get("composite_score", 0) >= score_threshold]
 
             # Select by token budget (score order replaces similarity order)
-            budget = token_budget if token_budget is not None else config.memory_context.max_tokens
+            budget = token_budget if token_budget is not None else config.vault_retrieval.max_tokens
             log.debug("Memory context: %d candidates, budget=%d tokens (%s)",
                       total_candidates, budget,
                       "dynamic" if token_budget is not None else "fixed")
@@ -425,7 +425,7 @@ class ContextComposer:
                 r["tokens_estimated"] = estimate_tokens(r.get("entry_text", ""))
 
             formatted = format_memory_context(results)
-            msg = {"role": "memory_context", "content": formatted}
+            msg = {"role": "vault_retrieval", "content": formatted}
 
             # Track injected paths so they're suppressed in future turns
             # (cleared on compaction when the content is summarized away)
@@ -456,7 +456,7 @@ class ContextComposer:
             log.warning("Memory context composition failed", exc_info=True)
             return [], "", [], None
 
-    def _compose_wiki_context(
+    def _compose_vault_references(
         self, ctx, config, user_message: str, history: list, mode: ComposerMode,
     ) -> tuple[list[dict], SourceEntry | None]:
         """Build wiki context messages for referenced/open pages.
@@ -495,7 +495,7 @@ class ContextComposer:
             else:
                 text = f"[Referenced wiki page: {ref['page']}]\n\n{content}"
             messages.append({
-                "role": "wiki_context",
+                "role": "vault_references",
                 "content": text,
                 "wiki_page": ref["page"],
             })

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -780,7 +780,7 @@ class MattermostClient:
                         f"{critique}")
                 await cd.on_tool_status("reflection", text)
 
-        async def handle_memory_context(event):
+        async def handle_vault_retrieval(event):
             assert cd is not None
             results = event.get("results") or []
             if results:
@@ -794,7 +794,7 @@ class MattermostClient:
                         parts.append(f"{source_counts[st]} {st}")
                 summary = ", ".join(parts) or "context"
                 await cd.on_tool_status(
-                    "memory_context",
+                    "vault_retrieval",
                     f"\U0001f9e0 Retrieved {summary}")
 
         async def handle_compaction_start(event):
@@ -847,7 +847,7 @@ class MattermostClient:
                 "tool_media_uploaded": handle_tool_media_uploaded,
                 "tool_confirm_request": handle_tool_confirm_request,
                 "reflection_result": handle_reflection_result,
-                "memory_context": handle_memory_context,
+                "vault_retrieval": handle_vault_retrieval,
             })
         dispatch["compaction_start"] = handle_compaction_start
         dispatch["compaction_end"] = handle_compaction_end

--- a/src/decafclaw/mattermost_display.py
+++ b/src/decafclaw/mattermost_display.py
@@ -164,7 +164,7 @@ class ConversationDisplay:
     async def on_tool_status(self, tool_name, message, tool_call_id=""):
         """Tool status update — edit the tool call's progress message.
 
-        If no existing tool post is found (e.g., memory_context or reflection
+        If no existing tool post is found (e.g., vault_retrieval or reflection
         events that arrive without a preceding tool_start), create a standalone post.
         """
         post_id = self._tool_posts.get(tool_call_id)

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -31,7 +31,7 @@ async def retrieve_memory_context(config, user_message: str) -> list[dict]:
     Fail-open: any error logs a warning and returns empty list.
     """
     try:
-        mc = config.memory_context
+        mc = config.vault_retrieval
         if not mc.enabled:
             return []
         if not config.embedding.model:

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -85,7 +85,7 @@ async def _run_child_turn(parent_ctx, task, effort: str = "",
     child_ctx.on_stream_chunk = None
     child_ctx.is_child = True
     child_ctx.skip_reflection = True
-    child_ctx.skip_memory_context = True
+    child_ctx.skip_vault_retrieval = True
 
     # Set effort level: explicit override > parent's level > default
     child_ctx.effort = effort if effort else getattr(parent_ctx, "effort", "default")

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -46,12 +46,12 @@ export class ChatMessage extends LitElement {
       return html`<tool-message .tool=${this.tool || 'reflection'} .content=${this.content} .icon=${'\u{1f441}'}></tool-message>`;
     }
 
-    if (this.role === 'memory_context') {
-      return html`<tool-message .tool=${'memory_context'} .content=${this.content} .icon=${'\u{1f9e0}'}></tool-message>`;
+    if (this.role === 'vault_retrieval') {
+      return html`<tool-message .tool=${'vault_retrieval'} .content=${this.content} .icon=${'\u{1f9e0}'}></tool-message>`;
     }
 
-    if (this.role === 'wiki_context') {
-      return html`<tool-message .tool=${'wiki_context'} .content=${this.content} .icon=${'\u{1f4d6}'}></tool-message>`;
+    if (this.role === 'vault_references') {
+      return html`<tool-message .tool=${'vault_references'} .content=${this.content} .icon=${'\u{1f4d6}'}></tool-message>`;
     }
 
     if (this.role === 'tool_call') {

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -98,7 +98,7 @@ export class ToolStatusStore {
       case 'tool_status':
         this.#toolStatus = `${msg.tool}: ${msg.message}`;
         if (msg.conv_id === currentConvId) {
-          if (msg.tool === 'memory_context' || msg.tool === 'wiki_context') {
+          if (msg.tool === 'vault_retrieval' || msg.tool === 'vault_references') {
             this.#messageStore.insertBeforeLastUser({
               role: msg.tool,
               content: msg.message,

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -471,22 +471,22 @@ async def _run_agent_turn(websocket, app_ctx, config, event_bus,
                     payload["display_short_text"] = short
                 await ws_send(payload)
 
-            elif event_type == "memory_context":
+            elif event_type == "vault_retrieval":
                 text = event.get("text", "")
                 if text:
                     await ws_send({
                         "type": "tool_status", "conv_id": conv_id,
-                        "tool": "memory_context",
+                        "tool": "vault_retrieval",
                         "message": text,
                         "tool_call_id": "",
                     })
 
-            elif event_type == "wiki_context":
+            elif event_type == "vault_references":
                 text = event.get("text", "")
                 if text:
                     await ws_send({
                         "type": "tool_status", "conv_id": conv_id,
-                        "tool": "wiki_context",
+                        "tool": "vault_references",
                         "message": text,
                         "tool_call_id": "",
                     })

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -148,10 +148,10 @@ class TestGetContextWindowSize:
 
 class TestComposeMemoryContext:
     @pytest.mark.asyncio
-    async def test_skips_when_skip_memory_context(self, ctx, config):
-        ctx.skip_memory_context = True
+    async def test_skips_when_skip_vault_retrieval(self, ctx, config):
+        ctx.skip_vault_retrieval = True
         composer = ContextComposer()
-        msgs, text, raw, entry = await composer._compose_memory_context(
+        msgs, text, raw, entry = await composer._compose_vault_retrieval(
             ctx, config, "hello", ComposerMode.INTERACTIVE,
         )
         assert msgs == []
@@ -162,7 +162,7 @@ class TestComposeMemoryContext:
     @pytest.mark.asyncio
     async def test_skips_for_heartbeat_mode(self, ctx, config):
         composer = ContextComposer()
-        msgs, text, raw, entry = await composer._compose_memory_context(
+        msgs, text, raw, entry = await composer._compose_vault_retrieval(
             ctx, config, "hello", ComposerMode.HEARTBEAT,
         )
         assert msgs == []
@@ -171,7 +171,7 @@ class TestComposeMemoryContext:
     @pytest.mark.asyncio
     async def test_skips_for_child_agent_mode(self, ctx, config):
         composer = ContextComposer()
-        msgs, text, raw, entry = await composer._compose_memory_context(
+        msgs, text, raw, entry = await composer._compose_vault_retrieval(
             ctx, config, "hello", ComposerMode.CHILD_AGENT,
         )
         assert msgs == []
@@ -189,11 +189,11 @@ class TestComposeMemoryContext:
                   return_value="formatted memory"),
         ):
             composer = ContextComposer()
-            msgs, text, raw, entry = await composer._compose_memory_context(
+            msgs, text, raw, entry = await composer._compose_vault_retrieval(
                 ctx, config, "hello", ComposerMode.INTERACTIVE,
             )
             assert len(msgs) == 1
-            assert msgs[0]["role"] == "memory_context"
+            assert msgs[0]["role"] == "vault_retrieval"
             assert text == "formatted memory"
             assert len(raw) == 1
             assert entry is not None
@@ -205,7 +205,7 @@ class TestComposeMemoryContext:
         with patch("decafclaw.memory_context.retrieve_memory_context",
                    new_callable=AsyncMock, side_effect=RuntimeError("boom")):
             composer = ContextComposer()
-            msgs, text, raw, entry = await composer._compose_memory_context(
+            msgs, text, raw, entry = await composer._compose_vault_retrieval(
                 ctx, config, "hello", ComposerMode.INTERACTIVE,
             )
             assert msgs == []
@@ -228,7 +228,7 @@ class TestComposeMemoryContext:
                   return_value="formatted"),
         ):
             composer = ContextComposer()
-            await composer._compose_memory_context(
+            await composer._compose_vault_retrieval(
                 ctx, config, "hello", ComposerMode.INTERACTIVE,
             )
             assert "pages/first.md" in composer.state.injected_paths
@@ -248,12 +248,12 @@ class TestComposeMemoryContext:
         ):
             composer = ContextComposer()
             # First turn: injected
-            _, _, _, entry1 = await composer._compose_memory_context(
+            _, _, _, entry1 = await composer._compose_vault_retrieval(
                 ctx, config, "hello", ComposerMode.INTERACTIVE,
             )
             assert entry1 is not None
             # Second turn: suppressed (already in context)
-            _, _, _, entry2 = await composer._compose_memory_context(
+            _, _, _, entry2 = await composer._compose_vault_retrieval(
                 ctx, config, "hello again", ComposerMode.INTERACTIVE,
             )
             assert entry2 is None  # no results after suppression
@@ -265,7 +265,7 @@ class TestComposeMemoryContext:
 class TestComposeWikiContext:
     def test_skips_for_heartbeat_mode(self, ctx, config):
         composer = ContextComposer()
-        msgs, entry = composer._compose_wiki_context(
+        msgs, entry = composer._compose_vault_references(
             ctx, config, "hello", [], ComposerMode.HEARTBEAT,
         )
         assert msgs == []
@@ -275,7 +275,7 @@ class TestComposeWikiContext:
         # Point vault to non-existent dir
         config.vault.vault_path = str(tmp_path / "nonexistent")
         composer = ContextComposer()
-        msgs, entry = composer._compose_wiki_context(
+        msgs, entry = composer._compose_vault_references(
             ctx, config, "hello", [], ComposerMode.INTERACTIVE,
         )
         assert msgs == []
@@ -291,11 +291,11 @@ class TestComposeWikiContext:
             with patch("decafclaw.agent._read_wiki_page",
                        return_value="Page content here"):
                 composer = ContextComposer()
-                msgs, entry = composer._compose_wiki_context(
+                msgs, entry = composer._compose_vault_references(
                     ctx, config, "@[[TestPage]]", [], ComposerMode.INTERACTIVE,
                 )
                 assert len(msgs) == 1
-                assert msgs[0]["role"] == "wiki_context"
+                assert msgs[0]["role"] == "vault_references"
                 assert "TestPage" in msgs[0]["content"]
                 assert entry is not None
                 assert entry.source == "wiki"
@@ -305,11 +305,11 @@ class TestComposeWikiContext:
         vault_dir = tmp_path / "vault"
         vault_dir.mkdir()
         config.vault.vault_path = str(vault_dir)
-        history = [{"role": "wiki_context", "content": "old", "wiki_page": "TestPage"}]
+        history = [{"role": "vault_references", "content": "old", "wiki_page": "TestPage"}]
         with patch("decafclaw.agent._parse_wiki_references",
                    return_value=[{"page": "TestPage", "source": "mention"}]):
             composer = ContextComposer()
-            msgs, entry = composer._compose_wiki_context(
+            msgs, entry = composer._compose_vault_references(
                 ctx, config, "@[[TestPage]]", history, ComposerMode.INTERACTIVE,
             )
             assert msgs == []

--- a/tests/test_memory_context.py
+++ b/tests/test_memory_context.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from decafclaw.config_types import MemoryContextConfig
+from decafclaw.config_types import VaultRetrievalConfig
 from decafclaw.memory_context import (
     _WIKI_LINK_RE,
     _enrich_results,
@@ -64,7 +64,7 @@ class TestRetrieveMemoryContext:
     @pytest.mark.asyncio
     async def test_disabled(self, config):
         from dataclasses import replace
-        cfg = replace(config, memory_context=MemoryContextConfig(enabled=False))
+        cfg = replace(config, vault_retrieval=VaultRetrievalConfig(enabled=False))
         results = await retrieve_memory_context(cfg, "hello")
         assert results == []
 
@@ -99,7 +99,7 @@ class TestRetrieveMemoryContext:
     @pytest.mark.asyncio
     async def test_respects_max_results(self, config):
         from dataclasses import replace
-        cfg = replace(config, memory_context=MemoryContextConfig(max_results=2))
+        cfg = replace(config, vault_retrieval=VaultRetrievalConfig(max_results=2))
         fake_embedding = [1.0] * 768
         search_results = [_make_result(similarity=0.8) for _ in range(5)]
         with patch("decafclaw.memory_context.embed_text", new_callable=AsyncMock, return_value=fake_embedding), \
@@ -117,7 +117,7 @@ class TestRetrieveMemoryContext:
     async def test_returns_all_candidates_for_composer(self, config):
         """retrieve_memory_context returns all candidates — the composer handles budget trimming."""
         from dataclasses import replace
-        cfg = replace(config, memory_context=MemoryContextConfig(max_tokens=100))
+        cfg = replace(config, vault_retrieval=VaultRetrievalConfig(max_tokens=100))
         fake_embedding = [1.0] * 768
         # Each entry is 400 chars = 100 tokens; all 3 should be returned
         search_results = [

--- a/tests/test_wiki_context.py
+++ b/tests/test_wiki_context.py
@@ -92,12 +92,12 @@ def test_already_injected_empty():
     assert _get_already_injected_pages([]) == set()
 
 
-def test_already_injected_finds_wiki_context():
+def test_already_injected_finds_vault_references():
     history = [
         {"role": "user", "content": "hi"},
-        {"role": "wiki_context", "content": "...", "wiki_page": "Page1"},
+        {"role": "vault_references", "content": "...", "wiki_page": "Page1"},
         {"role": "assistant", "content": "ok"},
-        {"role": "wiki_context", "content": "...", "wiki_page": "Page2"},
+        {"role": "vault_references", "content": "...", "wiki_page": "Page2"},
     ]
     assert _get_already_injected_pages(history) == {"Page1", "Page2"}
 
@@ -114,7 +114,7 @@ def test_already_injected_ignores_other_roles():
 
 
 @pytest.mark.asyncio
-async def test_prepare_messages_injects_wiki_context(ctx):
+async def test_prepare_messages_injects_vault_references(ctx):
     """Wiki context messages are injected into history."""
     from decafclaw.agent import _prepare_messages
 
@@ -129,13 +129,13 @@ async def test_prepare_messages_injects_wiki_context(ctx):
         ctx, ctx.config, "tell me about @[[TestPage]]", history,
     )
 
-    # Check that wiki_context was injected into history
-    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    # Check that vault_references was injected into history
+    wiki_msgs = [m for m in history if m.get("role") == "vault_references"]
     assert len(wiki_msgs) == 1
     assert "wiki content here" in wiki_msgs[0]["content"]
     assert wiki_msgs[0]["wiki_page"] == "TestPage"
 
-    # Check that wiki_context is remapped to "user" in LLM messages
+    # Check that vault_references is remapped to "user" in LLM messages
     user_msgs = [m for m in messages if m["role"] == "user"]
     assert any("wiki content here" in m["content"] for m in user_msgs)
 
@@ -152,14 +152,14 @@ async def test_prepare_messages_skips_already_injected(ctx):
     ctx.skip_memory_context = True
 
     history = [
-        {"role": "wiki_context", "content": "[Referenced wiki page: TestPage]\n\nwiki content",
+        {"role": "vault_references", "content": "[Referenced wiki page: TestPage]\n\nwiki content",
          "wiki_page": "TestPage"},
     ]
     messages, _ = await _prepare_messages(
         ctx, ctx.config, "tell me more about @[[TestPage]]", history,
     )
 
-    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    wiki_msgs = [m for m in history if m.get("role") == "vault_references"]
     assert len(wiki_msgs) == 1  # still just the original, no duplicate
 
 
@@ -180,7 +180,7 @@ async def test_prepare_messages_injects_open_page(ctx):
         ctx, ctx.config, "hello", history,
     )
 
-    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    wiki_msgs = [m for m in history if m.get("role") == "vault_references"]
     assert len(wiki_msgs) == 1
     assert "[Currently viewing wiki page: OpenPage]" in wiki_msgs[0]["content"]
 
@@ -200,6 +200,6 @@ async def test_prepare_messages_missing_page_error(ctx):
         ctx, ctx.config, "see @[[NonExistent]]", history,
     )
 
-    wiki_msgs = [m for m in history if m.get("role") == "wiki_context"]
+    wiki_msgs = [m for m in history if m.get("role") == "vault_references"]
     assert len(wiki_msgs) == 1
     assert "[Wiki page 'NonExistent' not found]" in wiki_msgs[0]["content"]


### PR DESCRIPTION
## Summary

Rename context roles to reflect vault unification (#175):

- `wiki_context` → `vault_references` (explicit @[[Page]] injection)
- `memory_context` → `vault_retrieval` (semantic search, auto-injected)
- `MemoryContextConfig` → `VaultRetrievalConfig`
- `skip_memory_context` → `skip_vault_retrieval`
- Config key: `memory_context` → `vault_retrieval`

The `memory_context.py` module file is kept as-is (named for purpose, not the old terminology). Internal function names (`retrieve_memory_context`, `format_memory_context`) also kept since they live in that module.

22 files touched — mechanical rename across context_composer, agent, compaction, config, context, mattermost, websocket, JS components, tests, and docs.

Closes #196.

## Test plan

- [x] All 1115 tests pass
- [x] `make check` clean (lint + pyright + tsc)
- [ ] Live test: verify vault retrieval still works (Mattermost + web UI)
- [ ] Live test: verify @[[Page]] references inject correctly
- [ ] Verify config.json `vault_retrieval` key is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)