### PR TITLE
Eval coverage audit: inline fixes + split-out plan for #240

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ vendor:
 config:
 	uv run decafclaw config show
 
+# Run all evals against the default model
+eval:
+	uv run python -m decafclaw.eval evals/
+
 # Rebuild eval embedding fixtures (run when changing embedding models)
 build-eval-fixtures:
 	uv run python scripts/build-eval-fixtures.py

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
@@ -115,35 +115,41 @@ See [notes.md](./notes.md) for minimal-viable test sets per file.
 
 Already inline-fixed on this branch: **H13** (reflect.py multi-turn input extraction bug), **H15** (`make eval` Makefile target), and all of `docs/eval-loop.md` field-name rot.
 
-## 5. Prioritized issue list (for filing)
+## 5. Prioritized issue list (filed)
 
-**16 issues to file now** (P1 + P2, actionable):
+**16 issues filed** as part of Step 10 of this session, plus 1 standalone bug caught by the audit:
 
 ### Eval-file issues (10)
 
-| Title | Pri | Size | Notes |
-|-------|-----|------|-------|
-| Eval coverage: vault skill (replaces broken memory-semantic.yaml) | P1 | M | Fixes `allowed_tools` rot + adds comprehensive coverage. |
-| Eval coverage: workspace tools (read/write/edit/search/glob/list/…) | P1 | M | Benefits from but doesn't require harness H6. |
-| Eval coverage: shell tools (shell, shell_patterns, background) | P2 | M | |
-| Eval coverage: conversation tools (search + compact) | P2 | M | **Blocked on harness H7 (conversation history seed).** |
-| Eval coverage: delegate_task | P2 | S | |
-| Eval coverage: tool deferral (tool_search + context budget) | P2 | S | **Blocked on harness H1 (expect_tool).** |
-| Eval coverage: checklist tools | P2 | S | Replaces the "todo tools" bullet in #240 (todos retired per #234). |
-| Eval coverage: user-invokable commands | P2 | S | Dispatch layer: unknown command, `$ARGUMENTS`, `context: fork`. |
-| Eval coverage: health skill | P2 | XS | |
-| Tighten existing memory evals (bounds, assertion-quality, stale names) | P2 | S | |
+| # | Title | Pri | Size | Notes |
+|---|-------|-----|------|-------|
+| #339 | Eval coverage: vault skill (replaces broken memory-semantic.yaml) | P1 | M | Fixes `allowed_tools` rot + adds comprehensive coverage. |
+| #340 | Eval coverage: workspace tools (read/write/edit/search/glob/list/…) | P1 | M | Benefits from but doesn't require harness H6. |
+| #341 | Eval coverage: shell tools (shell, shell_patterns, background) | P2 | M | |
+| #342 | Eval coverage: conversation tools (search + compact) | P2 | M | **Blocked on #353 (conversation history seed).** |
+| #343 | Eval coverage: delegate_task | P2 | S | |
+| #344 | Eval coverage: tool deferral (tool_search + context budget) | P2 | S | **Blocked on #349 (expect_tool).** |
+| #345 | Eval coverage: checklist tools | P2 | S | Replaces the "todo tools" bullet in #240 (todos retired per #234). |
+| #346 | Eval coverage: user-invokable commands | P2 | S | Dispatch layer: unknown command, `$ARGUMENTS`, `context: fork`. |
+| #347 | Eval coverage: health skill | P2 | XS | |
+| #348 | Tighten existing memory evals (bounds, assertion-quality, stale names) | P2 | S | |
 
 ### Harness issues (6)
 
