### PR TITLE
feat: extract ConversationManager, persistent confirmations, transport adapters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/__init__.py` — Entry point, config/context setup, mode dispatch
 - `src/decafclaw/agent.py` — Agent loop: turn orchestration, tool execution, LLM calls
 - `src/decafclaw/interactive_terminal.py` — Interactive terminal mode (stdin/stdout REPL)
-- `src/decafclaw/mattermost.py` — Mattermost client, message handling, flood protection, progress subscriber
+- `src/decafclaw/conversation_manager.py` — Central orchestrator: agent loop lifecycle, confirmation persistence, per-conversation event streams
+- `src/decafclaw/confirmations.py` — Confirmation types (ConfirmationAction, Request, Response), handler registry
+- `src/decafclaw/mattermost.py` — Mattermost transport adapter: message handling, debouncing, circuit breaker, ConversationDisplay lifecycle
 - `src/decafclaw/mattermost_display.py` — ConversationDisplay: per-turn Mattermost message sequencing
 - `src/decafclaw/llm/` — LLM client package: provider abstraction, registry, multi-provider support
 - `src/decafclaw/llm/types.py` — Provider protocol, StreamCallback type
@@ -63,7 +65,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/tools/search_tools.py` — `tool_search` tool: keyword and exact-name lookup for deferred tools
 - `src/decafclaw/reflection.py` — Self-reflection: judge call, prompt assembly, result parsing (Reflexion pattern)
 - `src/decafclaw/commands.py` — User-invokable commands: trigger parsing, argument substitution, execution (fork/inline)
-- `src/decafclaw/tools/confirmation.py` — Shared confirmation request helper (event-bus-based user approval)
+- `src/decafclaw/tools/confirmation.py` — Shared confirmation request helper (bridges to ConversationManager)
 - `src/decafclaw/runner.py` — Top-level orchestrator: manages MCP, HTTP server, Mattermost, heartbeat as parallel tasks
 - `src/decafclaw/web/` — Web gateway: auth, conversations, conversation folders, WebSocket chat handler
 - `src/decafclaw/web/conversation_folders.py` — Per-user conversation folder index (JSON file, metadata-only)
