### PR TITLE
fix(reflection): judge sees text emitted alongside tool calls

### DIFF
--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -168,6 +168,7 @@ async def _handle_reflection(
     ctx, config, messages, history, final_text,
     user_message, attachments, retrieved_context_text,
     turn_start_index, reflection_retries, last_reflection,
+    accumulated_text_parts=None,
 ) -> tuple[str | None, bool, int, "ReflectionResult | None"]:
     """Run the reflection phase on a candidate final response.
 
@@ -176,6 +177,12 @@ async def _handle_reflection(
     - Reflection failed with retries left: (None, True, retries+1, result)
       — critique has been injected into messages/history before returning
     - Reflection failed, no retries left: (text_with_escalation, False, retries, result)
+
+    `accumulated_text_parts` collects text the model emitted in earlier
+    iterations of this turn alongside tool calls (e.g. a skill that writes
+    a full report and then calls vault_write in the same LLM response). The
+    judge evaluates the concatenation so it sees the full user-visible
+    response, not just the final no-tools trailer.
     """
     if not _should_reflect(ctx, config, final_text, reflection_retries):
         reflection_exhausted = (
@@ -219,8 +226,14 @@ async def _handle_reflection(
             for a in attachments
         )
         judge_user_message += f"\n\n[User attached files: {att_desc}]"
+    # Combine text from tool-call iterations with the current final text so
+    # the judge sees the full visible response, not just the trailer.
+    judge_agent_response = "\n\n".join(
+        part for part in [*(accumulated_text_parts or []), final_text]
+        if part and part.strip()
+    ) or final_text
     result = await evaluate_response(
-        config, judge_user_message, final_text, tool_summary,
+        config, judge_user_message, judge_agent_response, tool_summary,
         prior_turn_summary=prior_turn_summary,
         retrieved_context=retrieved_context_text,
     )
@@ -1103,6 +1116,7 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                     ctx, config, messages, history, content,
                     user_message, attachments, retrieved_context_text,
                     turn_start_index, reflection_retries, last_reflection,
+                    accumulated_text_parts=accumulated_text_parts,
                 )
             )
             if should_retry:

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -809,6 +809,54 @@ async def test_reflection_error_delivers_response(ctx):
 
 
 @pytest.mark.asyncio
+async def test_reflection_sees_text_emitted_alongside_tool_calls(ctx):
+    """Regression: when the model emits user-visible text alongside tool calls
+    (e.g. the postmortem skill's report + vault_write), reflection should
+    evaluate the full visible response, not just the trailing no-tools message.
+
+    Before the fix, `evaluate_response` saw only the final-iteration trailer
+    ("I have delivered the report"), so the judge failed — it couldn't see the
+    report itself — and burned through reflection retries in a loop.
+    """
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+
+    report_text = "Here is the full postmortem report. Anomaly: ..."
+    trailer_text = "I have delivered the report and saved it to the vault."
+
+    report_plus_tool = _mock_llm_response(
+        content=report_text,
+        tool_calls=[{
+            "id": "tc1",
+            "function": {
+                "name": "memory_recent",
+                "arguments": json.dumps({"n": 1}),
+            },
+        }],
+    )
+    trailer_only = _mock_llm_response(trailer_text)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.side_effect = [report_plus_tool, trailer_only]
+        mock_eval.return_value = ReflectionResult(passed=True)
+
+        history = []
+        await run_agent_turn(ctx, "/postmortem", history)
+
+    mock_eval.assert_called_once()
+    # agent_response is the 3rd positional arg to evaluate_response
+    # (see agent.py _handle_reflection: evaluate_response(config, judge_user_message, final_text, ...))
+    agent_response_arg = mock_eval.call_args.args[2]
+    assert report_text in agent_response_arg, (
+        "Reflection judge should see text emitted alongside tool calls, "
+        f"but agent_response was: {agent_response_arg!r}"
+    )
+    assert trailer_text in agent_response_arg
+
+
+@pytest.mark.asyncio
 async def test_wake_turn_archives_nudge_as_wake_trigger_not_user(ctx, config):
     """A wake turn (task_mode='background_wake') archives the trigger prompt under
     'wake_trigger' role, not 'user', so the web UI doesn't render it as a real


### PR DESCRIPTION
## Summary
Reflection was evaluating only the final no-tools trailer of a turn. When a skill like `/postmortem` emits its full report text *and* calls tools (`current_time`, `vault_write`) in the same LLM response, the report text reached the user via `text_before_tools` but never reached the judge. The judge then failed the response for "not delivering the report", triggered a retry, which produced the same split pattern, and so on until `reflection.max_retries` — user sees the report repeated several times plus apologetic retries.

Threads `accumulated_text_parts` (already collected in the agent loop at `agent.py:1004`) into `_handle_reflection`. The judge's `agent_response` is now the concatenation of prior tool-call iterations' text plus the current final text, matching what the user actually sees. History entries (including the reflection-fail retry assistant message) keep using the per-iteration `final_text` — only the judge's view widens.

Adds a regression test that drives the split pattern (report + tool call, then trailer-only iteration) and asserts both the report text and trailer reach `evaluate_response`.

## Test plan
- [x] `pytest tests/test_agent_turn.py tests/test_reflection.py` — all green (81 tests).
- [x] `pytest` full suite — 1895 green.
- [x] `make lint` / `make typecheck` — clean.
- [ ] Run `/postmortem` live in the web UI and confirm reflection passes on the first attempt (no retry loop, no apologetic trailers).

## Context
Diagnosis thread: the bug surfaced when Les ran `/postmortem` and the judge kept critiquing "you didn't deliver the report" while the report was visibly present in the chat — reflection was looking at the wrong slice of the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)