### PR TITLE
Tool discovery polish — clearer prompts, better error messages

### DIFF
--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -59,24 +59,35 @@ skills. Use workspace tools for skills in `workspace/skills/`.
 
 ## Tools — Finding What You Need
 
-Tools come from three places:
-1. **Active tools** in your tool list — call them directly.
-2. **Skill tools** — call `activate_skill(name)` first. Check the
-   **Available Skills** block in your instructions.
-3. **Deferred tools** — listed by name in an **Available tools (use
-   tool_search to load)** block near the end of your system prompt.
-   Call `tool_search("keyword")` or `tool_search("select:exact_name")`
-   to fetch their full schemas, then call them normally.
+If a tool isn't in your active list:
 
-If you're looking for a capability and don't see it in your active
-tools, check the deferred catalog before concluding it's unavailable.
+1. **First, search the deferred catalog.** Look for an **Available
+   tools (use tool_search to load)** block near the end of your
+   system prompt. Call `tool_search("keyword")` or
+   `tool_search("select:exact_name")` to fetch full schemas.
+   MCP server tools (named `mcp__server__tool`) live here too — you do
+   NOT need to activate any skill to use them.
 
-**Common capabilities behind skills:**
-- Background processes (servers, watchers) → activate the `background` skill
-- MCP server admin (status, resources, prompts) → activate the `mcp` skill
+2. **If the catalog doesn't have it, check the Available Skills block.**
+   Skill tools only exist after `activate_skill(name)`. Skills with
+   `auto-approve: true` activate without a confirmation prompt.
 
-Skills with `auto-approve: true` activate without a confirmation
-prompt — `background` and `mcp` both do.
+3. **Common capabilities behind skills:**
+   - Background processes (servers, watchers) → `background` skill
+   - MCP *server admin* (status, restart, list resources/prompts)
+     → `mcp` skill. (For *using* an MCP server's tools, skip the skill
+     and use `tool_search` instead.)
+
+**Tool names are EXACT strings.** Copy them verbatim from your tool
+list — do not drop prefixes, substitute hyphens for underscores (or
+vice versa), abbreviate, or improvise a shorter form. MCP server tools
+use the full form `mcp__<server>__<tool>` and the server name may
+contain hyphens. A call to the wrong name fails; the system will
+suggest close matches, and you should retry with the exact suggested
+name rather than guessing again.
+
+If you're not sure a tool exists, search the catalog first — don't
+invent a name and call it.
 
 ## Workspace — Your Filesystem
 

--- a/src/decafclaw/skills/mcp/SKILL.md
+++ b/src/decafclaw/skills/mcp/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: mcp
-description: MCP (Model Context Protocol) admin tools — inspect connected servers, list resources and prompts, restart servers. Use when debugging MCP connectivity or fetching server-provided content.
+description: Admin tools for inspecting and restarting connected MCP servers — status, resources, prompts. Does NOT expose tools provided by MCP servers; those appear as mcp__server__tool and are fetched via tool_search.
 auto-approve: true
 ---
 
 # MCP admin
 
-MCP servers expose their own tools (namespaced as `mcp__server__tool`) that show up in the regular tool catalog. This skill is only for *administering* the MCP layer itself — inspecting status, fetching resources and prompts, or restarting servers.
+**This skill is NOT for calling tools that MCP servers provide.** Tools exposed by MCP servers are named `mcp__server__tool` and live in the regular tool catalog. If a tool like `mcp__github__create_issue` isn't immediately available, use `tool_search` to fetch it from the deferred catalog — do NOT activate this skill.
+
+This skill is only for *administering* the MCP layer itself — inspecting server status, listing or reading resources, listing or fetching prompts, or restarting servers.
 
 ## Tools
 

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -1,6 +1,7 @@
 """Tool registry — combines core and built-in tools. Skill tools loaded on demand."""
 
 import asyncio
+import difflib
 import logging
 
 from ..media import ToolResult
@@ -73,6 +74,38 @@ def _to_tool_result(value) -> ToolResult:
     return ToolResult(text=str(value))
 
 