@@ -129,9 +131,13 @@ Session docs live in `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` with `spec.md`, `
 - **`end_turn` on ToolResult.** Tools can return `ToolResult(text="...", end_turn=True)` to mechanically end the agent turn. The loop makes one final no-tools LLM call (forcing text output), then returns. For review gates, use `end_turn=EndTurnConfirm(message=..., on_approve=..., on_deny=...)` — the agent loop shows confirmation buttons; approval continues the loop, denial ends the turn. `EndTurnConfirm` takes priority over `True` in parallel batches.
 - **Dynamic skill tools via `get_tools(ctx)`.** Skills can export `get_tools(ctx) -> (dict, list)` to supply different tools per turn based on state. Called each iteration before `_build_tool_list()`. Falls back to static `TOOLS`/`TOOL_DEFINITIONS` for skills without it. Refreshes via `_refresh_dynamic_tools()` which tracks provider names to remove stale entries.
 - **Events for progress.** Tools publish `tool_status` events via `ctx.publish()`. The agent loop publishes `llm_start/end` and `tool_start/end`. Subscribers (Mattermost, terminal) handle display.
+- **ConversationManager owns agent loops.** All transports (WebSocket, Mattermost, interactive terminal) delegate turn lifecycle to the ConversationManager. The manager handles context setup, history loading, confirmation persistence, message queuing, and per-conversation event streams. Transports are thin adapters: parse input, format output, manage connections. Heartbeat and scheduled tasks bypass the manager (fire-and-forget, no persistent state).
+- **Confirmations are persistent conversation messages.** Confirmation requests and responses are written to the JSONL archive with `role: "confirmation_request"` / `role: "confirmation_response"`. The agent loop suspends mechanically at confirmations and resumes when resolved. Typed action handlers (`ConfirmationAction` enum) determine what happens on approval/denial. Pending confirmations survive page reload and server restart (startup scan recovers them).
+- **Transport adapters subscribe to per-conversation event streams.** Instead of subscribing to the global event bus, transports subscribe to a conversation's event stream via `manager.subscribe(conv_id, callback)`. Events include streaming chunks, tool lifecycle, confirmation requests, and turn completion. The manager bridges global event bus events to per-conversation streams.
 - **Web UI conversation management is REST-only.** All conversation listing, creation, renaming, archiving, folder management uses REST endpoints. WebSocket is only for real-time chat streaming, conversation selection/history loading, model changes, and turn cancellation. Conversation folders are metadata-only (per-user JSON index file); archive files stay in place.
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholder management, threading logic — all in `MattermostClient`.
 - **Mattermost PATCH API quirks.** Omitting `props` from a PATCH preserves existing props (including attachments). To strip attachments, you must explicitly send `props: {"attachments": []}`. However, sending a PATCH with only `props` and no `message` field clears the message text, showing "(message deleted)". Always include the message text when patching props — fetch it first if needed.
+- **Mattermost interactive button gotchas.** Button IDs must not contain underscores — Mattermost silently drops callbacks. The `http_callback_base` config must be reachable from the Mattermost server's network (not just the local machine). If buttons render but clicking does nothing and no callback hits the server, check: (1) `http_callback_base` points to an IP/host the MM server can reach, (2) the MM server's `AllowedUntrustedInternalConnections` includes that host, (3) the local IP hasn't changed (common on laptops with DHCP).
 - **Config via defaults → config.json → env vars.** Config is resolved in priority order: dataclass defaults → `data/{agent_id}/config.json` → env vars. Env vars are highest priority. Dataclass defaults in `config.py`, sub-dataclasses in `config_types.py`.
 - **Use `dataclasses.replace()` to copy Config.** Never copy fields manually — new fields get silently lost. This caused a real bug with semantic search in the eval runner. For nested sub-dataclasses, use the nested pattern: `dataclasses.replace(config, agent=dataclasses.replace(config.agent, data_home=tmp, id="eval"))`.
 - **Check for running bot instances before starting one.** Only one websocket connection per Mattermost bot account. A second instance silently misses events.

--- a/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/notes.md
+++ b/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/notes.md
@@ -1,0 +1,87 @@
+# Session Notes: Confirmation Redesign & Conversation Manager
+
+## Phase 1: Conversation Manager Core
+
+- Created `src/decafclaw/confirmations.py` — ConfirmationAction enum, ConfirmationRequest/Response dataclasses with archive serialization, ConfirmationHandler protocol, ConfirmationRegistry
+- Created `src/decafclaw/conversation_manager.py` — ConversationState dataclass, ConversationManager class with API skeleton (send_message, respond_to_confirmation, cancel_turn, get_state, subscribe/unsubscribe, emit, load_history, request_confirmation)
+- Phase 2 methods are stubs (raise NotImplementedError)
+- Verified: lint clean, type-check clean, serialization round-trips correctly
+
+## Phase 2: Agent Loop Integration
+
+- Implemented all ConversationManager methods: send_message, respond_to_confirmation, cancel_turn, request_confirmation
+- Manager handles: context setup, history loading, streaming via event emission, skill state persistence, message queuing/draining
+- Modified `tools/confirmation.py` to bridge to manager when `ctx.request_confirmation` is set, falls back to legacy event-bus flow
+- Added tool_name → ConfirmationAction mapping in the bridge
+- Manager sets `ctx.request_confirmation` as a closure capturing conv_id
+- Global event bus events forwarded to per-conversation subscribers via create_task (avoids blocking)
+- Tests: confirmation approve/deny/timeout, archive persistence, subscription, queueing, cancellation
+- All 1292 tests pass, lint clean, type-check clean
+
+## Phase 3: WebSocket Transport Adapter
+
+- Rewrote `websocket.py` as thin adapter over ConversationManager
+- Removed: `_start_agent_turn`, `_run_agent_turn`, `busy_convs`, `pending_msgs`, `cancel_events`, `agent_tasks`, `conv_viewers`, `conv_flags`, `streaming_buffer` management
+- `_handle_send` → `manager.send_message()` with `context_setup` callback for transport-specific fields
+- `_handle_cancel_turn` → `manager.cancel_turn()`
+- `_handle_confirm_response` → `manager.respond_to_confirmation()` (with legacy fallback)
+- Added `_subscribe_to_conv()` / `_unsubscribe_all()` for per-conversation event streams
+- Subscription callback handles streaming buffer, event formatting, confirmation forwarding
+- `_handle_select_conv` and `_handle_load_history` now include `pending_confirmation` for reload recovery
+- Wired manager through `runner.py` → `http_server.py` → `websocket_chat()`
+- Client-side: updated `PendingConfirm` typedef with `confirmation_id`, `conv_id`, `action_type`, `action_data`
+- Client-side: `respondToConfirm` now sends `confirmation_id` and `conv_id`
+- Client-side: `conv_history` and `conv_selected` restore pending confirmations from server state
+- Updated `test_ws_queue.py` to test through manager instead of removed internals
+- All 1291 tests pass, lint clean, type-check clean, JS type-check clean
+
+## Phase 4: Interactive Terminal Adapter
+
+- Rewrote `interactive_terminal.py` to use ConversationManager
+- Removed: direct `run_agent_turn()` call, manual history loading, manual event bus subscription
+- Uses `manager.send_message()` with `context_setup` callback, waits on `turn_done` asyncio.Event
+- Event subscriber handles: streaming chunks, tool status, confirmation prompts (with manager.respond_to_confirmation), turn completion
+- Confirmation prompts route through manager instead of event bus
+- All 1291 tests pass, lint clean, type-check clean
+
+## Phase 5: Mattermost Transport Adapter
+
+- Rewrote `mattermost.py` to use ConversationManager for turn lifecycle
+- Replaced `ConversationState` with `MattermostConvState` (transport concerns only: debounce, circuit breaker, cooldown, display)
+- Agent loop state (history, busy, skill_state) now in manager's ConversationState
+- `_process_conversation` → `manager.send_message()` with `context_setup` callback
+- `_subscribe_progress` → `_ensure_subscribed` subscribing to manager event stream
+- Manager event subscriber routes to `ConversationDisplay` callbacks (same display logic)
+- New `_poll_confirmation_manager` routes emoji reactions through `manager.respond_to_confirmation()`
+- `mattermost_display.py`: `on_confirm_request` now returns post_id, caller starts polling
+- Removed old `_poll_confirmation` (event-bus-based) and `_subscribe_progress`
+- Manager passed through `runner.py` → `client.run(app_ctx, shutdown_event, manager=manager)`
+- Updated `test_circuit_breaker.py` for `MattermostConvState`, `test_imports.py` for removed methods
+- All 1291 tests pass, lint clean, type-check clean
+
+## Phase 6: Startup Recovery
+
+- Added `startup_scan()` to ConversationManager: scans conversation archives for unresolved confirmation requests
+- Reads last messages from each archive, looks for `confirmation_request` without matching `confirmation_response`
+- Staleness check: ignores confirmations older than 24 hours
+- Added `recover_confirmation()`: dispatches to confirmation handler when response comes for a recovered (no running loop) confirmation
+- `respond_to_confirmation()` now calls `recover_confirmation()` when no confirmation_event is set
+- `runner.py` calls `manager.startup_scan()` before starting transports
+- Tests: recovery of pending, skip resolved, skip stale, empty archive, respond-to-recovered
+- All 1296 tests pass, lint clean, type-check clean
+
+## Phase 7: Cleanup, Tests, and Documentation
+
+- Added `request_confirmation` as a declared field on Context (no longer dynamic attribute)
+- `fork_for_tool_call` now copies `request_confirmation` to child contexts
+- `tools/confirmation.py`: manager path is primary, event-bus fallback kept with deprecation warning (for heartbeat/scheduled tasks that don't go through manager)
+- Updated `CLAUDE.md`:
+  - Added `conversation_manager.py` and `confirmations.py` to key files
+  - Updated `tools/confirmation.py` description
+  - Updated `mattermost.py` description
+  - Added conventions for ConversationManager, persistent confirmations, transport event streams
+- All 1296 tests pass, lint clean, type-check clean, JS type-check clean
+
+## Summary
+
+This session extracted a ConversationManager as the central orchestrator for agent loops, replacing transport-coupled agent turn invocation with a clean adapter pattern. All three transports (WebSocket, Mattermost, interactive terminal) now delegate to the manager. Confirmations are persisted as first-class conversation messages with typed action handlers, surviving page reload and server restart. The architecture enables future transport additions (Discord, Telegram, etc.) as thin adapters over the same manager API.

--- a/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/plan.md
+++ b/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/plan.md
@@ -1,0 +1,478 @@
+# Implementation Plan: Conversation Manager & Confirmation Redesign
+
+## Overview
+
+Seven phases, each leaving the system working. During migration, transports switch to the manager one at a time — the old event-bus confirmation flow coexists until all transports are migrated, then gets removed.
+
+Heartbeat and scheduled tasks remain direct `run_agent_turn` callers — they're fire-and-forget with no persistent state, no confirmations (heartbeat auto-approves, scheduled tasks pre-activate skills), and no connected viewers. They can migrate later if needed.
+
+---
+
+## Phase 1: Conversation Manager Core
+
+**What this builds:** The manager module with per-conversation state, confirmation types, event stream, and the public API skeleton. No changes to existing code yet — this is pure addition.
+
+**Codebase state after:** New modules exist but nothing uses them. All existing behavior unchanged.
+
+### Prompt
+
+Create two new modules:
+
+**`src/decafclaw/confirmations.py`** — Confirmation types and handler registry.
+
+- `ConfirmationAction` enum: `RUN_SHELL_COMMAND`, `ACTIVATE_SKILL`, `CONTINUE_TURN`, `ADVANCE_PROJECT_PHASE`
+- `ConfirmationRequest` dataclass: `confirmation_id` (auto-generated UUID), `action_type` (ConfirmationAction), `action_data` (dict), `message` (str), `approve_label` (str, default "Approve"), `deny_label` (str, default "Deny"), `tool_call_id` (str, optional), `timeout` (float, optional), `timestamp` (str, auto-set)
+- `ConfirmationResponse` dataclass: `confirmation_id` (str), `approved` (bool), `always` (bool, default False), `add_pattern` (bool, default False), `timestamp` (str, auto-set)
+- `ConfirmationHandler` protocol: `async def on_approve(ctx, request, response) -> dict` and `async def on_deny(ctx, request, response) -> dict` — returns a dict that the agent loop will use (e.g., `{"inject_message": "...", "continue_loop": True}`)
+- `ConfirmationRegistry` class: register handlers by action type, dispatch on response. Include default handlers for each action type that replicate current behavior.
+- Serialization: `to_archive_message()` on both dataclasses, producing dicts with `role: "confirmation_request"` / `role: "confirmation_response"` suitable for JSONL archive. `from_archive_message(dict)` class methods for deserialization.
+
+**`src/decafclaw/conversation_manager.py`** — The conversation manager.
+
+- `ConversationState` dataclass (replaces both mattermost.py's and websocket.py's scattered state):
+  - `conv_id: str`
+  - `history: list`
+  - `busy: bool` (turn in progress)
+  - `pending_messages: list` (queued while busy)
+  - `agent_task: asyncio.Task | None`
+  - `cancel_event: asyncio.Event | None`
+  - `pending_confirmation: ConfirmationRequest | None`
+  - `confirmation_event: asyncio.Event | None` (signals when response arrives)
+  - `confirmation_response: ConfirmationResponse | None`
+  - `skill_state: dict | None` (extra_tools, extra_definitions, activated_skills)
+  - `skip_vault_retrieval: bool`
+  - `subscribers: set` (event stream callbacks)
+  - `active_model: str`
+
+- `ConversationManager` class:
+  - Constructor takes `config`, `event_bus`, `confirmation_registry`
+  - Internal `_conversations: dict[str, ConversationState]`
+  - `_get_or_create(conv_id) -> ConversationState` — lazy init with history load from archive
+  - `async send_message(conv_id, text, user_id, ...)` — API stub (implementation in Phase 2)
+  - `async respond_to_confirmation(conv_id, confirmation_id, approved, always=False, add_pattern=False)` — API stub
+  - `async cancel_turn(conv_id)` — API stub
+  - `get_state(conv_id) -> ConversationState` — returns current state including pending confirmation
+  - `subscribe(conv_id, callback) -> str` — returns subscription ID
+  - `unsubscribe(conv_id, subscription_id)`
+  - `async emit(conv_id, event)` — publish event to all subscribers of a conversation
+  - `load_history(conv_id) -> list` — load from archive (compacted + newer)
+
+Lint and type-check after. No tests yet (API stubs aren't functional), but ensure imports resolve cleanly.
+
+---
+
+## Phase 2: Agent Loop Integration
+
+**What this builds:** The manager can run agent turns — context setup, history management, streaming, and the new confirmation suspension/resumption flow. The agent loop itself (`agent.py`) gets minimal changes (confirmation requests go through the manager instead of the event bus).
+
+**Builds on:** Phase 1 (manager and confirmation types exist)
+
+**Codebase state after:** The manager is fully functional. Nothing calls it yet — transports still use the old path. Both paths work independently.
+
+### Prompt
+
+Wire the conversation manager to actually run agent turns:
+
+**In `conversation_manager.py`:**
+
+Implement `send_message()`:
+1. Get or create conversation state
+2. If busy, queue the message and return
+3. Set busy, create cancel event
+4. Build a `Context` for the turn:
+   - Fork from a base context (passed to manager at init, or created from config + event_bus)
+   - Set `user_id`, `channel_id`, `conv_id`, `channel_name` from parameters
+   - Set `media_handler` from a factory passed by the transport (the manager shouldn't know about Mattermost vs LocalFile — the transport provides this)
+   - Restore per-conversation state: `skill_state`, `skip_vault_retrieval`, `active_model`
+   - Set `cancelled` to the cancel event
+   - Set `on_stream_chunk` to an internal callback that emits `chunk` events via `self.emit()`
+5. Load history via `load_history()`
+6. Create an `asyncio.Task` that calls `run_agent_turn(ctx, text, history, ...)`
+7. On task completion: save skill state back to conversation state, set not-busy, drain pending messages
+
+Implement `async _run_turn(state, ctx, text, history, ...)`:
+- Wrap `run_agent_turn()` call
+- On completion, emit `turn_complete` event
+- On error, emit `error` event
+- After turn completes, persist conversation state (skill_state, flags)
+- Drain queued messages (recursively call `send_message` for each)
+
+Implement `respond_to_confirmation()`:
+1. Look up conversation state, verify `pending_confirmation` matches `confirmation_id`
+2. Create `ConfirmationResponse`, persist to archive via `append_message()`
+3. Store response on state, set `confirmation_event` to wake the waiting loop
+4. Emit `confirmation_response` event to subscribers
+
+Implement `cancel_turn()`:
+- Set cancel event, cancel the asyncio task
+
+Implement `async request_confirmation(conv_id, request: ConfirmationRequest) -> ConfirmationResponse`:
+- This is what the agent loop calls instead of the old `request_confirmation()` from `tools/confirmation.py`
+- Persist request to archive via `append_message(request.to_archive_message())`
+- Set `state.pending_confirmation = request`
+- Create `state.confirmation_event = asyncio.Event()`
+- Emit `confirmation_request` event to subscribers
+- Wait on `confirmation_event` with timeout
+- On response: dispatch to confirmation handler, return response
+- On timeout: create a denial response, persist, return it
+
+**In `agent.py`:**
+
+Add a way for the agent loop to access the manager's `request_confirmation` method. The cleanest approach: put a `request_confirmation` callable on `ctx` (set by the manager when building the context). The agent loop and tools call `ctx.request_confirmation(...)` instead of importing from `tools/confirmation.py`. If `ctx.request_confirmation` is not set (old code path), fall back to the old event-bus pattern. This enables gradual migration.
+
+**In `tools/confirmation.py`:**
+
+Modify `request_confirmation()` to check for `ctx.request_confirmation` first. If present, delegate to it (building a `ConfirmationRequest` from the arguments). If not, use the existing event-bus flow. This makes the migration transparent to tool code — tools keep calling `request_confirmation(ctx, ...)` and it routes to the right place.
+
+**Streaming integration:**
+
+The manager's internal `on_stream_chunk` callback should:
+- For `"text"` chunks: emit `{"type": "chunk", "conv_id": conv_id, "text": data}` to subscribers
+- For `"done"`: emit `{"type": "stream_done", "conv_id": conv_id}`
+- For `"tool_call_start"`: emit `{"type": "tool_call_start", "conv_id": conv_id, "name": data["name"]}`
+
+**Event forwarding:**
+
+Subscribe to the global event bus for events matching the conversation's context_id. Forward them to the conversation's subscribers via `emit()`. This bridges existing agent loop events (tool_start, tool_end, llm_start, etc.) to the per-conversation stream. The subscription is created when the turn starts and removed when it ends.
+
+Write tests for:
+- `send_message` starts a turn and emits events
+- `respond_to_confirmation` wakes a blocked confirmation
+- Message queuing when busy
+- Confirmation timeout produces denial
+- Cancel turn stops the agent task
+
+Lint and type-check.
+
+---
+
+## Phase 3: WebSocket Transport Adapter
+
+**What this builds:** Refactor `websocket.py` to be a thin adapter over the conversation manager. This is the first transport to migrate and validates the approach. Fixes #235 and #258 for the web UI.
+
+**Builds on:** Phase 2 (manager can run turns and handle confirmations)
+
+**Codebase state after:** Web UI works through the manager. Confirmations are scoped per-conversation and survive reload. Mattermost and terminal still use old path.
+
+### Prompt
+
+Refactor `src/decafclaw/web/websocket.py`:
+
+**Remove from websocket.py:**
+- `_run_agent_turn()` function — the manager handles this now
+- `_start_agent_turn()` function — replaced by `manager.send_message()`
+- `busy_convs`, `pending_msgs`, `cancel_events`, `agent_tasks` from state dict — the manager tracks these
+- `on_turn_event()` callback — replaced by manager subscription
+- `streaming_buffer` management — the manager handles this
+- `conv_flags` — the manager tracks per-conversation flags
+
+**Keep in websocket.py:**
+- WebSocket connection management
+- Message parsing (`_handle_send_message`, `_handle_select_conv`, `_handle_load_history`, etc.)
+- Command dispatch (`dispatch_command`)
+- Conversation index management (REST endpoints are separate, this is the WS side)
+
+**New pattern:**
+
+When a WebSocket selects a conversation (`_handle_select_conv`):
+1. Subscribe to the conversation's event stream via `manager.subscribe(conv_id, callback)`
+2. Check `manager.get_state(conv_id)` for any pending confirmation — if present, send it to the client immediately
+3. Store the subscription ID so we can unsubscribe when switching conversations or disconnecting
+
+The subscription callback formats events as WebSocket JSON messages (same format as current `on_turn_event` output — the client shouldn't need changes yet).
+
+When the WebSocket sends a message (`_handle_send_message`):
+1. Parse text, attachments, command context as before
+2. Call `manager.send_message(conv_id, text, user_id=username, ...)` instead of `_start_agent_turn()`
+3. The manager handles queuing, context setup, and turn execution
+
+When the WebSocket sends a confirmation response (`_handle_confirm_response`):
+1. Call `manager.respond_to_confirmation(conv_id, confirmation_id, approved, ...)` instead of publishing to event bus
+
+When the WebSocket cancels a turn (`_handle_cancel_turn`):
+1. Call `manager.cancel_turn(conv_id)` instead of setting cancel events directly
+
+**Transport-specific context:**
+
+The manager needs transport-specific information it can't know about (media handler, channel name). Use a context factory or callback pattern: when calling `manager.send_message()`, the transport passes a `context_setup` callback that the manager calls with the fresh ctx before starting the turn. For WebSocket, this sets `media_handler = LocalFileMediaHandler(config)`, `channel_name = "web"`, etc.
+
+**Multiple connections:**
+
+`conv_viewers` tracking moves to the subscription model — each WebSocket that selects a conversation subscribes. The manager's `emit()` fans out to all subscribers. When a WebSocket disconnects, unsubscribe all its active subscriptions.
+
+**Update `_handle_load_history`:**
+
+Call `manager.load_history(conv_id)` instead of reading archives directly. The manager may have in-memory history that's newer than the archive.
+
+**Client-side changes (minimal):**
+
+The `confirm_request` WebSocket message format should stay the same so existing UI components work. The key change is that on page load / conversation select, the server now sends any pending confirmation as part of the initial state.
+
+Add to the `conv_selected` response a `pending_confirmation` field if one exists. The client's `ToolStatusStore` should handle this new field and render the confirmation widget.
+
+In `src/decafclaw/web/static/lib/tool-status-store.js`:
+- Handle `pending_confirmation` in `conv_selected` messages (same as receiving a `confirm_request`)
+
+In `src/decafclaw/web/static/components/confirm-view.js`:
+- No changes needed if the data shape matches
+
+**Wiring:**
+
+The conversation manager needs to be accessible in the WebSocket handler. Pass it through the app state or as a parameter to the handler function. Update `http_server.py` to create and pass the manager.
+
+Test manually:
+- Send a message, verify streaming and tool execution work through the manager
+- Trigger a shell command that needs approval, verify confirmation appears
+- Reload the page, verify confirmation re-appears
+- Open two tabs on the same conversation, verify both see the confirmation
+- Switch conversations, verify confirmations are scoped correctly
+- Respond to confirmation, verify the agent loop resumes
+
+Lint and type-check. Run existing tests to check for regressions.
+
+---
+
+## Phase 4: Interactive Terminal Adapter
+
+**What this builds:** Refactor interactive_terminal.py to use the conversation manager. Simplest adapter — validates that the manager API works for non-WebSocket transports.
+
+**Builds on:** Phase 3 (manager is proven with WebSocket)
+
+**Codebase state after:** Terminal mode works through the manager. Two of three transports migrated.
+
+### Prompt
+
+Refactor `src/decafclaw/interactive_terminal.py`:
+
+**Remove:**
+- Direct `run_agent_turn()` call
+- Manual history loading from archive
+- Manual event bus subscription for progress display
+
+**New pattern:**
+
+`run_interactive()` becomes:
+1. Create or get the conversation manager (passed in or created from config + event_bus)
+2. Use a fixed `conv_id` (e.g., `"interactive"` as before, or a new UUID per session)
+3. Subscribe to the conversation's event stream with a callback that prints to stdout (replaces `_create_interactive_progress_subscriber`)
+4. In the REPL loop:
+   - Read user input
+   - Call `manager.send_message(conv_id, text, user_id=username, context_setup=terminal_context_setup)`
+   - Wait for `turn_complete` event (use an asyncio.Event set by the subscriber callback)
+   - Print the final response
+
+**Confirmation handling:**
+
+The subscriber callback watches for `confirmation_request` events. When one arrives:
+- Print the confirmation message to stdout
+- Prompt the user for input (approve/deny/always) via `asyncio.to_thread(input, ...)`
+- Call `manager.respond_to_confirmation(conv_id, confirmation_id, approved, ...)`
+
+This replaces the current inline confirmation handler in `_create_interactive_progress_subscriber`.
+
+**Context setup callback:**
+
+```python
+def terminal_context_setup(ctx):
+    ctx.media_handler = LocalFileMediaHandler(config)
+    ctx.channel_name = "interactive"
+```
+
+The streaming callback is no longer set by the terminal — the manager sets its own callback that emits events. The terminal's subscriber handles `chunk` events by printing to stdout.
+
+Test manually:
+- Run interactive mode, send messages, verify responses
+- Trigger a confirmation, verify prompt appears and response works
+- Verify history persists across messages in the same session
+
+Lint and type-check.
+
+---
+
+## Phase 5: Mattermost Transport Adapter
+
+**What this builds:** Refactor mattermost.py to use the conversation manager. Most complex adapter — has debouncing, circuit breaker, emoji polling, post editing. Keep all display logic, delegate state and turn management.
+
+**Builds on:** Phase 4 (manager proven with two transports)
+
+**Codebase state after:** All three transports use the manager. Old direct `run_agent_turn` code paths removed from transports.
+
+### Prompt
+
+Refactor `src/decafclaw/mattermost.py`:
+
+**Remove:**
+- `ConversationState` dataclass (replaced by manager's state)
+- `_conversations` dict
+- Direct `run_agent_turn()` calls in `_process_conversation()`
+- Manual history loading in `_prepare_history()`
+- Per-conversation busy/queue management
+- `_save_skill_state()` / skill state restoration
+- `_subscribe_progress()` — replaced by manager subscription
+
+**Keep:**
+- `MattermostClient` class and WebSocket connection management
+- Message parsing (`_on_posted`, `_should_respond`, mention detection)
+- `ConversationDisplay` and all display logic (`mattermost_display.py`)
+- Emoji reaction polling for confirmations (but route responses through manager)
+- HTTP button callbacks for confirmations (but route through manager)
+- Circuit breaker logic (move to manager or keep as Mattermost-specific — see below)
+- Debounce timer logic
+
+**New pattern:**
+
+When a message arrives (`_on_posted`):
+1. Parse the message, determine conv_id (root_id or channel_id) as before
+2. Call `manager.send_message(conv_id, text, user_id=..., context_setup=mm_context_setup, ...)`
+3. The manager handles queuing, history, and turn execution
+
+**Context setup callback:**
+```python
+def mm_context_setup(ctx):
+    ctx.media_handler = MattermostMediaHandler(self._http, channel_id)
+    ctx.channel_name = ""
+    ctx.thread_id = root_id
+```
+
+**Event subscription:**
+
+On first message to a conversation, subscribe to the manager's event stream. The subscriber creates/manages a `ConversationDisplay` instance and routes events to its callbacks:
+- `chunk` → `display.on_text_chunk()`
+- `tool_start` → `display.on_tool_start()`
+- `tool_status` → `display.on_tool_status()`
+- `tool_end` → `display.on_tool_end()`
+- `confirmation_request` → `display.on_confirm_request()` (which creates Mattermost post with buttons/emoji hints)
+- `message_complete` → `display.on_text_complete()`
+- `turn_complete` → cleanup
+
+**Confirmation flow:**
+
+When a confirmation request event arrives, the Mattermost display creates a post with buttons/emoji as before. When the user responds (emoji reaction or HTTP button):
+- Instead of publishing `tool_confirm_response` on the event bus, call `manager.respond_to_confirmation(conv_id, confirmation_id, approved, ...)`
+- Update `http_server.py`'s `handle_confirm()` to route through the manager too
+
+**Debouncing and circuit breaker:**
+
+These are Mattermost-specific concerns (preventing rapid-fire posts from overwhelming the channel). Options:
+1. Keep in the Mattermost adapter as a wrapper around `manager.send_message()`
+2. Move into the manager as configurable per-transport policy
+
+Option 1 is simpler and keeps the manager generic. The adapter debounces before calling the manager, and the circuit breaker decides whether to call at all.
+
+**`mattermost_display.py` changes:**
+
+Minimal. The display still receives events and manages Mattermost posts. The only change is where events come from (manager subscription instead of direct event bus subscription) and how confirmations are responded to.
+
+**`mattermost_ui.py` changes:**
+
+The `ConfirmTokenRegistry` and button building stay. But `handle_confirm()` in `http_server.py` needs to call the manager instead of publishing to event bus.
+
+Test manually in Mattermost:
+- Send a message, verify streaming and tool execution work
+- Trigger shell approval, verify buttons/emoji appear
+- Approve via emoji, verify command executes
+- Approve via button, verify command executes
+- Verify conversation state persists across turns (skill activation, etc.)
+- Verify debouncing and circuit breaker still work
+- Verify confirmations are scoped to the right conversation
+
+Lint, type-check, run tests.
+
+---
+
+## Phase 6: Startup Recovery & Confirmation Persistence
+
+**What this builds:** On server startup, scan for conversations with interrupted confirmations. Re-create pending state so transports can re-render them.
+
+**Builds on:** Phase 5 (all transports use the manager, confirmations are persisted as archive messages)
+
+**Codebase state after:** Server restart with a pending confirmation is recoverable. All acceptance criteria met.
+
+### Prompt
+
+**In `conversation_manager.py`:**
+
+Add `async startup_scan(self)`:
+1. Scan `{workspace}/conversations/*.jsonl` for archives
+2. For each, read the last N messages (tail the file, don't load everything)
+3. If the last message has `role: "confirmation_request"` with no subsequent `role: "confirmation_response"`, this is an interrupted confirmation
+4. Deserialize the request via `ConfirmationRequest.from_archive_message()`
+5. Create a `ConversationState` for this conv_id with `pending_confirmation` set
+6. Don't create a `confirmation_event` yet — that happens when a transport calls `respond_to_confirmation()`
+
+Add `async recover_confirmation(self, conv_id)`:
+- Called when a response comes in for a conversation that has a pending confirmation but no running agent loop
+- Dispatch to the confirmation handler's `on_approve`/`on_deny`
+- For `run_shell_command`: execute the command, archive the result
+- For `activate_skill`: activate the skill (for the next turn — no loop to resume)
+- For `continue_turn`: start a new agent turn with the full history (the LLM will see the confirmation exchange and continue)
+- For `advance_project_phase`: advance the phase state
+
+**In `runner.py`:**
+
+After creating the conversation manager, call `await manager.startup_scan()` before starting transports. This ensures pending confirmations are in memory before any client connects.
+
+**Transport changes:**
+
+Already handled by the subscription model — when a transport connects and subscribes to a conversation, it calls `get_state()` which returns any pending confirmation. The only new thing is that on startup, there may be conversations with pending confirmations that no transport has connected to yet. That's fine — they sit in memory until a transport connects.
+
+**Edge cases:**
+- Multiple interrupted confirmations in the same conversation: only the last one matters (earlier ones timed out or were superseded)
+- Very old interrupted confirmations: add a staleness check (e.g., if the request is more than 24 hours old, discard it rather than recovering)
+- Confirmation for a conversation that no longer exists: skip it
+
+Write tests for:
+- Startup scan finds interrupted confirmations
+- Recovery dispatches to correct handler
+- Stale confirmations are discarded
+- Clean archives (no pending confirmations) produce no state
+
+Lint and type-check.
+
+---
+
+## Phase 7: Cleanup, Tests, and Documentation
+
+**What this builds:** Remove old code paths, dead code, update tests and documentation.
+
+**Builds on:** Phase 6 (everything works through the manager)
+
+**Codebase state after:** Clean codebase, all tests pass, docs updated.
+
+### Prompt
+
+**Remove old confirmation code:**
+- `tools/confirmation.py`: Remove the event-bus fallback path. The `request_confirmation()` function should now always delegate to `ctx.request_confirmation()` and raise an error if it's not set (meaning the caller isn't going through the manager).
+- `mattermost.py`: Remove `ConversationState` dataclass and `_conversations` dict (now in manager)
+- `websocket.py`: Remove `_run_agent_turn`, `_start_agent_turn`, and all state management code that was replaced
+- `events.py`: The event bus stays (used for global events, heartbeat, etc.) but `tool_confirm_request` / `tool_confirm_response` events are no longer used for confirmations — remove any code that depends on this pattern
+- `mattermost_ui.py`: The token registry stays (HTTP buttons still use tokens) but response routing goes through the manager
+
+**Update tests:**
+- Update any existing tests that mock `request_confirmation()` or event-bus confirmation patterns
+- Add integration tests for the full confirmation flow through the manager
+- Test confirmation persistence and recovery
+- Test multi-transport scenarios (if feasible with test harness)
+
+**Update documentation:**
+- `CLAUDE.md`: Update conventions section for confirmation patterns, add conversation_manager.py and confirmations.py to key files
+- `docs/`: Create a new `docs/conversation-manager.md` page documenting the architecture
+- `docs/`: Update any existing docs that reference the old confirmation flow
+- `README.md`: Update if the architecture section references the old pattern
+
+**Final verification:**
+- `make check` passes (lint + type-check, Python and JS)
+- `make test` passes
+- Manual testing in web UI: all acceptance criteria
+- Manual testing in Mattermost: confirmations work, no regressions
+- Manual testing in interactive terminal: confirmations work
+- Server restart recovery: works
+
+---
+
+## Risk Notes
+
+- **Biggest risk:** Phase 5 (Mattermost adapter) has the most surface area and the most transport-specific logic. Circuit breaker, debouncing, ConversationDisplay lifecycle — all need careful migration.
+- **Migration gap:** During Phases 3-4, Mattermost still uses the old code path. This is fine — the bugs are web-only and Mattermost confirmations already work. But it means we can't remove old confirmation code until Phase 7.
+- **Streaming fidelity:** The current streaming paths have subtle buffering logic (WebSocket's `streaming_buffer`, Mattermost's display buffer). The manager's unified event stream needs to preserve the same behavior or transports need to replicate it in their subscribers.
+- **Child agent confirmations:** Need to verify that child agent events still route correctly through the manager. The `event_context_id` mechanism needs to work with the manager's per-conversation event forwarding.

--- a/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/spec.md
+++ b/docs/dev-sessions/2026-04-14-1156-confirmation-redesign/spec.md
@@ -1,0 +1,162 @@
+# Confirmation Redesign & Conversation Manager
+
+## Problem
+
+Two related bugs (#235, #258) reveal a deeper architectural issue:
+
+1. **#235 — Confirmations appear in wrong conversation.** The event bus is global and confirmation events aren't scoped per-conversation. Switching conversations in the web UI can show a confirmation from conversation A in conversation B.
+
+2. **#258 — Confirmations lost on page reload.** Pending confirmations exist only in client-side memory (`ToolStatusStore.#pendingConfirms`) and a server-side `asyncio.Event`. Reloading the page loses the UI widget while the agent loop hangs waiting for a response that will never come.
+
+Both stem from the same root cause: the agent loop is coupled to the WebSocket handler, and confirmations are ephemeral in-memory events with no persistence or conversation scoping.
+
+## Solution
+
+Extract a **conversation manager** as the central orchestrator. Agent loops become server-side tasks owned by the manager, independent of any transport. WebSocket, Mattermost, and interactive terminal become thin transport adapters. Confirmations become first-class messages in the conversation log.
+
+## Architecture
+
+### Conversation Identity
+
+Conversations get a unique internal ID managed by the conversation manager, separate from any transport-specific identifier. Transports maintain their own mapping from channel-specific keys to conversation IDs:
+
+- **Mattermost:** `root_id` (threads) or `channel_id` (top-level) → conversation ID
+- **Web UI:** `web-{uuid}` slugs map 1:1 to conversation IDs (may be the same string)
+- **Interactive terminal:** single implicit conversation per session
+
+This decouples conversation identity from any particular transport. A conversation could theoretically be accessible from multiple channels (not in scope, but the model supports it).
+
+### Conversation Manager
+
+A server-side singleton that is the authority on conversation state. Owns:
+
+- **Agent loop lifecycle** — start, suspend (at confirmation), resume, cancel, timeout
+- **Conversation history** — load, append, archive
+- **Confirmation state** — persist request to history, accept response, resume loop
+- **Event stream** — uniform stream of events per conversation, fanned out to connected viewers
+- **Conversation state** — replaces the scattered state currently in `mattermost.py` (`ConversationState`), `websocket.py` (`state` dict, `busy_convs`, `pending_msgs`), etc.
+- **Message queuing** — when a turn is in progress (or suspended at confirmation), incoming messages are queued and drained when the turn completes. Replaces the `pending_msgs` dict currently in `websocket.py`.
+
+High-level API for transports:
+
+- `send_message(conv_id, text, attachments, ...)` — submit user input, starts/queues an agent turn
+- `respond_to_confirmation(conv_id, confirmation_id, response)` — resolve a pending confirmation
+- `cancel_turn(conv_id)` — cancel an in-progress agent turn
+- `get_state(conv_id)` — get current conversation state including any pending confirmation
+- `subscribe(conv_id, callback)` / `unsubscribe(conv_id, callback)` — attach/detach from a conversation's event stream
+- `list_conversations(user_id)` — list conversations for a user
+- `load_history(conv_id)` — load conversation history
+
+### Transport Adapters
+
+Thin adapters that handle connection management, input parsing, and output formatting. Each adapter:
+
+- Parses incoming messages from its channel
+- Calls the conversation manager's API
+- Subscribes to the conversation's event stream
+- Formats events for its channel (WebSocket JSON, Mattermost post edits, terminal stdout)
+- Manages transport-specific UI (Mattermost emoji reactions, web UI components, terminal prompts)
+
+Three adapters in scope:
+
+1. **WebSocket adapter** — replaces current `websocket.py` handler. Multiple WebSocket connections can observe the same conversation. Connect/disconnect doesn't affect the agent loop.
+2. **Mattermost adapter** — replaces current `mattermost.py` agent turn invocation. Keeps its display logic (post editing, progress formatting, emoji polling) but delegates agent loop and state management to the conversation manager.
+3. **Interactive terminal adapter** — replaces current `interactive_terminal.py`. Simple REPL that calls the manager API.
+
+### Confirmations as Conversation Messages
+
+Confirmation requests and responses are persisted as messages in the conversation log:
+
+```json
+{"role": "confirmation_request", "confirmation_id": "abc123", "action_type": "run_shell_command", "action_data": {"command": "rm -rf /tmp/build"}, "message": "Allow shell command?", "approve_label": "Approve", "deny_label": "Deny", "tool_call_id": "tc_456", "timestamp": "..."}
+```
+
+```json
+{"role": "confirmation_response", "confirmation_id": "abc123", "approved": true, "timestamp": "..."}
+```
+
+The agent loop suspends mechanically at a confirmation request. It resumes only when a matching response is appended to the history. This is a guardrail, not a signal for the LLM to interpret.
+
+### Typed Confirmation Actions
+
+Confirmations carry a fixed action type that determines what happens on approval. Each type has a known handler, making confirmations recoverable after server restart.
+
+Initial action types:
+
+- **`run_shell_command`** — execute a shell command. Data: `{command, suggested_pattern}`
+- **`activate_skill`** — activate a named skill. Data: `{skill_name}`
+- **`continue_turn`** — resume the agent loop (generic EndTurnConfirm). Data: `{}`
+- **`advance_project_phase`** — project skill phase gate. Data: `{phase, project_id}`
+
+New confirmation types require adding a handler to the registry — this is the right forcing function to ensure all confirmations are recoverable.
+
+**Handler-controlled LLM context.** Confirmation handlers own what the LLM sees after a confirmation is resolved. Some handlers may inject specific prompts, tool results, or context based on the approval/denial. For example:
+
+- Shell approval: on approve, execute the command and return the result as a tool result. On deny, inject a message telling the agent the command was denied.
+- EndTurnConfirm: on approve, continue the loop. On deny, inject a prompt asking the agent what to change.
+- Skill activation: on approve, activate and inject the skill context. On deny, tell the agent the skill was denied.
+
+The confirmation response message in history records what happened, but the handler determines what goes into the LLM's next turn.
+
+### Child Agent Confirmations
+
+Child agents (spawned via `delegate_task`) can trigger confirmations. These must appear in the **parent** conversation, not in the child's isolated context. The current `event_context_id` mechanism routes child events to the parent — the conversation manager must preserve this:
+
+- Child agent's confirmation request is persisted in the parent's conversation history
+- The parent conversation's connected transports see and can respond to it
+- The response routes back to the child agent's suspended loop via the manager
+
+### Startup Recovery
+
+On server startup, the conversation manager scans for conversations with interrupted confirmations:
+
+1. Scan conversation archives for messages where the last entry is a `confirmation_request` with no matching `confirmation_response`
+2. For each, register a pending confirmation in the manager's state
+3. When a transport connects and the user views that conversation, they see the pending confirmation
+4. When the user responds, the manager dispatches to the appropriate action handler based on the action type
+
+### Event Stream
+
+The conversation manager emits a uniform stream of events per conversation. Event types include (at minimum):
+
+- `llm_start`, `llm_end` — LLM call boundaries
+- `chunk` — streaming text chunk
+- `message_complete` — finalized assistant message
+- `tool_start`, `tool_end` — tool execution boundaries
+- `tool_status` — progress updates from tools
+- `confirmation_request` — a confirmation is pending
+- `confirmation_response` — a confirmation was resolved
+- `turn_complete` — agent turn finished
+- `error` — something went wrong
+
+Transports subscribe and format as appropriate. WebSocket forwards most events as JSON. Mattermost batches into post edits. Terminal prints text.
+
+## Scope
+
+### In scope
+
+- Conversation manager as central orchestrator
+- WebSocket, Mattermost, and interactive terminal as transport adapters
+- Confirmations as persistent conversation messages with typed actions
+- Startup recovery of interrupted confirmations
+- Uniform event stream from manager to transports
+- Multiple clients observing the same conversation
+- Client disconnect/reconnect without losing state
+
+### Out of scope
+
+- Recovering agent turns interrupted mid-execution (not at a confirmation) after server restart
+- New transport channels (Discord, Telegram, etc.) — but the adapter interface should make these straightforward to add later
+- Removing sidecar metadata files (future work, noted by Les)
+- Changes to the LLM client or tool execution internals
+
+## Acceptance Criteria
+
+1. Switching conversations in the web UI only shows confirmations for the active conversation (#235)
+2. Reloading the page re-renders any pending confirmation for the active conversation (#258)
+3. Multiple browser tabs viewing the same conversation both see confirmations and either can respond
+4. Mattermost confirmations (shell, skill, EndTurnConfirm) work through the conversation manager
+5. Interactive terminal confirmations work through the conversation manager
+6. Server restart with a pending confirmation: on reconnect, the confirmation is re-rendered and functional
+7. Agent loop runs independently of any transport connection — disconnecting all clients doesn't kill the turn
+8. No regressions in existing functionality: streaming, tool execution, compaction, commands, etc.

--- a/src/decafclaw/confirmations.py
+++ b/src/decafclaw/confirmations.py
@@ -1,0 +1,151 @@
+"""Confirmation types, serialization, and handler registry."""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Protocol
+from uuid import uuid4
+
+log = logging.getLogger(__name__)
+
+
+class ConfirmationAction(str, Enum):
+    """Known confirmation action types. Each maps to a registered handler."""
+    RUN_SHELL_COMMAND = "run_shell_command"
+    ACTIVATE_SKILL = "activate_skill"
+    CONTINUE_TURN = "continue_turn"
+    ADVANCE_PROJECT_PHASE = "advance_project_phase"
+
+
+@dataclass
+class ConfirmationRequest:
+    """A confirmation request that can be persisted in conversation history."""
+    action_type: ConfirmationAction
+    action_data: dict = field(default_factory=dict)
+    message: str = ""
+    approve_label: str = "Approve"
+    deny_label: str = "Deny"
+    tool_call_id: str = ""
+    timeout: float = 300.0
+    confirmation_id: str = field(default_factory=lambda: uuid4().hex[:12])
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_archive_message(self) -> dict:
+        """Serialize to a dict suitable for JSONL archive."""
+        return {
+            "role": "confirmation_request",
+            "confirmation_id": self.confirmation_id,
+            "action_type": self.action_type.value,
+            "action_data": self.action_data,
+            "message": self.message,
+            "approve_label": self.approve_label,
+            "deny_label": self.deny_label,
+            "tool_call_id": self.tool_call_id,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_archive_message(cls, msg: dict) -> "ConfirmationRequest":
+        """Deserialize from an archive message dict."""
+        return cls(
+            action_type=ConfirmationAction(msg["action_type"]),
+            action_data=msg.get("action_data", {}),
+            message=msg.get("message", ""),
+            approve_label=msg.get("approve_label", "Approve"),
+            deny_label=msg.get("deny_label", "Deny"),
+            tool_call_id=msg.get("tool_call_id", ""),
+            confirmation_id=msg["confirmation_id"],
+            timestamp=msg.get("timestamp", ""),
+        )
+
+
+@dataclass
+class ConfirmationResponse:
+    """A confirmation response that can be persisted in conversation history."""
+    confirmation_id: str
+    approved: bool
+    always: bool = False
+    add_pattern: bool = False
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_archive_message(self) -> dict:
+        """Serialize to a dict suitable for JSONL archive."""
+        msg: dict[str, Any] = {
+            "role": "confirmation_response",
+            "confirmation_id": self.confirmation_id,
+            "approved": self.approved,
+            "timestamp": self.timestamp,
+        }
+        if self.always:
+            msg["always"] = True
+        if self.add_pattern:
+            msg["add_pattern"] = True
+        return msg
+
+    @classmethod
+    def from_archive_message(cls, msg: dict) -> "ConfirmationResponse":
+        """Deserialize from an archive message dict."""
+        return cls(
+            confirmation_id=msg["confirmation_id"],
+            approved=msg.get("approved", False),
+            always=msg.get("always", False),
+            add_pattern=msg.get("add_pattern", False),
+            timestamp=msg.get("timestamp", ""),
+        )
+
+
+class ConfirmationHandler(Protocol):
+    """Protocol for confirmation action handlers.
+
+    Handlers return a dict that the agent loop uses to determine next steps.
+    Keys may include:
+    - inject_message: str — message to inject into history for the LLM
+    - continue_loop: bool — whether the agent loop should continue iterating
+    - result: Any — action-specific result data (e.g., shell command output)
+    """
+    async def on_approve(self, ctx: Any, request: ConfirmationRequest,
+                         response: ConfirmationResponse) -> dict: ...
+    async def on_deny(self, ctx: Any, request: ConfirmationRequest,
+                      response: ConfirmationResponse) -> dict: ...
+
+
+class ConfirmationRegistry:
+    """Registry of confirmation action handlers.
+
+    Each ConfirmationAction maps to a handler that knows how to execute
+    the action on approval and what to do on denial. This makes
+    confirmations recoverable after server restart — the action type
+    and data are enough to reconstruct the handler's behavior.
+    """
+
+    def __init__(self):
+        self._handlers: dict[ConfirmationAction, ConfirmationHandler] = {}
+
+    def register(self, action_type: ConfirmationAction,
+                 handler: ConfirmationHandler) -> None:
+        """Register a handler for an action type."""
+        self._handlers[action_type] = handler
+
+    def get_handler(self, action_type: ConfirmationAction
+                    ) -> ConfirmationHandler | None:
+        """Look up the handler for an action type."""
+        return self._handlers.get(action_type)
+
+    async def dispatch(self, ctx: Any, request: ConfirmationRequest,
+                       response: ConfirmationResponse) -> dict:
+        """Dispatch a confirmation response to the appropriate handler.
+
+        Returns the handler's result dict, or a default dict if no handler
+        is registered.
+        """
+        handler = self._handlers.get(request.action_type)
+        if handler is None:
+            log.warning("No handler for confirmation action %s",
+                        request.action_type)
+            return {"continue_loop": response.approved}
+
+        if response.approved:
+            return await handler.on_approve(ctx, request, response)
+        else:
+            return await handler.on_deny(ctx, request, response)

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -79,6 +79,7 @@ class Context:
         self.wiki_page: str | None = None  # open wiki page from web UI
         self.active_model: str = ""  # named model config from config.model_configs
         self.task_mode: str = ""  # "heartbeat" | "scheduled" | "" (interactive)
+        self.request_confirmation: Any = None  # set by ConversationManager
 
     @classmethod
     def for_task(
@@ -175,6 +176,7 @@ class Context:
         child.skip_vault_retrieval = self.skip_vault_retrieval
         child.wiki_page = self.wiki_page
         child.active_model = self.active_model
+        child.request_confirmation = self.request_confirmation
         # Share skills + composer (concurrent tool calls read but don't mutate)
         child.skills = self.skills
         child.composer = self.composer

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -1,0 +1,743 @@
+"""Conversation manager — central orchestrator for agent loops and state.
+
+The conversation manager owns agent loop lifecycle, conversation history,
+confirmation state, and event streams. Transport adapters (WebSocket,
+Mattermost, interactive terminal) talk to the manager via its public API.
+"""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+from uuid import uuid4
+
+from .confirmations import (
+    ConfirmationRegistry,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ConversationState:
+    """Per-conversation state managed by the ConversationManager."""
+    conv_id: str = ""
+    history: list = field(default_factory=list)
+    busy: bool = False
+    pending_messages: list = field(default_factory=list)
+    agent_task: asyncio.Task | None = None
+    cancel_event: asyncio.Event | None = None
+
+    # Confirmation state
+    pending_confirmation: ConfirmationRequest | None = None
+    confirmation_event: asyncio.Event | None = None
+    confirmation_response: ConfirmationResponse | None = None
+
+    # Per-conversation persistent state (survives across turns)
+    skill_state: dict | None = None
+    skip_vault_retrieval: bool = False
+    active_model: str = ""
+
+    # Circuit breaker state (rate-limiting turns per conversation)
+    turn_times: list = field(default_factory=list)
+    paused_until: float = 0
+
+    # Event stream subscribers: sub_id -> callback
+    subscribers: dict[str, Callable] = field(default_factory=dict)
+
+
+class ConversationManager:
+    """Central orchestrator for agent loops and conversation state.
+
+    Owns agent loop lifecycle, conversation history, confirmation state,
+    and per-conversation event streams. Transports interact via the
+    public API methods.
+    """
+
+    def __init__(self, config, event_bus,
+                 confirmation_registry: ConfirmationRegistry | None = None):
+        self.config = config
+        self.event_bus = event_bus
+        self.confirmation_registry = confirmation_registry or ConfirmationRegistry()
+        self._conversations: dict[str, ConversationState] = {}
+
+        # Circuit breaker config (from Mattermost config for now —
+        # these should move to a transport-agnostic config section)
+        self._cb_max_turns = getattr(config.mattermost, "circuit_breaker_max", 10)
+        self._cb_window_sec = getattr(config.mattermost, "circuit_breaker_window_sec", 60)
+        self._cb_pause_sec = getattr(config.mattermost, "circuit_breaker_pause_sec", 120)
+
+    def _get_or_create(self, conv_id: str) -> ConversationState:
+        """Get existing conversation state or create a new one."""
+        if conv_id not in self._conversations:
+            self._conversations[conv_id] = ConversationState(conv_id=conv_id)
+        return self._conversations[conv_id]
+
+    def _circuit_breaker_tripped(self, state: ConversationState) -> bool:
+        """Check if the circuit breaker has tripped for a conversation."""
+
+        now = time.monotonic()
+        if now < state.paused_until:
+            return True
+        cutoff = now - self._cb_window_sec
+        state.turn_times = [t for t in state.turn_times if t > cutoff]
+        if len(state.turn_times) >= self._cb_max_turns:
+            state.paused_until = now + self._cb_pause_sec
+            log.warning(
+                "Circuit breaker tripped for %s: %d turns in %ds, pausing %ds",
+                state.conv_id[:8], len(state.turn_times),
+                self._cb_window_sec, self._cb_pause_sec)
+            return True
+        return False
+
+    def _circuit_breaker_record(self, state: ConversationState) -> None:
+        """Record an agent turn completion for circuit breaker tracking."""
+
+        state.turn_times.append(time.monotonic())
+
+    # -- Public API ------------------------------------------------------------
+
+    async def send_message(
+        self,
+        conv_id: str,
+        text: str,
+        *,
+        user_id: str = "",
+        context_setup: Callable | None = None,
+        archive_text: str = "",
+        attachments: list[dict] | None = None,
+        command_ctx: Any = None,
+        wiki_page: str | None = None,
+    ) -> None:
+        """Submit user input to a conversation. Starts or queues an agent turn.
+
+        If the conversation is busy (turn in progress), the message is queued
+        and will be drained when the current turn completes.
+
+        Args:
+            conv_id: Conversation identifier.
+            text: User message text.
+            user_id: User identifier.
+            context_setup: Optional callback to configure transport-specific
+                context fields (media_handler, channel_name, etc.).
+            archive_text: If set, archive this instead of text.
+            attachments: Optional media attachments.
+            command_ctx: Optional pre-configured command context.
+            wiki_page: Optional wiki page to inject as context.
+        """
+        state = self._get_or_create(conv_id)
+
+        # Circuit breaker: drop messages for paused conversations
+        if self._circuit_breaker_tripped(state):
+            log.warning("Dropping message for paused conversation %s",
+                        conv_id[:8])
+            return
+
+        # Notify subscribers of the user message (for multi-tab sync)
+        await self.emit(conv_id, {
+            "type": "user_message",
+            "text": archive_text or text,
+            "user_id": user_id,
+        })
+
+        if state.busy:
+            # Cancel-on-new-message: cancel the current turn if configured
+            if (self.config.agent.turn_on_new_message == "cancel"
+                    and state.cancel_event
+                    and not state.cancel_event.is_set()):
+                log.info("Conv %s busy, cancelling for new message", conv_id[:8])
+                state.cancel_event.set()
+                if state.agent_task and not state.agent_task.done():
+                    state.agent_task.cancel()
+
+            state.pending_messages.append({
+                "text": text,
+                "user_id": user_id,
+                "context_setup": context_setup,
+                "archive_text": archive_text,
+                "attachments": attachments,
+                "command_ctx": command_ctx,
+                "wiki_page": wiki_page,
+            })
+            log.info("Conv %s busy, queued message (%d pending)",
+                     conv_id[:8], len(state.pending_messages))
+            return
+
+        await self._start_turn(state, text, user_id=user_id,
+                               context_setup=context_setup,
+                               archive_text=archive_text,
+                               attachments=attachments,
+                               command_ctx=command_ctx,
+                               wiki_page=wiki_page)
+
+    async def respond_to_confirmation(
+        self,
+        conv_id: str,
+        confirmation_id: str,
+        approved: bool,
+        *,
+        always: bool = False,
+        add_pattern: bool = False,
+    ) -> None:
+        """Resolve a pending confirmation request.
+
+        Persists the response to the archive and wakes the suspended
+        agent loop (if still running) or dispatches recovery (if the
+        loop died).
+        """
+        state = self._conversations.get(conv_id)
+        if not state or not state.pending_confirmation:
+            log.warning("No pending confirmation for conv %s", conv_id)
+            return
+        if state.pending_confirmation.confirmation_id != confirmation_id:
+            log.warning("Confirmation ID mismatch for conv %s: expected %s, got %s",
+                        conv_id, state.pending_confirmation.confirmation_id,
+                        confirmation_id)
+            return
+
+        response = ConfirmationResponse(
+            confirmation_id=confirmation_id,
+            approved=approved,
+            always=always,
+            add_pattern=add_pattern,
+        )
+
+        # Persist to archive
+        from .archive import append_message
+        append_message(self.config, conv_id, response.to_archive_message())
+
+        # Emit to subscribers
+        await self.emit(conv_id, {
+            "type": "confirmation_response",
+            "confirmation_id": confirmation_id,
+            "approved": approved,
+        })
+
+        # Wake the waiting agent loop or dispatch recovery
+        state.confirmation_response = response
+        if state.confirmation_event:
+            state.confirmation_event.set()
+        else:
+            # No running loop — dispatch recovery
+            log.info("No running loop for conv %s, dispatching recovery",
+                     conv_id)
+            result = await self.recover_confirmation(conv_id, response)
+            log.info("Recovery result for conv %s: %s", conv_id[:8], result)
+
+    async def cancel_turn(self, conv_id: str) -> None:
+        """Cancel an in-progress agent turn."""
+        state = self._conversations.get(conv_id)
+        if not state:
+            return
+        if state.cancel_event:
+            state.cancel_event.set()
+        if state.agent_task and not state.agent_task.done():
+            state.agent_task.cancel()
+            log.info("Cancelled agent turn for conv %s", conv_id[:8])
+
+    async def shutdown(self, timeout: float = 15) -> None:
+        """Wait for all in-flight agent turns to complete, then clean up.
+
+        Called during graceful shutdown so running turns can finish
+        rather than being abandoned.
+        """
+        tasks = [
+            s.agent_task for s in self._conversations.values()
+            if s.agent_task and not s.agent_task.done()
+        ]
+        if not tasks:
+            return
+        log.info("Waiting for %d in-flight agent turn(s)...", len(tasks))
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            log.warning("Shutdown timeout: cancelling %d agent turn(s)",
+                        len(pending))
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def get_state(self, conv_id: str) -> ConversationState | None:
+        """Get current conversation state, or None if not tracked."""
+        return self._conversations.get(conv_id)
+
+    def set_initial_history(self, conv_id: str, history: list) -> None:
+        """Pre-populate conversation history (e.g., for Mattermost thread-fork).
+
+        Only sets the history if the conversation doesn't already have one.
+        """
+        state = self._get_or_create(conv_id)
+        if not state.history:
+            state.history = history
+
+    def set_flag(self, conv_id: str, key: str, value) -> None:
+        """Set a per-conversation flag (e.g., skip_vault_retrieval, active_model)."""
+        state = self._get_or_create(conv_id)
+        if hasattr(state, key):
+            setattr(state, key, value)
+        else:
+            log.warning("Unknown conversation flag: %s", key)
+
+    def subscribe(self, conv_id: str, callback: Callable) -> str:
+        """Subscribe to a conversation's event stream. Returns subscription ID."""
+        state = self._get_or_create(conv_id)
+        sub_id = uuid4().hex[:12]
+        state.subscribers[sub_id] = callback
+        return sub_id
+
+    def unsubscribe(self, conv_id: str, subscription_id: str) -> None:
+        """Remove a subscriber from a conversation's event stream."""
+        state = self._conversations.get(conv_id)
+        if state:
+            state.subscribers.pop(subscription_id, None)
+
+    async def emit(self, conv_id: str, event: dict) -> None:
+        """Publish an event to all subscribers of a conversation.
+
+        Awaits each subscriber sequentially. When called from the
+        global event bus forwarder, the forwarder uses create_task
+        to avoid blocking the bus.
+        """
+        state = self._conversations.get(conv_id)
+        if not state or not state.subscribers:
+            return
+        event = {**event, "conv_id": conv_id}
+
+        async def _call(sub_id, callback):
+            try:
+                if asyncio.iscoroutinefunction(callback):
+                    await callback(event)
+                else:
+                    callback(event)
+            except Exception:
+                log.exception("Subscriber %s raised for conv %s",
+                              sub_id, conv_id)
+
+        await asyncio.gather(
+            *(_call(sid, cb) for sid, cb in list(state.subscribers.items())),
+            return_exceptions=True,
+        )
+
+    def load_history(self, conv_id: str) -> list:
+        """Load conversation history from archive.
+
+        Returns in-memory history if available, otherwise loads from disk.
+        """
+        state = self._conversations.get(conv_id)
+        if state and state.history:
+            return state.history
+
+        from .archive import restore_history
+        history = restore_history(self.config, conv_id) or []
+
+        # Cache in state
+        state = self._get_or_create(conv_id)
+        state.history = history
+        return history
+
+    async def request_confirmation(
+        self,
+        conv_id: str,
+        request: ConfirmationRequest,
+    ) -> ConfirmationResponse:
+        """Request a confirmation from the user. Suspends the agent loop.
+
+        Persists the request to the archive, emits to subscribers, and
+        waits for a response (or timeout).
+        """
+        state = self._get_or_create(conv_id)
+
+        # Persist to archive
+        from .archive import append_message
+        append_message(self.config, conv_id, request.to_archive_message())
+
+        # Set up waiting state
+        state.pending_confirmation = request
+        state.confirmation_event = asyncio.Event()
+        state.confirmation_response = None
+
+        # Emit to subscribers so transports can show the confirmation UI
+        await self.emit(conv_id, {
+            "type": "confirmation_request",
+            "confirmation_id": request.confirmation_id,
+            "action_type": request.action_type.value,
+            "action_data": request.action_data,
+            "message": request.message,
+            "approve_label": request.approve_label,
+            "deny_label": request.deny_label,
+            "tool_call_id": request.tool_call_id,
+        })
+
+        # Wait for response or timeout
+        try:
+            await asyncio.wait_for(
+                state.confirmation_event.wait(),
+                timeout=request.timeout,
+            )
+        except asyncio.TimeoutError:
+            log.info("Confirmation timed out for conv %s: %s",
+                     conv_id[:8], request.message)
+            # Create a timeout denial
+            response = ConfirmationResponse(
+                confirmation_id=request.confirmation_id,
+                approved=False,
+            )
+            append_message(self.config, conv_id, response.to_archive_message())
+            await self.emit(conv_id, {
+                "type": "confirmation_response",
+                "confirmation_id": request.confirmation_id,
+                "approved": False,
+            })
+            state.pending_confirmation = None
+            state.confirmation_event = None
+            return response
+
+        response = state.confirmation_response
+        assert response is not None, "confirmation_event set but no response"
+        state.pending_confirmation = None
+        state.confirmation_event = None
+        state.confirmation_response = None
+        return response
+
+    # -- Internal methods ------------------------------------------------------
+
+    async def _start_turn(
+        self,
+        state: ConversationState,
+        text: str,
+        *,
+        user_id: str = "",
+        context_setup: Callable | None = None,
+        archive_text: str = "",
+        attachments: list[dict] | None = None,
+        command_ctx: Any = None,
+        wiki_page: str | None = None,
+    ) -> None:
+        """Start an agent turn as an asyncio task."""
+        from .context import Context
+
+        conv_id = state.conv_id
+        state.busy = True
+        state.cancel_event = asyncio.Event()
+
+        # Build context
+        ctx = Context(config=self.config, event_bus=self.event_bus)
+        ctx.user_id = user_id
+        ctx.channel_id = conv_id
+        ctx.conv_id = conv_id
+        ctx.cancelled = state.cancel_event
+        ctx.wiki_page = wiki_page
+
+        # Restore per-conversation state from previous turns
+        if state.skill_state:
+            ctx.tools.extra = state.skill_state.get("extra_tools", {})
+            ctx.tools.extra_definitions = state.skill_state.get(
+                "extra_tool_definitions", [])
+            ctx.skills.activated = state.skill_state.get(
+                "activated_skills", set())
+        if state.skip_vault_retrieval:
+            ctx.skip_vault_retrieval = True
+        if state.active_model:
+            ctx.active_model = state.active_model
+
+        # Apply command context if provided
+        if command_ctx:
+            from .commands import apply_command_ctx
+            apply_command_ctx(ctx, command_ctx)
+            ctx.tools.extra_definitions = command_ctx.tools.extra_definitions
+
+        # Let the transport set transport-specific fields
+        if context_setup:
+            context_setup(ctx)
+
+        # Set up streaming callback that emits to subscribers
+        from .config import resolve_streaming
+        if resolve_streaming(self.config, ctx.active_model):
+            async def on_stream_chunk(chunk_type, data):
+                if chunk_type == "text":
+                    await self.emit(conv_id, {
+                        "type": "chunk", "text": data,
+                    })
+                elif chunk_type == "done":
+                    await self.emit(conv_id, {"type": "stream_done"})
+                elif chunk_type == "tool_call_start":
+                    name = data.get("name", "") if isinstance(data, dict) else ""
+                    await self.emit(conv_id, {
+                        "type": "tool_call_start", "name": name,
+                    })
+            ctx.on_stream_chunk = on_stream_chunk
+
+        # Set up manager-based confirmation on the context so tools
+        # route through the manager instead of the event bus
+        async def ctx_request_confirmation(request: ConfirmationRequest
+                                           ) -> ConfirmationResponse:
+            return await self.request_confirmation(conv_id, request)
+        ctx.request_confirmation = ctx_request_confirmation
+
+        # Load history
+        history = self.load_history(conv_id)
+        state.history = history
+
+        # Emit turn_start
+        await self.emit(conv_id, {"type": "turn_start"})
+
+        # Forward global event bus events for this context to subscribers.
+        # Uses a sync callback with create_task to avoid blocking the
+        # event bus publish loop.
+        forward_tasks: set[asyncio.Task] = set()
+
+        def on_global_event(event):
+            if event.get("context_id") != ctx.context_id:
+                return
+
+            async def _forward():
+                await self.emit(conv_id, event)
+
+            task = asyncio.create_task(_forward())
+            forward_tasks.add(task)
+            task.add_done_callback(forward_tasks.discard)
+
+        bus_sub_id = self.event_bus.subscribe(on_global_event)
+
+        # Create the turn task
+        async def run():
+            try:
+                from .agent import run_agent_turn
+                result = await run_agent_turn(
+                    ctx, text, history,
+                    archive_text=archive_text,
+                    attachments=attachments,
+                )
+
+                response_text = result.text if hasattr(result, "text") else str(result)
+                response_media = result.media if hasattr(result, "media") else []
+                await self.emit(conv_id, {
+                    "type": "message_complete",
+                    "role": "assistant",
+                    "text": response_text,
+                    "media": response_media,
+                    "final": True,
+                    "usage": {
+                        "prompt_tokens": ctx.tokens.last_prompt,
+                        "completion_tokens": ctx.tokens.total_completion,
+                        "total_tokens": (ctx.tokens.total_prompt
+                                         + ctx.tokens.total_completion),
+                    },
+                    "context_limit": self.config.compaction.max_tokens,
+                })
+            except asyncio.CancelledError:
+                log.info("Agent turn cancelled for conv %s", conv_id[:8])
+                await self.emit(conv_id, {
+                    "type": "message_complete",
+                    "role": "assistant",
+                    "text": "[cancelled]",
+                    "final": True,
+                })
+            except Exception as e:
+                log.error("Agent turn failed for conv %s: %s",
+                          conv_id[:8], e, exc_info=True)
+                await self.emit(conv_id, {
+                    "type": "error",
+                    "message": f"Agent turn failed: {e}",
+                })
+            finally:
+                self.event_bus.unsubscribe(bus_sub_id)
+                # Wait for any in-flight event forwards
+                if forward_tasks:
+                    await asyncio.gather(*forward_tasks,
+                                         return_exceptions=True)
+                # Persist per-conversation state and record turn for circuit breaker
+                self._save_conversation_state(state, ctx)
+                self._circuit_breaker_record(state)
+                state.busy = False
+                state.agent_task = None
+                state.cancel_event = None
+
+                await self.emit(conv_id, {"type": "turn_complete"})
+
+                # Drain queued messages
+                await self._drain_pending(state)
+
+        state.agent_task = asyncio.create_task(run())
+
+    def _save_conversation_state(self, state: ConversationState, ctx) -> None:
+        """Persist relevant context state back to conversation state."""
+        if ctx.skills.activated:
+            state.skill_state = {
+                "extra_tools": ctx.tools.extra,
+                "extra_tool_definitions": ctx.tools.extra_definitions,
+                "activated_skills": ctx.skills.activated,
+            }
+        if ctx.skip_vault_retrieval:
+            state.skip_vault_retrieval = True
+
+    async def _drain_pending(self, state: ConversationState) -> None:
+        """Process queued messages after a turn completes."""
+        if not state.pending_messages:
+            return
+
+        queued = state.pending_messages
+        state.pending_messages = []
+
+        # Combine all queued messages
+        texts = [q["text"] for q in queued]
+        combined = "\n".join(texts)
+        last = queued[-1]
+
+        # Merge attachments from all queued messages
+        all_attachments: list[dict] = []
+        for q in queued:
+            if q.get("attachments"):
+                all_attachments.extend(q["attachments"])
+
+        log.info("Draining %d queued message(s) for conv %s",
+                 len(queued), state.conv_id[:8])
+
+        await self._start_turn(
+            state, combined,
+            user_id=last.get("user_id", ""),
+            context_setup=last.get("context_setup"),
+            archive_text=last.get("archive_text", ""),
+            attachments=all_attachments or None,
+            command_ctx=last.get("command_ctx"),
+            wiki_page=last.get("wiki_page"),
+        )
+
+    # -- Startup recovery ------------------------------------------------------
+
+    async def startup_scan(self) -> int:
+        """Scan conversation archives for interrupted confirmations.
+
+        Called on server startup before transports connect. Finds
+        conversations where the last message is a confirmation_request
+        with no matching confirmation_response, and registers them as
+        pending confirmations in the manager's state.
+
+        Returns the number of recovered confirmations.
+        """
+        from datetime import datetime, timedelta
+
+        conversations_dir = self.config.workspace_path / "conversations"
+        if not conversations_dir.exists():
+            return 0
+
+        # Staleness threshold: ignore confirmations older than 24 hours
+        stale_cutoff = (datetime.now() - timedelta(hours=24)).isoformat()
+        recovered = 0
+
+        for archive_file in conversations_dir.glob("*.jsonl"):
+            # Skip compacted sidecar files
+            if archive_file.stem.endswith(".compacted"):
+                continue
+
+            conv_id = archive_file.stem
+            try:
+                pending = self._scan_archive_for_pending(
+                    archive_file, stale_cutoff)
+                if pending:
+                    state = self._get_or_create(conv_id)
+                    state.pending_confirmation = pending
+                    log.info("Recovered pending confirmation for conv %s: %s",
+                             conv_id[:8], pending.action_type.value)
+                    recovered += 1
+            except Exception as e:
+                log.warning("Error scanning archive %s: %s", conv_id, e)
+
+        if recovered:
+            log.info("Startup scan: recovered %d pending confirmation(s)",
+                     recovered)
+        return recovered
+
+    def _scan_archive_for_pending(self, archive_path, stale_cutoff: str
+                                  ) -> ConfirmationRequest | None:
+        """Read the tail of an archive file looking for an unresolved confirmation."""
+        import json
+
+        # Read last N lines from the tail of the file to avoid loading
+        # the entire archive into memory on startup.
+        max_tail_bytes = 64 * 1024  # 64KB — plenty for recent messages
+        lines = []
+        try:
+            with open(archive_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                start = max(0, size - max_tail_bytes)
+                f.seek(start)
+                tail = f.read().decode("utf-8", errors="replace")
+            for raw in tail.splitlines():
+                raw = raw.strip()
+                if raw:
+                    lines.append(raw)
+            # If we started mid-file, the first line may be truncated — drop it
+            if start > 0 and lines:
+                lines = lines[1:]
+        except Exception:
+            return None
+
+        if not lines:
+            return None
+
+        # Scan backward for confirmation messages
+        last_request = None
+        for line in reversed(lines):
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            role = msg.get("role", "")
+            if role == "confirmation_response":
+                # Found a response — no pending confirmation
+                return None
+            if role == "confirmation_request":
+                last_request = msg
+                break
+            # Keep scanning past non-confirmation messages (assistant, tool, etc.)
+            # but stop if we hit a user message (the confirmation would be
+            # between the tool result and the user's response)
+            if role == "user":
+                break
+
+        if not last_request:
+            return None
+
+        # Check staleness
+        ts = last_request.get("timestamp", "")
+        if ts and ts < stale_cutoff:
+            log.debug("Skipping stale confirmation in %s (from %s)",
+                      archive_path.stem, ts)
+            return None
+
+        return ConfirmationRequest.from_archive_message(last_request)
+
+    async def recover_confirmation(self, conv_id: str,
+                                   response: ConfirmationResponse) -> dict:
+        """Handle a confirmation response for a conversation with no running loop.
+
+        Dispatches to the appropriate confirmation handler based on the
+        action type. Returns the handler result dict.
+        """
+        state = self._conversations.get(conv_id)
+        if not state or not state.pending_confirmation:
+            return {"error": "No pending confirmation"}
+
+        request = state.pending_confirmation
+
+        if not self.confirmation_registry._handlers:
+            log.warning(
+                "No confirmation handlers registered — cannot recover "
+                "confirmation for conv %s (action: %s)",
+                conv_id[:8], request.action_type.value,
+            )
+            state.pending_confirmation = None
+            return {"error": "No confirmation handlers registered"}
+
+        result = await self.confirmation_registry.dispatch(
+            None,  # no ctx available for recovery
+            request, response,
+        )
+
+        state.pending_confirmation = None
+        return result

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -24,7 +24,7 @@ _CONFIG_FILES = [
 ]
 
 
-def create_app(config, event_bus, app_ctx=None) -> Starlette:
+def create_app(config, event_bus, app_ctx=None, manager=None) -> Starlette:
     """Create the Starlette ASGI app with routes."""
 
     async def health(request: Request) -> JSONResponse:
@@ -62,6 +62,10 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
             original_message = context.get("original_message", "")
             tool_call_id = context.get("tool_call_id", "")
 
+        # Extract manager-routing fields from token data
+        conv_id = (token_data or {}).get("conv_id", "") or context.get("conv_id", "")
+        confirmation_id = (token_data or {}).get("confirmation_id", "") or context.get("confirmation_id", "")
+
         log.info(f"Confirm callback: action={action} tool={tool_name} context={context_id[:8]}")
 
         # Map action to event fields
@@ -69,16 +73,22 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
         always = action == "always"
         add_pattern = action == "add_pattern"
 
-        # Publish confirmation event on the event bus
-        await event_bus.publish({
-            "type": "tool_confirm_response",
-            "context_id": context_id,
-            "tool": tool_name,
-            "approved": approved,
-            **({"tool_call_id": tool_call_id} if tool_call_id else {}),
-            **({"always": True} if always else {}),
-            **({"add_pattern": True} if add_pattern else {}),
-        })
+        # Route through manager if available, fall back to event bus
+        if manager and conv_id and confirmation_id:
+            await manager.respond_to_confirmation(
+                conv_id, confirmation_id,
+                approved=approved, always=always, add_pattern=add_pattern,
+            )
+        else:
+            await event_bus.publish({
+                "type": "tool_confirm_response",
+                "context_id": context_id,
+                "tool": tool_name,
+                "approved": approved,
+                **({"tool_call_id": tool_call_id} if tool_call_id else {}),
+                **({"always": True} if always else {}),
+                **({"add_pattern": True} if add_pattern else {}),
+            })
 
         # Determine result label
         labels = {
@@ -1024,7 +1034,8 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 
     async def ws_chat(websocket):
         from .web.websocket import websocket_chat
-        await websocket_chat(websocket, config, event_bus, app_ctx)
+        await websocket_chat(websocket, config, event_bus, app_ctx,
+                             manager=manager)
 
     async def handle_cancel(request: Request) -> JSONResponse:
         """Handle Mattermost interactive button callback for stop/cancel."""
@@ -1035,13 +1046,16 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
             log.warning("Cancel callback rejected: invalid or expired token")
             return JSONResponse({"error": "unauthorized"}, status_code=403)
 
-        conv_id = token_data["context_id"]
+        conv_id = token_data.get("conv_id", "") or token_data.get("context_id", "")
         log.info(f"Cancel button pressed for conversation {conv_id[:8]}")
 
-        await event_bus.publish({
-            "type": "cancel_turn",
-            "conv_id": conv_id,
-        })
+        if manager and conv_id:
+            await manager.cancel_turn(conv_id)
+        else:
+            await event_bus.publish({
+                "type": "cancel_turn",
+                "conv_id": conv_id,
+            })
 
         return JSONResponse({
             "update": {
@@ -1107,11 +1121,11 @@ def create_app(config, event_bus, app_ctx=None) -> Starlette:
 _http_server = None  # uvicorn.Server instance, set by run_http_server
 
 
-async def run_http_server(config, event_bus, app_ctx=None) -> None:
+async def run_http_server(config, event_bus, app_ctx=None, manager=None) -> None:
     """Start the HTTP server as an asyncio task."""
     global _http_server
     import uvicorn
-    app = create_app(config, event_bus, app_ctx=app_ctx)
+    app = create_app(config, event_bus, app_ctx=app_ctx, manager=manager)
     server_config = uvicorn.Config(
         app,
         host=config.http.host,

--- a/src/decafclaw/interactive_terminal.py
+++ b/src/decafclaw/interactive_terminal.py
@@ -1,4 +1,8 @@
-"""Interactive terminal mode for DecafClaw."""
+"""Interactive terminal mode for DecafClaw.
+
+Transport adapter that uses the ConversationManager for agent loop
+lifecycle. Handles stdin/stdout display and confirmation prompts.
+"""
 
 from __future__ import annotations
 
@@ -9,28 +13,6 @@ from .config import resolve_streaming
 from .tools import TOOL_DEFINITIONS
 
 log = logging.getLogger(__name__)
-
-
-def _setup_interactive_context(ctx) -> None:
-    """Populate context defaults and media handler for interactive mode."""
-    from .media import LocalFileMediaHandler
-    config = ctx.config
-
-    ctx.user_id = ctx.user_id or config.agent_user_id
-    ctx.channel_id = ctx.channel_id or "interactive"
-    ctx.channel_name = ctx.channel_name or "interactive"
-    ctx.thread_id = ctx.thread_id or ""
-    ctx.conv_id = "interactive"
-    ctx.media_handler = LocalFileMediaHandler(config)
-
-    if resolve_streaming(config):
-        async def _terminal_stream_chunk(chunk_type, data):
-            if chunk_type == "text":
-                print(data, end="", flush=True)
-            elif chunk_type == "tool_call_start":
-                print(f"\n  [calling {data['name']}...]", flush=True)
-
-        ctx.on_stream_chunk = _terminal_stream_chunk
 
 
 def _print_banner(config) -> None:
@@ -52,71 +34,105 @@ def _print_banner(config) -> None:
     print()
 
 
-def _create_interactive_progress_subscriber(ctx):
-    """Create the on_progress callback for interactive mode."""
-    async def on_progress(event):
-        event_type = event.get("type")
-        if event_type == "tool_status":
-            print(f"  [{event.get('tool', 'tool')}] {event['message']}")
-        elif event_type == "tool_start":
-            print(f"  [running {event.get('tool', 'tool')}...]")
-        elif event_type == "llm_start" and event.get("iteration", 1) > 1:
-            print("  [thinking...]")
-        elif event_type == "compaction_start":
-            print("  [compacting conversation...]")
-        elif event_type == "compaction_end":
-            print("  [compaction complete]")
-        elif event_type == "tool_confirm_request":
-            command = event.get("command", "")
-            tool_name = event.get("tool", "tool")
-            suggested_pattern = event.get("suggested_pattern", "")
-            print(f"\n  \U0001f6a8 Confirm {tool_name}: {command}")
-            if suggested_pattern and tool_name == "shell":
-                prompt = f"  Approve? [y]es / [n]o / [a]lways / [p]attern ({suggested_pattern}): "
-            else:
-                prompt = "  Approve? [y]es / [n]o / [a]lways: "
-            answer = await asyncio.to_thread(input, prompt)
-            choice = answer.strip().lower()
-            approved = choice in ("y", "yes", "a", "always", "p", "pattern")
-            always = choice in ("a", "always")
-            add_pattern = choice in ("p", "pattern")
-            await ctx.event_bus.publish({
-                "type": "tool_confirm_response",
-                "context_id": event.get("context_id"),
-                "tool": tool_name,
-                "approved": approved,
-                "always": always,
-                **({"add_pattern": True} if add_pattern else {}),
-            })
-
-    return on_progress
-
-
 # -- Interactive mode ----------------------------------------------------------
 
 
 async def run_interactive(ctx):
     """Run the agent in interactive terminal mode (stdin/stdout)."""
-    from .agent import run_agent_turn
-    from .archive import read_archive
+    from .conversation_manager import ConversationManager
     from .heartbeat import run_heartbeat_timer
     from .mcp_client import init_mcp, shutdown_mcp
+    from .media import LocalFileMediaHandler
 
     config = ctx.config
+    conv_id = "interactive"
 
-    _setup_interactive_context(ctx)
+    # Set up context identity
+    ctx.user_id = ctx.user_id or config.agent_user_id
+    ctx.channel_id = ctx.channel_id or "interactive"
+    ctx.channel_name = ctx.channel_name or "interactive"
+    ctx.conv_id = conv_id
+
     await init_mcp(config)
     _print_banner(config)
 
-    sub_id = ctx.event_bus.subscribe(_create_interactive_progress_subscriber(ctx))
+    # Create conversation manager
+    manager = ConversationManager(config, ctx.event_bus)
 
-    # Resume from archive if available
-    history = read_archive(config, ctx.conv_id)
-    if history:
-        log.info(f"Resumed interactive session from archive ({len(history)} messages)")
-        print(f"  (resumed {len(history)} messages from previous session)")
-    else:
-        history = []
+    # Track turn completion
+    turn_done = asyncio.Event()
+    last_response_text = {"text": ""}
+
+    # Subscribe to conversation events for terminal display
+    async def on_event(event):
+        event_type = event.get("type", "")
+
+        if event_type == "chunk":
+            print(event.get("text", ""), end="", flush=True)
+
+        elif event_type == "tool_call_start":
+            name = event.get("name", "tool")
+            print(f"\n  [calling {name}...]", flush=True)
+
+        elif event_type == "tool_start":
+            print(f"  [running {event.get('tool', 'tool')}...]")
+
+        elif event_type == "tool_status":
+            print(f"  [{event.get('tool', 'tool')}] {event.get('message', '')}")
+
+        elif event_type == "llm_start" and event.get("iteration", 1) > 1:
+            print("  [thinking...]")
+
+        elif event_type == "compaction_start":
+            print("  [compacting conversation...]")
+
+        elif event_type == "compaction_end":
+            print("  [compaction complete]")
+
+        elif event_type == "confirmation_request":
+            confirmation_id = event.get("confirmation_id", "")
+            message = event.get("message", "")
+            action_type = event.get("action_type", "")
+            action_data = event.get("action_data", {})
+
+            command = action_data.get("command", message)
+            suggested_pattern = action_data.get("suggested_pattern", "")
+
+            print(f"\n  \U0001f6a8 Confirm ({action_type}): {command}")
+            if suggested_pattern and action_type == "run_shell_command":
+                prompt = (f"  Approve? [y]es / [n]o / [a]lways / "
+                          f"[p]attern ({suggested_pattern}): ")
+            else:
+                prompt = "  Approve? [y]es / [n]o / [a]lways: "
+
+            answer = await asyncio.to_thread(input, prompt)
+            choice = answer.strip().lower()
+            approved = choice in ("y", "yes", "a", "always", "p", "pattern")
+            always = choice in ("a", "always")
+            add_pattern = choice in ("p", "pattern")
+
+            await manager.respond_to_confirmation(
+                conv_id, confirmation_id,
+                approved=approved, always=always, add_pattern=add_pattern,
+            )
+
+        elif event_type == "message_complete":
+            if event.get("final"):
+                last_response_text["text"] = event.get("text", "")
+
+        elif event_type == "turn_complete":
+            turn_done.set()
+
+        elif event_type == "error":
+            print(f"\n[error: {event.get('message', '')}]")
+            turn_done.set()
+
+    manager.subscribe(conv_id, on_event)
+
+    # Transport-specific context setup
+    def terminal_context_setup(ctx_arg):
+        ctx_arg.media_handler = LocalFileMediaHandler(config)
+        ctx_arg.channel_name = "interactive"
 
     # Start heartbeat timer
     shutdown_event = asyncio.Event()
@@ -154,16 +170,24 @@ async def run_interactive(ctx):
             if user_input.lower() in ("quit", "exit"):
                 break
 
-            try:
-                result = await run_agent_turn(ctx, user_input, history)
-            except Exception as e:
-                print(f"\n[error: {e}]\n")
-                continue
+            turn_done.clear()
+            last_response_text["text"] = ""
+
+            await manager.send_message(
+                conv_id, user_input,
+                user_id=ctx.user_id,
+                context_setup=terminal_context_setup,
+            )
+
+            # Wait for the turn to complete
+            await turn_done.wait()
 
             if resolve_streaming(config):
                 print()  # final newline after streamed text
             else:
-                print(f"\nagent> {result.text}\n")
+                text = last_response_text["text"]
+                if text:
+                    print(f"\nagent> {text}\n")
     finally:
         shutdown_event.set()
         heartbeat_task.cancel()
@@ -171,5 +195,4 @@ async def run_interactive(ctx):
             await heartbeat_task
         except asyncio.CancelledError:
             pass
-        ctx.event_bus.unsubscribe(sub_id)
         await shutdown_mcp()

--- a/src/decafclaw/llm/providers/vertex.py
+++ b/src/decafclaw/llm/providers/vertex.py
@@ -355,6 +355,38 @@ def _clean_schema(schema: dict) -> dict:
     return cleaned
 
 
+def _content_to_parts(content) -> list[dict]:
+    """Convert message content (string or multimodal list) to Vertex parts.
+
+    Handles both plain string content and the OpenAI multimodal format
+    produced by _resolve_attachments: [{"type": "text", ...}, {"type": "image_url", ...}].
+    """
+    if not content:
+        return []
+    if isinstance(content, str):
+        return [{"text": content}]
+    # Multimodal list (from _resolve_attachments)
+    parts = []
+    for item in content:
+        item_type = item.get("type", "")
+        if item_type == "text":
+            text = item.get("text", "")
+            if text:
+                parts.append({"text": text})
+        elif item_type == "image_url":
+            data_url = item.get("image_url", {}).get("url", "")
+            # Parse data:mime;base64,payload
+            if data_url.startswith("data:") and ";base64," in data_url:
+                header, payload = data_url.split(";base64,", 1)
+                mime_type = header[len("data:"):]
+                parts.append({
+                    "inlineData": {"mimeType": mime_type, "data": payload},
+                })
+            else:
+                log.warning("Unsupported image_url format (not a data URI), skipping")
+    return parts
+
+
 def _build_request_body(
     messages: list[dict], tools: list[dict] | None = None,
 ) -> dict:
@@ -380,9 +412,7 @@ def _build_request_body(
                 system_parts.append({"text": content})
 
         elif role == "user":
-            parts = []
-            if content:
-                parts.append({"text": content})
+            parts = _content_to_parts(content)
             if parts:
                 contents.append({"role": "user", "parts": parts})
 
@@ -408,6 +438,10 @@ def _build_request_body(
             tool_name = msg.get("name", "") or tc_id_to_name.get(tool_call_id, "")
             try:
                 response_obj = json.loads(content)
+                # Vertex requires response to be a Struct (JSON object).
+                # Wrap bare values (int, str, list, etc.) in an object.
+                if not isinstance(response_obj, dict):
+                    response_obj = {"result": response_obj}
             except (json.JSONDecodeError, TypeError):
                 response_obj = {"result": content}
 

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -1,4 +1,9 @@
-"""Mattermost client — WebSocket for receiving, REST for sending."""
+"""Mattermost client — WebSocket for receiving, REST for sending.
+
+Transport adapter that handles Mattermost connections, message parsing,
+display formatting, debouncing, and circuit breaking. Agent loop lifecycle
+and conversation state are owned by the ConversationManager.
+"""
 
 import asyncio
 import json
@@ -14,60 +19,23 @@ from .mattermost_display import THINKING_INDICATOR, ConversationDisplay  # noqa:
 log = logging.getLogger(__name__)
 
 
-# -- Per-conversation state ----------------------------------------------------
+# -- Mattermost-specific per-conversation state --------------------------------
 
 
 @dataclass
-class ConversationState:
-    """Per-conversation state tracked during the bot's lifetime."""
-    history: list = field(default_factory=list)
-    skill_state: dict | None = None
-    skip_vault_retrieval: bool = False
-    pending_msgs: list = field(default_factory=list)
+class MattermostConvState:
+    """Mattermost-specific per-conversation state (transport concerns only).
+
+    Agent loop state (history, busy, skill_state, circuit breaker, etc.)
+    is in the ConversationManager's ConversationState.
+    """
     debounce_timer: asyncio.Task | None = None
     last_response_time: float = 0
-    busy: bool = False
-    cancel: asyncio.Event | None = None
-    turn_times: list = field(default_factory=list)
-    paused_until: float = 0
-
-
-# -- Circuit breaker -----------------------------------------------------------
-
-
-class CircuitBreaker:
-    """Rate-limits agent turns per conversation to prevent runaway loops."""
-
-    def __init__(self, max_turns: int, window_sec: int, pause_sec: int):
-        self.max_turns = max_turns
-        self.window_sec = window_sec
-        self.pause_sec = pause_sec
-
-    def is_tripped(self, conv: ConversationState, conv_id: str = "") -> bool:
-        """Check if the circuit breaker has tripped. Mutates conv state."""
-        now = time.monotonic()
-
-        # Check if currently paused
-        if now < conv.paused_until:
-            return True
-
-        # Clean expired entries and check
-        cutoff = now - self.window_sec
-        conv.turn_times = [t for t in conv.turn_times if t > cutoff]
-
-        if len(conv.turn_times) >= self.max_turns:
-            conv.paused_until = now + self.pause_sec
-            log.warning(
-                f"Circuit breaker tripped for {conv_id[:8]}: "
-                f"{len(conv.turn_times)} turns in {self.window_sec}s, "
-                f"pausing for {self.pause_sec}s"
-            )
-            return True
-        return False
-
-    def record_turn(self, conv: ConversationState) -> None:
-        """Record an agent turn for tracking."""
-        conv.turn_times.append(time.monotonic())
+    pending_msgs: list = field(default_factory=list)
+    # Current turn display (set per-turn, cleared on completion)
+    conv_display: ConversationDisplay | None = None
+    cancel_task: asyncio.Task | None = None
+    manager_sub_id: str = ""
 
 
 # -- Mattermost client ---------------------------------------------------------
@@ -88,11 +56,6 @@ class MattermostClient:
         self.require_mention = config.mattermost.require_mention
         self.user_rate_limit_ms = config.mattermost.user_rate_limit_ms
         self.channel_blocklist = set(config.mattermost.channel_blocklist)
-        self.circuit_breaker = CircuitBreaker(
-            max_turns=config.mattermost.circuit_breaker_max,
-            window_sec=config.mattermost.circuit_breaker_window_sec,
-            pause_sec=config.mattermost.circuit_breaker_pause_sec,
-        )
         self._http = httpx.AsyncClient(
             base_url=self.url + "/api/v4",
             headers={
@@ -253,8 +216,6 @@ class MattermostClient:
                 message = message.replace(mention, "").strip()
 
         # In non-DM channels, require @-mention if configured.
-        # Always allow thread replies (root_id present) — if we're in the thread,
-        # the user expects us to respond.
         is_dm = channel_type == "D"
         in_thread = bool(post.get("root_id"))
         if self.require_mention and not is_dm and not mentioned and not in_thread:
@@ -281,118 +242,46 @@ class MattermostClient:
 
     # -- Conversation processing -----------------------------------------------
 
-    def _get_conv(self, conversations: dict, conv_id: str) -> ConversationState:
-        """Get or create conversation state."""
-        if conv_id not in conversations:
-            conversations[conv_id] = ConversationState()
-        return conversations[conv_id]
+    def _get_mm_state(self, mm_conversations: dict, conv_id: str) -> MattermostConvState:
+        """Get or create Mattermost-specific conversation state."""
+        if conv_id not in mm_conversations:
+            mm_conversations[conv_id] = MattermostConvState()
+        return mm_conversations[conv_id]
 
-    def _prepare_history(self, conv, conv_id, root_id, channel_id, conversations, config):
-        """Get or create conversation history, resuming from archive if available."""
-        from .archive import restore_history
+    async def _download_attachments(self, msgs, conv_id, config):
+        """Download user-uploaded files from Mattermost and save as conversation attachments."""
+        from .attachments import save_attachment
 
-        if root_id:
-            hist_id = root_id
-            if not conv.history:
-                restored = restore_history(config, hist_id)
-                if restored:
-                    conv.history = restored
-                    log.info(f"Resumed thread {hist_id[:8]} from archive ({len(restored)} messages)")
-                else:
-                    channel_conv = conversations.get(channel_id)
-                    channel_history = channel_conv.history if channel_conv else []
-                    conv.history = list(channel_history)
-                    log.debug(f"Forked thread history {hist_id[:8]} from channel {channel_id[:8]} ({len(channel_history)} msgs)")
-        else:
-            if not conv.history:
-                restored = restore_history(config, channel_id)
-                if restored:
-                    conv.history = restored
-                    log.info(f"Resumed channel {channel_id[:8]} from archive ({len(restored)} messages)")
+        max_bytes = getattr(getattr(config, "http", None), "max_upload_bytes", None)
 
-        return conv.history
+        attachments = []
+        for msg in msgs:
+            file_ids = msg.get("file_ids") or []
+            file_metadata = msg.get("file_metadata") or {}
+            for fid in file_ids:
+                try:
+                    resp = await self._http.get(f"/files/{fid}")
+                    resp.raise_for_status()
+                    data = resp.content
 
-    async def _build_request_context(self, app_ctx, conv, conv_id, channel_id,
-                                     root_id, placeholder_id):
-        """Fork a request context and set up streaming, cancellation, and progress."""
-        from .media import MattermostMediaHandler
+                    if max_bytes and len(data) > max_bytes:
+                        log.warning(f"Mattermost file {fid} too large: "
+                                    f"{len(data)} bytes > {max_bytes} limit, skipping")
+                        continue
 
-        req_ctx = app_ctx.fork(
-            user_id=app_ctx.config.agent.user_id,
-            channel_id=channel_id,
-            channel_name="",
-            thread_id=root_id or "",
-            conv_id=conv_id,
-        )
-        req_ctx.media_handler = MattermostMediaHandler(self._http, channel_id=channel_id)
+                    fmeta = file_metadata.get(fid, {})
+                    filename = fmeta.get("name", f"file-{fid}")
+                    mime_type = fmeta.get("mime_type", "application/octet-stream")
 
-        # Restore per-conversation state from previous turns
-        if conv.skill_state:
-            req_ctx.tools.extra = conv.skill_state.get("extra_tools", {})
-            req_ctx.tools.extra_definitions = conv.skill_state.get("extra_tool_definitions", [])
-            req_ctx.skills.activated = conv.skill_state.get("activated_skills", set())
-        if conv.skip_vault_retrieval:
-            req_ctx.skip_vault_retrieval = True
-
-        # Create conversation display for this turn
-        conv_display = ConversationDisplay(
-            self, channel_id, root_id,
-            throttle_ms=app_ctx.config.mattermost.stream_throttle_ms,
-            initial_post_id=placeholder_id,
-            config=app_ctx.config,
-            conv_id=conv_id,
-        )
-
-        # Set streaming callback
-        from .config import resolve_streaming
-        if resolve_streaming(app_ctx.config, req_ctx.active_model):
-            req_ctx.on_stream_chunk = conv_display.on_stream_chunk
-
-        # Set up cancellation event and poll for stop reaction
-        cancel_event = asyncio.Event()
-        req_ctx.cancelled = cancel_event
-        conv.cancel = cancel_event
-        cancel_task = None
-        if placeholder_id:
-            cancel_task = asyncio.create_task(
-                self._poll_cancel(placeholder_id, cancel_event)
-            )
-
-        # Attach interactive Stop button to messages during this turn
-        from .mattermost_ui import build_stop_button
-        stop_attachments = build_stop_button(app_ctx.config, conv_id)
-        if stop_attachments and placeholder_id:
-            conv_display._stop_attachments = stop_attachments
-            conv_display._stop_on_post = placeholder_id
-            # Patch placeholder to include the stop button
-            await self.edit_message(
-                placeholder_id, THINKING_INDICATOR,
-                props={"attachments": stop_attachments},
-            )
-            # Subscribe to cancel_turn events from the button callback
-            def on_cancel(event):
-                if event.get("type") == "cancel_turn" and event.get("conv_id") == conv_id:
-                    cancel_event.set()
-            conv_display._cancel_sub = req_ctx.event_bus.subscribe(on_cancel)
-
-        sub_id = self._subscribe_progress(
-            req_ctx.event_bus, req_ctx.context_id,
-            channel_id=channel_id, root_id=root_id,
-            streaming=resolve_streaming(app_ctx.config, req_ctx.active_model),
-            conv_display=conv_display,
-            reflection_visibility=app_ctx.config.reflection.visibility,
-        )
-
-        return req_ctx, conv_display, cancel_task, sub_id
+                    att = save_attachment(config, conv_id, filename, data, mime_type)
+                    attachments.append(att)
+                    log.info(f"Saved Mattermost attachment: {att['filename']} ({mime_type})")
+                except Exception as e:
+                    log.warning(f"Failed to download Mattermost file {fid}: {e}")
+        return attachments
 
     async def _post_response(self, response, channel_id, root_id, conv_display):
-        """Post any remaining response content not handled by ConversationDisplay.
-
-        ConversationDisplay handles text streaming and tool media during the turn.
-        This handles:
-        - Text-referenced media from the final response (workspace image refs)
-        - Error responses that ConversationDisplay may not have seen
-        """
+        """Post any remaining response content not handled by ConversationDisplay."""
         response_media = response.media or []
 
         if response_media:
@@ -406,56 +295,35 @@ class MattermostClient:
                     channel_id, "", file_ids, root_id=root_id
                 )
 
-    async def _download_attachments(self, msgs, conv_id, config):
-        """Download user-uploaded files from Mattermost and save as conversation attachments.
+    async def _process_conversation(self, conv_id, channel_id, msgs,
+                                    app_ctx, mm_conversations, manager):
+        """Process accumulated messages for a conversation."""
+        mm_state = self._get_mm_state(mm_conversations, conv_id)
+        cooldown_sec = self.cooldown_ms / 1000.0
 
-        Returns a list of attachment metadata dicts (same format as web UI uploads).
-        """
-        from .attachments import save_attachment
+        # Check if busy via the manager (circuit breaker is in the manager) — queue locally and re-debounce.
+        # Cancel-on-new-message is handled by manager.send_message().
+        mgr_state = manager.get_state(conv_id)
+        if mgr_state and mgr_state.busy:
+            log.info(f"Conversation {conv_id[:8]} busy, queuing {len(msgs)} message(s)")
+            mm_state.pending_msgs = msgs + mm_state.pending_msgs
+            mm_state.debounce_timer = asyncio.create_task(
+                self._debounce_fire(conv_id, channel_id, mm_conversations,
+                                    app_ctx, manager)
+            )
+            return
 
-        max_bytes = getattr(getattr(config, "http", None), "max_upload_bytes", None)
+        # Cooldown: wait if we responded too recently
+        now = time.monotonic()
+        wait = cooldown_sec - (now - mm_state.last_response_time)
+        if wait > 0:
+            log.info(f"Cooldown: waiting {wait:.1f}s before responding in {conv_id[:8]}")
+            await asyncio.sleep(wait)
 
-        attachments = []
-        for msg in msgs:
-            file_ids = msg.get("file_ids") or []
-            file_metadata = msg.get("file_metadata") or {}
-            for fid in file_ids:
-                try:
-                    # Download file content
-                    resp = await self._http.get(f"/files/{fid}")
-                    resp.raise_for_status()
-                    data = resp.content
-
-                    # Enforce size limit (same as web UI uploads)
-                    if max_bytes and len(data) > max_bytes:
-                        log.warning(f"Mattermost file {fid} too large: "
-                                    f"{len(data)} bytes > {max_bytes} limit, skipping")
-                        continue
-
-                    # Get filename and MIME type from metadata or file info
-                    fmeta = file_metadata.get(fid, {})
-                    filename = fmeta.get("name", f"file-{fid}")
-                    mime_type = fmeta.get("mime_type", "application/octet-stream")
-
-                    # Save to conversation uploads
-                    att = save_attachment(config, conv_id, filename, data, mime_type)
-                    attachments.append(att)
-                    log.info(f"Saved Mattermost attachment: {att['filename']} ({mime_type})")
-                except Exception as e:
-                    log.warning(f"Failed to download Mattermost file {fid}: {e}")
-        return attachments
-
-    async def _prepare_conversation(self, conv, conv_id, channel_id, msgs,
-                                    app_ctx, conversations):
-        """Prepare a conversation turn: combine messages, check commands, set up context.
-
-        Returns (req_ctx, conv_display, cancel_task, sub_id, combined_text, archive_text, cmd_ctx)
-        if the agent turn should proceed, or None if a command was fully handled.
-        """
+        # -- Command dispatch --
         from .commands import dispatch_command
         from .context import Context
 
-        # Combine accumulated messages into one
         combined_text = "\n".join(m["text"] for m in msgs)
         last_msg = msgs[-1]
 
@@ -471,156 +339,323 @@ class MattermostClient:
         senders = set(m["sender_name"] for m in msgs)
         log.info(f"Processing {len(msgs)} message(s) from {', '.join(senders)} in {conv_id[:8]}")
 
-        # -- Command dispatch (centralized in commands.py) --
         cmd_ctx = Context(config=app_ctx.config, event_bus=app_ctx.event_bus)
         cmd_ctx.user_id = app_ctx.config.agent.user_id
         cmd_result = await dispatch_command(cmd_ctx, combined_text, prefixes=["!"])
 
         if cmd_result.mode in ("help", "unknown", "error", "fork"):
             await self.send(channel_id, cmd_result.text, root_id=root_id)
-            return None
+            return
 
-        # Send placeholder immediately
+        # Send placeholder
         placeholder_id = await self.send_placeholder(channel_id, root_id=root_id)
         await self.send_typing(channel_id)
 
-        # Prepare history and request context
-        self._prepare_history(
-            conv, conv_id, root_id, channel_id, conversations, app_ctx.config
-        )
-        req_ctx, conv_display, cancel_task, sub_id = await self._build_request_context(
-            app_ctx, conv, conv_id, channel_id, root_id, placeholder_id
-        )
-
-        # Apply command state to the request context (inline mode)
         archive_text = ""
+        command_ctx = None
         if cmd_result.mode == "inline":
             combined_text = cmd_result.text
             archive_text = cmd_result.display_text
-            from .commands import apply_command_ctx
-            apply_command_ctx(req_ctx, cmd_ctx)
+            command_ctx = cmd_ctx
 
-        return req_ctx, conv_display, cancel_task, sub_id, combined_text, archive_text
+        # Download user-uploaded files
+        attachments = await self._download_attachments(msgs, conv_id, app_ctx.config)
 
-    async def _process_conversation(self, conv_id, channel_id, msgs,
-                                    app_ctx, conversations):
-        """Process accumulated messages for a conversation."""
-        from .agent import run_agent_turn
+        # Create ConversationDisplay for this turn
+        conv_display = ConversationDisplay(
+            self, channel_id, root_id,
+            throttle_ms=app_ctx.config.mattermost.stream_throttle_ms,
+            initial_post_id=placeholder_id,
+            config=app_ctx.config,
+            conv_id=conv_id,
+        )
+        mm_state.conv_display = conv_display
 
-        conv = self._get_conv(conversations, conv_id)
-        cooldown_sec = self.cooldown_ms / 1000.0
-
-        # Circuit breaker check
-        if self.circuit_breaker.is_tripped(conv, conv_id):
-            log.warning(f"Dropping messages for paused conversation {conv_id[:8]}")
-            return
-
-        # One agent turn at a time per conversation
-        if conv.busy:
-            if (app_ctx.config.agent.turn_on_new_message == "cancel"
-                    and conv.cancel and not conv.cancel.is_set()):
-                log.info(f"Conversation {conv_id[:8]} busy, cancelling current turn for new message")
-                conv.cancel.set()
-            else:
-                log.info(f"Conversation {conv_id[:8]} busy, queuing {len(msgs)} message(s)")
-            conv.pending_msgs = msgs + conv.pending_msgs
-            conv.debounce_timer = asyncio.create_task(
-                self._debounce_fire(conv_id, channel_id, conversations, app_ctx)
+        # Attach stop button and start emoji-based cancel polling
+        from .mattermost_ui import build_stop_button
+        stop_attachments = build_stop_button(app_ctx.config, conv_id)
+        if stop_attachments and placeholder_id:
+            conv_display._stop_attachments = stop_attachments
+            conv_display._stop_on_post = placeholder_id
+            await self.edit_message(
+                placeholder_id, THINKING_INDICATOR,
+                props={"attachments": stop_attachments},
             )
-            return
 
-        # Cooldown: wait if we responded too recently
-        now = time.monotonic()
-        wait = cooldown_sec - (now - conv.last_response_time)
-        if wait > 0:
-            log.info(f"Cooldown: waiting {wait:.1f}s before responding in {conv_id[:8]}")
-            await asyncio.sleep(wait)
+        if placeholder_id:
+            # Poll for stop emoji reactions — cancel via manager
+            async def poll_and_cancel():
+                cancel_sentinel = asyncio.Event()
+                await self._poll_cancel(placeholder_id, cancel_sentinel)
+                if cancel_sentinel.is_set():
+                    await manager.cancel_turn(conv_id)
+            mm_state.cancel_task = asyncio.create_task(poll_and_cancel())
 
-        # Prepare conversation: combine messages, dispatch commands, build context
-        prepared = await self._prepare_conversation(
-            conv, conv_id, channel_id, msgs, app_ctx, conversations
+        # Pre-load history with Mattermost thread-fork logic.
+        # For threads: if no archive exists, fork from the channel history.
+        # The manager's load_history will use this pre-loaded history.
+        from .archive import restore_history
+        restored = restore_history(app_ctx.config, conv_id)
+        if restored:
+            manager.set_initial_history(conv_id, restored)
+        elif root_id:
+            # New thread — fork from channel history
+            channel_state = manager.get_state(channel_id)
+            channel_history = channel_state.history if channel_state else []
+            if channel_history:
+                manager.set_initial_history(conv_id, list(channel_history))
+                log.debug("Forked thread %s history from channel %s (%d msgs)",
+                          conv_id[:8], channel_id[:8], len(channel_history))
+
+        # Subscribe to manager events for this conversation
+        self._ensure_subscribed(mm_state, conv_id, channel_id, root_id,
+                                app_ctx, manager)
+
+        # Transport-specific context setup
+        def context_setup(ctx):
+            from .media import MattermostMediaHandler
+            ctx.media_handler = MattermostMediaHandler(self._http, channel_id=channel_id)
+            ctx.channel_id = channel_id
+            ctx.channel_name = ""
+            ctx.thread_id = root_id or ""
+            ctx.user_id = app_ctx.config.agent.user_id
+
+        # Start the turn via the manager
+        await manager.send_message(
+            conv_id, combined_text,
+            user_id=app_ctx.config.agent.user_id,
+            context_setup=context_setup,
+            archive_text=archive_text,
+            attachments=attachments or None,
+            command_ctx=command_ctx,
         )
-        if prepared is None:
-            return  # Command was fully handled
 
-        req_ctx, conv_display, cancel_task, sub_id, combined_text, archive_text = prepared
+    def _ensure_subscribed(self, mm_state, conv_id, channel_id, root_id,
+                           app_ctx, manager):
+        """Subscribe to manager events for a conversation, routing to ConversationDisplay."""
+        # Unsubscribe previous subscription if any (fresh per-turn display)
+        if mm_state.manager_sub_id:
+            manager.unsubscribe(conv_id, mm_state.manager_sub_id)
+            mm_state.manager_sub_id = ""
 
-        # Download user-uploaded files and store as conversation attachments
-        attachments = await self._download_attachments(
-            msgs, conv_id, app_ctx.config)
+        client = self
+        config = app_ctx.config
+        from .config import resolve_streaming
+        reflection_visibility = config.reflection.visibility
 
-        conv.busy = True
-        try:
-            response = await run_agent_turn(
-                req_ctx, combined_text, conv.history, archive_text=archive_text,
-                attachments=attachments or None)
-        except BaseException as e:
-            log.error(f"Agent turn failed: {e}")
-            from .media import ToolResult
-            response = ToolResult(text=f"[error: agent turn failed: {e}]")
-            # Show error on the placeholder instead of leaving it to be deleted
-            if conv_display._current_post_id and not conv_display._text_has_content:
-                conv_display._text_buffer = f"\u26a0\ufe0f {e}"
-                conv_display._text_has_content = True
-        finally:
-            if cancel_task:
-                cancel_task.cancel()
-                try:
-                    await cancel_task
-                except asyncio.CancelledError:
+        def is_streaming():
+            """Resolve streaming for the conversation's active model."""
+            conv_state = manager.get_state(conv_id)
+            model = conv_state.active_model if conv_state else ""
+            return resolve_streaming(config, model)
+        compaction_post_id = None
+
+        async def on_manager_event(event):
+            nonlocal compaction_post_id
+            cd = mm_state.conv_display
+            event_type = event.get("type", "")
+
+            if event_type == "chunk" and cd:
+                await cd.on_stream_chunk("text", event.get("text", ""))
+
+            elif event_type == "stream_done" and cd:
+                await cd.on_stream_chunk("done", None)
+
+            elif event_type == "tool_call_start" and cd:
+                await cd.on_stream_chunk("tool_call_start", event)
+
+            elif event_type == "llm_start" and cd:
+                await cd.on_llm_start(event.get("iteration", 1))
+
+            elif event_type == "llm_end" and cd:
+                if not is_streaming():
+                    content = event.get("content")
+                    if content:
+                        await cd.on_text_complete(content)
+
+            elif event_type == "text_before_tools" and cd:
+                content = event.get("text", "")
+                if content and not is_streaming():
+                    await cd.on_text_complete(content)
+
+            elif event_type == "tool_start" and cd:
+                await cd.on_tool_start(
+                    event.get("tool", "tool"), event.get("args", {}),
+                    tool_call_id=event.get("tool_call_id", ""))
+
+            elif event_type == "tool_status" and cd:
+                await cd.on_tool_status(
+                    event.get("tool", "tool"), event.get("message", ""),
+                    tool_call_id=event.get("tool_call_id", ""))
+
+            elif event_type == "tool_end" and cd:
+                await cd.on_tool_end(
+                    event.get("tool", "tool"),
+                    event.get("result_text", ""),
+                    event.get("display_text"),
+                    event.get("media", []),
+                    tool_call_id=event.get("tool_call_id", ""),
+                    display_short_text=event.get("display_short_text"),
+                )
+
+            elif event_type == "tool_media_uploaded" and cd:
+                await cd.on_tool_media_uploaded(
+                    event.get("file_ids", []),
+                    tool_call_id=event.get("tool_call_id", ""),
+                )
+
+            elif event_type == "confirmation_request" and cd:
+                confirmation_id = event.get("confirmation_id", "")
+                action_data = event.get("action_data", {})
+                command = action_data.get("command", event.get("message", ""))
+                suggested_pattern = action_data.get("suggested_pattern", "")
+                action_type = event.get("action_type", "")
+
+                # Create confirmation post with buttons/emoji (no legacy polling)
+                confirm_post_id = await cd.on_confirm_request(
+                    action_type, command, suggested_pattern,
+                    app_ctx.event_bus, "",  # context_id not needed for manager flow
+                    tool_call_id=event.get("tool_call_id", ""),
+                    conv_id=conv_id,
+                    confirmation_id=confirmation_id,
+                )
+
+                # Start emoji polling routed through the manager
+                if confirm_post_id:
+                    asyncio.create_task(
+                        client._poll_confirmation_manager(
+                            confirm_post_id, manager, conv_id,
+                            confirmation_id, action_type,
+                        )
+                    )
+
+            elif event_type == "reflection_result" and cd:
+                if reflection_visibility == "hidden":
                     pass
-            req_ctx.event_bus.unsubscribe(sub_id)
-            cancel_sub = getattr(conv_display, "_cancel_sub", None)
-            if cancel_sub is not None:
-                req_ctx.event_bus.unsubscribe(cancel_sub)
-            conv.last_response_time = time.monotonic()
+                elif reflection_visibility == "debug":
+                    passed = event.get("passed", True)
+                    critique = event.get("critique", "")
+                    retry_num = event.get("retry_number", 0)
+                    raw = event.get("raw_response", "")
+                    error = event.get("error", "")
+                    text = (f"\U0001f50d **Reflection** (retry {retry_num}): "
+                            f"{'PASS' if passed else 'FAIL'}")
+                    if critique:
+                        text += f"\nCritique: {critique}"
+                    if error:
+                        text += f"\nError: {error}"
+                    if raw:
+                        text += (f"\n\n<details><summary>Raw judge output"
+                                 f"</summary>\n\n{raw}\n</details>")
+                    await cd.on_tool_status("reflection", text)
+                elif not event.get("passed", True):
+                    critique = event.get("critique", "")
+                    retry_num = event.get("retry_number", 0)
+                    text = f"\U0001f50d Reflection retry {retry_num}: {critique}"
+                    await cd.on_tool_status("reflection", text)
 
-            # Persist per-conversation state for next turn
-            if req_ctx.skills.activated:
-                conv.skill_state = {
-                    "extra_tools": req_ctx.tools.extra,
-                    "extra_tool_definitions": req_ctx.tools.extra_definitions,
-                    "activated_skills": req_ctx.skills.activated,
-                }
-            if req_ctx.skip_vault_retrieval:
-                conv.skip_vault_retrieval = True
+            elif event_type == "vault_retrieval" and cd:
+                results = event.get("results") or []
+                if results:
+                    source_counts: dict[str, int] = {}
+                    for item in results:
+                        st = item.get("source_type", "unknown")
+                        source_counts[st] = source_counts.get(st, 0) + 1
+                    parts = []
+                    for st in ("page", "user", "journal", "wiki", "memory"):
+                        if source_counts.get(st):
+                            parts.append(f"{source_counts[st]} {st}")
+                    summary = ", ".join(parts) or "context"
+                    await cd.on_tool_status(
+                        "vault_retrieval",
+                        f"\U0001f9e0 Retrieved {summary}")
 
-            await conv_display.finalize()
-            conv.busy = False
-            conv.cancel = None
-            self.circuit_breaker.record_turn(conv)
+            elif event_type == "compaction_start":
+                if channel_id:
+                    compaction_post_id = await client.send(
+                        channel_id, "\U0001f4e6 Compacting conversation...",
+                        root_id=root_id,
+                    )
 
-        await self._post_response(
-            response, channel_id, root_id=req_ctx.thread_id or None,
-            conv_display=conv_display,
-        )
+            elif event_type == "compaction_end":
+                if compaction_post_id:
+                    try:
+                        elapsed = event.get("elapsed_sec", 0)
+                        before = event.get("before_messages", 0)
+                        after = event.get("after_messages", 0)
+                        est_tokens = event.get("estimated_tokens_before", 0)
+                        if elapsed < 60:
+                            duration = f"{elapsed:.0f}s"
+                        else:
+                            duration = f"{elapsed/60:.1f}m"
+                        details = f"{duration}"
+                        if before and after:
+                            details += f", {before} → {after} messages"
+                        if est_tokens:
+                            details += f", ~{est_tokens:,} tokens compacted"
+                        await client.edit_message(
+                            compaction_post_id,
+                            f"\U0001f4e6 Conversation compacted ({details})",
+                        )
+                    except Exception:
+                        pass
+                    compaction_post_id = None
 
-    async def _debounce_fire(self, conv_id, channel_id, conversations, app_ctx):
+            elif event_type == "message_complete" and event.get("final"):
+                # Post any response media (workspace image refs, etc.)
+                media = event.get("media") or []
+                if media and channel_id:
+                    try:
+                        from .media import MattermostMediaHandler, upload_and_collect
+                        handler = MattermostMediaHandler(
+                            client._http, channel_id=channel_id)
+                        file_ids = await upload_and_collect(
+                            handler, channel_id, media)
+                        if file_ids:
+                            await handler.send_with_media(
+                                channel_id, "", file_ids, root_id=root_id)
+                    except Exception as e:
+                        log.warning("Failed to post response media: %s", e)
+
+            elif event_type == "error" and cd:
+                error_msg = event.get("message", "Unknown error")
+                cd._text_buffer = f"\u26a0\ufe0f {error_msg}"
+                cd._text_has_content = True
+
+            elif event_type == "turn_complete":
+                if cd:
+                    await cd.finalize()
+                # Cancel the emoji stop-polling task
+                if mm_state.cancel_task and not mm_state.cancel_task.done():
+                    mm_state.cancel_task.cancel()
+                    mm_state.cancel_task = None
+                mm_state.last_response_time = time.monotonic()
+                mm_state.conv_display = None
+
+        mm_state.manager_sub_id = manager.subscribe(conv_id, on_manager_event)
+
+    async def _debounce_fire(self, conv_id, channel_id, mm_conversations,
+                             app_ctx, manager):
         """Wait for debounce window, then process accumulated messages."""
         debounce_sec = self.debounce_ms / 1000.0
         await asyncio.sleep(debounce_sec)
-        conv = self._get_conv(conversations, conv_id)
-        msgs = conv.pending_msgs
-        conv.pending_msgs = []
-        conv.debounce_timer = None
+        mm_state = self._get_mm_state(mm_conversations, conv_id)
+        msgs = mm_state.pending_msgs
+        mm_state.pending_msgs = []
+        mm_state.debounce_timer = None
         if msgs:
             await self._process_conversation(
-                conv_id, channel_id, msgs, app_ctx, conversations
+                conv_id, channel_id, msgs, app_ctx, mm_conversations, manager
             )
 
     # -- Main run loop ---------------------------------------------------------
 
-    async def run(self, app_ctx, shutdown_event):
-        """Run the bot: connect, listen for messages, and dispatch to the agent.
-
-        Called by the top-level orchestrator (runner.py). MCP, HTTP server,
-        heartbeat, and signal handling are managed by the orchestrator.
-        """
+    async def run(self, app_ctx, shutdown_event, manager=None):
+        """Run the bot: connect, listen for messages, and dispatch to the agent."""
         await self.connect()
 
-        # Track in-flight agent tasks for graceful shutdown
         agent_tasks = set()
-        conversations: dict[str, ConversationState] = {}
+        mm_conversations: dict[str, MattermostConvState] = {}
         user_last_msg_time: dict[str, float] = {}
 
         debounce_sec = self.debounce_ms / 1000.0
@@ -642,35 +677,35 @@ class MattermostClient:
                 return
             user_last_msg_time[user_id] = now
 
-            conv = self._get_conv(conversations, conv_id)
-            log.info(f"Message from {msg['sender_name']} in {conv_id[:8]} "
-                      f"(busy={conv.busy}): "
+            mm_state = self._get_mm_state(mm_conversations, conv_id)
+            log.info(f"Message from {msg['sender_name']} in {conv_id[:8]}: "
                       f"{msg['text'][:50]}")
 
             # Accumulate message by conversation
-            conv.pending_msgs.append(msg)
+            mm_state.pending_msgs.append(msg)
 
             # Reset debounce timer for this conversation
-            if conv.debounce_timer:
-                conv.debounce_timer.cancel()
+            if mm_state.debounce_timer:
+                mm_state.debounce_timer.cancel()
 
             async def debounce_and_process():
                 await asyncio.sleep(debounce_sec)
-                conv_inner = self._get_conv(conversations, conv_id)
-                msgs = conv_inner.pending_msgs
-                conv_inner.pending_msgs = []
-                conv_inner.debounce_timer = None
+                mm_inner = self._get_mm_state(mm_conversations, conv_id)
+                msgs = mm_inner.pending_msgs
+                mm_inner.pending_msgs = []
+                mm_inner.debounce_timer = None
                 if msgs:
                     task = asyncio.current_task()
                     agent_tasks.add(task)
                     try:
                         await self._process_conversation(
-                            conv_id, channel_id, msgs, app_ctx, conversations
+                            conv_id, channel_id, msgs, app_ctx,
+                            mm_conversations, manager,
                         )
                     finally:
                         agent_tasks.discard(task)
 
-            conv.debounce_timer = asyncio.create_task(debounce_and_process())
+            mm_state.debounce_timer = asyncio.create_task(debounce_and_process())
 
         # Wrap the sync callback from WebSocket into async
         def on_message_sync(msg):
@@ -685,202 +720,18 @@ class MattermostClient:
             await self.close()
             log.info("Mattermost client stopped")
 
-    # -- Progress subscription -------------------------------------------------
+    # -- Confirmation polling (manager-based) ----------------------------------
 
-    def _subscribe_progress(self, event_bus, context_id,
-                            channel_id=None, root_id=None, streaming=False,
-                            conv_display=None, reflection_visibility="hidden"):
-        """Subscribe to progress events and route to ConversationDisplay.
-
-        Returns the subscription ID for later unsubscribe.
-        """
-        client = self
-        compaction_post_id = None
-
-        # -- Handlers for each event type --
-        # Note: handlers that reference `cd` are only added to the dispatch
-        # dict when conv_display is not None (see dispatch table below).
-        cd = conv_display  # narrowed alias for closures
-
-        async def handle_llm_start(event):
-            assert cd is not None
-            await cd.on_llm_start(event.get("iteration", 1))
-
-        async def handle_llm_end(event):
-            assert cd is not None
-            if not streaming:
-                content = event.get("content")
-                if content:
-                    await cd.on_text_complete(content)
-
-        async def handle_text_before_tools(event):
-            assert cd is not None
-            content = event.get("text", "")
-            if content and not streaming:
-                await cd.on_text_complete(content)
-
-        async def handle_tool_start(event):
-            assert cd is not None
-            await cd.on_tool_start(
-                event.get("tool", "tool"), event.get("args", {}),
-                tool_call_id=event.get("tool_call_id", ""))
-
-        async def handle_tool_status(event):
-            assert cd is not None
-            await cd.on_tool_status(
-                event.get("tool", "tool"), event.get("message", ""),
-                tool_call_id=event.get("tool_call_id", ""))
-
-        async def handle_tool_end(event):
-            assert cd is not None
-            await cd.on_tool_end(
-                event.get("tool", "tool"),
-                event.get("result_text", ""),
-                event.get("display_text"),
-                event.get("media", []),
-                tool_call_id=event.get("tool_call_id", ""),
-                display_short_text=event.get("display_short_text"),
-            )
-
-        async def handle_tool_media_uploaded(event):
-            assert cd is not None
-            await cd.on_tool_media_uploaded(
-                event.get("file_ids", []),
-                tool_call_id=event.get("tool_call_id", ""),
-            )
-
-        async def handle_tool_confirm_request(event):
-            assert cd is not None
-            await cd.on_confirm_request(
-                event.get("tool", "tool"),
-                event.get("command", ""),
-                event.get("suggested_pattern", ""),
-                event_bus, context_id,
-                tool_call_id=event.get("tool_call_id", ""),
-            )
-
-        async def handle_reflection_result(event):
-            assert cd is not None
-            visibility = reflection_visibility
-            if visibility == "hidden":
-                return
-            passed = event.get("passed", True)
-            critique = event.get("critique", "")
-            retry_num = event.get("retry_number", 0)
-            raw = event.get("raw_response", "")
-            error = event.get("error", "")
-            if visibility == "debug":
-                text = (f"\U0001f50d **Reflection** (retry {retry_num}): "
-                        f"{'PASS' if passed else 'FAIL'}")
-                if critique:
-                    text += f"\nCritique: {critique}"
-                if error:
-                    text += f"\nError: {error}"
-                if raw:
-                    text += f"\n\n<details><summary>Raw judge output</summary>\n\n{raw}\n</details>"
-                await cd.on_tool_status("reflection", text)
-            elif not passed:
-                text = (f"\U0001f50d Reflection retry {retry_num}: "
-                        f"{critique}")
-                await cd.on_tool_status("reflection", text)
-
-        async def handle_vault_retrieval(event):
-            assert cd is not None
-            results = event.get("results") or []
-            if results:
-                source_counts: dict[str, int] = {}
-                for item in results:
-                    st = item.get("source_type", "unknown")
-                    source_counts[st] = source_counts.get(st, 0) + 1
-                parts = []
-                for st in ("page", "user", "journal", "wiki", "memory"):
-                    if source_counts.get(st):
-                        parts.append(f"{source_counts[st]} {st}")
-                summary = ", ".join(parts) or "context"
-                await cd.on_tool_status(
-                    "vault_retrieval",
-                    f"\U0001f9e0 Retrieved {summary}")
-
-        async def handle_compaction_start(event):
-            nonlocal compaction_post_id
-            if channel_id:
-                compaction_post_id = await client.send(
-                    channel_id, "\U0001f4e6 Compacting conversation...",
-                    root_id=root_id,
-                )
-
-        async def handle_compaction_end(event):
-            nonlocal compaction_post_id
-            if not compaction_post_id:
-                return
-            try:
-                elapsed = event.get("elapsed_sec", 0)
-                before = event.get("before_messages", 0)
-                after = event.get("after_messages", 0)
-                est_tokens = event.get("estimated_tokens_before", 0)
-                if elapsed < 60:
-                    duration = f"{elapsed:.0f}s"
-                else:
-                    duration = f"{elapsed/60:.1f}m"
-                details = f"{duration}"
-                if before and after:
-                    details += f", {before} → {after} messages"
-                if est_tokens:
-                    details += f", ~{est_tokens:,} tokens compacted"
-                await client.edit_message(
-                    compaction_post_id,
-                    f"\U0001f4e6 Conversation compacted ({details})",
-                )
-            except Exception:
-                pass  # best effort
-            compaction_post_id = None
-
-        # -- Dispatch table --
-        # conv_display-dependent handlers require conv_display to be set;
-        # compaction handlers work independently.
-        from typing import Any, Callable
-        dispatch: dict[str, Callable[..., Any]] = {}
-        if conv_display:
-            dispatch.update({
-                "llm_start": handle_llm_start,
-                "llm_end": handle_llm_end,
-                "text_before_tools": handle_text_before_tools,
-                "tool_start": handle_tool_start,
-                "tool_status": handle_tool_status,
-                "tool_end": handle_tool_end,
-                "tool_media_uploaded": handle_tool_media_uploaded,
-                "tool_confirm_request": handle_tool_confirm_request,
-                "reflection_result": handle_reflection_result,
-                "vault_retrieval": handle_vault_retrieval,
-            })
-        dispatch["compaction_start"] = handle_compaction_start
-        dispatch["compaction_end"] = handle_compaction_end
-
-        async def on_progress(event):
-            if event.get("context_id") != context_id:
-                return
-            handler = dispatch.get(event.get("type"))
-            if handler:
-                await handler(event)
-
-        return event_bus.subscribe(on_progress)
-
-    # -- Reaction polling ------------------------------------------------------
-
-    async def _poll_confirmation(self, post_id, event_bus, context_id, tool_name,
-                                 timeout=60, poll_interval=2, tool_call_id=""):
-        """Poll a post for thumbs up/down reactions to approve/deny a tool."""
+    async def _poll_confirmation_manager(self, post_id, manager, conv_id,
+                                         confirmation_id, action_type,
+                                         timeout=60, poll_interval=2):
+        """Poll a post for reactions to resolve a confirmation via the manager."""
 
         async def _resolve(approved, always=False, add_pattern=False, label=""):
-            await event_bus.publish({
-                "type": "tool_confirm_response",
-                "context_id": context_id,
-                "tool": tool_name,
-                "approved": approved,
-                **({"tool_call_id": tool_call_id} if tool_call_id else {}),
-                **({"always": True} if always else {}),
-                **({"add_pattern": True} if add_pattern else {}),
-            })
+            await manager.respond_to_confirmation(
+                conv_id, confirmation_id,
+                approved=approved, always=always, add_pattern=add_pattern,
+            )
             try:
                 resp = await self._http.get(f"/posts/{post_id}")
                 original_text = resp.json().get("message", "") if resp.status_code == 200 else ""
@@ -893,18 +744,18 @@ class MattermostClient:
             try:
                 resp = await self._http.get(f"/posts/{post_id}/reactions")
                 resp.raise_for_status()
-                reactions = resp.json()
+                reactions = resp.json() or []
                 for r in reactions:
                     emoji = r.get("emoji_name", "")
                     user_id = r.get("user_id", "")
                     if user_id == self.bot_user_id:
                         continue
-                    if emoji in ("notebook",) and tool_name == "shell":
+                    if emoji in ("notebook",) and action_type == "run_shell_command":
                         log.info(f"Tool approved with pattern by {user_id}")
                         await _resolve(True, add_pattern=True,
                                        label="\U0001f4d3 approved + pattern added")
                         return
-                    elif emoji in ("white_check_mark", "heavy_check_mark") and tool_name != "shell":
+                    elif emoji in ("white_check_mark", "heavy_check_mark") and action_type != "run_shell_command":
                         log.info(f"Tool always-approved by {user_id}")
                         await _resolve(True, always=True, label="\u2705 always approved")
                         return
@@ -920,7 +771,7 @@ class MattermostClient:
                 log.debug(f"Reaction poll error: {e}")
             await asyncio.sleep(poll_interval)
 
-        log.info(f"Confirmation timed out for {tool_name}")
+        log.info(f"Confirmation timed out for {action_type}")
         await _resolve(False, label="\u23f0 timed out")
 
     async def _poll_cancel(self, post_id, cancel_event, poll_interval=2):
@@ -929,7 +780,7 @@ class MattermostClient:
             try:
                 resp = await self._http.get(f"/posts/{post_id}/reactions")
                 if resp.status_code == 200:
-                    reactions = resp.json()
+                    reactions = resp.json() or []
                     for r in reactions:
                         emoji = r.get("emoji_name", "")
                         user_id = r.get("user_id", "")
@@ -968,7 +819,7 @@ class MattermostClient:
         return None
 
     def _make_heartbeat_cycle(self, _channel_id, event_bus, config):
-        """Create an on_cycle callback that runs sections and posts results as they complete."""
+        """Create an on_cycle callback that runs sections and posts results."""
 
         async def on_cycle():
             from .tools.heartbeat_tools import _guarded_heartbeat

--- a/src/decafclaw/mattermost_display.py
+++ b/src/decafclaw/mattermost_display.py
@@ -230,9 +230,20 @@ class ConversationDisplay:
     # -- Confirmation ----------------------------------------------------------
 
     async def on_confirm_request(self, tool_name, command, suggested_pattern,
-                                  event_bus, context_id, tool_call_id=""):
-        """Tool needs confirmation — show prompt with buttons and/or emoji."""
+                                  event_bus, context_id, tool_call_id="",
+                                  conv_id="", confirmation_id="") -> str:
+        """Tool needs confirmation — show prompt with buttons and/or emoji.
+
+        Returns the post ID of the confirmation message so the caller
+        can start emoji polling via the conversation manager.
+        """
         from .mattermost_ui import build_confirm_buttons
+
+        # Map action types (e.g., "run_shell_command") back to legacy
+        # tool names the display and button builder expect.
+        _LEGACY_TOOL_NAMES = {"run_shell_command": "shell",
+                              "activate_skill": "activate_skill"}
+        tool_name = _LEGACY_TOOL_NAMES.get(tool_name) or tool_name
 
         config = self._config
 
@@ -240,7 +251,6 @@ class ConversationDisplay:
         msg = f"\U0001f6a8 **Confirm {tool_name}:**\n```\n{command}\n```"
 
         # Add emoji instructions (unless disabled)
-        # Show emoji instructions if enabled (default: on when HTTP off, off when HTTP on)
         show_emoji = not config or config.mattermost.enable_emoji_confirms
         if show_emoji:
             if tool_name == "shell" and suggested_pattern:
@@ -257,11 +267,13 @@ class ConversationDisplay:
             attachments = build_confirm_buttons(
                 config, tool_name, command, suggested_pattern,
                 context_id, msg, tool_call_id=tool_call_id,
+                conv_id=conv_id, confirmation_id=confirmation_id,
             )
             if attachments:
                 import json as _json
                 log.debug(f"Confirm buttons: {_json.dumps(attachments, indent=2)}")
 
+        confirm_post_id = ""
         tool_post_id = self._tool_posts.get(tool_call_id)
         if tool_post_id:
             # Edit existing post — can't add attachments to edit, so send new
@@ -283,14 +295,7 @@ class ConversationDisplay:
             )
             self._tool_posts[tool_call_id] = confirm_post_id
 
-        # Start emoji reaction polling if emoji confirms are enabled
-        if confirm_post_id and show_emoji:
-            asyncio.create_task(
-                self.client._poll_confirmation(
-                    confirm_post_id, event_bus, context_id, tool_name,
-                    tool_call_id=tool_call_id,
-                )
-            )
+        return confirm_post_id or ""
 
     # -- Finalization ----------------------------------------------------------
 

--- a/src/decafclaw/mattermost_ui.py
+++ b/src/decafclaw/mattermost_ui.py
@@ -58,7 +58,9 @@ def get_token_registry() -> ConfirmTokenRegistry:
 
 def build_confirm_buttons(config, tool_name: str, command: str,
                           suggested_pattern: str, context_id: str,
-                          original_message: str, tool_call_id: str = "") -> list[dict]:
+                          original_message: str, tool_call_id: str = "",
+                          conv_id: str = "",
+                          confirmation_id: str = "") -> list[dict]:
     """Build Mattermost attachment with interactive action buttons.
 
     Returns the attachments list to include in a post's props.
@@ -75,6 +77,8 @@ def build_confirm_buttons(config, tool_name: str, command: str,
             server_secret=config.http.secret,
             action=action,
             tool_call_id=tool_call_id,
+            conv_id=conv_id,
+            confirmation_id=confirmation_id,
         )
 
     base_url = f"{config.http_callback_base}/actions/confirm"
@@ -169,6 +173,7 @@ def build_stop_button(config, conv_id: str) -> list[dict]:
         tool_name="_cancel",
         original_message="",
         server_secret=config.http.secret,
+        conv_id=conv_id,
     )
     base_url = f"{config.http_callback_base}/actions/cancel"
 

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -51,11 +51,17 @@ async def run_all(app_ctx):
     schedule_task = None
 
     try:
+        # Create conversation manager (shared across web + future transports)
+        from .conversation_manager import ConversationManager
+        manager = ConversationManager(config, app_ctx.event_bus)
+        await manager.startup_scan()
+
         # Start HTTP server (button callbacks + web gateway)
         if config.http.enabled:
             from .http_server import run_http_server
             http_task = asyncio.create_task(
-                run_http_server(config, app_ctx.event_bus, app_ctx=app_ctx)
+                run_http_server(config, app_ctx.event_bus, app_ctx=app_ctx,
+                                manager=manager)
             )
             log.info(f"HTTP server enabled on {config.http.host}:{config.http.port}")
 
@@ -64,7 +70,7 @@ async def run_all(app_ctx):
             from .mattermost import MattermostClient
             client = MattermostClient(config)
             mattermost_task = asyncio.create_task(
-                client.run(app_ctx, shutdown_event)
+                client.run(app_ctx, shutdown_event, manager=manager)
             )
             log.info("Mattermost client starting")
 
@@ -134,6 +140,9 @@ async def run_all(app_ctx):
                 await _cancel_task(mattermost_task, "Mattermost")
             except asyncio.CancelledError:
                 pass
+
+        # Wait for in-flight agent turns managed by the conversation manager
+        await manager.shutdown()
 
         await shutdown_mcp()
         log.info("Shutdown complete")

--- a/src/decafclaw/tools/confirmation.py
+++ b/src/decafclaw/tools/confirmation.py
@@ -1,51 +1,81 @@
-"""Shared confirmation request helper for tools that need user approval."""
+"""Shared confirmation request helper for tools that need user approval.
+
+When the context has a ``request_confirmation`` callable (set by the
+ConversationManager), confirmations route through the manager for
+persistence and per-conversation scoping. Otherwise, falls back to the
+legacy event-bus pattern.
+"""
 
 import asyncio
 import logging
 
 log = logging.getLogger(__name__)
 
+# Maps tool_name to ConfirmationAction for the manager bridge.
+# Imported lazily to avoid circular imports at module level.
+_TOOL_ACTION_MAP: dict | None = None
 
-async def request_confirmation(
-    ctx,
-    tool_name: str,
-    command: str,
-    message: str,
-    timeout: float = 60,
-    **extra_event_fields,
-) -> dict:
-    """Request user confirmation via the event bus.
 
-    Publishes a tool_confirm_request event and waits for a matching
-    tool_confirm_response. Returns a dict with at least "approved" (bool).
-    May also contain "always", "add_pattern", etc. depending on the
-    response.
+def _get_tool_action_map():
+    global _TOOL_ACTION_MAP
+    if _TOOL_ACTION_MAP is None:
+        from ..confirmations import ConfirmationAction
+        _TOOL_ACTION_MAP = {
+            "shell": ConfirmationAction.RUN_SHELL_COMMAND,
+            "shell_background_start": ConfirmationAction.RUN_SHELL_COMMAND,
+            "activate_skill": ConfirmationAction.ACTIVATE_SKILL,
+            "end_turn_confirm": ConfirmationAction.CONTINUE_TURN,
+        }
+    return _TOOL_ACTION_MAP
 
-    Matches responses by context_id + tool_name. When tool_call_id is
-    available (via ctx.tools.current_call_id), it's included in the request
-    and used for stricter matching — required for concurrent tool calls
-    to the same tool.
 
-    Times out after `timeout` seconds, returning {"approved": False}.
-    """
-    # Check command pre-approval before prompting
-    if tool_name in ctx.tools.preapproved:
-        log.info(f"Confirmation pre-approved for {tool_name}")
-        return {"approved": True}
+async def _request_via_manager(ctx, tool_name, command, message, timeout,
+                               **extra_event_fields) -> dict:
+    """Bridge to the ConversationManager's confirmation flow."""
+    from ..confirmations import ConfirmationAction, ConfirmationRequest
 
+    action_map = _get_tool_action_map()
+    action_type = action_map.get(tool_name, ConfirmationAction.CONTINUE_TURN)
+
+    # Build action_data from the tool-specific parameters
+    action_data: dict = {"command": command}
+    for key in ("suggested_pattern", "skill_name"):
+        if key in extra_event_fields:
+            action_data[key] = extra_event_fields[key]
+
+    request = ConfirmationRequest(
+        action_type=action_type,
+        action_data=action_data,
+        message=message,
+        tool_call_id=ctx.tools.current_call_id,
+        timeout=timeout,
+        approve_label=extra_event_fields.get("approve_label", "Approve"),
+        deny_label=extra_event_fields.get("deny_label", "Deny"),
+    )
+
+    response = await ctx.request_confirmation(request)
+
+    # Convert ConfirmationResponse to the dict format tools expect
+    result: dict = {"approved": response.approved}
+    if response.always:
+        result["always"] = True
+    if response.add_pattern:
+        result["add_pattern"] = True
+    return result
+
+
+async def _request_via_event_bus(ctx, tool_name, command, message, timeout,
+                                 **extra_event_fields) -> dict:
+    """Legacy event-bus confirmation flow."""
     confirm_event = asyncio.Event()
     result = {"approved": False}
     tool_call_id = ctx.tools.current_call_id
-    # Match against the context_id used for publishing (event_context_id if set,
-    # otherwise context_id). Child agents publish under the parent's event_context_id.
     match_context_id = ctx.event_context_id or ctx.context_id
 
     def on_confirm(event):
         if (event.get("type") == "tool_confirm_response"
                 and event.get("context_id") == match_context_id
                 and event.get("tool") == tool_name):
-            # When both sides have tool_call_id, require match (concurrent safety).
-            # If the response omits it, accept anyway (backward compat with older UIs).
             resp_id = event.get("tool_call_id", "")
             if tool_call_id and resp_id and resp_id != tool_call_id:
                 return
@@ -71,3 +101,40 @@ async def request_confirmation(
         ctx.event_bus.unsubscribe(sub_id)
 
     return result
+
+
+async def request_confirmation(
+    ctx,
+    tool_name: str,
+    command: str,
+    message: str,
+    timeout: float = 60,
+    **extra_event_fields,
+) -> dict:
+    """Request user confirmation.
+
+    Routes through the ConversationManager when available (persisted,
+    per-conversation scoped). Falls back to the legacy event-bus pattern
+    for transports not yet migrated.
+
+    Returns a dict with at least ``"approved"`` (bool). May also contain
+    ``"always"``, ``"add_pattern"``, etc.
+    """
+    # Check command pre-approval before prompting
+    if tool_name in ctx.tools.preapproved:
+        log.info(f"Confirmation pre-approved for {tool_name}")
+        return {"approved": True}
+
+    # Route through manager
+    if ctx.request_confirmation is not None:
+        return await _request_via_manager(
+            ctx, tool_name, command, message, timeout, **extra_event_fields)
+
+    # Fallback for contexts not managed by ConversationManager
+    # (heartbeat, scheduled tasks). These should auto-approve via
+    # preapproved checks above, so hitting this path is unexpected.
+    log.warning("No ConversationManager for confirmation request "
+                "(tool=%s, user=%s) — using legacy event bus",
+                tool_name, getattr(ctx, "user_id", "?"))
+    return await _request_via_event_bus(
+        ctx, tool_name, command, message, timeout, **extra_event_fields)

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -54,6 +54,7 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
     child_ctx = parent_ctx.fork(config=child_config)
     child_ctx.conv_id = f"{parent_conv}--child-{child_ctx.context_id[:8]}"
     child_ctx.cancelled = getattr(parent_ctx, "cancelled", None)
+    child_ctx.request_confirmation = getattr(parent_ctx, "request_confirmation", None)
 
     # Route child events to the parent's UI subscriber so confirmations
     # and tool progress are visible in the parent conversation

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -23,6 +23,8 @@
 /**
  * @typedef {object} PendingConfirm
  * @property {string} context_id
+ * @property {string} confirmation_id
+ * @property {string} conv_id
  * @property {string} tool
  * @property {string} tool_call_id
  * @property {string} command
@@ -30,6 +32,8 @@
  * @property {string} message
  * @property {string} approve_label
  * @property {string} deny_label
+ * @property {string} action_type
+ * @property {object} action_data
  */
 
 /**
@@ -411,6 +415,7 @@ export class ConversationStore extends EventTarget {
   /** @param {string} convId */
   selectConversation(convId) {
     this.#currentConvId = convId;
+    this.#busy = false;
     this.#messageStore.clear();
     this.#toolStatusStore.clear();
     this.#contextUsage = 0;
@@ -520,6 +525,14 @@ export class ConversationStore extends EventTarget {
         if (msg.default_model) this.#defaultModel = msg.default_model;
         if (msg.read_only) this.#readOnly = true;
         if (msg.turn_active) this.#busy = true;
+        // Restore pending confirmation from server state (survives reload)
+        if (msg.pending_confirmation) {
+          this.#toolStatusStore.handleMessage({
+            type: 'confirm_request',
+            conv_id: this.#currentConvId,
+            ...msg.pending_confirmation,
+          }, this.#currentConvId);
+        }
       }
       if (msg.type === 'message_complete' && msg.conv_id === this.#currentConvId) {
         this.#toolStatusStore.clearToolStatus();
@@ -543,12 +556,22 @@ export class ConversationStore extends EventTarget {
     switch (msg.type) {
       case 'conv_selected':
         if (msg.read_only) this.#readOnly = true;
+        // Restore pending confirmation from server state (survives reload)
+        if (msg.pending_confirmation) {
+          this.#toolStatusStore.handleMessage({
+            type: 'confirm_request',
+            conv_id: msg.conv_id || this.#currentConvId,
+            ...msg.pending_confirmation,
+          }, this.#currentConvId);
+        }
         break;
 
       case 'turn_start':
-        this.#busy = true;
-        this.#messageStore.clearStreamingText();
-        this.#toolStatusStore.clearToolStatus();
+        if (!msg.conv_id || msg.conv_id === this.#currentConvId) {
+          this.#busy = true;
+          this.#messageStore.clearStreamingText();
+          this.#toolStatusStore.clearToolStatus();
+        }
         break;
 
       case 'model_changed':
@@ -564,8 +587,10 @@ export class ConversationStore extends EventTarget {
 
       case 'error':
         console.error('Server error:', msg.message);
-        this.#busy = false;
-        this.#toolStatusStore.clearToolStatus();
+        if (!msg.conv_id || msg.conv_id === this.#currentConvId) {
+          this.#busy = false;
+          this.#toolStatusStore.clearToolStatus();
+        }
         if (this.#currentConvId && this.#messageStore.currentMessages.length === 0) {
           this.#currentConvId = null;
         }

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -143,6 +143,21 @@ export class MessageStore {
         }
         return true;
 
+      case 'user_message':
+        // Multi-tab sync: add user message if not already present
+        // (the originating tab adds it locally before the event arrives)
+        if (msg.conv_id === currentConvId) {
+          const last = this.#currentMessages[this.#currentMessages.length - 1];
+          if (!last || last.role !== 'user' || last.content !== msg.text) {
+            this.#currentMessages.push({
+              role: 'user',
+              content: msg.text,
+              timestamp: new Date().toISOString(),
+            });
+          }
+        }
+        return true;
+
       case 'command_ack':
         if (msg.conv_id === currentConvId) {
           this.#currentMessages.push({

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -61,16 +61,27 @@ export class ToolStatusStore {
    * @param {object} [extra]
    */
   respondToConfirm(contextId, tool, toolCallId = '', approved = false, extra = {}) {
+    // Find the confirm to get its confirmation_id and conv_id
+    const confirm = this.#pendingConfirms.find(c => {
+      if (toolCallId) return c.tool_call_id === toolCallId;
+      return c.context_id === contextId && c.tool === tool;
+    });
+
     this.#ws.send({
       type: 'confirm_response',
       context_id: contextId,
       tool,
       approved,
+      // Include confirmation_id and conv_id for manager-based routing
+      ...(confirm?.confirmation_id ? { confirmation_id: confirm.confirmation_id } : {}),
+      ...(confirm?.conv_id ? { conv_id: confirm.conv_id } : {}),
       ...(toolCallId ? { tool_call_id: toolCallId } : {}),
       ...extra,
     });
     // Remove only this specific confirm
