### PR TITLE
feat(vault): add vault_delete and vault_rename tools

### DIFF
--- a/src/decafclaw/skills/vault/SKILL.md
+++ b/src/decafclaw/skills/vault/SKILL.md
@@ -47,6 +47,8 @@ Your files live under `agent/` in the vault:
 
 - `vault_write` modifies files in the vault. Default to writing in `agent/pages/`.
 - Use `vault_read` before `vault_write` when updating existing pages — `vault_write` overwrites the entire page.
+- `vault_rename` renames or moves an existing page (updates the embedding index). Prefer it over delete + rewrite when the content stays the same.
+- `vault_delete` permanently removes a page. Only for pages you own (under `agent/`) that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged.
 - The user's files are readable but not yours to modify autonomously. Only edit user files when asked.
 
 ## Organizing with Folders

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -85,13 +85,24 @@ def resolve_page(config, page: str, from_page: str | None = None) -> Path | None
 def _safe_write_path(config, page: str) -> Path | None:
     """Validate and return a safe write path within the vault root.
 
-    Returns None if the path would escape the vault directory.
+    Returns None for invalid names (empty, trailing slash, path traversal)
+    or paths that would escape the vault directory.
     """
-    if ".." in page or page.startswith("/"):
+    if not isinstance(page, str):
+        return None
+    page = page.strip()
+    if not page:
+        return None
+    if ".." in page or page.startswith("/") or page.endswith("/"):
         return None
     # Strip .md suffix if the caller included it (prevents Foo.md.md)
     if page.endswith(".md"):
         page = page[:-3]
+    # After stripping, the final path component must still be a real name —
+    # reject inputs like "" / "foo/" / ".md" that would resolve to a hidden
+    # ".md" file with an empty stem.
+    if not Path(page).name:
+        return None
     vault = _vault_root(config).resolve()
     path = (vault / f"{page}.md").resolve()
     if not path.is_relative_to(vault):
@@ -178,6 +189,99 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
         log.warning(f"Failed to index vault page '{page}': {e}")
 
     return f"Vault page '{page}' saved."
+
+
+async def tool_vault_delete(ctx, page: str) -> ToolResult:
+    """Delete a vault page. Agent-owned pages only (under the agent folder)."""
+    log.info(f"[tool:vault_delete] page={page}")
+    path = _safe_write_path(ctx.config, page)
+    if path is None:
+        return ToolResult(
+            text=f"[error: invalid page name '{page}' — must be within vault directory]")
+    if not path.exists():
+        return ToolResult(text=f"[error: vault page '{page}' not found]")
+    if not _is_in_agent_dir(ctx.config, path):
+        return ToolResult(
+            text=f"[error: refusing to delete '{page}' — only pages under the agent folder may be deleted]")
+
+    vault_resolved = _vault_root(ctx.config).resolve()
+    rel_path = str(path.resolve().relative_to(vault_resolved))
+    source_type = _source_type_for_path(ctx.config, path)
+
+    path.unlink()
+
+    # Clean up empty parent directories up to (but not including) the vault root.
+    parent = path.parent
+    while parent.resolve() != vault_resolved:
+        try:
+            parent.rmdir()  # only succeeds if empty
+        except OSError:
+            break
+        parent = parent.parent
+
+    # Remove from embedding index
+    try:
+        from decafclaw.embeddings import delete_entries
+        delete_entries(ctx.config, rel_path, source_type=source_type)
+    except Exception as e:
+        log.warning(f"Failed to remove embeddings for '{page}': {e}")
+
+    return ToolResult(text=f"Vault page '{page}' deleted.")
+
+
+async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
+    """Rename or move a vault page. Agent-owned pages only."""
+    log.info(f"[tool:vault_rename] {page} -> {rename_to}")
+    old_path = _safe_write_path(ctx.config, page)
+    if old_path is None:
+        return ToolResult(
+            text=f"[error: invalid page name '{page}' — must be within vault directory]")
+    new_path = _safe_write_path(ctx.config, rename_to)
+    if new_path is None:
+        return ToolResult(
+            text=f"[error: invalid target '{rename_to}' — must be within vault directory]")
+    if not old_path.exists():
+        return ToolResult(text=f"[error: vault page '{page}' not found]")
+    if new_path.exists():
+        return ToolResult(text=f"[error: target '{rename_to}' already exists]")
+    if not _is_in_agent_dir(ctx.config, old_path):
+        return ToolResult(
+            text=f"[error: refusing to rename '{page}' — only pages under the agent folder may be renamed]")
+    if not _is_in_agent_dir(ctx.config, new_path):
+        return ToolResult(
+            text=f"[error: refusing to move '{page}' outside the agent folder]")
+
+    vault_resolved = _vault_root(ctx.config).resolve()
+    old_rel = str(old_path.resolve().relative_to(vault_resolved))
+    old_source_type = _source_type_for_path(ctx.config, old_path)
+
+    new_path.parent.mkdir(parents=True, exist_ok=True)
+    old_path.rename(new_path)
+
+    # Clean up empty parent directories of the old path (up to vault root).
+    parent = old_path.parent
+    while parent.resolve() != vault_resolved:
+        try:
+            parent.rmdir()
+        except OSError:
+            break
+        parent = parent.parent
+
+    # Re-index: drop the old entry and index the new one.
+    try:
+        from decafclaw.embeddings import delete_entries, index_entry
+        from decafclaw.frontmatter import build_composite_text, parse_frontmatter
+        delete_entries(ctx.config, old_rel, source_type=old_source_type)
+        new_rel = str(new_path.resolve().relative_to(vault_resolved))
+        new_source_type = _source_type_for_path(ctx.config, new_path)
+        new_content = new_path.read_text()
+        metadata, body = parse_frontmatter(new_content)
+        embed_text = build_composite_text(metadata, body)
+        await index_entry(ctx.config, new_rel, embed_text, source_type=new_source_type)
+    except Exception as e:
+        log.warning(f"Failed to re-index after rename '{page}' -> '{rename_to}': {e}")
+
+    return ToolResult(text=f"Vault page '{page}' renamed to '{rename_to}'.")
 
 
 async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> str:
