### PR TITLE
fix(web): auto-refresh open file on agent edits, allow long paths to wrap

### DIFF
--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -206,9 +206,16 @@ function showFilePage(detail, { replace = false } = {}) {
   // rename across kinds (e.g. foo.txt → foo.png) picks the correct renderer.
   // Readonly still falls back to the current value; #fetchFile corrects it
   // from the server response as soon as the text fetch completes.
+  const sameFile = filePageEl.path === detail.path
+    && !filePageEl.classList.contains('hidden');
   filePageEl.path = detail.path;
   filePageEl.kind = detail.kind != null ? detail.kind : inferFileKindFromPath(detail.path);
   filePageEl.readonly = detail.readonly != null ? !!detail.readonly : !!filePageEl.readonly;
+  // Re-clicking the currently-open file is a manual refresh: willUpdate
+  // only fires #fetchFile on path *change*, so force it here.
+  if (sameFile && typeof filePageEl.reload === 'function') {
+    void filePageEl.reload();
+  }
   filePageEl.classList.remove('hidden');
   // Mutual exclusion: close any open wiki-page / config-panel.
   wikiPageEl?.classList.add('hidden');

--- a/src/decafclaw/web/static/components/file-editor.js
+++ b/src/decafclaw/web/static/components/file-editor.js
@@ -219,6 +219,13 @@ export class FileEditor extends LitElement {
     await this.#save();
   }
 
+  /** Public: true if the editor has unsaved edits or a debounced save queued. */
+  hasPendingChanges() {
+    if (this.readonly) return false;
+    if (this.#saveTimer != null) return true;
+    return this.#currentContent !== this.#lastSavedContent;
+  }
+
   async #save() {
     this.#saveTimer = null;
     const content = this.#currentContent;

--- a/src/decafclaw/web/static/components/file-page.js
+++ b/src/decafclaw/web/static/components/file-page.js
@@ -89,6 +89,54 @@ export class FilePage extends LitElement {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    // Auto-refresh when the agent finishes a turn — it may have edited the
+    // file we're viewing. Skip if the user has unsaved edits; the existing
+    // conflict flow handles that on next save.
+    this._onTurnComplete = async () => {
+      if (!this.path) return;
+      if (this._renaming) return;
+      // Only text files have a #fetchFile-backed editor view to refresh;
+      // image/binary bodies are `<img>`/`<a>` pointing at a stable URL, so
+      // the user can trigger a reload manually by re-clicking the filename.
+      if (this.kind !== 'text') return;
+      if (this._editing) {
+        /** @type {any} */
+        const editor = this.querySelector('file-editor');
+        if (editor && typeof editor.hasPendingChanges === 'function'
+            && editor.hasPendingChanges()) {
+          return;
+        }
+      }
+      // Silent mtime probe — only flash "Loading…" if the file actually
+      // changed on disk, so turns that don't touch this file are invisible.
+      try {
+        const res = await fetch('/api/workspace-file/' + encodePagePath(this.path));
+        if (!res.ok) return;
+        const data = await res.json();
+        if ((data.modified ?? 0) === this._modified) return;
+      } catch {
+        return;
+      }
+      void this.#fetchFile();
+    };
+    window.addEventListener('turn-complete', this._onTurnComplete);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._onTurnComplete) {
+      window.removeEventListener('turn-complete', this._onTurnComplete);
+    }
+  }
+
+  /** Public: re-fetch from disk and remount the editor. */
+  async reload() {
+    if (!this.path) return;
+    await this.#fetchFile();
+  }
+
   async #fetchFile() {
     this._loading = true;
     this._error = '';

--- a/src/decafclaw/web/static/components/file-page.js
+++ b/src/decafclaw/web/static/components/file-page.js
@@ -109,17 +109,25 @@ export class FilePage extends LitElement {
           return;
         }
       }
