### PR TITLE
fix: normalize hyphen→underscore in MCP tool names (Gemini workaround)

### DIFF
--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -124,6 +124,34 @@ async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
         registry = get_registry()
         mcp_tools = registry.get_tools() if registry else {}
         fn = mcp_tools.get(name)
+        # Workaround: Gemini normalizes hyphens to underscores in tool
+        # identifiers at the function-call serialization layer, so
+        # `mcp__oblique-strategies__get_strategy` comes back as
+        # `mcp__oblique_strategies__get_strategy`. The model can't emit
+        # hyphens even when it knows the correct name. When the exact
+        # match misses, try variants with underscores in the server
+        # segment flipped to hyphens. Only auto-correct when exactly one
+        # candidate matches — otherwise fall through to the "did you
+        # mean" suggestions path.
+        if fn is None:
+            parts = name.split("__", 2)
+            if len(parts) == 3 and "_" in parts[1]:
+                server_underscored = parts[1]
+                matches = [
+                    cand for cand in mcp_tools
+                    if cand.startswith("mcp__")
+                    and cand.count("__") >= 2
+                    and cand.split("__", 2)[1].replace("-", "_") == server_underscored
+                    and cand.split("__", 2)[2] == parts[2]
+                ]
+                if len(matches) == 1:
+                    corrected = matches[0]
+                    log.info(
+                        "MCP tool name normalized (hyphen workaround): %s → %s",
+                        name, corrected,
+                    )
+                    name = corrected
+                    fn = mcp_tools[corrected]
         if fn:
             try:
                 cancel_event = ctx.cancelled

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -54,6 +54,58 @@ async def test_execute_tool_unknown_suffix_match_suggests_mcp(ctx, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_mcp_hyphen_normalization(ctx, monkeypatch, caplog):
+    """Gemini normalizes hyphens to underscores in tool identifiers. When the
+    exact name misses but exactly one candidate differs only in server-segment
+    hyphens, auto-correct and route the call."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from decafclaw import mcp_client
+
+    mock_fn = AsyncMock(return_value="strategy result")
+    mock_registry = MagicMock()
+    mock_registry.get_tools.return_value = {
+        "mcp__oblique-strategies__get_strategy": mock_fn,
+    }
+    monkeypatch.setattr(mcp_client, "_registry", mock_registry)
+
+    with caplog.at_level("INFO"):
+        result = await execute_tool(
+            ctx, "mcp__oblique_strategies__get_strategy", {},
+        )
+    assert result.text == "strategy result"
+    mock_fn.assert_called_once_with({})
+    # Normalization is logged for visibility
+    assert any("hyphen workaround" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_mcp_hyphen_ambiguous_no_correction(ctx, monkeypatch):
+    """If multiple hyphenated candidates match the underscored server segment,
+    don't auto-correct — fall through to the 'did you mean' suggestions so the
+    agent can pick."""
+    from unittest.mock import MagicMock
+
+    from decafclaw import mcp_client
+
+    mock_registry = MagicMock()
+    mock_registry.get_tools.return_value = {
+        "mcp__foo-bar__run": MagicMock(),
+        "mcp__foo_bar__run": MagicMock(),  # exists with underscore as real name
+    }
+    # Note: "mcp__foo_bar__run" IS a real name here — it's not a normalization
+    # target. But "mcp__foo-bar__run" also maps back to the same underscored
+    # form. If the agent calls "mcp__foo_bar__run", the exact match wins.
+    monkeypatch.setattr(mcp_client, "_registry", mock_registry)
+
+    # Exact match path — no normalization needed, returns successfully.
+    result = await execute_tool(ctx, "mcp__foo_bar__run", {})
+    # Non-error: either called successfully or raised — either way, it did
+    # NOT route to the hyphenated variant via normalization.
+    assert "not found" not in result.text
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_mcp_routes_to_registry(ctx, monkeypatch):
     """MCP-namespaced tools route to the MCP registry."""
     from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
## Summary

Gemini normalizes hyphens to underscores in tool identifiers at the function-call serialization layer. A tool registered as \`mcp__oblique-strategies__get_strategy\` gets called by Gemini as \`mcp__oblique_strategies__get_strategy\` even when the model's **text response** correctly shows the hyphenated form. The model literally cannot emit a hyphen inside a tool identifier.

Observed in a non-terminating loop after PR #265 tightened prompting — the agent kept apologizing and retrying with the same underscored name, unable to self-correct because it's a model-level serialization issue, not a reasoning one.

## Fix

When an MCP tool lookup misses and exactly one registered tool differs only by hyphens-vs-underscores in the server segment, auto-correct the call and log the normalization. Ambiguous cases (multiple candidates) fall through to the existing \"did you mean\" suggestions.

Narrow by design:
- Only in the \`mcp__\` routing path
- Only when server segment contains underscores
- Only when exactly one hyphenated variant exists in the registry
- Logs at INFO so normalizations are visible

This is in the same category as the existing \`\$schema\` stripping for Vertex — a targeted workaround for a known provider serialization quirk, not general fuzzy matching.

## Test plan

- [x] \`make check\` (ruff + pyright + tsc) — clean
- [x] \`make test\` — 1502 passed
- [x] New tests in \`tests/test_tools.py\`:
  - \`test_execute_tool_mcp_hyphen_normalization\` — underscored call routes to hyphenated registered tool, logs normalization
  - \`test_execute_tool_mcp_hyphen_ambiguous_no_correction\` — exact-match path unaffected when both variants exist
- [ ] Live smoke with a connected MCP server that has hyphens in its name (e.g., \`oblique-strategies\`)

## Related

- #263 — priority system + skill extraction (landed)
- #265 — tool discovery polish (landed, exposed this bug during testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)