### PR TITLE
fix(vault): enforce agent-folder guardrail on vault_write

### DIFF
--- a/docs/dev-sessions/2026-04-23-1308-vault-write-agent-guardrail/spec.md
+++ b/docs/dev-sessions/2026-04-23-1308-vault-write-agent-guardrail/spec.md
@@ -1,0 +1,77 @@
+# Vault Write Agent-Folder Guardrail + Ingest Skill Fix
+
+## Context
+
+During a `/ingest` run, the agent wrote vault pages at the vault root (outside `agent/pages/`) despite the ingest skill explicitly requiring writes under `agent/pages/`. A subsequent `/postmortem` surfaced the failure and proposed skill-wording changes, but the root cause is deeper: `vault_write` has no hard guardrail — it only *logs a notice* when writing outside the agent folder. The ingest skill's own Step 3 also has an ambiguity ("update in place" for an existing page) that conflicts with Step 4's "stay under `agent/pages/`" rule.
+
+Separately, `vault_delete` already enforces agent-folder-only deletion — so once the stray pages landed, the agent could not clean them up, making the drift doubly expensive.
+
+## Goals
+
+1. Make `vault_write` refuse writes outside the agent folder, matching how `vault_delete` and `vault_rename` already behave. No override parameter.
+2. Fix the instruction tension inside the ingest skill so the "update in place" rule cannot contradict the "stay under `agent/pages/`" rule.
+3. Cover the new guardrail with a regression test.
+
+## Non-goals (deferred)
+
+- Introducing an alternate `vault_write`-with-approval tool for editing user notes. Defer until the "agent edits user notes" use case becomes concrete.
+- Changes to AGENT.md. The existing language ("only write within `agent/` unless the user explicitly asks otherwise") already states the rule; tool-level enforcement makes reinforcing prose unnecessary.
+- Cleaning up the stray root-level pages left behind by the original failure. Les will handle those manually.
+- Any change to `vault_delete` / `vault_rename` behavior.
+- Changes to the web UI's `/api/vault/*` endpoints (those are user-facing, not agent-facing, and are a separate code path).
+
+## Design
+
+### 1. `tool_vault_write` — hard guardrail
+
+In `src/decafclaw/skills/vault/tools.py`:
+
+- Replace the current soft behavior (lines 171–173: "Log notice if writing outside agent folder" + `log.info(...)`) with a hard error return, matching the shape already used by `tool_vault_delete`:
+
+  ```python
+  if not _is_in_agent_dir(ctx.config, path):
+      return ToolResult(
+          text=f"[error: refusing to write '{page}' — "
+               f"only pages under the agent folder may be written]")
+  ```
+
+  Keep the existing `_safe_write_path` path-traversal validation intact — the new guardrail is an additional check after `_safe_write_path` succeeds.
+
+- Update the `vault_write` tool description (TOOL_DEFINITIONS, ~line 572) to reflect the hard rule. Replace the current trailing sentence — *"Default to writing in agent/pages/ — only write outside the agent folder when the user explicitly asks."* — with language consistent with `vault_delete`'s description:
+
+  > "Writes are restricted to the agent folder (`agent/pages/`, `agent/journal/`); admin and user pages are off-limits."
+
+### 2. Ingest skill Step 3 clarification
+
+In `src/decafclaw/skills/ingest/SKILL.md`, replace the current Step 3 closing sentence:
+
+> **If a page on the exact source or its primary topic already exists, treat it as the primary page and update in place.** Do not create a duplicate at a different path.
+
+with:
+
+> **If a page on the exact source or its primary topic already exists under `agent/pages/`, treat it as the primary page and update in place.** If a strong match exists elsewhere in the vault (e.g. a user note), leave that page alone — Step 4 covers how to handle it.
+
+Step 4 remains the authoritative rule and is unchanged.
+
+### 3. Regression test
+
+In `tests/test_vault_tools.py`, inside `TestVaultWrite`:
+
+- Add `test_rejects_write_outside_agent_folder` — calls `tool_vault_write(ctx, "StrayRootPage", "# Stray")` and asserts:
+  - Return value is a `ToolResult` with `[error:` prefix in its text.
+  - No file is created at `vault_dir / "StrayRootPage.md"`.
+
+Write this test **first**, confirm it fails against the current code, then apply the tool change to make it pass (per CLAUDE.md "bug fix = test first").
+
+## Files changed
+
+- `src/decafclaw/skills/vault/tools.py` — guardrail + description update
+- `src/decafclaw/skills/ingest/SKILL.md` — Step 3 wording
+- `tests/test_vault_tools.py` — new regression test
+
+## Acceptance criteria
+
+- `pytest tests/test_vault_tools.py` passes (including the new test).
+- `make check` passes (lint + typecheck).
+- `make test` passes (full suite; no regressions).
+- Manual smoke check: re-reading the updated ingest skill's Steps 3 + 4 together reveals no conflict.

