### PR TITLE
Postmortem skill: blameless RCA for repeated failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/skills/project/` — Project workflow skill: state machine, plan parser, lifecycle tools
 - `src/decafclaw/skills/claude_code/` — Claude Code subagent skill (sessions, permissions, output logging)
 - `src/decafclaw/skills/health/` — Bundled `!health` command: agent diagnostic status
+- `src/decafclaw/skills/postmortem/` — Bundled `!postmortem` command: blameless RCA on the current conversation, archives report to vault
 - `src/decafclaw/skills/background/` — Background process management skill. Bundled, auto-activates.
 - `src/decafclaw/skills/mcp/` — MCP admin skill (status, resources, prompts, restart). Bundled, auto-activates.
 

--- a/docs/dev-sessions/2026-04-17-2135-postmortem-skill/notes.md
+++ b/docs/dev-sessions/2026-04-17-2135-postmortem-skill/notes.md
@@ -12,8 +12,38 @@ Filled in during/after execution.
 
 ## Surprises / pivots
 
-- _TBD_
+- **Eval harness didn't dispatch user-invokable commands.** Raw input
+  was passed directly to `run_agent_turn`, so `/postmortem` was read
+  as plain text. Transports (web, Mattermost) all route through
+  `dispatch_command` first. Added that path to the eval runner in a
+  separate commit — small (~40 lines) and unblocks evals for every
+  user-invokable skill going forward. Scope creep acknowledged; it
+  was on the critical path.
+- **`response_contains` is an OR match**, not AND. Caught this before
+  running — wrote a single `(?s)`-enabled regex asserting all five
+  section headings in order rather than a list of five patterns.
+- **`vault_write` parameter is `page`, not `path`.** First eval run
+  surfaced this as a tool error; fixed SKILL.md.
+- **First eval pass on gemini-flash produced exactly the wanted
+  output:** all five sections, blameless framing, specific proposed
+  patch tagged Systemic, concrete next steps for the user. The SKILL.md
+  body did not need tuning on this input. Manual smoke-test (Phase 2)
+  will validate richer conversations — that's where tuning may still
+  happen.
+
+## What's still open
+
+- **Phase 2 manual smoke test.** Les exercises `/postmortem` in his
+  running web UI against a real conversation with messier failure
+  patterns. May surface SKILL.md tuning needs.
 
 ## Final summary
 
-- _Write before squash + merge._
+Shipped v1 of the `postmortem` skill: SKILL.md-only, user-invokable
+via `/postmortem` and `!postmortem`, produces a structured five-section
+report (Anomaly / Root cause hypotheses / Proposed patches / Systemic
+vs session-specific / Next steps), writes it to
+`agent/pages/postmortems/` for later consolidation by dream/garden.
+Blameless framing enforced in the prompt. Eval case passes on the
+default eval model. Side benefit: eval runner now exercises user-invokable
+commands end-to-end.

--- a/docs/dev-sessions/2026-04-17-2135-postmortem-skill/notes.md
+++ b/docs/dev-sessions/2026-04-17-2135-postmortem-skill/notes.md
@@ -1,0 +1,19 @@
+# Notes: Postmortem skill
+
+Filled in during/after execution.
+
+## Decisions (2026-04-17)
+
+- Name: `postmortem` (confirmed).
+- Persistence: always write to `agent/pages/postmortems/YYYY-MM-DD-HHMM-slug.md`.
+- Context mode: `inline`.
+- Eval scope: one case — seeded three-repeat tool error.
+- Folder path and blameless-framing rule: proceed with defaults; revisit during prompt tuning if output disagrees.
+
+## Surprises / pivots
+
+- _TBD_
+
+## Final summary
+
+- _Write before squash + merge._

--- a/docs/dev-sessions/2026-04-17-2135-postmortem-skill/plan.md
+++ b/docs/dev-sessions/2026-04-17-2135-postmortem-skill/plan.md
@@ -1,0 +1,122 @@
+# Plan: Postmortem skill
+
+Spec: [spec.md](./spec.md). Decisions locked — `postmortem` / `inline` / always-write / one eval case.
+
+Branch: `session/postmortem-skill` (already checked out).
+
+## Pre-flight (verified 2026-04-17)
+
+- Skill discovery: dropping `src/decafclaw/skills/postmortem/SKILL.md` is sufficient — bundled skills auto-discover via `src/decafclaw/skills/__init__.py:178` (`discover_skills()`). No registry update.
+- `context: inline` semantics: the skill body is substituted and injected as a user message in the **current turn**, with full conversation history visible. Pre-approved tools and activated skills land on `ctx` before injection. (`src/decafclaw/commands.py:358+`.) **Implication for Phase 1**: write the SKILL.md body in second-person imperative voice ("Analyze what just went wrong…"). It will be read as a user-voiced instruction to the agent, not a description of a skill.
+- `$ARGUMENTS` substitution: literal token `$ARGUMENTS`. If body has no placeholder but user supplied args, they're appended as `ARGUMENTS: ...`. (`commands.py:44`.)
+- `vault_write` auto-creates parent folders via `path.parent.mkdir(parents=True, exist_ok=True)` (`src/decafclaw/skills/vault/tools.py:164`). No explicit folder creation step needed.
+- Eval harness is **not** wired into `make test`. Run evals with `uv run python -m decafclaw.eval evals/postmortem.yaml`. (`src/decafclaw/eval/__main__.py`, Makefile.)
+- **Les likely has `make dev` running.** I won't start my own bot instance. For Phase 2 smoke testing, Les exercises the skill in his running web UI and shares the output; I iterate on the SKILL.md.
+- **Name collision check**: no existing `postmortem` references in `src/` Python code.
+
+## Phase 1: Skill scaffold
+
+1. Create `src/decafclaw/skills/postmortem/SKILL.md`.
+2. Frontmatter:
+   ```yaml
+   name: postmortem
+   description: Structured blameless analysis of what went wrong in this conversation — identifies root causes and proposes minimal fixes
+   user-invocable: true
+   context: inline
+   allowed-tools: vault_write, current_time
+   ```
+3. Skill body (second-person imperative, because inline injection makes this a user-voiced instruction):
+   - Opening: short context framing — this is a blameless analysis, not a task to resume.
+   - Section headings the agent must produce: `## Anomaly`, `## Root cause hypotheses`, `## Proposed patches`, `## Systemic vs session-specific`, `## Next steps`.
+   - Root-cause categories to consider: ambiguous instruction, missing guardrail, tool-description gap, skill-body issue, LLM quirk, missing capability, user-facing ambiguity.
+   - Blameless framing rule: third-person / system-level phrasing. Forbid "I apologize", "I should have", "my mistake", "I'm sorry".
+   - Proposed patches must name specific artifacts (file paths, tool names, AGENT.md lines). No "rewrite everything".
+   - `$ARGUMENTS` block: if present, narrow the analysis to that focus; otherwise analyze whatever is most salient in the conversation.
+   - Persistence: call `vault_write` to save the report to `agent/pages/postmortems/{YYYY-MM-DD-HHMM}-{slug}.md` with YAML frontmatter (`tags: [postmortem]`, `importance: 0.6`) and a `## Sources` section listing the conversation ID. Use `current_time` for the timestamp.
+   - Turn boundary: after writing and delivering the report, stop. Do not resume the original task unless the user asks.
+4. No `tools.py`, no `SkillConfig` — markdown-only.
+
+**Verify**: `make lint` (Python lint — should be unchanged since this is markdown-only, but run it to confirm nothing breaks). Ask Les to confirm the skill appears in his running dev instance (may need a restart to pick up a new skill directory).
+
+**Commit**: `feat: bundle postmortem skill (scaffold)`.
+
+## Phase 2: Manual smoke test + prompt tuning
+
+1. Ask Les to exercise `/postmortem` in his web UI against a conversation with a simulated failure pattern (repeated tool errors, an ambiguous instruction, etc.).
+2. Check the output against all five acceptance criteria from the spec:
+   - All five sections present and populated.
+   - Report written to `agent/pages/postmortems/…md`.
+   - No apology/self-flagellation phrasing.
+   - Proposed patches reference specific artifacts.
+   - Agent stops after delivering the report.
+3. Iterate on SKILL.md until output is consistently structured and blameless. **Expect 2–4 rewrites** — skill bodies are control surfaces.
+4. Exercise the `$ARGUMENTS` path at least once (`/postmortem focused on the tool thrashing`) to confirm it narrows focus.
+
+**Verify**: Les signs off on an output sample before Phase 3.
+
+**Commit**: `polish: postmortem skill body tuning` (fold into Phase 1 if only one pass needed).
+
+## Phase 3: Eval case
+
+1. Create `evals/postmortem.yaml`.
+2. One case, simplest reliable shape — single turn where the user's message describes a failure pattern in prose and invokes the skill:
+   ```yaml
+   - name: "postmortem produces structured blameless report"
+     setup:
+       skills: [postmortem]
+     input: |
+       I asked you three times to search the vault for "quarterly plans"
+       and each attempt failed with an argument-type error on the query
+       parameter. /postmortem
+     expect:
+       response_contains:
+         - "re:##\\s*Anomaly"
+         - "re:##\\s*Root cause"
+         - "re:##\\s*Proposed patches"
+         - "re:##\\s*Systemic"
+         - "re:##\\s*Next steps"
+       response_not_contains:
+         - "I apologize"
+         - "I should have"
+         - "my mistake"
+         - "I'm sorry"
+       max_tool_calls: 6
+       max_tool_errors: 0
+   ```
+   (Prose-described failure is more reliable than trying to actually produce tool errors mid-eval. It tests the skill's output structure and framing — the real validation of pattern-analysis behavior on live failures happens in Phase 2's manual tests.)
+3. Run: `uv run python -m decafclaw.eval evals/postmortem.yaml`.
+4. Tune SKILL.md only if failures reflect real ambiguity; adjust the seeded prose if the setup itself is the flaky variable.
+
+**Verify**: eval passes.
+
+**Commit**: `test: eval case for postmortem skill`.
+
+## Phase 4: Docs
+
+1. Create `docs/postmortem-skill.md` describing: purpose, when to invoke, trigger syntax, report structure, vault page location, relationship to dream/garden, non-goals (no auto-trigger, no cross-session v1).
+2. Add an entry to `docs/index.md`.
+3. Update `CLAUDE.md` "Skills" key-files list to mention `src/decafclaw/skills/postmortem/`.
+4. Check `README.md` — only update if it already enumerates bundled skills.
+
+**Verify**: `make lint` still clean. Scan new docs for stale claims (paths, behavior descriptions).
+
+**Commit**: `docs: postmortem skill`.
+
+## Phase 5: PR + retro
+
+1. Fill in `notes.md` — what needed rewording in Phase 2, any surprises, final decisions.
+2. Push branch; open PR targeting `main`, body includes `Closes #279`.
+3. After merge: live-test `/postmortem` one more time against a real conversation; update docs if behavior diverged from written description.
+
+## Out of scope
+
+- Auto-trigger on repeated errors (v2 — needs error-pattern detection).
+- Cross-session pattern analysis via `conversation_search` (v2).
+- Auto-applying proposed patches (never — user reviews).
+
+## Risks to watch
+
+- **Skill body drift**: prompt wording is the whole feature. Phase 3 eval is the guardrail; do not skip it.
+- **Dev instance reload**: a newly added skill directory may not register without a bot restart. Confirm during Phase 1 handoff to Les; if needed, ask him to restart `make dev`.
+- **Importance weight**: `importance: 0.6` in frontmatter is a guess — tune if postmortem pages drown out higher-value pages in retrieval.
+- **Prose-described eval vs real failures**: the Phase 3 eval tests structure and framing, not live pattern analysis on real conversation history. If Phase 2 smoke-testing surfaces that the skill does well on prose-described failures but poorly on actual conversation analysis, we need a richer eval setup (seeded history) — defer to v2 unless Phase 2 signals it's urgent.

