### PR TITLE
Attach manager to !command dispatch ctx

### DIFF
--- a/docs/dev-sessions/2026-04-24-1549-context-fork-manager/notes.md
+++ b/docs/dev-sessions/2026-04-24-1549-context-fork-manager/notes.md
@@ -1,0 +1,57 @@
+# context: fork command manager fix — retrospective notes
+
+Session: 2026-04-24, 15:49 → ~17:00 PT
+Scope: Fix issue #361 — `!command` invocation of `context: fork` skills failing with missing `ctx.manager`.
+PR: https://github.com/lmorchard/decafclaw/pull/363
+
+## Recap
+
+1. Filed #361 during retro of #283/#356 (newsletter) as a latent-bug follow-up.
+2. Started dev session on `.claude/worktrees/context-fork-manager/`, rebased on fresh origin/main (post-newsletter-merge).
+3. Brainstormed: confirmed direction (a) — fix the propagation rather than flip dream/garden to inline. Fork isolation is the right UX for background-style user-invocable skills.
+4. Wrote spec, self-reviewed (caught a spec-vs-plan mismatch about which tests actually catch the bug), wrote plan, self-reviewed.
+5. Executed 4-task plan via `superpowers:subagent-driven-development` — 2 contract tests + 1 TDD regression test + 2 transport one-liners.
+6. Branch self-review caught: leftover unused imports/list in the new test file (flagged by per-task code reviewer, deferred for batch cleanup), plus the need to rebase on 2 new origin/main commits.
+7. Rebased, squashed, pushed, opened PR #363 with Copilot review.
+8. Copilot returned 1 comment — a genuine duplicate heading I'd left in spec.md during in-place editing. Fixed and force-pushed.
+
+## Divergences from plan
+
+None significant. The plan called for 4 tasks, executed 4 tasks. No surprises.
+
+## Key insights
+
+### Smoke-test findings drive the next round
+
+This PR exists BECAUSE of a smoke test finding from the prior session. The `!newsletter` smoke test surfaced the `ctx.manager is None` error; I worked around it for newsletter (inline) and filed #361 for the general fix. That filing-then-fixing cadence is working well — smoke tests become backlog items naturally.
+
+### In-place spec edits can drop visible dupes
+
+Copilot's only comment was "### Existing tests appears twice." I'd edited the spec in-place to distinguish contract vs regression tests, and the old `### Existing tests` block stayed alongside the new one. My `Edit` tool operations replaced content but the overall section structure drifted.
+
+**Takeaway:** after an `Edit` that restructures a section, read the whole section end-to-end before committing. Alternately, when restructuring, do a single `Edit` covering the entire section rather than multiple small ones — reduces the chance of leaving orphan sub-headings.
+
+### Manager attribute was already on Context — no convention smell
+
+I initially worried about the `ctx.manager = manager` pattern given CLAUDE.md's rule against undeclared-attribute-setattr. Exploring the code revealed `Context` is a plain class (not a `@dataclass`) and `self.manager: Any = None  # set by ConversationManager` is declared in `__init__` at context.py:94. So this wasn't a convention violation — just a code pattern I needed to confirm. Saved a tempting-but-unnecessary refactor.
+
+### Minor eval-runner gap left alone
+
+The branch reviewer spotted that `src/decafclaw/eval/runner.py:193` also constructs a `Context` without setting `manager` — so the eval harness would hit the same bug if it ever ran a `context: fork` command. Pre-existing, not introduced here, not in scope. Left for a future cleanup if the eval harness adds command-dispatch coverage.
+
+## Process observations
+
+- **Tight session.** Start-to-PR-ready in ~1 hour. Newsletter (#283/#356) took ~3 hours. Smaller scope = faster cycle, and I had the template from the newsletter session in muscle memory.
+- **Contract tests vs regression tests distinction paid off.** The plan explicitly separated "tests that pin behavior and always pass" from "tests that fail before the fix." Having that framing baked into the plan headings made the TDD RED step feel deliberate rather than accidental.
+- **Bundled web-UI cleanup from the prior session (#356) worked.** The double-bubble fix from the newsletter PR was still working when I invoked `!newsletter 7d` this afternoon to check. No regression.
+
+## Counts
+
+- Plan tasks: 4
+- Commits before squash: 6 (2 docs + contract tests + web fix + mattermost fix + cleanup)
+- Subagent dispatches: ~8 (3 implementer + 3 spec review + 2 code quality — skipped full review on Mattermost and final cleanup)
+- Copilot comments: 1 (duplicate heading) — fixed
+- Times main advanced during session: 1 (2 commits — XML delimiters + dream schedule)
+- Production lines changed: 2
+- Test lines added: ~105 (contract tests + regression test file)
+- Conversation turns: ~30 (estimate)

--- a/docs/dev-sessions/2026-04-24-1549-context-fork-manager/plan.md
+++ b/docs/dev-sessions/2026-04-24-1549-context-fork-manager/plan.md
@@ -1,0 +1,345 @@
+# context: fork command manager fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `!command` invocation of `context: fork` skills (`!dream`, `!garden`) by attaching the ConversationManager to the command-dispatch ctx in both web and Mattermost transports.
+
+**Architecture:** Two one-line additions at the transport call sites where `cmd_ctx = Context(...)` is constructed, plus regression tests at both the commands.py contract level and the web transport level. `Context` itself and `dispatch_command`'s signature are unchanged.
+
+**Tech Stack:** Python 3, existing pytest + pytest-asyncio test scaffolding, `unittest.mock` for patching.
+
+**Reference files:**
+- Spec: [`docs/dev-sessions/2026-04-24-1549-context-fork-manager/spec.md`](spec.md)
+- Existing fork-mode test pattern: `tests/test_commands.py:147-160` (`TestExecuteCommand::test_fork_mode`)
+- Transport call sites: `src/decafclaw/web/websocket.py:218-221`, `src/decafclaw/mattermost.py:342-344`
+- Error source: `src/decafclaw/tools/delegate.py:101-106`
+
+**Key invariants:**
+- Only `commands.py` pathway for `context: fork` is affected. `context: inline` commands (`!health`, `!ingest`, `!postmortem`, `!newsletter`) keep their current behavior.
+- Error-text assertion uses a substring match (`"ConversationManager"`) so minor wording tweaks to the error in delegate.py don't break the test.
+- `ctx.manager` remains a plain attribute on `Context` (not a dataclass field) — no Context refactor.
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/decafclaw/web/websocket.py` — one line added inside `_handle_send` after `cmd_ctx.conv_id = conv_id` to attach `cmd_ctx.manager = manager`.
+- `src/decafclaw/mattermost.py` — one line added inside the command-dispatch block, after the existing `cmd_ctx.user_id` assignment, to attach `cmd_ctx.manager = manager`.
+- `tests/test_commands.py` — two new tests in `TestExecuteCommand` (or a new test class) pinning fork-mode manager propagation and the defense-in-depth error path.
+
+**Create:**
+- `tests/test_web_websocket_commands.py` — a new focused test file for `_handle_send`'s command-dispatch manager attachment. (Alternative: extend `tests/test_web_websocket_notifications.py`. Prefer a dedicated file for clarity.)
+
+No doc updates. This is an internal bug fix; no user-facing feature was added or removed. `docs/newsletter.md` already reflects correct behavior (newsletter uses `context: inline`).
+
+---
+
+## Task 1: Commands.py contract tests — pin manager propagation
+
+Two tests at the `commands.py` level. These pin the existing commands.py behavior (that it passes `ctx.manager` through to `_run_child_turn`) so future refactors can't silently break it.
+
+**Files:**
+- Modify: `tests/test_commands.py`
+
+- [ ] **Step 1: Write the positive-path test**
+
+Append to the `TestExecuteCommand` class in `tests/test_commands.py` (find it around line 131-194; insert after `test_fork_mode`):
+
+```python
+    @pytest.mark.asyncio
+    async def test_fork_mode_propagates_manager_to_child_turn(self, ctx):
+        """The ctx handed to _run_child_turn MUST carry the manager from the
+        parent ctx — otherwise delegate.py bails and the fork never runs."""
+        sentinel_manager = object()
+        ctx.manager = sentinel_manager
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do $ARGUMENTS", context="fork",
+        )
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn",
+            new_callable=AsyncMock,
+        ) as mock:
+            mock.return_value = "child result"
+            mode, result = await execute_command(ctx, skill, "go")
+
+        assert mode == "fork"
+        # First positional arg to _run_child_turn is parent_ctx
+        called_ctx = mock.call_args.args[0]
+        assert called_ctx.manager is sentinel_manager
+```
+
+- [ ] **Step 2: Write the negative-path test (defense in depth)**
+
+Append to the same class, right below the positive test:
+
+```python
+    @pytest.mark.asyncio
+    async def test_fork_mode_without_manager_surfaces_clear_error(self, ctx):
+        """If a future transport forgets to attach the manager, the existing
+        error in delegate.py should still fire with a readable message —
+        not a silent KeyError or None-dereference."""
+        ctx.manager = None  # explicit for the test's intent
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do $ARGUMENTS", context="fork",
+        )
+        # Do NOT mock _run_child_turn — let the real function hit its own
+        # bail-out so the error text is the one real users would see.
+        mode, result = await execute_command(ctx, skill, "go")
+
+        assert mode == "fork"
+        assert "ConversationManager" in result
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `uv run pytest tests/test_commands.py::TestExecuteCommand -v`
+Expected: both new tests PASS (and all existing tests in `TestExecuteCommand` still pass). These are contract tests, not TDD red tests — they formalize current behavior rather than driving new code.
+
+- [ ] **Step 4: Run lint + typecheck**
+
+Run:
+```bash
+make lint && make typecheck
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_commands.py
+git commit -m "test(commands): pin fork-mode manager propagation (#361)"
+```
+
+---
+
+## Task 2: Web transport regression test — TDD RED → GREEN
+
+This test reproduces the bug: it fails BEFORE the websocket.py fix. That's the actual regression-catching test.
+
+**Files:**
+- Create: `tests/test_web_websocket_commands.py`
+- Modify: `src/decafclaw/web/websocket.py:218-221` (one line added)
+
+- [ ] **Step 1: Create the failing test**
+
+Create `tests/test_web_websocket_commands.py`:
+
+```python
+"""WebSocket command-dispatch tests: verify cmd_ctx carries the manager.
+
+Regression test for #361 — without the manager attached, bundled skills
+with context: fork (dream, garden) fail their !command invocation with
+'delegate_task requires a ConversationManager; no manager on parent ctx'.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from decafclaw.commands import CommandResult
+from decafclaw.skills import SkillInfo
+
+
+@pytest.mark.asyncio
+async def test_handle_send_attaches_manager_to_cmd_ctx(monkeypatch, config):
+    """When a user sends a message that triggers command dispatch,
+    the cmd_ctx passed to dispatch_command MUST have ctx.manager set
+    to the conversation manager from state."""
+    from decafclaw.web import websocket
+
+    # Capture the ctx passed into dispatch_command so we can assert on it.
+    captured = {}
+
+    async def fake_dispatch(ctx, text, **kwargs):
+        captured["ctx"] = ctx
+        return CommandResult(
+            mode="unknown", text="", display_text=text,
+            skill=None,
+        )
+
+    monkeypatch.setattr(
+        "decafclaw.commands.dispatch_command", fake_dispatch,
+    )
+
+    # Minimal state: real config + event_bus, sentinel manager.
+    from decafclaw.events import EventBus
+    bus = EventBus()
+    sentinel_manager = MagicMock()
+    state = {
+        "config": config,
+        "event_bus": bus,
+        "manager": sentinel_manager,
+    }
+
+    # Minimal conversation index with a conv owned by "testuser".
+    index = MagicMock()
+    conv = MagicMock()
+    conv.user_id = "testuser"
+    index.get.return_value = conv
+
+    # Capture outbound ws_send messages.
+    sent = []
+
+    async def ws_send(msg):
+        sent.append(msg)
+
+    msg = {"conv_id": "conv-1", "text": "!dream"}
+
+    await websocket._handle_send(
+        ws_send, index, "testuser", msg, state,
+    )
+
+    assert "ctx" in captured, "dispatch_command was not invoked"
+    assert captured["ctx"].manager is sentinel_manager
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+Run: `uv run pytest tests/test_web_websocket_commands.py -v`
+Expected: FAIL with `assert None is <MagicMock ...>` or similar — because websocket.py currently doesn't attach `manager`, so `captured["ctx"].manager` is `None`.
+
+- [ ] **Step 3: Apply the fix in websocket.py**
+
+Open `src/decafclaw/web/websocket.py`. Find the block around line 218-221:
+
+```python
+    cmd_ctx = Context(config=state["config"], event_bus=state["event_bus"])
+    cmd_ctx.user_id = username
+    cmd_ctx.conv_id = conv_id
+    cmd_result = await dispatch_command(cmd_ctx, text)
+```
+
+Change to:
+
+```python
+    cmd_ctx = Context(config=state["config"], event_bus=state["event_bus"])
+    cmd_ctx.user_id = username
+    cmd_ctx.conv_id = conv_id
+    cmd_ctx.manager = manager
+    cmd_result = await dispatch_command(cmd_ctx, text)
+```
+
+(The variable `manager` is already in scope from line 209: `manager = state.get("manager")`.)
+
+- [ ] **Step 4: Run the test — expect PASS**
+
+Run: `uv run pytest tests/test_web_websocket_commands.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `make test`
+Expected: all tests pass. No regressions.
+
+- [ ] **Step 6: Run lint + typecheck**
+
+Run: `make lint && make typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/decafclaw/web/websocket.py tests/test_web_websocket_commands.py
+git commit -m "fix(web): attach manager to command-dispatch ctx (#361)"
+```
+
+---
+
+## Task 3: Mattermost transport fix (symmetric)
+
+Same one-line fix in the Mattermost transport. No dedicated transport test — the dispatch lives deep inside `_process_msgs` and isolating it for a mock test costs more scaffolding than the one-line change is worth. The symmetry with the web fix (reviewable in diff) is enough, and the commands.py contract tests from Task 1 still pin the invariant across transports.
+
+**Files:**
+- Modify: `src/decafclaw/mattermost.py:342-344` (one line added)
+
+- [ ] **Step 1: Apply the fix in mattermost.py**
+
+Open `src/decafclaw/mattermost.py`. Find the block around line 342-344:
+
+```python
+        cmd_ctx = Context(config=app_ctx.config, event_bus=app_ctx.event_bus)
+        cmd_ctx.user_id = app_ctx.config.agent.user_id
+        cmd_result = await dispatch_command(cmd_ctx, combined_text, prefixes=["!"])
+```
+
+Change to:
+
+```python
+        cmd_ctx = Context(config=app_ctx.config, event_bus=app_ctx.event_bus)
+        cmd_ctx.user_id = app_ctx.config.agent.user_id
+        cmd_ctx.manager = manager
+        cmd_result = await dispatch_command(cmd_ctx, combined_text, prefixes=["!"])
+```
+
+(The `manager` variable is in scope as a parameter of the enclosing `_process_msgs` method — function signature at roughly line 299.)
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `make test`
+Expected: all existing Mattermost tests still pass. No new tests here — the symmetry with the web fix plus the commands.py contract tests in Task 1 cover the invariant.
+
+- [ ] **Step 3: Run lint + typecheck**
+
+Run: `make lint && make typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/decafclaw/mattermost.py
+git commit -m "fix(mattermost): attach manager to command-dispatch ctx (#361)"
+```
+
+---
+
+## Task 4: Final sanity check
+
+Everything above should already be green. This task just confirms the branch is in a shippable state before PR.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the whole matrix**
+
+Run:
+```bash
+make lint
+make typecheck
+make test
+```
+
+Expected: all green. If anything fails, stop and fix — don't open a PR with red tests.
+
+- [ ] **Step 2: Confirm no stray changes**
+
+Run: `git status`
+Expected: `working tree clean` and branch ahead of `origin/main` by 3 commits (Task 1, 2, 3 — Task 4 itself adds no commits).
+
+- [ ] **Step 3: Verify branch SHA count**
+
+Run: `git log --oneline origin/main..HEAD`
+Expected: 3 commits visible, in order:
+1. `test(commands): pin fork-mode manager propagation (#361)`
+2. `fix(web): attach manager to command-dispatch ctx (#361)`
+3. `fix(mattermost): attach manager to command-dispatch ctx (#361)`
+
+(Plus the spec commit from before we started this plan — so total could be 4 commits on the branch before the final squash.)
+
+---
+
+## Done checklist
+
+After Task 4, verify:
+
+- [ ] `make lint && make typecheck && make test` all green at HEAD
+- [ ] Regression test at `tests/test_web_websocket_commands.py` passes (it would fail if the websocket.py fix is reverted)
+- [ ] Contract tests at `tests/test_commands.py::TestExecuteCommand::test_fork_mode_propagates_manager_to_child_turn` and `::test_fork_mode_without_manager_surfaces_clear_error` both pass
+- [ ] No doc updates — internal bug fix; no user-facing behavior change other than `!dream` / `!garden` now working
+
+Ready for branch self-review and PR.

