### PR TITLE
feat: surface context usage to the agent for self-regulation

### DIFF
--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -107,6 +107,7 @@ class AgentConfig:
     child_max_tool_iterations: int = 10
     child_timeout_sec: int = 300
     turn_on_new_message: str = "queue"  # "queue" or "cancel"
+    show_context_status: bool = True
 
 
 @dataclass

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -288,6 +288,15 @@ class ContextComposer:
         # -- Total token estimate --
         total_tokens = sum(s.tokens_estimated for s in sources)
 
+        # -- Context status note (for agent self-regulation) --
+        if config.agent.show_context_status:
+            effective_window = self._get_context_window_size(config)
+            status_line = self._build_context_status(
+                total_tokens, effective_window, history_msg_count,
+            )
+            if status_line:
+                messages.append({"role": "system", "content": status_line})
+
         # -- Update state --
         self.state.last_sources = sources
         self.state.last_total_tokens_estimated = total_tokens
@@ -571,6 +580,25 @@ class ContextComposer:
         if window and window > 0:
             return window
         return config.compaction.max_tokens
+
+    @staticmethod
+    def _build_context_status(
+        total_tokens: int, context_window: int, message_count: int,
+    ) -> str | None:
+        """Build a one-line context usage note for the agent.
+
+        Returns None if context_window is zero (unconfigured).
+        """
+        if context_window <= 0:
+            return None
+        pct = total_tokens / context_window * 100
+        hint = ""
+        if pct > 70:
+            hint = " — consider being concise"
+        return (
+            f"[Context: ~{total_tokens:,} / {context_window:,} tokens"
+            f" ({pct:.0f}%), {message_count} messages{hint}]"
+        )
 
     def record_actuals(self, prompt_tokens: int, completion_tokens: int) -> None:
         """Record actual token usage from the LLM response."""

--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -78,6 +78,15 @@ to read just the section you need — large files are automatically capped at 20
 lines with a prompt to use line ranges. The line numbers from workspace_read can
 be used directly with workspace_insert and workspace_replace_lines.
 
+You receive a context usage status at the end of each turn showing your
+token consumption relative to the context window. When usage is moderate,
+no action is needed. As it climbs above 70%:
+- Prefer concise responses — skip verbose explanations the user didn't ask for.
+- Avoid dumping large tool outputs verbatim — summarize key findings instead.
+- Save important context to the vault before it gets compacted away.
+Compaction happens automatically when the budget is full, summarizing older
+history. Anything not saved to the vault may be lost in that summary.
+
 Users can share vault pages as conversation context in two ways:
 - Opening a page in the UI side panel — you'll see a message prefixed with
   `[Currently viewing wiki page: PageName]` followed by the page content.

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -421,8 +421,9 @@ class TestCompose:
             # Deferred text second (since tools are over budget)
             assert result.messages[1]["role"] == "system"
             assert "tool_search" in result.messages[1]["content"]
-            # User message last
-            assert result.messages[-1]["content"] == "hello"
+            # User message before context status
+            user_msgs = [m for m in result.messages if m.get("role") == "user"]
+            assert user_msgs[-1]["content"] == "hello"
 
     @pytest.mark.asyncio
     async def test_truncates_long_user_message(self, ctx, config):
@@ -438,8 +439,8 @@ class TestCompose:
             composer = ContextComposer()
             long_msg = "x" * 200
             result = await composer.compose(ctx, long_msg, [], mode=ComposerMode.INTERACTIVE)
-            user_msg = result.messages[-1]
-            assert "[truncated at" in user_msg["content"]
+            user_msgs = [m for m in result.messages if m.get("role") == "user"]
+            assert "[truncated at" in user_msgs[-1]["content"]
 
     @pytest.mark.asyncio
     async def test_stores_sources_on_state(self, ctx, config):
@@ -632,3 +633,71 @@ class TestContextComposerOnContext:
     def test_fork_for_tool_call_shares_composer(self, ctx):
         child = ctx.fork_for_tool_call("call-123")
         assert child.composer is ctx.composer
+
+
+# -- Context status ------------------------------------------------------------
+
+
+class TestBuildContextStatus:
+    def test_basic_format(self):
+        line = ContextComposer._build_context_status(12400, 100000, 5)
+        assert line is not None
+        assert "12,400" in line
+        assert "100,000" in line
+        assert "12%" in line
+        assert "5 messages" in line
+
+    def test_high_usage_hint(self):
+        line = ContextComposer._build_context_status(78000, 100000, 12)
+        assert line is not None
+        assert "consider being concise" in line
+
+    def test_low_usage_no_hint(self):
+        line = ContextComposer._build_context_status(5000, 100000, 2)
+        assert line is not None
+        assert "consider being concise" not in line
+
+    def test_zero_max_returns_none(self):
+        assert ContextComposer._build_context_status(5000, 0, 2) is None
+
+    def test_negative_max_returns_none(self):
+        assert ContextComposer._build_context_status(5000, -1, 2) is None
+
+
+class TestContextStatusInCompose:
+    @pytest.mark.asyncio
+    async def test_context_status_injected_by_default(self, ctx, config):
+        config.system_prompt = "System."
+        config.agent.tool_context_budget_pct = 1.0
+        config.compaction.max_tokens = 100000
+        with (
+            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composer = ContextComposer()
+            result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+            # Last message should be the context status
+            last = result.messages[-1]
+            assert last["role"] == "system"
+            assert "[Context:" in last["content"]
+            assert "100,000" in last["content"]
+            assert "messages" in last["content"]
+
+    @pytest.mark.asyncio
+    async def test_context_status_disabled(self, ctx, config):
+        config.system_prompt = "System."
+        config.agent.show_context_status = False
+        config.agent.tool_context_budget_pct = 1.0
+        config.compaction.max_tokens = 100000
+        with (
+            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composer = ContextComposer()
+            result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+            # Last message should be the user message, not context status
+            last = result.messages[-1]
+            assert last["role"] == "user"
+            assert last["content"] == "hello"


### PR DESCRIPTION
## Summary

Inject a one-line context usage status into the messages sent to the LLM, so the model can self-regulate verbosity and know when compaction is approaching.

Format: `[Context: ~12,400 / 100,000 tokens (12%), 5 turns]`
At >70%: `[Context: ~78,000 / 100,000 tokens (78%), 12 turns — consider being concise]`

- Added as a system message at the end of the composed messages array
- Controlled by `agent.show_context_status` (default true)
- 7 new tests (5 unit for the formatter, 2 integration for compose)

Closes #94

## Test plan

- [x] `make check` — lint, pyright, tsc all clean
- [x] `make test` — all pass, 7 new tests
- [ ] Live test: check agent responses reference context budget when approaching limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)