### PR TITLE
feat: claude_code delegation philosophy + tool progress history

### DIFF
--- a/src/decafclaw/skills/claude_code/SKILL.md
+++ b/src/decafclaw/skills/claude_code/SKILL.md
@@ -10,6 +10,31 @@ requires:
 
 Claude Code is a powerful coding agent that can read, edit, and execute code in repositories. Use this skill to delegate coding tasks that require file manipulation.
 
+## Delegation Philosophy
+
+**Prefer high-level, goal-oriented delegation over atomic step-by-step control.** Claude Code is a full coding agent — it can read code, write code, run tests, start servers, diagnose failures, and iterate on fixes. Your role is project manager, not micro-manager.
+
+**Default approach:** Give Claude Code the end-state goal and success criteria in a single `claude_code_send`. Let it handle the implementation, testing, debugging, and iteration autonomously. Only fall back to step-by-step orchestration when you have a specific reason (e.g., you need to inject external context between steps, or the task requires coordination across multiple repos).
+
+**Anti-pattern — avoid this:**
+1. `claude_code_send` → "Create file X with this content"
+2. `claude_code_exec` → run tests yourself
+3. `claude_code_send` → "Fix this test failure: ..."
+4. `claude_code_exec` → run tests again
+5. Repeat...
+
+**Preferred pattern — do this instead:**
+1. `claude_code_send` → "Implement feature X. Write the code, run the tests with `make test`, and fix any failures. The feature is done when all tests pass."
+
+Claude Code will run the full develop/test/debug cycle internally, iterating until it succeeds or exhausts its budget. This is faster, cheaper (fewer round-trips), and produces better results because Claude Code has direct access to error output, stack traces, and the full codebase context.
+
+**When composing prompts for `claude_code_send`:**
+- State the goal, not the steps. Describe what "done" looks like.
+- Include success criteria: "Tests pass", "Server responds 200 on /endpoint", "Linter reports no errors".
+- Include the verification method: "Run `make test`", "Start the server and hit the health endpoint", "Run `mypy .`".
+- If there's a debug/fix loop involved, say so explicitly: "If tests fail, diagnose and fix. Repeat until green."
+- Trust Claude Code to figure out the implementation details — it has the full codebase.
+
 ## Available Tools
 
 ### 1. `claude_code_start` — Start a new coding session
@@ -128,28 +153,32 @@ Shows all active sessions with ID, working directory, age, and cost so far.
 
 ## Workflow
 
-### Basic
-1. **Start** a session with `claude_code_start` pointing at the repo
-2. **Send** tasks with `claude_code_send` — iterate as needed
-3. **Stop** when done with `claude_code_stop`
+### Autonomous (preferred)
 
-### With context and review
+The default workflow. Delegate the full objective — implementation, verification, and debugging — in a single send.
+
 1. **Start** → `claude_code_start` with `instructions` for project conventions
-2. **Send** → `claude_code_send` with `context` (specs, vault pages) and `include_diff=true`
-3. **Review** → inspect the `diff` field in the structured result
-4. **Fix** → if changes need adjustment, `claude_code_send` with feedback
-5. **Verify** → `claude_code_exec` to run tests
-6. **Stop** → `claude_code_stop` when satisfied
+2. **Delegate** → `claude_code_send` with a goal-oriented prompt that includes success criteria and verification steps. Let Claude Code handle the build/test/debug loop internally.
+3. **Review** → inspect `diff` and `result_text` in the structured result
+4. **Adjust** → if the result needs refinement, send targeted feedback (not step-by-step instructions)
+5. **Stop** → `claude_code_stop` when satisfied
 
-### Verify loop (TDD-style)
+**Example prompt:**
+> "Build a REST API endpoint `POST /tasks` that creates a task and stores it in SQLite. Write tests. Run `make test` and fix any failures until all tests pass. Then start the server with `make run`, verify `curl -X POST localhost:8000/tasks -d '{"title":"test"}'` returns 201, and stop the server."
+
+### Supervised (when you need control between steps)
+
+Use when you need to inject external context, coordinate across repos, or make decisions between steps that Claude Code can't make on its own.
+
 1. **Start** → `claude_code_start` with optional `setup_command`
