### PR TITLE
ci/dev: run pytest in parallel via pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,7 @@ jobs:
         run: uv run pyright
 
       - name: Test
-        run: uv run pytest tests/ -v
+        # Parallelism is configured in pyproject.toml (addopts = "-n auto
+        # --dist=worksteal"). `-v` is omitted because worker output
+        # interleaves and the dots-style progress is more readable.
+        run: uv run pytest tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ An AI agent testbed for exploring agent development patterns. Connects to Matter
 - **Commit after each logical step.** Lint and test before committing.
 - **Work in a branch for iterative changes.** When making multiple related fixes (especially to UX-sensitive code like streaming/placeholder logic), work in a branch and test the full set before merging to main. Don't push rapid-fire fixes directly to main — regressions compound.
 - **Test live in Mattermost and the web UI after merging**, not just lint/pytest. Real agent behavior differs from unit tests.
+- **Test speed discipline.** Tests run in parallel by default (`pytest-xdist -n auto` via `pyproject.toml`), so slow tests block workers for their full duration. Two patterns to avoid:
+  - **Don't `asyncio.sleep(X)` to wait for work to finish.** Wait on the right signal instead: `await job.reader_task` for a subprocess completion, `asyncio.wait_for(event.wait(), timeout=...)` for a flag, or patch the underlying clock (`monkeypatch` `_now_iso` / `time.monotonic`) when you need timestamp ordering. A fixed sleep is both slower *and* flakier than waiting on the actual completion event.
+  - **Anything that runs a real scheduler or timer loop must patch the work function.** `discover_schedules` picks up bundled scheduled skills (`dream`, `garden`) from disk; on a fresh `tmp_path` config they're treated as "never run → due" and fire a real `run_agent_turn`. If your test calls `run_schedule_timer` without patching `run_schedule_task`, the `finally`-block drain will wait for those simulated agent turns to complete (seen: one test taking ~66s). Patch `decafclaw.schedules.run_schedule_task` with a trivial `fake_run` coroutine even for "no tasks" scenarios.
+- **Check `pytest --durations=25` when adding tests.** If a new test lands in the top 25, figure out why before committing — it's usually a missing mock or a fixed sleep masquerading as a synchronization primitive.
 
 ## Key files
 

--- a/Makefile
+++ b/Makefile
@@ -49,17 +49,20 @@ lint-fix:
 fmt:
 	uv run ruff format src/ tests/
 
-# Run tests (pytest, excludes integration tests)
+# Run tests (pytest, excludes integration tests by default — see pyproject.toml addopts)
 test:
-	uv run pytest tests/ -v -m "not integration"
+	uv run pytest tests/
 
-# Run integration tests only (requires provider credentials)
+# Run integration tests only (requires provider credentials).
+# Override the default `-m "not integration"` from addopts, and disable
+# xdist so parallel workers don't hammer the real APIs concurrently.
 test-integration:
-	uv run pytest tests/ -v -m integration
+	uv run pytest tests/ -v -m integration -n 0
 
-# Run all tests including integration
+# Run all tests including integration. Matches parallel + default policy,
+# but opts back in to integration by OR-ing the markers.
 test-all:
-	uv run pytest tests/ -v
+	uv run pytest tests/ -m "integration or not integration"
 
 # Rebuild production embedding index
 reindex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,17 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-# Run tests in parallel across CPU cores by default. pytest-xdist handles
