### PR TITLE
fix: trigger compaction on all turn exit paths

### DIFF
--- a/docs/conversations.md
+++ b/docs/conversations.md
@@ -28,11 +28,12 @@ When the conversation grows too large (exceeding the token budget), the agent au
 
 ### How it works
 
-1. The agent loop checks `prompt_tokens` after each LLM call
-2. If tokens exceed `COMPACTION_MAX_TOKENS`, compaction triggers
-3. The compaction LLM reads the **archive** (source of truth) and produces a summary
-4. In-memory history is replaced with: `[summary message] + [recent turns]`
-5. The archive is not modified — it remains the complete record
+1. Every LLM call records its `prompt_tokens` into the runtime context
+2. At the end of each agent turn (any exit path except cancellation), the loop checks the latest `prompt_tokens` against `COMPACTION_MAX_TOKENS`
+3. If tokens exceed the threshold, compaction triggers
+4. The compaction LLM reads the **archive** (source of truth) and produces a summary
+5. In-memory history is replaced with: `[summary message] + [recent turns]`
+6. The archive is not modified — it remains the complete record
 
 ### Configuration
 

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -466,6 +466,19 @@ async def _call_llm_with_events(ctx, config, messages, tools,
                 response = llm_task.result()
         else:
             response = await call_llm(config, messages, tools=tools, **llm_kwargs)
+    # Track token usage for every LLM call so compaction decisions (taken
+    # in the finally block of run_agent_turn) always see the latest values,
+    # regardless of which exit path the turn takes (normal response,
+    # end_turn=True, EndTurnConfirm presentation, max iterations).
+    usage = response.get("usage")
+    if usage:
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        ctx.tokens.total_prompt += prompt_tokens
+        ctx.tokens.total_completion += completion_tokens
+        ctx.tokens.last_prompt = prompt_tokens
+        ctx.composer.last_prompt_tokens_actual = prompt_tokens
+        ctx.composer.last_completion_tokens_actual = completion_tokens
     await ctx.publish("llm_end", iteration=iteration,
                       content=response.get("content"),
                       has_tool_calls=bool(response.get("tool_calls")))
@@ -871,7 +884,6 @@ async def run_agent_turn(ctx, user_message: str, history: list,
         else:
             deferred_msg = None
 
-        prompt_tokens = 0
         empty_retries = 0
         reflection_retries = 0
         last_reflection = None  # last ReflectionResult, for archiving after final response
@@ -907,16 +919,6 @@ async def run_agent_turn(ctx, user_message: str, history: list,
 
             response = await _call_llm_with_events(ctx, config, messages, all_tools,
                                                      **model_override)
-
-            # Track token usage
-            usage = response.get("usage")
-            if usage:
-                prompt_tokens = usage.get("prompt_tokens", 0)
-                completion_tokens = usage.get("completion_tokens", 0)
-                ctx.tokens.total_prompt += prompt_tokens
-                ctx.tokens.total_completion += completion_tokens
-                ctx.tokens.last_prompt = prompt_tokens
-                composer.record_actuals(prompt_tokens, completion_tokens)
 
             tool_calls = response.get("tool_calls")
             if tool_calls:
@@ -1062,8 +1064,6 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                     _archive(ctx, {"role": "reflection", "tool": label,
                                    "content": detail})
 
-            await _maybe_compact(ctx, config, history, prompt_tokens)
-
             # Extract workspace:// refs only for channels that need it
             # (Mattermost strips refs and uploads files; web/terminal render them in-place)
             handler = ctx.media_handler
@@ -1084,10 +1084,22 @@ async def run_agent_turn(ctx, user_message: str, history: list,
         final_msg = {"role": "assistant", "content": msg}
         history.append(final_msg)
         _archive(ctx, final_msg)
-        await _maybe_compact(ctx, config, history, prompt_tokens)
         return ToolResult(text=msg)
 
     finally:
+        # Compaction check runs on every exit path — normal response, end_turn
+        # signal from a tool, max iterations, or exception. Cancellation skips
+        # it since the user is redirecting and shouldn't pay for extra work.
+        # Relies on ctx.tokens.last_prompt tracked in _call_llm_with_events.
+        # Wrapped in try/except to preserve any in-flight exception from the
+        # try body (Python replaces the original if finally raises).
+        cancelled = ctx.cancelled is not None and ctx.cancelled.is_set()
+        if not cancelled:
+            try:
+                await _maybe_compact(ctx, config, history, ctx.tokens.last_prompt)
+            except Exception:
+                log.exception("Compaction check in finally failed")
+
         # Write context diagnostics on any exit path
         if composed is not None and composer is not None and conv_id:
             try:

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -806,3 +806,98 @@ async def test_reflection_error_delivers_response(ctx):
 
     assert result.text == "response"
     assert len(history) == 2  # no retry
+
+
+# -- Compaction trigger tests -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compaction_triggers_on_normal_response_over_threshold(ctx):
+    """Compaction fires on the normal (no-tool-calls) exit when tokens exceed threshold."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.compaction.max_tokens = 100
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.agent.compact_history", new_callable=AsyncMock) as mock_compact:
+        mock_llm.return_value = _mock_llm_response(
+            "hi", usage={"prompt_tokens": 500, "completion_tokens": 50})
+        mock_compact.return_value = True
+        history = []
+        await run_agent_turn(ctx, "hi", history)
+
+    assert mock_compact.called, (
+        "compact_history must be called when prompt tokens exceed the threshold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compaction_triggers_when_tool_signals_end_turn(ctx):
+    """Compaction fires when a turn ends via a tool returning end_turn=True."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.compaction.max_tokens = 100
+
+    tool_call_response = _mock_llm_response(
+        content=None,
+        tool_calls=[{
+            "id": "tc1",
+            "function": {"name": "memory_recent", "arguments": "{}"},
+        }],
+        usage={"prompt_tokens": 500, "completion_tokens": 50},
+    )
+    final_response = _mock_llm_response(
+        "Done.", usage={"prompt_tokens": 500, "completion_tokens": 50})
+
+    async def _end_turn_tool(ctx_arg, name, args):
+        return ToolResult(text="task complete", end_turn=True)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.agent.execute_tool", side_effect=_end_turn_tool), \
+         patch("decafclaw.agent.compact_history", new_callable=AsyncMock) as mock_compact:
+        mock_llm.side_effect = [tool_call_response, final_response]
+        mock_compact.return_value = True
+        history = []
+        await run_agent_turn(ctx, "do task", history)
+
+    assert mock_compact.called, (
+        "compact_history must be called even when the turn ends via "
+        "end_turn=True (e.g. checklist completion, project complete)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compaction_skipped_below_threshold(ctx):
+    """Compaction does not fire when prompt tokens are within the budget."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.compaction.max_tokens = 1000
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.agent.compact_history", new_callable=AsyncMock) as mock_compact:
+        mock_llm.return_value = _mock_llm_response(
+            "hi", usage={"prompt_tokens": 200, "completion_tokens": 50})
+        history = []
+        await run_agent_turn(ctx, "hi", history)
+
+    assert not mock_compact.called, (
+        "compact_history must not be called when prompt tokens are under the threshold"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compaction_skipped_on_cancellation(ctx):
+    """Compaction is skipped when the turn is cancelled, even if tokens exceed threshold."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.compaction.max_tokens = 100
+    ctx.cancelled = asyncio.Event()
+    ctx.cancelled.set()
+
+    with patch("decafclaw.agent.compact_history", new_callable=AsyncMock) as mock_compact:
+        history = []
+        await run_agent_turn(ctx, "hi", history)
+
+    assert not mock_compact.called, (
+        "compact_history must not be called when the turn is cancelled"
+    )


### PR DESCRIPTION
## Summary

- The agent loop's `_maybe_compact` call was only placed on two of the turn's exit paths — normal no-tool-calls response and max-iteration hit. Turns ending via a tool returning `end_turn=True` (checklist completion, project completion, EndTurnConfirm denial) returned without checking whether compaction was due.
- Since the checklist execution loop (#261) landed, `end_turn=True` became a dominant exit path and history grew unbounded — observed at 190% context / 894k actual tokens despite a 300k threshold.
- Fix moves compaction into the `run_agent_turn` `finally` block with cancellation as the only skip condition. Usage tracking moves into `_call_llm_with_events` so every LLM call (including the end_turn final call and EndTurnConfirm presentation call) updates `ctx.tokens.last_prompt`.

## Test plan

- [x] `make test` — 1477 passed
- [x] `make lint` — clean
- [x] `make check` (typecheck) — clean
- [x] New test `test_compaction_triggers_when_tool_signals_end_turn` fails on pre-fix code, passes after fix
- [x] New test coverage: normal path, end_turn path, below-threshold skip, cancellation skip
- [ ] Verify in live Mattermost / web UI that long checklist-driven conversations now trigger compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)