### PR TITLE
Ingest skill: one-shot URL / file / attachment ingestion into the vault

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - `src/decafclaw/skills/claude_code/` — Claude Code subagent skill (sessions, permissions, output logging)
 - `src/decafclaw/skills/health/` — Bundled `!health` command: agent diagnostic status
 - `src/decafclaw/skills/postmortem/` — Bundled `!postmortem` command: blameless RCA on the current conversation, archives report to vault
+- `src/decafclaw/skills/ingest/` — Bundled `!ingest` command: one-shot ingest of URL/workspace-file/attachment into vault pages; interactive counterpart to contrib scheduled ingest skills
 - `src/decafclaw/skills/background/` — Background process management skill. Bundled, auto-activates.
 - `src/decafclaw/skills/mcp/` — MCP admin skill (status, resources, prompts, restart). Bundled, auto-activates.
 

--- a/docs/dev-sessions/2026-04-19-1034-ingest-skill/notes.md
+++ b/docs/dev-sessions/2026-04-19-1034-ingest-skill/notes.md
@@ -1,0 +1,57 @@
+# Notes: /ingest skill
+
+Filled in during/after execution.
+
+## Decisions (2026-04-19)
+
+- Accepts URL, workspace file, attachment. No pasted text, no multi-URL.
+- Agent picks the folder (no forced prefix like bookmarks/ or mastodon/).
+- Agent picks the fetch mechanism. Tabstack first for URLs, web_fetch fallback.
+- Cap total pages touched at ~5 per ingest.
+- End turn after change summary.
+- No `log.md` / `index.md` integration (deferred to #288, #289).
+- Cross-graph link backfill stays with garden (#287).
+
+## Verifications (pre-execute)
+
+- Tool names confirmed: `workspace_read`, `web_fetch`, `tabstack_extract_markdown`, `list_attachments`, `get_attachment`.
+- Binary (PDF etc.) attachments return only base64 metadata from `get_attachment` — skill body explicitly notes this limitation and tells the agent to stop.
+
+## Surprises / pivots
+
+- **`workspace/` prefix double-application.** First eval pass failed with
+  a not-found because `workspace_read(path="workspace/imports/foo.md")`
+  resolves to `{workspace_path}/workspace/imports/foo.md`. The tool
+  expects paths relative to the workspace root. Fixed in the SKILL.md
+  with an explicit "strip the leading `workspace/` prefix" instruction
+  and an example.
+- **Eval-harness gap: no workspace-file fixtures.** `_setup_workspace`
+  only supported embeddings and journal memories. Added a
+  `setup.workspace_files` map (`path: content`) — small surgical
+  extension, same justification as the dispatch_command fix in the
+  postmortem session. Unblocks any eval that needs arbitrary seed files.
+- **First passing run was clean.** gemini-flash chose a sensible folder
+  (`agent/pages/tools/ripgrep`, inferred) and produced the expected
+  change-summary shape on one shot. No body tuning needed for the
+  workspace-file path — the real tuning signal will come from Les's
+  manual URL and attachment smoke tests.
+
+## What's still open (for Les)
+
+- **URL path.** Tabstack happy path + fallback to web_fetch on failure.
+  Eval can't cover this reliably.
+- **Attachment path.** Web UI upload → `/ingest` with no args or with a
+  filename. Needs manual smoke test.
+- **Focus arg effect.** Does `— focus on X` visibly shape output tone?
+- **Folder sprawl check.** After a few ingests, does the agent pick
+  coherent folders or spray singletons?
+
+## Final summary
+
+Shipped v1 of the `ingest` skill: user-invokable via `/ingest` and
+`!ingest`, accepts URL / workspace file / attachment (one source per
+invocation), agent-chosen fetch mechanism and output folder, up to ~5
+pages touched per ingest, ends the turn with a change summary. Eval
+covers the workspace-file path on the default model. Side benefit: eval
+harness now supports arbitrary workspace-file fixtures via
+`setup.workspace_files`.

--- a/docs/dev-sessions/2026-04-19-1034-ingest-skill/plan.md
+++ b/docs/dev-sessions/2026-04-19-1034-ingest-skill/plan.md
@@ -1,0 +1,92 @@
+# Plan: `/ingest` skill
+
+Spec: [spec.md](./spec.md). Decisions locked after brainstorm.
+
+Branch: `session/ingest-skill` (checked out).
+
+## Pre-flight (verified or deferred)
+
+- Bundled skill discovery: auto via `src/decafclaw/skills/__init__.py` (confirmed in postmortem session).
+- `context: inline` + `$ARGUMENTS` semantics: confirmed in postmortem session.
+- `vault_write` param name is `page`, auto-creates parent folders: confirmed.
+- Eval harness now dispatches `/` commands end-to-end (shipped in PR #284).
+- Workspace-file fetch: `workspace_read` tool name needs verification during Phase 1.
+- Attachment syntax for `$ARGUMENTS`: the spec assumes `@attachment:foo.pdf` may not be the right convention. Alternative: empty `$ARGUMENTS` + `list_attachments` triggers attachment flow. Verify during Phase 1 — if the convention is unclear, drop any `@attachment:` syntax from the body and rely on `list_attachments` heuristic.
+- Binary attachments (PDF, images) in `get_attachment`: behavior unverified. If bytes-only, the skill body acknowledges the limitation. If PDF text extraction exists, incorporate.
+- Les has `make dev` running; I will not start a second bot instance.
+
+## Phase 1: Skill scaffold
+
+1. Create `src/decafclaw/skills/ingest/SKILL.md`.
+2. Frontmatter:
+   ```yaml
+   name: ingest
+   description: Fetch a URL, workspace file, or attachment and integrate its content into the vault — one primary page plus linked updates
+   user-invocable: true
+   context: inline
+   required-skills:
+     - tabstack
+   allowed-tools: tabstack_extract_markdown, web_fetch, workspace_read, list_attachments, get_attachment, vault_search, vault_read, vault_write, vault_list, vault_backlinks, current_time
+   ```
+3. Before writing the body, grep to confirm tool names: `workspace_read` / `workspace_read_file` / other. Adjust `allowed-tools` to match reality.
+4. Body follows the synthesis workflow in the spec, written in second-person imperative (inline context makes the body a user-voiced instruction). Keep prose tight — this is a control surface.
+
+**Verify**: `make lint`; skill shows up in the catalog (needs agent restart in dev).
+
+**Commit**: `feat: bundle ingest skill (scaffold)`.
+
+## Phase 2: Eval — workspace-file ingest
+
+The workspace-file path is the one we can test reliably in evals. URL fetching is flaky; attachment flow needs web UI plumbing. Focus the eval on workspace-file ingest.
+
+1. Create `evals/ingest.yaml`.
+2. Eval setup should seed a workspace file with known content. Check whether `_setup_workspace` supports this; if not, extend it with a `workspace_files:` fixture (dict of `path: content`). This is a small harness change on the same justification as the `dispatch_command` fix — but only if needed. First preference: work with what we have.
+3. Eval assertion: after `/ingest workspace/<fixture>.md`, check:
+   - At least one `vault_write` call.
+   - Response contains a "Primary page" reference (by regex).
+   - Response contains a `## Sources` section written to the vault (check via `workspace_read` in a follow-up turn, or assert on the response text).
+   - No apology/error phrasing.
+   - `max_tool_calls` with generous headroom (ingest is multi-step).
+4. Run: `uv run python -m decafclaw.eval evals/ingest.yaml`.
+5. Tune skill body if assertions fail; the body is the control surface.
+
+**Verify**: eval passes.
+
+**Commit**: `test: eval case for ingest skill` (possibly combined with workspace_files fixture addition).
+
+## Phase 3: Docs
+
+1. Create `docs/ingest-skill.md` describing: purpose, input shapes, fetch mechanism selection, output folder policy, relationship to `linkding-ingest` / `mastodon-ingest` / `garden`, deferred pairings (#287/#288/#289).
+2. Add an entry to `docs/index.md` in the Tools & Skills section.
+3. Update `CLAUDE.md` bundled skills list.
+
+**Verify**: `make lint` still clean.
+
+**Commit**: `docs: ingest skill`.
+
+## Phase 4: PR + session notes
+
+1. Fill in `notes.md` with what needed tuning, any surprises, what's still open.
+2. Push, open PR with a test-plan checklist covering:
+   - Workspace file path (eval-covered)
+   - URL fetch (Les tests live; tabstack happy path + failure fallback to web_fetch)
+   - Attachment upload via web UI
+   - Focus arg effect on output
+   - Verify no writes outside `agent/pages/`
+3. Link deferred issues (#287, #288, #289) in the PR body so their relation to this skill is traceable.
+
+## Out of scope
+
+- Multiple URLs per invocation (see spec non-goals).
+- Pasted text as source.
+- `log.md` / `index.md` integration (#289 / #288).
+- Cross-graph link backfill (#287).
+- Scheduled operation (owned by aggregator-ingest skills).
+
+## Risks
+
+- **Skill body drift**: prompt wording is the whole feature. Eval is the guardrail. Expect 2–3 body tunings.
+- **Fetch-mechanism fallback**: if tabstack returns a soft error that looks like valid content, we write garbage. Step 3 of the workflow ("verify the fetched text looks like real content") is the mitigation. If this proves unreliable in Phase 2, add a regex check for common error strings.
+- **Folder sprawl**: "agent chooses a folder" can produce many singleton folders. Document the preference for existing folders; garden will eventually consolidate. Acceptable v1 risk.
+- **Multi-page updates in one turn**: exceeding the 5-page cap is a drift risk if the source is dense. Watch in Phase 2; tighten wording if it over-runs.
+- **Binary attachments**: if `get_attachment` returns bytes for PDFs, the skill fails silently. Phase 1 verification should make this visible.

--- a/docs/dev-sessions/2026-04-19-1034-ingest-skill/spec.md
+++ b/docs/dev-sessions/2026-04-19-1034-ingest-skill/spec.md
@@ -1,0 +1,145 @@
+# Spec: `/ingest` skill — interactive one-shot ingestion
+
+Tracking discussion: follow-up to the karpathy LLM-wiki analysis. Pairs with deferred issues #287 (garden lint), #288 (index.md), #289 (log.md).
+
+## Problem
+
+Our existing ingest skills (`linkding-ingest`, `mastodon-ingest`) are scheduled firehose-style: they pull from an aggregator on cron, filter for signal, and synthesize into per-source folders. We don't have the **interactive one-shot** mode — "I just came across this, file it away" — which karpathy's doc frames as the primary human-LLM wiki workflow.
+
+The gap costs us: one-off reading doesn't get captured unless the user bookmarks it first (linkding-ingest) or posts about it on Mastodon (mastodon-ingest). Direct "process this now" ingestion is missing.
+
+## Goal
+
+Ship a bundled `ingest` skill that is:
+
+- **User-invokable**: `/ingest <source>` in web UI, `!ingest <source>` in Mattermost.
+- **Multi-input**: accepts URL, workspace file path, or file attachment. One source per invocation.
+- **Self-directing**: the agent picks the fetch mechanism, extracts content, searches the existing vault, and decides the output folder.
+- **Multi-page capable**: a single ingest can create one primary page and update multiple related pages. Cross-graph link refinement is out of scope (handled by the scheduled `garden` skill).
+- **Terminal**: after writing, the agent delivers a summary of changes and ends the turn. User drives any follow-up.
+
+## Non-goals
+
+- **Multiple URLs per invocation.** One source per call. User invokes again for a second source.
+- **Pasted text as a source.** Tricky to distinguish from user instructions; skip for v1.
+- **`log.md` / `index.md` updates.** Deferred to #288 and #289. This skill ships without them; if they land later, the ingest skill body grows to call them.
+- **Cross-graph link backfill.** Identifying missing `[[wiki-links]]` across the whole vault after ingestion is the `garden` skill's job (and #287 expands it). This skill only adds links to pages it directly touches.
+- **Scheduled operation.** This is interactive-only. Scheduled ingest is covered by linkding-ingest, mastodon-ingest, and future contrib skills.
+- **Source-specific optimization.** Unlike linkding-ingest (which enforces `agent/pages/bookmarks/`) or mastodon-ingest (which enforces `agent/pages/mastodon/`), `/ingest` is generic. Agent chooses folder based on content.
+
+## Design
+
+### Invocation shapes
+
+```
+/ingest https://example.com/article
+/ingest workspace/inbox/paper.md
+/ingest @attachment:meeting-notes.pdf     # attachment form (exact syntax TBD, see Phase 1)
+/ingest <source> [— optional free-text focus]
+```
+
+Examples of focus arg:
+
+```
+/ingest https://example.com/post — focus on the security implications
+/ingest workspace/imports/rfc.md — compare against our current auth design
+```
+
+The agent parses `$ARGUMENTS` to determine the input type and focus. Heuristics (for the skill body):
+
+- Starts with `http://` or `https://` → URL.
+- Starts with `workspace/` or is an existing file path → workspace file.
+- Bare filename with no slashes → try `list_attachments` to resolve.
+- Anything after ` — ` or `; ` in `$ARGUMENTS` is free-text focus.
+
+### Fetch mechanism
+
+Agent chooses. In the skill body we list the options and guidance:
+
+- URLs: try `tabstack_extract_markdown` first for article-style pages. Fall back to `web_fetch` if tabstack errors (rate-limited, unsupported site, credits exhausted).
+- Workspace files: `workspace_read`.
+- Attachments: `get_attachment(filename)`.
+
+Agent decides; the body doesn't hardcode a first-try order in a way that blocks recovery.
+
+### Synthesis workflow (skill body)
+
+Structured as a short checklist the agent follows:
+
+1. **Identify the source.** Parse `$ARGUMENTS`. If empty, call `list_attachments` and use the most recent attachment. Confirm what you're about to fetch (one short line for the user).
+2. **Fetch.** Use the appropriate tool. If it fails, report the error and stop — do not fabricate content. For large sources (long articles, multi-page PDFs), extract the core claims and notable details; don't attempt to mirror the whole thing into the vault.
+3. **Understand.** Read the fetched content. Note the main topic, key entities, and any specific claims worth preserving. Verify the fetched text looks like real content, not an error page or stub.
+4. **Search the vault.** Use `vault_search` (and `vault_list` if needed) to find existing pages that relate to this source's topics. Typical hits: a page on the primary topic, pages on entities/concepts the source references. **If a page on the exact source or its primary topic already exists, treat it as the primary page and update in place** — do not create a duplicate with a different slug.
+5. **Plan the updates.** Decide:
+   - One primary page: update existing if match is strong, or create a new page with a topical folder chosen by the agent (e.g. `agent/pages/tools/ripgrep`, `agent/pages/papers/attention-is-all-you-need`, `agent/pages/people/karpathy`).
+   - Zero or more secondary pages: related pages that should be updated with a sentence or cross-link, not rewritten wholesale.
+   - **Cap at ~5 pages total (primary + secondary).** If more seem relevant, note them in the summary as candidates for the next garden run rather than touching them this turn.
+6. **Write.** For each planned update, `vault_read` → revise → `vault_write`. For each new page, `vault_write` with:
+   - YAML frontmatter (`tags` including at least `ingested` for the primary, `summary`, optionally `importance`).
+   - Body with `[[wiki-links]]` to related pages touched in this ingest.
+   - `## Sources` section with the URL, date (from `current_time`), and any relevant attribution.
+   - **Prefer synthesis in your own words over direct quotation.** If you quote, attribute inline and keep quotes short.
+7. **Summarize.** Deliver a change summary to the user:
+   ```
+   Ingested: <source>
+   Primary page: [[Name]] (new | updated)
+   Secondary updates: [[A]], [[B]]
+   (Other pages that might benefit: [[C]], [[D]] — deferred to the next garden pass)
+   ```
+   Then stop. Do not re-engage unless asked.
+
+### Focus arg semantics
+
+When a focus is supplied (e.g. `— focus on the security implications`), it shapes the **content and emphasis** of the written pages — what gets pulled out of the source, which claims are foregrounded. It does **not** override folder choice: a paper on transformers stays under `agent/pages/papers/`, even with a focus on the history of AI.
+
+### Frontmatter
+
+- Primary page gets `tags: [ingested, ...topic-tags]` and a one-line `summary:` field. (`summary` aligns with frontmatter we already support — #288 may later use it for an index.)
+- Secondary page updates do not add an `ingested` tag; they already have their own identity.
+
+### Output folder policy
+
+- Agent-chosen, based on content. No forced prefix.
+- Prefer existing folders (`agent/pages/tools/`, `agent/pages/people/`, `agent/pages/papers/`) if they exist and fit.
+- Create a new subfolder if the topic is distinct and likely to grow.
+- Do NOT write outside `agent/pages/`. (The vault skill enforces agent-folder writes already; the ingest body should not override.)
+
+### Pre-approved tools
+
+```
+tabstack_extract_markdown, web_fetch, workspace_read,
+list_attachments, get_attachment,
+vault_search, vault_read, vault_write, vault_list, vault_backlinks,
+current_time
+```
+
+Rationale: the skill needs all three fetch paths, the full vault CRUD surface, and timestamping. Pre-approval avoids mid-ritual confirmation prompts.
+
+### Required skills
+
+- `tabstack` (for `tabstack_extract_markdown`) — auto-activated when the skill runs.
+- `vault` is always-loaded, no declaration needed.
+
+### Context mode
+
+`inline`. The user may have conversational context that should shape the ingest ("focus on the security angle", "this is for the decafclaw project"). Fork mode would drop that.
+
+### Turn boundary
+
+End of turn after the summary. Matches postmortem. User follows up in the next turn if they want more work done (expand a page, add more sources, etc.).
+
+## Open items for Phase 1 verification
+
+- **Attachment reference syntax.** `/ingest @attachment:foo.pdf` is a guess. Need to confirm what the actual convention is, or whether the agent should just inspect `list_attachments` when `$ARGUMENTS` is empty or a bare filename. Worst case: drop the `@attachment:` syntax and let the agent figure it out via `list_attachments`.
+- **Focus arg delimiter.** ` — ` is nicer but em-dash input is awkward. `; ` or `|` might be better. Cheap to adjust.
+- **Tabstack availability detection.** We assume the agent will see a failure and fall back. If tabstack returns a soft error that the agent interprets as success, we get garbage. Skill body should include a "verify the content looks like a real article, not an error message" check.
+
+## Acceptance
+
+- `/ingest <url>` fetches the URL, writes a primary page under `agent/pages/`, optionally updates related pages, and ends the turn with a change summary.
+- `/ingest <workspace/path>` reads a workspace file and produces the same output.
+- `/ingest <attachment>` works for a file uploaded in the web UI.
+- Focus arg, when provided, visibly shapes the output (e.g. a focus on "security implications" produces a security-angled summary).
+- No writes outside `agent/pages/`.
+- Eval case validates the end-to-end ingest-from-workspace-file path with a seeded fixture (URL fetching is flaky in evals).
+- `docs/ingest-skill.md` documents the skill.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@
 - [User Commands](commands.md) — User-invokable commands (!command / /command) with argument substitution
 - [Project Skill](project-skill.md) — Structured workflow: brainstorm → spec → plan → execute for multi-step tasks
 - [Postmortem Skill](postmortem-skill.md) — User-invokable blameless RCA: structured report on what went wrong, archived to the vault
+- [Ingest Skill](ingest-skill.md) — User-invokable one-shot ingestion: fetch a URL/file/attachment, synthesize it into vault pages
 - [File Attachments](file-attachments.md) — Upload files, MCP media, workspace image refs, rich cards
 
 ## Agent Behavior

--- a/docs/ingest-skill.md
+++ b/docs/ingest-skill.md
@@ -1,0 +1,100 @@
+# Ingest Skill
+
+User-invokable skill for one-shot ingestion of an external source into the
+vault. Fetches the source, synthesizes it in the agent's own words, and
+writes one primary page plus optional cross-linked updates to related
+pages. Interactive counterpart to the scheduled
+[linkding-ingest](https://github.com/lmorchard/decafclaw/blob/main/contrib/skills/linkding-ingest/SKILL.md)
+and
+[mastodon-ingest](https://github.com/lmorchard/decafclaw/blob/main/contrib/skills/mastodon-ingest/SKILL.md)
+contrib skills — when you come across a single thing and want it captured
+right now.
+
+## Triggers
+
+- Mattermost: `!ingest <source>`
+- Web UI / terminal: `/ingest <source>`
+
+## Input shapes
+
+| Form | Example |
+|------|---------|
+| URL | `/ingest https://example.com/article` |
+| Workspace file | `/ingest workspace/imports/paper.md` |
+| Attachment | Upload a file in the web UI, then `/ingest` (or `/ingest <filename>`) |
+
+Optional focus instruction, separated by ` — `:
+
+```
+/ingest https://example.com/post — focus on the security implications
+```
+
+The focus shapes the content emphasis of the written pages — what gets
+pulled out and foregrounded. It does not override folder choice.
+
+## Fetch mechanism
+
+The agent picks the right tool for the source type:
+
+- **URL**: tries `tabstack_extract_markdown` first. Falls back to
+  `web_fetch` if tabstack fails (rate limit, unsupported site, credits
+  exhausted). The agent stops if what came back looks like an error page
+  or stub rather than real content — it won't fabricate.
+- **Workspace file**: `workspace_read`.
+- **Attachment**: `get_attachment`. Text files return content; images
+  return media. Other binary formats (PDF, etc.) currently return only
+  base64 metadata — the skill reports the limitation and stops. Extract
+  text yourself and pass a workspace file for those.
+
+## Output
+
+One primary page plus zero or more secondary updates, capped at ~5 pages
+total. Writes stay under `agent/pages/`.
+
+- **Primary page**: a new page created by the agent in a topical folder
+  of its choice (`agent/pages/tools/`, `agent/pages/papers/`,
+  `agent/pages/people/`, etc.), OR an existing page updated in place if
+  the vault already has a strong match. Includes YAML frontmatter with
+  `tags` (including `ingested`), a `summary` line, `[[wiki-links]]` to
+  related pages, and a `## Sources` section.
+- **Secondary updates**: related pages that gain a sentence or a
+  cross-link. Not rewritten wholesale.
+- **Deferred candidates**: if the source touches more than ~5 pages, the
+  extras are listed in the change summary as candidates for the next
+  [garden](https://github.com/lmorchard/decafclaw/blob/main/src/decafclaw/skills/garden/SKILL.md)
+  pass rather than edited this turn. Cross-graph link backfill is
+  garden's job.
+
+After writing, the agent ends the turn with a change summary:
+
+```
+Ingested: <source>
+Primary page: [[Name]] (new | updated)
+Secondary updates: [[A]], [[B]]
+(Candidates for the next garden pass: [[C]], [[D]])
+```
+
+You follow up in a new turn if you want to expand a page, add more
+sources, or trigger garden.
+
+## Non-goals
+
+- **No multi-URL ingest.** One source per invocation. Run it again for
+  the next.
+- **No pasted text as source.** The source is a reference (URL, path, or
+  attachment), not inline body text.
+- **No `log.md` append yet.** Per-ingest structured log entries are
+  tracked in [#289](https://github.com/lmorchard/decafclaw/issues/289).
+- **No index.md update yet.** LLM-maintained catalog of pages is tracked
+  in [#288](https://github.com/lmorchard/decafclaw/issues/288).
+- **No cross-vault link refinement.** Identifying `[[wiki-links]]` that
+  should exist across pages untouched by this ingest is garden's job;
+  [#287](https://github.com/lmorchard/decafclaw/issues/287) expands
+  garden with contradiction / stale-claim / data-gap detection.
+
+## Related
+
+- [vault](./vault.md) — the knowledge base this skill writes into.
+- [garden](https://github.com/lmorchard/decafclaw/blob/main/src/decafclaw/skills/garden/SKILL.md) — structural maintenance sweep that follows ingest activity.
+- [dream](./dream-consolidation.md) — episodic consolidation (journal → pages).
+- karpathy's LLM wiki pattern — the design inspiration.

--- a/evals/ingest.yaml
+++ b/evals/ingest.yaml
@@ -1,0 +1,36 @@
+# Evals for the ingest skill.
+# Focuses on the workspace-file ingest path — URL fetching is flaky in evals
+# and the attachment flow needs web UI plumbing. Les will test those paths
+# manually.
+
+- name: "ingest workspace file produces primary page + change summary"
+  setup:
+    skills: [ingest]
+    workspace_files:
+      imports/ripgrep-notes.md: |
+        # ripgrep (rg)
+
+        ripgrep is a recursive, line-based search tool written in Rust. It
+        respects `.gitignore` by default and uses SIMD-optimized regex
+        matching via the regex crate.
+
+        Notable technical choices:
+        - Uses memchr for SIMD-accelerated literal scanning.
+        - Parallel directory traversal via the ignore crate.
+        - Per-thread buffered writers to avoid output contention.
+
+        ripgrep is commonly compared to `ag` (The Silver Searcher) and
+        `ack`; benchmarks consistently show rg winning on large trees
+        with gitignore-heavy repos.
+
+        Original author: Andrew Gallant (BurntSushi). License: MIT/Unlicense.
+  input: "/ingest workspace/imports/ripgrep-notes.md"
+  expect:
+    response_contains:
+      - "re:(?is)ingested:.*ripgrep-notes\\.md.*primary page.*\\[\\[.*\\]\\]"
+    response_not_contains:
+      - "I apologize"
+      - "I'm sorry"
+      - "[error"
+    max_tool_calls: 12
+    max_tool_errors: 0

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -52,6 +52,21 @@ async def _setup_workspace(config, test_case: dict):
             shutil.copy2(fixture_path, dest)
             log.info(f"Copied embeddings fixture from {fixture_path}")
 
+    # Seed arbitrary workspace files (path → content). Parent dirs created.
+    # Sandbox-check each path — absolute paths and `..` escapes would otherwise
+    # let a test fixture clobber files outside the temp workspace on the runner.
+    workspace_files = setup.get("workspace_files", {})
+    workspace_root = config.workspace_path.resolve()
+    for rel_path, content in workspace_files.items():
+        rel = Path(rel_path)
+        if rel.is_absolute():
+            raise ValueError(f"workspace_files path must be relative: {rel_path}")
+        dest = (config.workspace_path / rel).resolve()
+        if not dest.is_relative_to(workspace_root):
+            raise ValueError(f"workspace_files path escapes workspace: {rel_path}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+
     # Save journal entries (replaces memories)
     memories = setup.get("memories", [])
     if memories:

--- a/src/decafclaw/skills/ingest/SKILL.md
+++ b/src/decafclaw/skills/ingest/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: ingest
+description: Fetch a URL, workspace file, or attachment and integrate its content into the vault — one primary page plus cross-linked updates to related pages
+user-invocable: true
+context: inline
+required-skills:
+  - tabstack
+allowed-tools: tabstack_extract_markdown, web_fetch, workspace_read, list_attachments, get_attachment, vault_search, vault_read, vault_write, vault_list, vault_backlinks, current_time
+---
+
+# Ingest
+
+You are processing a single source into the vault. One source in, a handful of pages out. Stop when done — do not re-engage with the prior conversation unless the user asks in a new turn.
+
+The source is in `$ARGUMENTS`. Parse it:
+
+- Starts with `http://` or `https://` → URL.
+- Starts with `workspace/`, or otherwise contains a `/` and therefore names a relative path → workspace file.
+- No `$ARGUMENTS` at all, or a bare filename with no `/` → attachment. Call `list_attachments`; if there is exactly one, use it; if there are several, use the most recent and mention the choice; if none, report the error and stop.
+- A ` — ` separator splits the source from an optional focus instruction (e.g. `https://... — focus on the security angle`). The focus shapes the content emphasis of what you write; it does NOT override the output folder.
+
+Announce the source in one short line before you start (e.g. "Ingesting: https://example.com/article").
+
+## Step 1: Fetch
+
+Pick the right tool for the source type:
+
+- **URL**: try `tabstack_extract_markdown` first. If it errors (rate limit, unsupported site, credits exhausted), fall back to `web_fetch`. Inspect the returned content — if it looks like an error page, a stub, or unrelated boilerplate, report the failure and stop. Do not fabricate content.
+- **Workspace file**: `workspace_read(path=<path>)`. The `path` argument is relative to the workspace root — strip any leading `workspace/` prefix before calling. Example: `/ingest workspace/imports/paper.md` → `workspace_read(path="imports/paper.md")`.
+- **Attachment**: `get_attachment(filename=<name>)`. For text files this returns the content. For images it returns media. For other binary formats (PDF, etc.) it returns only base64 metadata — in that case, report "binary attachment not directly ingestible — please extract text first" and stop.
+
+For large sources, extract the core claims and notable details; don't try to mirror everything. A long paper becomes a page or two of distilled knowledge, not a wholesale copy.
+
+## Step 2: Understand
+
+Read the fetched content. Note:
+
+- The primary topic (what the source is fundamentally about).
+- Key entities (people, projects, tools, concepts) it references.
+- Specific claims, findings, or recommendations worth preserving.
+- Any focus instruction from `$ARGUMENTS` — let it shape what you foreground.
+
+## Step 3: Search the vault
+
+Use `vault_search` (and `vault_list` if you need to browse a folder) to find existing pages related to this source's topics. Cast a net wide enough to find:
+
+- A page on the primary topic (may exist under a different slug).
+- Pages on the major entities referenced.
+- Pages on the broader concepts it touches.
+
+**If a page on the exact source or its primary topic already exists, treat it as the primary page and update in place.** Do not create a duplicate at a different path.
+
+## Step 4: Plan the updates
+
+Decide what pages to touch:
+
+**All writes from this skill stay under `agent/pages/` — do not write to admin pages, user pages, or anywhere else in the vault.** If `vault_search` surfaces a strong match that lives outside `agent/pages/`, do NOT edit it; instead create or update a page under `agent/pages/` that links to it.
+
+- **One primary page** (required):
+  - If a strong match under `agent/pages/` exists, update it. Keep the existing path.
+  - Otherwise, create a new page under `agent/pages/`. Choose the subfolder based on content — prefer existing folders where they fit (`agent/pages/tools/`, `agent/pages/papers/`, `agent/pages/people/`, `agent/pages/projects/`, etc.). Create a new subfolder only when the topic is distinct and likely to grow.
+- **Zero or more secondary pages** (optional): related pages under `agent/pages/` that should get a sentence or a cross-link added. Do not rewrite them wholesale. Skip any related page that lives outside `agent/pages/`.
+- **Cap total pages at ~5** (primary + secondary). If more seem relevant, list them in the summary as candidates for the next garden pass rather than touching them this turn.
+
+## Step 5: Write
+
+For each planned update (all paths must start with `agent/pages/` — if you catch yourself about to write elsewhere, stop and reconsider):
+
+- `vault_read` the existing page, then revise and `vault_write` the updated content. Keep the existing path (still under `agent/pages/`).
+- For the new primary page, `vault_write(page=agent/pages/<subfolder>/<name>, content=...)` with:
+  - YAML frontmatter:
+    ```yaml
+    ---
+    tags: [ingested, <topic-tags>]
+    summary: <one-line summary of the page>
+    ---
+    ```
+  - Body that synthesizes the source in your own words. Add `[[wiki-links]]` to related pages you touched in this ingest.
+  - `## Sources` section at the bottom with the URL or file path and the current date (use `current_time`).
+
+Prefer synthesis over quotation. If you do quote, keep quotes short and attribute inline.
+
+## Step 6: Summarize and stop
+
+Deliver a change summary to the user in this shape:
+
+```
+Ingested: <source>
+Primary page: [[Name]] (new | updated)
+Secondary updates: [[A]], [[B]]
+(Candidates for the next garden pass: [[C]], [[D]])
+```
+
+Only include the parenthetical line if there are deferred candidates.
+
+Then stop. The user will tell you in a new turn if they want to expand a page, add more sources, or kick off a garden run.


### PR DESCRIPTION
## Summary

- Bundled `ingest` skill: user-invokable via `/ingest` or `!ingest`. Accepts URL, workspace file, or attachment (one source per invocation). Agent picks the fetch mechanism and the output folder. Produces one primary page plus up to ~4 linked secondary updates, all under `agent/pages/`. Ends the turn with a change summary.
- Interactive counterpart to the scheduled `contrib/skills/linkding-ingest` and `contrib/skills/mastodon-ingest` — fills the "I just came across this, file it away" workflow from karpathy's LLM-wiki pattern.
- Eval case covers the workspace-file path. URL and attachment paths need manual smoke testing in the web UI.
- Eval harness side-benefit: `setup.workspace_files` fixture map for seeding arbitrary files under the temp workspace (parallel to the `dispatch_command` addition in PR #284).

Deferred / complementary issues (intentionally out of scope):
- #287 — garden lint upgrades (contradictions, stale claims, data gaps)
- #288 — LLM-maintained `index.md` catalog
- #289 — structured `log.md` ingest log

Session docs: `docs/dev-sessions/2026-04-19-1034-ingest-skill/`.

## Test plan

- [x] `make lint` clean
- [x] `uv run python -m decafclaw.eval evals/ingest.yaml` — passes on gemini-flash
- [ ] **URL path (happy)**: `/ingest <some article URL>` — tabstack extracts content, agent creates a topical page under `agent/pages/` with sources section
- [ ] **URL path (fallback)**: point at something tabstack doesn't support (e.g. a GitHub README). Expect fallback to `web_fetch` or a graceful failure message; no fabrication
- [ ] **Workspace file path**: drop a markdown file into `workspace/imports/`, `/ingest workspace/imports/<file>` — confirm strip-prefix handling works in practice
- [ ] **Attachment path**: upload a small text file in the web UI, `/ingest` with no args or with the filename — confirm `list_attachments`/`get_attachment` flow
- [ ] **Binary attachment**: upload a PDF — confirm the skill reports the limitation and stops (does not fabricate)
- [ ] **Focus arg**: `/ingest <url> — focus on X` — confirm X visibly shapes the page content
- [ ] **Folder discipline**: after two or three varied ingests, check `agent/pages/` — agent picks reasonable folders, no writes outside `agent/pages/`
- [ ] **Idempotency**: run `/ingest <same url>` twice — second run updates the existing page rather than creating a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)