--- a/src/decafclaw/skills/ingest/SKILL.md
+++ b/src/decafclaw/skills/ingest/SKILL.md
@@ -48,7 +48,7 @@ Use `vault_search` (and `vault_list` if you need to browse a folder) to find exi
 - Pages on the major entities referenced.
 - Pages on the broader concepts it touches.
 
-**If a page on the exact source or its primary topic already exists, treat it as the primary page and update in place.** Do not create a duplicate at a different path.
+**If a page on the exact source or its primary topic already exists under `agent/pages/`, treat it as the primary page and update in place.** If a strong match exists elsewhere in the vault (e.g. a user note), leave that page alone — Step 4 covers how to handle it.
 
 ## Step 4: Plan the updates
 

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -167,10 +167,10 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
             text=f"[error: invalid page name '{page}' — must be within vault directory]")
     if not content or not content.strip():
         return ToolResult(text=f"[error: refusing to write empty vault page '{page}']")
-
-    # Log notice if writing outside agent folder
     if not _is_in_agent_dir(ctx.config, path):
-        log.info(f"[tool:vault_write] writing outside agent folder: {page}")
+        return ToolResult(
+            text=f"[error: refusing to write '{page}' — "
+                 f"only pages under the agent folder may be written]")
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
@@ -576,8 +576,9 @@ TOOL_DEFINITIONS = [
                 "workspace_write for those. ALWAYS vault_read first if "
                 "updating an existing page to preserve content you want to keep. "
                 "Use [[Page Name]] syntax to link to other pages. Include a "
-                "## Sources section. Default to writing in agent/pages/ — only "
-                "write outside the agent folder when the user explicitly asks."
+                "## Sources section. Writes are restricted to the agent folder "
+                "(agent/pages/, agent/journal/); admin and user pages are "
+                "off-limits."
             ),
             "parameters": {
                 "type": "object",

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -146,6 +146,15 @@ class TestVaultWrite:
         assert "error" in result.text.lower()
 
     @pytest.mark.asyncio
+    async def test_rejects_write_outside_agent_folder(self, ctx, vault_dir):
+        """vault_write must refuse paths outside the agent folder, mirroring
+        vault_delete / vault_rename behavior."""
+        result = await tool_vault_write(ctx, "StrayRootPage", "# Stray")
+        assert "error" in result.text.lower()
+        assert "agent folder" in result.text.lower()
+        assert not (vault_dir / "StrayRootPage.md").exists()
+
+    @pytest.mark.asyncio
     async def test_creates_subdirectory(self, ctx, vault_dir):
         with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
             await tool_vault_write(ctx, "agent/pages/people/Alice", "# Alice")


### PR DESCRIPTION
## Summary

- `vault_write` now refuses writes outside the agent folder (matching `vault_delete` / `vault_rename`), preventing stray pages at the vault root when skill instructions drift
- Updates the `vault_write` tool description to reflect the hard rule
- Resolves a wording tension in the ingest skill between Step 3 ("update in place if a matching page exists") and Step 4 ("stay under `agent/pages/`")

## Why

A `/ingest` run landed multiple pages at the vault root. The ingest skill's Step 4 already said "stay under `agent/pages/`", but Step 3's unqualified "update in place" guidance won out when the agent found an existing root-level page. And because `vault_write` only *logged a notice* for out-of-agent-folder writes (vs. refusing), drift at the skill level produced real filesystem side effects — which `vault_delete` then refused to clean up since it already has the hard agent-folder rule.

This patch closes the loop: tool-level enforcement matches `vault_delete`, and the ingest skill's Step 3 is qualified so it can no longer contradict Step 4.

## Non-goals (deferred)

- Override parameter / approval-gated alternate write tool for user notes. Defer until that use case is concrete.
- AGENT.md changes — existing prose already says "only write within `agent/`"; tool-level enforcement makes reinforcing prose moot.

## Test plan

- [x] `make check` passes (ruff, pyright, tsc)
- [x] `make test` passes (1444 tests)
- [x] New regression test `test_rejects_write_outside_agent_folder` fails on main, passes here (TDD)
- [ ] Smoke-test by re-running `/ingest` on a URL in the web UI after merge

See `docs/dev-sessions/2026-04-23-1308-vault-write-agent-guardrail/spec.md` for the design writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)