@@ -426,6 +530,8 @@ async def tool_vault_backlinks(ctx, page: str) -> str:
 TOOLS = {
     "vault_read": tool_vault_read,
     "vault_write": tool_vault_write,
+    "vault_delete": tool_vault_delete,
+    "vault_rename": tool_vault_rename,
     "vault_journal_append": tool_vault_journal_append,
     "vault_search": tool_vault_search,
     "vault_list": tool_vault_list,
@@ -490,6 +596,68 @@ TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["page", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_delete",
+            "description": (
+                "DESTRUCTIVE — permanently delete a vault page and its embedding "
+                "entries. Only pages under the agent folder (agent/pages/, "
+                "agent/journal/) may be deleted; admin and user pages are "
+                "off-limits. Prefer vault_write with updated content to retire "
+                "or mark pages superseded; use delete only when the page is "
+                "definitively wrong, duplicate, or no longer reachable."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": (
+                            "Page path relative to vault root "
+                            "(e.g. 'agent/pages/Stale Draft')."
+                        ),
+                    },
+                },
+                "required": ["page"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_rename",
+            "description": (
+                "Rename or move a vault page. Updates the embedding index so "
+                "search results stay consistent. Agent-owned pages only (under "
+                "the agent folder); target must also land under the agent "
+                "folder and must not already exist. Use this to reorganize or "
+                "refine page names — prefer it over delete + rewrite when the "
+                "content stays the same."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": (
+                            "Current page path relative to vault root "
+                            "(e.g. 'agent/pages/old-name')."
+                        ),
+                    },
+                    "rename_to": {
+                        "type": "string",
+                        "description": (
+                            "New page path relative to vault root "
+                            "(e.g. 'agent/pages/new-name', or "
+                            "'agent/pages/people/Alice' to move into a subfolder)."
+                        ),
+                    },
+                },
+                "required": ["page", "rename_to"],
             },
         },
     },

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -7,9 +7,11 @@ import pytest
 from decafclaw.skills.vault.tools import (
     resolve_page,
     tool_vault_backlinks,
+    tool_vault_delete,
     tool_vault_journal_append,
     tool_vault_list,
     tool_vault_read,
+    tool_vault_rename,
     tool_vault_search,
     tool_vault_write,
 )