-2. **Implement** → `claude_code_send` with the coding task
-3. **Verify** → `claude_code_exec` to run tests (`make test`, `pytest`, etc.)
-4. **Fix** → if tests failed, `claude_code_send` with the failure output
-5. **Verify** → `claude_code_exec` again to confirm the fix
-6. **Stop** → `claude_code_stop` when satisfied
+2. **Send** → `claude_code_send` with a focused task and `include_diff=true`
+3. **Review** → inspect the `diff` field
+4. **Verify** → `claude_code_exec` to run tests (cheap, no LLM cost)
+5. **Fix** → if changes need adjustment, `claude_code_send` with feedback + test output
+6. **Repeat** steps 3-5 as needed
+7. **Stop** → `claude_code_stop` when satisfied
 
-The exec tool makes the verify steps cheap (no LLM cost, no latency). Use this pattern for iterative development.
+Only use this pattern when you have a concrete reason the autonomous pattern won't work. Examples: you need to pull a file from another session between steps, you need to ask the user a question mid-task, or the task spans multiple repositories.
 
 Sessions expire after 30 minutes of inactivity. If a session expires, start a new one and restate the context.
 
@@ -165,9 +194,10 @@ If the cwd isn't already a git repo, consider running `claude_code_exec` with `g
 ## Cost Awareness
 
 Each Claude Code interaction costs money (Anthropic API usage). The structured result after each `claude_code_send` includes the cost. Be mindful of:
-- Keep tasks focused — one clear objective per send
-- Use `claude_code_exec` for verification instead of burning a full `claude_code_send`
+- **One high-level goal per send is usually cheaper than many small sends** — each send has prompt overhead; a single autonomous send avoids re-transmitting context repeatedly
+- Use `claude_code_exec` for quick checks when you *do* need to orchestrate between steps
 - Use `claude_code_stop` when done to free the session
+- Set an appropriate `budget_usd` on start — higher budgets for complex autonomous tasks that may need many internal iterations
 - Default budget limit applies per session
 
 ## Permission Model

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -378,6 +378,96 @@ def _send_error_data(exit_status: str, **extra) -> dict:
     return data
 
 