-    if (toolCallId) {
+    if (confirm?.confirmation_id) {
+      this.#pendingConfirms = this.#pendingConfirms.filter(c => c.confirmation_id !== confirm.confirmation_id);
+    } else if (toolCallId) {
       this.#pendingConfirms = this.#pendingConfirms.filter(c => c.tool_call_id !== toolCallId);
     } else {
       this.#pendingConfirms = this.#pendingConfirms.filter(c => !(c.context_id === contextId && c.tool === tool));
@@ -133,18 +144,39 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'confirm_request':
+      case 'confirm_request': {
+        // Only show confirmations for the active conversation (#235)
+        if (msg.conv_id && msg.conv_id !== currentConvId) return true;
+        // Deduplicate by confirmation_id (can arrive via both conv_history and live event)
+        const cid = msg.confirmation_id || '';
+        if (cid && this.#pendingConfirms.some(c => c.confirmation_id === cid)) {
+          return true; // already have this one
+        }
         this.#pendingConfirms = [...this.#pendingConfirms, {
-          context_id: msg.context_id,
-          tool: msg.tool,
+          context_id: msg.context_id || '',
+          confirmation_id: msg.confirmation_id || '',
+          conv_id: msg.conv_id || '',
+          tool: msg.tool || '',
           tool_call_id: msg.tool_call_id || '',
           command: msg.command || '',
           suggested_pattern: msg.suggested_pattern || '',
           message: msg.message || '',
           approve_label: msg.approve_label || '',
           deny_label: msg.deny_label || '',
+          action_type: msg.action_type || '',
+          action_data: msg.action_data || {},
         }];
         return true;
+      }
+
+      case 'confirmation_response': {
+        // Multi-tab sync: remove the resolved confirmation widget
+        const resolvedId = msg.confirmation_id || '';
+        if (resolvedId) {
+          this.#pendingConfirms = this.#pendingConfirms.filter(c => c.confirmation_id !== resolvedId);
+        }
+        return true;
+      }
 
       case 'reflection_result':
         if (msg.conv_id === currentConvId) {

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -1,4 +1,9 @@
-"""WebSocket handler for web gateway chat."""
+"""WebSocket handler for web gateway chat.
+
+This is a transport adapter — it handles WebSocket connections, input
+parsing, and output formatting. Agent loop lifecycle and conversation
+state are owned by the ConversationManager.
+"""
 
 import asyncio
 import json
@@ -18,8 +23,30 @@ def _is_safe_conv_id(conv_id: str) -> bool:
     return bool(conv_id and _SAFE_CONV_ID.match(conv_id))
 
 
-# -- WebSocket message handlers ------------------------------------------------
+def _legacy_tool_name(action_type: str) -> str:
+    """Map ConfirmationAction values to the legacy tool names the web UI expects."""
+    return {"run_shell_command": "shell"}.get(action_type, action_type)
 
+
+def _confirmation_to_dict(req) -> dict:
+    """Convert a ConfirmationRequest to the dict shape the client expects."""
+    action_data = req.action_data or {}
+    action_type = req.action_type.value
+    return {
+        "confirmation_id": req.confirmation_id,
+        "action_type": action_type,
+        "tool": _legacy_tool_name(action_type),
+        "command": action_data.get("command", req.message),
+        "suggested_pattern": action_data.get("suggested_pattern", ""),
+        "message": req.message,
+        "approve_label": req.approve_label,
+        "deny_label": req.deny_label,
+        "tool_call_id": req.tool_call_id,
+        "action_data": action_data,
+    }
+
+
+# -- WebSocket message handlers ------------------------------------------------
 
 
 async def _handle_select_conv(ws_send, index, username, msg, state):
@@ -29,7 +56,15 @@ async def _handle_select_conv(ws_send, index, username, msg, state):
         return
     conv = index.get(conv_id)
     if conv and conv.user_id == username:
-        await ws_send({"type": "conv_selected", "conv_id": conv_id})
+        response = {"type": "conv_selected", "conv_id": conv_id}
+        # Check for pending confirmation via the manager
+        manager = state.get("manager")
+        if manager:
+            conv_state = manager.get_state(conv_id)
+            if conv_state and conv_state.pending_confirmation:
+                response["pending_confirmation"] = _confirmation_to_dict(
+                    conv_state.pending_confirmation)
+        await ws_send(response)
     else:
         # Check if it's a system conversation (archive exists on disk)
         # Reject other users' web conversations
@@ -70,7 +105,7 @@ async def _handle_load_history(ws_send, index, username, msg, state):
         limit = 50
     before = msg.get("before", "")
     # Metadata roles that should not be rendered as chat messages
-    _HIDDEN_ROLES = {"effort", "model"}
+    _HIDDEN_ROLES = {"effort", "model", "confirmation_request", "confirmation_response"}
 
     # Read archive once and reuse for history, token estimation, and model scan
     from ..archive import read_archive as _read_archive
@@ -118,16 +153,21 @@ async def _handle_load_history(ws_send, index, username, msg, state):
         response["available_models"] = sorted(config.model_configs.keys())
         response["default_model"] = config.default_model
 
-    # Register this WebSocket as a viewer of this conversation so it
-    # receives live events (including for in-progress turns after reload).
-    conv_viewers = state.setdefault("conv_viewers", {})
-    conv_viewers.setdefault(conv_id, set()).add(state["websocket"])
-    busy_convs = state.get("busy_convs", set())
-    if conv_id in busy_convs:
-        response["turn_active"] = True
+    # Check if a turn is active for this conversation via the manager
+    manager = state.get("manager")
+    if manager:
+        conv_state = manager.get_state(conv_id)
+        if conv_state and conv_state.busy:
+            response["turn_active"] = True
+        # Include pending confirmation if any
+        if conv_state and conv_state.pending_confirmation:
+            response["pending_confirmation"] = _confirmation_to_dict(
+                conv_state.pending_confirmation)
+
+    # Subscribe this WebSocket as a viewer for live events
+    _subscribe_to_conv(state, conv_id)
 
     await ws_send(response)
-
 
 
 async def _handle_send(ws_send, index, username, msg, state):
@@ -141,6 +181,11 @@ async def _handle_send(ws_send, index, username, msg, state):
     conv = index.get(conv_id)
     if not conv or conv.user_id != username:
         await ws_send({"type": "error", "message": "Conversation not found"})
+        return
+
+    manager = state.get("manager")
+    if not manager:
+        await ws_send({"type": "error", "message": "Chat service unavailable"})
         return
 
     # -- Command dispatch (centralized in commands.py) --
@@ -166,14 +211,16 @@ async def _handle_send(ws_send, index, username, msg, state):
         })
         return
 
