### PR TITLE
fix(web): refresh sidebar vault listing after page delete

### DIFF
--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -100,11 +100,18 @@ export class ConversationSidebar extends LitElement {
         this._chatFolders = this.store?.folders || [];
       }
     };
+    this._onVaultPageDeleted = () => {
+      if (this._sidebarTab !== 'wiki') return;
+      if (this._vaultView === 'recent') this.#fetchRecentPages();
+      else this.#fetchWikiPages();
+    };
+    window.addEventListener('vault-page-deleted', this._onVaultPageDeleted);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.store?.removeEventListener('change', this._onStoreChange);
+    window.removeEventListener('vault-page-deleted', this._onVaultPageDeleted);
   }
 
   /** @param {Map} changedProps */

--- a/src/decafclaw/web/static/components/wiki-page.js
+++ b/src/decafclaw/web/static/components/wiki-page.js
@@ -194,6 +194,9 @@ export class WikiPage extends LitElement {
         alert(data.error || `Delete failed (${res.status})`);
         return;
       }
+      window.dispatchEvent(new CustomEvent('vault-page-deleted', {
+        detail: { page: this.page },
+      }));
       this._close();
     } catch {
       alert('Delete failed.');


### PR DESCRIPTION
## Summary

- When a page was deleted from the wiki editor's trash button, the sidebar's vault listing kept the deleted entry until the next tab switch or folder navigation.
- Root cause: `wiki-page.js:#deletePage()` only fired the generic `wiki-close` event on success, and the sidebar has no vault-change refresh trigger — its only refresh paths are tab switch, folder nav, and its own local "create" action.
- Fix: dispatch a `vault-page-deleted` window event from `#deletePage()` on success; the sidebar listens for it and refetches the current view (browse or recent) when the wiki tab is active.

## Test plan

- [x] `make check-js` passes.
- [x] Manual: delete a page from the browse view — sidebar drops the entry.
- [x] Manual: delete a page from the recent view — sidebar drops the entry.
- [ ] Sanity: deleting a page while the sidebar is on the Conversations tab does not trigger a vault refetch.

## Notes

- Rename has an analogous latent bug (sidebar keeps the old path in `_wikiPages`) but isn't user-visible in the normal flow — left for a follow-up so this PR stays minimal.
- If we ever add agent-triggered vault mutations that should update open browser tabs, a server-broadcast `vault-changed` websocket event is the right upgrade path; for now the browser-only custom event is the smallest fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)