--- a/docs/dev-sessions/2026-04-17-2135-postmortem-skill/spec.md
+++ b/docs/dev-sessions/2026-04-17-2135-postmortem-skill/spec.md
@@ -1,0 +1,94 @@
+# Spec: Postmortem skill
+
+Tracking issue: [#279](https://github.com/lmorchard/decafclaw/issues/279)
+
+## Problem
+
+When the agent hits repeated errors in a conversation, it defaults to apology-and-correction rather than pattern-analysis. We already added a narrow AGENT.md rule ("Name the pattern on repeated errors") as an inline reactive nudge, but deferred a heavier blameless-postmortem ritual because baking it into every error path would be too heavyweight.
+
+We want RCA available as an explicit, user-invoked ritual: the user says "stop and reflect on what just happened" and gets a structured report back.
+
+## Goal
+
+Ship a bundled `postmortem` skill that is:
+
+- **User-invokable** via `/postmortem` (web UI) and `!postmortem` (Mattermost).
+- **Lean** — SKILL.md-only for v1, no new Python tools.
+- **Structured** — produces a report with named sections (Anomaly / Root cause hypotheses / Proposed patches / Next steps).
+- **Archival** — persists the report as a vault page so the dream/garden processes can consolidate patterns across sessions over time.
+- **Bounded** — stops when the report is delivered; does not pivot back into the original task.
+- **Non-destructive** — proposes fixes, never auto-applies them.
+
+## Non-goals
+
+- Auto-triggering based on repeated errors. v1 is user-invoked only; revisit after we see how often it gets used and whether auto-trigger would add signal or noise.
+- Cross-session pattern analysis. v1 analyzes only the current conversation. `conversation_search` is available for later versions.
+- New Python tool code. If v1 needs only existing tools (`vault_write`, `current_time`, optionally `vault_search`/`vault_list`), keep it SKILL.md-only.
+- Changing AGENT.md or the reactive "name the pattern" rule. Those stay as-is.
+
+## Design
+
+### Name and trigger
+
+- Skill name: `postmortem`.
+- Trigger: `!postmortem` / `/postmortem`.
+- Rationale: "postmortem" has industry-standard associations (blameless, structured, shared artifact). `rca` is jargon. `retro`/`debrief` feel too lightweight for the intended depth.
+
+### Frontmatter
+
+```yaml
+---
+name: postmortem
+description: Structured blameless analysis of what went wrong in this conversation — identifies root causes and proposes minimal fixes
+user-invocable: true
+context: inline
+allowed-tools: vault_write, current_time
+---
+```
+
+- `context: inline` so the skill sees the current conversation's full context. (`fork` would isolate it and force us to replay via `conversation_search`, which is both slower and unreliable for recent turns.)
+- `allowed-tools` pre-approved so the skill doesn't prompt for confirmation mid-ritual.
+- Not `always-loaded`. Skill body lives behind `activate_skill` as usual; user invocation activates it for the turn.
+
+### Report structure
+
+Prompt the agent to produce a markdown report with these sections in order:
+
+1. **Anomaly** — What specifically went wrong? One or two sentences. Concrete and blameless (no "I should have…").
+2. **Root cause hypotheses** — Ranked list. Each hypothesis names a *category*: ambiguous instruction, missing guardrail, tool-description gap, skill-body issue, LLM quirk, missing capability, user-facing ambiguity.
+3. **Proposed patches** — Specific, minimal, testable changes. Each patch names the artifact being changed ("AGENT.md line 42", "tool `foo` description", "add skill `bar`") and what to change. No "rewrite everything."
+4. **Systemic vs session-specific** — Which proposed patches belong in the codebase (systemic) vs which were just handled in this conversation (session-specific)?
+5. **Next steps** — Short list of what the user should decide: accept/reject each proposed patch, file an issue, run an eval case, etc.
+
+### Persistence
+
+- Always write the report to `agent/pages/postmortems/YYYY-MM-DD-HHMM-slug.md` via `vault_write`.
+- Slug derives from the anomaly framing (agent generates).
+- Include a `## Sources` section with the conversation ID, for traceability.
+- Include optional YAML frontmatter (`tags: [postmortem]`, `importance: 0.6`) so dream/garden pick it up.
+
+### Turn boundary
+
+The skill body ends with an explicit instruction: "Once the report is written and delivered, stop. Do not resume the original task unless the user asks." This matches the issue's "stop when done" requirement.
+
+### `$ARGUMENTS` support
+
+Optional focus arg: `/postmortem tool-call thrashing in the wiki search` lets the user narrow the analysis. Substituted into the skill body via the existing argument mechanism. If no args, agent analyzes whatever is salient.
+
+## Decisions (confirmed 2026-04-17)
+
+1. **Name**: `postmortem`. Trigger: `/postmortem`, `!postmortem`.
+2. **Vault persistence**: always-write. Every invocation writes `agent/pages/postmortems/YYYY-MM-DD-HHMM-slug.md`. No `--save`/`--quick` flag in v1.
+3. **Vault folder path**: `agent/pages/postmortems/` (default; assumed confirmed — if Les wants a different home, fix during Phase 1).
+4. **Invocation context**: `inline`. Skill runs in the current turn with full conversation visible.
+5. **Eval scope**: one case — seeded three-repeat tool error. Assert report structure (all five section headings present) and framing (no "I apologize"/"I should have" phrases; proposed patches reference specific artifacts).
+6. **Blameless framing**: skill body explicitly forbids self-flagellation phrasing and requires third-person / system-level language. (Assumed — confirm during Phase 2 prompt tuning if output disagrees.)
+
+## Acceptance
+
+- `/postmortem` in the web UI triggers the skill and produces a structured report with the five sections above.
+- The report is written to `agent/pages/postmortems/…md`.
+- The agent does not resume the prior task after the report.
+- The skill is pre-approved for its `allowed-tools` (no mid-ritual confirmations).
+- At least one eval case validates the report structure and pattern-analysis framing.
+- `docs/` has a page (or a section in an existing page) describing the skill.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@
 - [Pre-emptive Tool Search](preemptive-tool-search.md) — Keyword-match user message at turn start to auto-promote relevant tools
 - [User Commands](commands.md) — User-invokable commands (!command / /command) with argument substitution
 - [Project Skill](project-skill.md) — Structured workflow: brainstorm → spec → plan → execute for multi-step tasks
+- [Postmortem Skill](postmortem-skill.md) — User-invokable blameless RCA: structured report on what went wrong, archived to the vault
 - [File Attachments](file-attachments.md) — Upload files, MCP media, workspace image refs, rich cards
 
 ## Agent Behavior

--- a/docs/postmortem-skill.md
+++ b/docs/postmortem-skill.md
@@ -1,0 +1,81 @@
+# Postmortem Skill
+
+User-invokable skill for blameless analysis of what went wrong in a
+conversation. Produces a structured report, writes it to the vault, and
+stops — without pivoting back into the original task.
+
+Use when the agent has stumbled repeatedly and you want pattern-analysis
+instead of apology-and-correction.
+
+## Triggers
+
+- Mattermost: `!postmortem`
+- Web UI / terminal: `/postmortem`
+
+Optional focus argument narrows the analysis:
+
+```
+/postmortem on the repeated tool errors in the wiki search
+```
+
+## Report structure
+
+The skill instructs the agent to produce five H2 sections in order:
+
+1. **Anomaly** — one or two sentences stating concretely what went wrong.
+2. **Root cause hypotheses** — ranked list, each tagged with a category
+   (ambiguous instruction, missing guardrail, tool-description gap,
+   skill-body issue, LLM quirk, missing capability, user-facing
+   ambiguity).
+3. **Proposed patches** — specific, minimal, testable changes that each
+   name the artifact being changed (file path, tool name, skill name).
+4. **Systemic vs session-specific** — each proposed patch tagged as
+   "Systemic" (needs a codebase change) or "Session-specific" (already
+   handled in this conversation).
+5. **Next steps** — short bulleted list of decisions the user needs to
+   make. The skill does not act on any of them.
+
+Blameless framing is enforced: no "I apologize" / "I should have" /
+"my mistake" phrasing. Anomalies are attributed to systems, not the
+agent as a person.
+
+## Persistence
+
+Every invocation writes the report to the vault at
+
+```
+agent/pages/postmortems/{YYYY-MM-DD-HHMM}-{slug}.md
+```
+
+with YAML frontmatter (`tags: [postmortem]`, `importance: 0.6`,
+`summary: …`) and a `## Sources` section. The report is both delivered
+inline and archived, so dream/garden can consolidate postmortem patterns
+over time.
+
+## Non-goals
+
+- **No auto-trigger.** v1 is user-invoked only. An auto-trigger on
+  repeated errors would either under- or over-fire. Revisit after we
+  see how often the skill actually gets used.
+- **No cross-session analysis.** v1 analyzes only the current
+  conversation. A future version could use `conversation_search` to
+  scan prior sessions, but the simpler current-conversation mode ships
+  first.
+- **No auto-applied patches.** The report surfaces proposed patches;
+  the user reviews and commits them separately. The skill never edits
+  the codebase on its own.
+
+## Related
+
+- `AGENT.md`'s "Name the pattern on repeated errors" rule is the inline
+  reactive counterpart — a nudge the agent follows every turn. The
+  postmortem skill is the explicit ritual for going deeper.
+- The dream consolidation and garden skills will pick up the archived
+  postmortem pages as regular vault content, rolling recurring root
+  causes into higher-level pages over time.
+
+## Configuration
+
+Bundled skill at `src/decafclaw/skills/postmortem/SKILL.md`. No Python
+tools, no per-skill config. Pre-approved tools: `vault_write`,
+`current_time`.

--- a/evals/postmortem.yaml
+++ b/evals/postmortem.yaml
@@ -1,0 +1,26 @@
+# Evals for the postmortem skill.
+# Tests that /postmortem produces a structured, blameless report with all
+# five required sections and specific proposed patches.
+#
+# Note: response_contains is an OR match — for all-of assertions we use a
+# single (?s)-enabled regex that matches all section headings in order.
+
+- name: "postmortem produces all five sections, blamelessly framed"
+  setup:
+    skills: [postmortem]
+  input: |
+    /postmortem on this pattern: earlier in this conversation the agent
+    made three attempts to search the vault for "quarterly plans" and
+    each attempt failed with an argument-type error on the query
+    parameter. The agent retried the same call each time with the same
+    malformed argument shape rather than diagnosing the error.
+  expect:
+    response_contains:
+      - "re:(?s)##\\s*Anomaly.*##\\s*Root cause.*##\\s*Proposed patches.*##\\s*Systemic.*##\\s*Next steps"
+    response_not_contains:
+      - "I apologize"
+      - "I'm sorry"
+      - "my mistake"
+      - "my fault"
+    max_tool_calls: 5
+    max_tool_errors: 0

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -6,9 +6,11 @@ from datetime import datetime
 from pathlib import Path
 
 from ..agent import run_agent_turn
+from ..commands import dispatch_command
 from ..config import Config
 from ..context import Context
 from ..events import EventBus
+from ..skills import discover_skills as _discover_skills_fn
 
 log = logging.getLogger(__name__)
 
@@ -168,6 +170,10 @@ async def run_test(config: Config, test_case: dict) -> dict:
     Multi-turn tests share history across turns (same conversation).
     All turns must pass for the test to pass.
     """
+    # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
+    if not getattr(config, "discovered_skills", None):
+        config.discovered_skills = _discover_skills_fn(config)
+
     bus = EventBus()
     ctx = Context(config=config, event_bus=bus)
     ctx.conv_id = "eval"
@@ -226,8 +232,41 @@ async def run_test(config: Config, test_case: dict) -> dict:
         pre_turn_tool_calls = _count_tool_calls(history)
         pre_turn_tool_errors = _count_tool_errors(history)
 
+        # Dispatch user-invokable commands (/foo, !foo) just like real transports
+        # do — this gives us end-to-end coverage for skills with user-invocable: true.
+        turn_input = turn["input"]
+        cmd = await dispatch_command(ctx, turn_input)
+        if cmd.mode == "inline":
+            turn_input = cmd.text
+        elif cmd.mode in ("help", "fork"):
+            # Help/fork responses don't run the agent loop; treat cmd.text as the response.
+            # This keeps assertions working for commands that don't need a turn.
+            start = time.monotonic()
+            response = cmd.text
+            duration = time.monotonic() - start
+            all_responses.append({
+                "turn": turn_idx + 1,
+                "input": turn["input"],
+                "response": response,
+                "duration_sec": round(duration, 1),
+                "tool_calls": 0,
+            })
+            expect = turn.get("expect", {})
+            if expect:
+                passed, reason = _check_assertions(turn, response, 0, 0)
+                if not passed:
+                    overall_passed = False
+                    failure_reason = f"Turn {turn_idx + 1}: {reason}"
+                    break
+            continue
+        elif cmd.mode in ("unknown", "error"):
+            overall_passed = False
+            failure_reason = f"Turn {turn_idx + 1}: command dispatch {cmd.mode}: {cmd.text}"
+            break
+        # mode == "not_command" or "inline": fall through to run_agent_turn with turn_input
+
         start = time.monotonic()
-        result = await run_agent_turn(ctx, turn["input"], history)
+        result = await run_agent_turn(ctx, turn_input, history)
         response = result.text
         duration = time.monotonic() - start
         total_duration += duration

--- a/src/decafclaw/skills/postmortem/SKILL.md
+++ b/src/decafclaw/skills/postmortem/SKILL.md
@@ -69,7 +69,7 @@ After producing the report (and only after), write it to the vault so it can be 
 1. Call `current_time` to get the current timestamp.
 2. Derive a short kebab-case slug from the anomaly (3–5 words).
 3. Call `vault_write` with:
-   - **path**: `agent/pages/postmortems/{YYYY-MM-DD-HHMM}-{slug}.md`
+   - **page**: `agent/pages/postmortems/{YYYY-MM-DD-HHMM}-{slug}` (no `.md` extension — the tool adds it)
    - **content**: the report, prefixed with YAML frontmatter:
 
      ```yaml

--- a/src/decafclaw/skills/postmortem/SKILL.md
+++ b/src/decafclaw/skills/postmortem/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: postmortem
+description: Structured blameless analysis of what went wrong in this conversation — identifies root causes and proposes minimal, specific fixes
+user-invocable: true
+context: inline
+allowed-tools: vault_write, current_time
+---
+
+# Blameless postmortem
+
+Stop what you were doing. This is an explicit reflection ritual — not a task to resume. Produce a structured postmortem report about what went wrong in this conversation, then write it to the vault, then stop.
+
+If `$ARGUMENTS` is set (the user supplied a focus), narrow the analysis to that topic. Otherwise analyze whatever is most salient across the conversation so far.
+
+## What this is and isn't
+
+- It *is* a blameless, systems-level analysis: what broke, why, and what minimal change would prevent a recurrence.
+- It *isn't* an apology, a retry, or a pivot back into the original task.
+
+**Forbidden phrasing** — do not use "I apologize", "I'm sorry", "I should have", "my mistake", "my fault", or any first-person self-flagellation. Frame anomalies systemically: "the agent did X", "the tool description lacked Y", "the instruction was ambiguous about Z".
+
+## Report structure
+
+Produce the report with these five sections, in order, as H2 headings. Keep each section tight — a few sentences or a short list, not paragraphs.
+
+### `## Anomaly`
+
+One or two sentences stating concretely what went wrong. Reference specific turns, tool calls, or outputs where possible.
+
+### `## Root cause hypotheses`
+
+A ranked list (most likely first). Each hypothesis must name a category:
+
+- **Ambiguous instruction** — the user or system prompt underspecified a requirement.
+- **Missing guardrail** — no rule existed to prevent the failure mode.
+- **Tool-description gap** — a tool's description was unclear, missing a constraint, or actively misleading.
+- **Skill-body issue** — a skill's SKILL.md produced unintended behavior.
+- **LLM quirk** — model-level tendency (over-eagerness, sycophancy, context loss, pattern-matching a wrong template).
+- **Missing capability** — the agent lacked a needed tool, data source, or skill.
+- **User-facing ambiguity** — the UI or command surface let the user form a wrong mental model.
+
+Each hypothesis: one line naming the category, then one line of evidence from the conversation.
+
+### `## Proposed patches`
+
+Specific, minimal, testable changes. Each patch must name the artifact being changed (file path, tool name, AGENT.md line, skill name) and what exactly to change. Examples of acceptable specificity:
+
+- "Add a line to AGENT.md under 'Tool use' saying: …"
+- "Tighten the `web_fetch` tool description: add 'Prefer workspace_read when the URL is a local path.'"
+- "Create a new `foo` skill that …"
+
+Not acceptable: "the agent should be more careful", "improve the prompt", "rewrite the tool".
+
+### `## Systemic vs session-specific`
+
+For each proposed patch, tag it as:
+
+- **Systemic** — a change to the codebase (code, SKILL.md, AGENT.md, tool description, docs).
+- **Session-specific** — already handled in this conversation; no codebase change needed.
+
+### `## Next steps`
+
+A short bulleted list of decisions the user needs to make: accept/reject each proposed patch, file an issue, add an eval case, etc. Do not act on any of them — just surface them.
+
+## Persistence
+
+After producing the report (and only after), write it to the vault so it can be consolidated later by the dream/garden processes.
+
+1. Call `current_time` to get the current timestamp.
+2. Derive a short kebab-case slug from the anomaly (3–5 words).
+3. Call `vault_write` with:
+   - **path**: `agent/pages/postmortems/{YYYY-MM-DD-HHMM}-{slug}.md`
+   - **content**: the report, prefixed with YAML frontmatter:
+
+     ```yaml
+     ---
+     tags: [postmortem]
+     importance: 0.6
+     summary: <one-sentence anomaly summary>
+     ---
+     ```
+
+   - Append a `## Sources` section to the bottom referencing the conversation (ID if available, else a brief description of the session).
+
+## Delivery and stop
+
+1. Deliver the report text in the assistant response (the vault page is for archival; the user still reads the report inline).
+2. End the turn. Do not re-engage with the original task. If the user wants to act on a proposed patch, they will ask in the next turn.


### PR DESCRIPTION
## Summary

- Bundled `postmortem` skill: user-invokable via `/postmortem` or `!postmortem`, produces a structured five-section blameless RCA (Anomaly / Root cause hypotheses / Proposed patches / Systemic vs session-specific / Next steps), archives the report to `agent/pages/postmortems/` so dream/garden can consolidate patterns over time.
- Eval harness now dispatches user-invokable commands end-to-end (was a pre-existing gap — raw input was going straight to `run_agent_turn`, so triggers like `/postmortem` were read as plain text). Unblocks evals for any skill with `user-invocable: true`.
- Eval case validates all five sections appear (via a single `(?s)` regex since `response_contains` is OR-matched) and that blameless framing ("I apologize", "my mistake", etc.) is absent.
- Docs: new `docs/postmortem-skill.md`, linked from the index, and bundled skills list in CLAUDE.md updated.

Session docs: `docs/dev-sessions/2026-04-17-2135-postmortem-skill/`.

Closes #279

## Test plan

- [x] `make lint` clean
- [x] `uv run python -m decafclaw.eval evals/postmortem.yaml` — passes on gemini-flash (default eval model)
- [ ] Manual smoke test in web UI: `/postmortem` against a conversation with repeated tool errors — confirm report structure, blameless framing, vault page written to `agent/pages/postmortems/`, agent stops without resuming the original task
- [ ] Try `$ARGUMENTS` path: `/postmortem on the wiki-search tool errors` narrows focus
- [ ] Confirm agent picks up the new bundled skill after restart (or live if the dev loop hot-reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)