### PR TITLE
feat: add delete conversation to web UI

### DIFF
--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -780,6 +780,39 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         index.unarchive(conv_id)
         return JSONResponse({"ok": True})
 
+    @_authenticated
+    async def delete_conversation(request: Request, username: str) -> JSONResponse:
+        """Permanently delete a conversation and all associated files."""
+        conv_id = request.path_params["id"]
+        from .web.conversations import ConversationIndex
+        index = ConversationIndex(config)
+        conv = index.get(conv_id)
+        if not conv or conv.user_id != username:
+            return JSONResponse({"error": "not found"}, status_code=404)
+
+        # Delete files on disk (with path sandboxing)
+        conv_dir = config.workspace_path / "conversations"
+        for suffix in [".jsonl", ".compacted.jsonl", ".context.json"]:
+            path = (conv_dir / f"{conv_id}{suffix}").resolve()
+            if not path.is_relative_to(conv_dir.resolve()):
+                continue  # path traversal guard
+            if path.exists():
+                path.unlink()
+
+        # Delete uploads directory
+        from .attachments import delete_conversation_uploads
+        delete_conversation_uploads(config, conv_id)
+
+        # Remove from conversation index
+        index.delete(conv_id)
+
+        # Remove from folder index
+        from .web.conversation_folders import ConversationFolderIndex
+        folder_index = ConversationFolderIndex(config, username)
+        await folder_index.remove_assignment(conv_id)
+
+        return JSONResponse({"ok": True})
+
     # -- Conversation folder routes -----------------------------------------------
 
     @_authenticated
@@ -994,6 +1027,7 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         Route("/api/conversations/folders", create_conv_folder, methods=["POST"]),
         Route("/api/conversations/folders/{path:path}", delete_conv_folder, methods=["DELETE"]),
         Route("/api/conversations/folders/{path:path}", rename_conv_folder, methods=["PUT"]),
+        Route("/api/conversations/{id}", delete_conversation, methods=["DELETE"]),
         Route("/api/conversations/{id}/archive", archive_conversation, methods=["POST"]),
         Route("/api/conversations/{id}/unarchive", unarchive_conversation, methods=["POST"]),
         Route("/api/upload/{conv_id}", handle_upload, methods=["POST"]),

--- a/src/decafclaw/web/conversations.py
+++ b/src/decafclaw/web/conversations.py
@@ -215,6 +215,16 @@ class ConversationIndex:
                 return True
         return False
 
+    def delete(self, conv_id: str) -> bool:
+        """Remove a conversation from the index entirely."""
+        data = self._load()
+        new_data = [d for d in data if d.get("conv_id") != conv_id]
+        if len(new_data) == len(data):
+            return False
+        self._save(new_data)
+        log.info(f"Deleted web conversation {conv_id} from index")
+        return True
+
     def touch(self, conv_id: str) -> None:
         """Update the updated_at timestamp."""
         data = self._load()

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -344,6 +344,12 @@ export class ConversationSidebar extends LitElement {
     this.store?.unarchiveConversation(convId);
   }
 
