### PR TITLE
feat(widgets): phase 2 — input widgets, multiple_choice, ask_user (#256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ See [docs/tools.md](docs/tools.md), [docs/tool-priority.md](docs/tool-priority.m
 - **Tool descriptions are a control surface.** Wording changes ("MUST", "NEVER", checklists) measurably change LLM behavior. Run `make eval-tools` to validate disambiguation between overlapping tools.
 - **Shell approval via shared `check_shell_approval()`** in `shell_tools.py`. Don't duplicate the approval checks.
 - **Per-tool timeout** wraps every non-MCP tool call (default 180s, env `TOOL_TIMEOUT_SEC`). Override via `timeout` key in `TOOL_DEFINITIONS`; `None` opts out. Current opt-outs: `delegate_task`, `conversation_compact`, `claude_code_send`. MCP tools use their own per-server timeout.
-- **`end_turn=True` on `ToolResult`** mechanically ends the turn (one final no-tools LLM call, then return). For review gates use `end_turn=EndTurnConfirm(message=..., on_approve=..., on_deny=...)`. `EndTurnConfirm` wins over `True` in parallel batches.
+- **`end_turn=True` on `ToolResult`** mechanically ends the turn (one final no-tools LLM call, then return). For review gates use `end_turn=EndTurnConfirm(message=..., on_approve=..., on_deny=...)`. For input widgets (`accepts_input=true`), pair with `end_turn=True` and the loop auto-promotes to a `WidgetInputPause` that pauses via the confirmation infra and resumes with the user's selection injected as a synthetic user message. Priority in one batch: `WidgetInputPause` > `EndTurnConfirm` > `True`.
 - **Checklist tools (`checklist_create/_step_done/_abort/_status`)** are always-loaded. Iteration happens within a single turn: do step → step_done → next.
 - **Events for progress.** Tools publish `tool_status` via `ctx.publish()`.
 
@@ -156,7 +156,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `heartbeat.py`, `schedules.py`, `polling.py`
 - `notifications.py`, `notification_channels/`, `mail.py`
 - `mcp_client.py`
-- `media.py`, `widgets.py`, `web/static/widgets/`, `web/static/components/widgets/widget-host.js`
+- `media.py`, `widgets.py`, `widget_input.py`, `web/static/widgets/`, `web/static/components/widgets/widget-host.js`
 - `util.py`, `eval/`
 
 ## Running

--- a/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/notes.md
+++ b/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/notes.md
@@ -1,0 +1,102 @@
+# Notes — Widget catalog Phase 2 (#256)
+
+## Session setup
+
+- Worktree: `.claude/worktrees/widgets-phase-2-256/` (branch
+  `widgets-phase-2-256`)
+- Baseline: lint clean, 1837 tests pass, branched from `main` at
+  `44b002c` (Phase 1 merge)
+- Issue: https://github.com/lmorchard/decafclaw/issues/256
+- Phase 1 PR (merged): #360 — widget plumbing, registry,
+  `data_table`, `vault_search` retrofit
+- Follow-up filed: **#364** — collapse `EndTurnConfirm` into a
+  `confirm_prompt` widget with a Mattermost-buttons adapter
+
+## Scope locked during brainstorm
+
+**Light convergence (option b):** input widgets ride on the existing
+confirmation infra via a small set of extensions rather than adding
+a parallel pause/resume mechanism. Kept `EndTurnConfirm` as-is for v2;
+collapsing it into a widget moves to #364 once Phase 2 is proven.
+
+Key decisions:
+
+- Pause/resume reuses `confirmations.py` machinery: new
+  `ConfirmationAction.WIDGET_RESPONSE`, new `data` field on
+  `ConfirmationResponse`, `timeout=None` disables the deadline
+  (native `asyncio.wait_for` behavior).
+- Live vs recovery paths diverge intentionally: live path invokes the
+  tool's `on_response` callback and injects the returned string;
+  recovery path (no running loop) uses the registered
+  `WidgetResponseHandler` to write a synthetic user message directly
+  to the archive. Both end with the same archive state.
+- LLM view of the answer = synthetic
+  `{role: "user", source: "widget_response", content: "..."}` message.
+- New `ask_user` core tool (`priority=low`) is the first-class
+  capability demonstrating the feature. Description wording
+  discourages frivolous use.
+- `WidgetInputPause` sentinel parallels `EndTurnConfirm`; agent-loop
+  precedence is `WidgetInputPause > EndTurnConfirm > True`.
+
+## Running notes
+
+### Surprises encountered during execution
+
+- **Handler dispatch context.** Existing `recover_confirmation`
+  passed `ctx=None` to handlers, but the widget-response recovery
+  handler needs `config + conv_id` to write the synthetic user
+  message to the archive. Added a `_RecoveryContext` dataclass that's
+  passed in lieu of None — minimal surface change, handler protocol
+  unchanged.
+- **Conv_history annotation vs frontend merge.** Originally planned
+  to do the widget-request ↔ widget-response pairing in the frontend
+  `#mergeToolMessages`. Had to pivot: `confirmation_request` and
+  `confirmation_response` are in `_HIDDEN_ROLES` on the backend load
+  path, so the frontend never sees them. Solved by adding a pure
+  helper `_annotate_widget_responses` on the backend that attaches
+  `submitted` + `response` to tool records before stripping the
+  hidden roles.
+- **Auto-expand tool message on widget.** Widgets inside a collapsed
+  tool-message would be invisible until the user clicked the header.
+  Added `willUpdate` hook in `tool-message.js` that flips `_expanded`
+  true on first render where `widget` is set; the flag tracking
+  (`_autoExpanded`) ensures user collapse isn't overridden later.
+- **Pyright type hint for `end_turn`.** `ToolResult.end_turn` was
+  typed `bool | EndTurnConfirm`; adding `WidgetInputPause` required
+  widening. Caught by `make typecheck`, not by any test.
+- **Lit change detection gotcha (avoided).** Mutating
+  `msg.submitted = true` in place on a message in
+  `message-store.#currentMessages` doesn't change the array
+  reference. The sibling `#pendingConfirms` filter creates a new
+  array reference which does trigger a re-render; the render picks
+  up the mutated message. Works, but fragile — flagged in the
+  implementation comments.
+- **`confirm_response` vs `widget_response`.** Frontend sends
+  `widget_response` (widget-shaped naming); backend handler maps to
+  `respond_to_confirmation`. `confirm_response` stays as the WS
+  message type for approve/deny button paths. Both route to the
+  same manager entry point.
+
+### Testing notes
+
+- All four new tests files (`test_widget_input_pause.py`,
+  `test_widgets_input_flow.py`, `test_ask_user.py`,
+  `test_web_widget_response_handler.py`) plus extensions to
+  `test_agent_widgets.py` + `test_conversation_manager.py` +
+  `test_widgets.py` cover the pause/resume plumbing end-to-end
+  without hitting the live WS path.
+- Integration test builds a real `ConversationManager` + registers
+  the handler + drives a pause with a canned response.
+- No live WS / browser test — ran `make check && make test` only,
+  same as Phase 1. Live smoke falls to Les post-merge.
+
+### Unable to live-test the UI
+
+`make dev` is running in Les's terminal. Can't start a second
+instance (MM websocket is single-connection). Manual live smoke
+steps captured in the PR description test plan.
+
+### Final shape
+
+12 commits, 1882 tests passing (~45 new), lint + typecheck (pyright +
+tsc) clean.

--- a/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/plan.md
+++ b/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/plan.md
@@ -1,0 +1,361 @@
+# Plan — Widget catalog Phase 2 (#256)
+
+Goal: implement input widgets per `spec.md`. Each step ends green
+(`make check && make test`) with one commit. Branch is
+`widgets-phase-2-256`; PR at the end.
+
+## Ordering rationale
+
+Backend convergence first (confirmation infra extensions, agent-loop
+pause), then the `ask_user` tool to exercise it with unit tests, then
+frontend wiring (widget-host reload props, `multiple_choice`
+component, tool-message reload merge, WS bridge), then dev + docs.
+This order is test-driven throughout — the first several steps don't
+need the UI to verify correctness.
+
+Rough size: ~11 steps, ~15 files touched.
+
+## Steps
+
+### Step 1 — Confirmation infra extensions
+
+**Files:**
+- `src/decafclaw/confirmations.py`:
+  - Add `ConfirmationAction.WIDGET_RESPONSE = "widget_response"`.
+  - Widen `ConfirmationRequest.timeout` to `float | None = 300.0`.
+  - Add `ConfirmationResponse.data: dict = field(default_factory=dict)`.
+    Serialize in `to_archive_message` when non-empty; deserialize via
+    `from_archive_message`.
+- `src/decafclaw/conversation_manager.py`:
+  - `request_confirmation`: switch `asyncio.wait_for` call to support
+    `timeout=None` (already works natively — just pass through).
+  - `respond_to_confirmation`: new kwarg `data: dict | None = None`,
+    plumbed into the `ConfirmationResponse` construction and the
+    emitted event payload.
+- `tests/test_confirmations.py` (extend) — serialization round-trip
+  for `data` field; timeout=None on request dataclass.
+- `tests/test_conversation_manager.py` (or similar) — extend
+  existing confirm tests: response with `data` field emits and
+  persists; timeout=None doesn't raise.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `feat(widgets): confirmation infra extensions for widget responses`
+
+### Step 2 — `WidgetInputPause` sentinel + default handler
+
+**Files:**
+- `src/decafclaw/media.py` (or `agent.py` — wherever `EndTurnConfirm`
+  lives) — add `WidgetInputPause` dataclass:
+  ```python
+  @dataclass
+  class WidgetInputPause:
+      tool_call_id: str
+      widget_payload: dict  # {widget_type, target, data}
+      on_response: Callable[[dict], str] | None = None
+  ```
+- `src/decafclaw/agent.py` (or new `widget_input.py`) — default
+  `WIDGET_RESPONSE` confirmation handler. On recovery (ctx=None),
+  writes a synthetic user message directly to the archive with
+  `"User responded with: {data}"` formatting. On live path, wouldn't
+  normally fire since the agent loop handles live responses directly
+  — but safe to keep as a fallback.
+- Register the handler at the two `ConversationManager(...)`
+  construction sites — `runner.py:56` and `interactive_terminal.py:60`.
+  There are currently no registered confirmation handlers; this is
+  the first. Expose a `register_widget_handler(registry)` function
+  from the new widget-input module; both call-sites invoke it right
+  after constructing the manager:
+  `register_widget_handler(manager.confirmation_registry)`.
+- `tests/test_widget_input_pause.py` (new):
+  - `WidgetInputPause` construction happy path.
+  - Default handler on recovery writes a user message to the archive.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `feat(widgets): WidgetInputPause sentinel and default recovery handler`
+
+### Step 3 — Agent-loop branch: input-widget enforcement + pause
+
+**Files:**
+- `src/decafclaw/agent.py`:
+  - Extend `_resolve_widget` with input-widget enforcement:
+    - If `desc.accepts_input=True` and `end_turn is False` → strip
+      widget with warning.
+    - If `desc.accepts_input=True` and `end_turn=EndTurnConfirm(...)`
+      → strip `end_turn` (keep widget, set `end_turn=True`) with
+      warning.
+    - If `desc.accepts_input=True` and `end_turn=True` → happy path;
+      promote to `WidgetInputPause(tool_call_id, widget_payload,
+      on_response)`.
+  - `_execute_single_tool` / `_execute_tool_calls` returns
+    `WidgetInputPause` in the same `end_turn` slot where
+    `EndTurnConfirm` lives today; the prioritization logic already
+    knows to prefer richer signals — extend it so `WidgetInputPause`
+    sits alongside `EndTurnConfirm` (only one can win per batch; if
+    both somehow occur, `WidgetInputPause` wins).
+  - In the outer loop's switch block, add:
+    ```python
+    elif isinstance(end_turn_signal, WidgetInputPause):
+        inject_message = await _handle_widget_input_pause(
+            ctx, end_turn_signal, callbacks_map)
+        if inject_message:
+            synthetic = {"role": "user",
+                         "source": "widget_response",
+                         "content": inject_message}
+            _archive(ctx, synthetic)
+            history.append(synthetic)
+            # continue the loop
+    ```
+  - New `_handle_widget_input_pause(ctx, signal, callbacks_map)`:
+    builds `ConfirmationRequest`, awaits via `ctx.request_confirmation`,
+    looks up callback by `tool_call_id`, returns inject string.
+- In-memory callbacks registry: a module-level (or Context-carried)
+  `dict[tool_call_id, Callable]`. Registered in `_resolve_widget`,
+  cleared after response. Not serialized.
+- `tests/test_agent_widgets.py` (extend) — enforcement rules
+  exercised with stub widgets (accepts_input descriptors):
+  - Input widget + `end_turn=True` → pause signal emitted.
+  - Input widget + `end_turn=False` → widget stripped, warning logged.
+  - Input widget + `end_turn=EndTurnConfirm` → widget kept,
+    `EndTurnConfirm` dropped with warning.
+  - Display widget (accepts_input=False) is unaffected.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `feat(widgets): agent-loop pauses on input widgets and resumes with inject`
+
+### Step 4 — End-to-end pause/resume integration test
+
+Ensures the pieces from steps 1-3 talk correctly. Uses the
+ConversationManager + a stub widget that sets `accepts_input=True`
+with a callback.
+
+**Files:**
+- `tests/test_widgets_input_flow.py` (new):
+  - Set up ConversationManager + stub widget registry with an
+    `accepts_input=true` widget.
+  - Monkeypatch `execute_tool` to return a `ToolResult` with a
+    `WidgetRequest` and `end_turn=True`.
+  - Invoke a simulated turn (similar to existing manager tests).
+  - Assert: agent loop pauses (confirmation_request event emitted).
+  - Resolve the confirmation manually via
+    `respond_to_confirmation(conv_id, confirmation_id, approved=True,
+    data={"selected": "a"})`.
+  - Assert: agent loop resumed; archive contains a synthetic
+    `role: "user"` message with inject-string; the widget's
+    callback was called exactly once; pending_confirmation cleared.
+- Also test the callback-missing case: drop the callback from the
+  in-memory map before resolving → confirm the default handler's
+  path kicks in and archives a `"User responded with: ..."` message.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `test(widgets): end-to-end input widget pause/resume integration`
+
+### Step 5 — `ask_user` tool
+
+**Files:**
+- `src/decafclaw/tools/ask_user.py` (new) — the tool function,
+  options normalization (strings → `{value, label}` dicts), default
+  `on_response` callback producing `"User selected: X"` /
+  `"User selected: X, Y"` for multi.
+- `src/decafclaw/tools/__init__.py` — register `ask_user` in
+  `TOOL_DEFINITIONS` with `priority="low"`. Tool description text
+  per the spec: used sparingly, only when genuinely ambiguous.
+- `tests/test_ask_user.py` (new):
+  - Happy path: returns ToolResult with widget + end_turn=True.
+  - Option normalization: strings, dicts, mixed.
+  - `allow_multiple=True` → widget data reflects it.
+  - Empty `options` → returns a descriptive error result (no widget).
+  - Default `on_response` builds the expected inject-string for
+    single and multi.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `feat(widgets): ask_user tool for multiple-choice prompts`
+
+### Step 6 — WebSocket `widget_response` incoming handler
+
+**Files:**
+- `src/decafclaw/web/websocket.py`:
+  - New `_handle_widget_response(ws_send, index, username, msg, state)`.
+    Fields expected: `conv_id, confirmation_id, tool_call_id, data`.
+    Calls `manager.respond_to_confirmation(conv_id, confirmation_id,
+    approved=True, data=msg["data"])`.
+  - Register in the handler map alongside `confirm_response`.
+- `tests/test_web_widgets_input.py` (new) OR extend
+  `test_web_widgets.py`:
+  - Set up a pending widget confirmation via manager; send
+    `widget_response` WS message; assert `respond_to_confirmation`
+    was called with the right args; assert the confirmation_response
+    event carries `data`.
+
+**Verification:** `make check && make test`.
+
+**Commit:** `feat(widgets): WS widget_response handler routes to confirmation infra`
+
+### Step 7 — Bundled `multiple_choice` widget
+
+**Files:**
+- `src/decafclaw/web/static/widgets/multiple_choice/widget.json`:
+  - data_schema requires `prompt` (string), `options` (array of
+    `{value, label, description?}`), optional `allow_multiple`.
+  - `accepts_input: true`, `modes: ["inline"]`.
+- `src/decafclaw/web/static/widgets/multiple_choice/widget.js` —
+  `<dc-widget-multiple-choice>`:
+  - Props: `data`, `submitted`, `response`.
+  - Radios (single) or checkboxes (multi).
+  - Descriptions render as muted secondary text under the label.
+  - Submit button disabled until a selection exists.
+  - On submit: dispatch `widget-response` CustomEvent with
+    `{bubbles: true, composed: true}` and
+    `detail = {selected: "<value>"}` (string for single; array for
+    multi).
+  - Post-submit state: controls disabled; submit labeled "Submitted"
+    and disabled; selected option marked visually.
+- `src/decafclaw/web/static/styles/widgets.css` — `multiple_choice`
+  styles (radio/checkbox alignment, description text, submit button).
+
+**Verification:** `make check-js`. Also extend
+`tests/test_widgets.py` to assert a fresh registry scan finds
+`multiple_choice` with the expected schema fields.
+
+**Commit:** `feat(widgets): bundled multiple_choice widget`
+
+### Step 8 — Frontend: widget-host forwards submitted/response + tool-message reload merge
+
+**Files:**
+- `src/decafclaw/web/static/components/widgets/widget-host.js`:
+  - Add props `submitted` (boolean) and `response` (object).
+  - Forward both to the mounted child widget via property assignment
+    (along with `data`).
+- `src/decafclaw/web/static/components/messages/tool-message.js`:
+  - Accept `submitted` + `response` props.
+  - Pass through to `dc-widget-host`.
+- `src/decafclaw/web/static/components/chat-message.js` — add
+  `submitted`, `response` to the forwarded `<tool-message>` props.
+- `src/decafclaw/web/static/components/chat-view.js` — pass
+  `submitted` / `response` from the merged message.
+- `src/decafclaw/web/static/lib/message-store.js`:
+  - Extend `#mergeToolMessages` to scan for a `confirmation_response`
+    record matching the tool_call_id whenever the tool message has a
+    widget. If found with `data`, set `submitted=true, response=data`
+    on the synthetic tool message.
+  - Lenient: if response exists without `data` (e.g., old records),
+    just set `submitted=true` with `response={}`.
+- `src/decafclaw/web/static/lib/conversation-store.js` — ChatMessage
+  typedef gets `submitted?: boolean`, `response?: object`.
+
+**Verification:** `make check-js`.
+
+**Commit:** `feat(web): reload-merge widget responses and forward submitted state`
+
+### Step 9 — Frontend: live WS bridge for widget-response
+
+**Files:**
+- `src/decafclaw/web/static/lib/tool-status-store.js`:
+  - Handler for `widget-response` CustomEvent bubbling up from the
+    chat region. Builds and sends the `widget_response` WebSocket
+    message with `{conv_id, confirmation_id, tool_call_id, data}`.
+  - The confirmation_id comes from `#pendingConfirms` lookup by
+    `tool_call_id`.
+  - Existing `confirmation_response` handler needs an extension:
+    when the response has `data`, update the tool message's
+    `submitted=true, response=data` so the widget flips.
+- `src/decafclaw/web/static/components/confirm-view.js` — filter
+  out pending confirms with `action_type === "widget_response"` so
+  they don't render as approve/deny buttons.
+- `src/decafclaw/web/static/components/chat-view.js` (or chat
+  container) — add a single `@widget-response` listener that
+  delegates to the store.
+
+**Verification:** `make check-js`.
+
+**Commit:** `feat(web): widget-response WS bridge and post-submit state flip`
+
+### Step 10 — Full check + live smoke test gate
+
+`make check && make test` one more time to confirm no regressions
+across the backend + frontend.
+
+**Live smoke (Les, post-push):**
+- Invoke `ask_user` in a web-UI conversation. Confirm the widget
+  renders (radios or checkboxes depending on `allow_multiple`).
+- Submit. Confirm the widget disables and the next LLM response sees
+  the choice ("User selected: X").
+- Reload the conversation. Confirm the widget re-renders in its
+  post-submit state.
+- Open a second tab on the same conversation BEFORE submitting.
+  Submit from tab A. Confirm tab B flips to post-submit state.
+
+### Step 11 — Docs + follow-up issue
+
+**Files:**
+- `docs/widgets.md` — Phase 2 addendum: input-widget contract,
+  `multiple_choice`, `ask_user` example, the "agent can stop and ask"
+  affordance.
+- `CLAUDE.md` — note input widget path in key files (ask_user tool,
+  widget-input agent-loop branch).
+- Log follow-up issue: "collapse EndTurnConfirm into a widget with
+  Mattermost adapter" — via `gh issue create`. Prereq: this PR
+  lands. References #256 and the EndTurnConfirm analysis from this
+  session.
+
+**Verification:** `make check && make test`. Visual check of
+`docs/widgets.md`.
+
+**Commit:** `docs(widgets): input widget contract + ask_user example`
+
+### Step 12 — Final review + PR prep
+
+- `git fetch origin && git rebase origin/main` — re-run lint + tests
+  after.
+- Update `notes.md` with observations from execution.
+- Push branch, open PR against main, request Copilot review.
+- Move #256 to "In review" on the project board if possible.
+
+## Verification gates (per step)
+
+1. `make lint` — ruff clean.
+2. `make typecheck` — pyright clean.
+3. `make check-js` — tsc clean (if any JS touched).
+4. `make test` — pytest clean.
+5. `git add {specific paths} && git commit` with
+   `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+   trailer.
+
+## Risk log
+
+- **In-memory callback map lifecycle.** If we leak entries (e.g., the
+  loop crashes after `_resolve_widget` registered a callback but
+  before the await), the map grows unbounded. Mitigation: wrap the
+  pause in `try/finally` that pops the entry regardless of outcome.
+- **Confirmation_id plumbing on reload.** The archive persists the
+  `confirmation_request` with its `confirmation_id`. The frontend's
+  `#pendingConfirms` state is populated on reload via the
+  `conv_history.pending_confirmation` seed (line 531 in
+  `conversation-store.js`). That seed currently assumes a single
+  confirm but we might have a widget confirm + nothing else — verify
+  the seed path carries widget-typed confirms too.
+- **`action_data` serialization.** Widget payload could contain
+  arbitrary JSON — options list, prompt strings with special chars.
+  `jsonschema` already validated before this point so it's trusted;
+  archive JSONL just serializes and reads back, so this is fine.
+  Worth having a test case with Unicode / quotes in the prompt.
+- **Live-test difficulty.** Same as Phase 1: I can't hit Les's dev
+  instance; live smoke falls to review time.
+- **`_scan_archive_for_pending` scans the tail (64KB) of the
+  archive.** For conversations with lots of chatter between
+  confirmation_request and the end, the request could be off the
+  scanned window. Inherits existing behavior — not a regression —
+  but worth noting if it bites us.
+
+## What's deliberately not here
+
+- Collapsing `EndTurnConfirm` into a widget — follow-up issue.
+- Canvas panel / Phase 3 work.
+- Other widget types (`code_block`, `markdown_document`).
+- Widget hot-reload.
+- Making `on_response` async. Sync-only for v2; can widen later.
+- Relaxing the 24h staleness check on startup recovery.

--- a/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/spec.md
+++ b/docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/spec.md
@@ -1,0 +1,493 @@
+# Spec — Widget catalog Phase 2: input widgets (#256)
+
+Tracking issue: https://github.com/lmorchard/decafclaw/issues/256
+Builds on Phase 1 (PR #360, merged): widget plumbing, registry,
+`data_table`, `vault_search` retrofit.
+
+## Session scope
+
+This session ships **input widgets**: the agent can pause its turn,
+render an interactive widget in the web UI, and resume when the user
+submits. The one bundled interactive widget is **`multiple_choice`**,
+exercised by a new core tool **`ask_user`** — the first real capability
+for "agent stops and asks the user to pick something."
+
+Phases 3 (canvas panel) and 4 (`code_block`, polish) are out of scope
+for this session.
+
+## Problem
+
+Phase 1 unlocked rich display output. The agent still has no way to
+pause mid-turn and collect structured input from the user. The existing
+pause primitive (`EndTurnConfirm`) only offers Approve/Deny buttons.
+
+We want the agent to be able to say "there are three reasonable paths
+here — which one?" and show a radio-button picker, not a wall of text
+begging the user to respond with free-form text we then have to parse.
+
+## Goals
+
+- The agent has a way to ask the user a multiple-choice question
+  mid-turn, pausing the loop until the user responds.
+- Tools return `WidgetRequest(widget_type="multiple_choice", ...,
+  on_response=cb, end_turn=True)`; the loop pauses and the frontend
+  renders radio buttons / checkboxes.
+- The user submits; the loop wakes up; the on_response callback
+  decides what synthetic user message gets injected into history so
+  the LLM sees the choice on its next iteration.
+- Persistence survives server restart and browser reload via the
+  existing confirmation archive + restart-scan path (with a sensible
+  default when the in-memory callback is gone).
+- Multi-tab: first-to-submit wins; other tabs reconcile via the
+  broadcast response event.
+- Mattermost / terminal get the text fallback (existing `ToolResult.text`
+  behavior — no change to those channels).
+
+## Non-goals (Phase 2)
+
+- Widgetizing `EndTurnConfirm` — **deferred to a follow-up issue**.
+  The parallel `EndTurnConfirm` UI stays exactly as-is. Phase 2
+  converges the pause/resume backend under `confirmations.py` so
+  collapsing `EndTurnConfirm` into a widget later is a small refactor.
+- Canvas panel (`canvas_set`, `canvas_update`, `dc-canvas-panel`,
+  `canvas.json`) — Phase 3.
+- `code_block` / `markdown_document` widgets — Phase 3/4.
+- Widgets with more complex input shapes than "submit once" (chat
+  inside a widget, live streaming, etc.) — future.
+- Workspace-tier widgets / iframe sandbox — still #358.
+
+## Acceptance criteria
+
+1. The LLM can call `ask_user(prompt, options, allow_multiple=False)`;
+   the web UI renders a `<dc-widget-multiple-choice>` with the options
+   as radios (or checkboxes if `allow_multiple=True`) and a Submit
+   button.
+2. The agent turn pauses until the user submits.
+3. When the user submits, the next LLM iteration sees a user message
+   that reflects the choice (default wording: `"User selected: <label>"`;
+   `ask_user` uses this default).
+4. Mattermost and terminal show only the tool's `text` — the
+   "[awaiting user choice]" marker plus whatever `display_short_text`
+   the tool set. No widget rendering there.
+5. Reload a conversation that contains an answered `ask_user`: the
+   `multiple_choice` widget re-renders with the chosen option visible,
+   all controls disabled, the submit button relabeled. The injected
+   user message is in the transcript as expected.
+6. Server restart mid-pause: on next startup, the pending widget
+   request is recovered from the archive. If the user submits after
+   restart, a **default handler** injects `"User responded with: <data>"`
+   as the user message (the in-memory `on_response` callback is gone
+   but the loop can still resume gracefully).
+7. Multi-tab: two tabs on the same conversation both show the widget.
+   Submitting from one tab disables the widget in the other tab via
+   the broadcast confirmation response event. Second submit attempt
+   is a no-op (confirmation already resolved).
+8. A tool sets `widget=WidgetRequest(accepts_input=True)` without
+   `end_turn=True` → warning logged, widget stripped, text flows
+   normally. A tool sets BOTH an input widget AND an
+   `end_turn=EndTurnConfirm(...)` → widget wins, `EndTurnConfirm`
+   dropped with warning.
+9. Lint + typecheck + tests clean.
+
+## Architecture
+
+### Backend convergence: pause/resume rides on the confirmation infra
+
+The `confirmations.py` module already provides:
+
+- Persistent JSONL request + response records
+  (`role: "confirmation_request"` / `"confirmation_response"`), keyed
+  by `tool_call_id` + `confirmation_id`.
+- A per-conversation pause via `request_confirmation(...)` that awaits
+  an event-bus response.
+- Startup-scan recovery of pending requests after server restart.
+- Typed `ConfirmationAction` enum + a `ConfirmationRegistry` of
+  handlers that dispatch on approve/deny.
+
+Phase 2 adds **small extensions**:
+
+1. **New `ConfirmationAction.WIDGET_RESPONSE`.** Action data carries
+   the widget type + the serialized widget request (widget_type,
+   target, data).
+2. **`ConfirmationResponse.data: dict`** — a new free-form response
+   field, populated for widget responses (the `{selected: "a"}` or
+   `{selected: ["a", "b"]}` payload). Confirmation handlers for
+   existing actions ignore it; the new widget handler reads it.
+3. **`ConfirmationRequest.timeout: float | None = 300.0`** —
+   `asyncio.wait_for(..., timeout=None)` already disables the deadline
+   natively, so we widen the type and widget requests pass
+   `timeout=None`. Existing confirmations keep their 5-min default
+   with no code change.
+4. **Added `respond_to_confirmation(..., data: dict | None = None)`**
+   on the manager so WS handlers can pass the widget response payload
+   through. The emitted `confirmation_response` event carries `data`
+   when present.
+5. **A default `WIDGET_RESPONSE` handler registered at startup.** Used
+   by the recovery path (`recover_confirmation`) when the agent loop
+   has died and a submit comes in. Handler writes a synthetic user
+   message directly to the archive
+   (`append_message(config, conv_id, {role: "user", content: "User
+   responded with: <data>"})`). Returns
+   `{"inject_message": "...", "continue_loop": False}` but the
+   recovery path doesn't act on `continue_loop` beyond its own logic
+   — the archive sync is the important bit.
+
+### Live vs recovery paths (asymmetric — worth being explicit)
+
+The confirmation infra has two convergent user-input paths but the
+code for handling the response is DIFFERENT between them:
+
+- **Live path:** agent-loop calls `request_confirmation` → waits on
+  event → response arrives → loop directly reads
+  `state.confirmation_response` and continues. No handler dispatch.
+- **Recovery path:** a response arrives when no loop is waiting →
+  `recover_confirmation` dispatches to the registered handler →
+  handler does its thing.
+
+Existing confirmations (`EndTurnConfirm`, shell approval, etc.) rely
+on `approved: bool` alone in the live path; the recovery handler is a
+defensive fallback.
+
+For widgets, the live path is where the `on_response` callback lives:
+the agent-loop branch for widget-input pauses looks up the callback
+by `tool_call_id` in the in-memory map, calls it with `response.data`,
+gets the inject string, and appends a synthetic user message to both
+in-memory `history` and the archive. The recovery path's registered
+`WIDGET_RESPONSE` handler does the archive append directly (there's
+no `history` to sync, since no loop is running).
+
+Both paths must produce the same archive end-state: a user message
+whose content is the inject-string. Reload + next turn then reads
+that message via normal history flow.
+
+### Agent loop changes
+
+In `_execute_single_tool` / `_resolve_widget`:
+
+- After validating the widget payload (Phase 1), check if
+  `widget.descriptor.accepts_input == True`.
+- **Enforcement rules:**
+  1. Input widget with no `end_turn=True` and no `EndTurnConfirm` →
+     log warning, strip the widget, continue (text flows normally).
+  2. Input widget with `end_turn=EndTurnConfirm(...)` → log warning,
+     overwrite `end_turn=True` (widget-pause wins; no buttons).
+  3. Display widget (`accepts_input=False`) + any `end_turn` — no
+     conflict, no changes.
+- If the widget is kept and is input-type, register the `on_response`
+  callback (if set) in an in-memory map keyed by `tool_call_id`.
+- Convert `result.end_turn = True` into a new `WidgetInputPause`
+  sentinel dataclass: `WidgetInputPause(tool_call_id, widget_payload)`.
+  Stored/returned the same way `EndTurnConfirm` is today (the
+  `end_turn` flag on ToolResult + the `end_turn_signal` the tool-call
+  batch carries up).
+- Emit the `tool_end` event with the widget (as Phase 1).
+
+In the outer agent loop, extend the existing `end_turn_signal` switch:
+
+- `isinstance(end_turn_signal, EndTurnConfirm)` → existing buttons
+  path (unchanged).
+- **New:** `isinstance(end_turn_signal, WidgetInputPause)` → build
+  `ConfirmationRequest(action_type=WIDGET_RESPONSE,
+  action_data={widget_type, target, data}, tool_call_id=...,
+  timeout=None)` and call `ctx.request_confirmation(request)`
+  directly. This bypasses the `tools/confirmation.py` helper (which
+  builds action_data from a fixed set of tool-specific extras) —
+  widget requests carry arbitrary widget data and don't fit that
+  helper's shape. The manager sets up `ctx.request_confirmation`
+  during context setup (`conversation_manager.py:615`), so this call
+  is already available.
+
+  On response, look up the callback in the in-memory map, call it
+  with `response.data`, get the inject-string, append as a user
+  message to history + archive. Clear the in-memory callback entry.
+  Continue loop.
+
+The LLM's *last message* on the iteration before the pause is a tool
+result with "[awaiting user choice]" text. When the loop resumes, the
+injected synthetic user message follows that tool result, and the
+next LLM call sees the question (via the tool's text) and the answer
+(via the synthetic user message) in proper sequence.
+
+### `on_response` callback contract
+
+Signature: `on_response(response_data: dict) -> str` — sync for now.
+Returns the string to inject into history as a user message.
+
+If the tool wants structured state change, it can close over local
+variables and do work inside the callback; the return value is only
+the injected-into-LLM-visible text.
+
+Restart-recovery default (no callback registered): inject
+`f"User responded with: {response_data}"` as a user message.
+
+### The `ask_user` tool
+
+New core tool in `src/decafclaw/tools/core.py` (or a new
+`user_input.py` if it grows). Always-loaded is overkill — set
+`priority=low` so it's fetched on demand when relevant via tool_search
+or preempt-match.
+
+Signature (Python):
+
+```python
+async def ask_user(
+    ctx,
+    prompt: str,
+    options: list[str | dict],
+    allow_multiple: bool = False,
+) -> ToolResult:
+    ...
+```
+
+- `options` accepts bare strings (treated as `{value: s, label: s}`)
+  or dicts `{value, label, description?}`.
+- Returns `ToolResult` with:
+  - `text`: `"[awaiting user response: <prompt>]"` (placeholder so the
+    archive is readable; the injected response will follow later)
+  - `display_short_text`: e.g. `"ask: pick one of N"`
+  - `widget`: `WidgetRequest(widget_type="multiple_choice", data={...},
+    on_response=_default_cb, end_turn=True)`
+- Default `on_response`: formats selection as
+  `"User selected: <label>"` (or `"User selected: a, b"` for multi).
+
+### Tool description (LLM-facing)
+
+> `ask_user` — Pause the turn and ask the user to choose from a list
+> of options. Use ONLY when the right answer is genuinely ambiguous
+> from context and you cannot make a reasonable choice on your own.
+> Prefer to act on your best judgment; calling this tool is costly —
+> it interrupts the user's flow. Reserve for decisions the user would
+> want to weigh in on (e.g., "which of these three files should I
+> edit?", "publish or save as draft?").
+
+Wording matters — we want the LLM to reach for this sparingly. Eval
+loop can validate.
+
+### Bundled `multiple_choice` widget
+
+New directory: `src/decafclaw/web/static/widgets/multiple_choice/`
+
+**`widget.json`:**
+
+- `name: "multiple_choice"`
+- `description`: "Ask the user to choose one (or several) option(s)
+  from a list. Radio buttons for single, checkboxes for multi."
+- `modes: ["inline"]` — no canvas mode in Phase 2
+- `accepts_input: true`
+- `data_schema`:
+  - required: `prompt` (string), `options` (array of `{value, label,
+    description?}` objects)
+  - optional: `allow_multiple` (boolean, default false)
+
+**`widget.js`** — `<dc-widget-multiple-choice>`:
+
+Props:
+
+- `data`: `{prompt, options, allow_multiple}`
+- `submitted`: boolean — when true, controls are disabled and the
+  submit button is relabeled
+- `response`: `{selected}` — for the reload/submitted case, shows
+  which option(s) were picked
+
+Behavior:
+
+- Renders `prompt` as a small text header.
+- Radios (allow_multiple=false) or checkboxes (true) for each option.
+  Description shown as muted secondary text under the label, when
+  present.
+- Submit button disabled until at least one option is selected.
+- On submit: dispatch `widget-response` CustomEvent with
+  `detail = {selected: "..."}` (string for single; array for multi).
+  `{bubbles: true, composed: true}` so it bubbles past `dc-widget-host`
+  to the parent tool-message.
+- Post-submit state: same DOM, but controls `disabled`, submit button
+  relabeled "Submitted" and disabled, selected option visually
+  indicated (bold + checked).
+- Reload: parent passes `submitted=true` + `response={selected}` → same
+  visual as post-submit.
+
+### Frontend: bridge `widget-response` → WebSocket
+
+Currently `dc-widget-host` doesn't touch WebSocket. The response path
+adds:
+
+- A listener on tool-message (or chat-view, whichever is cleaner) that
+  catches `widget-response` events bubbling up, packages the detail as
+  a `widget_response` WebSocket message with `tool_call_id` + `data`
+  detail, and sends it over the existing WS.
+- Receiving side: after the backend resolves and publishes the
+  `confirmation_response` event, the existing `tool-status-store`
+  gets that event (it already handles confirmation responses for
+  EndTurnConfirm-style buttons); it needs one small extension to also
+  forward the response `data` to the matching widget so it flips to
+  `submitted=true, response=...`.
+- Live case and reload case converge on: tool-message examines
+  history, finds the matching `confirmation_response` for this
+  `tool_call_id`, pulls `data`, and renders widget with
+  `submitted=true, response=data`.
+
+### WebSocket message names
+
+Mirrors the existing `confirm_response` pattern, just for widgets:
+
+- **Frontend → backend:** new incoming type `widget_response` with
+  fields `{conv_id, confirmation_id, tool_call_id, data}`. Handler
+  registered in the `websocket.py` handler map alongside
+  `confirm_response`.
+- **Backend handler** calls
+  `manager.respond_to_confirmation(conv_id, confirmation_id,
+  approved=True, data=msg["data"])`. `approved=True` because a widget
+  submission isn't a yes/no decision; a submit happens, that's it.
+- **Backend → frontend:** when a widget pause starts, the manager
+  emits a `confirmation_request` event with
+  `action_type="widget_response"` and `action_data={widget_type,
+  target, data}`. The existing frontend `#pendingConfirms` state
+  captures it (so the frontend knows the confirmation_id for this
+  `tool_call_id`). When the widget submits, the frontend looks up the
+  matching confirmation by `tool_call_id` and sends
+  `widget_response` with the `confirmation_id`.
+- **Confirmation UI filtering:** `confirm-view.js` renders
+  approve/deny buttons for every pending confirm. We need to filter
+  out confirms with `action_type="widget_response"` — those are
+  rendered inline inside the tool message (by the widget itself). Add
+  a filter: `pendingConfirms.filter(c => c.action_type !==
+  "widget_response")` at the render site.
+- **Live response emit:** when the manager resolves, it emits a
+  `confirmation_response` event with the response fields. This event
+  needs a new `data` field for the widget selection, so the frontend
+  can update the widget's post-submit state.
+
+### Archive shapes
+
+**Request side:** The same `role: "confirmation_request"` record Phase
+1 uses. For a widget request, `action_type = "widget_response"` and
+`action_data = {widget_type, target, data}` — everything the frontend
+needs to re-render the widget on reload.
+
+The existing `tool` role record (Phase 1) already carries the `widget`
+payload. The `confirmation_request` record is redundant with the `tool`
+record's widget for the rendering case, but it's what the restart-scan
+path picks up to recover. Having both:
+
+- `tool` record: what the live Phase 1 pipeline uses to render the
+  widget (frontend already wired).
+- `confirmation_request` record: what the restart-scan + pause
+  mechanism uses.
+
+That redundancy is fine — they're independent concerns.
+
+**Response side:** `role: "confirmation_response"` with `data = {...}`
+(the widget's selection). The `data` field is new — Phase 2 adds it.
+
+### Reload UX
+
+On conversation reload, the frontend's message-store merges pairs:
+
+- Phase 1: assistant `tool_calls` + matching `tool` records → tool
+  message with widget.
+- Phase 2: additionally, scan forward from the `tool` record for a
+  matching `confirmation_response` (by `tool_call_id`). If found with
+  `data`, pass `submitted=true, response=data` to the tool-message.
+  Widget renders in post-submit state.
+
+For a widget that was never answered (server died mid-pause and was
+never resumed): `confirmation_request` exists, no
+`confirmation_response`. On reload, the widget is live — user can
+still submit. Backend startup-scan will have recovered the pending
+request so the submission still flows through the confirmation infra
+(just without the in-memory callback, hitting the default handler).
+
+## Error handling / edge cases
+
+- **Input widget without `end_turn=True`** → warning, strip widget,
+  text only.
+- **Input widget + `EndTurnConfirm`** → warning, widget wins,
+  `EndTurnConfirm` dropped.
+- **Input widget + `end_turn=True`** (happy path) → pause, await
+  response, resume.
+- **Widget type `multiple_choice` marked `accepts_input=true` but tool
+  set `end_turn=False`** → same as "input widget without end_turn":
+  strip, warn.
+- **User disconnects before submitting** → pending confirmation stays
+  in the archive. On next connect, widget renders as live (not
+  submitted) — they can resume. Server restart is equivalent.
+- **Tool returns widget with `widget_type` that has `accepts_input=true`
+  but provides a callback that raises on call** → exception logged;
+  fall through to the default handler ("User responded with: <data>").
+  Do NOT fail the turn.
+- **Second tab submits after first already resolved** → backend's
+  confirmation-already-resolved path (same as EndTurnConfirm today).
+  Second submit is a no-op; second tab's UI reconciles via the
+  broadcast response event.
+- **Archive has `confirmation_response` but registry lacks
+  `WIDGET_RESPONSE` action (e.g., old archive from before Phase 2)** —
+  not possible: the `WIDGET_RESPONSE` enum value is added by Phase 2
+  and older archives wouldn't reference it. If a newer archive gets
+  loaded by an older binary, the enum parse fails in
+  `ConfirmationRequest.from_archive_message`; we'd handle that as a
+  generic "unknown action type — skip" (matches existing behavior).
+- **24h staleness on startup recovery.** Existing `_scan_archive_for_pending`
+  skips confirmations older than 24h. Widgets inherit this — a user
+  returning to a week-old pending widget won't have a registered
+  pending confirmation, so a submit attempt would error out with "No
+  pending confirmation for conv X." Acceptable for Phase 2; we can
+  relax this later if it bites. The widget itself still renders from
+  the archive record, just can't be submitted.
+- **`options` list is empty** → agent-loop validation via `jsonschema`
+  (data_schema requires `options` as an array; empty array is allowed
+  by default JSON schema but the tool-level enforcement can tighten:
+  `ask_user` returns an error if options is empty). Tool-level check
+  in `ask_user` for sanity; widget renders nothing useful with empty
+  options but doesn't crash.
+- **`options` with duplicate values** → not forbidden by schema. UI
+  would show two items with the same value; first-match wins on
+  submit. Fine, tool-author problem.
+
+## File inventory
+
+New:
+
+- `src/decafclaw/web/static/widgets/multiple_choice/widget.json`
+- `src/decafclaw/web/static/widgets/multiple_choice/widget.js`
+- `tests/test_widgets_input.py` — pause/resume, callback, default
+  handler, enforcement rules.
+- `tests/test_ask_user.py` — the new tool, happy path + option shapes.
+
+Modified:
+
+- `src/decafclaw/confirmations.py` — add `WIDGET_RESPONSE` action,
+  extend `ConfirmationResponse` with `data` field, timeout=0 sentinel
+  handling.
+- `src/decafclaw/agent.py` — enforcement rules in `_resolve_widget`;
+  pause-on-input-widget branch in the agent-loop end_turn switch;
+  in-memory callback map; registry handler for `WIDGET_RESPONSE`.
+- `src/decafclaw/tools/core.py` (or new `ask_user.py`) — the tool.
+- `src/decafclaw/tools/__init__.py` — tool registration.
+- `src/decafclaw/web/websocket.py` — `widget_response` incoming
+  message handler; `confirmation_response` outgoing carries `data`.
+- `src/decafclaw/web/static/components/messages/tool-message.js` —
+  forward `submitted` + `response` to `dc-widget-host`; listen for
+  `widget-response` to fire WS message.
+- `src/decafclaw/web/static/components/widgets/widget-host.js` —
+  pass `submitted` + `response` to the child widget component.
+- `src/decafclaw/web/static/lib/tool-status-store.js` — widget
+  response handling (update tool message with `submitted=true` +
+  `response=data`).
+- `src/decafclaw/web/static/lib/message-store.js` — reload-merge pass
+  to pair widgets with their `confirmation_response` + attach
+  submitted/response props.
+- `src/decafclaw/web/static/styles/widgets.css` — styles for the
+  `multiple_choice` widget.
+- `docs/widgets.md` — Phase 2 addendum: `multiple_choice`, input
+  widget contract, `ask_user` example.
+- `CLAUDE.md` — key files note mentioning `ask_user` and the
+  input-widget path.
+
+## Open follow-ups tracked elsewhere
+
+- **Collapse `EndTurnConfirm` into a widget** with multi-channel
+  (Mattermost buttons) adapter — to be filed as a new follow-up
+  issue during execution. Pre-req: Phase 2 lands.
+- **Workspace-tier widgets + iframe sandbox** — #358 (still).
+- **Per-tool renderer registry (#151)** — still held open; reassess
+  after Phase 2.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -120,6 +120,94 @@ The browser dynamic-imports this module the first time the widget is
 needed. Use bare specifiers like `'lit'` — they resolve through the
 existing importmap.
 
+## Input widgets (Phase 2)
+
+Some widgets collect structured input from the user. They pause the
+agent turn until the user submits, then resume with the selection
+injected as a synthetic user message so the next LLM iteration sees
+the answer.
+
+To mark a widget as interactive, set `"accepts_input": true` in its
+`widget.json`. Tools that emit an input widget MUST also set
+`end_turn=True` on the `ToolResult`.
+
+### The `ask_user` core tool
+
+The agent can ask the user to pick from a list via the built-in
+`ask_user` tool:
+
+```python
+# Inside the LLM's tool-calling loop
+await ask_user(
+    prompt="Which deploy target?",
+    options=["production", "staging", "dev"],
+    allow_multiple=False,  # radios; set True for checkboxes
+)
+```
+
+The user sees a `multiple_choice` widget inline in the tool message;
+the agent pauses. When the user submits, the conversation continues
+with a synthetic `role: "user"` message like
+`"User selected: production"`.
+
+### Building your own input widget
+
+Tool-side:
+
+```python
+from decafclaw.media import ToolResult, WidgetRequest
+
+def on_response(data: dict) -> str:
+    # data is {selected: ...} (or whatever the widget sends)
+    return f"The user answered: {data['selected']}"
+
+async def my_input_tool(ctx, ...):
+    return ToolResult(
+        text="[awaiting user response]",
+        widget=WidgetRequest(
+            widget_type="my_prompt",
+            data={"prompt": "pick one", "options": [...]},
+            on_response=on_response,
+        ),
+        end_turn=True,  # REQUIRED for input widgets
+    )
+```
+
+Widget-side, the Lit component gets three props:
+
+- `data` — the widget's data payload.
+- `submitted` — `true` once the user has submitted (live or reloaded).
+- `response` — the response payload after submit; seed your UI to show
+  the selection.
+
+When the user submits, dispatch a `widget-response` CustomEvent that
+bubbles past `dc-widget-host`:
+
+```js
+this.dispatchEvent(new CustomEvent('widget-response', {
+  detail: { selected: chosenValue },
+  bubbles: true,
+  composed: true,
+}));
+```
+
+The response payload (whatever goes in `detail`) reaches the tool's
+`on_response` callback as its single argument. The callback's return
+string is what gets injected as the synthetic user message.
+
+### Restart recovery
+
+Pending input widgets survive server restart. If the server dies
+between the user seeing the widget and submitting it, the next
+startup scan picks up the pending confirmation from the archive. When
+the user submits after restart, the in-memory `on_response` callback
+is gone, so a default handler injects `"User responded with: <data>"`
+as the user message so the loop stays coherent.
+
+Input widgets ride on the existing confirmation infra in
+`src/decafclaw/confirmations.py`: a pause is a `WIDGET_RESPONSE`-typed
+confirmation request + response in the JSONL archive.
+
 ## Dev workflow
 
 `make dev` watches the bundled widgets directory for `.json` / `.js`
@@ -130,21 +218,23 @@ reload the browser — the cache-busting query param
 Admin-tier widgets under `data/{agent_id}/widgets/` are not auto-watched
 — edit or add one and restart `make dev` manually.
 
-## Out-of-scope for Phase 1
+## Out-of-scope
 
-- Input widgets (pause-the-turn + user-submits widgets) — tracked in
-  #256 Phase 2.
 - Canvas panel (persistent sidebar surface with widgets that update
   across turns) — tracked in #256 Phase 3.
-- Additional widget types: `multiple_choice`, `code_block`,
-  `markdown_document` — later phases of #256.
+- Additional widget types: `code_block`, `markdown_document` — later
+  phases of #256.
+- Collapsing `EndTurnConfirm` into a widget with a Mattermost-buttons
+  adapter — filed as a follow-up issue.
 - Agent-authored widget JS (workspace tier + iframe sandbox) — #358.
 - Hot-reload of widget catalog without server restart — future.
 
 ## Related files
 
 - `src/decafclaw/widgets.py` — registry scan + validation
-- `src/decafclaw/media.py` — `WidgetRequest` + `ToolResult.widget`
-- `src/decafclaw/web/static/widgets/` — bundled widgets
+- `src/decafclaw/media.py` — `WidgetRequest`, `WidgetInputPause`, `ToolResult.widget`
+- `src/decafclaw/widget_input.py` — input-widget handler + callback map
+- `src/decafclaw/tools/core.py` — `ask_user` tool
+- `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice)
 - `src/decafclaw/web/static/components/widgets/widget-host.js` — frontend host
 - `src/decafclaw/web/static/lib/widget-catalog.js` — catalog client

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -11,6 +11,7 @@ This is where the interesting stuff happens. The loop:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import json
 import logging
@@ -27,7 +28,7 @@ from .compaction import compact_history
 from .context_cleanup import clear_old_tool_results
 from .context_composer import ComposerMode, ContextComposer
 from .llm import call_llm
-from .media import EndTurnConfirm, ToolResult, extract_workspace_media
+from .media import EndTurnConfirm, ToolResult, WidgetInputPause, extract_workspace_media
 from .persistence import read_skill_data, read_skills_state, write_skill_data, write_skills_state
 from .tools import TOOL_DEFINITIONS, execute_tool
 from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
@@ -307,6 +308,106 @@ async def _handle_reflection(
 
     # Reflection passed (or errored out — fail-open)
     return final_text, False, reflection_retries, last_reflection
+
+
+async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
+                                     ) -> str | None:
+    """Pause the agent turn on an input widget and resume with the
+    user's answer formatted as a synthetic user-message string.
+
+    Returns the inject-string to append to history. Returns None if
+    the pause infra isn't available, OR if the user cancels the turn
+    while the widget is pending — both cases route the outer loop to
+    end the turn cleanly without injecting a synthetic answer.
+    """
+    from .confirmations import (
+        ConfirmationAction,
+        ConfirmationRequest,
+    )
+    from .widget_input import (
+        default_inject_message,
+        pending_callbacks,
+    )
+
+    request_confirmation = getattr(ctx, "request_confirmation", None)
+    if request_confirmation is None:
+        log.warning(
+            "WidgetInputPause received but ctx has no request_confirmation "
+            "— cannot pause, ending turn gracefully")
+        # Drop the registered callback so it can't leak across turns.
+        pending_callbacks.pop(signal.tool_call_id, None)
+        return None
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        action_data=signal.widget_payload,
+        tool_call_id=signal.tool_call_id,
+        timeout=None,  # widget responses have no deadline
+    )
+
+    # Race the confirmation await against ctx.cancelled so a "stop turn"
+    # click while the widget is pending unblocks the loop. The
+    # confirmation infra's await on confirmation_event doesn't observe
+    # cancel_event natively.
+    cancel_event = getattr(ctx, "cancelled", None)
+    confirm_task = asyncio.create_task(request_confirmation(request))
+    response = None
+    cancelled_during_pause = False
+    try:
+        if cancel_event is not None:
+            cancel_task = asyncio.create_task(cancel_event.wait())
+            done, _pending = await asyncio.wait(
+                [confirm_task, cancel_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            cancel_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await cancel_task
+            if confirm_task in done:
+                response = confirm_task.result()
+            else:
+                # Cancel won. Tear down the pause cleanly: cancel the
+                # confirm await and clear the pending confirmation in
+                # the manager so the archive doesn't keep showing a
+                # stale pending widget after the cancelled turn. We
+                # use cancel_pending_confirmation rather than
+                # respond_to_confirmation because the latter would
+                # dispatch the recovery handler and inject a synthetic
+                # "user responded with: ..." message — but the user
+                # didn't respond, they cancelled.
+                cancelled_during_pause = True
+                confirm_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await confirm_task
+                manager = getattr(ctx, "manager", None)
+                conv_id = getattr(ctx, "conv_id", None)
+                if manager and conv_id:
+                    try:
+                        await manager.cancel_pending_confirmation(conv_id)
+                    except Exception as exc:
+                        log.debug(
+                            "Failed to clear pending widget confirmation "
+                            "on cancel for %s: %s", conv_id, exc)
+        else:
+            response = await confirm_task
+    finally:
+        # Always remove the callback entry so a crashed await doesn't
+        # leak it across later turns. pop() with a default is a no-op
+        # if the entry was already consumed.
+        callback = pending_callbacks.pop(signal.tool_call_id, None)
+
+    if cancelled_during_pause or response is None:
+        return None
+
+    if callback is not None:
+        try:
+            return callback(response.data)
+        except Exception as exc:
+            log.warning(
+                "widget on_response callback raised for %s: %s",
+                signal.tool_call_id, exc)
+            return default_inject_message(response.data)
+    return default_inject_message(response.data)
 
 
 async def _handle_end_turn_confirm(ctx, action: EndTurnConfirm) -> bool:
@@ -614,7 +715,7 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
             log.error(f"Tool call {fn_name} failed: {e}", exc_info=True)
             result = ToolResult(text=f"[error executing {fn_name}: {e}]")
         finally:
-            widget_payload = _resolve_widget(fn_name, result)
+            widget_payload = _resolve_widget(fn_name, result, tool_call_id)
             publish_kwargs = {
                 "tool": fn_name,
                 "result_text": result.text,
@@ -648,12 +749,21 @@ async def _execute_single_tool(call_ctx, tc, semaphore):
     return tool_msg, result.end_turn
 
 
-def _resolve_widget(fn_name: str, result: ToolResult) -> dict | None:
+def _resolve_widget(fn_name: str, result: ToolResult,
+                    tool_call_id: str = "") -> dict | None:
     """Validate result.widget against the registry and return a
     serializable payload, or None if no widget / validation fails.
 
-    Side effect: on validation failure, clears result.widget so the
-    stripped widget doesn't accidentally surface elsewhere.
+    Phase-2 side effects for input widgets (``accepts_input=True``):
+
+    - If ``end_turn`` is falsy, strip the widget (input widgets require
+      the turn to pause).
+    - If ``end_turn`` is an ``EndTurnConfirm``, drop the confirm (widget
+      pause wins) and set ``end_turn=True``.
+    - Register the ``on_response`` callback in
+      ``widget_input.pending_callbacks`` keyed by ``tool_call_id``.
+    - Promote ``result.end_turn`` to a ``WidgetInputPause`` sentinel
+      that the agent loop detects and routes to the pause path.
     """
     widget = getattr(result, "widget", None)
     if widget is None:
@@ -688,11 +798,39 @@ def _resolve_widget(fn_name: str, result: ToolResult) -> dict | None:
             fn_name, widget.widget_type, target, desc.modes)
         result.widget = None
         return None
-    return {
+    payload = {
         "widget_type": widget.widget_type,
         "target": target,
         "data": widget.data,
     }
+
+    # Phase 2: input-widget enforcement + pause-signal promotion.
+    if desc is not None and desc.accepts_input:
+        # Rule: input widget requires end_turn truthy (True or
+        # EndTurnConfirm; widget-pause wins over EndTurnConfirm).
+        if not result.end_turn:
+            log.warning(
+                "tool %s emitted input widget %r without end_turn=True "
+                "— stripping (input widgets must pause the turn)",
+                fn_name, widget.widget_type)
+            result.widget = None
+            return None
+        if isinstance(result.end_turn, EndTurnConfirm):
+            log.warning(
+                "tool %s emitted input widget %r alongside EndTurnConfirm "
+                "— dropping EndTurnConfirm (widget-pause takes priority)",
+                fn_name, widget.widget_type)
+        # Register the callback for live-path pickup.
+        if widget.on_response is not None and tool_call_id:
+            from .widget_input import pending_callbacks
+            pending_callbacks[tool_call_id] = widget.on_response
+        # Promote end_turn to the pause sentinel.
+        result.end_turn = WidgetInputPause(
+            tool_call_id=tool_call_id,
+            widget_payload=payload,
+        )
+
+    return payload
 
 
 async def _execute_tool_calls(ctx, tool_calls, history, messages):
@@ -744,9 +882,10 @@ async def _execute_tool_calls(ctx, tool_calls, history, messages):
         return cancelled, False
 
     # Collect results in original call order (gather preserves order).
-    # end_turn_signal: False (no signal), True (simple end), or EndTurnConfirm.
-    # EndTurnConfirm takes priority over True if both appear in a batch.
-    end_turn_signal: bool | EndTurnConfirm = False
+    # Priority among end-turn signals in a single batch:
+    #   WidgetInputPause > EndTurnConfirm > True
+    # Only one pause/end signal wins per batch.
+    end_turn_signal: bool | EndTurnConfirm | WidgetInputPause = False
     for i, result in enumerate(results):
         if isinstance(result, BaseException):
             # Task was cancelled or failed — gather with return_exceptions.
@@ -765,9 +904,13 @@ async def _execute_tool_calls(ctx, tool_calls, history, messages):
             _archive(ctx, tool_msg)
         else:
             tool_msg, end_turn = result
-            if isinstance(end_turn, EndTurnConfirm):
-                end_turn_signal = end_turn  # EndTurnConfirm takes priority
-            elif end_turn and not isinstance(end_turn_signal, EndTurnConfirm):
+            if isinstance(end_turn, WidgetInputPause):
+                end_turn_signal = end_turn  # Widget pause wins over all
+            elif isinstance(end_turn, EndTurnConfirm):
+                if not isinstance(end_turn_signal, WidgetInputPause):
+                    end_turn_signal = end_turn
+            elif end_turn and not isinstance(
+                    end_turn_signal, (EndTurnConfirm, WidgetInputPause)):
                 end_turn_signal = True
             history.append(tool_msg)
             messages.append(tool_msg)
@@ -1049,6 +1192,30 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                 )
                 if cancelled:
                     return cancelled
+
+                if isinstance(end_turn_signal, WidgetInputPause):
+                    # Input-widget pause: route through the confirmation
+                    # infra, await user submit, call the tool's
+                    # on_response callback (if any), inject the returned
+                    # string as a synthetic user message, and continue
+                    # the loop for the next LLM iteration.
+                    inject_content = await _handle_widget_input_pause(
+                        ctx, end_turn_signal)
+                    if inject_content is None:
+                        # request_confirmation not available (unusual —
+                        # no manager wired); strip the pause and end
+                        # the turn gracefully.
+                        end_turn_signal = True
+                    else:
+                        synthetic = {
+                            "role": "user",
+                            "source": "widget_response",
+                            "content": inject_content,
+                        }
+                        history.append(synthetic)
+                        messages.append(synthetic)
+                        _archive(ctx, synthetic)
+                        continue  # next LLM iteration sees the answer
 
                 if isinstance(end_turn_signal, EndTurnConfirm):
                     # Confirmation gate: present the artifact, show buttons, wait.

--- a/src/decafclaw/confirmations.py
+++ b/src/decafclaw/confirmations.py
@@ -17,18 +17,23 @@ class ConfirmationAction(str, Enum):
     ACTIVATE_SKILL = "activate_skill"
     CONTINUE_TURN = "continue_turn"
     ADVANCE_PROJECT_PHASE = "advance_project_phase"
+    WIDGET_RESPONSE = "widget_response"
 
 
 @dataclass
 class ConfirmationRequest:
-    """A confirmation request that can be persisted in conversation history."""
+    """A confirmation request that can be persisted in conversation history.
+
+    ``timeout=None`` disables the await deadline — used by widget requests
+    where the user responds when ready.
+    """
     action_type: ConfirmationAction
     action_data: dict = field(default_factory=dict)
     message: str = ""
     approve_label: str = "Approve"
     deny_label: str = "Deny"
     tool_call_id: str = ""
-    timeout: float = 300.0
+    timeout: float | None = 300.0
     confirmation_id: str = field(default_factory=lambda: uuid4().hex[:12])
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
 
@@ -57,23 +62,31 @@ class ConfirmationRequest:
 
 @dataclass
 class ConfirmationResponse:
-    """A confirmation response that can be persisted in conversation history."""
+    """A confirmation response that can be persisted in conversation history.
+
+    ``data`` carries free-form response payload for actions that need more
+    than approve/deny — e.g., widget submissions send their selected
+    values here.
+    """
     confirmation_id: str
     approved: bool
     always: bool = False
     add_pattern: bool = False
+    data: dict = field(default_factory=dict)
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
 
     def to_archive_message(self) -> dict:
         """Serialize to a dict suitable for JSONL archive."""
         msg = dataclasses.asdict(self)
         msg["role"] = "confirmation_response"
-        # Drop falsy optional flags to keep archive output lean; from_archive
-        # tolerates their absence via the dataclass defaults.
+        # Drop falsy optional flags / containers to keep archive output lean;
+        # from_archive tolerates their absence via the dataclass defaults.
         if not msg["always"]:
             msg.pop("always")
         if not msg["add_pattern"]:
             msg.pop("add_pattern")
+        if not msg["data"]:
+            msg.pop("data")
         return msg
 
     @classmethod

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -284,12 +284,16 @@ class ConversationManager:
         *,
         always: bool = False,
         add_pattern: bool = False,
+        data: dict | None = None,
     ) -> None:
         """Resolve a pending confirmation request.
 
         Persists the response to the archive and wakes the suspended
         agent loop (if still running) or dispatches recovery (if the
         loop died).
+
+        ``data`` carries free-form response payload (widget selections,
+        etc.).
         """
         state = self._conversations.get(conv_id)
         if not state or not state.pending_confirmation:
@@ -306,6 +310,7 @@ class ConversationManager:
             approved=approved,
             always=always,
             add_pattern=add_pattern,
+            data=data or {},
         )
 
         # Persist to archive
@@ -313,11 +318,14 @@ class ConversationManager:
         append_message(self.config, conv_id, response.to_archive_message())
 
         # Emit to subscribers
-        await self.emit(conv_id, {
+        emit_payload: dict[str, Any] = {
             "type": "confirmation_response",
             "confirmation_id": confirmation_id,
             "approved": approved,
-        })
+        }
+        if response.data:
+            emit_payload["data"] = response.data
+        await self.emit(conv_id, emit_payload)
 
         # Wake the waiting agent loop or dispatch recovery
         state.confirmation_response = response
@@ -329,6 +337,32 @@ class ConversationManager:
                      conv_id)
             result = await self.recover_confirmation(conv_id, response)
             log.info("Recovery result for conv %s: %s", conv_id[:8], result)
+
+    async def cancel_pending_confirmation(self, conv_id: str) -> bool:
+        """Drop a pending confirmation without triggering recovery.
+
+        Used when the caller is itself unwinding (e.g., the agent loop
+        racing the confirmation await against a cancel and the cancel
+        won). Persists a denial response to the archive so reload sees
+        the request as resolved, and clears the manager state so a
+        future submission attempt is a no-op rather than reviving the
+        cancelled turn. Returns True if a pending confirmation was
+        cleared, False otherwise.
+        """
+        state = self._conversations.get(conv_id)
+        if not state or not state.pending_confirmation:
+            return False
+        request = state.pending_confirmation
+        response = ConfirmationResponse(
+            confirmation_id=request.confirmation_id,
+            approved=False,
+        )
+        from .archive import append_message
+        append_message(self.config, conv_id, response.to_archive_message())
+        state.pending_confirmation = None
+        state.confirmation_event = None
+        state.confirmation_response = None
+        return True
 
     async def cancel_turn(self, conv_id: str) -> None:
         """Cancel an in-progress agent turn."""
@@ -975,10 +1009,21 @@ class ConversationManager:
             state.pending_confirmation = None
             return {"error": "No confirmation handlers registered"}
 
+        # The handler needs config + conv_id to write back to the archive
+        # (no running loop means no real ctx). Provide a minimal recovery
+        # context that handlers can duck-type against.
+        recovery_ctx = _RecoveryContext(config=self.config, conv_id=conv_id)
         result = await self.confirmation_registry.dispatch(
-            None,  # no ctx available for recovery
-            request, response,
+            recovery_ctx, request, response,
         )
 
         state.pending_confirmation = None
         return result
+
+
+@dataclass
+class _RecoveryContext:
+    """Minimal ctx-shaped object passed to confirmation handlers during
+    recovery, when there's no live agent loop to provide a real ctx."""
+    config: Any
+    conv_id: str

--- a/src/decafclaw/interactive_terminal.py
+++ b/src/decafclaw/interactive_terminal.py
@@ -57,7 +57,9 @@ async def run_interactive(ctx):
     _print_banner(config)
 
     # Create conversation manager
+    from .widget_input import register_widget_handler
     manager = ConversationManager(config, ctx.event_bus)
+    register_widget_handler(manager.confirmation_registry)
 
     # Track turn completion
     turn_done = asyncio.Event()

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -512,6 +512,21 @@ class MattermostClient:
                 suggested_pattern = action_data.get("suggested_pattern", "")
                 action_type = event.get("action_type", "")
 
+                # Widget responses are a web-UI-only interaction. Skip
+                # rendering approve/deny buttons in Mattermost — there's
+                # no widget surface here, and the buttons would resolve
+                # the confirmation with no data, producing an unhelpful
+                # "User responded with: {}" inject. The agent's tool
+                # description for ask_user already discourages calls
+                # outside the web UI.
+                if action_type == "widget_response":
+                    log.info(
+                        "Skipping Mattermost render for widget_response "
+                        "confirmation %s — not a Mattermost-supported "
+                        "widget surface",
+                        confirmation_id)
+                    return
+
                 # Create confirmation post with buttons/emoji (no legacy polling)
                 confirm_post_id = await cd.on_confirm_request(
                     action_type, command, suggested_pattern,

--- a/src/decafclaw/media.py
+++ b/src/decafclaw/media.py
@@ -37,15 +37,32 @@ class EndTurnConfirm:
 class WidgetRequest:
     """Rich-rendering hint attached to a ToolResult.
 
-    Phase 1 only renders inline widgets in the web UI; Mattermost and
-    terminal fall back to ToolResult.text. The on_response and
-    response_message fields are reserved for Phase 2 input widgets.
+    Phase 1 renders inline widgets in the web UI; Mattermost and
+    terminal fall back to ToolResult.text. Phase 2 adds the
+    ``on_response`` callback for input widgets (``accepts_input=true``)
+    which returns the synthetic user message to inject after the user
+    submits. ``response_message`` is reserved for future use (e.g., a
+    "waiting" placeholder shown to the user during the pause).
     """
     widget_type: str                           # registered widget name
     data: dict                                 # conforms to widget.data_schema
     target: str = "inline"                     # "inline" | "canvas" (Phase 3)
-    on_response: Callable[[dict], Any] | None = None   # Phase 2
-    response_message: str | None = None        # Phase 2
+    on_response: Callable[[dict], str] | None = None
+    response_message: str | None = None
+
+
+@dataclass
+class WidgetInputPause:
+    """Agent-loop signal for an input-widget pause.
+
+    Returned by the tool-execution path as the ``end_turn`` signal when a
+    tool emits a widget with ``accepts_input=True`` and ``end_turn=True``.
+    The agent loop detects this sentinel and routes to the input-widget
+    pause path (request_confirmation with action_type=WIDGET_RESPONSE).
+    Parallel to ``EndTurnConfirm`` — only one per batch wins.
+    """
+    tool_call_id: str
+    widget_payload: dict  # {widget_type, target, data}
 
 
 @dataclass
@@ -59,7 +76,10 @@ class ToolResult:
     data: dict | None = None
     # end_turn: True = end turn with final no-tools LLM call.
     # EndTurnConfirm = show confirmation buttons; approved → continue, denied → end.
-    end_turn: bool | EndTurnConfirm = False
+    # WidgetInputPause = pause on input widget, resume with user selection.
+    # The agent loop promotes input-widget end_turn=True to WidgetInputPause
+    # inside _resolve_widget.
+    end_turn: bool | EndTurnConfirm | WidgetInputPause = False
     widget: WidgetRequest | None = None
 
     @classmethod

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -131,7 +131,13 @@ def _summarize_tool_result(content: str, max_len: int) -> str:
 
 
 def _extract_tool_lines(messages: list, max_result_len: int) -> list[str]:
-    """Extract tool call/result lines from a slice of history messages."""
+    """Extract tool call/result lines from a slice of history messages.
+
+    Also surfaces user replies that came in via input widgets
+    (``source: "widget_response"``) — these sit between a tool result
+    and the next assistant turn and are essential context for the
+    judge: without them, the judge thinks the user never answered.
+    """
     tool_lines: list[str] = []
     for msg in messages:
         if msg.get("role") == "assistant" and msg.get("tool_calls"):
@@ -141,6 +147,9 @@ def _extract_tool_lines(messages: list, max_result_len: int) -> list[str]:
             content = msg.get("content", "")
             content = _summarize_tool_result(content, max_result_len)
             tool_lines.append(f"Result: {content}")
+        if msg.get("role") == "user" and msg.get("source") == "widget_response":
+            content = msg.get("content", "")
+            tool_lines.append(f"User responded to widget: {content}")
     return tool_lines
 
 
@@ -171,10 +180,12 @@ def build_prior_turn_summary(
 
     prior = history[:turn_start_index]
 
-    # Find turn boundaries (indices of real user messages, not reflection critiques)
+    # Find turn boundaries (indices of real user messages, not reflection
+    # critiques and not in-flight synthetic widget responses).
     turn_starts = [
         i for i, msg in enumerate(prior)
         if msg.get("role") == "user"
+        and msg.get("source") != "widget_response"
         and not str(msg.get("content", "")).startswith("[reflection]")
     ]
     if not turn_starts:

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -53,7 +53,9 @@ async def run_all(app_ctx):
     try:
         # Create conversation manager (shared across web + future transports)
         from .conversation_manager import ConversationManager
+        from .widget_input import register_widget_handler
         manager = ConversationManager(config, app_ctx.event_bus)
+        register_widget_handler(manager.confirmation_registry)
         await manager.startup_scan()
 
         # Start HTTP server (button callbacks + web gateway)

--- a/src/decafclaw/tools/core.py
+++ b/src/decafclaw/tools/core.py
@@ -1,11 +1,11 @@
-"""Core tools — web fetch, debug, time, context stats."""
+"""Core tools — web fetch, debug, time, context stats, ask_user."""
 
 import json
 import logging
 
 import httpx
 
-from ..media import ToolResult
+from ..media import ToolResult, WidgetRequest
 from ..util import estimate_tokens
 
 log = logging.getLogger(__name__)
@@ -135,6 +135,96 @@ async def tool_wait(ctx, seconds: int = 30) -> str | ToolResult:
     return f"Waited {seconds} seconds."
 
 
+def _normalize_ask_user_options(options: list) -> list[dict] | None:
+    """Normalize mixed options into the widget's data_schema shape.
+
+    Accepts each option as a bare string (used as both value and label)
+    or as a dict with both ``value`` and ``label`` (description
+    optional). Returns None if the list is empty or contains an
+    unusable entry. The dict form requires both fields to match the
+    tool-definition schema's ``required: ["value", "label"]``.
+    """
+    if not options:
+        return None
+    out: list[dict] = []
+    for opt in options:
+        if isinstance(opt, str):
+            out.append({"value": opt, "label": opt})
+        elif isinstance(opt, dict):
+            value = opt.get("value")
+            label = opt.get("label")
+            if not value or not label:
+                return None
+            entry = {"value": str(value), "label": str(label)}
+            desc = opt.get("description")
+            if desc:
+                entry["description"] = str(desc)
+            out.append(entry)
+        else:
+            return None
+    return out
+
+
+def _ask_user_default_on_response(options: list[dict],
+                                  allow_multiple: bool):
+    """Build the default ``on_response`` callback for ask_user.
+
+    Single: returns ``"User selected: <label>"``; multi: comma-joins
+    the labels of selected values. Looks up labels from the option list
+    so the inject text reads well even when callers use distinct
+    value/label pairs.
+    """
+    by_value = {o["value"]: o["label"] for o in options}
+
+    def _cb(data: dict) -> str:
+        selected = data.get("selected")
+        if allow_multiple:
+            values = selected if isinstance(selected, list) else []
+            labels = [by_value.get(v, v) for v in values]
+            if not labels:
+                return "User selected nothing."
+            return "User selected: " + ", ".join(labels)
+        value = selected if isinstance(selected, str) else ""
+        if not value:
+            return "User did not select an option."
+        return f"User selected: {by_value.get(value, value)}"
+
+    return _cb
+
+
+async def tool_ask_user(ctx, prompt: str, options: list,
+                        allow_multiple: bool = False) -> ToolResult:
+    """Pause the turn and ask the user to pick from a list of options."""
+    log.info(f"[tool:ask_user] prompt={prompt!r} "
+             f"options={len(options)} allow_multiple={allow_multiple}")
+    if not prompt or not prompt.strip():
+        return ToolResult(text="[error: ask_user requires a non-empty prompt]")
+    normalized = _normalize_ask_user_options(options)
+    if normalized is None:
+        return ToolResult(
+            text="[error: ask_user needs at least one option; "
+                 "each must be a string or {value, label} dict]")
+    widget_data = {
+        "prompt": prompt,
+        "options": normalized,
+        "allow_multiple": bool(allow_multiple),
+    }
+    widget = WidgetRequest(
+        widget_type="multiple_choice",
+        data=widget_data,
+        on_response=_ask_user_default_on_response(normalized,
+                                                  bool(allow_multiple)),
+    )
+    short = (f"ask: {len(normalized)} option(s)"
+             + (" (multi)" if allow_multiple else ""))
+    return ToolResult(
+        text=f"[awaiting user response: {prompt}]",
+        display_short_text=short,
+        widget=widget,
+        end_turn=True,
+    )
+
+
 def tool_context_stats(ctx) -> str | ToolResult:
     """Report token budget statistics for the current conversation."""
     log.info("[tool:context_stats]")
@@ -226,6 +316,7 @@ CORE_TOOLS = {
     "context_stats": tool_context_stats,
     "current_time": tool_current_time,
     "wait": tool_wait,
+    "ask_user": tool_ask_user,
 }
 
 CORE_TOOL_DEFINITIONS = [
@@ -306,6 +397,61 @@ CORE_TOOL_DEFINITIONS = [
                     },
                 },
                 "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "priority": "low",
+        "function": {
+            "name": "ask_user",
+            "description": (
+                "Pause the turn and ask the user to pick from a list of "
+                "options. Use ONLY when the right answer is genuinely "
+                "ambiguous from context and you cannot make a reasonable "
+                "choice on your own. Prefer to act on your best judgment; "
+                "calling this tool is costly — it interrupts the user's "
+                "flow. Reserve for decisions the user would want to weigh "
+                "in on (e.g., \"which of these three files should I edit?\", "
+                "\"publish or save as draft?\"). "
+                "Only works in the web UI; Mattermost / terminal render "
+                "the prompt as text and the turn ends without the choice."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Question presented to the user. Should be concise and answerable by picking one of the options.",
+                    },
+                    "options": {
+                        "type": "array",
+                        "description": (
+                            "Options to choose from. Each entry is either a "
+                            "bare string (used as both value and label) or a "
+                            "{value, label, description?} object."
+                        ),
+                        "items": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {"type": "string"},
+                                        "label": {"type": "string"},
+                                        "description": {"type": "string"},
+                                    },
+                                    "required": ["value", "label"],
+                                },
+                            ],
+                        },
+                    },
+                    "allow_multiple": {
+                        "type": "boolean",
+                        "description": "If true, the user can select multiple options (checkboxes); otherwise a single choice (radios). Default false.",
+                    },
+                },
+                "required": ["prompt", "options"],
             },
         },
     },

--- a/src/decafclaw/web/static/components/chat-message.js
+++ b/src/decafclaw/web/static/components/chat-message.js
@@ -19,6 +19,8 @@ export class ChatMessage extends LitElement {
     attachments: { type: Array, attribute: false },
     record: { type: Object, attribute: false },
     widget: { type: Object, attribute: false },
+    submitted: { type: Boolean },
+    response: { type: Object, attribute: false },
   };
 
   createRenderRoot() { return this; }
@@ -44,6 +46,25 @@ export class ChatMessage extends LitElement {
     this.record = null;
     /** @type {object|null} */
     this.widget = null;
+    this.submitted = false;
+    /** @type {object|null} */
+    this.response = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Input widgets bubble `widget-response` CustomEvents when the user
+    // submits. Forward them to the store with our tool_call_id so the
+    // store can look up the matching confirmation and send the WS.
+    this.addEventListener('widget-response', (ev) => {
+      if (this.role !== 'tool' || !this.toolCallId) return;
+      const detail = /** @type {CustomEvent} */ (ev).detail || {};
+      // Get the store via the chat-view ancestor (keeps chat-message
+      // prop-free of the store reference).
+      const host = /** @type {any} */ (this.closest('chat-view'));
+      const store = host?.store;
+      store?.respondToWidget?.(this.toolCallId, detail);
+    });
   }
 
   render() {
@@ -92,7 +113,7 @@ export class ChatMessage extends LitElement {
     }
 
     if (this.role === 'tool') {
-      return html`<tool-message .tool=${this.tool} .content=${this.content} .display_short_text=${this.display_short_text || ''} .statusHistory=${this.statusHistory} .timestamp=${this.timestamp} .widget=${this.widget}></tool-message>`;
+      return html`<tool-message .tool=${this.tool} .content=${this.content} .display_short_text=${this.display_short_text || ''} .statusHistory=${this.statusHistory} .timestamp=${this.timestamp} .widget=${this.widget} .submitted=${this.submitted} .response=${this.response}></tool-message>`;
     }
 
     if (this.role === 'assistant' && this.toolCalls?.length) {

--- a/src/decafclaw/web/static/components/chat-view.js
+++ b/src/decafclaw/web/static/components/chat-view.js
@@ -149,6 +149,8 @@ export class ChatView extends LitElement {
           .attachments=${m.attachments || null}
           .record=${m.record || null}
           .widget=${m.widget || null}
+          .submitted=${!!m.submitted}
+          .response=${m.response || null}
         ></chat-message>
       `)}
 

--- a/src/decafclaw/web/static/components/confirm-view.js
+++ b/src/decafclaw/web/static/components/confirm-view.js
@@ -33,7 +33,14 @@ export class ConfirmView extends LitElement {
   render() {
     if (!this.confirms?.length) return '';
 
-    return html`${this.confirms.map(c => html`
+    // Widget confirmations render inside their own tool message as the
+    // widget UI (radios, checkboxes, etc.) — don't show approve/deny
+    // buttons for them here.
+    const visible = this.confirms.filter(
+      c => c.action_type !== 'widget_response');
+    if (!visible.length) return '';
+
+    return html`${visible.map(c => html`
       <div class="confirm-card">
         <div class="confirm-header">
           <strong>Confirm ${c.tool}:</strong>

--- a/src/decafclaw/web/static/components/messages/tool-message.js
+++ b/src/decafclaw/web/static/components/messages/tool-message.js
@@ -13,6 +13,10 @@ export class ToolMessage extends LitElement {
     statusHistory: { type: Array, attribute: false },
     /** Optional widget payload: {widget_type, target, data} */
     widget: { type: Object, attribute: false },
+    /** True once an input widget has been submitted (live or reloaded) */
+    submitted: { type: Boolean },
+    /** Response data for a submitted input widget: {selected, ...} */
+    response: { type: Object, attribute: false },
     _expanded: { type: Boolean, state: true },
   };
 
@@ -28,7 +32,24 @@ export class ToolMessage extends LitElement {
     this.statusHistory = null;
     /** @type {{widget_type: string, target: string, data: object}|null} */
     this.widget = null;
+    this.submitted = false;
+    /** @type {object|null} */
+    this.response = null;
     this._expanded = false;
+    // Tracks whether we've auto-expanded for this widget yet, so user
+    // collapse choices aren't overridden on re-render.
+    this._autoExpanded = false;
+  }
+
+  /** @param {Map<string, any>} changed */
+  willUpdate(changed) {
+    // Auto-expand on the first render that has a widget present — so
+    // input widgets are visible without requiring a click. User can
+    // still collapse afterward.
+    if (changed.has('widget') && this.widget && !this._autoExpanded) {
+      this._expanded = true;
+      this._autoExpanded = true;
+    }
   }
 
   #toggleExpand() {
@@ -89,6 +110,8 @@ export class ToolMessage extends LitElement {
                 .widgetType=${this.widget.widget_type}
                 .data=${this.widget.data}
                 .fallbackText=${this.content}
+                .submitted=${this.submitted}
+                .response=${this.response}
               ></dc-widget-host>
               ${hasContent ? html`
                 <details class="tool-result-raw">

--- a/src/decafclaw/web/static/components/widgets/widget-host.js
+++ b/src/decafclaw/web/static/components/widgets/widget-host.js
@@ -34,6 +34,8 @@ export class WidgetHost extends LitElement {
     widgetType: { type: String },
     data: { type: Object },
     fallbackText: { type: String },
+    submitted: { type: Boolean },
+    response: { type: Object, attribute: false },
     _state: { type: String, state: true },  // 'loading' | 'ready' | 'error'
   };
 
@@ -44,21 +46,36 @@ export class WidgetHost extends LitElement {
     this.widgetType = '';
     this.data = null;
     this.fallbackText = '';
+    this.submitted = false;
+    /** @type {object|null} */
+    this.response = null;
     this._state = 'loading';
     /** @type {Element|null} */
     this._child = null;
     this._lastType = null;
     this._lastData = null;
+    this._lastSubmitted = false;
+    this._lastResponse = null;
   }
 
   updated(changed) {
     if (changed.has('widgetType') && this.widgetType !== this._lastType) {
       this._lastType = this.widgetType;
       this._loadAndMount();
-    } else if (changed.has('data') && this._child && this.data !== this._lastData) {
-      this._lastData = this.data;
-      // Update live — widget components re-render on .data change.
-      /** @type {any} */ (this._child).data = this.data;
+    } else if (this._child) {
+      const child = /** @type {any} */ (this._child);
+      if (changed.has('data') && this.data !== this._lastData) {
+        this._lastData = this.data;
+        child.data = this.data;
+      }
+      if (changed.has('submitted') && this.submitted !== this._lastSubmitted) {
+        this._lastSubmitted = this.submitted;
+        child.submitted = this.submitted;
+      }
+      if (changed.has('response') && this.response !== this._lastResponse) {
+        this._lastResponse = this.response;
+        child.response = this.response;
+      }
     }
   }
 
@@ -89,7 +106,11 @@ export class WidgetHost extends LitElement {
     if (this._child) this._child.remove();
     const el = document.createElement(tag);
     /** @type {any} */ (el).data = this.data;
+    /** @type {any} */ (el).submitted = this.submitted;
+    /** @type {any} */ (el).response = this.response;
     this._lastData = this.data;
+    this._lastSubmitted = this.submitted;
+    this._lastResponse = this.response;
     this._child = el;
     // Render() will append it below.
     this._state = 'ready';

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -20,6 +20,9 @@
  * @property {{prompt_tokens: number, completion_tokens: number, total_tokens: number}|null} [usage]
  * @property {object} [record]
  * @property {{widget_type: string, target: string, data: object}|null} [widget]
+ * @property {boolean} [submitted]
+ * @property {object} [response]
+ * @property {string} [source]
  */
 
 /**
@@ -510,6 +513,15 @@ export class ConversationStore extends EventTarget {
    */
   respondToConfirm(contextId, tool, toolCallId = '', approved = false, extra = {}) {
     this.#toolStatusStore.respondToConfirm(contextId, tool, toolCallId, approved, extra);
+  }
+
+  /**
+   * Send a widget_response for an input widget submission.
+   * @param {string} toolCallId
+   * @param {object} data
+   */
+  respondToWidget(toolCallId, data) {
+    this.#toolStatusStore.respondToWidget(toolCallId, data);
   }
 
   // -- WebSocket message handling (chat streaming) ----------------------------

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -67,6 +67,24 @@ export class MessageStore {
     }
   }
 
+  /** Mark a tool message's widget as submitted with the given response
+   * data. Used by live confirmation_response events and multi-tab sync:
+   * the widget flips to its post-submit state once the backend
+   * resolves the pending confirmation.
+   * @param {string} toolCallId
+   * @param {object} response
+   */
+  markToolWidgetSubmitted(toolCallId, response) {
+    if (!toolCallId) return;
+    const msg = this.#currentMessages.find(
+      m => m.role === 'tool' && m.tool_call_id === toolCallId
+    );
+    if (msg) {
+      msg.submitted = true;
+      msg.response = response;
+    }
+  }
+
   /** Replace a tool_call message by tool_call_id with a completed tool result.
    * Carries over statusHistory from the in-progress message so the UI can still show it.
    */
@@ -244,21 +262,29 @@ export class MessageStore {
           let resultShortText = '';
           /** @type {object|null} */
           let resultWidget = null;
+          let resultSubmitted = false;
+          /** @type {object|null} */
+          let resultResponse = null;
           for (let j = i + 1; j < messages.length; j++) {
             if (messages[j].role === 'tool' && messages[j].tool_call_id === tcId) {
               resultContent = messages[j].content || '';
               resultShortText = messages[j].display_short_text || '';
               resultWidget = messages[j].widget || null;
+              resultSubmitted = !!messages[j].submitted;
+              resultResponse = messages[j].response || null;
               messages[j]._merged = true; // mark as consumed
               break;
             }
           }
           merged.push({
             role: 'tool',
+            tool_call_id: tcId,
             tool: toolName,
             content: resultContent,
             display_short_text: resultShortText,
             widget: resultWidget,
+            submitted: resultSubmitted,
+            response: resultResponse,
             timestamp: msg.timestamp,
           });
         }

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -90,6 +90,36 @@ export class ToolStatusStore {
   }
 
   /**
+   * Send a widget_response for an input widget submission. Looks up
+   * the matching confirmation_id from pendingConfirms (seeded by the
+   * confirmation_request event fired when the agent paused).
+   * @param {string} toolCallId
+   * @param {object} data
+   */
+  respondToWidget(toolCallId = '', data = {}) {
+    const confirm = this.#pendingConfirms.find(
+      c => c.tool_call_id === toolCallId);
+    if (!confirm?.confirmation_id || !confirm?.conv_id) {
+      console.warn(
+        '[widget] respondToWidget: no pending widget confirm for',
+        toolCallId);
+      return;
+    }
+    this.#ws.send({
+      type: 'widget_response',
+      conv_id: confirm.conv_id,
+      confirmation_id: confirm.confirmation_id,
+      tool_call_id: toolCallId,
+      data,
+    });
+    // Remove this confirm from the pending list — the backend will
+    // broadcast confirmation_response which flips the widget UI state.
+    this.#pendingConfirms = this.#pendingConfirms.filter(
+      c => c.confirmation_id !== confirm.confirmation_id);
+    this.#onChange();
+  }
+
+  /**
    * Handle a WebSocket message if it's tool-related.
    * @param {object} msg
    * @param {string|null} currentConvId
@@ -135,6 +165,7 @@ export class ToolStatusStore {
         if (msg.conv_id === currentConvId) {
           this.#messageStore.replaceToolCall(tcId, {
             role: 'tool',
+            tool_call_id: tcId,
             content: msg.result_text || '',
             tool: msg.tool,
             display_short_text: msg.display_short_text || '',
@@ -171,10 +202,24 @@ export class ToolStatusStore {
       }
 
       case 'confirmation_response': {
-        // Multi-tab sync: remove the resolved confirmation widget
+        // Multi-tab sync: remove the resolved confirmation widget.
+        // For widget responses, also flip the matching tool message to
+        // submitted + carry the response data so the widget UI
+        // transitions even on tabs other than the one that submitted.
         const resolvedId = msg.confirmation_id || '';
         if (resolvedId) {
-          this.#pendingConfirms = this.#pendingConfirms.filter(c => c.confirmation_id !== resolvedId);
+          const resolved = this.#pendingConfirms.find(
+            c => c.confirmation_id === resolvedId);
+          if (resolved?.action_type === 'widget_response'
+              && resolved.tool_call_id) {
+            // The response event is the submit signal — empty data
+            // still means the widget was submitted (tabs need to
+            // transition to the post-submit state).
+            this.#messageStore.markToolWidgetSubmitted(
+              resolved.tool_call_id, msg.data || {});
+          }
+          this.#pendingConfirms = this.#pendingConfirms.filter(
+            c => c.confirmation_id !== resolvedId);
         }
         return true;
       }

--- a/src/decafclaw/web/static/styles/widgets.css
+++ b/src/decafclaw/web/static/styles/widgets.css
@@ -132,3 +132,84 @@ chat-message .tool-result-raw pre {
 .widget-data-table tbody tr:hover {
   background: var(--pico-secondary-background, rgba(0, 0, 0, 0.03));
 }
+
+/* ---- multiple_choice ---- */
+
+.widget-multiple-choice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.widget-multiple-choice__prompt {
+  margin: 0;
+  font-weight: 600;
+}
+
+.widget-multiple-choice__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.widget-multiple-choice__option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--pico-muted-border-color, #ccc);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.widget-multiple-choice__option:hover {
+  background: var(--pico-secondary-background, rgba(0, 0, 0, 0.04));
+}
+
+.widget-multiple-choice__option input {
+  margin: 0;
+  grid-row: 1;
+  grid-column: 1;
+}
+
+.widget-multiple-choice__option .widget-multiple-choice__label {
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.widget-multiple-choice__option .widget-multiple-choice__description {
+  grid-row: 2;
+  grid-column: 2;
+  opacity: 0.7;
+  font-size: 0.8rem;
+}
+
+.widget-multiple-choice__option--winner {
+  border-color: var(--pico-primary, #1a73e8);
+  background: var(--pico-primary-background, rgba(26, 115, 232, 0.08));
+  font-weight: 600;
+}
+
+.widget-multiple-choice__option:has(input:disabled) {
+  cursor: default;
+}
+
+.widget-multiple-choice__option:has(input:disabled):hover {
+  background: inherit;
+}
+
+.widget-multiple-choice__option--winner:has(input:disabled):hover {
+  background: var(--pico-primary-background, rgba(26, 115, 232, 0.08));
+}
+
+.widget-multiple-choice__actions {
+  margin-top: 0.25rem;
+}
+
+.widget-multiple-choice__submit {
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+}

--- a/src/decafclaw/web/static/widgets/multiple_choice/widget.js
+++ b/src/decafclaw/web/static/widgets/multiple_choice/widget.js
@@ -1,0 +1,150 @@
+import { LitElement, html, nothing } from 'lit';
+
+/**
+ * Multiple-choice input widget. Radios for single selection (default),
+ * checkboxes when data.allow_multiple is true. Submit dispatches
+ * widget-response with `{selected}` (string or array), then the widget
+ * transitions to a submitted state (disabled controls, relabeled
+ * button, winning option highlighted).
+ *
+ * Props:
+ *   data      { prompt, options: [{value, label, description?}], allow_multiple? }
+ *   submitted boolean — true after user submits or when reloaded from archive
+ *   response  { selected: string | string[] } — populated on reload
+ */
+export class MultipleChoiceWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+    submitted: { type: Boolean },
+    response: { type: Object, attribute: false },
+    _selectedSingle: { type: String, state: true },
+    _selectedMulti: { type: Array, state: true },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    /** @type {{prompt: string, options: {value: string, label: string, description?: string}[], allow_multiple?: boolean}|null} */
+    this.data = null;
+    this.submitted = false;
+    /** @type {{selected?: string|string[]}|null} */
+    this.response = null;
+    this._selectedSingle = '';
+    /** @type {string[]} */
+    this._selectedMulti = [];
+  }
+
+  /** @param {Map<string, any>} changed */
+  updated(changed) {
+    // On reload, seed local selection state from the archived response
+    // so the render can show the winning choice in the submitted UI.
+    if ((changed.has('response') || changed.has('submitted'))
+        && this.submitted && this.response) {
+      const sel = this.response.selected;
+      if (Array.isArray(sel)) {
+        this._selectedMulti = sel.map(String);
+      } else if (typeof sel === 'string') {
+        this._selectedSingle = sel;
+      }
+    }
+  }
+
+  _onRadioChange(e) {
+    this._selectedSingle = /** @type {HTMLInputElement} */ (e.target).value;
+  }
+
+  _onCheckboxChange(e) {
+    const target = /** @type {HTMLInputElement} */ (e.target);
+    const value = target.value;
+    if (target.checked) {
+      if (!this._selectedMulti.includes(value)) {
+        this._selectedMulti = [...this._selectedMulti, value];
+      }
+    } else {
+      this._selectedMulti = this._selectedMulti.filter(v => v !== value);
+    }
+  }
+
+  _canSubmit() {
+    if (this.submitted) return false;
+    if (this._isMulti()) return this._selectedMulti.length > 0;
+    return !!this._selectedSingle;
+  }
+
+  _isMulti() {
+    return !!this.data?.allow_multiple;
+  }
+
+  _onSubmit() {
+    if (!this._canSubmit()) return;
+    const detail = this._isMulti()
+      ? { selected: [...this._selectedMulti] }
+      : { selected: this._selectedSingle };
+    this.dispatchEvent(new CustomEvent('widget-response', {
+      detail,
+      bubbles: true,
+      composed: true,
+    }));
+    // Don't flip `submitted` locally — the parent tool-message flips
+    // it via the broadcast confirmation_response event so all tabs
+    // stay in sync.
+  }
+
+  /** @param {{value: string, label: string, description?: string}} option */
+  _renderOption(option) {
+    const multi = this._isMulti();
+    const name = multi ? `mc-${option.value}` : 'mc-single';
+    const type = multi ? 'checkbox' : 'radio';
+    const isChecked = multi
+      ? this._selectedMulti.includes(option.value)
+      : this._selectedSingle === option.value;
+    const isWinner = this.submitted && isChecked;
+    const classes = isWinner
+      ? 'widget-multiple-choice__option widget-multiple-choice__option--winner'
+      : 'widget-multiple-choice__option';
+    return html`
+      <label class=${classes}>
+        <input
+          type=${type}
+          name=${name}
+          value=${option.value}
+          .checked=${isChecked}
+          ?disabled=${this.submitted}
+          @change=${multi ? this._onCheckboxChange : this._onRadioChange}
+        />
+        <span class="widget-multiple-choice__label">${option.label}</span>
+        ${option.description ? html`
+          <small class="widget-multiple-choice__description">${option.description}</small>
+        ` : nothing}
+      </label>
+    `;
+  }
+
+  render() {
+    const d = this.data;
+    if (!d || !Array.isArray(d.options)) {
+      return html`<div class="widget-multiple-choice widget-multiple-choice--empty"><em>no options</em></div>`;
+    }
+    const submitLabel = this.submitted ? 'Submitted' : 'Submit';
+    return html`
+      <div class="widget-multiple-choice">
+        ${d.prompt ? html`<p class="widget-multiple-choice__prompt">${d.prompt}</p>` : nothing}
+        <div class="widget-multiple-choice__options"
+             role=${this._isMulti() ? 'group' : 'radiogroup'}>
+          ${d.options.map(o => this._renderOption(o))}
+        </div>
+        <div class="widget-multiple-choice__actions">
+          <button
+            type="button"
+            class="widget-multiple-choice__submit"
+            ?disabled=${!this._canSubmit()}
+            @click=${this._onSubmit}
+          >${submitLabel}</button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('dc-widget-multiple-choice', MultipleChoiceWidget);

--- a/src/decafclaw/web/static/widgets/multiple_choice/widget.json
+++ b/src/decafclaw/web/static/widgets/multiple_choice/widget.json
@@ -1,0 +1,30 @@
+{
+  "name": "multiple_choice",
+  "description": "Ask the user to choose one (or several) option(s) from a list. Radio buttons for single; checkboxes for multi. Pauses the agent turn until the user submits.",
+  "modes": ["inline"],
+  "accepts_input": true,
+  "data_schema": {
+    "type": "object",
+    "required": ["prompt", "options"],
+    "properties": {
+      "prompt": {
+        "type": "string",
+        "minLength": 1
+      },
+      "options": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["value", "label"],
+          "properties": {
+            "value": { "type": "string" },
+            "label": { "type": "string" },
+            "description": { "type": "string" }
+          }
+        }
+      },
+      "allow_multiple": { "type": "boolean" }
+    }
+  }
+}

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -103,6 +103,53 @@ async def _handle_select_conv(ws_send, index, username, msg, state):
                            "message": f"Conversation not found: {conv_id}"})
 
 
+def _annotate_widget_responses(messages: list[dict],
+                               hidden_roles: set[str]) -> list[dict]:
+    """Pair resolved widget confirmations with their tool records.
+
+    Walks the messages looking for a confirmation_request whose
+    action_type is "widget_response" (carries tool_call_id →
+    confirmation_id mapping) and a following confirmation_response
+    (carries selection in `data`). Attaches `submitted=True` +
+    `response=data` to the matching tool record. Hidden roles are
+    stripped from the returned list.
+    """
+    widget_responses_by_tool: dict[str, dict] = {}
+    pending_widget_ids: dict[str, str] = {}  # confirmation_id -> tool_call_id
+    for m in messages:
+        role = m.get("role", "")
+        if role == "confirmation_request" and \
+                m.get("action_type") == "widget_response":
+            cid = m.get("confirmation_id", "")
+            tcid = m.get("tool_call_id", "")
+            if cid and tcid:
+                pending_widget_ids[cid] = tcid
+        elif role == "confirmation_response":
+            cid = m.get("confirmation_id", "")
+            tcid = pending_widget_ids.pop(cid, "")
+            if tcid:
+                # The presence of a confirmation_response is the real
+                # "submitted" signal — data may legitimately be empty
+                # for widgets where the submit itself is the answer.
+                raw = m.get("data")
+                widget_responses_by_tool[tcid] = raw if isinstance(
+                    raw, dict) else {}
+
+    visible: list[dict] = []
+    for m in messages:
+        if m.get("role") in hidden_roles:
+            continue
+        if m.get("role") == "tool":
+            tcid = m.get("tool_call_id", "")
+            resp = widget_responses_by_tool.get(tcid)
+            if resp is not None:
+                m = dict(m)
+                m["submitted"] = True
+                m["response"] = resp
+        visible.append(m)
+    return visible
+
+
 async def _handle_load_history(ws_send, index, username, msg, state):
     config = state["config"]
     conv_id = msg.get("conv_id", "")
@@ -142,7 +189,10 @@ async def _handle_load_history(ws_send, index, username, msg, state):
         filtered = [m for m in all_msgs if m.get("timestamp", "") < before]
     has_more = len(filtered) > limit
     messages = filtered[-limit:] if has_more else filtered
-    messages = [m for m in messages if m.get("role") not in _HIDDEN_ROLES]
+
+    # Pair resolved widget confirmations with their tool records so the
+    # frontend can show submitted input widgets on reload.
+    messages = _annotate_widget_responses(messages, _HIDDEN_ROLES)
 
     estimated_tokens = None
     current_model = None
@@ -328,6 +378,36 @@ async def _handle_set_model(ws_send, index, username, msg, state):
     })
 
 
+async def _handle_widget_response(ws_send, index, username, msg, state):
+    """Route a widget-input submission through the confirmation infra.
+
+    Widget submits are always 'approved=True' in the confirmation sense;
+    the user's selection rides on ``data``. The manager resolves the
+    pending confirmation, which wakes the agent loop's pause-await.
+    """
+    manager = state.get("manager")
+    conv_id = msg.get("conv_id", "")
+    confirmation_id = msg.get("confirmation_id", "")
+    # Defensive: coerce non-dict `data` to {} so on_response callbacks
+    # can assume they're always handed a dict. Clients SHOULD send a
+    # dict; a non-dict here means the client is malformed / malicious.
+    raw_data = msg.get("data")
+    data = raw_data if isinstance(raw_data, dict) else {}
+    if raw_data is not None and not isinstance(raw_data, dict):
+        log.warning(
+            "widget_response data is not a dict (got %s); coercing to {}",
+            type(raw_data).__name__)
+
+    if manager and conv_id and confirmation_id:
+        await manager.respond_to_confirmation(
+            conv_id, confirmation_id,
+            approved=True, data=data)
+    else:
+        log.warning(
+            "widget_response missing manager / conv_id / confirmation_id; "
+            "dropping (msg=%s)", msg)
+
+
 async def _handle_confirm_response(ws_send, index, username, msg, state):
     """Route confirmation response through the manager."""
     manager = state.get("manager")
@@ -487,11 +567,17 @@ def _subscribe_to_conv(state, conv_id):
 
         elif event_type == "confirmation_response":
             # Forward to all tabs so non-originating tabs clear the widget
-            await ws_send({
+            payload = {
                 "type": "confirmation_response", "conv_id": event_conv_id,
                 "confirmation_id": event.get("confirmation_id", ""),
                 "approved": event.get("approved", False),
-            })
+            }
+            data = event.get("data")
+            if data is not None:
+                # Widget responses ride here so other tabs can show the
+                # selection in their post-submit widget state.
+                payload["data"] = data
+            await ws_send(payload)
 
         elif event_type == "message_complete":
             if event.get("suppress_user_message"):
@@ -569,6 +655,7 @@ _HANDLERS = {
     "set_effort": _handle_set_model,  # backward compat for old web UI
     "set_model": _handle_set_model,
     "confirm_response": _handle_confirm_response,
+    "widget_response": _handle_widget_response,
 }
 
 

--- a/src/decafclaw/widget_input.py
+++ b/src/decafclaw/widget_input.py
@@ -1,0 +1,107 @@
+"""Input-widget pause/resume support.
+
+Phase 2 (#256): input widgets (``accepts_input=True``) pause the agent
+turn via the existing confirmation infra. An in-memory callback map
+lets tools provide a custom ``on_response`` callback that runs when
+the user submits. The callback returns a string that's injected as a
+synthetic user message so the next LLM iteration sees the choice.
+
+This module provides:
+
+- ``pending_callbacks``: the in-memory map keyed by ``tool_call_id``.
+- ``WidgetResponseHandler``: the default confirmation handler for
+  ``WIDGET_RESPONSE`` actions. Used only by the recovery path
+  (``ConversationManager.recover_confirmation``) when a response
+  arrives for a conversation with no running agent loop. Writes a
+  synthetic user message directly to the archive so the next turn's
+  LLM call sees the answer.
+- ``register_widget_handler(registry)``: wires the handler into a
+  ``ConfirmationRegistry`` instance at startup.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .confirmations import (
+    ConfirmationAction,
+    ConfirmationRegistry,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+
+log = logging.getLogger(__name__)
+
+
+# In-memory callback map: tool_call_id -> on_response callable.
+# Populated by the agent loop when it promotes an input widget into
+# a WidgetInputPause signal; consumed once the user submits. Cleared
+# in a finally block so crashes don't leak entries.
+pending_callbacks: dict[str, Callable[[dict], str]] = {}
+
+
+def default_inject_message(response_data: dict) -> str:
+    """Fallback inject-string used when no ``on_response`` callback is
+    registered (e.g., after server restart)."""
+    return f"User responded with: {response_data}"
+
+
+class WidgetResponseHandler:
+    """Confirmation handler for ``WIDGET_RESPONSE`` actions.
+
+    Invoked only by the recovery path. Writes a synthetic user message
+    to the archive carrying the response data so the next turn's LLM
+    call sees the user's choice.
+
+    The live path (agent loop awaiting ``ctx.request_confirmation``)
+    handles responses directly without dispatching to this handler; the
+    handler's job here is strictly recovery when no loop is running.
+    """
+
+    async def on_approve(self, ctx: Any, request: ConfirmationRequest,
+                         response: ConfirmationResponse) -> dict:
+        return await self._inject(ctx, request, response)
+
+    async def on_deny(self, ctx: Any, request: ConfirmationRequest,
+                      response: ConfirmationResponse) -> dict:
+        # Widget submits are always "approved" in the confirmation sense
+        # — there's no deny path. If we see a denial, something odd
+        # happened (timeout maybe). Still inject a best-effort message
+        # so the conversation stays coherent.
+        log.warning(
+            "WIDGET_RESPONSE denied for tool_call_id=%s — unusual; "
+            "injecting a terse placeholder",
+            request.tool_call_id,
+        )
+        return await self._inject(ctx, request, response)
+
+    async def _inject(self, ctx: Any, request: ConfirmationRequest,
+                      response: ConfirmationResponse) -> dict:
+        # Consume callback if present; recovery path won't have one.
+        callback = pending_callbacks.pop(request.tool_call_id, None)
+        if callback is not None:
+            try:
+                content = callback(response.data)
+            except Exception as exc:
+                log.warning(
+                    "widget on_response callback raised for %s: %s",
+                    request.tool_call_id, exc)
+                content = default_inject_message(response.data)
+        else:
+            content = default_inject_message(response.data)
+
+        # Write the synthetic user message so a subsequent turn sees it.
+        if ctx is not None and getattr(ctx, "conv_id", None):
+            from .archive import append_message
+            append_message(ctx.config, ctx.conv_id, {
+                "role": "user",
+                "source": "widget_response",
+                "content": content,
+            })
+        return {"inject_message": content, "continue_loop": False}
+
+
+def register_widget_handler(registry: ConfirmationRegistry) -> None:
+    """Register the default WIDGET_RESPONSE handler on a registry."""
+    registry.register(ConfirmationAction.WIDGET_RESPONSE,
+                      WidgetResponseHandler())

--- a/tests/test_agent_widgets.py
+++ b/tests/test_agent_widgets.py
@@ -20,17 +20,34 @@ _PANEL_SCHEMA = {
 
 
 def _make_test_registry(tmp_path):
-    """Build a registry with a single 'data_table' widget for tests."""
+    """Build a registry with a display widget ('data_table') plus an
+    input widget ('pick') so Phase 2 enforcement tests have an
+    accepts_input=True descriptor to point at."""
     bundled = tmp_path / "bundled"
-    d = bundled / "data_table"
-    d.mkdir(parents=True)
-    (d / "widget.json").write_text(json.dumps({
+    dt = bundled / "data_table"
+    dt.mkdir(parents=True)
+    (dt / "widget.json").write_text(json.dumps({
         "name": "data_table",
         "description": "test",
         "modes": ["inline"],
         "data_schema": _PANEL_SCHEMA,
     }))
-    (d / "widget.js").write_text("// stub\n")
+    (dt / "widget.js").write_text("// stub\n")
+
+    pk = bundled / "pick"
+    pk.mkdir(parents=True)
+    (pk / "widget.json").write_text(json.dumps({
+        "name": "pick",
+        "description": "test input widget",
+        "modes": ["inline"],
+        "accepts_input": True,
+        "data_schema": {
+            "type": "object",
+            "required": ["options"],
+            "properties": {"options": {"type": "array"}},
+        },
+    }))
+    (pk / "widget.js").write_text("// stub\n")
 
     class _Cfg:
         agent_path = tmp_path / "agent_home"
@@ -42,6 +59,10 @@ def _make_test_registry(tmp_path):
 def test_registry(tmp_path, monkeypatch):
     registry = _make_test_registry(tmp_path)
     monkeypatch.setattr(widgets_module, "_registry", registry)
+    # Clear the pending_callbacks map before each test — keeps state
+    # from leaking across tests that exercise the input-widget path.
+    from decafclaw import widget_input
+    monkeypatch.setattr(widget_input, "pending_callbacks", {})
     yield registry
 
 
@@ -135,6 +156,90 @@ def test_resolve_widget_no_registry(monkeypatch, caplog):
     assert payload is None
     assert result.widget is None
     assert any("registry is not" in r.message for r in caplog.records)
+
+
+# -------------- Phase 2: input widget enforcement --------------
+
+
+def test_input_widget_with_end_turn_promotes_to_pause(test_registry):
+    """Input widget (accepts_input=True) + end_turn=True → end_turn
+    becomes a WidgetInputPause sentinel; callback registered in the
+    pending_callbacks map."""
+    from decafclaw import widget_input
+    from decafclaw.media import WidgetInputPause
+
+    def on_response(_data):
+        return "picked!"
+
+    result = ToolResult(
+        text="[awaiting]",
+        widget=WidgetRequest(
+            widget_type="pick",
+            data={"options": []},
+            on_response=on_response),
+        end_turn=True,
+    )
+    payload = _resolve_widget("my_tool", result, "tc-input")
+    assert payload is not None
+    assert payload["widget_type"] == "pick"
+    assert isinstance(result.end_turn, WidgetInputPause)
+    assert result.end_turn.tool_call_id == "tc-input"
+    assert result.end_turn.widget_payload == payload
+    assert widget_input.pending_callbacks["tc-input"] is on_response
+
+
+def test_input_widget_without_end_turn_strips(test_registry, caplog):
+    """Input widget with end_turn=False violates the contract — strip
+    the widget and log a warning."""
+    result = ToolResult(
+        text="ok",
+        widget=WidgetRequest(
+            widget_type="pick",
+            data={"options": []}),
+        end_turn=False,
+    )
+    payload = _resolve_widget("my_tool", result, "tc-no-end")
+    assert payload is None
+    assert result.widget is None
+    assert any("without end_turn=True" in r.message for r in caplog.records)
+
+
+def test_input_widget_with_end_turn_confirm_drops_confirm(
+        test_registry, caplog):
+    """Input widget + EndTurnConfirm → widget wins, EndTurnConfirm
+    dropped, end_turn becomes WidgetInputPause."""
+    from decafclaw.media import EndTurnConfirm, WidgetInputPause
+
+    result = ToolResult(
+        text="[awaiting]",
+        widget=WidgetRequest(
+            widget_type="pick",
+            data={"options": []}),
+        end_turn=EndTurnConfirm(message="review?"),
+    )
+    payload = _resolve_widget("my_tool", result, "tc-both")
+    assert payload is not None
+    assert isinstance(result.end_turn, WidgetInputPause)
+    assert any("alongside EndTurnConfirm" in r.message
+               for r in caplog.records)
+
+
+def test_display_widget_unchanged_by_phase2(test_registry):
+    """accepts_input=False widgets keep the Phase 1 behavior — end_turn
+    is passed through verbatim, no callback registration."""
+    from decafclaw import widget_input
+
+    result = ToolResult(
+        text="ok",
+        widget=WidgetRequest(
+            widget_type="data_table",
+            data={"columns": [], "rows": []}),
+        end_turn=False,
+    )
+    payload = _resolve_widget("my_tool", result, "tc-display")
+    assert payload is not None
+    assert result.end_turn is False
+    assert "tc-display" not in widget_input.pending_callbacks
 
 
 # -------------- _execute_tool_calls integration tests --------------

--- a/tests/test_ask_user.py
+++ b/tests/test_ask_user.py
@@ -1,0 +1,150 @@
+"""Tests for the ask_user core tool."""
+
+import pytest
+
+from decafclaw.media import ToolResult, WidgetRequest
+from decafclaw.tools.core import (
+    _ask_user_default_on_response,
+    _normalize_ask_user_options,
+    tool_ask_user,
+)
+
+# ------------- option normalization -------------
+
+
+def test_normalize_bare_strings():
+    out = _normalize_ask_user_options(["alpha", "beta"])
+    assert out == [
+        {"value": "alpha", "label": "alpha"},
+        {"value": "beta", "label": "beta"},
+    ]
+
+
+def test_normalize_dicts_with_description():
+    out = _normalize_ask_user_options([
+        {"value": "a", "label": "Alpha", "description": "first"},
+        {"value": "b", "label": "Beta"},
+    ])
+    assert out == [
+        {"value": "a", "label": "Alpha", "description": "first"},
+        {"value": "b", "label": "Beta"},
+    ]
+
+
+def test_normalize_dict_missing_label_is_rejected():
+    """Per the tool-definition schema, dict options require both value
+    and label. A dict with only value is invalid input — callers should
+    use the bare-string shortcut if they want value=label."""
+    assert _normalize_ask_user_options([{"value": "x"}]) is None
+
+
+def test_normalize_mixed_strings_and_dicts():
+    out = _normalize_ask_user_options(
+        ["alpha", {"value": "b", "label": "Beta"}])
+    assert out[0]["label"] == "alpha"
+    assert out[1]["label"] == "Beta"
+
+
+def test_normalize_empty_returns_none():
+    assert _normalize_ask_user_options([]) is None
+
+
+def test_normalize_bad_entry_returns_none():
+    assert _normalize_ask_user_options([123]) is None
+    assert _normalize_ask_user_options([{"label": "no value"}]) is None
+
+
+# ------------- default on_response -------------
+
+
+def test_default_response_single_uses_label():
+    options = [{"value": "a", "label": "Alpha"},
+               {"value": "b", "label": "Beta"}]
+    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    assert cb({"selected": "a"}) == "User selected: Alpha"
+
+
+def test_default_response_single_unknown_value_falls_back():
+    options = [{"value": "a", "label": "Alpha"}]
+    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    assert cb({"selected": "mystery"}) == "User selected: mystery"
+
+
+def test_default_response_single_missing_selection():
+    options = [{"value": "a", "label": "Alpha"}]
+    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    assert "did not select" in cb({})
+
+
+def test_default_response_multi_joins_labels():
+    options = [{"value": "a", "label": "Alpha"},
+               {"value": "b", "label": "Beta"},
+               {"value": "c", "label": "Gamma"}]
+    cb = _ask_user_default_on_response(options, allow_multiple=True)
+    assert cb({"selected": ["a", "c"]}) == "User selected: Alpha, Gamma"
+
+
+def test_default_response_multi_empty():
+    options = [{"value": "a", "label": "Alpha"}]
+    cb = _ask_user_default_on_response(options, allow_multiple=True)
+    assert "nothing" in cb({"selected": []})
+
+
+# ------------- tool_ask_user integration -------------
+
+
+@pytest.mark.asyncio
+async def test_ask_user_happy_path():
+    ctx = object()  # unused
+    result = await tool_ask_user(
+        ctx, prompt="Which deploy target?",
+        options=["production", "staging"])
+    assert isinstance(result, ToolResult)
+    assert result.end_turn is True
+    assert isinstance(result.widget, WidgetRequest)
+    assert result.widget.widget_type == "multiple_choice"
+    assert result.widget.data["prompt"] == "Which deploy target?"
+    assert len(result.widget.data["options"]) == 2
+    assert result.widget.data["allow_multiple"] is False
+    assert result.widget.on_response is not None
+    assert "awaiting user response" in result.text
+
+
+@pytest.mark.asyncio
+async def test_ask_user_allow_multiple():
+    ctx = object()
+    result = await tool_ask_user(
+        ctx, prompt="Which?",
+        options=["a", "b"], allow_multiple=True)
+    assert result.widget.data["allow_multiple"] is True
+    # Callback handles a list of selections.
+    inject = result.widget.on_response({"selected": ["a", "b"]})
+    assert inject == "User selected: a, b"
+
+
+@pytest.mark.asyncio
+async def test_ask_user_empty_options_returns_error():
+    ctx = object()
+    result = await tool_ask_user(ctx, prompt="?", options=[])
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_ask_user_blank_prompt_returns_error():
+    ctx = object()
+    result = await tool_ask_user(ctx, prompt="   ", options=["a"])
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_ask_user_default_callback_wired_correctly():
+    """The default callback formatting matches what tests would
+    expect: integrates with the normalized options so label > value."""
+    ctx = object()
+    result = await tool_ask_user(
+        ctx, prompt="?",
+        options=[{"value": "v1", "label": "Nice Label"}])
+    inject = result.widget.on_response({"selected": "v1"})
+    assert inject == "User selected: Nice Label"

--- a/tests/test_confirmation.py
+++ b/tests/test_confirmation.py
@@ -94,14 +94,16 @@ class TestConfirmationResponseArchive:
         assert roundtripped == resp
 
     def test_to_archive_emits_all_dataclass_fields_when_truthy(self):
-        """When all optional flags are True the archive contains every
-        declared field. Serves as the iterate-over-fields check —
-        a new dataclass field that to_archive forgets would surface here."""
+        """When all optional flags / containers are non-empty the archive
+        contains every declared field. Serves as the iterate-over-fields
+        check — a new dataclass field that to_archive forgets would
+        surface here."""
         resp = ConfirmationResponse(
             confirmation_id="conf_abc",
             approved=True,
             always=True,
             add_pattern=True,
+            data={"choice": "option_a"},
         )
         msg = resp.to_archive_message()
         expected = {f.name for f in dataclasses.fields(ConfirmationResponse)}

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -214,6 +214,103 @@ async def test_confirmation_persisted_to_archive(manager):
     assert "confirmation_response" in roles
 
 
+def test_confirmation_response_data_serialization_roundtrip():
+    """ConfirmationResponse.data is serialized when non-empty and
+    deserialized cleanly, including nested structures."""
+    resp = ConfirmationResponse(
+        confirmation_id="abc",
+        approved=True,
+        data={"selected": ["a", "b"], "meta": {"ts": 123}},
+    )
+    msg = resp.to_archive_message()
+    assert msg["data"] == {"selected": ["a", "b"], "meta": {"ts": 123}}
+
+    restored = ConfirmationResponse.from_archive_message(msg)
+    assert restored.data == resp.data
+    assert restored.approved is True
+
+
+def test_confirmation_response_data_omitted_when_empty():
+    """Empty data dict stays out of the archive message to keep
+    existing confirmations unchanged on the wire."""
+    resp = ConfirmationResponse(confirmation_id="abc", approved=True)
+    msg = resp.to_archive_message()
+    assert "data" not in msg
+
+    restored = ConfirmationResponse.from_archive_message(msg)
+    assert restored.data == {}
+
+
+@pytest.mark.asyncio
+async def test_respond_with_data_field_roundtrips(manager):
+    """Widget-shaped responses carry a `data` dict; verify it surfaces
+    on the response dataclass, the emitted event, and the archive."""
+    from decafclaw.archive import read_archive
+
+    conv_id = "conv-data"
+    manager._get_or_create(conv_id)
+
+    events: list[dict] = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        action_data={"widget_type": "multiple_choice"},
+        message="",
+        timeout=2.0,
+    )
+
+    async def respond():
+        await asyncio.sleep(0.05)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True,
+            data={"selected": "production"})
+
+    asyncio.create_task(respond())
+    response = await manager.request_confirmation(conv_id, request)
+
+    assert response.data == {"selected": "production"}
+
+    resp_events = [e for e in events if e.get("type") == "confirmation_response"]
+    assert resp_events
+    assert resp_events[0]["data"] == {"selected": "production"}
+
+    messages = read_archive(manager.config, conv_id)
+    response_msgs = [m for m in messages if m.get("role") == "confirmation_response"]
+    assert response_msgs
+    assert response_msgs[0]["data"] == {"selected": "production"}
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_no_timeout(manager):
+    """timeout=None disables the await deadline — used by widget requests."""
+    conv_id = "conv-no-timeout"
+    manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        message="",
+        timeout=None,
+    )
+
+    async def respond_after_delay():
+        # Sleep longer than any reasonable default timeout would be,
+        # to prove that None-timeout doesn't raise TimeoutError.
+        await asyncio.sleep(0.1)
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True,
+            data={"selected": "x"})
+
+    asyncio.create_task(respond_after_delay())
+    response = await manager.request_confirmation(conv_id, request)
+    assert response.approved is True
+    assert response.data == {"selected": "x"}
+
+
 @pytest.mark.asyncio
 async def test_respond_wrong_id_ignored(manager):
     conv_id = "conv-1"

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -46,6 +46,61 @@ class TestBuildToolSummary:
         assert "cats" in result
         assert "cat facts document" in result
 
+    def test_includes_widget_response_user_messages(self):
+        """A synthetic user message from a widget submission should
+        surface in the tool summary so the judge knows the user
+        actually answered the question the agent asked."""
+        history = [
+            {"role": "user", "content": "ask me a question"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "ask_user",
+                    "arguments": json.dumps(
+                        {"prompt": "Pick one", "options": ["a", "b"]}),
+                }},
+            ]},
+            {"role": "tool",
+             "content": "[awaiting user response: Pick one]"},
+            {"role": "user", "source": "widget_response",
+             "content": "User selected: a"},
+            {"role": "assistant", "content": "You picked A."},
+        ]
+        result = build_tool_summary(history, 0)
+        assert "ask_user" in result
+        assert "User responded to widget" in result
+        assert "User selected: a" in result
+
+    def test_widget_response_not_treated_as_turn_boundary(self):
+        """build_prior_turn_summary must skip synthetic widget
+        responses when finding turn starts — they're mid-turn, not
+        new turns."""
+        from decafclaw.reflection import build_prior_turn_summary
+        history = [
+            {"role": "user", "content": "first turn"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc1", "function": {
+                    "name": "ask_user",
+                    "arguments": json.dumps({"prompt": "x", "options": []}),
+                }},
+            ]},
+            {"role": "tool", "content": "[awaiting]"},
+            {"role": "user", "source": "widget_response",
+             "content": "User selected: a"},
+            {"role": "assistant", "content": "ok"},
+            # Current turn starts here:
+            {"role": "user", "content": "second turn"},
+        ]
+        # turn_start_index is the second-turn user (idx 5); prior is
+        # first turn + synthetic. Synthetic must NOT be a turn boundary.
+        result = build_prior_turn_summary(history, 5, max_turns=3)
+        # Should have exactly one prior turn ("first turn"), with
+        # the ask_user call in its tool lines.
+        assert "ask_user" in result
+        # The synthetic response is included as a tool-line entry;
+        # there's no second "User selected" turn-boundary spawning a
+        # second prior turn.
+        assert result.count("Tools used in prior turns") == 1
+
     def test_truncates_long_results(self):
         long_result = "x" * 3000
         history = [

--- a/tests/test_web_widget_response_handler.py
+++ b/tests/test_web_widget_response_handler.py
@@ -1,0 +1,247 @@
+"""Tests for the websocket `widget_response` incoming handler + the
+`_annotate_widget_responses` helper used on conv_history reload."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from decafclaw.web.websocket import (
+    _annotate_widget_responses,
+    _handle_widget_response,
+)
+
+_HIDDEN = {"effort", "model", "confirmation_request",
+           "confirmation_response", "wake_trigger"}
+
+
+def _ctx(manager):
+    """Minimal state shape the handler reads from."""
+    return {"manager": manager}
+
+
+@pytest.mark.asyncio
+async def test_widget_response_routes_to_manager():
+    respond = AsyncMock()
+    manager = SimpleNamespace(respond_to_confirmation=respond)
+    ws_send = AsyncMock()
+    msg = {
+        "type": "widget_response",
+        "conv_id": "conv-1",
+        "confirmation_id": "cfx-1",
+        "tool_call_id": "tc-1",
+        "data": {"selected": "production"},
+    }
+
+    await _handle_widget_response(
+        ws_send, index=None, username="alice",
+        msg=msg, state=_ctx(manager))
+
+    respond.assert_awaited_once_with(
+        "conv-1", "cfx-1", approved=True,
+        data={"selected": "production"})
+
+
+@pytest.mark.asyncio
+async def test_widget_response_missing_data_is_empty_dict():
+    """If the client sends no `data` key, the handler still resolves
+    the confirmation with an empty dict (approved=True)."""
+    respond = AsyncMock()
+    manager = SimpleNamespace(respond_to_confirmation=respond)
+    msg = {
+        "type": "widget_response",
+        "conv_id": "conv-1",
+        "confirmation_id": "cfx-1",
+        # no data field
+    }
+    await _handle_widget_response(
+        AsyncMock(), None, "alice", msg, _ctx(manager))
+    respond.assert_awaited_once_with(
+        "conv-1", "cfx-1", approved=True, data={})
+
+
+@pytest.mark.asyncio
+async def test_widget_response_missing_manager_noop(caplog):
+    """Without a manager in state, the handler logs and drops."""
+    msg = {
+        "type": "widget_response",
+        "conv_id": "conv-1",
+        "confirmation_id": "cfx-1",
+        "data": {"selected": "x"},
+    }
+    await _handle_widget_response(
+        AsyncMock(), None, "alice", msg, {"manager": None})
+    assert any("dropping" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_widget_response_non_dict_data_coerced(caplog):
+    """A client sending data: [1,2,3] or similar shouldn't reach
+    on_response callbacks as an unexpected type — the handler coerces
+    to {} with a warning."""
+    respond = AsyncMock()
+    manager = SimpleNamespace(respond_to_confirmation=respond)
+    msg = {
+        "type": "widget_response",
+        "conv_id": "conv-1",
+        "confirmation_id": "cfx-1",
+        "data": [1, 2, 3],  # not a dict
+    }
+    await _handle_widget_response(
+        AsyncMock(), None, "alice", msg, _ctx(manager))
+    respond.assert_awaited_once_with(
+        "conv-1", "cfx-1", approved=True, data={})
+    assert any("not a dict" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_widget_response_missing_confirmation_id_noop(caplog):
+    respond = AsyncMock()
+    manager = SimpleNamespace(respond_to_confirmation=respond)
+    msg = {
+        "type": "widget_response",
+        "conv_id": "conv-1",
+        # no confirmation_id
+        "data": {"selected": "x"},
+    }
+    await _handle_widget_response(
+        AsyncMock(), None, "alice", msg, _ctx(manager))
+    respond.assert_not_called()
+    assert any("dropping" in r.message for r in caplog.records)
+
+
+# ---------- _annotate_widget_responses ----------
+
+
+def test_annotate_pairs_widget_response_to_tool():
+    """A full widget cycle in the archive: tool (with widget) →
+    confirmation_request(widget_response) → confirmation_response(data)
+    should flip the tool record to submitted + response."""
+    archive = [
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "tc-1",
+                         "function": {"name": "ask_user", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "tc-1", "content": "[awaiting]",
+         "widget": {"widget_type": "multiple_choice",
+                    "target": "inline", "data": {}}},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "widget_response",
+         "tool_call_id": "tc-1"},
+        {"role": "confirmation_response",
+         "confirmation_id": "cfx-1",
+         "approved": True,
+         "data": {"selected": "production"}},
+    ]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    # Confirmations stripped.
+    roles = [m["role"] for m in out]
+    assert "confirmation_request" not in roles
+    assert "confirmation_response" not in roles
+    # Tool record got submitted + response attached.
+    tool = next(m for m in out if m["role"] == "tool")
+    assert tool["submitted"] is True
+    assert tool["response"] == {"selected": "production"}
+
+
+def test_annotate_empty_data_still_marks_submitted():
+    """The presence of a matching confirmation_response — even with
+    empty/missing data — is the real submitted signal. Don't leave the
+    widget looking live just because the payload was empty."""
+    archive = [
+        {"role": "tool", "tool_call_id": "tc-1", "content": "ok",
+         "widget": {}},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "widget_response",
+         "tool_call_id": "tc-1"},
+        {"role": "confirmation_response",
+         "confirmation_id": "cfx-1",
+         "approved": True,
+         "data": {}},  # empty but present
+    ]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    tool = next(m for m in out if m["role"] == "tool")
+    assert tool["submitted"] is True
+    assert tool["response"] == {}
+
+
+def test_annotate_non_dict_data_coerced():
+    """Defensive: if data is somehow a non-dict (corrupted archive),
+    coerce to {} rather than propagating the type confusion."""
+    archive = [
+        {"role": "tool", "tool_call_id": "tc-1", "content": "ok",
+         "widget": {}},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "widget_response",
+         "tool_call_id": "tc-1"},
+        {"role": "confirmation_response",
+         "confirmation_id": "cfx-1",
+         "approved": True,
+         "data": "not a dict"},
+    ]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    tool = next(m for m in out if m["role"] == "tool")
+    assert tool["submitted"] is True
+    assert tool["response"] == {}
+
+
+def test_annotate_pending_widget_no_response():
+    """Widget request with no matching response stays unannotated —
+    user can still submit live."""
+    archive = [
+        {"role": "tool", "tool_call_id": "tc-1", "content": "[awaiting]",
+         "widget": {"widget_type": "multiple_choice",
+                    "target": "inline", "data": {}}},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "widget_response",
+         "tool_call_id": "tc-1"},
+    ]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    tool = next(m for m in out if m["role"] == "tool")
+    assert "submitted" not in tool
+    assert "response" not in tool
+
+
+def test_annotate_ignores_non_widget_confirmation_responses():
+    """A regular (non-widget) confirmation_response doesn't attach to
+    any tool record — only action_type=widget_response triggers the
+    pairing."""
+    archive = [
+        {"role": "tool", "tool_call_id": "tc-1", "content": "executed"},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "run_shell_command",  # not widget_response
+         "tool_call_id": "tc-1"},
+        {"role": "confirmation_response",
+         "confirmation_id": "cfx-1",
+         "approved": True},
+    ]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    tool = next(m for m in out if m["role"] == "tool")
+    assert "submitted" not in tool
+
+
+def test_annotate_returns_visible_list_does_not_mutate_input():
+    """Input messages list isn't modified; returned list has hidden
+    roles stripped and a dict copy for annotated tool records."""
+    archive = [
+        {"role": "tool", "tool_call_id": "tc-1", "content": "ok",
+         "widget": {}},
+        {"role": "confirmation_request",
+         "confirmation_id": "cfx-1",
+         "action_type": "widget_response",
+         "tool_call_id": "tc-1"},
+        {"role": "confirmation_response",
+         "confirmation_id": "cfx-1",
+         "data": {"selected": "x"}},
+    ]
+    original_tool = archive[0]
+    out = _annotate_widget_responses(archive, _HIDDEN)
+    # Original not mutated.
+    assert "submitted" not in original_tool
+    # Output tool is a different dict.
+    assert out[0] is not original_tool
+    assert out[0]["submitted"] is True