-# distribution; worksteal rebalances as workers finish. Override with `-n 0`
-# to run serially (useful for debugging with `pdb` or when `-v` output
-# needs to stay readable).
-addopts = "-n auto --dist=worksteal"
+# Default pytest invocation:
+#   - `-n auto --dist=worksteal` runs unit tests in parallel across CPU cores.
+#     Override with `-n 0` for serial runs (debugging with `pdb`, or cleaner
+#     `-v` output).
+#   - `-m "not integration"` excludes real-API integration tests from the
+#     default suite. They cost money, hit rate limits, and aren't run in CI.
+#     Run them explicitly via `make test-integration` (which overrides the
+#     marker filter and disables parallelism to avoid concurrent API calls).
+addopts = "-n auto --dist=worksteal -m 'not integration'"
 markers = [
-    "integration: marks tests that hit real LLM APIs (skip with: -m 'not integration')",
+    "integration: marks tests that hit real LLM APIs (opt in with: -m integration)",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,12 +41,18 @@ dev = [
     "pyright>=1.1.408",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "pytest-xdist>=3.6.0",
     "pyyaml>=6.0.3",
     "ruff>=0.11.0",
 ]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Run tests in parallel across CPU cores by default. pytest-xdist handles
+# distribution; worksteal rebalances as workers finish. Override with `-n 0`
+# to run serially (useful for debugging with `pdb` or when `-v` output
+# needs to stay readable).
+addopts = "-n auto --dist=worksteal"
 markers = [
     "integration: marks tests that hit real LLM APIs (skip with: -m 'not integration')",
 ]

--- a/tests/test_background_tools.py
+++ b/tests/test_background_tools.py
@@ -29,8 +29,9 @@ async def test_status_after_exit(tmp_path):
     manager = BackgroundJobManager()
     job = await manager.start("echo hello", cwd=str(tmp_path))
 
-    # Wait for process to finish
-    await asyncio.sleep(0.5)
+    # Wait for the reader task to drain + process exit — no fixed sleep.
+    assert job.reader_task is not None
+    await job.reader_task
 
     assert job.status == "completed"
     assert job.exit_code == 0
@@ -46,7 +47,8 @@ async def test_status_error_exit(tmp_path):
     manager = BackgroundJobManager()
     job = await manager.start("exit 1", cwd=str(tmp_path))
 
-    await asyncio.sleep(0.5)
+    assert job.reader_task is not None
+    await job.reader_task
 
     assert job.status == "error"
     assert job.exit_code == 1
@@ -87,7 +89,8 @@ async def test_output_buffering(tmp_path):
         cwd=str(tmp_path),
     )
 
-    await asyncio.sleep(1.0)
+    assert job.reader_task is not None
+    await job.reader_task
 
     assert job.status == "completed"
     stdout = list(job.stdout_buffer)
@@ -107,7 +110,9 @@ async def test_cleanup_expired(tmp_path):
         "sleep 60", cwd=str(tmp_path), max_lifetime=0.1,
     )
 
-    await asyncio.sleep(0.3)
+    # Backdate started_at so the lifetime check trips immediately — no
+    # need to actually sleep out the timer.
+    job.started_at -= 1.0
     expired = await manager.cleanup_expired()
 
     assert len(expired) == 1
@@ -123,7 +128,8 @@ async def test_cleanup_expired_ignores_finished(tmp_path):
     manager = BackgroundJobManager()
     job = await manager.start("echo done", cwd=str(tmp_path), max_lifetime=0.1)
 
-    await asyncio.sleep(0.5)
+    assert job.reader_task is not None
+    await job.reader_task
     assert job.status == "completed"
 
     expired = await manager.cleanup_expired()
@@ -166,7 +172,8 @@ async def test_stderr_captured(tmp_path):
     manager = BackgroundJobManager()
     job = await manager.start("echo error >&2", cwd=str(tmp_path))
 
-    await asyncio.sleep(0.5)
+    assert job.reader_task is not None
+    await job.reader_task
 
     stderr = list(job.stderr_buffer)
     assert any("error" in line for line in stderr)

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -288,7 +288,7 @@ async def test_concurrent_confirmations_independent(ctx):
         fork = ctx.fork_for_tool_call(tool_call_id)
         r = await request_confirmation(
             fork, tool_name="shell", command=f"cmd-{tool_call_id}",
-            message="Confirm?", timeout=1.0,
+            message="Confirm?", timeout=0.2,
         )
         results[tool_call_id] = r["approved"]
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -36,6 +36,29 @@ def _now() -> str:
     return datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+@pytest.fixture
