### PR TITLE
feat: vault recent changes improvements + fix double .md.md

### DIFF
--- a/scripts/fix-double-md.sh
+++ b/scripts/fix-double-md.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Fix double .md.md extensions in vault files.
+# Usage: ./scripts/fix-double-md.sh /path/to/vault
+#
+# Dry run by default. Pass --apply to actually rename files.
+
+set -euo pipefail
+
+VAULT="${1:?Usage: $0 /path/to/vault [--apply]}"
+APPLY="${2:-}"
+
+if [ ! -d "$VAULT" ]; then
+    echo "Error: $VAULT is not a directory"
+    exit 1
+fi
+
+count=0
+while IFS= read -r -d '' bad_file; do
+    # Strip the extra .md: Foo.md.md -> Foo.md
+    good_file="${bad_file%.md}"
+    count=$((count + 1))
+
+    if [ -f "$good_file" ]; then
+        echo "[CONFLICT] $bad_file -> $good_file already exists (skipping)"
+    elif [ "$APPLY" = "--apply" ]; then
+        mv "$bad_file" "$good_file"
+        echo "[RENAMED] $bad_file -> $good_file"
+    else
+        echo "[DRY RUN] $bad_file -> $good_file"
+    fi
+done < <(find "$VAULT" -name '*.md.md' -print0)
+
+if [ "$count" -eq 0 ]; then
+    echo "No .md.md files found."
+else
+    echo ""
+    echo "Found $count file(s) with double .md extension."
+    if [ "$APPLY" != "--apply" ]; then
+        echo "Run with --apply to rename them."
+    fi
+fi

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -487,12 +487,20 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
     @_authenticated
     async def vault_recent(request: Request, username: str) -> JSONResponse:
-        """List recently modified vault pages sorted by mtime descending."""
-        vault = _vault_root()
-        if not vault.is_dir():
+        """List recently modified agent vault pages sorted by mtime descending.
+
+        Only scans the agent's folder within the vault (pages + journal),
+        not the user's personal vault files.
+        """
+        agent_dir = config.vault_agent_dir
+        if not agent_dir.is_dir():
             return JSONResponse({"pages": []})
 
-        vault_resolved = vault.resolve()
+        vault_resolved = _vault_root().resolve()
+        agent_resolved = agent_dir.resolve()
+        if not agent_resolved.is_relative_to(vault_resolved):
+            log.warning("vault_agent_dir is outside vault_root, skipping recent changes")
+            return JSONResponse({"pages": []})
         limit = config.vault.recent_changes_limit
         try:
             limit = int(request.query_params.get("limit", limit))
@@ -501,13 +509,13 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         limit = max(0, limit)
 
         pages = []
-        for md_file in vault_resolved.rglob("*.md"):
+        for md_file in agent_resolved.rglob("*.md"):
             if not md_file.is_file():
                 continue
-            if not md_file.resolve().is_relative_to(vault_resolved):
+            if not md_file.resolve().is_relative_to(agent_resolved):
                 continue
             # Skip hidden directories (.obsidian, .git, .trash, etc.)