+def _build_short_text(exit_status: str, logger: SessionLogger) -> str:
+    """Build a plain-text short preview for the collapsed tool result in the web UI."""
+    cost_str = f"${logger.total_cost_usd:.2f}" if logger.total_cost_usd else ""
+    n_files = len(dict.fromkeys(logger.files_changed))
+    short_parts = [exit_status]
+    if cost_str:
+        short_parts.append(cost_str)
+    if n_files:
+        short_parts.append(f"{n_files} file{'s' if n_files != 1 else ''} changed")
+    if logger.errors:
+        short_parts.append(f"{len(logger.errors)} error{'s' if len(logger.errors) != 1 else ''}")
+    return " - ".join(short_parts)
+
+
+def _summarize_tool_use(name: str, inp: dict) -> str:
+    """Build a one-liner describing a Claude Code sub-agent tool call."""
+    # Well-known tools get formatted summaries
+    if name in ("Edit", "Write", "NotebookEdit"):
+        path = inp.get("file_path", "")
+        return f"{name} {path}" if path else name
+    if name == "Read":
+        path = inp.get("file_path", "")
+        offset = inp.get("offset")
+        limit = inp.get("limit")
+        suffix = ""
+        if offset is not None and limit is not None:
+            suffix = f" (lines {offset}-{offset + limit})"
+        elif offset is not None:
+            suffix = f" (from line {offset})"
+        return f"{name} {path}{suffix}" if path else name
+    if name == "Bash":
+        cmd = inp.get("command", "")
+        # Show first line, truncated
+        first_line = cmd.split("\n", 1)[0]
+        if len(first_line) > 80:
+            first_line = first_line[:77] + "..."
+        return f"{name} — {first_line}" if first_line else name
+    if name == "Glob":
+        pattern = inp.get("pattern", "")
+        path = inp.get("path", "")
+        parts = [name, pattern]
+        if path:
+            parts.append(f"in {path}")
+        return " ".join(parts)
+    if name == "Grep":
+        pattern = inp.get("pattern", "")
+        path = inp.get("path", "")
+        parts = [name, f"/{pattern}/"]
+        if path:
+            parts.append(f"in {path}")
+        return " ".join(parts)
+    if name == "WebSearch":
+        query = inp.get("query", "")
+        return f'{name} "{query}"' if query else name
+    if name == "WebFetch":
+        url = inp.get("url", "")
+        return f"{name} {url}" if url else name
+    # Fallback: show the tool name + compact key=value pairs from input
+    if not inp:
+        return name
+    pairs = []
+    for k, v in inp.items():
+        s = str(v)
+        if len(s) > 40:
+            s = s[:37] + "..."
+        pairs.append(f"{k}={s}")
+    detail = ", ".join(pairs)
+    if len(detail) > 120:
+        detail = detail[:117] + "..."
+    return f"{name} — {detail}"
+
+
+def _summarize_tool_result(tool_name: str, content: "str | list | None",
+                           is_error: bool) -> str:
+    """Build a one-liner describing a tool result."""
+    if is_error:
+        snippet = (content if isinstance(content, str)
+                   else str(content) if content else "")[:100]
+        return f"{tool_name} failed — {snippet}"
+    # Successful result — show a brief snippet
+    text = content if isinstance(content, str) else str(content) if content else ""
+    if not text:
+        return f"{tool_name} — done"
+    # For Bash, show exit code or first line of output
+    first_line = text.split("\n", 1)[0].strip()
+    if len(first_line) > 100:
+        first_line = first_line[:97] + "..."
+    return f"{tool_name} — {first_line}" if first_line else f"{tool_name} — done"
+
+
 async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                                 context: str = "",
                                 include_diff: bool = True) -> ToolResult:
@@ -489,14 +579,14 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
             }
 
         # Stream messages from the SDK
-        await ctx.publish("tool_status", tool="claude_code",
+        await ctx.publish("tool_status", tool="claude_code_send",
                           message=f"Sending to Claude Code ({session.cwd})...")
         try:
             async for message in query(prompt=prompt_stream(), options=options):
                 log.debug(f"Claude Code message: {type(message).__name__}")
                 logger.log_message(message)
 
-                # Publish progress for Mattermost display
+                # Publish progress for web UI / Mattermost display
                 if isinstance(message, AssistantMessage):
                     for block in message.content:
                         if isinstance(block, TextBlock) and block.text:
@@ -505,21 +595,22 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                         elif isinstance(block, ToolUseBlock):
                             tool_call_count += 1
                             tool_id_to_name[block.id] = block.name
+                            summary = _summarize_tool_use(block.name, block.input)
                             await ctx.publish(
-                                "tool_status", tool="claude_code",
-                                message=f"Tool call {tool_call_count}: Using {block.name}..."
+                                "tool_status", tool="claude_code_send",
+                                message=f"[{tool_call_count}] {summary}"
                             )
 
                 elif isinstance(message, UserMessage):
                     for block in getattr(message, "content", []):
-                        if isinstance(block, ToolResultBlock) and block.is_error:
+                        if isinstance(block, ToolResultBlock):
                             tool_name = tool_id_to_name.get(
                                 block.tool_use_id, "unknown tool")
-                            snippet = (block.content if isinstance(block.content, str)
-                                       else str(block.content))[:100]
+                            summary = _summarize_tool_result(
+                                tool_name, block.content, bool(block.is_error))
                             await ctx.publish(
-                                "tool_status", tool="claude_code",
-                                message=f"{tool_name} failed — {snippet}"
+                                "tool_status", tool="claude_code_send",
+                                message=f"\u2192 {summary}"
                             )
 
                 elif isinstance(message, ResultMessage):
@@ -530,7 +621,7 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                     if message.total_cost_usd is not None:
                         session.total_cost_usd = message.total_cost_usd
                         await ctx.publish(
-                            "tool_status", tool="claude_code",
+                            "tool_status", tool="claude_code_send",
                             message=(f"Session cost: ${session.total_cost_usd:.2f} "
                                      f"of ${session.budget_usd:.2f} budget")
                         )
@@ -539,7 +630,7 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
                             warnings_fired
                         ):
                             await ctx.publish(
-                                "tool_status", tool="claude_code",
+                                "tool_status", tool="claude_code_send",
                                 message=warning
                             )
         except Exception as e:
@@ -561,14 +652,17 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
         diff = await _capture_git_diff(session.cwd, baseline_ref)
 
     summary = logger.build_summary(session_id)
+    exit_status = "error" if logger.errors else "success"
     data = logger.build_data(
         session_id=session_id,
-        exit_status="error" if logger.errors else "success",
+        exit_status=exit_status,
         sdk_session_id=session.sdk_session_id,
         send_count=session.send_count,
         diff=diff,
     )
-    return ToolResult(text=summary, data=data)
+    # Build a short preview for the collapsed tool result in the web UI
+    short_text = _build_short_text(exit_status, logger)
+    return ToolResult(text=summary, data=data, display_short_text=short_text)
 
 
 async def tool_claude_code_exec(ctx, session_id: str, command: str,

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -13,6 +13,7 @@ export class ChatMessage extends LitElement {
     display_short_text: { type: String, attribute: false },
     toolCalls: { type: Array, attribute: false },
     toolCallId: { type: String, attribute: false },
+    statusHistory: { type: Array, attribute: false },
     usage: { type: Object, attribute: false },
     timestamp: { type: String },
     attachments: { type: Array, attribute: false },
@@ -30,6 +31,8 @@ export class ChatMessage extends LitElement {
     /** @type {Array|null} */
     this.toolCalls = null;
     this.toolCallId = '';
+    /** @type {Array<{text: string, timestamp: string}>|null} */
+    this.statusHistory = null;
     /** @type {object|null} */
     this.usage = null;
     this.timestamp = '';
@@ -55,11 +58,11 @@ export class ChatMessage extends LitElement {
     }
 
     if (this.role === 'tool_call') {
-      return html`<tool-call-message variant="tool_call" .content=${this.content}></tool-call-message>`;
+      return html`<tool-call-message variant="tool_call" .content=${this.content} .statusHistory=${this.statusHistory}></tool-call-message>`;
     }
 
     if (this.role === 'tool') {
-      return html`<tool-message .tool=${this.tool} .content=${this.content} .display_short_text=${this.display_short_text || ''} .timestamp=${this.timestamp}></tool-message>`;
+      return html`<tool-message .tool=${this.tool} .content=${this.content} .display_short_text=${this.display_short_text || ''} .statusHistory=${this.statusHistory} .timestamp=${this.timestamp}></tool-message>`;
     }
 
     if (this.role === 'assistant' && this.toolCalls?.length) {

--- a/src/decafclaw/web/static/components/chat-view.js
+++ b/src/decafclaw/web/static/components/chat-view.js
@@ -143,6 +143,7 @@ export class ChatView extends LitElement {
           .display_short_text=${m.display_short_text || ''}
           .toolCalls=${m.tool_calls || null}
           .toolCallId=${m.tool_call_id || ''}
+          .statusHistory=${m.statusHistory || null}
           .usage=${m.usage || null}
           .timestamp=${m.timestamp || ''}
           .attachments=${m.attachments || null}

--- a/src/decafclaw/web/static/components/messages/tool-call-message.js
+++ b/src/decafclaw/web/static/components/messages/tool-call-message.js
@@ -14,6 +14,9 @@ export class ToolCallMessage extends LitElement {
     content: { type: String },
     /** Array of tool call objects from assistant message history */
     toolCalls: { type: Array, attribute: false },
+    /** Array of {text, timestamp} status history entries */
+    statusHistory: { type: Array, attribute: false },
+    _expanded: { type: Boolean, state: true },
   };
 
   createRenderRoot() { return this; }
@@ -24,18 +27,41 @@ export class ToolCallMessage extends LitElement {
     this.content = '';
     /** @type {Array|null} */
     this.toolCalls = null;
+    /** @type {Array<{text: string, timestamp: string}>|null} */
+    this.statusHistory = null;
+    this._expanded = false;
+  }
+
+  #toggleExpand() {
+    if (this.statusHistory?.length > 1) {
+      this._expanded = !this._expanded;
+    }
   }
 
   render() {
     if (this.variant === 'tool_call') {
-      // Live tool call in progress
+      const hasHistory = this.statusHistory?.length > 1;
       return html`
         <div class="message tool">
-          <div class="tool-result-header">
+          <div class="tool-result-header" @click=${hasHistory ? this.#toggleExpand : nothing}>
             <span class="tool-icon">\u{1f527}</span>
             <span class="tool-summary">${this.content}</span>
             <span class="streaming-indicator"></span>
+            ${hasHistory ? html`
+              <span class="status-history-badge" title="Click to show progress history">${this.statusHistory.length}</span>
+              <span class="expand-toggle">${this._expanded ? '\u25b2' : '\u25bc'}</span>
+            ` : nothing}
           </div>
+          ${this._expanded ? html`
+            <div class="status-history">
+              ${this.statusHistory.map(entry => html`
+                <div class="status-history-entry">
+                  <span class="status-history-time">${this.#formatTime(entry.timestamp)}</span>
+                  <span class="status-history-text">${entry.text}</span>
+                </div>
+              `)}
+            </div>
+          ` : nothing}
         </div>
       `;
     }
@@ -56,6 +82,16 @@ export class ToolCallMessage extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  /** @param {string} isoStr */
+  #formatTime(isoStr) {
+    try {
+      const d = new Date(isoStr);
+      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    } catch {
+      return '';
+    }
   }
 }
 

--- a/src/decafclaw/web/static/components/messages/tool-message.js
+++ b/src/decafclaw/web/static/components/messages/tool-message.js
@@ -7,6 +7,8 @@ export class ToolMessage extends LitElement {
     content: { type: String },
     icon: { type: String },
     display_short_text: { type: String },
+    /** Array of {text, timestamp} status history entries from the tool_call phase */
+    statusHistory: { type: Array, attribute: false },
     _expanded: { type: Boolean, state: true },
   };
 
@@ -18,6 +20,8 @@ export class ToolMessage extends LitElement {
     this.content = '';
     this.icon = '\u{1f527}';
     this.display_short_text = '';
+    /** @type {Array<{text: string, timestamp: string}>|null} */
+    this.statusHistory = null;
     this._expanded = false;
   }
 
@@ -31,22 +35,52 @@ export class ToolMessage extends LitElement {
     return content.substring(0, maxLen) + '...';
   }
 
+  /** @param {string} isoStr */
+  #formatTime(isoStr) {
+    try {
+      const d = new Date(isoStr);
+      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    } catch {
+      return '';
+    }
+  }
+
   render() {
     const hasContent = this.content && this.content.length > 0;
+    const hasHistory = this.statusHistory?.length > 0;
+    const expandable = hasContent || hasHistory;
     return html`
       <div class="message tool">
-        <div class="tool-result-header" @click=${hasContent ? this.#toggleExpand : nothing}>
+        <div class="tool-result-header" @click=${expandable ? this.#toggleExpand : nothing}>
           <span class="tool-icon">${this.icon}</span>
           <span class="tool-name">${this.tool}</span>
           ${hasContent ? html`
             <span class="tool-preview">${this.display_short_text || this.#truncate(this.content)}</span>
+          ` : nothing}
+          ${hasHistory && !hasContent ? html`
+            <span class="tool-preview">${this.statusHistory.length} progress updates</span>
+          ` : nothing}
+          ${expandable ? html`
+            ${hasHistory ? html`<span class="status-history-badge">${this.statusHistory.length}</span>` : nothing}
             <span class="expand-toggle">${this._expanded ? '\u25b2' : '\u25bc'}</span>
           ` : nothing}
         </div>
         ${this._expanded ? html`
-          <div class="tool-result-detail">
-            <pre>${this.content}</pre>
-          </div>
+          ${hasHistory ? html`
+            <div class="status-history">
+              ${this.statusHistory.map(entry => html`
+                <div class="status-history-entry">
+                  <span class="status-history-time">${this.#formatTime(entry.timestamp)}</span>
+                  <span class="status-history-text">${entry.text}</span>
+                </div>
+              `)}
+            </div>
+          ` : nothing}
+          ${hasContent ? html`
+            <div class="tool-result-detail">
+              <pre>${this.content}</pre>
+            </div>
+          ` : nothing}
         ` : nothing}
       </div>
     `;

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -16,6 +16,7 @@
  * @property {string} [display_short_text]
  * @property {object[]} [tool_calls]
  * @property {boolean} [_merged]
+ * @property {Array<{text: string, timestamp: string}>} [statusHistory]
  * @property {{prompt_tokens: number, completion_tokens: number, total_tokens: number}|null} [usage]
  */
 

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -43,7 +43,9 @@ export class MessageStore {
     this.#currentMessages.push(msg);
   }
 
-  /** Update a tool_call message by tool_call_id (for status updates). */
+  /** Update a tool_call message by tool_call_id (for status updates).
+   * Accumulates a statusHistory array so the UI can show the full progress log.
+   */
   updateToolCall(/** @type {string} */ toolCallId, /** @type {string} */ content) {
     if (!toolCallId) {
       // Fallback: update the last tool_call message (legacy behavior)
@@ -54,10 +56,20 @@ export class MessageStore {
     const msg = this.#currentMessages.find(
       m => m.role === 'tool_call' && m.tool_call_id === toolCallId
     );
-    if (msg) msg.content = content;
+    if (msg) {
+      if (!msg.statusHistory) msg.statusHistory = [];
+      msg.statusHistory.push({ text: content, timestamp: new Date().toISOString() });
+      // Cap history to prevent unbounded growth from long-running tools
+      if (msg.statusHistory.length > 200) {
+        msg.statusHistory = msg.statusHistory.slice(-200);
+      }
+      msg.content = content;
+    }
   }
 
-  /** Replace a tool_call message by tool_call_id with a completed tool result. */
+  /** Replace a tool_call message by tool_call_id with a completed tool result.
+   * Carries over statusHistory from the in-progress message so the UI can still show it.
+   */
   replaceToolCall(/** @type {string} */ toolCallId, /** @type {ChatMessage} */ msg) {
     if (!toolCallId) {
       // Fallback: replace the last tool_call (legacy behavior)
@@ -68,7 +80,13 @@ export class MessageStore {
     const idx = this.#currentMessages.findIndex(
       m => m.role === 'tool_call' && m.tool_call_id === toolCallId
     );
-    if (idx >= 0) this.#currentMessages[idx] = msg;
+    if (idx >= 0) {
+      const old = this.#currentMessages[idx];
+      if (old.statusHistory?.length) {
+        msg.statusHistory = old.statusHistory;
+      }
+      this.#currentMessages[idx] = msg;
+    }
   }
 
   /** Insert a message before the last user message (for memory context). */

--- a/src/decafclaw/web/static/styles/chat.css
+++ b/src/decafclaw/web/static/styles/chat.css
@@ -225,6 +225,46 @@ chat-message .confirm-buttons button {
   margin: 0;
 }
 
+/* Status history (tool progress log) */
+.status-history-badge {
+  flex-shrink: 0;
+  background: var(--pico-muted-border-color);
+  color: var(--pico-color);
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+  border-radius: 8px;
+  min-width: 1.2em;
+  text-align: center;
+  line-height: 1.3;
+}
+
+.status-history {
+  margin-top: 0.5rem;
+  max-height: 300px;
+  overflow-y: auto;
+  border-left: 2px solid var(--pico-muted-border-color);
+  padding-left: 0.5rem;
+}
+
+.status-history-entry {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--pico-muted-color);
+}
+
+.status-history-time {
+  flex-shrink: 0;
+  font-family: monospace;
+  opacity: 0.6;
+}
+
+.status-history-text {
+  word-break: break-word;
+}
+
 /* Thinking indicator (three bouncing dots) */
 .thinking-indicator {
   display: flex;

--- a/tests/test_claude_code_output.py
+++ b/tests/test_claude_code_output.py
@@ -11,6 +11,11 @@ from claude_code_sdk import (
 )
 
 from decafclaw.skills.claude_code.output import SessionLogger
+from decafclaw.skills.claude_code.tools import (
+    _build_short_text,
+    _summarize_tool_result,
+    _summarize_tool_use,
+)
 
 
 def test_log_creates_file(tmp_path):
@@ -253,3 +258,159 @@ def test_deduplicates_files_changed(tmp_path):
     )
     logger.log_message(msg)
     assert logger.files_changed == ["x.py"]  # deduplicated
+
+
+# -- _build_short_text tests --------------------------------------------------
+
+
+def test_short_text_success_with_cost_and_files(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    logger.total_cost_usd = 0.36
+    logger.files_changed = ["a.py", "b.py", "c.py"]
+    result = _build_short_text("success", logger)
+    assert result == "success - $0.36 - 3 files changed"
+
+
+def test_short_text_success_single_file(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    logger.total_cost_usd = 0.10
+    logger.files_changed = ["a.py"]
+    result = _build_short_text("success", logger)
+    assert result == "success - $0.10 - 1 file changed"
+
+
+def test_short_text_success_no_cost_no_files(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    result = _build_short_text("success", logger)
+    assert result == "success"
+
+
+def test_short_text_error_with_errors(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    logger.total_cost_usd = 0.05
+    logger.errors = ["ImportError", "SyntaxError"]
+    result = _build_short_text("error", logger)
+    assert result == "error - $0.05 - 2 errors"
+
+
+def test_short_text_error_single_error(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    logger.errors = ["boom"]
+    result = _build_short_text("error", logger)
+    assert result == "error - 1 error"
+
+
+def test_short_text_deduplicates_files(tmp_path):
+    logger = SessionLogger(tmp_path, "test")
+    logger.files_changed = ["a.py", "b.py", "a.py"]
+    result = _build_short_text("success", logger)
+    assert result == "success - 2 files changed"
+
+
+# -- _summarize_tool_use tests ------------------------------------------------
+
+
+def test_summarize_edit():
+    assert _summarize_tool_use("Edit", {"file_path": "src/foo.py", "old_string": "x", "new_string": "y"}) == "Edit src/foo.py"
+
+
+def test_summarize_write():
+    assert _summarize_tool_use("Write", {"file_path": "new.py", "content": "..."}) == "Write new.py"
+
+
+def test_summarize_read_with_range():
+    result = _summarize_tool_use("Read", {"file_path": "bar.py", "offset": 10, "limit": 40})
+    assert result == "Read bar.py (lines 10-50)"
+
+
+def test_summarize_read_with_offset_only():
+    result = _summarize_tool_use("Read", {"file_path": "bar.py", "offset": 100})
+    assert result == "Read bar.py (from line 100)"
+
+
+def test_summarize_read_simple():
+    assert _summarize_tool_use("Read", {"file_path": "bar.py"}) == "Read bar.py"
+
+
+def test_summarize_bash():
+    assert _summarize_tool_use("Bash", {"command": "make test"}) == "Bash — make test"
+
+
+def test_summarize_bash_multiline():
+    result = _summarize_tool_use("Bash", {"command": "echo hello\necho world"})
+    assert result == "Bash — echo hello"
+
+
+def test_summarize_bash_truncated():
+    long_cmd = "x" * 100
+    result = _summarize_tool_use("Bash", {"command": long_cmd})
+    assert len(result) < 100
+    assert result.endswith("...")
+
+
+def test_summarize_glob():
+    assert _summarize_tool_use("Glob", {"pattern": "**/*.py"}) == "Glob **/*.py"
+
+
+def test_summarize_glob_with_path():
+    result = _summarize_tool_use("Glob", {"pattern": "*.js", "path": "src/"})
+    assert result == "Glob *.js in src/"
+
+
+def test_summarize_grep():
+    result = _summarize_tool_use("Grep", {"pattern": "TODO", "path": "src/"})
+    assert result == "Grep /TODO/ in src/"
+
+
+def test_summarize_websearch():
+    result = _summarize_tool_use("WebSearch", {"query": "python asyncio"})
+    assert result == 'WebSearch "python asyncio"'
+
+
+def test_summarize_webfetch():
+    result = _summarize_tool_use("WebFetch", {"url": "https://example.com"})
+    assert result == "WebFetch https://example.com"
+
+
+def test_summarize_unknown_tool_with_input():
+    result = _summarize_tool_use("CustomTool", {"target": "xyz", "mode": "fast"})
+    assert result == "CustomTool — target=xyz, mode=fast"
+
+
+def test_summarize_unknown_tool_empty_input():
+    assert _summarize_tool_use("CustomTool", {}) == "CustomTool"
+
+
+def test_summarize_unknown_tool_long_value():
+    result = _summarize_tool_use("CustomTool", {"data": "x" * 100})
+    assert "..." in result
+    assert len(result) < 200
+
+
+# -- _summarize_tool_result tests ---------------------------------------------
+
+
+def test_result_success():
+    result = _summarize_tool_result("Bash", "Tests passed\n5 passed in 2s", False)
+    assert result == "Bash — Tests passed"
+
+
+def test_result_success_empty():
+    assert _summarize_tool_result("Edit", "", False) == "Edit — done"
+
+
+def test_result_success_none():
+    assert _summarize_tool_result("Edit", None, False) == "Edit — done"
+
+
+def test_result_error():
+    result = _summarize_tool_result("Bash", "Command not found: foobar", True)
+    assert "failed" in result
+    assert "Command not found" in result
+
+
+def test_result_long_first_line():
+    long_line = "x" * 200
+    result = _summarize_tool_result("Read", long_line, False)
+    assert len(result) < 200
+    assert result.endswith("...")


### PR DESCRIPTION
## Summary

- **SKILL.md**: Add "Delegation Philosophy" section encouraging high-level goal-oriented delegation over atomic step-by-step control. Restructure workflow section: "Autonomous (preferred)" as default, "Supervised" as fallback with explicit reasons. Update cost guidance.
- **Tool progress history**: Accumulate status updates per tool_call_id in the web UI. Clicking the progress indicator (or completed result) reveals the full timestamped progress log. History carries over from in-progress → completed state.
- **Fix tool name mismatch**: `claude_code_send` progress events were published with `tool="claude_code"` but `tool_start`/`tool_end` used `"claude_code_send"`, making progress appear to vanish on completion. Now consistent.
- **display_short_text**: `claude_code_send` results now include a short preview (e.g. "**success** - $0.36 - 3 files changed") for informative collapsed display.

## Test plan

- [x] Lint, typecheck (Python + JS), and pytest all pass
- [ ] Start a claude_code session in the web UI — verify progress shows with consistent "claude_code_send" tool name
- [ ] Verify clicking the progress indicator during execution expands the status history
- [ ] Verify the completed tool result preserves and shows the progress history on click
- [ ] Verify the collapsed result shows the short preview text

🤖 Generated with [Claude Code](https://claude.com/claude-code)