+    command_ctx = None
+    archive_text = ""
+
     if cmd_result.mode == "inline":
         text = cmd_result.text
-        # cmd_ctx has preapproved_tools, activated_skills, extra_tools set
-        state["_command_ctx"] = cmd_ctx
-        state["_command_display"] = cmd_result.display_text
+        command_ctx = cmd_ctx
+        archive_text = cmd_result.display_text
         # Persist command flags for subsequent turns in this conversation
         if cmd_ctx.skip_vault_retrieval:
-            state["conv_flags"].setdefault(conv_id, {})["skip_vault_retrieval"] = True
+            manager.set_flag(conv_id, "skip_vault_retrieval", True)
         # Acknowledge the command so the user sees it was recognized
         skill_name = cmd_result.skill.name if cmd_result.skill else "unknown"
         await ws_send({
@@ -181,106 +228,49 @@ async def _handle_send(ws_send, index, username, msg, state):
             "command": cmd_result.display_text,
             "skill": skill_name,
         })
-    else:
-        pass  # not a command, text unchanged
 
-    # Check if a turn is already running for this conversation
-    busy_convs = state.setdefault("busy_convs", set())
-    pending_queue = state.setdefault("pending_msgs", {})
+    # Ensure we're subscribed to this conversation's events
+    _subscribe_to_conv(state, conv_id)
 