-            if any(part.startswith('.') for part in md_file.relative_to(vault_resolved).parts[:-1]):
+            if any(part.startswith('.') for part in md_file.relative_to(agent_resolved).parts[:-1]):
                 continue
             rel = md_file.relative_to(vault_resolved)
             pages.append({

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -36,6 +36,9 @@ def resolve_page(config, page: str, from_page: str | None = None) -> Path | None
     """
     if ".." in page or page.startswith("/"):
         return None
+    # Strip .md suffix if the caller included it (prevents Foo.md.md)
+    if page.endswith(".md"):
+        page = page[:-3]
     vault = _vault_root(config).resolve()
     if not vault.is_dir():
         return None
@@ -86,6 +89,9 @@ def _safe_write_path(config, page: str) -> Path | None:
     """
     if ".." in page or page.startswith("/"):
         return None
+    # Strip .md suffix if the caller included it (prevents Foo.md.md)
+    if page.endswith(".md"):
+        page = page[:-3]
     vault = _vault_root(config).resolve()
     path = (vault / f"{page}.md").resolve()
     if not path.is_relative_to(vault):

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -617,7 +617,8 @@ export class ConversationSidebar extends LitElement {
         const pagePath = p.path || p.title;
         const isOpen = pagePath === this._openWikiPage;
         return html`
-          <div class="conv-item wiki-item ${isOpen ? 'active' : ''}" @click=${() => this.#handleWikiSelect(pagePath)} title=${pagePath}>
+          <div class="conv-item wiki-item recent-item ${isOpen ? 'active' : ''}" @click=${() => this.#handleWikiSelect(pagePath)} title=${pagePath}>
+            ${p.folder ? html`<span class="recent-folder">${p.folder}/</span>` : nothing}
             <span class="conv-title">${p.title}</span>
             <span class="recent-time">${this.#formatRelativeTime(p.modified)}</span>
           </div>

--- a/src/decafclaw/web/static/styles/sidebar.css
+++ b/src/decafclaw/web/static/styles/sidebar.css
@@ -386,6 +386,20 @@ conversation-sidebar .mobile-close-btn:hover {
   color: var(--pico-color);
 }
 
+.recent-item {
+  flex-wrap: wrap;
+}
+
+.recent-folder {
+  width: 100%;
+  font-size: 0.7rem;
+  color: var(--pico-muted-color);
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .recent-time {
   font-size: 0.75rem;
   color: var(--pico-muted-color);

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -321,9 +321,10 @@ async def test_vault_recent_empty(client):
 
 @pytest.mark.asyncio
 async def test_vault_recent_sorted_by_mtime(client, http_config):
-    vault = http_config.vault_root
-    old_page = vault / "Old.md"
-    new_page = vault / "New.md"
+    pages_dir = http_config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    old_page = pages_dir / "Old.md"
+    new_page = pages_dir / "New.md"
     old_page.write_text("# Old")
     new_page.write_text("# New")
     os.utime(old_page, (1_700_000_000, 1_700_000_000))
@@ -339,9 +340,10 @@ async def test_vault_recent_sorted_by_mtime(client, http_config):
 
 @pytest.mark.asyncio
 async def test_vault_recent_respects_limit(client, http_config):
-    vault = http_config.vault_root
+    pages_dir = http_config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
     for i in range(5):
-        (vault / f"Page{i}.md").write_text(f"# Page {i}")
+        (pages_dir / f"Page{i}.md").write_text(f"# Page {i}")
 
     resp = await client.get("/api/vault/recent?limit=2")
     assert resp.status_code == 200
@@ -350,8 +352,7 @@ async def test_vault_recent_respects_limit(client, http_config):
 
 @pytest.mark.asyncio
 async def test_vault_recent_includes_subfolders(client, http_config):
-    vault = http_config.vault_root
-    sub = vault / "agent" / "pages"
+    sub = http_config.vault_agent_pages_dir / "people"
     sub.mkdir(parents=True, exist_ok=True)
     (sub / "Deep.md").write_text("# Deep")
 
@@ -359,4 +360,20 @@ async def test_vault_recent_includes_subfolders(client, http_config):
     pages = resp.json()["pages"]
     deep = [p for p in pages if p["title"] == "Deep"]
     assert len(deep) == 1
-    assert deep[0]["folder"] == "agent/pages"
+    assert "people" in deep[0]["folder"]
+
+
+@pytest.mark.asyncio
+async def test_vault_recent_excludes_user_pages(client, http_config):
+    """Pages outside the agent dir should not appear in recent changes."""
+    vault = http_config.vault_root
+    (vault / "UserNote.md").write_text("# My personal note")
+    pages_dir = http_config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    (pages_dir / "AgentPage.md").write_text("# Agent page")
+
+    resp = await client.get("/api/vault/recent")
+    pages = resp.json()["pages"]
+    titles = [p["title"] for p in pages]
+    assert "AgentPage" in titles
+    assert "UserNote" not in titles

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -72,6 +72,14 @@ class TestResolvePage:
     def test_nonexistent_returns_none(self, config, vault_dir):
         assert resolve_page(config, "DoesNotExist") is None
 
+    def test_strips_md_suffix(self, config, vault_dir):
+        """Passing 'Page.md' should resolve to Page.md, not Page.md.md."""
+        (vault_dir / "Hello.md").write_text("# Hello")
+        result = resolve_page(config, "Hello.md")
+        assert result is not None
+        assert result.name == "Hello.md"
+        assert not (vault_dir / "Hello.md.md").exists()
+
 
 class TestVaultRead:
     @pytest.mark.asyncio
@@ -145,6 +153,15 @@ class TestVaultWrite:
     async def test_rejects_empty_content(self, ctx, vault_dir):
         result = await tool_vault_write(ctx, "agent/pages/Empty", "")
         assert "error" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_strips_md_suffix(self, ctx, vault_dir):
+        """Writing 'page.md' should create page.md, not page.md.md."""
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            result = await tool_vault_write(ctx, "agent/pages/Test.md", "# Test")
+        assert "saved" in result.lower() or "saved" in str(result).lower()
+        assert (vault_dir / "agent" / "pages" / "Test.md").exists()
+        assert not (vault_dir / "agent" / "pages" / "Test.md.md").exists()
 
 
 class TestVaultJournalAppend:


### PR DESCRIPTION
## Summary

Follow-up to #229 with several improvements discovered during live testing:

**Vault recent changes:**
- Scope scan to agent dir only — excludes user's personal Obsidian pages
- Show parent folder path above page title in dimmer text for disambiguation
- Skip hidden directories (.obsidian, .git, .trash)
- Clamp negative limit values

**Double .md.md fix:**
- `resolve_page` and `_safe_write_path` now strip `.md` suffix before appending it, preventing `Foo.md.md` when the LLM passes `"Foo.md"` as the page name
- Cleanup script: `scripts/fix-double-md.sh` (dry run by default, `--apply` to rename)

**Bonus:**
- Fix pre-existing JS typecheck error from #225 (Element → HTMLElement cast)
- Tab switch respects current vault view (Browse/Recent)

Closes #228

## Test plan

- [x] `make check` — lint, pyright, tsc all clean
- [x] 5 vault recent API tests (empty, mtime sort, limit, subfolders, user page exclusion)
- [x] 2 vault .md suffix stripping tests (resolve_page, vault_write)
- [x] Visual test: toggle Recent view, verify folder paths and timestamps display correctly
- [ ] Run `fix-double-md.sh` on deployed vault to clean up existing .md.md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)