### PR TITLE
feat: show language labels on code blocks in web UI

### DIFF
--- a/src/decafclaw/web/static/components/messages/assistant-message.js
+++ b/src/decafclaw/web/static/components/messages/assistant-message.js
@@ -34,6 +34,20 @@ export class AssistantMessage extends LitElement {
   updated() {
     this.querySelectorAll('pre:not(.has-copy)').forEach(pre => {
       pre.classList.add('has-copy');
+
+      // Add language label if the code block specifies a language
+      const code = pre.querySelector('code[class*="language-"]');
+      if (code) {
+        const match = code.className.match(/language-(\S+)/);
+        if (match) {
+          const label = document.createElement('span');
+          label.className = 'code-lang-label';
+          label.textContent = match[1];
+          pre.style.paddingTop = '2rem';
+          pre.appendChild(label);
+        }
+      }
+
       const btn = document.createElement('button');
       btn.className = 'copy-btn';
       btn.textContent = 'Copy';

--- a/src/decafclaw/web/static/styles/chat.css
+++ b/src/decafclaw/web/static/styles/chat.css
@@ -340,3 +340,14 @@ chat-message .copy-btn {
 chat-message pre:hover .copy-btn {
   opacity: 1;
 }
+
+chat-message .code-lang-label {
+  position: absolute;
+  top: 4px;
+  left: 8px;
+  font-size: 0.75rem;
+  color: var(--pico-muted-color);
+  pointer-events: none;
+  user-select: none;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary

Show the language name on fenced code blocks in assistant messages. The label appears in the top-left corner of the code block (copy button is top-right).

- Reads the `language-*` class from `<code>` elements inside `<pre>` blocks
- Injects a small muted label in the same `updated()` lifecycle hook that adds copy buttons
- 24 lines across 2 files

Closes #63

## Test plan

- [x] `make check-js` — tsc clean
- [ ] Visual check: send a message with ```python, ```js, etc. and verify labels appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)