--- a/docs/dev-sessions/2026-04-24-1549-context-fork-manager/spec.md
+++ b/docs/dev-sessions/2026-04-24-1549-context-fork-manager/spec.md
@@ -1,0 +1,107 @@
+# context: fork command manager fix — spec
+
+Tracks: [#361](https://github.com/lmorchard/decafclaw/issues/361)
+
+## Goal
+
+Make `!command` invocation work for bundled skills that have `context: fork` in their SKILL.md frontmatter (today: `dream`, `garden`; latent for any future skill with the same pattern). Currently these commands fail with:
+
+> `[error: delegate_task requires a ConversationManager; no manager on parent ctx]`
+
+This was surfaced during smoke-testing of PR #356 (newsletter). Newsletter worked around it by flipping its own skill to `context: inline`. Dream and garden still have the latent bug.
+
+## Why fork matters (vs flipping everything to inline)
+
+`context: fork` is worth preserving for user-invocable background-style skills. Dream and garden do multi-turn work with many tool calls (reading journal, writing pages, pruning). A forked child conversation gives the user a clean summary reply in their chat, with the scaffolding isolated. Flipping those skills to `context: inline` would dump all the tool-call noise into the user's main chat — a regression in UX.
+
+So the direction is: **fix the propagation**, not eliminate fork.
+
+## Root cause
+
+Both transport entry points that dispatch `!commands` construct a fresh, minimal `Context` for the dispatcher but don't attach a `ConversationManager`:
+
+- `src/decafclaw/web/websocket.py:218-220` — `cmd_ctx = Context(config=..., event_bus=...)` + `cmd_ctx.user_id`, `cmd_ctx.conv_id`. No `cmd_ctx.manager`.
+- `src/decafclaw/mattermost.py:342-344` — same pattern.
+
+`dispatch_command` routes `context: fork` skills through `commands.py:419-429` → `tools/delegate.py::_run_child_turn`, which reads `parent_ctx.manager` at line 101. If `None`, it returns the error above and never attempts the fork.
+
+The normal (non-command) user-message flow attaches the manager in `conversation_manager.py::_start_turn` (line ~619) via `ctx.manager = self`. Command dispatch bypasses that path, which is why the manager never gets attached for the dispatcher ctx.
+
+Both transports already have `manager` in scope at the construction site (web: `state["manager"]`; Mattermost: function parameter). So the fix is literally two lines — one per transport.
+
+## Design
+
+### Scope
+
+Two one-line additions to two files, plus a regression test. No new subsystems, no signature changes, no refactor of `Context`.
+
+### Files touched
+
+- `src/decafclaw/web/websocket.py` — attach `cmd_ctx.manager = manager` after the existing `cmd_ctx.user_id`/`cmd_ctx.conv_id` assignments.
+- `src/decafclaw/mattermost.py` — attach `cmd_ctx.manager = manager` after the existing `cmd_ctx.user_id` assignment.
+- `tests/test_commands.py` (extend or create if absent) — regression test at the `commands.py` level, mock-based.
+
+### Context dataclass
+
+`Context` at `src/decafclaw/context.py` is NOT a `@dataclass` — it's a plain class. `self.manager: Any = None` is already declared in `Context.__init__` line 94. No change needed there; no convention smell (the "declare on the dataclass" rule in CLAUDE.md doesn't apply to plain classes with inline-annotated init attributes).
+
+### Data flow after fix
+
+1. User types `!dream` in web (or Mattermost).
+2. Transport handler parses message, constructs `cmd_ctx = Context(config=..., event_bus=...)`.
+3. Transport attaches identifiers **and now the manager**: `cmd_ctx.manager = manager`.
+4. `dispatch_command(cmd_ctx, "!dream")` parses trigger, finds `dream` skill with `context: fork`.
+5. `execute_command` (commands.py:419-429) calls `_run_child_turn(cmd_ctx, body, ...)`.
+6. `_run_child_turn` reads `parent_ctx.manager` — populated — and calls `manager.enqueue_turn(kind=CHILD_AGENT, ...)` for the forked child conv.
+7. Child conv runs dream's SKILL.md body, produces a final narrative string.
+8. `cmd_result.mode == "fork"`; transport sends `cmd_result.text` as an assistant message in the user's chat.
+9. User sees the dream summary with none of the intermediate tool-call scaffolding.
+
+### Error handling
+
+No new error cases. The existing `[error: delegate_task requires a ConversationManager; no manager on parent ctx]` stays as defense-in-depth: if a future transport forgets to attach the manager, the error message points the reader back to the attachment sites.
+
+## Testing
+
+Two test layers — the first pins commands.py behavior, the second actually catches the bug we're fixing.
+
+### Contract tests at commands.py (pin existing behavior)
+
+Mock-based, so no ConversationManager scaffolding needed:
+
+- **Happy path:** monkeypatch `decafclaw.tools.delegate._run_child_turn` to record its `parent_ctx` argument. Build a fake `SkillInfo(context="fork")`, set `ctx.manager = sentinel`, call `execute_command`. Assert the recorded ctx has `manager is sentinel`.
+- **Negative (defense-in-depth):** same setup but `ctx.manager = None`. Do NOT mock `_run_child_turn` — let the real function hit its bail-out at `delegate.py:101-106`. Assert `cmd_result.mode == "fork"` and `"ConversationManager" in cmd_result.text` (substring match, stable against minor wording changes).
+
+Note: both tests **pass before the fix** — commands.py already propagates `ctx.manager` through correctly. These are contract tests pinning the invariant, not regression tests for the specific bug.
+
+### Regression test at web transport (catches the actual bug)
+
+This is the test that fails before the fix and passes after. It exercises the real code path we're modifying:
+
+- Call `websocket._handle_send` with a minimal fake `state` containing a sentinel manager.
+- Monkeypatch `decafclaw.commands.dispatch_command` to capture its first positional argument.
+- Assert the captured `ctx.manager` is the sentinel.
+
+Before the fix, `ctx.manager` is `None` because `_handle_send` never attaches it. After the fix, it matches `state["manager"]`. This is the test that would flag a regression if someone reverts the websocket.py line — or if a new transport is added that forgets the same attachment.
+
+### Mattermost transport
+
+Skipping a dedicated transport-level test for Mattermost. The command-dispatch lives inside `_process_msgs`, which needs substantial scaffolding (MM config, message shapes) to isolate for a mock test. The one-line fix is symmetric to web and visible in the diff; the commands.py contract tests cover the invariant across transports. If the Mattermost code path is later restructured to be more test-friendly, adding the symmetric test is a small follow-up.
+
+### Existing tests
+
+All existing `pytest` tests must still pass. No behavior changes for `context: inline` commands or for `dispatch_command`'s help/unknown/error/inline paths.
+
+## Out of scope
+
+- Making `Context` a `@dataclass`. Context has never been one; the conversion would ripple through many call sites unrelated to this fix.
+- Changing `dispatch_command`'s signature to require `manager` as a parameter. Only two callers today — the enforcement gain doesn't justify the churn, and the post-construction assignment idiom is consistent with how `cmd_ctx.user_id` etc. are set.
+- Upgrading the `ctx.manager` type annotation from `Any` to `ConversationManager | None`. Introduces an import-cycle risk between `context.py` and `conversation_manager.py`. A separate cleanup if/when the two modules get restructured.
+- Addressing the paired latent issue at #362 (scheduled skills ending with `HEARTBEAT_OK` instead of narrative summaries). Independent concern, tracked separately.
+
+## Success criteria
+
+- `!dream` and `!garden` invoked from the web UI AND Mattermost produce a forked reply showing the skill's summary output — no `ctx.manager` error.
+- Existing `context: inline` commands (`!health`, `!ingest`, `!postmortem`, `!newsletter`) continue to work unchanged.
+- Regression test covers both happy path (manager attached → fork proceeds) and defense-in-depth (manager missing → clear error).
+- `make lint && make typecheck && make test` clean.

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -341,6 +341,7 @@ class MattermostClient:
 
         cmd_ctx = Context(config=app_ctx.config, event_bus=app_ctx.event_bus)
         cmd_ctx.user_id = app_ctx.config.agent.user_id