--- a/tests/test_widget_input_pause.py
+++ b/tests/test_widget_input_pause.py
@@ -1,0 +1,184 @@
+"""Tests for WidgetInputPause + default WIDGET_RESPONSE recovery handler."""
+
+import pytest
+
+from decafclaw.archive import read_archive
+from decafclaw.confirmations import (
+    ConfirmationAction,
+    ConfirmationRegistry,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+from decafclaw.conversation_manager import _RecoveryContext
+from decafclaw.media import WidgetInputPause
+from decafclaw.widget_input import (
+    WidgetResponseHandler,
+    pending_callbacks,
+    register_widget_handler,
+)
+
+
+def test_widget_input_pause_construction():
+    p = WidgetInputPause(
+        tool_call_id="tc-1",
+        widget_payload={"widget_type": "multiple_choice",
+                        "target": "inline",
+                        "data": {"prompt": "?", "options": []}})
+    assert p.tool_call_id == "tc-1"
+    assert p.widget_payload["widget_type"] == "multiple_choice"
+
+
+def test_register_widget_handler():
+    registry = ConfirmationRegistry()
+    register_widget_handler(registry)
+    handler = registry.get_handler(ConfirmationAction.WIDGET_RESPONSE)
+    assert isinstance(handler, WidgetResponseHandler)
+
+
+@pytest.mark.asyncio
+async def test_recovery_handler_with_callback_writes_user_message(
+        config, tmp_path, monkeypatch):
+    """When a callback is registered for a pending widget, the recovery
+    handler invokes it and writes the returned string to the archive."""
+    monkeypatch.setattr("decafclaw.widget_input.pending_callbacks",
+                        {"tc-1": lambda data: f"Picked: {data['selected']}"})
+    handler = WidgetResponseHandler()
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        action_data={"widget_type": "multiple_choice"},
+        tool_call_id="tc-1",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+        data={"selected": "production"},
+    )
+    ctx = _RecoveryContext(config=config, conv_id="conv-recovery")
+
+    result = await handler.on_approve(ctx, request, response)
+
+    assert result["inject_message"] == "Picked: production"
+
+    archived = read_archive(config, "conv-recovery")
+    user_msgs = [m for m in archived
+                 if m.get("role") == "user"
+                 and m.get("source") == "widget_response"]
+    assert len(user_msgs) == 1
+    assert user_msgs[0]["content"] == "Picked: production"
+
+
+@pytest.mark.asyncio
+async def test_recovery_handler_without_callback_uses_default(
+        config, monkeypatch):
+    """No registered callback → handler writes a default 'User responded
+    with: X' message."""
+    monkeypatch.setattr("decafclaw.widget_input.pending_callbacks", {})
+    handler = WidgetResponseHandler()
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        action_data={"widget_type": "multiple_choice"},
+        tool_call_id="tc-default",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+        data={"selected": "staging"},
+    )
+    ctx = _RecoveryContext(config=config, conv_id="conv-default")
+
+    result = await handler.on_approve(ctx, request, response)
+
+    assert "User responded with" in result["inject_message"]
+    assert "staging" in result["inject_message"]
+
+    archived = read_archive(config, "conv-default")
+    user_msgs = [m for m in archived if m.get("role") == "user"]
+    assert len(user_msgs) == 1
+    assert "staging" in user_msgs[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_handler_callback_raises_falls_back_to_default(
+        config, monkeypatch, caplog):
+    def boom(_data):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr("decafclaw.widget_input.pending_callbacks",
+                        {"tc-boom": boom})
+    handler = WidgetResponseHandler()
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        tool_call_id="tc-boom",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+        data={"selected": "x"},
+    )
+    ctx = _RecoveryContext(config=config, conv_id="conv-boom")
+
+    result = await handler.on_approve(ctx, request, response)
+    assert "User responded with" in result["inject_message"]
+    assert any("callback raised" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_recovery_handler_consumes_callback(config, monkeypatch):
+    """After handling, the callback is popped from the map (so it can't
+    fire twice)."""
+    called = {"count": 0}
+
+    def cb(_data):
+        called["count"] += 1
+        return "one-shot"
+
+    cb_map = {"tc-pop": cb}
+    monkeypatch.setattr("decafclaw.widget_input.pending_callbacks", cb_map)
+    handler = WidgetResponseHandler()
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        tool_call_id="tc-pop",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+        data={},
+    )
+    ctx = _RecoveryContext(config=config, conv_id="conv-pop")
+
+    await handler.on_approve(ctx, request, response)
+    assert called["count"] == 1
+    assert "tc-pop" not in cb_map
+
+
+@pytest.mark.asyncio
+async def test_recovery_via_manager_dispatches_to_handler(config):
+    """Go through the manager's recover_confirmation dispatch path end
+    to end: register handler, seed a pending confirmation, respond."""
+    from decafclaw.conversation_manager import ConversationManager
+    from decafclaw.events import EventBus
+
+    bus = EventBus()
+    manager = ConversationManager(config, bus)
+    register_widget_handler(manager.confirmation_registry)
+
+    conv_id = "conv-manager-recovery"
+    state = manager._get_or_create(conv_id)
+    state.pending_confirmation = ConfirmationRequest(
+        action_type=ConfirmationAction.WIDGET_RESPONSE,
+        action_data={"widget_type": "multiple_choice"},
+        tool_call_id="tc-mgr",
+        confirmation_id="cfx-mgr",
+    )
+    # No confirmation_event → manager will dispatch recovery.
+
+    await manager.respond_to_confirmation(
+        conv_id, "cfx-mgr", approved=True,
+        data={"selected": "yes"})
+
+    archived = read_archive(config, conv_id)
+    user_msgs = [m for m in archived
+                 if m.get("role") == "user"
+                 and m.get("source") == "widget_response"]
+    assert len(user_msgs) == 1
+    assert "yes" in user_msgs[0]["content"]

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -254,3 +254,26 @@ def test_bundled_data_table_is_registered(fake_config):
     # A missing-rows payload fails.
     ok, err = reg.validate("data_table", {"columns": []})
     assert ok is False