-    # Pop pre-configured command state (set by dispatch_command for inline mode)
-    command_ctx = state.pop("_command_ctx", None)
-    command_display = state.pop("_command_display", "")
+    # Transport-specific context setup
+    def context_setup(ctx):
+        from ..media import LocalFileMediaHandler
+        ctx.media_handler = LocalFileMediaHandler(state["config"])
+        ctx.channel_name = "web"
+        ctx.thread_id = ""
 
-    if conv_id in busy_convs:
-        mode = state["config"].agent.turn_on_new_message
-        if mode == "cancel":
-            cancel_ev = state["cancel_events"].get(conv_id)
-            if cancel_ev and not cancel_ev.is_set():
-                log.info(f"WS: cancelling current turn for {conv_id} (new message)")
-                cancel_ev.set()
-        else:
-            log.info(f"WS: queuing message for busy conversation {conv_id}")
-        pending_queue.setdefault(conv_id, []).append(
-            {"text": text, "command_ctx": command_ctx,
-             "command_display": command_display, "attachments": attachments,
-             "wiki_page": wiki_page})
-        return
-
-    _start_agent_turn(state, index, conv_id, username, text, ws_send,
-                      command_ctx=command_ctx, archive_text=command_display,
-                      attachments=attachments, wiki_page=wiki_page)
-
-
-def _start_agent_turn(state, index, conv_id, username, text, ws_send,
-                      command_ctx=None, archive_text="", attachments=None,
-                      wiki_page=None):
-    """Launch an agent turn task with queue drain on completion."""
-    busy_convs = state.setdefault("busy_convs", set())
-    pending_queue = state.setdefault("pending_msgs", {})
-
-    cancel_event = asyncio.Event()
-    state["cancel_events"][conv_id] = cancel_event
-    busy_convs.add(conv_id)
-
-    conv_viewers = state.setdefault("conv_viewers", {})
-    task = asyncio.create_task(
-        _run_agent_turn(
-            state["websocket"], state["app_ctx"], state["config"], state["event_bus"],
-            index, conv_id, username, text, cancel_event,
-            command_ctx=command_ctx, archive_text=archive_text,
-            attachments=attachments, wiki_page=wiki_page,
-            conv_viewers=conv_viewers,
-            conv_flags=state.get("conv_flags", {}).get(conv_id),
-        )
+    # Send message through the manager — it handles queueing and turn lifecycle
+    await manager.send_message(
+        conv_id, text,
+        user_id=username,
+        context_setup=context_setup,
+        archive_text=archive_text,
+        attachments=attachments,
+        command_ctx=command_ctx,
+        wiki_page=wiki_page,
     )
-    state["agent_tasks"].add(task)
 
-    def _on_task_done(t, cid=conv_id):
-        state["agent_tasks"].discard(t)
-        state["cancel_events"].pop(cid, None)
-        busy_convs.discard(cid)
+    # Auto-title: use first user message if title is still default
+    conv = index.get(conv_id)
+    if conv and conv.title == "New conversation":
+        title = text[:100]
+        if len(text) > 100:
+            last_space = title.rfind(" ")
+            if last_space > 50:
+                title = title[:last_space]
+            title += "..."
+        index.rename(conv_id, title)
 
-        # Don't drain queue if the connection is closing
-        if state.get("closing"):
-            pending_queue.pop(cid, None)
-            return
-
-        # Drain pending messages for this conversation
-        queued = pending_queue.pop(cid, [])
-        if queued:
-            texts = [q["text"] for q in queued]
-            last_ctx = queued[-1].get("command_ctx")
-            last_display = queued[-1].get("command_display", "")
-            # Merge attachments from all queued messages
-            all_attachments = []
-            for q in queued:
-                if q.get("attachments"):
-                    all_attachments.extend(q["attachments"])
-            # Use last wiki_page — it reflects what's currently open.
-            # Earlier pages from queued messages are still available via @[[...]] syntax.
-            last_wiki_page = queued[-1].get("wiki_page")
-            combined = "\n".join(texts)
-            log.info(f"WS: draining {len(queued)} queued message(s) for {cid}")
-            _start_agent_turn(state, index, cid, username, combined, ws_send,
-                              command_ctx=last_ctx, archive_text=last_display,
-                              attachments=all_attachments or None,
-                              wiki_page=last_wiki_page)
-
-    task.add_done_callback(_on_task_done)
+    # Touch conversation metadata
+    index.touch(conv_id)
 
 
 async def _handle_cancel_turn(ws_send, index, username, msg, state):
     conv_id = msg.get("conv_id", "")
-    event = state["cancel_events"].get(conv_id)
-    if event:
+    manager = state.get("manager")
+    if manager:
+        await manager.cancel_turn(conv_id)
         log.info(f"Cancelling agent turn for {conv_id}")
-        event.set()
-        # Also cancel the asyncio task for immediate interruption
-        # (the event alone only works when checked in the streaming loop)
-        for task in list(state.get("agent_tasks", set())):
-            if not task.done():
-                task.cancel()
 
 
 async def _handle_set_model(ws_send, index, username, msg, state):
@@ -303,6 +293,11 @@ async def _handle_set_model(ws_send, index, username, msg, state):
     from ..archive import append_message
     append_message(config, conv_id, {"role": "model", "content": model_name})
 
+    # Update manager's conversation state
+    manager = state.get("manager")
+    if manager:
+        manager.set_flag(conv_id, "active_model", model_name)
+
     await ws_send({
         "type": "model_changed", "conv_id": conv_id,
         "model": model_name,
@@ -310,16 +305,237 @@ async def _handle_set_model(ws_send, index, username, msg, state):
 
 
 async def _handle_confirm_response(ws_send, index, username, msg, state):
-    tool_call_id = msg.get("tool_call_id", "")
-    await state["event_bus"].publish({
-        "type": "tool_confirm_response",
-        "context_id": msg.get("context_id", ""),
-        "tool": msg.get("tool", ""),
-        "approved": msg.get("approved", False),
-        **({"tool_call_id": tool_call_id} if tool_call_id else {}),
-        **({"always": True} if msg.get("always") else {}),
-        **({"add_pattern": True} if msg.get("add_pattern") else {}),
-    })
+    """Route confirmation response through the manager."""
+    manager = state.get("manager")
+    conv_id = msg.get("conv_id", "")
+    confirmation_id = msg.get("confirmation_id", "")
+
+    if manager and conv_id and confirmation_id:
+        await manager.respond_to_confirmation(
+            conv_id,
+            confirmation_id,
+            approved=msg.get("approved", False),
+            always=msg.get("always", False),
+            add_pattern=msg.get("add_pattern", False),
+        )
+    else:
+        # Legacy fallback: publish to event bus for non-manager confirmations
+        tool_call_id = msg.get("tool_call_id", "")
+        await state["event_bus"].publish({
+            "type": "tool_confirm_response",
+            "context_id": msg.get("context_id", ""),
+            "tool": msg.get("tool", ""),
+            "approved": msg.get("approved", False),
+            **({"tool_call_id": tool_call_id} if tool_call_id else {}),
+            **({"always": True} if msg.get("always") else {}),
+            **({"add_pattern": True} if msg.get("add_pattern") else {}),
+        })
+
+
+def _subscribe_to_conv(state, conv_id):
+    """Subscribe this WebSocket to a conversation's event stream.
+
+    Unsubscribes from all other conversations first — the web UI only
+    shows one conversation at a time, so stale subscriptions just waste
+    bandwidth pushing events the client will ignore.
+    """
+    manager = state.get("manager")
+    if not manager:
+        return
+    subscriptions = state.setdefault("conv_subscriptions", {})
+    if conv_id in subscriptions:
+        return  # already subscribed
+
+    # Unsubscribe from other conversations
+    for old_id, old_sub_id in list(subscriptions.items()):
+        if old_id != conv_id:
+            manager.unsubscribe(old_id, old_sub_id)
+            del subscriptions[old_id]
+
+    ws_send = state["ws_send"]
+    config = state["config"]
+    streaming_buffer = {"text": ""}
+
+    async def on_conv_event(event):
+        """Format manager events as WebSocket JSON messages."""
+        event_type = event.get("type", "")
+        event_conv_id = event.get("conv_id", conv_id)
+
+        if event_type == "user_message":
+            # Multi-tab sync: show user messages from other tabs.
+            # Sent as distinct type so the client can deduplicate
+            # (the originating tab already has the message locally).
+            await ws_send({
+                "type": "user_message", "conv_id": event_conv_id,
+                "text": event.get("text", ""),
+            })
+
+        elif event_type == "chunk":
+            streaming_buffer["text"] += event.get("text", "")
+            await ws_send({
+                "type": "chunk", "conv_id": event_conv_id,
+                "text": event.get("text", ""),
+            })
+
+        elif event_type == "stream_done":
+            pass  # buffer finalized by llm_start or message_complete
+
+        elif event_type == "llm_start":
+            iteration = event.get("iteration", 1)
+            if iteration > 1 and streaming_buffer["text"]:
+                await ws_send({
+                    "type": "message_complete", "conv_id": event_conv_id,
+                    "role": "assistant", "text": streaming_buffer["text"],
+                })
+                streaming_buffer["text"] = ""
+
+        elif event_type == "text_before_tools":
+            text = streaming_buffer["text"] or event.get("text", "")
+            if text:
+                await ws_send({
+                    "type": "message_complete", "conv_id": event_conv_id,
+                    "role": "assistant", "text": text,
+                })
+                streaming_buffer["text"] = ""
+
+        elif event_type == "tool_start":
+            await ws_send({
+                "type": "tool_start", "conv_id": event_conv_id,
+                "tool": event.get("tool", ""),
+                "tool_call_id": event.get("tool_call_id", ""),
+            })
+
+        elif event_type == "tool_status":
+            await ws_send({
+                "type": "tool_status", "conv_id": event_conv_id,
+                "tool": event.get("tool", ""),
+                "message": event.get("message", ""),
+                "tool_call_id": event.get("tool_call_id", ""),
+            })
+
+        elif event_type == "tool_end":
+            payload = {
+                "type": "tool_end", "conv_id": event_conv_id,
+                "tool": event.get("tool", ""),
+                "result_text": event.get("result_text", ""),
+                "tool_call_id": event.get("tool_call_id", ""),
+            }
+            short = event.get("display_short_text")
+            if short:
+                payload["display_short_text"] = short
+            await ws_send(payload)
+
+        elif event_type == "vault_retrieval":
+            text = event.get("text", "")
+            if text:
+                await ws_send({
+                    "type": "tool_status", "conv_id": event_conv_id,
+                    "tool": "vault_retrieval",
+                    "message": text, "tool_call_id": "",
+                })
+
+        elif event_type == "vault_references":
+            text = event.get("text", "")
+            if text:
+                await ws_send({
+                    "type": "tool_status", "conv_id": event_conv_id,
+                    "tool": "vault_references",
+                    "message": text, "tool_call_id": "",
+                })
+
+        elif event_type == "confirmation_request":
+            # Flush any pending streamed text
+            if streaming_buffer["text"]:
+                await ws_send({
+                    "type": "message_complete", "conv_id": event_conv_id,
+                    "role": "assistant", "text": streaming_buffer["text"],
+                })
+                streaming_buffer["text"] = ""
+            action_type = event.get("action_type", "")
+            action_data = event.get("action_data", {})
+            log.info("Forwarding confirm request to web UI: %s",
+                     action_type)
+            await ws_send({
+                "type": "confirm_request", "conv_id": event_conv_id,
+                "confirmation_id": event.get("confirmation_id", ""),
+                "action_type": action_type,
+                # Provide tool/command for backward compat with confirm-view
+                "tool": _legacy_tool_name(action_type),
+                "command": action_data.get("command", event.get("message", "")),
+                "suggested_pattern": action_data.get("suggested_pattern", ""),
+                "message": event.get("message", ""),
+                "approve_label": event.get("approve_label", ""),
+                "deny_label": event.get("deny_label", ""),
+                "tool_call_id": event.get("tool_call_id", ""),
+                "action_data": action_data,
+            })
+
+        elif event_type == "confirmation_response":
+            # Forward to all tabs so non-originating tabs clear the widget
+            await ws_send({
+                "type": "confirmation_response", "conv_id": event_conv_id,
+                "confirmation_id": event.get("confirmation_id", ""),
+                "approved": event.get("approved", False),
+            })
+
+        elif event_type == "message_complete":
+            if event.get("final"):
+                streaming_buffer["text"] = ""
+            await ws_send(event)
+
+        elif event_type == "turn_start":
+            await ws_send({"type": "turn_start", "conv_id": event_conv_id})
+
+        elif event_type == "turn_complete":
+            streaming_buffer["text"] = ""
+            await ws_send({"type": "turn_complete", "conv_id": event_conv_id})
+
+        elif event_type == "error":
+            await ws_send({
+                "type": "error", "conv_id": event_conv_id,
+                "message": event.get("message", ""),
+            })
+
+        elif event_type == "reflection_result":
+            visibility = config.reflection.visibility
+            passed = event.get("passed", True)
+            if visibility == "hidden":
+                pass
+            elif visibility == "visible" and passed:
+                pass
+            else:
+                await ws_send({
+                    "type": "reflection_result", "conv_id": event_conv_id,
+                    "passed": passed,
+                    "critique": event.get("critique", ""),
+                    "retry_number": event.get("retry_number", 0),
+                    "raw_response": (
+                        event.get("raw_response", "")
+                        if visibility == "debug" else ""
+                    ),
+                    "error": event.get("error", ""),
+                })
+
+        elif event_type == "compaction_end":
+            await ws_send({
+                "type": "compaction_done", "conv_id": event_conv_id,
+                "before_messages": event.get("before_messages", 0),
+                "after_messages": event.get("after_messages", 0),
+            })
+
+    sub_id = manager.subscribe(conv_id, on_conv_event)
+    subscriptions[conv_id] = sub_id
+
+
+def _unsubscribe_all(state):
+    """Unsubscribe from all conversation event streams."""
+    manager = state.get("manager")
+    if not manager:
+        return
+    subscriptions = state.get("conv_subscriptions", {})
+    for conv_id, sub_id in subscriptions.items():
+        manager.unsubscribe(conv_id, sub_id)
+    subscriptions.clear()
 
 
 _HANDLERS = {
@@ -336,7 +552,8 @@ _HANDLERS = {
 # -- Main WebSocket handler ----------------------------------------------------
 
 
-async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx):
+async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx,
+                         manager=None):
     """Handle a WebSocket chat connection."""
     from .auth import get_current_user
     from .conversations import ConversationIndex
@@ -366,13 +583,12 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx):
 
     index = ConversationIndex(config)
     state = {
-        "agent_tasks": set(),
-        "cancel_events": {},
-        "conv_flags": {},  # per-conversation flags (e.g., skip_vault_retrieval)
         "config": config,
         "event_bus": event_bus,
         "app_ctx": app_ctx,
         "websocket": websocket,
+        "ws_send": ws_send,
+        "manager": manager,
     }
 
     try:
@@ -396,285 +612,4 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx):
     except Exception as e:
         log.error(f"WebSocket error for {username}: {e}", exc_info=True)
     finally:
-        # Remove this WebSocket from all conversation viewer sets
-        for viewers in state.get("conv_viewers", {}).values():
-            viewers.discard(state["websocket"])
-        state["closing"] = True
-        # Wait for all in-flight tasks, including any spawned by queue drain
-        while state["agent_tasks"]:
-            tasks = list(state["agent_tasks"])
-            log.info(f"Waiting for {len(tasks)} in-flight web agent turn(s)")
-            await asyncio.gather(*tasks, return_exceptions=True)
-
-
-async def _run_agent_turn(websocket, app_ctx, config, event_bus,
-                          index, conv_id, username, text, cancel_event=None,
-                          command_ctx=None, archive_text="", attachments=None,
-                          wiki_page=None, conv_viewers=None, conv_flags=None):
-    """Run an agent turn for a web conversation, streaming events to WebSocket."""
-    from ..agent import run_agent_turn  # deferred: circular dep
-    from ..archive import read_archive
-    from ..context import Context
-
-    # Track all WebSockets viewing each conversation so events reach every
-    # tab (including reconnections after a page reload mid-turn).
-    if conv_viewers is None:
-        conv_viewers = {}
-    conv_viewers.setdefault(conv_id, set()).add(websocket)
-
-    async def ws_send(msg):
-        """Send JSON to all WebSockets currently viewing this conversation."""
-        viewers = conv_viewers.get(conv_id, set())
-        # Always include the originating WebSocket even if not yet registered
-        targets = viewers | {websocket}
-        for ws in list(targets):
-            try:
-                await ws.send_json(msg)
-            except Exception:
-                viewers.discard(ws)
-
-    # Fork a request context for this turn
-    from ..media import LocalFileMediaHandler
-    ctx = Context(config=config, event_bus=event_bus)
-    ctx.user_id = username
-    ctx.channel_id = conv_id
-    ctx.channel_name = "web"
-    ctx.thread_id = ""
-    ctx.conv_id = conv_id
-    ctx.media_handler = LocalFileMediaHandler(config)
-    ctx.wiki_page = wiki_page
-    # Apply pre-configured command state (set by dispatch_command)
-    if command_ctx:
-        from ..commands import apply_command_ctx
-        apply_command_ctx(ctx, command_ctx)
-        ctx.tools.extra_definitions = command_ctx.tools.extra_definitions
-    # Restore per-conversation flags from previous turns
-    if conv_flags:
-        if conv_flags.get("skip_vault_retrieval"):
-            ctx.skip_vault_retrieval = True
-    if cancel_event:
-        ctx.cancelled = cancel_event
-
-    # Set up streaming callback
-    async def on_stream_chunk(chunk_type, data):
-        if chunk_type == "text":
-            streaming_buffer["text"] += data
-            await ws_send({"type": "chunk", "conv_id": conv_id, "text": data})
-        elif chunk_type == "done":
-            # LLM iteration done — buffer will be finalized by llm_start
-            # (next iteration) or message_complete (end of turn)
-            pass
-
-    from ..config import resolve_streaming
-    if resolve_streaming(config, ctx.active_model):
-        ctx.on_stream_chunk = on_stream_chunk
-
-    # Track streaming state across LLM iterations
-    streaming_buffer = {"text": ""}
-
-    # Set up event forwarding for this turn's events.
-    # Uses create_task to avoid blocking the event bus publish loop —
-    # the event bus awaits each subscriber, and if we await websocket.send_json
-    # inline, it can deadlock with request_confirmation which is also
-    # awaiting on the same event loop.
-    def on_turn_event(event):
-        if event.get("context_id") != ctx.context_id:
-            return
-        event_type = event.get("type", "")
-
-        async def _forward():
-            if event_type == "llm_start":
-                iteration = event.get("iteration", 1)
-                if iteration > 1 and streaming_buffer["text"]:
-                    await ws_send({
-                        "type": "message_complete", "conv_id": conv_id,
-                        "role": "assistant", "text": streaming_buffer["text"],
-                    })
-                    streaming_buffer["text"] = ""
-
-            elif event_type == "text_before_tools":
-                # Flush streamed text as a complete message before tools start
-                text = streaming_buffer["text"] or event.get("text", "")
-                if text:
-                    await ws_send({
-                        "type": "message_complete", "conv_id": conv_id,
-                        "role": "assistant", "text": text,
-                    })
-                    streaming_buffer["text"] = ""
-
-            elif event_type == "tool_start":
-                await ws_send({
-                    "type": "tool_start", "conv_id": conv_id,
-                    "tool": event.get("tool", ""),
-                    "tool_call_id": event.get("tool_call_id", ""),
-                })
-
-            elif event_type == "tool_status":
-                await ws_send({
-                    "type": "tool_status", "conv_id": conv_id,
-                    "tool": event.get("tool", ""),
-                    "message": event.get("message", ""),
-                    "tool_call_id": event.get("tool_call_id", ""),
-                })
-
-            elif event_type == "tool_end":
-                payload = {
-                    "type": "tool_end", "conv_id": conv_id,
-                    "tool": event.get("tool", ""),
-                    "result_text": event.get("result_text", ""),
-                    "tool_call_id": event.get("tool_call_id", ""),
-                }
-                short = event.get("display_short_text")
-                if short:
-                    payload["display_short_text"] = short
-                await ws_send(payload)
-
-            elif event_type == "vault_retrieval":
-                text = event.get("text", "")
-                if text:
-                    await ws_send({
-                        "type": "tool_status", "conv_id": conv_id,
-                        "tool": "vault_retrieval",
-                        "message": text,
-                        "tool_call_id": "",
-                    })
-
-            elif event_type == "vault_references":
-                text = event.get("text", "")
-                if text:
-                    await ws_send({
-                        "type": "tool_status", "conv_id": conv_id,
-                        "tool": "vault_references",
-                        "message": text,
-                        "tool_call_id": "",
-                    })
-
-            elif event_type == "tool_confirm_request":
-                # Flush any pending streamed text before showing confirmation
-                if streaming_buffer["text"]:
-                    await ws_send({
-                        "type": "message_complete", "conv_id": conv_id,
-                        "role": "assistant", "text": streaming_buffer["text"],
-                    })
-                    streaming_buffer["text"] = ""
-                log.info(f"Forwarding confirm request to web UI: {event.get('tool')}")
-                await ws_send({
-                    "type": "confirm_request", "conv_id": conv_id,
-                    "context_id": event.get("context_id", ""),
-                    "tool": event.get("tool", ""),
-                    "command": event.get("command", ""),
-                    "suggested_pattern": event.get("suggested_pattern", ""),
-                    "message": event.get("message", ""),
-                    "tool_call_id": event.get("tool_call_id", ""),
-                    "approve_label": event.get("approve_label", ""),
-                    "deny_label": event.get("deny_label", ""),
-                })
-
-            elif event_type == "reflection_result":
-                visibility = config.reflection.visibility
-                passed = event.get("passed", True)
-                # hidden: suppress all; visible: only failures; debug: everything
-                if visibility == "hidden":
-                    pass
-                elif visibility == "visible" and passed:
-                    pass
-                else:
-                    await ws_send({
-                        "type": "reflection_result", "conv_id": conv_id,
-                        "passed": passed,
-                        "critique": event.get("critique", ""),
-                        "retry_number": event.get("retry_number", 0),
-                        "raw_response": (
-                            event.get("raw_response", "")
-                            if visibility == "debug" else ""
-                        ),
-                        "error": event.get("error", ""),
-                    })
-
-            elif event_type == "compaction_end":
-                await ws_send({
-                    "type": "compaction_done", "conv_id": conv_id,
-                    "before_messages": event.get("before_messages", 0),
-                    "after_messages": event.get("after_messages", 0),
-                })
-
-        task = asyncio.create_task(_forward())
-        forward_tasks.add(task)
-        task.add_done_callback(forward_tasks.discard)
-
-    forward_tasks: set[asyncio.Task] = set()
-    turn_sub_id = event_bus.subscribe(on_turn_event)
-
-    try:
-        # Load history: use compacted base if available, then append newer messages
-        from ..archive import read_compacted_history
-        compacted = read_compacted_history(config, conv_id)
-        if compacted:
-            full = read_archive(config, conv_id)
-            last_ts = compacted[-1].get("timestamp", "")
-            newer = [m for m in full if m.get("timestamp", "") > last_ts]
-            history = compacted + newer
-        else:
-            history = read_archive(config, conv_id)
-
-        # Notify browser that processing has started
-        await ws_send({
-            "type": "turn_start", "conv_id": conv_id,
-        })
-
-        # Run the agent turn
-        result = await run_agent_turn(ctx, text, history, archive_text=archive_text,
-                                      attachments=attachments)
-
-        # Notify browser of completion — clear streaming and send final text
-        response_text = result.text if hasattr(result, "text") else str(result)
-        streaming_buffer["text"] = ""  # prevent double-send from event handler
-        await ws_send({
-            "type": "message_complete",
-            "conv_id": conv_id,
-            "role": "assistant",
-            "text": response_text,
-            "final": True,
-            "usage": {
-                "prompt_tokens": ctx.tokens.last_prompt,
-                "completion_tokens": ctx.tokens.total_completion,
-                "total_tokens": ctx.tokens.total_prompt + ctx.tokens.total_completion,
-            },
-            "context_limit": config.compaction.max_tokens,
-        })
-
-        # Update conversation metadata
-        index.touch(conv_id)
-
-        # Auto-title: use first user message if title is still default
-        conv = index.get(conv_id)
-        if conv and conv.title == "New conversation":
-            title = text[:100]
-            if len(text) > 100:
-                # Truncate at word boundary
-                last_space = title.rfind(" ")
-                if last_space > 50:
-                    title = title[:last_space]
-                title += "..."
-            index.rename(conv_id, title)
-
-    except asyncio.CancelledError:
-        log.info(f"Web agent turn cancelled for {conv_id}")
-        try:
-            await ws_send({
-                "type": "message_complete", "conv_id": conv_id,
-                "role": "assistant", "text": "[cancelled]", "final": True,
-            })
-        except Exception:
-            pass
-    except Exception as e:
-        log.error(f"Web agent turn failed: {e}", exc_info=True)
-        try:
-            await ws_send({
-                "type": "error", "conv_id": conv_id,
-                "message": f"Agent turn failed: {e}",
-            })
-        except Exception:
-            pass
-    finally:
-        event_bus.unsubscribe(turn_sub_id)
+        _unsubscribe_all(state)

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,103 +1,116 @@
-"""Tests for CircuitBreaker and ConversationState."""
+"""Tests for circuit breaker in ConversationManager."""
 
 import time
 
-from decafclaw.mattermost import CircuitBreaker, ConversationState
+import pytest
+
+from decafclaw.conversation_manager import ConversationManager, ConversationState
+from decafclaw.events import EventBus
+
+
+@pytest.fixture
+def manager(config):
+    bus = EventBus()
+    return ConversationManager(config, bus)
 
 
 def test_conversation_state_defaults():
     conv = ConversationState()
-    assert conv.history == []
-    assert conv.skill_state is None
-    assert conv.pending_msgs == []
-    assert conv.debounce_timer is None
-    assert conv.last_response_time == 0
-    assert conv.busy is False
-    assert conv.cancel is None
     assert conv.turn_times == []
     assert conv.paused_until == 0
+    assert conv.pending_messages == []
+    assert conv.busy is False
 
 
 def test_conversation_state_independent_instances():
     """Verify mutable defaults aren't shared between instances."""
     a = ConversationState()
     b = ConversationState()
-    a.history.append("msg")
-    a.pending_msgs.append("pending")
-    assert b.history == []
-    assert b.pending_msgs == []
+    a.pending_messages.append("pending")
+    a.turn_times.append(1.0)
+    assert b.pending_messages == []
+    assert b.turn_times == []
 
 
-def test_circuit_breaker_not_tripped_under_limit():
-    cb = CircuitBreaker(max_turns=3, window_sec=10, pause_sec=5)
-    conv = ConversationState()
-    cb.record_turn(conv)
-    cb.record_turn(conv)
-    assert not cb.is_tripped(conv)
+def test_circuit_breaker_not_tripped_under_limit(manager):
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
+    manager._circuit_breaker_record(state)
+    assert not manager._circuit_breaker_tripped(state)
 
 
-def test_circuit_breaker_trips_at_limit():
-    cb = CircuitBreaker(max_turns=3, window_sec=10, pause_sec=5)
-    conv = ConversationState()
-    cb.record_turn(conv)
-    cb.record_turn(conv)
-    cb.record_turn(conv)
-    assert cb.is_tripped(conv)
+def test_circuit_breaker_trips_at_limit(manager):
+    # Default is 10 turns — set a low limit for testing
+    manager._cb_max_turns = 3
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
+    manager._circuit_breaker_record(state)
+    manager._circuit_breaker_record(state)
+    assert manager._circuit_breaker_tripped(state)
 
 
-def test_circuit_breaker_stays_tripped_during_pause():
-    cb = CircuitBreaker(max_turns=2, window_sec=10, pause_sec=100)
-    conv = ConversationState()
-    cb.record_turn(conv)
-    cb.record_turn(conv)
-    # First call trips it and sets paused_until
-    assert cb.is_tripped(conv)
-    # Second call: still paused
-    assert cb.is_tripped(conv)
+def test_circuit_breaker_stays_tripped_during_pause(manager):
+    manager._cb_max_turns = 2
+    manager._cb_pause_sec = 100
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
+    manager._circuit_breaker_record(state)
+    assert manager._circuit_breaker_tripped(state)
+    assert manager._circuit_breaker_tripped(state)  # still paused
 
 
-def test_circuit_breaker_recovers_after_pause():
-    cb = CircuitBreaker(max_turns=2, window_sec=10, pause_sec=0)
-    conv = ConversationState()
-    cb.record_turn(conv)
-    cb.record_turn(conv)
-    # Trip it — but pause_sec=0 so paused_until is now
-    assert cb.is_tripped(conv)
-    # After trip, turn_times still has 2 entries in window, so still tripped
-    # But paused_until is in the past, so it rechecks turn_times
-    # We need to clear the turn_times to simulate window expiry
-    conv.turn_times = []
-    assert not cb.is_tripped(conv)
+def test_circuit_breaker_recovers_after_pause(manager):
+    manager._cb_max_turns = 2
+    manager._cb_pause_sec = 0
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
+    manager._circuit_breaker_record(state)
+    assert manager._circuit_breaker_tripped(state)
+    # Clear turn_times to simulate window expiry
+    state.turn_times = []
+    assert not manager._circuit_breaker_tripped(state)
 
 
-def test_circuit_breaker_cleans_expired_turns():
-    cb = CircuitBreaker(max_turns=3, window_sec=10, pause_sec=5)
-    conv = ConversationState()
-    # Add turns that are "old" (before the window)
-    old_time = time.monotonic() - 20
-    conv.turn_times = [old_time, old_time, old_time]
-    # Old turns should be cleaned, not counted
-    assert not cb.is_tripped(conv)
-    assert len(conv.turn_times) == 0
+def test_circuit_breaker_cleans_expired_turns(manager):
+    manager._cb_max_turns = 3
+    state = manager._get_or_create("conv-1")
+    old_time = time.monotonic() - 200
+    state.turn_times = [old_time, old_time, old_time]
+    assert not manager._circuit_breaker_tripped(state)
+    assert len(state.turn_times) == 0
 
 
-def test_circuit_breaker_record_turn():
-    cb = CircuitBreaker(max_turns=10, window_sec=10, pause_sec=5)
-    conv = ConversationState()
-    assert len(conv.turn_times) == 0
-    cb.record_turn(conv)
-    assert len(conv.turn_times) == 1
-    cb.record_turn(conv)
-    assert len(conv.turn_times) == 2
+def test_circuit_breaker_record_turn(manager):
+    state = manager._get_or_create("conv-1")
+    assert len(state.turn_times) == 0
+    manager._circuit_breaker_record(state)
+    assert len(state.turn_times) == 1
+    manager._circuit_breaker_record(state)
+    assert len(state.turn_times) == 2
 
 
-def test_circuit_breaker_sets_paused_until_on_trip():
-    cb = CircuitBreaker(max_turns=1, window_sec=10, pause_sec=30)
-    conv = ConversationState()
-    cb.record_turn(conv)
+def test_circuit_breaker_sets_paused_until_on_trip(manager):
+    manager._cb_max_turns = 1
+    manager._cb_pause_sec = 30
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
     before = time.monotonic()
-    cb.is_tripped(conv)
+    manager._circuit_breaker_tripped(state)
     after = time.monotonic()
-    # paused_until should be roughly now + 30
-    assert conv.paused_until >= before + 30
-    assert conv.paused_until <= after + 30
+    assert state.paused_until >= before + 30
+    assert state.paused_until <= after + 30
+
+
+@pytest.mark.asyncio
+async def test_send_message_blocked_by_circuit_breaker(manager):
+    """Messages should be dropped when circuit breaker is tripped."""
+    manager._cb_max_turns = 1
+    state = manager._get_or_create("conv-1")
+    manager._circuit_breaker_record(state)
+
+    # This should be dropped (circuit breaker tripped)
+    await manager.send_message("conv-1", "should be dropped", user_id="user")
+
+    # No pending messages or busy state — message was dropped
+    assert len(state.pending_messages) == 0
+    assert not state.busy

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,400 @@
+"""Tests for the conversation manager."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from decafclaw.confirmations import (
+    ConfirmationAction,
+    ConfirmationRegistry,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+from decafclaw.conversation_manager import ConversationManager, ConversationState
+from decafclaw.events import EventBus
+
+
+@pytest.fixture
+def manager(config):
+    bus = EventBus()
+    return ConversationManager(config, bus)
+
+
+# -- State management ---------------------------------------------------------
+
+def test_get_or_create(manager):
+    state = manager._get_or_create("conv-1")
+    assert state.conv_id == "conv-1"
+    assert state is manager._get_or_create("conv-1")  # same instance
+
+
+def test_get_state_returns_none_for_unknown(manager):
+    assert manager.get_state("nonexistent") is None
+
+
+# -- Subscription --------------------------------------------------------------
+
+def test_subscribe_and_unsubscribe(manager):
+    cb = MagicMock()
+    sub_id = manager.subscribe("conv-1", cb)
+    state = manager.get_state("conv-1")
+    assert state is not None
+    assert sub_id in state.subscribers
+
+    manager.unsubscribe("conv-1", sub_id)
+    assert sub_id not in state.subscribers
+
+
+@pytest.mark.asyncio
+async def test_emit_calls_subscribers(manager):
+    received = []
+
+    async def cb(event):
+        received.append(event)
+
+    manager.subscribe("conv-1", cb)
+    await manager.emit("conv-1", {"type": "test", "data": 42})
+
+    assert len(received) == 1
+    assert received[0]["type"] == "test"
+    assert received[0]["conv_id"] == "conv-1"
+
+
+@pytest.mark.asyncio
+async def test_emit_subscriber_error_doesnt_break_others(manager):
+    received = []
+
+    def bad_cb(event):
+        raise RuntimeError("boom")
+
+    async def good_cb(event):
+        received.append(event)
+
+    manager.subscribe("conv-1", bad_cb)
+    manager.subscribe("conv-1", good_cb)
+    await manager.emit("conv-1", {"type": "test"})
+
+    assert len(received) == 1  # good_cb still called
+
+
+# -- History -------------------------------------------------------------------
+
+def test_load_history_empty(manager):
+    history = manager.load_history("new-conv")
+    assert history == []
+
+
+def test_load_history_cached(manager):
+    state = manager._get_or_create("conv-1")
+    state.history = [{"role": "user", "content": "hello"}]
+    assert manager.load_history("conv-1") == state.history
+
+
+# -- Confirmation request/response --------------------------------------------
+
+@pytest.mark.asyncio
+async def test_request_confirmation_approved(manager):
+    conv_id = "conv-1"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow shell command?",
+        timeout=2.0,
+    )
+
+    # Approve after a short delay
+    async def approve():
+        await asyncio.sleep(0.05)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True)
+
+    asyncio.create_task(approve())
+    response = await manager.request_confirmation(conv_id, request)
+
+    assert response.approved is True
+    assert response.confirmation_id == request.confirmation_id
+    # Pending state should be cleared
+    state = manager.get_state(conv_id)
+    assert state.pending_confirmation is None
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_denied(manager):
+    conv_id = "conv-1"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.ACTIVATE_SKILL,
+        action_data={"skill_name": "test"},
+        message="Activate skill?",
+        timeout=2.0,
+    )
+
+    async def deny():
+        await asyncio.sleep(0.05)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=False)
+
+    asyncio.create_task(deny())
+    response = await manager.request_confirmation(conv_id, request)
+
+    assert response.approved is False
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_timeout(manager):
+    conv_id = "conv-1"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.CONTINUE_TURN,
+        message="Continue?",
+        timeout=0.1,
+    )
+
+    response = await manager.request_confirmation(conv_id, request)
+    assert response.approved is False
+
+
+@pytest.mark.asyncio
+async def test_confirmation_emits_request_event(manager):
+    conv_id = "conv-1"
+    events = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+        timeout=0.1,
+    )
+
+    await manager.request_confirmation(conv_id, request)
+
+    # Should have emitted confirmation_request
+    req_events = [e for e in events if e["type"] == "confirmation_request"]
+    assert len(req_events) == 1
+    assert req_events[0]["confirmation_id"] == request.confirmation_id
+    assert req_events[0]["message"] == "Allow?"
+
+
+@pytest.mark.asyncio
+async def test_confirmation_persisted_to_archive(manager):
+    from decafclaw.archive import read_archive
+
+    conv_id = "conv-persist"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+        timeout=2.0,
+    )
+
+    async def approve():
+        await asyncio.sleep(0.05)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True)
+
+    asyncio.create_task(approve())
+    await manager.request_confirmation(conv_id, request)
+
+    # Check archive has both request and response
+    messages = read_archive(manager.config, conv_id)
+    roles = [m["role"] for m in messages]
+    assert "confirmation_request" in roles
+    assert "confirmation_response" in roles
+
+
+@pytest.mark.asyncio
+async def test_respond_wrong_id_ignored(manager):
+    conv_id = "conv-1"
+    state = manager._get_or_create(conv_id)
+    state.pending_confirmation = ConfirmationRequest(
+        action_type=ConfirmationAction.CONTINUE_TURN,
+        message="test",
+        confirmation_id="correct-id",
+    )
+    state.confirmation_event = asyncio.Event()
+
+    await manager.respond_to_confirmation(
+        conv_id, "wrong-id", approved=True)
+
+    # Event should NOT be set
+    assert not state.confirmation_event.is_set()
+
+
+# -- Message queueing ---------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_message_queued_when_busy(manager):
+    state = manager._get_or_create("conv-1")
+    state.busy = True
+
+    await manager.send_message("conv-1", "queued msg", user_id="user")
+
+    assert len(state.pending_messages) == 1
+    assert state.pending_messages[0]["text"] == "queued msg"
+
+
+# -- Cancel turn ---------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cancel_turn_sets_event(manager):
+    state = manager._get_or_create("conv-1")
+    state.cancel_event = asyncio.Event()
+
+    async def fake_task():
+        await asyncio.sleep(10)
+
+    state.agent_task = asyncio.create_task(fake_task())
+
+    await manager.cancel_turn("conv-1")
+    assert state.cancel_event.is_set()
+    # Give the task a moment to be cancelled
+    await asyncio.sleep(0.05)
+    assert state.agent_task.cancelled()
+
+
+# -- Send message with mocked agent turn ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_message_queues_multiple_when_busy(manager):
+    """Multiple messages while busy all get queued."""
+    state = manager._get_or_create("conv-1")
+    state.busy = True
+
+    await manager.send_message("conv-1", "msg 1", user_id="user")
+    await manager.send_message("conv-1", "msg 2", user_id="user")
+    await manager.send_message("conv-1", "msg 3", user_id="user")
+
+    assert len(state.pending_messages) == 3
+    assert [m["text"] for m in state.pending_messages] == ["msg 1", "msg 2", "msg 3"]
+
+
+@pytest.mark.asyncio
+async def test_always_field_in_confirmation_response(manager):
+    conv_id = "conv-1"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.ACTIVATE_SKILL,
+        action_data={"skill_name": "test"},
+        message="Activate?",
+        timeout=2.0,
+    )
+
+    async def approve_always():
+        await asyncio.sleep(0.05)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True, always=True)
+
+    asyncio.create_task(approve_always())
+    response = await manager.request_confirmation(conv_id, request)
+
+    assert response.approved is True
+    assert response.always is True
+
+
+# -- Startup recovery ----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_startup_scan_finds_pending_confirmation(manager):
+    """Startup scan should find conversations with unresolved confirmation requests."""
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-recovery"
+    # Write a confirmation request to the archive (no response)
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls -la"},
+        message="Allow shell command?",
+    )
+    append_message(manager.config, conv_id, request.to_archive_message())
+
+    recovered = await manager.startup_scan()
+    assert recovered == 1
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is not None
+    assert state.pending_confirmation.confirmation_id == request.confirmation_id
+    assert state.pending_confirmation.action_type == ConfirmationAction.RUN_SHELL_COMMAND
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_ignores_resolved_confirmations(manager):
+    """Startup scan should not recover confirmations that have a response."""
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-resolved"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.ACTIVATE_SKILL,
+        action_data={"skill_name": "test"},
+        message="Activate?",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+    )
+    append_message(manager.config, conv_id, request.to_archive_message())
+    append_message(manager.config, conv_id, response.to_archive_message())
+
+    recovered = await manager.startup_scan()
+    assert recovered == 0
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_ignores_stale_confirmations(manager):
+    """Confirmations older than 24 hours should be ignored."""
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-stale"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.CONTINUE_TURN,
+        message="Continue?",
+        timestamp="2020-01-01T00:00:00",  # very old
+    )
+    append_message(manager.config, conv_id, request.to_archive_message())
+
+    recovered = await manager.startup_scan()
+    assert recovered == 0
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_empty_archive(manager):
+    """Startup scan with no archives should recover nothing."""
+    recovered = await manager.startup_scan()
+    assert recovered == 0
+
+
+@pytest.mark.asyncio
+async def test_respond_to_recovered_confirmation(manager):
+    """Responding to a recovered confirmation (no running loop) dispatches recovery."""
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-recover-respond"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    append_message(manager.config, conv_id, request.to_archive_message())
+
+    await manager.startup_scan()
+
+    # Respond — should dispatch recovery (no running loop)
+    await manager.respond_to_confirmation(
+        conv_id, request.confirmation_id, approved=True)
+
+    # Pending confirmation should be cleared
+    state = manager.get_state(conv_id)
+    assert state.pending_confirmation is None

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -53,8 +53,7 @@ def test_import_mattermost_client_methods():
     assert hasattr(MattermostClient, "close")
     assert hasattr(MattermostClient, "_make_heartbeat_cycle")
     assert hasattr(MattermostClient, "_resolve_heartbeat_channel")
-    assert hasattr(MattermostClient, "_subscribe_progress")
-    assert hasattr(MattermostClient, "_poll_confirmation")
+    assert hasattr(MattermostClient, "_poll_confirmation_manager")
 
 
 def test_import_streaming():

--- a/tests/test_vertex_translation.py
+++ b/tests/test_vertex_translation.py
@@ -302,3 +302,70 @@ def test_parse_usage():
 
 def test_parse_usage_missing():
     assert _parse_usage({}) is None
+
+
+# -- Multimodal content (image attachments) ------------------------------------
+
+
+def test_user_message_with_image_attachment():
+    """Multimodal user content (from _resolve_attachments) → Vertex inlineData."""
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+            },
+        ],
+    }]
+    body = _build_request_body(messages)
+    parts = body["contents"][0]["parts"]
+    assert len(parts) == 2
+    assert parts[0] == {"text": "What's in this image?"}
+    assert parts[1] == {
+        "inlineData": {"mimeType": "image/png", "data": "iVBORw0KGgo="},
+    }
+
+
+def test_user_message_with_image_only():
+    """Multimodal content with no text, just an image."""
+    messages = [{
+        "role": "user",
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64,/9j/4AAQ="},
+            },
+        ],
+    }]
+    body = _build_request_body(messages)
+    parts = body["contents"][0]["parts"]
+    assert len(parts) == 1
+    assert parts[0] == {
+        "inlineData": {"mimeType": "image/jpeg", "data": "/9j/4AAQ="},
+    }
+
+
+def test_user_message_with_multiple_images():
+    """Multiple images in one message."""
+    messages = [{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Compare these:"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,BBBB"},
+            },
+        ],
+    }]
+    body = _build_request_body(messages)
+    parts = body["contents"][0]["parts"]
+    assert len(parts) == 3
+    assert parts[0] == {"text": "Compare these:"}
+    assert parts[1]["inlineData"]["data"] == "AAAA"
+    assert parts[2]["inlineData"]["data"] == "BBBB"

--- a/tests/test_ws_queue.py
+++ b/tests/test_ws_queue.py
@@ -1,28 +1,38 @@
-"""Tests for WebSocket message queuing during agent turns."""
+"""Tests for WebSocket message handling via ConversationManager.
+
+The queueing and turn lifecycle are now owned by the ConversationManager
+(tested in test_conversation_manager.py). These tests verify the WebSocket
+handler correctly delegates to the manager.
+"""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from decafclaw.conversation_manager import ConversationManager
 from decafclaw.events import EventBus
 from decafclaw.web.conversations import ConversationIndex
-from decafclaw.web.websocket import _handle_send, _start_agent_turn
+from decafclaw.web.websocket import _handle_cancel_turn, _handle_send
 
 
 @pytest.fixture
-def ws_state(config):
-    """Minimal WebSocket handler state."""
+def manager(config):
+    bus = EventBus()
+    return ConversationManager(config, bus)
+
+
+@pytest.fixture
+def ws_state(config, manager):
+    """Minimal WebSocket handler state with manager."""
     config.agent_path.mkdir(parents=True, exist_ok=True)
     return {
-        "agent_tasks": set(),
-        "cancel_events": {},
-        "busy_convs": set(),
-        "pending_msgs": {},
         "config": config,
-        "event_bus": EventBus(),
-        "app_ctx": MagicMock(config=config, event_bus=EventBus()),
+        "event_bus": manager.event_bus,
+        "app_ctx": MagicMock(config=config, event_bus=manager.event_bus),
         "websocket": MagicMock(),
+        "ws_send": AsyncMock(),
+        "manager": manager,
     }
 
 
@@ -42,32 +52,29 @@ def index(config):
 
 class TestQueueMode:
     @pytest.mark.asyncio
-    async def test_queues_when_busy(self, ws_state, conv_id, index):
-        """New messages should queue when a turn is in progress (queue mode)."""
-        ws_state["config"].agent.turn_on_new_message = "queue"
+    async def test_queues_when_busy(self, ws_state, conv_id, index, manager):
+        """New messages should queue in the manager when a turn is in progress."""
         ws_send = AsyncMock()
 
-        # Mark conversation as busy
-        ws_state["busy_convs"].add(conv_id)
-        ws_state["cancel_events"][conv_id] = asyncio.Event()
+        # Mark conversation as busy in the manager
+        state = manager._get_or_create(conv_id)
+        state.busy = True
 
         await _handle_send(ws_send, index, "testuser",
                            {"conv_id": conv_id, "text": "queued msg"}, ws_state)
 
-        queued = ws_state["pending_msgs"].get(conv_id, [])
-        assert len(queued) == 1
-        assert queued[0]["text"] == "queued msg"
-        assert queued[0]["command_ctx"] is None
+        assert len(state.pending_messages) == 1
+        assert state.pending_messages[0]["text"] == "queued msg"
 
     @pytest.mark.asyncio
-    async def test_does_not_cancel_in_queue_mode(self, ws_state, conv_id, index):
-        """Queue mode should not set the cancel event."""
-        ws_state["config"].agent.turn_on_new_message = "queue"
+    async def test_does_not_cancel_in_queue_mode(self, ws_state, conv_id, index, manager):
+        """Queue mode should not cancel — messages queue in the manager."""
         ws_send = AsyncMock()
 
         cancel_event = asyncio.Event()
-        ws_state["busy_convs"].add(conv_id)
-        ws_state["cancel_events"][conv_id] = cancel_event
+        state = manager._get_or_create(conv_id)
+        state.busy = True
+        state.cancel_event = cancel_event
 
         await _handle_send(ws_send, index, "testuser",
                            {"conv_id": conv_id, "text": "queued msg"}, ws_state)
@@ -77,80 +84,46 @@ class TestQueueMode:
 
 class TestCancelMode:
     @pytest.mark.asyncio
-    async def test_cancels_when_busy(self, ws_state, conv_id, index):
-        """Cancel mode should cancel the current turn."""
-        ws_state["config"].agent.turn_on_new_message = "cancel"
+    async def test_cancels_when_requested(self, ws_state, conv_id, index, manager):
+        """Cancel turn should cancel via the manager."""
         ws_send = AsyncMock()
 
         cancel_event = asyncio.Event()
-        ws_state["busy_convs"].add(conv_id)
-        ws_state["cancel_events"][conv_id] = cancel_event
+        state = manager._get_or_create(conv_id)
+        state.cancel_event = cancel_event
 
-        await _handle_send(ws_send, index, "testuser",
-                           {"conv_id": conv_id, "text": "new msg"}, ws_state)
+        async def fake_task():
+            await asyncio.sleep(10)
+
+        state.agent_task = asyncio.create_task(fake_task())
+
+        await _handle_cancel_turn(ws_send, index, "testuser",
+                                  {"conv_id": conv_id}, ws_state)
 
         assert cancel_event.is_set()
-        # Message should still be queued for processing after cancel
-        queued = ws_state["pending_msgs"].get(conv_id, [])
-        assert len(queued) == 1
+        await asyncio.sleep(0.05)
+        assert state.agent_task.cancelled()
 
 
 class TestQueueDrain:
     @pytest.mark.asyncio
-    async def test_drains_queue_after_turn(self, ws_state, conv_id, index):
-        """Queued messages should be processed after the current turn completes."""
-        ws_send = AsyncMock()
-        turn_started = asyncio.Event()
-        turn_texts = []
+    async def test_drains_queue_after_turn(self, manager, conv_id):
+        """Queued messages drain via the manager after turn completes."""
+        state = manager._get_or_create(conv_id)
 
-        async def fake_agent_turn(*args, **kwargs):
-            # Record what text was passed
-            turn_texts.append(args[7])  # text is the 8th positional arg
-            turn_started.set()
+        # Simulate a completed turn with queued messages
+        state.pending_messages = [
+            {"text": "queued msg", "user_id": "testuser",
+             "context_setup": None, "archive_text": "",
+             "attachments": None, "command_ctx": None, "wiki_page": None},
+        ]
 
-        with patch("decafclaw.web.websocket._run_agent_turn", side_effect=fake_agent_turn):
-            # Start a turn
-            _start_agent_turn(ws_state, index, conv_id, "testuser", "first msg", ws_send)
-            await turn_started.wait()
+        # Drain should process the queued message
+        # (will try to start a turn, which will fail without full agent setup,
+        # but we can verify the queue was consumed)
+        try:
+            await manager._drain_pending(state)
+        except Exception:
+            pass  # Expected — no real agent to run
 
-            # Queue a message
-            ws_state["pending_msgs"][conv_id] = [
-                {"text": "second msg", "command_ctx": None}
-            ]
-
-            # Let the done callback fire
-            turn_started.clear()
-            task = list(ws_state["agent_tasks"])[0]
-            await task
-
-            # The done callback should have started a new turn
-            await asyncio.sleep(0.01)  # let the new task start
-            assert "first msg" in turn_texts
-            if len(turn_texts) > 1:
-                assert "second msg" in turn_texts[1]
-
-    @pytest.mark.asyncio
-    async def test_skips_drain_when_closing(self, ws_state, conv_id, index):
-        """Queue should not drain when the connection is closing."""
-        ws_send = AsyncMock()
-
-        async def fake_agent_turn(*args, **kwargs):
-            pass
-
-        with patch("decafclaw.web.websocket._run_agent_turn", side_effect=fake_agent_turn):
-            _start_agent_turn(ws_state, index, conv_id, "testuser", "msg", ws_send)
-
-            # Queue a message and mark closing
-            ws_state["pending_msgs"][conv_id] = [
-                {"text": "should not run", "command_ctx": None}
-            ]
-            ws_state["closing"] = True
-
-            # Let the task complete
-            task = list(ws_state["agent_tasks"])[0]
-            await task
-            await asyncio.sleep(0.01)
-
-            # Queue should have been cleared, no new task started
-            assert conv_id not in ws_state["pending_msgs"]
-            assert len(ws_state["agent_tasks"]) == 0
+        assert len(state.pending_messages) == 0


### PR DESCRIPTION
## Summary

- Extracts a **ConversationManager** as the central orchestrator for agent loops, replacing transport-coupled agent turn invocation
- All three transports (WebSocket, Mattermost, interactive terminal) become thin adapters over the manager API
- **Confirmations are first-class conversation messages** persisted in the JSONL archive with typed action handlers — they survive page reload and server restart
- Startup recovery scans archives for unresolved confirmations on server start

## What this fixes

- **#235**: Confirmation requests are now scoped per-conversation via the manager's per-conversation event streams — no more cross-conversation leakage
- **#258**: Pending confirmations are persisted in the archive and sent to clients on `conv_selected`/`conv_history` — they survive page reload

## Architecture

- `confirmations.py` — typed confirmation actions, request/response dataclasses, handler registry
- `conversation_manager.py` — ConversationState, agent loop lifecycle, confirmation persistence/suspension/resumption, per-conversation event streams, message queuing, startup recovery
- Transport adapters call `manager.send_message()`, `manager.respond_to_confirmation()`, `manager.cancel_turn()`, and subscribe to conversation event streams

## Test plan

- [x] Web UI: send message, verify streaming works through the manager
- [x] Web UI: trigger shell command → confirmation appears → approve → command runs
- [x] Web UI: reload page with pending confirmation → confirmation re-appears
- [x] Web UI: open two tabs on same conversation → both see confirmation
- [x] Web UI: switch conversations → confirmations scoped correctly
- [x] Mattermost: send message → response works
- [x] Mattermost: shell approval via emoji → works
- [ ] Mattermost: shell approval via HTTP button → works
- [ ] Mattermost: stop button cancels turn
- [x] Interactive terminal: send message, verify response
- [x] Server restart with pending confirmation → confirmation recoverable
- [x] `make check` passes (lint + typecheck + JS)
- [x] `make test` passes (1296 tests)

Closes #235, closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)