-      // Silent mtime probe — only flash "Loading…" if the file actually
-      // changed on disk, so turns that don't touch this file are invisible.
+      // Capture path/mtime before the await so a mid-probe file switch can't
+      // make us compare file A's returned mtime against file B's current one.
+      const path = this.path;
+      const modified = this._modified;
+      let data;
       try {
-        const res = await fetch('/api/workspace-file/' + encodePagePath(this.path));
+        const res = await fetch('/api/workspace-file/' + encodePagePath(path));
         if (!res.ok) return;
-        const data = await res.json();
-        if ((data.modified ?? 0) === this._modified) return;
+        data = await res.json();
       } catch {
         return;
       }
-      void this.#fetchFile();
+      if (this.path !== path) return; // user switched files during probe
+      if (this._loading) return;      // another load is already in flight
+      if ((data.modified ?? 0) === modified) return; // unchanged — no flash
+      // Reuse the probe's data directly instead of calling #fetchFile again.
+      // The probe already returned full content; a second GET would just
+      // re-download the same bytes.
+      await this.#applyFetchedData(data);
     };
     window.addEventListener('turn-complete', this._onTurnComplete);
   }
@@ -133,8 +141,27 @@ export class FilePage extends LitElement {
 
   /** Public: re-fetch from disk and remount the editor. */
   async reload() {
-    if (!this.path) return;
+    // Non-text bodies are `<img>`/`<a>` served from a stable URL; #fetchFile
+    // hits the text-only endpoint and 415s, which would show a "not a text
+    // file" error. Re-clicking an image/binary is a no-op here — the preview
+    // stays as-is.
+    if (!this.path || this.kind !== 'text') return;
     await this.#fetchFile();
+  }
+
+  /** Apply already-fetched file data and force an editor remount. */
+  async #applyFetchedData(data) {
+    this._loading = true;
+    this._error = '';
+    this._content = '';
+    // Give Lit a render tick so the editor unmounts on `_loading=true`
+    // before we populate the new content and flip it back.
+    await this.updateComplete;
+    this._content = data.content ?? '';
+    this._modified = data.modified ?? 0;
+    if (data.readonly === true) this.readonly = true;
+    this._conflict = false;
+    this._loading = false;
   }
 
   async #fetchFile() {

--- a/src/decafclaw/web/static/styles/sidebar.css
+++ b/src/decafclaw/web/static/styles/sidebar.css
@@ -420,9 +420,7 @@ conversation-sidebar .mobile-close-btn:hover {
   padding: 0.4rem 0.75rem;
   font-size: 0.8rem;
   color: var(--pico-muted-color);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
 }
 
 button.vault-breadcrumb-segment {


### PR DESCRIPTION
## Summary
- `<file-page>` now listens for `turn-complete` and silently re-fetches the open file when its on-disk mtime has changed; skips the reload if the editor has unsaved edits so the existing 409-conflict flow still handles that case.
- Re-clicking the currently-open file in the Files sidebar reloads it instead of no-op'ing. Adds a public `reload()` on `<file-page>` that `showFilePage` calls when `detail.path` already matches the open file.
- Long folder paths in the Files/Vault breadcrumbs no longer truncate with ellipsis — swapped `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` on `.vault-breadcrumbs` for `word-break: break-all`, so the full path is visible and selectable.
- Minor: `<file-editor>` grows a public `hasPendingChanges()` so the page can make the safe-to-reload decision without reaching into private state.

## Test plan
- [ ] Open a text file in the Files tab; have the agent edit it in a turn; confirm it auto-refreshes after the turn ends (no "Loading…" flash on turns that don't touch the file).
- [ ] Open a file, start typing (unsaved edits), have the agent edit the same file; confirm the view does NOT clobber your in-flight edits, and that the next save surfaces the existing conflict banner.
- [ ] Re-click the currently-open file in the sidebar; confirm it refreshes.
- [ ] Navigate into a deeply-nested folder in both the Files and Vault tabs; confirm the breadcrumb wraps instead of truncating and the full path is selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)