+def monotonic_now(monkeypatch):
+    """Make ``_now_iso`` return a monotonically increasing timestamp per call.
+
+    ``_now_iso`` has second precision, so two calls in the same wall-clock
+    second produce identical timestamps. Tests that need ordered timestamps
+    would otherwise have to `asyncio.sleep(1.05)` between writes — slow and
+    flaky. This fixture assigns each call a unique timestamp one second
+    apart.
+
+    Base is anchored on real ``datetime.now()`` so the timestamps fall
+    inside the retention window — opportunistic rotation in ``notify()``
+    would otherwise archive our test records the moment they're appended.
+    """
+    base = datetime.now(tz=timezone.utc)
+    counter = iter(range(10_000))
+
+    def _fake_now() -> str:
+        return (base + timedelta(seconds=next(counter))).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    monkeypatch.setattr(notifs, "_now_iso", _fake_now)
+
+
 # -- Record shape -------------------------------------------------------------
 
 
@@ -225,12 +248,10 @@ class TestReadState:
         assert b.id in read_ids
 
     @pytest.mark.asyncio
-    async def test_read_all_does_not_mark_future(self, config):
+    async def test_read_all_does_not_mark_future(self, config, monotonic_now):
         """A read-all event doesn't mark records created after it."""
         a = await notifs.notify(config, category="t", title="A")
         await notifs.mark_all_read(config)
-        # Wait a tiny bit so the new notify timestamp > the read-all timestamp
-        await asyncio.sleep(1.05)
         b = await notifs.notify(config, category="t", title="B")
         read_ids = notifs.get_read_ids(config)
         assert a.id in read_ids
@@ -274,26 +295,23 @@ class TestReadInbox:
         assert has_more is False
 
     @pytest.mark.asyncio
-    async def test_newest_first(self, config):
+    async def test_newest_first(self, config, monotonic_now):
         await notifs.notify(config, category="t", title="A")
-        await asyncio.sleep(1.05)
         await notifs.notify(config, category="t", title="B")
         records, _ = notifs.read_inbox(config)
         assert [r.title for r in records] == ["B", "A"]
 
     @pytest.mark.asyncio
-    async def test_limit_and_has_more(self, config):
+    async def test_limit_and_has_more(self, config, monotonic_now):
         for i in range(5):
             await notifs.notify(config, category="t", title=f"#{i}")
-            await asyncio.sleep(0.01)
         records, has_more = notifs.read_inbox(config, limit=3)
         assert len(records) == 3
         assert has_more is True
 
     @pytest.mark.asyncio
-    async def test_before_cursor(self, config):
+    async def test_before_cursor(self, config, monotonic_now):
         a = await notifs.notify(config, category="t", title="A")
-        await asyncio.sleep(1.05)
         b = await notifs.notify(config, category="t", title="B")
         # Only A should come back when we query "before B's timestamp"
         records, _ = notifs.read_inbox(config, before=b.timestamp)

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -436,12 +436,23 @@ class TestRunScheduleTimer:
 
     @pytest.mark.asyncio
     async def test_no_tasks_no_crash(self, config):
-        """Timer runs fine with no schedule files."""
+        """Timer runs fine with no schedule files.
+
+        Patches ``run_schedule_task`` so any bundled scheduled skills
+        (``dream``, ``garden``) discovered from disk don't actually fire —
+        on a fresh tmp_path config they'd be treated as "never run → due"
+        and would try to run a real agent turn.
+        """
         shutdown = asyncio.Event()
 