+        cmd_ctx.manager = manager
         cmd_result = await dispatch_command(cmd_ctx, combined_text, prefixes=["!"])
 
         if cmd_result.mode in ("help", "unknown", "error", "fork"):

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -218,6 +218,7 @@ async def _handle_send(ws_send, index, username, msg, state):
     cmd_ctx = Context(config=state["config"], event_bus=state["event_bus"])
     cmd_ctx.user_id = username
     cmd_ctx.conv_id = conv_id
+    cmd_ctx.manager = manager
     cmd_result = await dispatch_command(cmd_ctx, text)
 
     if cmd_result.mode in ("help", "unknown", "error"):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -236,3 +236,44 @@ class TestExecuteCommand:
             await execute_command(ctx, skill, "")
 
         mock_activate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fork_mode_propagates_manager_to_child_turn(self, ctx):
+        """The ctx handed to _run_child_turn MUST carry the manager from the
+        parent ctx — otherwise delegate.py bails and the fork never runs."""
+        sentinel_manager = object()
+        ctx.manager = sentinel_manager
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do $ARGUMENTS", context="fork",
+        )
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn",
+            new_callable=AsyncMock,
+        ) as mock:
+            mock.return_value = "child result"
+            mode, result = await execute_command(ctx, skill, "go")
+
+        assert mode == "fork"
+        # First positional arg to _run_child_turn is parent_ctx
+        called_ctx = mock.call_args.args[0]
+        assert called_ctx.manager is sentinel_manager
+
+    @pytest.mark.asyncio
+    async def test_fork_mode_without_manager_surfaces_clear_error(self, ctx):
+        """If a future transport forgets to attach the manager, the existing
+        error in delegate.py should still fire with a readable message —
+        not a silent KeyError or None-dereference."""
+        ctx.manager = None  # explicit for the test's intent
+
+        skill = SkillInfo(
+            name="test-cmd", description="Test", location=Path("."),
+            body="Do $ARGUMENTS", context="fork",
+        )
+        # Do NOT mock _run_child_turn — let the real function hit its own
+        # bail-out so the error text is the one real users would see.
+        mode, result = await execute_command(ctx, skill, "go")
+
+        assert mode == "fork"
+        assert "ConversationManager" in result