+
+
+def test_bundled_multiple_choice_is_registered(fake_config):
+    """Fresh registry scan finds the bundled multiple_choice widget."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    desc = reg.get("multiple_choice")
+    assert desc is not None
+    assert desc.tier == "bundled"
+    assert desc.accepts_input is True
+    assert "inline" in desc.modes
+    required = desc.data_schema.get("required", [])
+    assert "prompt" in required
+    assert "options" in required
+    ok, err = reg.validate("multiple_choice", {
+        "prompt": "pick one",
+        "options": [{"value": "a", "label": "Alpha"}],
+    })
+    assert ok is True, err
+    # Empty options list violates minItems.
+    ok, _ = reg.validate("multiple_choice",
+                         {"prompt": "x", "options": []})
+    assert ok is False

--- a/tests/test_widgets_input_flow.py
+++ b/tests/test_widgets_input_flow.py
@@ -1,0 +1,253 @@
+"""Integration tests for the full input-widget pause/resume flow.
+
+Exercises _handle_widget_input_pause with a real ConversationManager,
+verifying the round-trip from WidgetInputPause → request_confirmation
+→ respond_to_confirmation → on_response callback → inject-string.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw import widget_input as widget_input_module
+from decafclaw.agent import _handle_widget_input_pause
+from decafclaw.conversation_manager import ConversationManager
+from decafclaw.events import EventBus
+from decafclaw.media import WidgetInputPause
+from decafclaw.widget_input import register_widget_handler
+
+
+def _make_manager(config):
+    bus = EventBus()
+    manager = ConversationManager(config, bus)
+    register_widget_handler(manager.confirmation_registry)
+    return manager, bus
+
+
+def _make_ctx(manager, conv_id):
+    """Build a minimal ctx that has the manager-bound
+    request_confirmation closure, mirroring how the ConversationManager
+    wires it in production."""
+    async def request_confirmation(request):
+        return await manager.request_confirmation(conv_id, request)
+
+    return SimpleNamespace(request_confirmation=request_confirmation)
+
+
+@pytest.mark.asyncio
+async def test_live_pause_invokes_callback_and_injects(
+        config, monkeypatch):
+    """With a callback registered, the live path awaits the submit,
+    calls the callback with the response data, and returns the
+    callback's inject-string."""
+    manager, _bus = _make_manager(config)
+    conv_id = "conv-live-cb"
+    manager._get_or_create(conv_id)
+
+    # Register a callback that captures its arg + formats an answer.
+    seen: list[dict] = []
+
+    def on_response(data: dict) -> str:
+        seen.append(data)
+        return f"You picked {data['selected']}!"
+
+    monkeypatch.setattr(widget_input_module, "pending_callbacks",
+                        {"tc-1": on_response})
+
+    signal = WidgetInputPause(
+        tool_call_id="tc-1",
+        widget_payload={
+            "widget_type": "multiple_choice",
+            "target": "inline",
+            "data": {"prompt": "which?", "options": []},
+        })
+
+    ctx = _make_ctx(manager, conv_id)
+
+    # Resolve the confirmation shortly after the pause begins.
+    async def respond_soon():
+        await asyncio.sleep(0.05)
+        # Resolver needs the confirmation_id; read from state.
+        state = manager.get_state(conv_id)
+        assert state.pending_confirmation is not None
+        await manager.respond_to_confirmation(
+            conv_id, state.pending_confirmation.confirmation_id,
+            approved=True, data={"selected": "red"})
+
+    asyncio.create_task(respond_soon())
+    inject = await _handle_widget_input_pause(ctx, signal)
+
+    assert inject == "You picked red!"
+    assert seen == [{"selected": "red"}]
+    # Callback was popped.
+    assert "tc-1" not in widget_input_module.pending_callbacks
+    # Pending confirmation cleared on the manager side.
+    assert manager.get_state(conv_id).pending_confirmation is None
+
+
+@pytest.mark.asyncio
+async def test_live_pause_without_callback_uses_default(
+        config, monkeypatch):
+    """No callback registered → default inject ('User responded with:')."""
+    manager, _bus = _make_manager(config)
+    conv_id = "conv-live-default"
+    manager._get_or_create(conv_id)
+
+    monkeypatch.setattr(widget_input_module, "pending_callbacks", {})
+
+    signal = WidgetInputPause(
+        tool_call_id="tc-no-cb",
+        widget_payload={
+            "widget_type": "multiple_choice",
+            "target": "inline",
+            "data": {"prompt": "which?", "options": []},
+        })
+    ctx = _make_ctx(manager, conv_id)
+
+    async def respond_soon():
+        await asyncio.sleep(0.05)
+        state = manager.get_state(conv_id)
+        await manager.respond_to_confirmation(
+            conv_id, state.pending_confirmation.confirmation_id,
+            approved=True, data={"selected": "blue"})
+
+    asyncio.create_task(respond_soon())
+    inject = await _handle_widget_input_pause(ctx, signal)
+
+    assert "User responded with" in inject
+    assert "blue" in inject
+
+
+@pytest.mark.asyncio
+async def test_live_pause_callback_exception_falls_back_to_default(
+        config, monkeypatch, caplog):
+    manager, _bus = _make_manager(config)
+    conv_id = "conv-live-raises"
+    manager._get_or_create(conv_id)
+
+    def raising_cb(_data):
+        raise RuntimeError("oops")
+
+    monkeypatch.setattr(widget_input_module, "pending_callbacks",
+                        {"tc-raises": raising_cb})
+
+    signal = WidgetInputPause(
+        tool_call_id="tc-raises",
+        widget_payload={
+            "widget_type": "multiple_choice",
+            "target": "inline",
+            "data": {"prompt": "?", "options": []},
+        })
+    ctx = _make_ctx(manager, conv_id)
+
+    async def respond_soon():
+        await asyncio.sleep(0.05)
+        state = manager.get_state(conv_id)
+        await manager.respond_to_confirmation(
+            conv_id, state.pending_confirmation.confirmation_id,
+            approved=True, data={"selected": "x"})
+
+    asyncio.create_task(respond_soon())
+    inject = await _handle_widget_input_pause(ctx, signal)
+
+    assert "User responded with" in inject
+    assert any("callback raised" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_ctx_without_request_confirmation_ends_turn(caplog):
+    """If ctx doesn't have request_confirmation (e.g., manager not
+    wired), the pause logic logs + returns None so the outer loop
+    ends the turn gracefully."""
+    signal = WidgetInputPause(
+        tool_call_id="tc-no-mgr",
+        widget_payload={})
+    ctx = SimpleNamespace()  # no request_confirmation
+
+    inject = await _handle_widget_input_pause(ctx, signal)
+    assert inject is None
+    assert any("no request_confirmation" in r.message
+               for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_pause_unblocks_loop(
+        config, monkeypatch):
+    """User cancels the turn while the widget is pending → the await
+    races against ctx.cancelled and returns None, so the outer loop
+    can end the turn cleanly. The pending confirmation is cleared in
+    the manager so reload doesn't show a stale pending widget."""
+    manager, _bus = _make_manager(config)
+    conv_id = "conv-cancel-during-pause"
+    state = manager._get_or_create(conv_id)
+    state.cancel_event = asyncio.Event()
+
+    cb_marker = {"called": False}
+
+    def on_response(_data):
+        cb_marker["called"] = True
+        return "should not happen"
+
+    monkeypatch.setattr(widget_input_module, "pending_callbacks",
+                        {"tc-cancel": on_response})
+
+    signal = WidgetInputPause(
+        tool_call_id="tc-cancel",
+        widget_payload={
+            "widget_type": "multiple_choice",
+            "target": "inline",
+            "data": {"prompt": "?", "options": []},
+        })
+
+    # Build a ctx with the cancel event + manager reference so the
+    # helper can clear the pending confirmation on cancel.
+    async def request_confirmation(request):
+        return await manager.request_confirmation(conv_id, request)
+
+    ctx = SimpleNamespace(
+        request_confirmation=request_confirmation,
+        cancelled=state.cancel_event,
+        manager=manager,
+        conv_id=conv_id,
+    )
+
+    # Fire the cancel after the pause begins.
+    async def cancel_soon():
+        await asyncio.sleep(0.05)
+        state.cancel_event.set()
+
+    asyncio.create_task(cancel_soon())
+    inject = await _handle_widget_input_pause(ctx, signal)
+
+    assert inject is None
+    assert cb_marker["called"] is False
+    # Callback was cleared, manager state cleared.
+    assert "tc-cancel" not in widget_input_module.pending_callbacks
+    assert manager.get_state(conv_id).pending_confirmation is None
+
+
+@pytest.mark.asyncio
+async def test_live_pause_clears_callback_even_on_exception(
+        config, monkeypatch):
+    """If request_confirmation raises, the try/finally still clears
+    the pending callback entry."""
+    manager, _bus = _make_manager(config)
+    conv_id = "conv-live-raise-await"
+    manager._get_or_create(conv_id)
+
+    monkeypatch.setattr(widget_input_module, "pending_callbacks",
+                        {"tc-leak": lambda d: "unreached"})
+
+    class _FailingCtx:
+        async def request_confirmation(self, _req):
+            raise asyncio.CancelledError()
+
+    signal = WidgetInputPause(
+        tool_call_id="tc-leak",
+        widget_payload={})
+
+    with pytest.raises(asyncio.CancelledError):
+        await _handle_widget_input_pause(_FailingCtx(), signal)
+
+    assert "tc-leak" not in widget_input_module.pending_callbacks


### PR DESCRIPTION
## Summary

Phase 2 of #256 — input widgets. Tools can now return an interactive widget that pauses the agent turn until the user submits, then the turn resumes with the selection injected as a synthetic user message.

- **Backend convergence.** Input widgets ride on the existing confirmation infra (`confirmations.py`) rather than introducing a parallel pause/resume mechanism. New `ConfirmationAction.WIDGET_RESPONSE`, `ConfirmationResponse.data` free-form dict, `timeout: float | None` to disable the deadline for user input. No other changes to the confirmation pattern.
- **New `WidgetInputPause` sentinel.** Promoted in `_resolve_widget` when a tool emits a widget with `accepts_input=True` + `end_turn=True`. Enforcement rules strip the widget or drop EndTurnConfirm with a warning on misuse.
- **Agent-loop pause + resume.** New outer-loop branch calls `ctx.request_confirmation` with `timeout=None`, awaits the user submit, invokes the tool's `on_response` callback with `response.data`, appends the returned string as a `{role: "user", source: "widget_response"}` synthetic message to history + archive, and continues the loop. `try/finally` ensures the in-memory callback map never leaks entries.
- **Recovery path** (no running loop when the user submits): `WidgetResponseHandler` writes the synthetic user message to the archive directly. Default inject is `"User responded with: <data>"` when no callback is registered. Registered at both `ConversationManager` construction sites.
- **`ask_user` core tool** (`priority=low`) — first-class capability for "agent stops and asks the user to pick something." Tool description nudges sparing use.
- **Bundled `multiple_choice` widget** — radios (single) or checkboxes (multi) with per-option descriptions and a Submit button. Post-submit state disables controls and highlights the winning option. `widget.json` schema requires `prompt` + non-empty `options`; each option is `{value, label, description?}`.
- **Frontend wiring.** `dc-widget-host` + `tool-message` + `chat-message` + `chat-view` forward `submitted` / `response` props end to end. Live submissions: `chat-message` listens for bubbling `widget-response` events, sends `widget_response` WS message. Live responses: `confirmation_response` handler flips the tool message via `markToolWidgetSubmitted` so all tabs reconcile. Reload: backend `_annotate_widget_responses` walks the archive pairing `confirmation_request(widget_response)` with `confirmation_response(data)` and attaches `{submitted, response}` to matching tool records before hidden roles are stripped. `confirm-view.js` filters out widget-typed confirms so they don't render approve/deny buttons.
- **Docs.** `docs/widgets.md` gains an input-widget contract section, `ask_user` example, restart-recovery behavior. `CLAUDE.md` key files entry updated.

## What's deferred

- **Collapsing `EndTurnConfirm` into a widget** with a Mattermost-buttons adapter — filed as **#364**. Path-dependent: this PR converges the backend under confirmation infra, making #364 a cleanup session rather than architecture work.
- Canvas panel (#256 Phase 3), `code_block` / `markdown_document` widgets (#256 Phase 4), workspace-tier widgets (#358).

Session docs: `docs/dev-sessions/2026-04-24-1545-widgets-phase-2-256/`.

## Test plan

- [x] `make lint` clean
- [x] `make typecheck` clean (pyright)
- [x] `make check-js` clean (tsc)
- [x] `make test` clean (1882 tests, ~45 new)
- [x] **Live smoke, web UI:** call `ask_user` with 3 options. Widget renders with radios + Submit disabled. Click an option; Submit enables. Click Submit. Widget disables, winning option highlighted. Agent's next message references the choice by label.
- [x] **Live smoke, multi-tab:** open a second web tab on the same conversation before submitting. Both tabs show the live widget. Submit from tab A. Tab B's widget transitions to submitted state with the same selection visible.
- [x] **Reload:** reload the conversation after submit. The widget re-renders in post-submit state from the archive.
- [ ] **Mattermost/terminal fallback:** run `ask_user` through a non-web channel (if wired). The text placeholder shows; the channel doesn't pause for input (no regression beyond the expected "ask_user is web-UI only" contract). Tool description + spec already call this out.
- [ ] **Restart recovery:** trigger `ask_user`, restart the server before submitting, then submit via the UI. The conversation archive gets a synthetic user message ("User responded with: ...") so next user turn still sees the choice.

## Notes for reviewers

- Could not live-test the UI from this session (single-MM-connection rule). All tests pass, but the live smokes in the test plan still need human eyes.
- The Lit change-detection for `submitted` / `response` mutations in place relies on a sibling `pendingConfirms` array-reference change to trigger chat-view re-render. Noted inline; something to keep in mind if someone refactors the pendingConfirms path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)