### PR TITLE
fix(web): preserve sidebar scroll position during refetches

### DIFF
--- a/src/decafclaw/web/static/components/files-sidebar.js
+++ b/src/decafclaw/web/static/components/files-sidebar.js
@@ -174,11 +174,13 @@ export class FilesSidebar extends LitElement {
    */
   navigateToFileFolder(filePath) {
     this._openFilePath = filePath;
+    // Recent view isn't folder-scoped — clicking a recent file shouldn't
+    // refetch the browse list (and thus blank the list / reset scroll).
+    if (this._view === 'recent') return;
     const lastSlash = filePath.lastIndexOf('/');
     const folder = lastSlash >= 0 ? filePath.substring(0, lastSlash) : '';
-    if (folder !== this._currentFolder || this._view !== 'browse') {
+    if (folder !== this._currentFolder) {
       this._currentFolder = folder;
-      this._view = 'browse';
       this.#fetchBrowse();
     }
   }
@@ -290,7 +292,7 @@ export class FilesSidebar extends LitElement {
         `;
       })}
       ${!hasContent
-        ? html`<p style="padding: 1rem; color: var(--pico-muted-color);">Empty folder.</p>`
+        ? html`<p style="padding: 1rem; color: var(--pico-muted-color);">${this._loading ? 'Loading files...' : 'Empty folder.'}</p>`
         : nothing
       }
     `;
@@ -301,7 +303,7 @@ export class FilesSidebar extends LitElement {
       ? this._recentFiles
       : this._recentFiles.filter(f => !this.#isHidden(f.name));
     if (!files.length) {
-      return html`<p style="padding: 1rem; color: var(--pico-muted-color);">No recent changes.</p>`;
+      return html`<p style="padding: 1rem; color: var(--pico-muted-color);">${this._loading ? 'Loading files...' : 'No recent changes.'}</p>`;
     }
     return html`
       ${files.map(f => {
@@ -340,10 +342,7 @@ export class FilesSidebar extends LitElement {
           </label>
           <button class="outline" @click=${() => this.#refresh()} title="Refresh">Refresh</button>
         </div>
-        ${this._loading
-          ? html`<p style="padding: 1rem; color: var(--pico-muted-color);">Loading files...</p>`
-          : (this._view === 'browse' ? this.#renderBrowse() : this.#renderRecent())
-        }
+        ${this._view === 'browse' ? this.#renderBrowse() : this.#renderRecent()}
       </div>
     `;
   }

--- a/src/decafclaw/web/static/components/vault-sidebar.js
+++ b/src/decafclaw/web/static/components/vault-sidebar.js
@@ -136,6 +136,9 @@ export class VaultSidebar extends LitElement {
    */
   navigateToPageFolder(pagePath) {
     this._openWikiPage = pagePath;
+    // Recent view isn't folder-scoped — refetching here would flip
+    // _wikiLoading and replace the list with a placeholder, resetting scroll.
+    if (this._vaultView === 'recent') return;
     const lastSlash = pagePath.lastIndexOf('/');
     const folder = lastSlash >= 0 ? pagePath.substring(0, lastSlash) : '';
     if (folder !== this._vaultFolder) {
@@ -271,7 +274,7 @@ export class VaultSidebar extends LitElement {
         `;
       })}
       ${!hasContent
-        ? html`<p style="padding: 1rem; color: var(--pico-muted-color);">Empty folder.</p>`
+        ? html`<p style="padding: 1rem; color: var(--pico-muted-color);">${this._wikiLoading ? 'Loading vault pages...' : 'Empty folder.'}</p>`
         : nothing
       }
     `;
@@ -279,7 +282,7 @@ export class VaultSidebar extends LitElement {
 
   #renderVaultRecent() {
     if (!this._recentPages.length) {
-      return html`<p style="padding: 1rem; color: var(--pico-muted-color);">No recent changes.</p>`;
+      return html`<p style="padding: 1rem; color: var(--pico-muted-color);">${this._wikiLoading ? 'Loading vault pages...' : 'No recent changes.'}</p>`;
     }
     return html`
       ${this._recentPages.map(p => {
@@ -297,9 +300,10 @@ export class VaultSidebar extends LitElement {
   }
 
   render() {
-    if (this._wikiLoading) {
-      return html`<div class="conv-list"><p style="padding: 1rem; color: var(--pico-muted-color);">Loading vault pages...</p></div>`;
-    }
+    // Don't gate the whole list on _wikiLoading — replacing the list with a
+    // placeholder during refetch destroys the user's scroll position. Render
+    // the list as-is; only the empty-state line swaps to "Loading..." so a
+    // first-load gives feedback. Refetches with existing data update in place.
     return html`
       <div class="conv-list">
         <div class="vault-view-toggle">


### PR DESCRIPTION
## Summary

- Clicking a Recent entry in the Vault sidebar reset the list scroll to the top — and the same pattern affected the Files sidebar.
- Root cause: `_wikiLoading` / `_loading` early-returned a "Loading..." placeholder that replaced the entire `.conv-list`. Even worse, `navigateToPageFolder` (Vault) and `navigateToFileFolder` (Files) triggered a browse-list refetch when in Recent view, blanking the list the user was actually looking at.
- Fix: skip the navigate-and-refetch in Recent view, and stop gating the list render on the loading flag. The list is always rendered; "Loading..." appears only as the empty-state text so first-loads still give feedback.

## Test plan

- [ ] Open Vault → Recent. Scroll down. Click an entry whose page is in a different folder. Scroll position is preserved; the recent list does not flicker.
- [ ] Open Vault → Browse. Scroll down. Click a different folder. List updates in place without flashing a "Loading..." placeholder.
- [ ] Open Vault → Browse on a fresh tab. First load shows "Loading vault pages..." until results arrive.
- [ ] Same checks in Files sidebar (Recent and Browse).
- [ ] `make check-js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)