### PR TITLE
docs(readme): link to docs/dev-sessions/ as design history

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ make vendor    # Rebuild web UI vendor bundle
 make config    # Show resolved config values
 ```
 
+Most major features are developed in **dev sessions**, with design artifacts preserved under [`docs/dev-sessions/`](docs/dev-sessions/) — each session directory holds a `spec.md`, `plan.md`, and `notes.md` capturing the thinking behind the change. Browse those for the history of how the project grew.
+
 ## What this is NOT
 
 This is not a framework. It's a learning project — built to understand how tools like OpenClaw, nanobot, and picoclaw work under the hood. The code is intentionally simple, with minimal abstractions.


### PR DESCRIPTION
## Summary

- Add a short paragraph after the Development section pointing readers at [`docs/dev-sessions/`](docs/dev-sessions/) as the home for design artifacts (spec / plan / notes) for major features.
- Small, docs-only change.

## Test plan

- [x] Rendered preview of the README looks right (link target + formatting)
- [ ] GitHub renders the relative link correctly on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)