### PR TITLE
fix(mcp): normalize hyphens to underscores in registered tool names

### DIFF
--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -54,7 +54,7 @@ Use `${VAR}` or `${VAR:-default}` in any string value. Variables are expanded fr
 
 ### Server name requirements
 
-Server names must be lowercase alphanumeric with hyphens (e.g., `my-server`). They become part of the tool namespace.
+Server names must be lowercase alphanumeric with hyphens or underscores (e.g., `my-server` or `my_server`). They become part of the tool namespace — **hyphens are normalized to underscores** in the identifier the LLM sees (see [Tool namespacing](#tool-namespacing) below).
 
 ## How it works
 
@@ -67,15 +67,27 @@ Server names must be lowercase alphanumeric with hyphens (e.g., `my-server`). Th
 
 ## Tool namespacing
 
-All MCP tools are prefixed with the server name to prevent collisions:
+All MCP tools are prefixed with the server name to prevent collisions.
+
+**Hyphens in server names are normalized to underscores in the namespaced tool identifier.** For a server configured as `oblique-strategies`, the agent sees:
 
 ```
-mcp__oblique-strategies__get_strategy
-mcp__oblique-strategies__search_strategies
-mcp__oblique-strategies__list_editions
+mcp__oblique_strategies__get_strategy
+mcp__oblique_strategies__search_strategies
+mcp__oblique_strategies__list_editions
 ```
 
-The agent calls them by the full namespaced name. The prefix is stripped before forwarding to the server.
+### Why normalize?
+
+Gemini normalizes hyphens to underscores in tool identifiers at the function-call serialization layer — a tool registered as `mcp__oblique-strategies__get_strategy` gets emitted as `mcp__oblique_strategies__get_strategy` and fails to route. The model literally cannot produce a hyphen inside a tool identifier, even when it knows the correct name. By advertising underscored names up-front, every provider round-trips the identifier reliably.
+
+This is a DecafClaw-layer convention — the actual MCP SDK call preserves the original server name (including hyphens), so protocol interop is unaffected. Only the identifier the LLM sees changes.
+
+### Consequences
+
+- **Config server names can use hyphens or underscores** — e.g., `my-api-server` or `my_api_server`. Both produce the same advertised tool names (`mcp__my_api_server__...`). Collisions would be rare but possible; avoid configuring two servers whose names differ only in separator.
+- **User-invokable prompt commands still use the raw server name** — if you named a server `oblique-strategies` you invoke prompts as `!mcp__oblique-strategies__promptname` (humans can type hyphens fine). This asymmetry is small and targeted; we may unify later.
+- **The agent calls tools by the normalized name.** The prefix is stripped and the *original* server name is used to route to the correct MCP session.
 
 ## Resources
 

--- a/src/decafclaw/mcp_client.py
+++ b/src/decafclaw/mcp_client.py
@@ -140,13 +140,39 @@ def load_mcp_config(config) -> list[MCPServerConfig]:
 # -- Tool namespacing ----------------------------------------------------------
 
 
+def _normalize_server_segment(server_name: str) -> str:
+    """Normalize a server name for use in namespaced tool identifiers.
+
+    Hyphens are replaced with underscores. This is a workaround for
+    Gemini, which normalizes hyphens to underscores at the function-call
+    serialization layer — a tool registered as ``mcp__foo-bar__baz``
+    would be emitted as ``mcp__foo_bar__baz`` and fail to route. By
+    advertising underscored names up-front, every provider can
+    round-trip the identifier.
+
+    The *actual* MCP SDK server name (used for calls via
+    ``session.call_tool``) is preserved separately — this only affects
+    the identifier seen by the LLM.
+    """
+    return server_name.replace("-", "_")
+
+
 def _namespace_tool(server_name: str, tool_name: str) -> str:
-    """Create a namespaced tool name: mcp__<server>__<tool>."""
-    return f"mcp__{server_name}__{tool_name}"
+    """Create a namespaced tool name: mcp__<server>__<tool>.
+
+    The server segment is normalized (hyphens → underscores) for
+    provider-compatibility; see ``_normalize_server_segment``.
+    """
+    return f"mcp__{_normalize_server_segment(server_name)}__{tool_name}"
 
 
 def _parse_namespace(namespaced: str) -> tuple[str, str] | None:
-    """Parse a namespaced MCP tool name into (server_name, tool_name).
+    """Parse a namespaced MCP tool name into (server_segment, tool_name).
+
+    Note: the returned ``server_segment`` is the normalized form
+    (hyphens replaced with underscores). It will not match an original
+    MCP server name if the server had hyphens. Callers that need the
+    original server name should look it up via the registry.
 
     Returns None if the name doesn't match the mcp__<server>__<tool> pattern.
     """

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -162,14 +162,25 @@ def test_load_mcp_config_custom_timeout(config):
 # -- namespacing tests --
 
 
-def test_namespace_tool():
-    assert _namespace_tool("my-server", "get_data") == "mcp__my-server__get_data"
+def test_namespace_tool_normalizes_hyphens_to_underscores():
+    """Hyphens in server names are normalized to underscores in the
+    advertised tool name (workaround for Gemini's hyphen-to-underscore
+    serialization of function-call identifiers)."""
+    assert _namespace_tool("my-server", "get_data") == "mcp__my_server__get_data"
 
 
-def test_parse_namespace_roundtrip():
+def test_namespace_tool_underscore_unchanged():
+    """Server names already using underscores round-trip unchanged."""
+    assert _namespace_tool("my_server", "get_data") == "mcp__my_server__get_data"
+
+
+def test_parse_namespace_returns_normalized_segment():
+    """Parsed server segment is the normalized form, not the original MCP
+    server name. Callers that need the original must look it up via the
+    registry."""
     namespaced = _namespace_tool("my-server", "get_data")
     result = _parse_namespace(namespaced)
-    assert result == ("my-server", "get_data")
+    assert result == ("my_server", "get_data")
 
 
 def test_parse_namespace_non_mcp():
@@ -198,7 +209,9 @@ def test_convert_tool_definition_dict():
     }
     result = _convert_tool_definition("weather-server", mcp_tool)
     assert result["type"] == "function"
-    assert result["function"]["name"] == "mcp__weather-server__get_weather"
+    # Server name hyphens are normalized to underscores in the advertised
+    # tool identifier (Gemini function-call compatibility).
+    assert result["function"]["name"] == "mcp__weather_server__get_weather"
     assert result["function"]["description"] == "Get weather for a location"
     assert result["function"]["parameters"]["required"] == ["location"]
 
@@ -211,7 +224,7 @@ def test_convert_tool_definition_object():
         inputSchema = {"type": "object", "properties": {}}
 
     result = _convert_tool_definition("my-server", FakeTool())
-    assert result["function"]["name"] == "mcp__my-server__search"
+    assert result["function"]["name"] == "mcp__my_server__search"
 
 
 # -- response conversion tests --
@@ -383,7 +396,8 @@ async def test_connect_server_success():
 
     state = registry.servers["test-server"]
     assert state.status == "connected"
-    assert "mcp__test-server__get_strategy" in state.tools
+    # Server name hyphens are normalized in the advertised tool name.
+    assert "mcp__test_server__get_strategy" in state.tools
     assert len(state.tool_definitions) == 1
 
 


### PR DESCRIPTION
## Summary

Supersedes #266. Moves the Gemini hyphen workaround from runtime correction to **registration-time normalization** — the LLM never sees a hyphen in a tool identifier, so there's nothing to correct.

## Problem (recap)

Gemini normalizes hyphens to underscores in tool identifiers at the function-call serialization layer. A tool registered as \`mcp__oblique-strategies__get_strategy\` gets emitted by Gemini as \`mcp__oblique_strategies__get_strategy\`. The model literally cannot produce a hyphen inside a tool identifier, even when its text response correctly shows the hyphenated form. Observed in an infinite self-apology loop after prompt-tightening in #265.

## Approach (Option A)

At registration time, normalize the server segment of the namespaced tool identifier (\`hyphen → underscore\`). The MCP SDK call path still uses the original server name, so protocol interop is unaffected — only the identifier shown to the LLM changes.

- \`_namespace_tool(server, tool)\` → produces \`mcp__<server_with_underscores>__<tool>\`
- \`_make_tool_caller\` → unchanged, captures original \`server_name\` from config
- \`_parse_namespace\` → docstring updated to note the returned segment is normalized

### Why this over #266?

The runtime workaround in #266 corrects each incoming call that misses. Registration-time normalization removes the mismatch entirely — the agent sees underscored names and round-trips them cleanly on every provider. Same fix, eliminated at the source.

## Scope

Limited to tool names. User-invokable prompt commands (\`!mcp__server__promptname\`) still use the raw server name — humans can type hyphens fine; this is a Gemini function-call serialization issue specifically. If we later want full consistency we can extend, but scoped-narrow here.

## Docs

\`docs/mcp-servers.md\` updated:
- \"Server name requirements\" now notes hyphens-normalize-to-underscores
- \"Tool namespacing\" section expanded with a \"Why normalize?\" subsection and a \"Consequences\" note (config accepts either separator, prompts still use raw names, MCP protocol call unaffected)

## Test plan

- [x] \`make check\` — clean
- [x] \`make test\` — 1501 passed
- [x] Updated tests in \`tests/test_mcp.py\`:
  - \`test_namespace_tool_normalizes_hyphens_to_underscores\` — new
  - \`test_namespace_tool_underscore_unchanged\` — new
  - \`test_parse_namespace_returns_normalized_segment\` — replaces roundtrip test
  - \`test_convert_tool_definition_dict\` / \`_object\` — updated expectations
  - \`test_connect_server_success\` — updated expectations
- [x] Live smoke against oblique-strategies MCP server — verify Gemini can call the underscored name and the SDK routes correctly

## Related

- Closes/supersedes #266
- Follows #263 (priority system + skill extraction) and #265 (tool discovery polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)