### PR TITLE
fix: concurrent tool calls display correctly in web UI

### DIFF
--- a/docs/dev-sessions/2026-04-06-1146-concurrent-tool-display/plan.md
+++ b/docs/dev-sessions/2026-04-06-1146-concurrent-tool-display/plan.md
@@ -1,0 +1,27 @@
+# Concurrent Tool Display — Plan
+
+## Step 1: message-store.js — key updates on tool_call_id
+
+- `pushMessage` for tool_start: include `tool_call_id` on the message object
+- `updateLastToolCall(content)` → `updateToolCall(toolCallId, content)`: find by tool_call_id, not position
+- `replaceLastToolCall(msg)` → `replaceToolCall(toolCallId, msg)`: find by tool_call_id, not position
+
+## Step 2: tool-status-store.js — track multiple concurrent tools
+
+- Replace `#toolStatus` (single string) with `#activeTools` (Map of tool_call_id → status string)
+- `tool_start`: add entry to map
+- `tool_status`: update entry in map
+- `tool_end`: remove entry from map
+- Expose getter that returns a combined status or null if map is empty
+- Update callers in tool-status-store to pass tool_call_id to message-store methods
+
+## Step 3: tool-status-store.js — pass tool_call_id through to message-store
+
+- `tool_start`: include tool_call_id in pushed message
+- `tool_status`: call `updateToolCall(toolCallId, ...)` instead of `updateLastToolCall(...)`
+- `tool_end`: call `replaceToolCall(toolCallId, ...)` instead of `replaceLastToolCall(...)`
+
+## Step 4: Tests + verify
+
+- Run make check-js (typecheck)
+- Manual verification with concurrent tool scenario