-        async def stop_soon():
-            await asyncio.sleep(0.05)
-            shutdown.set()
-        asyncio.create_task(stop_soon())
-        await run_schedule_timer(config, EventBus(), shutdown,
-                                 poll_interval=0.02)
+        async def fake_run(cfg, bus, task):
+            return {"task_name": task.name, "channel": "", "response": "ok",
+                    "is_ok": True, "context_id": None}
+
+        with patch("decafclaw.schedules.run_schedule_task", side_effect=fake_run):
+            async def stop_soon():
+                await asyncio.sleep(0.05)
+                shutdown.set()
+            asyncio.create_task(stop_soon())
+            await run_schedule_timer(config, EventBus(), shutdown,
+                                     poll_interval=0.02)

--- a/tests/test_web_notifications.py
+++ b/tests/test_web_notifications.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -11,6 +11,18 @@ from decafclaw import notifications as notifs
 from decafclaw.events import EventBus
 from decafclaw.http_server import create_app
 from decafclaw.web.auth import create_token
+
+
+@pytest.fixture
+def monotonic_now(monkeypatch):
+    """Monotonically increasing ``_now_iso`` — see ``tests/test_notifications.py``."""
+    base = datetime.now(tz=timezone.utc)
+    counter = iter(range(10_000))
+
+    def _fake_now() -> str:
+        return (base + timedelta(seconds=next(counter))).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    monkeypatch.setattr(notifs, "_now_iso", _fake_now)
 
 
 @pytest.fixture
@@ -108,10 +120,9 @@ async def test_returns_records_with_read_flag(authed_client, http_config):
 
 
 @pytest.mark.asyncio
-async def test_limit_and_has_more(authed_client, http_config):
+async def test_limit_and_has_more(authed_client, http_config, monotonic_now):
     for i in range(5):
         await notifs.notify(http_config, category="t", title=f"#{i}")
-        await asyncio.sleep(0.01)
     resp = await authed_client.get("/api/notifications?limit=3")
     data = resp.json()
     assert len(data["records"]) == 3
@@ -119,9 +130,8 @@ async def test_limit_and_has_more(authed_client, http_config):
 
 
 @pytest.mark.asyncio
-async def test_before_cursor(authed_client, http_config):
+async def test_before_cursor(authed_client, http_config, monotonic_now):
     a = await notifs.notify(http_config, category="t", title="A")
-    await asyncio.sleep(1.05)
     b = await notifs.notify(http_config, category="t", title="B")
     resp = await authed_client.get(f"/api/notifications?before={b.timestamp}")
     data = resp.json()

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "ruff" },
 ]
@@ -300,6 +301,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
@@ -311,6 +313,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -643,6 +654,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `pytest-xdist` as a dev dependency and makes `-n auto --dist=worksteal` the default via `pyproject.toml` `addopts`. Both local `make test` and the CI `Test` step pick it up automatically — no call-site changes needed.

**Measured locally (M-series, many cores):** 1590 tests went from ~100s serial to ~11s parallel (~9x). GitHub Actions ubuntu-latest runners have 4 vCPUs, so expect roughly 3-4x there.

## Why `worksteal`

The suite has a few slow tests (integration providers, compaction) that would leave workers idle under the default `load` distribution. `worksteal` rebalances as workers finish.

## Escape hatch

`uv run pytest -n 0` runs serially — useful when debugging with `pdb` or when `-v` output needs to stay readable (worker stdout interleaves under parallel mode). Noted in the `pyproject.toml` comment.

## Risk check

Scanned for shared mutable state across tests. Things that could in principle cause worker collisions:
- `_locks` dict in `notifications.py` — per-process, not cross-worker. Safe.
- `_managers` dict in `skills/background/tools.py` — per-process. Safe.
- `config` fixture — uses `tmp_path`, unique per test. Safe.
- Module-level skill registries — read-mostly, populated at import. Safe.

Verified by running the full 1590-test suite 3x locally with `-n auto` — zero failures, deterministic pass rates.

## Test plan

- [x] `make check` clean
- [x] Full suite passes locally with `-n auto` (3 runs, all 1590 green)
- [x] Serial escape hatch (`-n 0`) still works
- [x] CI run on this PR green with the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)