-| Title | Pri | Size | Notes |
-|-------|-----|------|-------|
-| Eval harness: add `expect_tool` / `expect_no_tool` assertions | P1 | S | Foundation for tool-deferral evals + strengthens most others. |
-| Eval harness: multi-model matrix runner + combined report | P2 | M | Per #240's "run against multiple models" ask. |
-| Eval harness: pass-rate trend tracking across runs | P2 | S | Lets us detect regressions over time. |
-| Eval harness: post-turn workspace-state assertion | P2 | S | Strengthens workspace/vault/ingest evals. |
-| Eval harness: `setup.conversation_history` to seed archives | P2 | S | Unblocks conversation evals. |
-| Eval harness: misc quality (judge-prompt assertion coverage + `response_contains_all`) | P2 | XS | Bundles H14 + H16. |
+| # | Title | Pri | Size | Notes |
+|---|-------|-----|------|-------|
+| #349 | Eval harness: `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` | P1 | S | Foundation for tool-deferral evals + strengthens most others. |
+| #350 | Eval harness: multi-model matrix runner + combined report | P2 | M | Per #240's "run against multiple models" ask. |
+| #351 | Eval harness: pass-rate trend tracking across runs | P2 | S | Lets us detect regressions over time. |
+| #352 | Eval harness: post-turn workspace-state assertion | P2 | S | Strengthens workspace/vault/ingest evals. |
+| #353 | Eval harness: `setup.conversation_history` to seed archives | P2 | S | Unblocks #342. |
+| #354 | Eval harness: misc quality (judge-prompt assertion coverage + `response_contains_all`) | P2 | XS | Bundles H14 + H16. |
+
+### Standalone (surfaced by audit, not #240 child)
+
+| # | Title | Pri | Size | Notes |
+|---|-------|-----|------|-------|
+| #355 | Tool registry: did-you-mean error suggests the same unknown tool name | P2 | XS | Real tool-dispatch bug caught during the eval run. |
 
 ### Deferred issues (9) — noted here, not filed yet
 

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
@@ -117,22 +117,22 @@ Already inline-fixed on this branch: **H13** (reflect.py multi-turn input extrac
 
 ## 5. Prioritized issue list (filed)
 
-**16 issues filed** as part of Step 10 of this session, plus 1 standalone bug caught by the audit:
+**16 issues filed** as part of Step 10 of this session, plus 1 standalone bug caught by the audit. Subsequent triage closed 3 as redundant with existing unit-test coverage and narrowed 4 more to LLM-behavior-only scope — see notes column.
 
-### Eval-file issues (10)
+### Eval-file issues (7 open + 3 closed)
 
 | # | Title | Pri | Size | Notes |
 |---|-------|-----|------|-------|
-| #339 | Eval coverage: vault skill (replaces broken memory-semantic.yaml) | P1 | M | Fixes `allowed_tools` rot + adds comprehensive coverage. |
-| #340 | Eval coverage: workspace tools (read/write/edit/search/glob/list/…) | P1 | M | Benefits from but doesn't require harness H6. |
-| #341 | Eval coverage: shell tools (shell, shell_patterns, background) | P2 | M | |
-| #342 | Eval coverage: conversation tools (search + compact) | P2 | M | **Blocked on #353 (conversation history seed).** |
-| #343 | Eval coverage: delegate_task | P2 | S | |
-| #344 | Eval coverage: tool deferral (tool_search + context budget) | P2 | S | **Blocked on #349 (expect_tool).** |
-| #345 | Eval coverage: checklist tools | P2 | S | Replaces the "todo tools" bullet in #240 (todos retired per #234). |
-| #346 | Eval coverage: user-invokable commands | P2 | S | Dispatch layer: unknown command, `$ARGUMENTS`, `context: fork`. |
-| #347 | Eval coverage: health skill | P2 | XS | |
-| #348 | Tighten existing memory evals (bounds, assertion-quality, stale names) | P2 | S | |
+| #339 | Eval coverage: vault skill (replaces broken memory-semantic.yaml) | P1 | M | **Narrowed**: tool implementation already covered by 51+ unit tests; eval scope is now LLM tool-choice + fixing the silently-broken `memory-semantic.yaml`. |
+| #340 | Eval coverage: workspace tools (tool-selection only) | P2 | S | **Narrowed & demoted** from P1/M. 78 unit tests cover tool behavior; eval scope reduced to "does the agent pick the right workspace_* tool for the request?" |
+| #341 | Eval coverage: shell tools (approval-flow focus) | P2 | S | **Narrowed**. 39 unit tests cover execution; eval scope reduced to auto_confirm / denial recovery / allowlist bypass. |
+| #342 | Eval coverage: conversation tools (post-compaction recall) | P2 | S | **Narrowed**. 28 unit tests cover search/compaction mechanics; eval scope reduced to "does LLM-driven summarization preserve salient facts?". Blocked on #353. |
+| #343 | Eval coverage: delegate_task (delegation-decision only) | P2 | S | **Narrowed**. 10 unit tests cover the fork mechanism; eval scope reduced to "does the agent decide to delegate at appropriate times?". |
+| #344 | Eval coverage: tool deferral (tool_search + context budget) | P2 | S | Unchanged — tool-deferral behavior is genuinely LLM-driven and not unit-testable. Blocked on #349. |
+| #348 | Tighten existing memory evals (bounds, assertion-quality, stale names) | P2 | S | Unchanged — this is existing-YAML cleanup. |
+| ~~#345~~ | ~~Eval coverage: checklist tools~~ | — | — | **Closed as redundant** — `test_checklist.py` + `test_checklist_tools.py` (21 tests) cover the state machine; remaining LLM-behavior question is too thin to justify a dedicated file. |
+| ~~#346~~ | ~~Eval coverage: user-invokable commands~~ | — | — | **Closed as redundant** — `test_commands.py` (27 tests) covers the dispatch layer; all proposed test cases are deterministic code paths, not LLM behavior. |
+| ~~#347~~ | ~~Eval coverage: health skill~~ | — | — | **Closed as redundant** — `test_health.py` (9 tests) covers every section; no LLM-specific behavior. |
 
 ### Harness issues (6)
 

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md
@@ -1,0 +1,180 @@
+# Eval coverage audit — 2026-04-24
+
+Point-in-time audit of the existing eval harness and YAML suite, produced by the `eval-coverage` dev session. Driven by [#240](https://github.com/lmorchard/decafclaw/issues/240).
+
+This doc freezes a snapshot of audit findings + the issue split it drives. For evolving guidance on the harness itself, see [../../eval-loop.md](../../eval-loop.md), updated inline on the same branch.
+
+## Executive summary
+
+- **29 existing tests across 6 YAML files.** Full run against the default model: **25/29 pass (86.2%)**.
+- **Apparent pass rate is misleading.** `memory-semantic.yaml` (7/7 pass) is silently broken: its `allowed_tools` list references removed tool names (`memory_search`, `memory_recent`, `memory_save`, `think`) but the tests pass anyway because proactive memory retrieval injects seeded memories directly into context. The file claims to test semantic search; it is not.
+- **4 runtime failures** — all category "real behavior issue" (not bit-rot). 2 in memory.yaml (agent doesn't reach for memory on under-specified prompts) + 2 in project-skill.yaml (project-skill step-parsing regressions). None indicate harness bugs.
+- **Doc rot fixed inline** on this branch: `docs/eval-loop.md` had stale field names and documented an `expect_tool` assertion that doesn't exist in the runner.
+- **Two real harness bugs fixed inline**: `reflect.py` multi-turn input extraction (broken for every multi-turn failure reflection) + added a `make eval` target.
+- **Coverage gaps are large.** 15-bullet scope in #240 vs. existing 6 files = ~10 new eval files needed.
+- **Harness gaps are real and several are load-bearing.** The most important: no `expect_tool` assertion (runner claims but doesn't implement), no multi-model matrix, no pass-rate trend tracking, no post-turn workspace state assertion.
+
+This audit drives a split of #240 into **16 per-system issues** (filed as part of Step 10) + **1 standalone bug** surfaced by the run + **9 deferred issues** that are either P3 or blocked on harness work (noted below for future filing).
+
+## 1. Harness capabilities
+
+Current runner (`src/decafclaw/eval/runner.py`, `__main__.py`):
+
+**Schema:**
+- Single turn: `{name, input, expect, setup?, allowed_tools?}`
+- Multi turn: `{name, turns: [{input, expect}], setup?, allowed_tools?}`
+- `setup` fields: `skills` (pre-activate), `memories` (journal seed + semantic index), `workspace_files` (sandboxed path writes), `embeddings_fixture` (copy-in), `auto_confirm` (default true).
+- `expect` fields: `response_contains` (str/list/`re:`; **OR semantics** on list), `response_not_contains` (str/list; AND semantics), `max_tool_calls`, `max_tool_errors`.
+- `allowed_tools`: list of tool names; unlisted calls return an error.
+
+**Execution:**
+- Per-test isolation via `tempfile.TemporaryDirectory()` as `config.agent.data_home`.
+- User-invokable commands (`/foo`, `!foo`) dispatched before `run_agent_turn` — works in evals.
+- Concurrency default 4 (asyncio semaphore). Override via `--concurrency`.
+- Failure reflection via a judge model; results saved to `evals/results/{timestamp}-{model}/reflections/{slug}.md`.
+
+**What the harness does NOT support today:**
+- `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` / `expect_tool_args` — tool-name-level assertions. (Docs claimed, runner lacked.)
+- `response_contains_all` — no AND semantics on list-form response assertions.
+- Multi-model matrix — `--model` takes one; no combined pass-rate report across models.
+- Pass-rate trend tracking — no aggregation across runs.
+- Post-turn workspace state assertion — can't assert "file X exists with content Y after the turn".
+- Conversation history seeding — can't preload an archive for `conversation_search` / `conversation_compact` tests.
+- Scheduled / heartbeat mode simulation.
+- Cancel / stop mid-turn probe.
+- Effort-level switching probe.
+- Context-budget / deferred-tool-fetch probe.
+- Claude Code sandbox / mock.
+
+## 2. Per-file verdict
+
+Merged from static review and the runtime pass/fail pass (`evals/results/2026-04-24-1015-default/`).
+
+| File | Tests | Pass | Fail | Real issues |
+|------|-------|------|------|-------------|
+| `ingest.yaml` | 1 | 1 | 0 | None |
+| `memory.yaml` | 8 | 6 | 2 | Unbounded tests; OR-vs-AND assertion quality; 2 real behavior failures |
+| `memory-multi-turn.yaml` | 4 | 4 | 0 | No `max_tool_calls` bounds anywhere; OR-vs-AND on several tests |
+| `memory-semantic.yaml` | 7 | 7 | 0 | **Silently broken** — `allowed_tools` uses removed tool names; passes because proactive retrieval bypasses the intended path |
+| `postmortem.yaml` | 1 | 1 | 0 | None |
+| `project-skill.yaml` | 8 | 6 | 2 | 2 real failures due to project-skill tool-dispatch / step-parsing regressions |
+
+### Observations by file
+
+**`ingest.yaml`** — Clean. Only one test (workspace-file path). URL/attachment paths explicitly left out per a file comment. Could grow.
+
+**`memory.yaml`** — Tool references are all current. Assertion-quality issues: list-form `response_contains` is OR not AND (5 tests potentially laxer than their names suggest). Test #7 is named "uses think tool for complex question" — `think` doesn't exist; name is stale. Missing bounds on several tests.
+
+**`memory-multi-turn.yaml`** — Clean tool references. No `max_tool_calls` bounds on any test — a runaway agent loop would not fail these.
+
+**`memory-semantic.yaml`** — The big finding. All 7 tests pass but they test nothing. The `allowed_tools` allowlist references `memory_search`/`memory_recent`/`memory_save`/`think` — tools that don't exist in the current codebase. The tests pass because the agent doesn't call any of those; it just echoes seeded memories that proactive retrieval injects into context. This is worse than failing outright — it's silent coverage loss.
+
+**`postmortem.yaml`** — Clean. Single-turn test using `/postmortem` command dispatch. Regex assertion matches the SKILL.md-defined five-section structure.
+
+**`project-skill.yaml`** — Well-designed (gold standard after #17's iteration). Two runtime failures surface real project-skill tool-dispatch issues (not eval bugs): a self-contradicting "did you mean" error message (`unknown tool 'foo'. Did you mean: foo`) and brittle step-parsing that doesn't tolerate some model output formats.
+
+## 3. Coverage gaps (new eval files needed)
+
+Per the spec's "one eval file ≈ one issue ≈ one PR" model. Derived from #240's 15-bullet scope list:
+
+| Proposed file | Covers | Size | Harness deps | Priority |
+|---------------|--------|------|--------------|----------|
+| `vault.yaml` | All 11 vault tools (read/write/search/journal/backlinks/list/delete/rename/section tools). Also rewrites/replaces `memory-semantic.yaml`. | M | None | **P1** |
+| `workspace-tools.yaml` | 12 workspace tools (read/write/edit/search/glob/list/move/delete/diff/insert/replace_lines/append) | M | Post-turn workspace assertion helps | **P1** |
+| `shell.yaml` | shell, shell_patterns, shell_background_* (4) | M | None (uses `auto_confirm`) | P2 |
+| `conversation.yaml` | conversation_search, conversation_compact | M | **Conversation history seed (harness)** | P2 |
+| `delegate.yaml` | delegate_task | S | None | P2 |
+| `tool-deferral.yaml` | tool_search + deferred loading + context budget | S | **`expect_tool` assertion (harness)** | P2 |
+| `checklist.yaml` | checklist_* (4 always-loaded tools; replaces deprecated todo tools per #234) | S | None | P2 |
+| `commands.yaml` | `/command` / `!command` dispatch layer | S | None | P2 |
+| `health.yaml` | `!health` + `health_status` tool | XS | None | P2 |
+| (tighten) `memory.yaml` + `memory-multi-turn.yaml` | Add `max_tool_calls` bounds; rename / regex-ify OR-vs-AND tests; drop stale "think tool" name | S | None | P2 |
+| `consolidation.yaml` (dream + garden) | dream, garden consolidation skills | L | **Scheduled mode sim (harness)** | P3 (blocked) |
+| `claude-code.yaml` | claude_code_* (7) | L | **Subprocess sandbox (harness)** | P3 (blocked) |
+| `effort-switching.yaml` | Effort level switching behavior | L | **Effort probe (harness)** | P3 (blocked) |
+| `cancel.yaml` | Stop / cancel mid-turn | L | **Cancel probe (harness)** | P3 (blocked) |
+
+See [notes.md](./notes.md) for minimal-viable test sets per file.
+
+## 4. Harness gaps
+
+| ID | Gap | Size | Priority |
+|----|-----|------|----------|
+| H1+H2 | `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` assertions. Load-bearing — docs already claim, many future evals need. | S | **P1** |
+| H4 | Multi-model matrix runner (single invocation → combined report across configured models). | M | P2 |
+| H5 | Pass-rate trend tracking (per-run summary committed to git). | S | P2 |
+| H6 | Post-turn workspace state assertion (`expect.workspace_files: {path: content}`). | S | P2 |
+| H7 | Conversation archive seeding in `setup` (for conversation_search / compact evals). | S | P2 |
+| H14+H16 | Misc harness quality — judge prompt should interpolate non-`response_contains` assertions; add `response_contains_all` for AND semantics on lists. | XS | P2 |
+| H8 | Scheduled / heartbeat mode simulation (for dream/garden evals). | M | P3 (deferred) |
+| H9 | Cancel probe (simulated mid-turn stop). | L | P3 (deferred) |
+| H10 | Effort-level switching probe. | M | P3 (deferred) |
+| H11 | Claude Code sandbox / mock (safe subprocess testing). | L | P3 (deferred) |
+| H12 | Context-budget / deferred-tool probe. Overlaps with H1; may ride on `expect_tool_fetch_history`. | S | P2 |
+| H3 | `expect_tool_args` assertion. Extension of H1; brittle, defer. | M | P3 (deferred) |
+
+Already inline-fixed on this branch: **H13** (reflect.py multi-turn input extraction bug), **H15** (`make eval` Makefile target), and all of `docs/eval-loop.md` field-name rot.
+
+## 5. Prioritized issue list (for filing)
+
+**16 issues to file now** (P1 + P2, actionable):
+
+### Eval-file issues (10)
+
+| Title | Pri | Size | Notes |
+|-------|-----|------|-------|
+| Eval coverage: vault skill (replaces broken memory-semantic.yaml) | P1 | M | Fixes `allowed_tools` rot + adds comprehensive coverage. |
+| Eval coverage: workspace tools (read/write/edit/search/glob/list/…) | P1 | M | Benefits from but doesn't require harness H6. |
+| Eval coverage: shell tools (shell, shell_patterns, background) | P2 | M | |
+| Eval coverage: conversation tools (search + compact) | P2 | M | **Blocked on harness H7 (conversation history seed).** |
+| Eval coverage: delegate_task | P2 | S | |
+| Eval coverage: tool deferral (tool_search + context budget) | P2 | S | **Blocked on harness H1 (expect_tool).** |
+| Eval coverage: checklist tools | P2 | S | Replaces the "todo tools" bullet in #240 (todos retired per #234). |
+| Eval coverage: user-invokable commands | P2 | S | Dispatch layer: unknown command, `$ARGUMENTS`, `context: fork`. |
+| Eval coverage: health skill | P2 | XS | |
+| Tighten existing memory evals (bounds, assertion-quality, stale names) | P2 | S | |
+
+### Harness issues (6)
+
+| Title | Pri | Size | Notes |
+|-------|-----|------|-------|
+| Eval harness: add `expect_tool` / `expect_no_tool` assertions | P1 | S | Foundation for tool-deferral evals + strengthens most others. |
+| Eval harness: multi-model matrix runner + combined report | P2 | M | Per #240's "run against multiple models" ask. |
+| Eval harness: pass-rate trend tracking across runs | P2 | S | Lets us detect regressions over time. |
+| Eval harness: post-turn workspace-state assertion | P2 | S | Strengthens workspace/vault/ingest evals. |
+| Eval harness: `setup.conversation_history` to seed archives | P2 | S | Unblocks conversation evals. |
+| Eval harness: misc quality (judge-prompt assertion coverage + `response_contains_all`) | P2 | XS | Bundles H14 + H16. |
+
+### Deferred issues (9) — noted here, not filed yet
+
+Either blocked on harness work that itself is P3, or low-priority extensions. File when the blocker is ready:
+
+- Eval coverage: dream + garden consolidation (blocked on scheduled-mode harness, H8)
+- Eval coverage: Claude Code subagent (blocked on sandbox/mock harness, H11)
+- Eval coverage: effort-level switching (blocked on effort-probe harness, H10)
+- Eval coverage: cancel / stop behavior (blocked on cancel-probe harness, H9)
+- Eval harness: scheduled / heartbeat mode simulation (H8)
+- Eval harness: Claude Code sandbox / mock (H11)
+- Eval harness: effort-level switching probe (H10)
+- Eval harness: cancel probe (H9)
+- Eval harness: `expect_tool_args` assertion (H3, extends `expect_tool`)
+
+### Standalone (1) — not linked to #240
+
+| Title | Pri | Size | Notes |
+|-------|-----|------|-------|
+| Tool registry: "did you mean" error suggests the same unknown tool name | P2 | XS | Self-contradicting error: `unknown tool 'project_advance'. Did you mean: project_advance, ...`. Surfaced during the eval run (project-skill failures). Real tool-dispatch bug, not eval-harness. |
+
+## 6. Non-goals of this audit
+
+- **Fixing failing tests.** The 4 runtime failures surface real behavior gaps (memory retrieval triggers, project-skill step-parsing). Those belong in the respective per-system issues, not this audit.
+- **Writing new eval YAML files.** That's what the spun-out issues are for.
+- **Building the harness features.** Spun out.
+- **Fixing tool descriptions / SKILL.md wording.** Out of scope. The audit lists opportunities; execution belongs with the per-skill evals.
+
+## 7. Execution state at audit time
+
+- Branch: `eval-coverage` (worktree at `.claude/worktrees/eval-coverage`).
+- Commits on this branch at audit time: spec scaffolding + inline doc/bug fixes (3 files: `docs/eval-loop.md`, `src/decafclaw/eval/reflect.py`, `Makefile`). Audit doc + full plan/notes follow in the next commit.
+- Eval run bundle: `evals/results/2026-04-24-1015-default/`.
+- Default model in use: resolves to `default` in config (likely `vertex-gemini-flash` per recent history; not explicitly introspected during this run).

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/notes.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/notes.md
@@ -1,0 +1,471 @@
+# Dev session notes: eval coverage audit
+
+## Step 1: Harness capabilities
+
+### CLI (`python -m decafclaw.eval`)
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `path` (positional) | required | YAML file or directory — directory auto-discovers `*.yaml` |
+| `--model` | `default_model` or `llm.model` | Override LLM model; looks up `model_configs` first, else treated as raw name |
+| `--judge-model` | same as `--model` | Model for failure reflection |
+| `--verbose` | off | Print truncated response for each test |
+| `--concurrency` | 4 | Max concurrent tests via asyncio semaphore |
+
+Exits non-zero if any test fails (useful for CI).
+
+### Test case schema (single-turn)
+
+Required: `name`, `input`, `expect`.
+Optional: `setup`, `allowed_tools`.
+
+### Test case schema (multi-turn)
+
+Replaces `input`/`expect` with `turns: [{input, expect}]`. Each turn gets its own assertions; all must pass. History is shared across turns within a test.
+
+### `setup` fields
+
+| Field | Purpose |
+|-------|---------|
+| `skills: [names]` | Pre-activate skills before the turn |
+| `memories: [{content, tags}]` | Seed journal entries (also indexed for semantic search if strategy == semantic) |
+| `workspace_files: {path: content}` | Seed arbitrary files into `config.workspace_path` (sandboxed against `..` escape) |
+| `embeddings_fixture: path` | Copy pre-built embeddings.db into workspace |
+| `auto_confirm: bool` | Default true. Auto-approve (or deny) all confirmation requests. |
+
+### `expect` assertions
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `response_contains` | str / list[str] / `"re:pattern"` | Any match passes (case-insensitive for non-regex) |
+| `response_not_contains` | str / list[str] | All absent (case-insensitive); any match fails |
+| `max_tool_calls` | int | Fail if `tool_calls > max` |
+| `max_tool_errors` | int | Fail if count of tool messages containing `[error` > max |
+
+Regex is opt-in with the `re:` prefix. Lists use OR semantics for `response_contains`, AND for `response_not_contains`.
+
+### Per-test isolation
+
+Each test runs in `tempfile.TemporaryDirectory()` as `config.agent.data_home` via `dataclasses.replace(agent=replace(..., id="eval"))`. Different tests cannot see each other's workspace.
+
+### Command dispatch
+
+The runner calls `dispatch_command` before `run_agent_turn`, so `/foo` and `!foo` user-invocable skill commands work in evals. `help`/`fork`/`inline`/`unknown`/`error` modes all handled. Fork commands skip the agent loop and treat `cmd.text` as the response for assertion purposes.
+
+### Result bundle
+
+Written to `evals/results/{YYYY-MM-DD-HHMM}-{model}/`:
+- `results.json` — full per-test details
+- `reflections/{slug}.md` — LLM-generated failure analysis, one per failed test
+
+### Makefile targets
+
+Only `make build-eval-fixtures` (runs `scripts/build-eval-fixtures.py`). **No `make eval` / `make evals` target** — ad hoc invocation via `uv run python -m decafclaw.eval evals/`. Candidate Makefile addition.
+
+### What's missing vs #240 scope
+
+Capabilities #240 implies we need but the runner doesn't currently provide:
+
+- **`expect_tool` assertion** (assert a specific tool WAS called by name). Docs (`docs/eval-loop.md`) claim this exists; runner's `_check_assertions` has no such branch.
+- **`expect_no_tool` assertion** (assert a specific tool was NOT called). Same doc claim, same missing impl.
+- **Tool-argument inspection** (assert a tool was called with a specific arg value). No hook.
+- **Multi-model matrix runner** — `--model` takes one value; no combined pass-rate report across models.
+- **Pass-rate trend tracking** — each run writes a standalone bundle; no aggregation across runs.
+- **Post-turn workspace state assertion** (assert file X exists or contains Y after the turn). No assertion hook.
+- **Cancel / stop-mid-turn probe** — no way to simulate user cancellation.
+- **Effort-level switching probe** — no assertion on effort flips.
+- **Context-budget / deferred-tool probe** — no way to assert "tool X was fetched via tool_search" or "context size stayed under budget".
+
+### Bugs / doc rot caught already
+
+1. **`docs/eval-loop.md` uses wrong field names.** Doc shows `prompt`/`expect_contains`/`expect_tool` as flat fields; runner uses `input`/`expect: {response_contains}`. Doc's `expect_tool` table row describes an assertion that does not exist in `runner._check_assertions`. (→ Step 7 inline fix + spin-out issue for actually implementing `expect_tool`.)
+2. **`reflect.py` multi-turn bug.** Lines 38–42 extract `role`/`content` keys from turns, but our turn schema is `{input, expect: ...}`. For multi-turn failures, `input_text` will always be `[user] ` with no content, so the judge prompt is malformed. (→ Step 7 candidate; trivial fix.)
+3. **`reflect.py` ignores non-`response_contains` assertions.** The prompt template only interpolates `expected = expect.get("response_contains", "?")`. If a test fails on `max_tool_calls` or `response_not_contains`, the judge sees `"?"` and can't give useful advice. (→ could inline-fix or note as harness-gap; decide in Step 7.)
+
+---
+
+## Step 2: Static audit
+
+### Tool-name reality check
+
+Current tool inventory (grepped from `src/decafclaw/tools/*.py` + `src/decafclaw/skills/*/tools.py`):
+
+- **Core tools**: `activate_skill`, `checklist_*` (4), `context_stats`, `conversation_compact`, `conversation_search`, `current_time`, `debug_context`, `delegate_task`, `file_share`, `get_attachment`, `health_status`, `heartbeat_trigger`, `http_request`, `list_attachments`, `refresh_skills`, `send_email`, `send_notification`, `shell`, `shell_patterns`, `tool_search`, `wait`, `web_fetch`, `workspace_*` (11).
+- **Skills**: `claude_code_*` (7), `mcp_*` (5), `project_*` (12), `shell_background_*` (4), `tabstack_*` (5), `vault_*` (11).
+
+**Tools that DO NOT EXIST anymore**: `memory_search`, `memory_recent`, `memory_save`, `think`.
+
+Renaming history (inferred): `memory_*` → `vault_*` as part of the vault unification. `think` — never existed in current tree; possibly an old Claude-specific convention that was never implemented here.
+
+### Per-file verdicts
+
+#### `ingest.yaml` (1 test)
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1 | "ingest workspace file produces primary page + change summary" | 🔍 needs-runtime-evidence — command `/ingest` and all referenced tools (`tabstack_extract_markdown`, `workspace_read`, `vault_search`, `vault_read`, `vault_write`, `vault_list`, `vault_backlinks`, `current_time`) all exist. Path arg semantics (`workspace/imports/ripgrep-notes.md` → `workspace_read(path="imports/ripgrep-notes.md")`) matches SKILL.md Step 1. Regex assertion `ingested:.*ripgrep-notes\.md.*primary page.*\[\[.*\]\]` matches the skill's Step 6 output shape. |
+
+Overall: **structurally valid, pending runtime confirmation.**
+
+#### `memory.yaml` (8 tests)
+
+No `allowed_tools` restriction; agent has full tool set. `memories:` setup still works (the runner seeds the journal directory + indexes for semantic search if strategy is semantic).
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1 | "finds preference by direct term" | ✅ should-work — journal seed + vault search flow is intact |
+| 2 | "finds preference by related term" | ✅ should-work |
+| 3 | "recalls recent memories" | ⚠️ assertion-quality — `response_contains: [concise, event bus]` is OR per runner semantics; the test name implies AND |
+| 4 | "handles missing memories gracefully" | ✅ should-work — expects "don't" in response |
+| 5 | "saves memory when asked" | ✅ should-work — expects "Python" in response |
+| 6 | "connects related memories" | ⚠️ assertion-quality — same OR-vs-AND issue as #3 |
+| 7 | "uses think tool for complex question" | ⚠️ test-name-rot — test is named after a `think` tool that no longer exists; the test itself just uses response-text matching so it still works, but the name is misleading |
+| 8 | "finds info with indirect phrasing" | ⚠️ assertion-quality — three alternatives all count as match (`software engineer`, `engineer`, `platform`); the last alone is too weak |
+
+Overall: **mostly valid, but assertion-quality issues permeate**. Not bit-rot; test design.
+
+#### `memory-multi-turn.yaml` (4 tests)
+
+All tests lack `max_tool_calls` and `max_tool_errors` bounds — runaway tool-loop behavior wouldn't fail these. Otherwise clean.
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1 | "save then recall hobby" | ✅ should-work |
+| 2 | "save preference then ask about it indirectly" | ⚠️ assertion-quality — OR semantics on `["Thai", "spicy"]` |
+| 3 | "save multiple facts then recall all" | ⚠️ assertion-quality — OR semantics on `["Luna", "Mozilla"]`; test name implies AND |
+| 4 | "correct a memory" | ✅ should-work (final-turn assertion is a single string) |
+
+Overall: **valid but loose**. No bounds + OR semantics mean these catch gross regressions only.
+
+#### `memory-semantic.yaml` (7 tests)
+
+**❌ ALL FUNDAMENTALLY BROKEN.** Every test has `allowed_tools: [memory_search, memory_recent, memory_save, think]` — **none of these tools exist**. The runner's `ctx.tools.allowed = set(allowed_tools)` means the agent can't call any real tool; every attempt returns a disallowed-tool error. Predicted runtime: 0/7 pass, possibly all failing with `[error: tool not allowed]` or similar.
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1–7 | (all) | ❌ fundamentally-broken — `allowed_tools` references removed tool names |
+
+Fix requires replacing the `allowed_tools` list with current `vault_*` tools. That's more than a sentence-level fix — it's a substantive rewrite of every test in the file, and should probably be done as part of the "vault evals" spun-out issue.
+
+#### `postmortem.yaml` (1 test)
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1 | "postmortem produces all five sections, blamelessly framed" | 🔍 needs-runtime-evidence — command `/postmortem` exists. SKILL's `allowed-tools: vault_write, current_time` both exist. The five-section regex matches SKILL.md's required structure exactly. `response_not_contains` list of apology phrases matches SKILL.md's "Forbidden phrasing" rule. |
+
+Overall: **structurally valid.**
+
+#### `project-skill.yaml` (7 tests)
+
+Uses `setup: skills: [project]` for pre-activation. All `project_*` tools referenced (`project_update_spec`, etc.) still exist. `spec_review` appears in `response_not_contains` — it's a **state name** in `project.state.WorkflowState.SPEC_REVIEW`, not a tool, so the assertion is about the LLM not narrating entering that state. Still meaningful.
+
+| # | Test | Verdict |
+|---|------|---------|
+| 1 | "creates project before asking questions" | 🔍 needs-runtime-evidence — well-bounded (max_tool_calls: 3, max_tool_errors: 0) |
+| 2 | "asks a question on first turn, does not jump to spec" | 🔍 needs-runtime-evidence |
+| 3 | "continues interviewing after first answer" | 🔍 needs-runtime-evidence |
+| 4 | "writes spec when asked" | 🔍 needs-runtime-evidence — `max_tool_calls: 50` is very loose for a 2-turn test (intentional per file's top-comment about auto_confirm chaining) |
+| 5 | "writes plan after spec approval" | 🔍 needs-runtime-evidence — similar |
+| 6 | "does not ask verbal approval question" | 🔍 needs-runtime-evidence |
+| 7 | "executes plan steps" | 🔍 needs-runtime-evidence |
+| 8 | "handles review denial gracefully" | 🔍 needs-runtime-evidence — sets `auto_confirm: false`, so EndTurnConfirm denies |
+
+Overall: **structurally valid, well-designed.** This is the most carefully-built eval file; recent work on #17.
+
+### Summary table
+
+| File | Tests | Structurally valid | Bit-rotted | Assertion-quality flags |
+|------|-------|--------------------|------------|-------------------------|
+| `ingest.yaml` | 1 | 1 | 0 | 0 |
+| `memory.yaml` | 8 | 8 | 0 | 4 (OR-vs-AND, stale test name) |
+| `memory-multi-turn.yaml` | 4 | 4 | 0 | 3 (OR-vs-AND, no bounds) |
+| `memory-semantic.yaml` | 7 | 0 | **7** | n/a — all broken |
+| `postmortem.yaml` | 1 | 1 | 0 | 0 |
+| `project-skill.yaml` | 8 | 8 | 0 | 0 |
+| **Total** | **29** | **22** | **7** | **7** |
+
+### Structural issues worth flagging
+
+- **OR-vs-AND semantics on `response_contains` lists.** The runner's implementation is OR (matches any). ~7 tests across the memory files use list form where the test name suggests AND. If AND semantics are wanted, either:
+  - The runner grows a `response_contains_all` assertion (harness gap), OR
+  - Tests are rewritten using regex alternation or multiple test cases.
+  - At minimum, document the OR semantics clearly in `docs/eval-loop.md`.
+
+- **Missing `max_tool_calls` on `memory-multi-turn.yaml`.** All 4 tests lack any tool-budget bound. Adding generous bounds (e.g. 20 per turn) would catch agent-loop regressions.
+
+- **Missing bounds audit in `memory.yaml`.** Tests 3 ("recalls recent"), 4 ("handles missing"), 6 ("connects related"), 7 ("uses think tool"), 8 ("finds info indirect") lack `max_tool_calls`.
+
+- **`memory-semantic.yaml` is completely bit-rotted.** This is the big ticket item for the "vault evals" spun-out issue — the test content (input/expected output) is largely fine, but the `allowed_tools` field needs wholesale replacement with current `vault_*` tool names. Also an opportunity to verify semantic-search behavior actually still works end-to-end.
+
+### Notes on runtime prediction
+
+Going into Step 3 with this prediction:
+
+- `ingest.yaml`: 1/1 likely passes (pending `tabstack_extract_markdown` key being present; note ingest.yaml is workspace-path, not URL, so shouldn't need Tabstack at all — but SKILL.md requires the `tabstack` skill per `required-skills` frontmatter even for workspace paths? Worth checking runtime.)
+- `memory.yaml`: 8/8 likely passes (OR-semantics means most tests are very generous).
+- `memory-multi-turn.yaml`: 4/4 likely passes.
+- `memory-semantic.yaml`: **0/7 expected** (fundamentally broken allowed_tools).
+- `postmortem.yaml`: 1/1 likely passes.
+- `project-skill.yaml`: probably 6-7/8 based on #17 prior pass rate.
+
+Total predicted pass rate: **~21-22 / 29 = 72-76%**, with the bulk of failures concentrated in `memory-semantic.yaml`. If that pattern holds, Step 4's triage will have a clear "fix the vault allowed_tools" bucket and a small "real per-test" bucket.
+
+---
+
+## Step 9: Filing recipe (pre-computed)
+
+Project: `decafclaw` — number 6, ID `PVT_kwHNVLfOAUg5pw`, owner `lmorchard`.
+
+### Field IDs
+
+| Field | Field ID | Options |
+|-------|----------|---------|
+| Status | `PVTSSF_lAHNVLfOAUg5p84P7O9L` | Backlog `f75ad846`, Ready `61e4505c`, In progress `47fc9ee4`, In review `df73e18b`, Done `98236657` |
+| Priority | `PVTSSF_lAHNVLfOAUg5p84P7O_D` | P0 `79628723`, P1 `0a877460`, **P2 `da944a9c`**, P3 `19341fa5`, P4 `8657c355` |
+| Size | `PVTSSF_lAHNVLfOAUg5p84P7O_E` | XS `6c6483d2`, S `f784b110`, **M `7515a9f1`**, L `817d0097`, XL `db339eb2` |
+
+Defaults for this batch per spec: **P2 / M / Backlog** (P2 = `da944a9c`, M = `7515a9f1`).
+
+### Recipe (bash)
+
+```bash
+# 1. File issue with project membership
+URL=$(gh issue create \
+  --repo lmorchard/decafclaw \
+  --title "<TITLE>" \
+  --body-file /tmp/body.md \
+  --project "decafclaw")
+
+# 2. Resolve project item ID from the issue URL
+ITEM_ID=$(gh project item-list 6 --owner lmorchard --format json --limit 200 \
+  | jq -r ".items[] | select(.content.url == \"$URL\") | .id")
+
+# 3. Set Priority (P2) and Size (M)
+gh project item-edit --project-id PVT_kwHNVLfOAUg5pw --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHNVLfOAUg5p84P7O_D --single-select-option-id da944a9c
+gh project item-edit --project-id PVT_kwHNVLfOAUg5pw --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHNVLfOAUg5p84P7O_E --single-select-option-id 7515a9f1
+```
+
+Step 10 verifies this works end-to-end on the first issue before bulk-applying.
+
+---
+
+## Step 5: Coverage gap walk
+
+#240's scope is a mix of skills, tools, and system behaviors. Walking each bullet and mapping to a proposed eval file. Grouping follows the "one issue ≈ one eval file ≈ one PR" model from spec.md.
+
+Note: #234 ("Evaluate todo tools") was closed as completed on 2026-04-15. The current always-loaded `checklist_*` tools replaced todos. So the "Todo tools" bullet in #240 should be read as **checklist tools**.
+
+### Proposed eval files
+
+| Proposed file | Covers (from #240 and adjacent) | Current state | Notes |
+|---------------|--------------------------------|---------------|-------|
+| `vault.yaml` | Vault skill: read, write, search, journal_append, backlinks, list, delete, rename, show_sections, move_lines, section | Partial (memory*.yaml cover journal/search indirectly via "remember" prompts; no direct tool-call coverage for most) | `memory-semantic.yaml` needs wholesale rewrite (broken `allowed_tools`). `memory.yaml` + `memory-multi-turn.yaml` can stay as "conversational recall" tests but the *new* file should directly exercise each tool. |
+| `health.yaml` | Health skill + `health_status` tool | None | Test `!health` invocation + raw tool call. Mostly a smoke test since health is descriptive. |
+| `consolidation.yaml` | Dream + garden skills | None | Hard to eval: these are scheduled long-running skills. Probably needs harness support for "simulated scheduled context" or canonical seed vaults. Could split into `dream.yaml` + `garden.yaml` — recommend combined. |
+| `claude-code.yaml` | Claude Code subagent skill | None | Dangerous to run in eval — spawns real subprocesses. Likely needs sandbox/mock. Flag as "blocked on harness support" unless we're OK running real claude_code sessions in the eval. |
+| `project.yaml` | Project skill | `project-skill.yaml` exists, 8 tests, well-built | Leave as-is; possibly rename for consistency. Per #17 lessons, this is the gold standard eval file. |
+| `workspace-tools.yaml` | workspace_read/write/edit/search/glob/list/move/delete/diff/insert/replace_lines/append | None | 12 tools; biggest file. Should test happy paths + error paths (e.g. write to outside workspace, read non-existent file). |
+| `shell.yaml` | shell, shell_patterns, shell_background_* (4) | None | `auto_confirm` behavior is central — test the approval flow. shell_patterns test: confirm allowlist-bypass. |
+| `conversation.yaml` | conversation_search, conversation_compact | None | Compaction requires a populated history. Needs harness support for seeding conversation history, or multi-turn setup that builds history then triggers compact. |
+| `delegate.yaml` | delegate_task | None | Forks a child agent. Test: simple delegate returns result; delegate with failing task returns error. |
+| `tool-deferral.yaml` | tool_search + deferred loading + context budget awareness | None | Test: agent fetches a deferred tool via `tool_search`. Harness gap: can't currently assert "tool X was fetched" — need new assertion or check via tool_calls history. |
+| `checklist.yaml` | checklist_create, checklist_step_done, checklist_abort, checklist_status (was "todo tools") | None | Always-loaded tools. Bullet in #240 was stale ("todo tools if we keep them"); we do keep them under new name. |
+| `commands.yaml` | User-invokable `/command` and `!command` dispatch | Implicitly tested via `ingest.yaml`, `postmortem.yaml`, `project-skill.yaml` | Dedicated file should test the dispatch layer: unknown command, missing required args, `$ARGUMENTS` substitution, `context: fork` isolation, `--help` listing. |
+| `effort-switching.yaml` | Effort level switching | None | **Blocked on harness support** — need a way to assert effort state changed. |
+| `cancel.yaml` | Stop/cancel mid-turn | None | **Blocked on harness support** — need a way to simulate user cancellation mid-turn. |
+
+### Existing files that stay as-is (with fixes)
+
+| File | Action |
+|------|--------|
+| `ingest.yaml` | Keep — touches ingest skill (not in #240 list). May expand to cover URL + attachment paths. |
+| `postmortem.yaml` | Keep — touches postmortem skill (not in #240 list). |
+| `project-skill.yaml` | Keep — is the project eval file. Consider renaming to `project.yaml` for consistency. |
+| `memory.yaml` | Keep, tighten — add `max_tool_calls` bounds, fix OR-vs-AND test naming (either rename tests or convert to regex alternation / split into separate tests). |
+| `memory-multi-turn.yaml` | Keep, tighten — same as memory.yaml. |
+| `memory-semantic.yaml` | **Rewrite** as part of the `vault.yaml` issue. Fix `allowed_tools` to current `vault_*` names; rethink whether it should live as a semantic subset of `vault.yaml` or separately. |
+
+### Minimal viable test set per new eval file
+
+For the "medium" priced issues, a 3–5 test minimum. Sketches below — not detailed YAML, just test ideas.
+
+#### `vault.yaml`
+
+- `vault_read`: seed workspace_files with a page, agent reads it when referenced.
+- `vault_write`: agent creates a new page with frontmatter under `agent/pages/`.
+- `vault_search`: seed memories, semantic-query finds the right one (fix the existing `memory-semantic.yaml` tests here).
+- `vault_backlinks`: seed two pages with wiki-links between them, check backlinks query returns the linker.
+- `vault_journal_append`: "remember X" prompt triggers the right tool.
+- Section-aware: `vault_section` + `vault_show_sections` + `vault_move_lines` — probably one test showing a section edit that leaves the rest intact.
+
+#### `workspace-tools.yaml`
+
+- `workspace_read`: seed file, read it by path.
+- `workspace_write` + sandbox: attempt to write outside workspace, expect error.
+- `workspace_edit`: search-replace in a seeded file; verify via `workspace_read` after.
+- `workspace_glob`: seed dir with 3 matching + 3 non-matching; query finds the 3.
+- `workspace_search`: seed files with ripgrep-findable content; query finds the match.
+- `workspace_diff`: edit a file then diff to see the change.
+
+#### `shell.yaml`
+
+- Unapproved shell command with `auto_confirm: true` (default): agent runs `echo hello`, returns stdout.
+- Unapproved shell command with `auto_confirm: false`: agent's call is denied; agent gracefully recovers.
+- `shell_patterns` allowlist bypass: `ls` is allowlisted, agent runs it without confirmation overhead.
+- Background start + status + stop lifecycle.
+
+#### `conversation.yaml`
+
+- `conversation_search`: seed a conversation archive file, agent searches it. **Needs harness gap closed — `setup` doesn't currently seed conversation archives.**
+- `conversation_compact`: multi-turn test that gets long enough to trigger compaction; agent calls `conversation_compact` and history shrinks.
+
+#### `delegate.yaml`
+
+- Delegate a trivial task (e.g. "count the letters in this string"); child returns result.
+- Delegate a task that times out; parent gets error.
+
+#### `tool-deferral.yaml`
+
+- Agent is asked something requiring a deferred tool; agent calls `tool_search`, then calls the fetched tool.
+- Tool budget: context budget stays under N tokens; verify via new harness assertion.
+
+#### `commands.yaml`
+
+- `/unknown-command` dispatch returns clean error, agent doesn't crash.
+- `/ingest` with no args uses attachment flow (covered by `ingest.yaml`, but worth including here).
+- `$ARGUMENTS` substitution: a test skill with `$1` in its command body gets the arg.
+- `context: fork` isolation: fork command has no access to prior conversation history.
+
+#### `health.yaml`
+
+- `!health` command returns the agent's status block.
+- `health_status` tool called mid-conversation returns a structured result.
+
+#### `consolidation.yaml`
+
+- Seed a journal with several days of entries; run the dream consolidation; expect a vault page update.
+- Seed a messy vault; run garden; expect cross-link fixes.
+- **Requires harness support for "simulated scheduled context"** — scheduled runs don't go through the normal interactive path. Blocked.
+
+#### `checklist.yaml`
+
+- Agent given a multi-step task; creates a checklist; iterates step-by-step; completes.
+- Agent aborts a checklist mid-way.
+- `checklist_status` returns remaining steps.
+
+### Harness capabilities required per new file
+
+| File | Requires new harness capability? |
+|------|----------------------------------|
+| `vault.yaml` | No |
+| `health.yaml` | No |
+| `consolidation.yaml` | **Yes** — simulated scheduled context |
+| `claude-code.yaml` | **Yes** — sandbox or mock for subprocess spawning |
+| `workspace-tools.yaml` | Mild — post-turn workspace state assertion would strengthen tests, but existing `workspace_files` setup + follow-up `workspace_read` via a multi-turn test can substitute |
+| `shell.yaml` | Mild — a way to assert a shell command ran with specific args (currently only count-based) |
+| `conversation.yaml` | **Yes** — setup needs to seed a conversation archive |
+| `delegate.yaml` | Possibly — child-agent timeout simulation |
+| `tool-deferral.yaml` | **Yes** — assertion on which specific tool was called (the planned `expect_tool`) |
+| `commands.yaml` | No |
+| `effort-switching.yaml` | **Yes** — effort-state assertion |
+| `cancel.yaml` | **Yes** — simulated cancellation mid-turn |
+| `checklist.yaml` | Mild — post-turn workspace assertion for the checklist markdown file would help |
+
+**Pattern:** most new eval files can be built with the current harness. The blocked-on-harness ones are `consolidation.yaml`, `claude-code.yaml`, `conversation.yaml`, `tool-deferral.yaml`, `effort-switching.yaml`, `cancel.yaml`. Two of these (`effort-switching`, `cancel`) may be hard enough that they're better treated as "investigate how to eval these at all" exploration issues rather than "write these tests" issues.
+
+---
+
+## Step 3: Runtime results
+
+Run: `evals/results/2026-04-24-1015-default/` (worktree).
+
+Summary: **25/29 passed (86.2%)**, 4 failures, ~372s total wall time, 744k tokens. Model resolved as `default` (whatever config default_model points to — needs checking for Step 4; likely Gemini Flash per config.json).
+
+### Pass/fail by file
+
+| File | Passed | Failed | Pass rate |
+|------|--------|--------|-----------|
+| `ingest.yaml` | 1 | 0 | 100% |
+| `memory.yaml` | 6 | 2 | 75% |
+| `memory-multi-turn.yaml` | 4 | 0 | 100% |
+| `memory-semantic.yaml` | 7 | 0 | **100% (but see note)** |
+| `postmortem.yaml` | 1 | 0 | 100% |
+| `project-skill.yaml` | 6 | 2 | 75% |
+
+### Critical non-failure finding: `memory-semantic.yaml` passes for the wrong reason
+
+Every test in `memory-semantic.yaml` has `tool_calls: 0` or 5 for the one that actually needs it. The allowed_tools list references nonexistent tools, but **the agent doesn't NEED those tools** because proactive memory retrieval injects the seeded memories directly into context. The tests pass by the agent echoing back injected memories, not by actually exercising `vault_search`.
+
+This is worse than the tests failing outright — it's a silent loss of coverage. The file claims to test semantic search, but the assertions pass even if vault_search is completely broken.
+
+Contrast:
+- Test "finds specific cat fact via semantic search" — `tool_calls: 5` — this one actually drove a tool call, possibly because "When was Felix the Cat created?" is outside the seeded memories, so proactive retrieval didn't help and the agent reached for a tool.
+- All other tests — `tool_calls: 0` — agent answered straight from the context-injected memory.
+
+**Implication for the vault rewrite issue**: new vault tests must force tool use. Either seed memories via a path that bypasses proactive retrieval (e.g. only index them without adding to recent memories), or use `allowed_tools: [vault_search]` (correct name this time) + force the distractor fixture, or use longer distractor vaults that push relevant entries out of the proactive retrieval window.
+
+---
+
+## Step 4: Failure triage
+
+| # | Test (file) | Category | Analysis |
+|---|-------------|----------|----------|
+| 15 | "recalls recent memories" (memory.yaml) | **(d) real coverage issue** | Agent response: "I don't have any specific information about your past projects..." — 1 tool call. Seeded memories (`DecafClaw event bus refactor`, `Prefers concise answers`) existed but agent failed to surface them. Proactive memory retrieval didn't inject; vault_search returned unhelpful results. **Fix direction:** the test exposes a real gap where memory retrieval doesn't fire for an open-ended "what do you know about me" prompt. Belongs in the `vault.yaml` issue's scope to investigate — either the test is too vague (model interprets "what do you know about me" as "what did the user tell *you*" and doesn't reach for stored knowledge) or the retrieval heuristic needs tuning. Not bit-rot. |
+| 19 | "uses think tool for complex question" (memory.yaml) | **(d) real coverage issue** | Agent response: invented a fictitious Caprese/etc. menu, 0 tool calls. Expected: reference Thai/Japanese food OR cocktails (per seeded memories). Agent didn't reach for memory at all. **Fix direction:** the prompt "If you were planning a dinner party for me, what would you serve?" doesn't explicitly say "based on my preferences" — the agent treats it as a generic creative prompt. Same as #15: either tighten the prompt, or tune retrieval triggers. Note: test name says "uses think tool" but `think` doesn't exist; test name is stale (already flagged in static audit). |
+| 25 | "writes spec when asked" (project-skill.yaml) | **(d) real project-skill behavior issue** | 3 tool errors: `unknown tool 'project_advance'. Did you mean: project_advance, ...` (self-contradicting error message — **separate bug**), `write the plan with project_update_plan before project_task_done`, `no steps parsed. Use checkbox format`. Agent produced the haiku but stumbled through the project workflow. **Fix direction:** project skill step-parsing regex is strict; the agent's output format doesn't match. Belongs in project-skill issue tracking, NOT this audit. |
+| 26 | "writes plan after spec approval" (project-skill.yaml) | **(d) real project-skill behavior issue** | Same pattern: 31 tool calls, 3 tool errors around step ordering and parsing. Agent eventually completed but ran over the `max_tool_errors: 1` bound. **Fix direction:** same as #25. |
+
+### Harness bug caught (by accident)
+
+- **Self-contradicting "did you mean" error message.** Error reads: `unknown tool 'project_advance'. Did you mean: project_advance, ...` — the suggested alternative is identical to the unknown tool. This is a bug somewhere in the tool dispatch / unknown-tool-suggestion path (possibly `src/decafclaw/tools/__init__.py` or the registry). **Separate issue, not eval-related.** Spin out.
+
+### What the results bundle captured
+
+- `results.json` — per-test details with full history on failures.
+- `reflections/` — 4 markdown files, one per failure, with judge-model analysis. Worth reviewing briefly to see if judge's suggestions match my manual triage.
+
+### Pass-rate discipline
+
+No flaky pattern in the failures (each has a consistent, reproducible root cause). No rate-limit-shaped failures. Concurrency at 4 was fine. No need to re-run sequentially.
+
+### Re-prediction scorecard
+
+My static audit predicted `memory-semantic.yaml` at 0/7 (actual: 7/7 — but for the wrong reasons, see note above) and 72-76% total (actual 86.2%). The static analysis underweighted proactive memory injection. Worth remembering: eval test coverage isn't just "does it pass" — it's "does it test what it claims to test." The harness can't detect tests that pass trivially.
+
+---
+
+## Step 6: Harness gaps
+
+Consolidated list of harness capability issues surfaced across steps 1, 4, 5. Each is a candidate for its own spin-out issue.
+
+| # | Gap | Rationale | Size |
+|---|-----|-----------|------|
+| H1 | **`expect_tool` / `expect_no_tool` assertions** | Docs already claim these exist; runner doesn't implement them. Fundamental for testing "did the agent reach for the right tool" without relying on fragile `response_contains` strings. Unblocks `tool-deferral.yaml`, strengthens nearly every other eval. | S |
+| H2 | **`expect_tool_count_by_name` assertion** | Fine-grained counting — e.g. assert exactly 1 `vault_search` call. Complements H1. | XS |
+| H3 | **`expect_tool_args` assertion** | Assert a specific tool was called with specific arg values. More powerful but also more brittle. Defer until we hit a test that really needs it. | M |
+| H4 | **Multi-model matrix runner** | `--model` takes one value. Need a single invocation that runs the suite across a configured list of models and produces a combined pass-rate report. Requested by #240 ("run against multiple models") and #17's lesson that different models fail differently. | M |
+| H5 | **Pass-rate trend tracking** | Each run writes a standalone bundle. `evals/results/` is gitignored so there's no history. Proposal: `evals/history.jsonl` (or similar) capturing per-run summary, committed to git. Lets us detect regressions. | S |
+| H6 | **Post-turn workspace state assertions** | Currently can only assert on response text and tool-call count. No way to check "after this turn, `agent/pages/foo` exists with frontmatter `summary: ...`". Critical for vault/workspace/ingest evals. | S–M |
+| H7 | **Conversation archive seeding in `setup`** | `setup` can't seed a conversation archive for `conversation_search` / `conversation_compact` evals. Need `setup.conversation_history: [...messages]` or `setup.conversation_archive_file`. | S |
+| H8 | **Scheduled/heartbeat mode simulation** | Evals run as `AgentMode.INTERACTIVE`. Dream/garden/heartbeat-mode tests need the scheduled context path (different system prompt assembly). Probably `setup.mode: scheduled` + a per-task preamble injection. | M |
+| H9 | **Cancel probe (simulated stop mid-turn)** | No way to test cancel behavior. Needs a hook that triggers `ctx.cancelled = True` at a scripted point mid-turn. | M–L |
+| H10 | **Effort-level switching probe** | No way to assert effort state changed. Need visibility into effort-level transitions (or a probe that inspects post-turn state). | M |
+| H11 | **Claude Code sandbox/mock** | `claude_code_*` tools spawn real subprocesses — dangerous in parallel eval runs. Need a mock mode or a sandbox that exercises the skill's dispatch without real execution. | L |
+| H12 | **Context-budget / deferred-tool probe** | Assertion on "tool X was fetched via tool_search" or "context size under N tokens". Could ride on H1 (`expect_tool_call_sequence`) or be its own thing. | S |
+| H13 | **`reflect.py` multi-turn bug** | Lines 38-42 extract `role`/`content` keys from turns; our turn schema is `{input, expect}`. Multi-turn failure reflections have malformed inputs. **Trivial fix — can be inline.** | XS |
+| H14 | **`reflect.py` ignores non-`response_contains` assertions** | Judge prompt only interpolates `expected = expect.get("response_contains", "?")`. Failures on `max_tool_calls` / `max_tool_errors` / `response_not_contains` get useless judge advice. **Trivial fix — can be inline.** | XS |
+| H15 | **`make eval` target** | No Makefile target. Current invocation is `uv run python -m decafclaw.eval evals/`. Add `make eval` (single-run) and maybe `make eval-matrix` (after H4). | XS |
+| H16 | **`response_contains_all` assertion (AND semantics)** | The runner's list form of `response_contains` is OR (matches any). Several tests are mis-named implying AND. A `response_contains_all` would close the gap without rewriting tests. | XS |
+| H17 | **Silent-pass detection / test quality guard** | `memory-semantic.yaml` passed for the wrong reason (proactive retrieval bypassed the `allowed_tools` constraint because the agent didn't need any tool). No mechanical fix; instead, a docs addition: "when your test aims to exercise a specific tool, assert `tool_calls > 0` via a new `min_tool_calls` or equivalent, OR explicitly `expect_tool` (H1)." Half-harness, half-docs. | XS |
+| H18 | **Separate tool-registry bug (self-contradicting "did you mean")** | Not an eval harness issue per se, but surfaced by the eval run. Tool dispatch produces `unknown tool 'foo'. Did you mean: foo, ...` where the suggestion is identical to the unknown. File as its own (non-eval) issue. | XS |
+
+### Inline-fix candidates from this list
+
+H13, H14, H15, H16 are each tiny and borderline between "inline fix on this branch" and "spin out". Per the spec's inline bar ("sentence-level" fixes only), H13+H14 fit (bug fix ≤ 5 lines each), H15 fits (Makefile line), H16 debatable (new assertion = small new feature, probably spin out).
+
+**Decision for Step 7:** inline-fix H13, H14, H15 + `docs/eval-loop.md` field names. Spin out everything else.
+
+H18 (tool dispatch "did you mean" bug) is not an eval issue at all — file separately, not part of the eval-coverage umbrella.
+

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/notes.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/notes.md
@@ -469,3 +469,62 @@ H13, H14, H15, H16 are each tiny and borderline between "inline fix on this bran
 
 H18 (tool dispatch "did you mean" bug) is not an eval issue at all — file separately, not part of the eval-coverage umbrella.
 
+---
+
+## Session retrospective
+
+### Recap
+
+Audit session for #240 ("Eval coverage: audit and expand"). Produced:
+
+- **PR #338** — 4 commits on branch `eval-coverage`. Session scaffolding + spec, inline doc/bug fixes (`docs/eval-loop.md` schema rewrite, `reflect.py` multi-turn fix, `make eval` target), the audit doc + plan + notes, and the audit-doc issue-number update.
+- **16 GitHub issues filed** (#339–#354) as children of #240, each on the decafclaw project board with priority + size set.
+- **1 standalone issue filed** (#355) for the tool-registry did-you-mean bug caught by accident during the eval run.
+- **#240 closed** with an umbrella comment linking all children.
+- **9 deferred issues noted** in the audit doc but not filed — all P3 and blocked on P3 harness work.
+
+### Divergences from plan
+
+- **Step 12 reordered.** Plan had "final sync, PR, retro" as the last step. Les asked mid-execute to push the PR before filing issues so the filed issue bodies could point at a visible branch + PR. Executed as push + PR → Step 10 → Step 11 → retro.
+- **Added Commit 4.** Not in the original plan. After filing issues I updated the audit doc's Section 5 with actual issue numbers (#339–#355) so the frozen audit record is self-sufficient, and committed that as a 4th commit. Small cost, useful artifact.
+- **Issue count landed at 17 filed, not 16.** The standalone tool-registry bug (#355) was a side finding, not a #240 child. Filed it anyway as a separate issue since it's a real tool-dispatch bug surfaced by the eval run.
+
+### Key findings (the actual content payoff)
+
+- **`memory-semantic.yaml` was silently broken.** 7/7 runtime pass but testing nothing — allowed_tools referenced removed tool names, but proactive memory retrieval injected the seeded memories directly into context so the agent never reached for a tool. The insight "a test passing doesn't mean it's testing what it claims" was the most important audit finding and drove a docs update in `eval-loop.md` about forcing tool use when you mean to test a tool.
+- **Doc rot in `docs/eval-loop.md`.** Field names (`prompt`/`expect_contains`/`expect_tool` as flat fields) described a schema the runner never had, including an `expect_tool` row documenting an assertion that doesn't exist. Fixed inline.
+- **Two real harness bugs in `reflect.py`.** Multi-turn input extraction used the wrong schema keys (`role`/`content` vs. `input`/`expect`); fixed inline. Judge prompt only interpolates `response_contains` and gives useless advice for `max_tool_calls` / `max_tool_errors` failures; spun out to #354.
+- **Self-contradicting "did you mean" error** in tool dispatch, caught during the eval run — filed as #355, unrelated to #240.
+
+### Insights
+
+- **Audit before solution.** Spending the brainstorm phase on "what's the scope of this session" rather than "how to build N evals" made the whole downstream work sharper. The discovery that `memory-semantic.yaml` silently passes is a good example — would have been invisible if I'd jumped straight to writing new eval files.
+- **Per-eval-file issue granularity was right at this count.** 16 issues is a lot, but each is discrete and has a clear PR shape. Coarser would've muddied priorities; finer would've been annoying to track.
+- **Don't trust a "pass" — check whether the test exercises the path it claims to.** This belongs in `docs/eval-loop.md` (now added) and in every future eval review.
+- **GitHub Project Board filing is scriptable but tedious.** `gh issue create --project "NAME"` gets it on the board; `gh project item-edit` sets the custom fields. Three calls per issue. Fine for 16; would want a helper for 50+.
+- **Reflections have real informational value even for an audit.** The judge model's reflections on the 4 runtime failures mostly matched my manual triage, which was useful as an independent check. Worth keeping `reflections/` generation enabled.
+
+### Efficiency observations
+
+- **Parallelization worked well.** Step 3 (eval run, ~2 min wall-clock) overlapped with Step 9 (gh project probe + field discovery) — saved some minutes. Similarly, writing the 15 issue body files happened in parallel tool calls where possible.
+- **The runner's concurrency default (4) was right.** Zero rate-limit-shaped failures; no need to fall back to sequential. The pre-committed fallback plan was reassuring but unused.
+- **The venv ambiguity was a near-miss.** My initial `ps aux` check showed the eval run was using Homebrew Python, not clearly the worktree venv. Turned out to be fine because main and worktree were on the same commit (no Python changes yet), but a future session with real code changes would need a deliberate `cd` into the worktree or absolute paths.
+- **Writing the audit doc at end was the right shape.** Trying to draft it incrementally while still gathering evidence would have been choppy. Better to accumulate in `notes.md` and synthesize once the picture is complete.
+
+### Process improvements
+
+- **Memory: venv discipline in worktrees.** Every worktree command that invokes Python should use the worktree's venv path explicitly (`$WORKTREE/.venv/bin/python`), OR the session should start with `cd "$WORKTREE" && source .venv/bin/activate` as a preamble. The project CLAUDE.md already says "Worktrees go under `.claude/worktrees/`; each needs its own venv" — could expand that to "and every Python command should reference `$WORKTREE/.venv/bin/python` explicitly."
+- **Helper for bulk issue filing.** The shell loop in Step 10 worked, but worth extracting as a shared utility (maybe a small `scripts/file-project-issue.sh`) since this pattern will repeat for future splits. Field IDs are stable per project, so hardcoded is fine.
+- **Audit doc location principle (applied, keep).** Point-in-time audits live in the session dir; living guidance goes inline in `docs/` — this split worked and is worth keeping as a convention.
+
+### Conversation turns
+
+Roughly 20 back-and-forth exchanges. The brainstorm phase was ~6 turns (one question per turn), plan phase 2 turns, execute phase the bulk (~12 turns including the two intermediate checkpoints).
+
+### Other highlights
+
+- **PR body serves as a mini-retro.** Because the PR summarizes findings + test plan, readers get the audit's bottom-line without reading the full 900-line audit doc. Session doc is the deep record; PR is the elevator pitch.
+- **#240's closing comment doubles as a dashboard.** The checkbox list of 16 children with blocker notes lets Les (or anyone) pick up where this left off without re-reading the audit.
+- **Zero `make dev` conflict.** The parallel eval run didn't interfere with any running dev instance.
+
+

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/plan.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/plan.md
@@ -9,7 +9,7 @@ This is a research/audit session, not feature-building. Most steps produce analy
 - Branch: `eval-coverage` (already created; spec already committed).
 - Commit 1 already landed: session scaffolding + spec.
 - Commit 2: inline doc/comment rot fixes (step 7).
-- Commit 3: audit doc (`docs/evals-audit.md` — see note on location in step 8).
+- Commit 3: audit doc at `docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md` (see Step 8 for the location decision — point-in-time artifact, not a living doc).
 - No other code changes on this branch.
 - Rebase against origin/main before opening the final PR.
 

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/plan.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/plan.md
@@ -1,0 +1,240 @@
+# Plan: eval coverage audit
+
+See [spec.md](./spec.md) for scope, deliverables, and acceptance criteria.
+
+This is a research/audit session, not feature-building. Most steps produce analysis output (notes in this dir or the final audit doc), not code. Only two steps produce commits: the inline-doc-rot fix (step 7) and the audit doc itself (step 8). Issue-filing (step 10) mutates GitHub, not the repo.
+
+## Commit / branch strategy
+
+- Branch: `eval-coverage` (already created; spec already committed).
+- Commit 1 already landed: session scaffolding + spec.
+- Commit 2: inline doc/comment rot fixes (step 7).
+- Commit 3: audit doc (`docs/evals-audit.md` — see note on location in step 8).
+- No other code changes on this branch.
+- Rebase against origin/main before opening the final PR.
+
+## Steps
+
+### Step 1: Harness capability survey
+
+**Build on:** Already partially done during brainstorm (read `runner.py`, `memory.yaml`, `project-skill.yaml`, `docs/eval-loop.md`). This step completes it.
+
+**Action:** Read the remaining eval harness files — `src/decafclaw/eval/__main__.py`, `src/decafclaw/eval/reflect.py`, `src/decafclaw/eval/__init__.py`. Read `Makefile` targets related to evals (`make build-eval-fixtures`, anything calling `decafclaw.eval`).
+
+**Output:** Write findings to `notes.md` under a "Harness capabilities" section. Include:
+- Supported `setup` fields (skills, memories, workspace_files, embeddings_fixture, auto_confirm)
+- Supported assertions (response_contains, response_not_contains, max_tool_calls, max_tool_errors)
+- CLI flags (model, verbose, concurrency, judge-model, etc.)
+- Concurrency model and per-test isolation
+- What's missing vs what #240 implies is needed (expect_tool-by-name, multi-model matrix, pass-rate history, cancel/effort/context-budget hooks, tool-arg inspection)
+
+**Commit:** None — notes are scratch.
+
+---
+
+### Step 2: Static per-file audit
+
+**Build on:** Step 1's harness survey.
+
+**Action:** For each of the 6 YAML files (`ingest.yaml`, `memory.yaml`, `memory-multi-turn.yaml`, `memory-semantic.yaml`, `postmortem.yaml`, `project-skill.yaml`):
+- Read the file.
+- Cross-reference each test's assertions against current tool names, skill SKILL.md wording, and runner support. Tools to cross-reference against: `src/decafclaw/tools/` + `src/decafclaw/skills/*/SKILL.md` + `src/decafclaw/skills/*/tools.py`.
+- For each test, classify: still-valid / stale-but-fixable (e.g. tool renamed, SKILL.md text changed) / fundamentally-broken (assertion impossible or meaningless now) / needs-runtime-evidence (can't tell without running).
+
+**Output:** Per-file verdict table in `notes.md` under "Static audit".
+
+**Commit:** None — notes are scratch.
+
+**Parallelization:** This is cheap enough sequentially; all 6 files total ~250 lines. One pass in one message.
+
+---
+
+### Step 3: Full eval run (default model)
+
+**Build on:** Step 2. We know what to expect.
+
+**Action:**
+- From the worktree venv: `.venv/bin/python -m decafclaw.eval evals/ --verbose`.
+- Capture stdout + the resulting `evals/results/{timestamp}-{model}/results.json`.
+- If widespread failures that look rate-limit-shaped (timeouts, 429s, identical failure patterns across independent tests), abort and re-run with `--concurrency 1`.
+- Run in the background so we can keep working on steps 4/5/7 while it runs.
+
+**Output:** Pass/fail summary per file in `notes.md` under "Runtime results", plus the JSON bundle path. Note the model used and wall-clock duration.
+
+**Commit:** None — the results bundle is in `evals/results/` which is already gitignored.
+
+**Risk:** If the harness itself is broken (crashes, doesn't start), that's its own finding — log it and fall back to static analysis only.
+
+**`make dev` note:** Les likely has `make dev` running. The eval run uses the same LLM provider / credentials but not the same state (per-test tempdir). Shouldn't conflict. Do NOT start a second `make run` / `make dev` / `make debug`.
+
+---
+
+### Step 4: Failure analysis
+
+**Build on:** Steps 2 + 3.
+
+**Action:** For each failure from step 3, categorize:
+- (a) **Genuine bit-rot** — assertion no longer matches current behavior. Inline-fix the test assertion? Or leave for the per-subsystem issue? Judgment call per case.
+- (b) **Harness limitation** — test is trying to assert something the runner can't cleanly check (usually via fragile `response_contains` strings). Note as harness-gap.
+- (c) **Flaky / model variance** — one-off, consider re-running sequentially to confirm.
+- (d) **Real coverage bug** — tool/skill behavior has a real issue that the eval exposed. File a separate bug, not part of the audit scope.
+
+**Output:** Failure triage table in `notes.md` under "Failure triage".
+
+**Commit:** None.
+
+---
+
+### Step 5: Coverage gap walk
+
+**Build on:** Step 1 (harness capabilities) + #240 scope list.
+
+**Action:** Walk the 15-bullet scope of #240. For each bullet:
+- Does an eval file already cover it (from step 2)? If yes, is coverage complete or partial?
+- Which eval file *should* it live in (per the "one issue ≈ one eval file" model from spec)?
+- Minimum viable test set — 3–5 test ideas per subsystem, without writing them in detail.
+- Harness support needed — does the runner already support the assertions this subsystem needs? If not, flag the missing capability.
+
+**Output:** Coverage gap table in `notes.md` under "Coverage gaps", grouped by proposed eval file.
+
+**Commit:** None.
+
+---
+
+### Step 6: Harness gap list
+
+**Build on:** Steps 1, 4, 5.
+
+**Action:** Consolidate harness-level issues from steps 1, 4, 5. Expected candidates (from spec + what I already saw during brainstorm):
+- `expect_tool` / `expect_tool_count_by_name` assertions
+- `expect_no_tool` assertion
+- Tool-args inspection (assert a specific tool was called with specific args)
+- Multi-model matrix runner + combined report
+- Pass-rate trend tracking over time
+- Post-turn workspace state assertion (file X should exist with content Y)
+- Cancel / stop-mid-turn hook
+- Effort-level switching hook
+- Context-budget probe (deferred tool fetched / not fetched)
+
+**Output:** Harness-gap table in `notes.md` under "Harness gaps". Each row: title, one-line rationale, rough size estimate.
+
+**Commit:** None.
+
+---
+
+### Step 7: Inline fix pass
+
+**Build on:** Steps 1, 2, 4.
+
+**Action:** Apply all sentence-level doc/comment rot caught so far. Known targets (from brainstorm):
+- `docs/eval-loop.md`: field names (`prompt`/`expect_contains`/`expect_tool` as flat fields) → replace with actual runner format (`input`/`expect.response_contains`, no `expect_tool`). Remove the `expect_tool` row from the field table (or note it as not-yet-implemented → spin out).
+- `docs/eval-loop.md`: examples should match runner format.
+
+Plus anything discovered during steps 2/4. Bar per spec: sentence-level fixes only; anything bigger goes to the harness-gap list (step 6).
+
+**Output:** A commit titled `docs(eval-loop): correct stale field names and examples`.
+
+**Verification:** `grep -n "expect_contains\|expect_tool\b" docs/eval-loop.md` after the fix should return only intentional mentions (e.g. in a "not supported, tracked in #XXX" callout).
+
+**Commit:** Yes — Commit 2.
+
+---
+
+### Step 8: Synthesize audit doc
+
+**Build on:** Everything above.
+
+**Action:** Write the final audit doc. **Location decision:** I'm going to put it at `docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md` rather than `docs/evals-audit.md` — the audit is a point-in-time artifact, not a living doc. Future readers find it via git log. Anything that belongs in a living doc (e.g. updated guidance in `docs/eval-loop.md`) is inlined in step 7, not duplicated here.
+
+Structure:
+- Executive summary (pass rate across all files, count of stale tests, count of spun-out issues).
+- Harness capabilities (from step 1).
+- Per-file verdict (from steps 2 + 4, merged).
+- Coverage gaps (from step 5).
+- Harness gaps (from step 6).
+- Prioritized issue list: one row per spun-out issue with title, priority, size, one-line summary. This table drives step 10.
+
+**Commit:** Yes — Commit 3, titled `docs(eval-coverage): audit of existing evals and split-out plan`.
+
+---
+
+### Step 9: Verify project-board filing mechanism
+
+**Build on:** None — can run early as background prep.
+
+**Action:**
+- `gh auth status` to confirm creds.
+- Find the project's numeric ID: `gh project list --owner lmorchard` → locate "decafclaw".
+- Examine an existing issue on the board (e.g. #240 itself) to see how it was added: `gh issue view 240 --json projectItems`.
+- Determine the right incantation. Candidates:
+  - `gh issue create --project "decafclaw" ...`
+  - `gh issue create` then `gh project item-add <PROJECT_NUMBER> --owner lmorchard --url <ISSUE_URL>`
+  - `gh project item-add` with `--field` flags for priority/size.
+- Probe with **one** drafted issue: file it, verify it landed on the board with the right priority+size, THEN use the same pattern for the rest.
+
+**Output:** One-line incantation in `notes.md` under "Filing recipe".
+
+**Commit:** None.
+
+---
+
+### Step 10: File spun-out issues
+
+**Build on:** Steps 8 + 9.
+
+**Action:** For each row in the audit doc's prioritized issue list, file an issue via `gh`:
+- Title per audit doc.
+- Body includes: problem statement (lifted from audit), scope bullets, acceptance criteria, link back to `#240` with `(split from #240)`, link to the audit doc in the dev-session dir.
+- Priority + Size fields set per audit doc (defaults P2/M).
+- Add to project board using the verified incantation from step 9.
+
+Keep a running list of filed issue numbers in `notes.md` under "Filed issues" so we can verify step 11 doesn't miss any.
+
+**Output:** Issues filed on GitHub. Running list in `notes.md`.
+
+**Commit:** None — this mutates GitHub, not git.
+
+---
+
+### Step 11: Close #240
+
+**Build on:** Step 10.
+
+**Action:** Post a comment on #240 with:
+- One-line summary: "Split into per-subsystem issues per audit in `<path-to-audit-doc>`."
+- Checklist linking every filed child issue.
+- Close the issue.
+
+Use `gh issue comment 240 --body-file -` with a heredoc, then `gh issue close 240`.
+
+**Output:** #240 closed.
+
+**Commit:** None.
+
+---
+
+### Step 12: Final sync, PR, retro
+
+**Build on:** All prior steps.
+
+**Action:**
+- `git fetch origin && git rebase origin/main` on the `eval-coverage` branch. Resolve conflicts if any (unlikely — we only touched `docs/`).
+- Push branch: `git push -u origin eval-coverage`.
+- Open PR with `gh pr create`. PR body summarizes the audit and links every spun-out issue.
+- **Request Copilot review** per memory: `gh pr edit <N> --add-reviewer copilot-pull-request-reviewer`.
+- Move to retro phase (write `notes.md` session retrospective; squash-merge when Les approves).
+
+**Commit:** No new commits unless rebase produces conflicts requiring resolution.
+
+---
+
+## Stopping rules / when to bail out
+
+- **Harness itself broken.** If step 3 reveals the eval runner doesn't even start, shift scope: the session becomes "fix harness + audit". Flag before continuing.
+- **Pass rate catastrophically low (<30%).** Not automatic stop, but reconsider whether inline fixes can patch many of these before filing per-subsystem issues. Possibly a separate "stabilize current evals" issue before layering new coverage.
+- **Gh project add isn't scriptable.** If step 9 reveals board add requires interactive UI only, fall back to: file issues via `gh`, then Les adds them to the board manually from a list in the audit doc. Spec says "board add must happen"; the mechanism is negotiable.
+
+## Open risks
+
+- **Model cost/time of step 3.** Full eval run across 6 files (~30+ tests) at default concurrency. Budget assumption: <5 min wall-clock, <$0.50 API spend. If much longer, sequential fallback will be 4× slower — still acceptable.
+- **Semantic eval requires `cat-facts-embeddings.db` fixture.** If fixture is bit-rotted vs current embeddings schema, that's a real harness-gap finding and step 3 will partially fail.

--- a/docs/dev-sessions/2026-04-24-0941-eval-coverage/spec.md
+++ b/docs/dev-sessions/2026-04-24-0941-eval-coverage/spec.md
@@ -1,0 +1,71 @@
+# Eval coverage: audit and expand
+
+Tracking: [#240](https://github.com/lmorchard/decafclaw/issues/240)
+
+## Problem
+
+Eval coverage is thin and likely stale. The issue calls out `evals/memory*.yaml` as the only coverage, but a quick scan shows there are also `ingest.yaml`, `postmortem.yaml`, and `project-skill.yaml` — so the issue text itself is already out of date. Doc rot is visible in `docs/eval-loop.md`, which describes fields (`prompt`, `expect_contains`, `expect_tool` as flat keys) that don't match what the runner actually accepts (`input`, `expect: {response_contains, ...}`). No `expect_tool` assertion exists in the runner.
+
+#240 is large (5 skills + 6 tool groups + 4 system behaviors). It should be an umbrella, not a single PR.
+
+## Session scope
+
+This session is an **audit + trivial inline fixes + split #240 into smaller per-system issues**. Not writing new eval files. Not building new harness features.
+
+### Deliverables
+
+1. **`evals-audit.md`** in the session dir — per-file verdict for every existing eval, per-subsystem coverage gap list, harness-gap list, priority ordering for the spun-out issues.
+2. **Inline PR(s)** on the `eval-coverage` branch for any doc/comment rot caught during the audit (sentence-level).
+3. **Per-system GitHub issues filed via `gh`** on the project board, linked from the audit doc, each scoped to roughly one eval file ≈ one PR.
+4. **#240 closed** once children are filed and linked.
+
+## Audit approach
+
+1. **Static read** of each existing eval YAML + eval runner + eval docs. Per-file notes: tests covered, assertions used, any obvious mismatch against current tool signatures or skill SKILL.md text.
+2. **Full run** of all existing evals against the default model (single-model data point). Record pass/fail per test. Failures feed into per-file verdicts.
+3. **Harness capability survey** — what the runner actually supports vs what #240's scope implies we need. Note gaps.
+4. **Coverage gap survey** — walk the list in #240 against the file inventory. For each uncovered area, note which eval file it should live in and what the minimal viable test set looks like.
+5. **Inline fix pass** — apply sentence-level doc/comment fixes surfaced by steps 1–3.
+6. **Prioritize and file issues** — one per eval file (≈ per subsystem) plus separate issues for harness gaps. Each issue: title, problem statement, scope, acceptance criteria, link back to #240, priority, size.
+
+### Inline-fix bar
+
+- ✅ Fix inline on this branch: doc field names that don't match the runner, comments that describe removed behavior, outdated tool names in eval assertions where the intent is obvious, missing `max_tool_errors` where the current tests silently pass despite errors.
+- 🔀 Spin out as its own issue: `expect_tool` / `expect_tool_args` / `expect_tool_count_by_name` assertions, multi-model matrix runner, pass-rate trend tracking, context-budget / cancel / effort-switching harness support, anything requiring > ~20 lines or new test surface.
+
+### Issue filing policy
+
+- File directly via `gh` once the audit doc is committed. Add each to the project board with priority and size.
+- Default priority: **P2**. Default size: **M**. Override only when obviously different (e.g. XS for a known-tiny fix, P1 if flagged critical during audit).
+- Each issue links back to #240 with `(split from #240)` in the body and references the audit doc for detailed scope.
+- Close #240 with a summary comment linking all spun-out children.
+
+### Model
+
+Default model only (whatever `default_model` resolves to in the runner venv). Multi-model matrix is flagged as a spun-out infrastructure issue.
+
+## Acceptance criteria
+
+- `evals-audit.md` exists, committed, with per-file verdicts + gap list + harness-gap list + prioritized issue list.
+- All current evals have been actually run (or explicitly noted as un-runnable with reason).
+- Any inline doc/comment rot caught is fixed on this branch.
+- Each spun-out issue is filed on GitHub with project-board priority + size, and linked from the audit doc.
+- #240 is closed with a comment linking the children.
+
+## Out of scope
+
+- Writing new eval YAML files for any subsystem. (That's what the spun-out issues are for.)
+- Building harness features (`expect_tool` assertion, multi-model matrix, trend tracking). Spun out.
+- Fixing broken tool descriptions / SKILL.md wording caught during the audit unless it's a trivial sentence-level fix. Non-trivial fixes get noted in the audit doc and tracked on their own.
+- Running evals against non-default models.
+- Touching the eval result bundles under `evals/results/` (those are ignored).
+
+## Self-review: gaps worth flagging
+
+These are questions I noticed *after* the initial brainstorm — surfacing now so we can resolve before planning:
+
+- **Eval fixtures.** `evals/fixtures/` contains at least `cat-facts-embeddings.db`; the `make build-eval-fixtures` target regenerates them. If the audit reveals that fixture shape is stale (e.g. schema changed in `embeddings.py`), that's a real infrastructure issue, not a sentence-level fix. Treat as spin-out.
+- **Harness runs tests concurrently at 4×.** A full `evals/` run will hammer the default LLM provider in parallel. If the provider is rate-limited, we may get spurious failures that look like bit-rot. **Decision:** fall back to `--concurrency 1` and re-run before concluding anything's broken. Note the fallback in the audit.
+- **`auto_confirm: true` masks confirmation UX.** The existing project-skill evals already note this explicitly. Worth confirming during the audit that no current eval accidentally relies on the wrong auto-confirm default.
+- **`make dev` may be running.** Running evals from the worktree venv should be fine since each test creates its own tempdir `data_home`, but there's shared state for the LLM provider. Non-issue functionally, but if Les is actively using the dev instance during the run, eval results could bleed into his prompt budget.
+- **Project board mutation.** Filing issues via `gh` adds them to the GitHub project board only if invoked with the right flags or via the `gh project` subcommand. **Decision:** every filed issue MUST end up on the board with priority + size set. Figure out the right incantation during plan-phase (either `gh issue create --project "decafclaw"` or `gh issue create` + `gh project item-add`), verify with the first filed issue, then apply the same pattern to the rest.

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -41,7 +41,7 @@ Tests are YAML files with a list of test cases. Single-turn form:
 
 | Field | Description |
 |-------|-------------|
-| `setup.skills` | List of skill names to pre-activate before the turn |
+| `setup.skills` | List of skill names to pre-activate before the test case (once, shared across turns) |
 | `setup.memories` | List of `{content, tags}`; seeded as journal entries (and indexed for semantic search if the strategy is `semantic`) |
 | `setup.workspace_files` | Map of `{relative_path: content}` to seed into the test workspace. Paths are sandboxed — no `..` escape |
 | `setup.embeddings_fixture` | Path to a pre-built embeddings.db to copy into the workspace |

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -5,29 +5,25 @@ DecafClaw includes an eval harness for testing prompts and tools with real LLM c
 ## Running evals
 
 ```bash
-uv run python -m decafclaw.eval evals/             # Run all YAML test files
-uv run python -m decafclaw.eval evals/memory.yaml   # Run a specific file
+make eval                                            # Run all YAML test files (default model)
+uv run python -m decafclaw.eval evals/               # Same, via Python invocation
+uv run python -m decafclaw.eval evals/memory.yaml    # Run a specific file
 uv run python -m decafclaw.eval evals/ --model gemini-2.5-pro  # Override model
-uv run python -m decafclaw.eval evals/ --verbose     # Show full responses
+uv run python -m decafclaw.eval evals/ --verbose     # Show truncated response snippets per test
+uv run python -m decafclaw.eval evals/ --concurrency 1  # Run tests sequentially (default: 4)
 ```
 
 ## Test case format
 
-Tests are YAML files with a list of test cases:
+Tests are YAML files with a list of test cases. Single-turn form:
 
 ```yaml
 - name: "saves to journal when asked"
-  prompt: "Remember that my favorite color is blue"
-  expect_tool: "vault_journal_append"
-  expect_contains: "blue"
-
-- name: "recalls from vault"
-  prompt: "What's my favorite color?"
-  setup:
-    memories:
-      - content: "User's favorite color is blue"
-        tags: ["preference"]
-  expect_contains: "blue"
+  input: "Remember that my favorite color is blue"
+  expect:
+    response_contains: "blue"
+    max_tool_calls: 5
+    max_tool_errors: 0
 ```
 
 ### Test case fields
@@ -35,25 +31,47 @@ Tests are YAML files with a list of test cases:
 | Field | Description |
 |-------|-------------|
 | `name` | Test name (shown in output) |
-| `prompt` | User message to send (single-turn) or first message (multi-turn) |
-| `turns` | List of `{prompt, expect_contains, expect_tool}` for multi-turn tests |
-| `expect_contains` | Response must contain this string (case-insensitive) |
-| `expect_tool` | Agent must call this tool |
-| `expect_no_tool` | Agent must NOT call this tool |
-| `setup.memories` | Pre-populate memory entries before the test |
-| `setup.embeddings_fixture` | Path to a pre-built embeddings.db to copy in |
-| `allowed_tools` | Restrict which tools the agent can use |
+| `input` | User message to send (single-turn) |
+| `turns` | List of `{input, expect}` for multi-turn tests (see below) |
+| `setup` | Fixture setup — see [Setup fields](#setup-fields) |
+| `expect` | Assertions to check — see [Expect assertions](#expect-assertions) |
+| `allowed_tools` | List of tool names; the agent can only call these. Unlisted tool calls return an error. |
+
+### Setup fields
+
+| Field | Description |
+|-------|-------------|
+| `setup.skills` | List of skill names to pre-activate before the turn |
+| `setup.memories` | List of `{content, tags}`; seeded as journal entries (and indexed for semantic search if the strategy is `semantic`) |
+| `setup.workspace_files` | Map of `{relative_path: content}` to seed into the test workspace. Paths are sandboxed — no `..` escape |
+| `setup.embeddings_fixture` | Path to a pre-built embeddings.db to copy into the workspace |
+| `setup.auto_confirm` | Default `true`. Auto-approve (or deny) all tool confirmation requests (shell, email, `EndTurnConfirm`, etc.) |
+
+### Expect assertions
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `response_contains` | str / list[str] / `"re:pattern"` | **OR semantics.** Matches if any listed string/regex is in the response. Case-insensitive for non-regex; regex uses `re:` prefix. |
+| `response_not_contains` | str / list[str] | **AND semantics.** Fails if any listed string is in the response. Case-insensitive. |
+| `max_tool_calls` | int | Fail if tool calls in this turn exceed the bound |
+| `max_tool_errors` | int | Fail if tool results containing `[error` in this turn exceed the bound |
+
+Note that `response_contains` with a list uses OR semantics — to require several strings, use a single `re:(?s).*foo.*bar.*` regex, or use multiple assertions by splitting into separate test cases.
 
 ### Multi-turn tests
 
 ```yaml
 - name: "save then recall"
   turns:
-    - prompt: "Remember that my cat's name is Sassy"
-      expect_tool: "vault_journal_append"
-    - prompt: "What's my cat's name?"
-      expect_contains: "Sassy"
+    - input: "Remember that my cat's name is Sassy"
+      expect:
+        response_contains: "Sassy"
+    - input: "What's my cat's name?"
+      expect:
+        response_contains: "Sassy"
 ```
+
+Each turn has its own `expect`; all must pass for the test to pass. History is shared across turns within a single test.
 
 ### Semantic search tests
 
@@ -61,14 +79,30 @@ To test semantic search, provide a pre-built embeddings fixture with distractor 
 
 ```yaml
 - name: "finds relevant memory among distractors"
-  prompt: "What's my cat's name?"
   setup:
     memories:
       - content: "User's cat is named Sassy"
         tags: ["pets"]
     embeddings_fixture: "evals/fixtures/cat-facts-embeddings.db"
   allowed_tools: ["vault_search"]
-  expect_contains: "Sassy"
+  input: "What's my cat's name?"
+  expect:
+    response_contains: "Sassy"
+```
+
+**Important:** proactive memory retrieval can inject seeded memories directly into context without the agent ever calling `vault_search`. Tests that intend to exercise search specifically should be designed so the answer isn't reachable from proactively-retrieved context (e.g. by using enough distractors, or relying on the embeddings fixture alone and not seeding memories that will surface via the retrieval window).
+
+### User-invokable commands
+
+The runner dispatches `/foo` and `!foo` commands before running the agent, so user-invokable skills can be tested end-to-end:
+
+```yaml
+- name: "postmortem produces a report"
+  setup:
+    skills: [postmortem]
+  input: "/postmortem on this test pattern"
+  expect:
+    response_contains: "## Anomaly"
 ```
 
 ## Result bundles
@@ -77,7 +111,7 @@ Each eval run creates a result bundle at `evals/results/{timestamp}-{model}/`:
 
 ```
 evals/results/
-  20260315-013000-gemini-2.5-flash/
+  2026-04-24-1015-default/
     results.json              # Full results with per-test details
     reflections/              # LLM-generated analysis of failures
       test-name.md
@@ -102,6 +136,8 @@ The `cat-facts-embeddings.db` fixture contains ~97 cat facts as a distractor noi
 ## Tips
 
 - **Tool descriptions are the primary control surface.** Wording changes measurably affect behavior. Use evals to validate.
+- **Bound every test with `max_tool_calls` and `max_tool_errors`.** Unbounded tests pass silently on agent-loop regressions.
+- **If a test targets a specific tool, make sure the agent actually has to call it.** Proactive context injection can make tests pass without exercising the tool they claim to exercise. Consider `allowed_tools: [the_tool]` or distractor-heavy fixtures.
 - **Start with substring search tests**, then add semantic search tests with distractors.
 - **Use `allowed_tools`** to constrain which tools the agent can reach for, testing specific behaviors.
 - **Run evals after changing prompts or tool descriptions** — regressions are easy to introduce.

--- a/src/decafclaw/eval/__main__.py
+++ b/src/decafclaw/eval/__main__.py
@@ -24,7 +24,8 @@ def main():
     parser.add_argument("path", help="YAML file or directory of YAML files")
     parser.add_argument("--model", help="Override LLM model")
     parser.add_argument("--judge-model", help="Model for failure reflection (default: same as --model)")
-    parser.add_argument("--verbose", action="store_true", help="Show full responses")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show a truncated response snippet (first 200 chars) per test")
     parser.add_argument("--concurrency", type=int, default=4, help="Max concurrent tests (default: 4)")
     args = parser.parse_args()
 

--- a/src/decafclaw/eval/reflect.py
+++ b/src/decafclaw/eval/reflect.py
@@ -37,8 +37,8 @@ async def reflect_on_failure(config, test_case: dict, result: dict,
     # Multi-turn tests use "turns" instead of "input"
     if "turns" in test_case:
         input_text = "\n".join(
-            f"[{t.get('role', 'user')}] {t.get('content', '')}"
-            for t in test_case["turns"]
+            f"[turn {i + 1}] {t.get('input', '')}"
+            for i, t in enumerate(test_case["turns"])
         )
     else:
         input_text = test_case.get("input", "")


### PR DESCRIPTION
## Summary

Audit-and-split session for #240. This PR lands:

1. The audit doc at `docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md` — full per-file verdict, harness-gap list, and prioritized split-out plan.
2. Three inline fixes surfaced by the audit:
   - `docs/eval-loop.md` — rewrite with correct runner schema (stale field names described a schema that doesn't exist; the `expect_tool` table row documented an assertion the runner never implemented).
   - `src/decafclaw/eval/reflect.py` — multi-turn input extraction used `role`/`content` keys; our schema is `{input, expect}`, so every multi-turn failure reflection was sending an empty input to the judge.
   - `Makefile` — add `make eval` convenience target.

Everything bigger gets spun out as its own per-system issue (filed as follow-ups on the project board). The per-system issues close #240.

## Key findings

- **25/29 existing tests pass (86.2%)** against the default model.
- **`memory-semantic.yaml` is silently broken.** All 7 tests pass but their `allowed_tools` lists reference removed tool names (`memory_search`, `memory_recent`, `memory_save`, `think`). The tests pass because proactive memory retrieval injects the seeded memories into context, so the agent never needs to call the blocked tools. The file claims to test semantic search; it is not. Replaces → rewritten as part of the vault-evals issue.
- **4 runtime failures** are all real behavior issues (2 memory retrieval gaps, 2 project-skill step-parsing regressions), not bit-rot.
- **One separate tool-registry bug** surfaced during the run: unknown-tool error says \"Did you mean: <same name>\" — filed as a standalone, not eval-harness.

## Test plan

- [x] `make lint` passes on the branch.
- [x] `make eval` runs the full suite end-to-end (took ~6 minutes, 25/29 passing).
- [ ] Doc review: confirm `docs/eval-loop.md` examples match the runner's actual schema.
- [ ] Session doc review: audit doc + plan + notes read cleanly and reference real file paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)