--- a/tests/test_web_websocket_commands.py
+++ b/tests/test_web_websocket_commands.py
@@ -1,0 +1,65 @@
+"""WebSocket command-dispatch tests: verify cmd_ctx carries the manager.
+
+Regression test for #361 — without the manager attached, bundled skills
+with context: fork (dream, garden) fail their !command invocation with
+'delegate_task requires a ConversationManager; no manager on parent ctx'.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from decafclaw.commands import CommandResult
+
+
+@pytest.mark.asyncio
+async def test_handle_send_attaches_manager_to_cmd_ctx(monkeypatch, config):
+    """When a user sends a message that triggers command dispatch,
+    the cmd_ctx passed to dispatch_command MUST have ctx.manager set
+    to the conversation manager from state."""
+    from decafclaw.web import websocket
+
+    # Capture the ctx passed into dispatch_command so we can assert on it.
+    captured = {}
+
+    async def fake_dispatch(ctx, text, **kwargs):
+        captured["ctx"] = ctx
+        return CommandResult(
+            mode="unknown", text="", display_text=text,
+            skill=None,
+        )
+
+    monkeypatch.setattr(
+        "decafclaw.commands.dispatch_command", fake_dispatch,
+    )
+
+    # Minimal state: real config + event_bus, sentinel manager.
+    from decafclaw.events import EventBus
+    bus = EventBus()
+    sentinel_manager = MagicMock()
+    state = {
+        "config": config,
+        "event_bus": bus,
+        "manager": sentinel_manager,
+    }
+
+    # Minimal conversation index with a conv owned by "testuser".
+    index = MagicMock()
+    conv = MagicMock()
+    conv.user_id = "testuser"
+    index.get.return_value = conv
+
+    # ws_send must be an awaitable; the test doesn't assert on outbound traffic.
+    async def ws_send(_msg):
+        pass
+
+    msg = {"conv_id": "conv-1", "text": "!dream"}
+
+    await websocket._handle_send(
+        ws_send, index, "testuser", msg, state,
+    )
+
+    assert "ctx" in captured, "dispatch_command was not invoked"
+    assert captured["ctx"].manager is sentinel_manager


### PR DESCRIPTION
## Summary

Fixes #361. `!dream`, `!garden`, and any future user-invocable skill with `context: fork` in its SKILL.md frontmatter were failing interactive invocation with:

> `[error: delegate_task requires a ConversationManager; no manager on parent ctx]`

Surfaced during #356 smoke-testing; newsletter dodged it by flipping to `context: inline`. Dream and garden kept the latent bug.

## Fix

One-line `cmd_ctx.manager = manager` added to each of the two transport command-dispatch sites. `manager` is already in scope at both locations:

- `src/decafclaw/web/websocket.py:221` — from `state.get("manager")` at line 209.
- `src/decafclaw/mattermost.py:344` — as a parameter of `_process_conversation`.

No new subsystems, no signature changes, no refactor of `Context` (which remains a plain class with `self.manager: Any = None` already declared in `__init__`).

## Why not flip `dream` / `garden` to `context: inline` instead

Fork isolation is the right UX for these skills. Dream does multi-turn work (reading journal, writing vault pages, pruning) — the user wants a clean summary reply in their chat, not the scaffolding. Newsletter's situation was different: its output IS the reply, so inline was semantically correct. For dream/garden, fixing fork is the proper direction.

## Tests

- **Contract tests** (`tests/test_commands.py::TestExecuteCommand`) — pin that `execute_command` passes `ctx.manager` through to `_run_child_turn` (happy path) and that the defense-in-depth error surfaces when `manager` is None (both pass pre- and post-fix).
- **Regression test** (`tests/test_web_websocket_commands.py`) — drives `_handle_send` with a sentinel manager, asserts the dispatched ctx carries it. TDD RED before the fix, GREEN after.
- **No Mattermost-side transport test.** The dispatch site is deep in `_process_conversation`; isolation requires substantial scaffolding. The commands.py contract tests plus the symmetric one-line fix (reviewable in diff) cover the invariant.

## Test plan

- [x] `make lint` clean
- [x] `make typecheck` clean (pyright 0 errors)
- [x] `make test` — all 1878 tests pass, no regressions
- [x] TDD RED→GREEN confirmed on the web regression test
- [ ] Manual: `!dream` in the web UI returns a forked summary, not the error
- [ ] Manual: `!garden` in the web UI behaves the same
- [ ] Manual (optional): same two commands in Mattermost

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)