@@ -162,6 +164,172 @@ class TestVaultWrite:
         assert "saved" in result.lower() or "saved" in str(result).lower()
         assert (vault_dir / "agent" / "pages" / "Test.md").exists()
         assert not (vault_dir / "agent" / "pages" / "Test.md.md").exists()
+
+
+class TestVaultDelete:
+    @pytest.mark.asyncio
+    async def test_deletes_agent_page(self, ctx, agent_pages):
+        (agent_pages / "Stale.md").write_text("old")
+        with patch("decafclaw.embeddings.delete_entries") as mock_del:
+            result = await tool_vault_delete(ctx, "agent/pages/Stale")
+        assert "deleted" in result.text.lower()
+        assert not (agent_pages / "Stale.md").exists()
+        mock_del.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_empty_parent_dirs(self, ctx, vault_dir, config):
+        # Nested page with its own folder; folder should go away after delete.
+        pages = config.vault_agent_pages_dir
+        nested = pages / "people" / "obsolete"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "Alice.md").write_text("old")
+        with patch("decafclaw.embeddings.delete_entries"):
+            await tool_vault_delete(ctx, "agent/pages/people/obsolete/Alice")
+        assert not nested.exists()
+        # But the vault root itself must still exist
+        assert vault_dir.exists()
+
+    @pytest.mark.asyncio
+    async def test_rejects_page_outside_agent_dir(self, ctx, vault_dir):
+        # A page directly at the vault root is outside agent/
+        (vault_dir / "User Notes.md").write_text("mine")
+        result = await tool_vault_delete(ctx, "User Notes")
+        assert "error" in result.text.lower()
+        assert "agent folder" in result.text.lower()
+        assert (vault_dir / "User Notes.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_page(self, ctx, vault_dir):
+        result = await tool_vault_delete(ctx, "agent/pages/Never Existed")
+        assert "error" in result.text.lower()
+        assert "not found" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, ctx, vault_dir):
+        result = await tool_vault_delete(ctx, "../../../etc/passwd")
+        assert "error" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_strips_md_suffix(self, ctx, agent_pages):
+        (agent_pages / "Test.md").write_text("x")
+        with patch("decafclaw.embeddings.delete_entries"):
+            result = await tool_vault_delete(ctx, "agent/pages/Test.md")
+        assert "deleted" in result.text.lower()
+        assert not (agent_pages / "Test.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_page_name(self, ctx, vault_dir):
+        # A bare ".md" file at the vault root must NOT be matched by empty
+        # or trailing-slash inputs.
+        (vault_dir / ".md").write_text("hidden")
+        for bad in ["", "   ", "agent/pages/", ".md", "/"]:
+            result = await tool_vault_delete(ctx, bad)
+            assert "error" in result.text.lower(), f"bad input {bad!r} was accepted"
+        assert (vault_dir / ".md").exists()
+
+
+class TestVaultRename:
+    @pytest.mark.asyncio
+    async def test_renames_agent_page(self, ctx, agent_pages):
+        (agent_pages / "Old Name.md").write_text("body")
+        with patch("decafclaw.embeddings.delete_entries"), \
+             patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            result = await tool_vault_rename(
+                ctx, "agent/pages/Old Name", "agent/pages/New Name"
+            )
+        assert "renamed" in result.text.lower()
+        assert not (agent_pages / "Old Name.md").exists()
+        assert (agent_pages / "New Name.md").exists()
+        assert (agent_pages / "New Name.md").read_text() == "body"
+
+    @pytest.mark.asyncio
+    async def test_can_move_to_subfolder(self, ctx, agent_pages, config):
+        (agent_pages / "Alice.md").write_text("about alice")
+        with patch("decafclaw.embeddings.delete_entries"), \
+             patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_rename(
+                ctx, "agent/pages/Alice", "agent/pages/people/Alice"
+            )
+        assert not (agent_pages / "Alice.md").exists()
+        assert (agent_pages / "people" / "Alice.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_empty_parent_dirs(self, ctx, config):
+        pages = config.vault_agent_pages_dir
+        old_dir = pages / "stale-folder"
+        old_dir.mkdir(parents=True, exist_ok=True)
+        (old_dir / "Doc.md").write_text("x")
+        with patch("decafclaw.embeddings.delete_entries"), \
+             patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_rename(
+                ctx, "agent/pages/stale-folder/Doc", "agent/pages/Doc"
+            )
+        assert not old_dir.exists()
+        assert (pages / "Doc.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_refuses_to_clobber_existing(self, ctx, agent_pages):
+        (agent_pages / "A.md").write_text("a")
+        (agent_pages / "B.md").write_text("b")
+        result = await tool_vault_rename(
+            ctx, "agent/pages/A", "agent/pages/B"
+        )
+        assert "error" in result.text.lower()
+        assert "already exists" in result.text.lower()
+        # Neither file should be touched
+        assert (agent_pages / "A.md").read_text() == "a"
+        assert (agent_pages / "B.md").read_text() == "b"
+
+    @pytest.mark.asyncio
+    async def test_rejects_rename_outside_agent_dir(self, ctx, vault_dir, agent_pages):
+        (agent_pages / "Inside.md").write_text("x")
+        result = await tool_vault_rename(
+            ctx, "agent/pages/Inside", "Escaped"
+        )
+        assert "error" in result.text.lower()
+        assert "agent folder" in result.text.lower()
+        assert (agent_pages / "Inside.md").exists()
+        assert not (vault_dir / "Escaped.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_rejects_source_outside_agent_dir(self, ctx, vault_dir, agent_pages):
+        (vault_dir / "User Notes.md").write_text("mine")
+        result = await tool_vault_rename(
+            ctx, "User Notes", "agent/pages/Stolen"
+        )
+        assert "error" in result.text.lower()
+        assert (vault_dir / "User Notes.md").exists()
+        assert not (agent_pages / "Stolen.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_source(self, ctx, vault_dir):
+        result = await tool_vault_rename(
+            ctx, "agent/pages/Never Existed", "agent/pages/New"
+        )
+        assert "error" in result.text.lower()
+        assert "not found" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal(self, ctx, agent_pages):
+        (agent_pages / "Doc.md").write_text("x")
+        result = await tool_vault_rename(
+            ctx, "agent/pages/Doc", "../../../etc/passwd"
+        )
+        assert "error" in result.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_source_or_target(self, ctx, agent_pages):
+        (agent_pages / "Doc.md").write_text("x")
+        # Empty / trailing-slash / bare-".md" inputs on either side must be
+        # rejected so a rename can't land at a hidden ".md" file.
+        bad_values = ["", "   ", "agent/pages/", ".md"]
+        for bad in bad_values:
+            result = await tool_vault_rename(ctx, bad, "agent/pages/New")
+            assert "error" in result.text.lower(), f"bad source {bad!r} accepted"
+        for bad in bad_values:
+            result = await tool_vault_rename(ctx, "agent/pages/Doc", bad)
+            assert "error" in result.text.lower(), f"bad target {bad!r} accepted"
+        assert (agent_pages / "Doc.md").exists()
 
 
 class TestVaultJournalAppend:


### PR DESCRIPTION
## Summary

Closes #296.

The vault skill exposed read/write/search/list/backlinks + journal_append, but the agent had no way to delete or rename pages — noticed during a scheduled task that wanted to tidy up stale pages. The REST endpoints already existed for the web UI; these tools are thin wrappers reusing the same sandboxing rules.

- `vault_delete(page)` — unlink the page, clean empty parent dirs, remove embedding entries.
- `vault_rename(page, rename_to)` — rename/move with embedding re-index.

Both enforce agent-folder ownership: admin and user pages are off-limits on both sides of a rename. Target of a rename must not clobber an existing page.

Tool descriptions steer toward safe defaults: prefer rename over delete+rewrite when content stays the same; prefer editing over deleting when a page can be salvaged. SKILL.md "Boundaries" section updated.

## Test plan

- [x] `make check` — lint + pyright + tsc clean
- [x] 14 new unit tests (6 delete, 8 rename) covering sandbox, nonexistent, clobber, path traversal, empty-dir cleanup, and subfolder moves
- [x] Full test suite passing (one flaky unrelated Vertex integration test retried clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)