--- a/docs/dev-sessions/2026-04-06-1146-concurrent-tool-display/spec.md
+++ b/docs/dev-sessions/2026-04-06-1146-concurrent-tool-display/spec.md
@@ -1,0 +1,32 @@
+# Concurrent Tool Display Bug — Spec
+
+## Problem
+
+When the agent executes multiple tool calls concurrently (e.g., vault_search x2 + tabstack_research), the web UI displays them incorrectly:
+
+1. Progress updates from slow tools (tabstack_research) don't appear
+2. When a fast tool finishes, its `tool_end` replaces the wrong message (the slow tool's message)
+3. When the slow tool finishes, its result overwrites a fast tool's result
+4. The tool status bar tracks only one tool at a time — any `tool_end` clears it
+
+## Root Cause
+
+Three interacting bugs in the web UI JavaScript:
+
+### 1. `message-store.js` — `updateLastToolCall()` and `replaceLastToolCall()` are position-based
+
+Both methods find the "last" `tool_call` message without checking `tool_call_id`. When concurrent tools finish out of order, results get swapped.
+
+### 2. `tool-status-store.js` — single `#toolStatus` string
+
+One string can't represent multiple concurrent tools. Any `tool_end` sets it to `null`, clearing progress for still-running tools.
+
+### 3. No tool_call_id correlation in the UI
+
+The websocket handler already forwards `tool_call_id` on all tool events. The UI ignores it.
+
+## Fix
+
+- Key message updates on `tool_call_id`, not position
+- Track multiple concurrent tool statuses
+- Only clear status when ALL tools have completed

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -43,20 +43,32 @@ export class MessageStore {
     this.#currentMessages.push(msg);
   }
 
-  /** Update the content of the last tool_call message (for status updates). */
-  updateLastToolCall(/** @type {string} */ content) {
-    const last = this.#currentMessages[this.#currentMessages.length - 1];
-    if (last?.role === 'tool_call') {
-      last.content = content;
+  /** Update a tool_call message by tool_call_id (for status updates). */
+  updateToolCall(/** @type {string} */ toolCallId, /** @type {string} */ content) {
+    if (!toolCallId) {
+      // Fallback: update the last tool_call message (legacy behavior)
+      const last = this.#currentMessages[this.#currentMessages.length - 1];
+      if (last?.role === 'tool_call') last.content = content;
+      return;
     }
+    const msg = this.#currentMessages.find(
+      m => m.role === 'tool_call' && m.tool_call_id === toolCallId
+    );
+    if (msg) msg.content = content;
   }
 
-  /** Replace the last tool_call message with a completed tool result. */
-  replaceLastToolCall(/** @type {ChatMessage} */ msg) {
-    const idx = this.#currentMessages.findLastIndex(m => m.role === 'tool_call');
-    if (idx >= 0) {
-      this.#currentMessages[idx] = msg;
+  /** Replace a tool_call message by tool_call_id with a completed tool result. */
+  replaceToolCall(/** @type {string} */ toolCallId, /** @type {ChatMessage} */ msg) {
+    if (!toolCallId) {
+      // Fallback: replace the last tool_call (legacy behavior)
+      const idx = this.#currentMessages.findLastIndex(m => m.role === 'tool_call');
+      if (idx >= 0) this.#currentMessages[idx] = msg;
+      return;
     }
+    const idx = this.#currentMessages.findIndex(
+      m => m.role === 'tool_call' && m.tool_call_id === toolCallId
+    );
+    if (idx >= 0) this.#currentMessages[idx] = msg;
   }
 
   /** Insert a message before the last user message (for memory context). */

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -9,8 +9,8 @@
  * Sub-store managing tool execution status and confirmation requests.
  */
 export class ToolStatusStore {
-  /** @type {string|null} */
-  #toolStatus = null;
+  /** @type {Map<string, string>} tool_call_id → status text */
+  #activeTools = new Map();
   /** @type {PendingConfirm[]} */
   #pendingConfirms = [];
   /** @type {() => void} */
@@ -33,8 +33,11 @@ export class ToolStatusStore {
 
   // -- Getters ----------------------------------------------------------------
 
-  /** @returns {string|null} */
-  get toolStatus() { return this.#toolStatus; }
+  /** @returns {string|null} Combined status of all active tools, or null if idle. */
+  get toolStatus() {
+    if (this.#activeTools.size === 0) return null;
+    return [...this.#activeTools.values()].join(' | ');
+  }
   /** @returns {PendingConfirm[]} */
   get pendingConfirms() { return this.#pendingConfirms; }
 
@@ -42,12 +45,12 @@ export class ToolStatusStore {
 
   /** Reset state when switching conversations. */
   clear() {
-    this.#toolStatus = null;
+    this.#activeTools.clear();
     this.#pendingConfirms = [];
   }
 
   clearToolStatus() {
-    this.#toolStatus = null;
+    this.#activeTools.clear();
   }
 
   /**
@@ -83,20 +86,24 @@ export class ToolStatusStore {
    */
   handleMessage(msg, currentConvId) {
     switch (msg.type) {
-      case 'tool_start':
-        this.#toolStatus = `Running ${msg.tool}...`;
+      case 'tool_start': {
+        const tcId = msg.tool_call_id || '';
+        this.#activeTools.set(tcId, `Running ${msg.tool}...`);
         if (msg.conv_id === currentConvId) {
           this.#messageStore.pushMessage({
             role: 'tool_call',
             content: `Running ${msg.tool}...`,
             tool: msg.tool,
+            tool_call_id: tcId,
             timestamp: new Date().toISOString(),
           });
         }
         return true;
+      }
 
-      case 'tool_status':
-        this.#toolStatus = `${msg.tool}: ${msg.message}`;
+      case 'tool_status': {
+        const tcId = msg.tool_call_id || '';
+        this.#activeTools.set(tcId, `${msg.tool}: ${msg.message}`);
         if (msg.conv_id === currentConvId) {
           if (msg.tool === 'vault_retrieval' || msg.tool === 'vault_references') {
             this.#messageStore.insertBeforeLastUser({
@@ -105,15 +112,17 @@ export class ToolStatusStore {
               timestamp: new Date().toISOString(),
             });
           } else {
-            this.#messageStore.updateLastToolCall(`${msg.tool}: ${msg.message}`);
+            this.#messageStore.updateToolCall(tcId, `${msg.tool}: ${msg.message}`);
           }
         }
         return true;
+      }
 
-      case 'tool_end':
-        this.#toolStatus = null;
+      case 'tool_end': {
+        const tcId = msg.tool_call_id || '';
+        this.#activeTools.delete(tcId);
         if (msg.conv_id === currentConvId) {
-          this.#messageStore.replaceLastToolCall({
+          this.#messageStore.replaceToolCall(tcId, {
             role: 'tool',
             content: msg.result_text || '',
             tool: msg.tool,
@@ -122,6 +131,7 @@ export class ToolStatusStore {
           });
         }
         return true;
+      }
 
       case 'confirm_request':
         this.#pendingConfirms = [...this.#pendingConfirms, {


### PR DESCRIPTION
## Summary

When multiple tools run concurrently (e.g., vault_search x2 + tabstack_research), the web UI displayed them incorrectly:
- Fast tools' `tool_end` replaced the wrong message (the slow tool's placeholder)
- Progress updates from slow tools went to the wrong message or didn't appear
- The tool status bar could only track one tool — any `tool_end` cleared it

**Root cause:** `message-store.js` used position-based lookups (`findLastIndex`) and `tool-status-store.js` had a single `#toolStatus` string. Neither used `tool_call_id` to correlate events to messages, even though the websocket handler already forwards it.

**Fix:**
- `message-store.js`: `updateToolCall(toolCallId, content)` and `replaceToolCall(toolCallId, msg)` find messages by `tool_call_id` instead of position
- `tool-status-store.js`: replace single `#toolStatus` string with `Map<tool_call_id, status>` so concurrent tools each have independent status tracking
- `tool_start` includes `tool_call_id` on the pushed message object
- `tool_end` only removes its own entry from the active tools map

## Test plan

- [x] `make check` — lint, pyright, tsc all clean
- [x] `make test` — 1115 passed, 0 warnings
- [ ] Manual test: trigger concurrent tool calls (e.g., ask something that hits vault_search + tabstack_research) and verify each tool's progress and result appear in the correct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)