+def _suggest_tool_names(name: str, candidates: set[str], max_results: int = 5) -> list[str]:
+    """Suggest tool names close to ``name`` using difflib + suffix match.
+
+    Returns up to ``max_results`` suggestions, most likely first. Used to
+    give the agent a "did you mean?" hint when it calls a tool that
+    doesn't exist. No correction happens — the agent must retry with the
+    exact name on the next turn.
+    """
+    if not candidates:
+        return []
+    suggestions: list[str] = []
+    # Suffix match catches the common "dropped prefix" case (e.g. Gemini
+    # truncating `mcp__oblique-strategies__get_strategy` to
+    # `strategies__get_strategy`).
+    for cand in candidates:
+        if cand.endswith(f"__{name}") or cand.endswith(name):
+            if cand != name and cand not in suggestions:
+                suggestions.append(cand)
+    # difflib fuzzy match for general typos
+    for cand in difflib.get_close_matches(name, list(candidates), n=max_results, cutoff=0.6):
+        if cand not in suggestions:
+            suggestions.append(cand)
+    return suggestions[:max_results]
+
+
+def _format_suggestions(suggestions: list[str]) -> str:
+    """Format suggestion list as 'Did you mean: a, b, c.' for error messages."""
+    if not suggestions:
+        return ""
+    return f" Did you mean: {', '.join(suggestions)}."
+
+
 async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
     """Execute a tool by name and return the result.
 
@@ -89,19 +122,32 @@ async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
     if name.startswith("mcp__"):
         from ..mcp_client import get_registry
         registry = get_registry()
-        if registry:
-            mcp_tools = registry.get_tools()
-            fn = mcp_tools.get(name)
-            if fn:
-                try:
-                    cancel_event = ctx.cancelled
-                    tool_task, interrupted = await _run_with_cancel(fn(arguments), cancel_event)
-                    if interrupted:
-                        return interrupted
-                    return _to_tool_result(tool_task.result())
-                except Exception as e:
-                    return ToolResult(text=f"[error executing {name}: {e}]")
-        return ToolResult(text=f"[error: MCP tool '{name}' not available]")
+        mcp_tools = registry.get_tools() if registry else {}
+        fn = mcp_tools.get(name)
+        if fn:
+            try:
+                cancel_event = ctx.cancelled
+                tool_task, interrupted = await _run_with_cancel(fn(arguments), cancel_event)
+                if interrupted:
+                    return interrupted
+                return _to_tool_result(tool_task.result())
+            except Exception as e:
+                return ToolResult(text=f"[error executing {name}: {e}]")
+        # Tool not found — suggest close matches, require the agent to retry
+        # with the exact name. No auto-correction.
+        suggestions = _suggest_tool_names(name, set(mcp_tools.keys()))
+        hint = _format_suggestions(suggestions)
+        if not mcp_tools:
+            return ToolResult(
+                text=f"[error: MCP tool '{name}' not found; no MCP servers are connected.]"
+            )
+        return ToolResult(
+            text=(
+                f"[error: MCP tool '{name}' not found.{hint} "
+                f"Use the exact name from your tool list. To discover "
+                f"available tools, call tool_search.]"
+            )
+        )
 
     # Check skill-provided tools first, then global registry, then search tools
     from .search_tools import SEARCH_TOOLS
@@ -118,7 +164,29 @@ async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
             add_fetched_tools(ctx, {name})
             fn = extra_tools.get(name) or TOOLS.get(name)
         if fn is None:
-            return ToolResult(text=f"[error: unknown tool: {name}]")
+            # Unknown tool — suggest close matches from everything the
+            # agent could reach: active, skill, deferred pool, and MCP.
+            candidates: set[str] = set()
+            candidates.update(extra_tools.keys())
+            candidates.update(TOOLS.keys())
+            candidates.update(SEARCH_TOOLS.keys())
+            candidates.update(deferred_names)
+            try:
+                from ..mcp_client import get_registry
+                reg = get_registry()
+                if reg:
+                    candidates.update(reg.get_tools().keys())
+            except Exception:
+                pass
+            suggestions = _suggest_tool_names(name, candidates)
+            hint = _format_suggestions(suggestions)
+            return ToolResult(
+                text=(
+                    f"[error: unknown tool '{name}'.{hint} "
+                    f"Use the exact name from your tool list. To discover "
+                    f"available tools, call tool_search.]"
+                )
+            )
     cancel_event = ctx.cancelled
     try:
         coro = fn(ctx, **arguments) if asyncio.iscoroutinefunction(fn) else asyncio.to_thread(fn, ctx, **arguments)

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -248,7 +248,7 @@ def build_deferred_list_text(
         lines.append("")
 
     for server in sorted(mcp_tools):
-        lines.append(f"### MCP: {server}")
+        lines.append(f"### Tools from MCP server `{server}`")
         lines.extend(_render(mcp_tools[server]))
         lines.append("")
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -289,8 +289,8 @@ class TestBuildDeferredListText:
             _make_tool_def("mcp__slack__send", "Send a message"),
         ]
         text = build_deferred_list_text(tools, core_names=set())
-        assert "### MCP: playwright" in text
-        assert "### MCP: slack" in text
+        assert "### Tools from MCP server `playwright`" in text
+        assert "### Tools from MCP server `slack`" in text
 
     def test_skill_tools(self):
         tools = [
@@ -324,9 +324,9 @@ class TestBuildDeferredListText:
             _make_tool_def("mcp__slack__msg", "s", priority="normal"),
         ]
         text = build_deferred_list_text(tools, core_names=set())
-        assert "### MCP: github" in text
-        assert "### MCP: slack" in text
-        github_section = text.split("### MCP: github")[1].split("###")[0]
+        assert "### Tools from MCP server `github`" in text
+        assert "### Tools from MCP server `slack`" in text
+        github_section = text.split("### Tools from MCP server `github`")[1].split("###")[0]
         # critical issue_a before normal issue_b
         a_idx = github_section.index("issue_a")
         b_idx = github_section.index("issue_b")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -18,9 +18,39 @@ async def test_execute_tool_with_extra_tools(ctx):
 
 @pytest.mark.asyncio
 async def test_execute_tool_unknown(ctx):
-    """Unknown tool returns error message."""
+    """Unknown tool returns error message with guidance to use tool_search."""
     result = await execute_tool(ctx, "nonexistent_tool", {})
-    assert "[error: unknown tool:" in result.text
+    assert "unknown tool" in result.text
+    assert "nonexistent_tool" in result.text
+    assert "tool_search" in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_unknown_suggests_close_match(ctx):
+    """When the unknown name is close to a real tool, the error includes it as a suggestion."""
+    # workspace_read is a real core tool; try a typo.
+    result = await execute_tool(ctx, "workspce_read", {})
+    assert "Did you mean" in result.text
+    assert "workspace_read" in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_unknown_suffix_match_suggests_mcp(ctx, monkeypatch):
+    """Dropped mcp__ prefix should surface the full MCP name as a suggestion."""
+    from unittest.mock import MagicMock
+
+    from decafclaw import mcp_client
+
+    mock_registry = MagicMock()
+    mock_registry.get_tools.return_value = {
+        "mcp__oblique-strategies__get_strategy": MagicMock(),
+    }
+    monkeypatch.setattr(mcp_client, "_registry", mock_registry)
+
+    # Call with the prefix dropped, as Gemini sometimes does.
+    result = await execute_tool(ctx, "strategies__get_strategy", {})
+    assert "Did you mean" in result.text
+    assert "mcp__oblique-strategies__get_strategy" in result.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #263. Live testing against a connected MCP server surfaced three observed behaviors:

1. The agent treated the `mcp` admin skill as the home for MCP server tools (which actually live in the deferred catalog as `mcp__server__tool`), activating the skill and then being unable to find the tool it wanted.
2. The agent read the deferred catalog's `### MCP: <server>` subheading as a skill listing and claimed "oblique-strategies is a skill."
3. The agent emitted truncated tool names (e.g. `strategies__get_strategy` instead of `mcp__oblique-strategies__get_strategy`) and dead-ended on a bare "unknown tool" error.

## Changes

**Prompt tightening**
- `AGENT.md` — rewrote the *Tools — Finding What You Need* section so **search-first** is step 1 and **activate-skill** is step 2, matching the actual decision flow. Added explicit "tool names are EXACT strings" language (no dropped prefixes, no hyphen/underscore substitution, no abbreviation). Clarified that MCP server tools live in the deferred catalog, not behind the `mcp` skill.
- `skills/mcp/SKILL.md` — tightened description and body to lead with "NOT for calling MCP server tools."

**Deferred catalog rendering**
- `tool_registry.py` — renamed the subheading from \`### MCP: <server>\` to \`### Tools from MCP server \`<server>\`\` so it no longer reads as a skill category.

**Error message upgrade**
- `tools/__init__.py` — replaced bare \`[error: unknown tool: X]\` and \`[error: MCP tool ... not available]\` with rich *"did you mean"* hints built from \`difflib.get_close_matches\` + explicit suffix match (catches the common Gemini failure mode of dropping the \`mcp__\` prefix). **No auto-correction** — the agent is required to retry with the exact suggested name on the next turn. Candidate pool covers core tools, activated skill tools, deferred pool, and the MCP registry.

## Test plan

- [x] \`make check\` (ruff + pyright + tsc) — clean
- [x] \`make test\` — 1500 passed
- [x] New tests in \`tests/test_tools.py\`:
  - \`test_execute_tool_unknown\` updated for new error shape
  - \`test_execute_tool_unknown_suggests_close_match\` — typo like \`workspce_read\` surfaces \`workspace_read\` as a suggestion
  - \`test_execute_tool_unknown_suffix_match_suggests_mcp\` — \`strategies__get_strategy\` surfaces \`mcp__oblique-strategies__get_strategy\`
- [x] Live smoke against MCP oblique-strategies server: agent can now recover from a wrong-name call with a single additional turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)