+  /** @param {string} convId */
+  #handleDelete(convId) {
+    if (!confirm('Permanently delete this conversation? This cannot be undone.')) return;
+    this.store?.deleteConversation(convId);
+  }
+
   #openConfig() {
     this.dispatchEvent(new CustomEvent('config-open', {
       bubbles: true,
@@ -371,6 +377,9 @@ export class ConversationSidebar extends LitElement {
    * @param {string}   [opts.actionLabel] - Button label/symbol (e.g. '×', '↩')
    * @param {string}   [opts.actionTitle] - Button title text
    * @param {function} [opts.onAction]    - Click handler for the action button
+   * @param {string}   [opts.action2Label] - Second action button label
+   * @param {string}   [opts.action2Title] - Second action button title
+   * @param {function} [opts.onAction2]   - Click handler for the second action button
    * @param {function} [opts.onDblClick]  - Double-click handler on the title span
    * @param {string}   [opts.badge]       - Optional badge text shown after title
    * @param {string}   [opts.titleSuffix] - Extra text appended to the title attr
@@ -393,6 +402,13 @@ export class ConversationSidebar extends LitElement {
           @dblclick=${opts.onDblClick || nothing}
         >${conv.title}</span>
         ${opts.badge ? html`<span class="conv-type-badge">${opts.badge}</span>` : nothing}
+        ${opts.onAction2 ? html`
+          <button
+            class="conv-archive"
+            @click=${(/** @type {Event} */ e) => { e.stopPropagation(); opts.onAction2(conv.conv_id); }}
+            title=${opts.action2Title || ''}
+          >${opts.action2Label}</button>
+        ` : nothing}
         ${opts.onAction ? html`
           <button
             class="conv-archive"
@@ -595,6 +611,9 @@ export class ConversationSidebar extends LitElement {
               actionLabel: '\u21a9',
               actionTitle: 'Unarchive conversation',
               onAction: (id) => this.#handleUnarchive(id),
+              action2Label: '\u{1F5D1}',
+              action2Title: 'Delete conversation permanently',
+              onAction2: (id) => this.#handleDelete(id),
             }))
           : this._chatSection === '_system'
             ? this._conversations.map(c => this.#renderConversationItem(c, {

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -304,6 +304,26 @@ export class ConversationStore extends EventTarget {
   }
 
   /** @param {string} convId */
+  async deleteConversation(convId) {
+    try {
+      const resp = await fetch(`/api/conversations/${convId}`, {
+        method: 'DELETE',
+      });
+      if (!resp.ok) return;
+      // If we're viewing the deleted conversation, deselect it
+      if (this.#currentConvId === convId) {
+        this.#currentConvId = null;
+        this.#messageStore.clear();
+      }
+      // Re-fetch archived listing to update folder counts
+      await this.listArchivedConversations(this.#archivedCurrentFolder);
+      this.#emitChange();
+    } catch (err) {
+      console.error('Failed to delete conversation:', err);
+    }
+  }
+
+  /** @param {string} convId */
   async unarchiveConversation(convId) {
     try {
       const resp = await fetch(`/api/conversations/${convId}/unarchive`, {

--- a/tests/test_web_conversations.py
+++ b/tests/test_web_conversations.py
@@ -561,3 +561,68 @@ async def test_create_conv_folder_reserved_prefix(authed_client):
         "/api/conversations/folders", json={"path": "_reserved"}
     )
     assert resp.status_code == 400
+
+
+# -- Delete conversation tests ------------------------------------------------
+
+
+def test_delete_from_index(config):
+    config.agent_path.mkdir(parents=True, exist_ok=True)
+    index = ConversationIndex(config)
+    conv = index.create("alice", "Deletable")
+    assert index.get(conv.conv_id) is not None
+    assert index.delete(conv.conv_id) is True
+    assert index.get(conv.conv_id) is None
+
+
+def test_delete_nonexistent_from_index(config):
+    config.agent_path.mkdir(parents=True, exist_ok=True)
+    index = ConversationIndex(config)
+    assert index.delete("nonexistent") is False
+
+
+@pytest.mark.asyncio
+async def test_delete_conv_route(authed_client, http_config):
+    http_config.workspace_path.mkdir(parents=True, exist_ok=True)
+    r = await authed_client.post("/api/conversations", json={"title": "To delete"})
+    conv_id = r.json()["conv_id"]
+
+    # Add some archive content so we can verify file cleanup
+    append_message(http_config, conv_id, {"role": "user", "content": "hello"})
+    conv_dir = http_config.workspace_path / "conversations"
+    (conv_dir / f"{conv_id}.compacted.jsonl").write_text("{}\n")
+    (conv_dir / f"{conv_id}.context.json").write_text("{}\n")
+
+    resp = await authed_client.delete(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+    # Should not appear in any listing
+    resp = await authed_client.get("/api/conversations")
+    ids = [c["conv_id"] for c in resp.json()["conversations"]]
+    assert conv_id not in ids
+
+    # Files should be gone
+    assert not (conv_dir / f"{conv_id}.jsonl").exists()
+    assert not (conv_dir / f"{conv_id}.compacted.jsonl").exists()
+    assert not (conv_dir / f"{conv_id}.context.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_conv_not_found(authed_client):
+    resp = await authed_client.delete("/api/conversations/nonexistent")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_conv_wrong_user(authed_client, http_config):
+    """Cannot delete another user's conversation."""
+    http_config.agent_path.mkdir(parents=True, exist_ok=True)
+    index = ConversationIndex(http_config)
+    conv = index.create("otheruser", "Not yours")
+
+    resp = await authed_client.delete(f"/api/conversations/{conv.conv_id}")
+    assert resp.status_code == 404
+
+    # Should still exist
+    assert index.get(conv.conv_id) is not None


### PR DESCRIPTION
## Summary

Add the ability to permanently delete conversations from the web UI.

- `DELETE /api/conversations/{id}` endpoint: removes archive, compacted sidecar, context sidecar, uploads directory, index entry, and folder assignment
- Delete button (trash icon) shown on archived conversations in the sidebar
- Confirmation prompt before deletion
- 5 new tests covering: index deletion, route handler, file cleanup, auth checks

Closes #61

## Test plan

- [x] `make check` — lint, pyright, tsc all clean
- [x] `make test` — all pass, 5 new tests
- [ ] Live test: archive a conversation, then delete it from the archived section

🤖 Generated with [Claude Code](https://claude.com/claude-code)