### PR TITLE
chore: code-quality sweep — convention violations and small smells

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -120,9 +120,11 @@ Semantic search embedding settings. Empty `url`/`api_key` fall back to `llm` gro
 | Field | Type | Default | Env Var | Secret |
 |-------|------|---------|---------|--------|
 | `model` | str | `text-embedding-004` | `EMBEDDING_MODEL` | |
+| `provider` | str | `""` | `EMBEDDING_PROVIDER` | |
 | `url` | str | (from llm) | `EMBEDDING_URL` | |
 | `api_key` | str | (from llm) | `EMBEDDING_API_KEY` | yes |
 | `search_strategy` | str | `substring` | `MEMORY_SEARCH_STRATEGY` | |
+| `dimensions` | int | `768` | `EMBEDDING_DIMENSIONS` | |
 
 ### `reflection`
 

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -165,7 +165,7 @@ All settings live under the `vault_retrieval` section in `config.json`:
 | `max_tokens` | int | `500` | Token budget for injected context |
 | `show_in_ui` | bool | `true` | Show retrieval indicator in chat UI |
 
-Environment variable prefix: `VAULT_RETRIEVAL_` (e.g., `VAULT_RETRIEVAL_ENABLED=false`).
+Environment variable prefix: `MEMORY_CONTEXT_` (e.g., `MEMORY_CONTEXT_ENABLED=false`). The config section was renamed from `memory_context` to `vault_retrieval`, but the env-var prefix was left unchanged for backward compatibility.
 
 ### Requirements
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,7 +32,7 @@ vim ~/decafclaw/.env
 ```
 
 Required:
-- `LLM_URL`, `LLM_MODEL`, `LLM_API_KEY`
+- LLM connection — either a `providers` + `model_configs` block in `config.json` (preferred, see [installation.md](installation.md) and [providers.md](providers.md)) or the legacy `LLM_URL` / `LLM_MODEL` / `LLM_API_KEY` env vars
 - `MATTERMOST_URL`, `MATTERMOST_TOKEN`, `MATTERMOST_BOT_USERNAME`
 
 Optional:

--- a/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/notes.md
+++ b/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/notes.md
@@ -1,0 +1,26 @@
+# Notes — code-quality sweep
+
+## Findings deferred to later sessions
+
+These surfaced during exploration but are out of scope for this sweep:
+
+- **`run_agent_turn` (~314 lines) and `_handle_reflection` (~117 lines)** in `agent.py` are large enough to be friction during review, but the structure isn't actively bug-prone. A targeted refactor is a separate effort.
+- **`http_server.create_app`** is a single closure with 40+ route handlers. Same story — large but stable. If we add more routes, splitting into a Router class becomes worthwhile.
+- **WebSocket message-type strings** (~43 occurrences) are not centralized. A shared `web/message_types.py` module would help, but it's a coordinated edit across the JS client too.
+- **`archive.append_message` has no file locking**. Today this is fine (per-conv files + serialized turns), but if we ever allow concurrent turns per conv, revisit.
+- **`conversation_manager._save_conversation_state` is a hand-maintained field list.** Same pattern CLAUDE.md flags, but the `state` and `ctx` shapes differ enough that a mechanical fix isn't obvious. Worth a focused mini-session.
+- **Skill `init(config, skill_config)` stores config as a module global.** Re-activating in another conversation overwrites; today only one config is in play, but it's a footgun if we ever support multi-tenant skills.
+- **`embeddings.py:62` `except sqlite3.OperationalError: pass`** for the column-already-exists migration could log at debug. Tiny tweak but not critical.
+
+## Session log
+
+- Phase 1: replaced `getattr(obj, "field", default)` with direct attribute access at every verified call site. 13 `discovered_skills` sites (interactive_terminal, context_composer, commands ×3, agent ×2, schedules, eval/runner, tool_registry, delegate, skill_tools ×2). 1 `relevance` site (memory_context). 1 `active_model` site (health). Plus `manager` / `conv_id` / `cancelled` / `request_confirmation` / `event_context_id` / `channel_id` / `always_loaded` sites in agent.py, delegate.py, skill_tools.py, widget_input.py.
+- Phase 2: removed dead `_skill_shutdown_hooks` storage (registered in `skill_tools._call_init` but never read anywhere — orphan code).
+- Phase 3: replaced 9 `except: pass` (or `except SpecificType: pass`) sites with `except ... as exc: log.debug(...)`. Sites: `tools/__init__.py`, `agent.py`, `mattermost.py` ×4, `mcp_client.py`, `web/websocket.py`, `llm/__init__.py`.
+- Phase 4: extracted `PRIORITY_ORDER` / `PRIORITY_GLYPH` / `meets_priority` to `notification_channels/__init__.py`. Three channels (email, mattermost_dm, vault_page) now import from there.
+- Phase 5: wrapped `mail.py` attachment read with `asyncio.to_thread(path.read_bytes)`.
+- Verification: `make lint` (ruff) clean, `make typecheck` (pyright) clean, `make test` 2027/2027 passing in ~21s.
+
+## Outcome
+
+Hygiene-only changes; no behavior changed. Five categories of convention violations and small smells closed across ~15 files.

--- a/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/plan.md
+++ b/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/plan.md
@@ -1,0 +1,84 @@
+# Plan — code-quality sweep
+
+## Approach
+
+One branch, one PR, multiple commits (one per phase). Each phase is mechanical and independently green; if one breaks tests, it's easy to bisect.
+
+## Phases
+
+### Phase 1 — `getattr` for declared fields → direct access
+
+Files touched:
+- `interactive_terminal.py`, `context_composer.py`, `commands.py`, `agent.py`, `schedules.py`, `eval/runner.py`, `tools/tool_registry.py`, `tools/delegate.py`, `tools/skill_tools.py`, `tools/health.py`, `memory_context.py`
+
+For each replacement, confirm the attribute is declared on the type with a sensible default, so the fallback was redundant. Where the variable name was used both with `getattr(...)` and direct access in the same module, prefer the direct form.
+
+Special cases:
+- `agent.py:382` (`getattr(ctx, "manager", None)`) — `Context.manager` defaults to `None` already, so direct access is a no-op semantic-wise.
+- `delegate.py:59` already uses direct `parent_ctx.context_id` as a fallback for `event_context_id` — fine.
+
+### Phase 2 — Remove dead `_skill_shutdown_hooks` storage
+
+Investigation showed the hook is *registered* in `skill_tools.py:205–209` but never *read* anywhere — no caller iterates `ctx._skill_shutdown_hooks`. There's no skill-deactivation lifecycle yet, so the hook is orphaned.
+
+The smallest correct fix is to delete the dead storage block (5 lines), which simultaneously removes the convention violation (hasattr + setattr on an undeclared attr). The single skill that defines a `shutdown()` callback (`claude_code/tools.py:947`) stays in place as a marker for if/when deactivation is implemented.
+
+### Phase 3 — `except: pass` → logged debug
+
+For each site, replace with `except Exception as exc: log.debug(...)` (or specific exception class where one is already named, e.g., `except KeyError as exc: log.debug(...)`). Preserve the existing comment as part of the log message where it adds context.
+
+Where `log` doesn't already exist in the module, import `logging` and define `log = logging.getLogger(__name__)` if not already present.
+
+### Phase 4 — Extract notification-priority helpers
+
+Create or extend `notification_channels/__init__.py` with:
+
+```python
+PRIORITY_ORDER = {"low": 0, "normal": 1, "high": 2}
+PRIORITY_GLYPH = {"low": "·", "normal": "🔔", "high": "⚠️"}
+
+def meets_priority(record_priority: str, min_priority: str) -> bool:
+    return (PRIORITY_ORDER.get(record_priority, 1)
+            >= PRIORITY_ORDER.get(min_priority, 1))
+```
+
+Update `vault_page.py`, `mattermost_dm.py`, `email.py` to import from there. Drop their local copies.
+
+### Phase 5 — Async-safe attachment read in `mail.py`
+
+```python
+data = await asyncio.to_thread(path.read_bytes)
+```
+
+(Adds `import asyncio` if not present.)
+
+### Phase 6 — Verify
+
+- `make lint` — quick compile-check
+- `make typecheck` — pyright
+- `make test` — full suite
+- Spot-check: `grep -rn "getattr(.*discovered_skills" src/` returns no hits in the in-scope files.
+
+### Phase 7 — Commit per phase, push, PR
+
+Commit messages follow project style (terse, imperative). Open PR against `main` with summary listing the five categories. Request Copilot review.
+
+## Self-review of plan
+
+What could go wrong?
+
+- **`Context` field name**: dropping the underscore on `_skill_shutdown_hooks` is a small renaming. There may be tests that read the underscored name. Will grep before changing.
+- **`ctx.manager` direct access vs `getattr`**: `Context.manager: Any = None` is set to None by default and assigned by `ConversationManager`. If tests build a bare `Context` without `ConversationManager`, direct access still returns `None`. Same semantics — safe.
+- **`config.discovered_skills`**: if any test builds a `Config` instance without going through `load_config`, the dataclass default already gives `[]`. Safe.
+- **`config.relevance`**: declared with `field(default_factory=RelevanceConfig)`; always present. Safe.
+- **`except KeyError: pass` in `llm/__init__.py:127`** — the pattern is "try named default, fall through to default registry." Replacing with `except KeyError as exc: log.debug(...)` is a behavior-equivalent change that just adds a debug log. Safe.
+- **Notification channels**: tests likely construct records via the public API and assert side effects (file written, post sent). Renaming the priority helper shouldn't change side effects. Safe.
+- **`mail.py to_thread`**: tests of email sending probably mock `aiosmtplib.send`. The attachment read happens before that, so changing it to `to_thread` is observable only via the event loop's responsiveness, which tests don't measure. Safe.
+
+What is *not* covered by this plan?
+
+- The bigger structural concerns (large functions, magic-string event types, lack of a central WebSocket message catalog) are intentionally out of scope. Document as known follow-ups in `notes.md` so they don't get lost.
+
+## Estimated complexity
+
+Each phase is a few minutes of mechanical editing plus running checks. Total wall time: 30–45 minutes of editing, plus test runtime.

--- a/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/spec.md
+++ b/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/spec.md
@@ -1,0 +1,52 @@
+# Code-quality and maintainability sweep
+
+## Goal
+
+After a stretch of feature landings (widgets phase 2, tool-result clearing, narrative summaries, scheduled-task ctx fixes, etc.), do a focused pass to clean up convention violations and clear small maintainability traps that have accumulated across the codebase.
+
+## Scope (in)
+
+Each item is a real, verified violation of conventions stated in `CLAUDE.md`:
+
+1. **`getattr(obj, "field", default)` on declared dataclass fields.** CLAUDE.md flags this as a maintenance trap: "Don't `getattr(obj, "_field", fallback)` to read undeclared attributes." Verified call sites read fields that *are* declared on `Config`, `Context`, or `SkillInfo`:
+   - `getattr(config, "discovered_skills", [])` — 13 sites; field is on `Config` (config.py:177)
+   - `getattr(config, "relevance", None)` — memory_context.py:64; field is on `Config`
+   - `getattr(ctx, "active_model", "")` — agent.py:586, health.py:395; field is on `Context`
+   - `getattr(parent_ctx, "conv_id", "")`, `event_context_id`, `channel_id` — delegate.py:56–59
+   - `getattr(ctx, "manager", None)`, `getattr(ctx, "conv_id", None)` — agent.py:382–383
+   - `getattr(skill_info, "always_loaded", False)` — skill_tools.py:214
+
+2. **`hasattr(ctx, "_skill_shutdown_hooks")` + setattr** — skill_tools.py:205–209 stores skill `shutdown` callbacks on a lazy-created undeclared attribute. CLAUDE.md flags the pattern, but on closer look the stored hooks are *never invoked anywhere*. Remove the dead storage block. (If skill deactivation gets wired up later, the new code can declare the field properly on `Context`.)
+
+3. **Bare `except: pass`** — CLAUDE.md: "never acceptable; use `except Exception as exc: log.debug(...)`."
+   - tools/__init__.py:261 (MCP registry probe)
+   - agent.py:1374 (context sidecar write)
+   - mattermost.py:117, 616, 772, 826 (best-effort post/edit)
+   - mcp_client.py:579 (exit-stack cleanup on failure)
+   - web/websocket.py:710 (ws send)
+   - llm/__init__.py:127 (KeyError on missing model — bare on a specific exception, but the pattern is the same)
+
+4. **Duplicated `_PRIORITY_ORDER` / `_PRIORITY_GLYPH` / `_meets_priority`** across `notification_channels/{vault_page,mattermost_dm,email}.py` (3 copies, identical body). Extract to `notification_channels/__init__.py`.
+
+5. **Sync file I/O on the event loop** — `mail.py:86` reads attachments with blocking `path.open("rb").read()` inside async `send_mail`. Wrap with `asyncio.to_thread`.
+
+## Scope (out — explicitly rejected)
+
+The exploration phase surfaced larger refactor suggestions; rejecting these for this sweep because they violate "smallest reasonable changes" and risk regressions in code that has been stable:
+
+- Splitting `run_agent_turn` (314 lines), `_handle_reflection` (117 lines), or `http_server.create_app` (1500+ lines). These are not bug-prone; restructuring them is a separate effort with its own design discussion.
+- Centralizing all WebSocket message types into a constants module. Big surface, low payoff for a quality sweep.
+- `archive.append_message` lacks file locking. Per-conversation files + serialized turns mean this isn't actually a bug today.
+- `conversation_manager._save_conversation_state` hand-maintained field list. It's the right shape of finding, but the `state` and `ctx` shapes differ enough that a mechanical fix isn't safe — defer.
+- Cosmetic fixes (`re as _re` import, missing docstrings on private helpers, etc.).
+
+## Success criteria
+
+- All in-scope violations removed (verifiable by grep).
+- `make check` clean.
+- `make test` green.
+- No behavior changes (this is hygiene, not feature work).
+
+## Risk
+
+Low. All changes are mechanical: replace getattr with attribute access, change exception handler bodies, move three identical helpers into a shared module, wrap one read with `to_thread`. Test suite covers the affected paths.

--- a/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/todo.md
+++ b/docs/dev-sessions/2026-04-26-1028-code-quality-sweep/todo.md
@@ -1,0 +1,9 @@
+# Todo — code-quality sweep
+
+- [ ] Phase 1: replace `getattr` for declared fields → direct access
+- [ ] Phase 2: remove dead `_skill_shutdown_hooks` storage (registered but never invoked)
+- [ ] Phase 3: replace `except: pass` with `except Exception as exc: log.debug(...)` across the verified sites
+- [ ] Phase 4: extract `PRIORITY_ORDER`/`PRIORITY_GLYPH`/`meets_priority` to `notification_channels/__init__.py`
+- [ ] Phase 5: wrap `mail.py` attachment read in `asyncio.to_thread`
+- [ ] Phase 6: `make check` + `make test`, fix any failures
+- [ ] Phase 7: commit per phase, push, open PR, request Copilot review

--- a/docs/dream-consolidation.md
+++ b/docs/dream-consolidation.md
@@ -6,7 +6,7 @@ DecafClaw can periodically "dream" — reviewing recent journal entries and conv
 
 | Command | Schedule | Description |
 |---------|----------|-------------|
-| `!dream` / `/dream` | Hourly (`0 * * * *`) | Review recent journal/conversations, update vault pages |
+| `!dream` / `/dream` | Daily 3am (`0 3 * * *`) | Review recent journal/conversations, update vault pages |
 | `!garden` / `/garden` | Weekly (Sunday 3am: `0 3 * * 0`) | Structural vault maintenance: merge, link, split, tidy |
 
 Both commands can be configured with a specific model for quality page writing. They can be triggered manually or run automatically via [scheduled tasks](schedules.md).

--- a/docs/project-skill.md
+++ b/docs/project-skill.md
@@ -9,13 +9,6 @@ markdown artifacts at each stage.
 Any task involving 3+ steps, research, or work spanning multiple turns.
 Not for quick one-off questions.
 
-## Modes
-
-- **Normal:** Pauses at review gates (spec_review, plan_review) for user feedback.
-- **Express:** Auto-advances through all phases, still generating artifacts.
-
-Switch at any time with `project_set_mode`.
-
 ## State machine
 
 ```
@@ -59,13 +52,14 @@ Sub-steps are indented under parents. Steps can be inserted mid-execution.
 | Tool | Description |
 |------|-------------|
 | `project_create` | Create a new project |
+| `project_next_task` | Get the next instruction for the current phase |
+| `project_task_done` | Mark the current phase's work complete and advance |
 | `project_status` | Check current state and progress |
 | `project_list` | List all projects |
-| `project_set_mode` | Switch normal/express mode |
-| `project_advance` | Move to next phase (or backward) |
+| `project_switch` | Switch the active project |
+| `project_advance` | Move backward to an earlier phase (e.g. replan) |
 | `project_update_spec` | Write/update the spec |
 | `project_update_plan` | Write/update the plan |
-| `project_next` | Get the next actionable step |
 | `project_update_step` | Update a step's status |
 | `project_add_steps` | Insert new steps into the plan |
 | `project_note` | Append a timestamped note |
@@ -79,12 +73,11 @@ Sub-steps are indented under parents. Steps can be inserted mid-execution.
 
 ## Execution loop
 
-The agent follows a tight loop during execution:
+The two driver tools are `project_next_task` (asks "what should I do now?") and `project_task_done` (signals "I finished — advance"). The general loop:
 
-1. `project_next` → get next step
-2. `project_update_step(step, "in_progress")` → mark it started
-3. Do the work
-4. `project_update_step(step, "done", note="...")` → mark it done
-5. Repeat
+1. `project_next_task` → tells you what to do this turn
+2. Do the work — for the executing phase, this means picking a step, marking it in_progress with `project_update_step`, completing it, and marking it done
+3. `project_task_done` → advance the phase (or, in `executing`, finalize when all steps are checked off)
+4. Repeat
 
-For parallel work, use `delegate_task` for independent steps.
+For parallel work within a single step, use `delegate_task` for independent sub-tasks.

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -17,7 +17,7 @@ The judge uses a chain-of-thought-before-verdict prompt (G-Eval pattern): it rea
 The judge receives only the current turn's context, not the full conversation history:
 
 - The user's message that started this turn
-- A condensed summary of tool calls and results (each result truncated to 500 chars)
+- A condensed summary of tool calls and results (each result truncated to `reflection.max_tool_result_len`, default 2000 chars)
 - The agent's final response
 
 This keeps the judge context small and focused.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -4,7 +4,7 @@ DecafClaw uses embedding-based semantic search for finding relevant memories and
 
 ## How it works
 
-1. Text is sent to an embedding API (default: `text-embedding-004` via LiteLLM)
+1. Text is sent to an embedding API. Default model: `text-embedding-004`. The endpoint is resolved either through a named provider (`embedding.provider`, routing through `config.providers`) or, when that's empty, via legacy fallback to the `llm` group's URL/key (with `/chat/completions` rewritten to `/embeddings`).
 2. The resulting vector is stored in a SQLite database using [sqlite-vec](https://github.com/asg017/sqlite-vec)
 3. On search, the query is embedded and compared using SIMD-accelerated cosine distance via sqlite-vec's `vec0` virtual table
 4. Top-K most similar results are returned

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -264,7 +264,7 @@ Tools: `tabstack_extract_markdown`, `tabstack_extract_json`, `tabstack_generate`
 
 Delegates coding tasks to [Claude Code](https://claude.com/claude-code) as a subagent. The agent can start sessions, send coding tasks, and get results back — all within Mattermost conversations. Requires `ANTHROPIC_API_KEY`.
 
-Tools: `claude_code_start`, `claude_code_send`, `claude_code_stop`, `claude_code_sessions`
+Tools: `claude_code_start`, `claude_code_send`, `claude_code_exec`, `claude_code_push_file`, `claude_code_pull_file`, `claude_code_stop`, `claude_code_sessions`
 
 Features:
 - Persistent sessions via SDK `resume` (one per working directory, 30min idle expiration)

--- a/docs/tool-search.md
+++ b/docs/tool-search.md
@@ -45,7 +45,7 @@ Use `CRITICAL_TOOLS` to force-promote additional tools (extends, does not replac
 
 **Keyword search**: case-insensitive substring match on tool name and description.
 
-**Exact selection**: `select:vault_read,vault_show` fetches those specific tools.
+**Exact selection**: `select:vault_read,vault_show_sections` fetches those specific tools.
 
 Returns full JSON schema definitions. Tools become callable on the next LLM iteration.
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -75,6 +75,8 @@ The vault skill is **always loaded** — its tools are available in every conver
 |------|-------------|
 | `vault_read(page)` | Read a page by name or path. Searches subdirectories. |
 | `vault_write(page, content)` | Create or overwrite a page. Indexes in semantic search. |
+| `vault_delete(page)` | Delete an agent-owned page. |
+| `vault_rename(from_page, to_page)` | Rename/move an agent-owned page (preserves links). |
 | `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. |
 | `vault_search(query, source_type?, days?, folder?)` | Semantic + substring search across the vault. |
 | `vault_list(folder?, pattern?)` | List pages with last-modified dates. |

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -329,7 +329,7 @@ async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
         pending_callbacks,
     )
 
-    request_confirmation = getattr(ctx, "request_confirmation", None)
+    request_confirmation = ctx.request_confirmation
     if request_confirmation is None:
         log.warning(
             "WidgetInputPause received but ctx has no request_confirmation "
@@ -349,7 +349,7 @@ async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
     # click while the widget is pending unblocks the loop. The
     # confirmation infra's await on confirmation_event doesn't observe
     # cancel_event natively.
-    cancel_event = getattr(ctx, "cancelled", None)
+    cancel_event = ctx.cancelled
     confirm_task = asyncio.create_task(request_confirmation(request))
     response = None
     cancelled_during_pause = False
@@ -379,8 +379,8 @@ async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
                 confirm_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await confirm_task
-                manager = getattr(ctx, "manager", None)
-                conv_id = getattr(ctx, "conv_id", None)
+                manager = ctx.manager
+                conv_id = ctx.conv_id
                 if manager and conv_id:
                     try:
                         await manager.cancel_pending_confirmation(conv_id)
@@ -494,7 +494,7 @@ def _collect_all_tool_defs(ctx) -> list:
     _cached = _skill_def_cache.get(config_id)
     if _cached is None:
         _cached = []
-        for skill_info in getattr(ctx.config, "discovered_skills", []):
+        for skill_info in ctx.config.discovered_skills:
             if skill_info.has_native_tools:
                 try:
                     from .tools.skill_tools import _load_native_tools
@@ -583,7 +583,7 @@ async def _call_llm_with_events(ctx, config, messages, tools,
     iteration = ctx._current_iteration
     await ctx.publish("llm_start", iteration=iteration)
     from .config import resolve_streaming
-    if resolve_streaming(config, getattr(ctx, "active_model", "")):
+    if resolve_streaming(config, ctx.active_model):
         from .llm import call_llm_streaming
         on_chunk = ctx.on_stream_chunk
         cancel_event = ctx.cancelled
@@ -951,7 +951,7 @@ async def _setup_turn_state(ctx, config, history) -> dict[str, str]:
     # Auto-activate always-loaded skills (bundled only — trust boundary)
     from .skills import _BUNDLED_SKILLS_DIR
     bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
-    discovered = getattr(config, "discovered_skills", [])
+    discovered = config.discovered_skills
     for skill_info in discovered:
         if not skill_info.always_loaded or skill_info.name in ctx.skills.activated:
             continue
@@ -1371,8 +1371,8 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                 from .context_composer import write_context_sidecar
                 diagnostics = composer.build_diagnostics(config, composed)
                 write_context_sidecar(config, conv_id, diagnostics)
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug("context sidecar write failed for %s: %s", conv_id, exc)
 
         # Persist activated skills and skill_data after every turn
         if conv_id:

--- a/src/decafclaw/commands.py
+++ b/src/decafclaw/commands.py
@@ -319,12 +319,12 @@ async def dispatch_command(ctx, text: str, prefixes: list[str] | None = None,
 
     # Help is special
     if cmd_name == "help":
-        discovered = getattr(ctx.config, "discovered_skills", [])
+        discovered = ctx.config.discovered_skills
         help_text = format_help(discovered, prefix=matched_prefix)
         return CommandResult(mode="help", text=help_text)
 
     # Look up the command
-    discovered = getattr(ctx.config, "discovered_skills", [])
+    discovered = ctx.config.discovered_skills
     skill = find_command(cmd_name, discovered)
     if skill is None:
         # Check if it's an MCP prompt command
@@ -394,7 +394,7 @@ async def execute_command(ctx, skill: SkillInfo, arguments: str) -> tuple[str, s
 
     # Pre-activate required skills (user invoked the command = implicit approval)
     if skill.requires_skills:
-        discovered = getattr(ctx.config, "discovered_skills", [])
+        discovered = ctx.config.discovered_skills
         skill_map = {s.name: s for s in discovered}
         for req_name in skill.requires_skills:
             if req_name in ctx.skills.activated:

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -804,7 +804,7 @@ class ContextComposer:
         if not input_tokens:
             return None, None
 
-        discovered = getattr(config, "discovered_skills", []) or []
+        discovered = config.discovered_skills or []
         candidates = [
             s for s in discovered
             if s.name and s.name not in ctx.skills.activated

--- a/src/decafclaw/embeddings.py
+++ b/src/decafclaw/embeddings.py
@@ -59,8 +59,11 @@ def _init_schema(conn, config):
     # Migration: add source_type column to very old DBs
     try:
         conn.execute("ALTER TABLE memory_embeddings ADD COLUMN source_type TEXT NOT NULL DEFAULT 'memory'")
-    except sqlite3.OperationalError:
-        pass  # column already exists
+    except sqlite3.OperationalError as exc:
+        # Already-applied migration on every existing DB; only logged for
+        # parity with other except-paths so a genuine schema problem is
+        # observable instead of swallowed.
+        log.debug("embeddings: source_type migration skipped (already applied?): %s", exc)
     dim = config.embedding.dimensions
     conn.execute(f"""
         CREATE VIRTUAL TABLE IF NOT EXISTS embeddings_vec USING vec0(

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -186,7 +186,7 @@ async def run_test(config: Config, test_case: dict) -> dict:
     All turns must pass for the test to pass.
     """
     # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
-    if not getattr(config, "discovered_skills", None):
+    if not config.discovered_skills:
         config.discovered_skills = _discover_skills_fn(config)
 
     bus = EventBus()

--- a/src/decafclaw/interactive_terminal.py
+++ b/src/decafclaw/interactive_terminal.py
@@ -22,7 +22,7 @@ def _print_banner(config) -> None:
     print("DecafClaw interactive mode. Type 'quit' to exit.")
     print(f"Model: {config.default_model or config.llm.model}")
     print(f"Tools: {', '.join(t['function']['name'] for t in TOOL_DEFINITIONS)}")
-    skills = getattr(config, "discovered_skills", [])
+    skills = config.discovered_skills
     if skills:
         print(f"Skills: {', '.join(s.name for s in skills)} (activate to use)")
     mcp_registry = get_registry()

--- a/src/decafclaw/llm/__init__.py
+++ b/src/decafclaw/llm/__init__.py
@@ -124,8 +124,9 @@ def _resolve(
             mc = config.model_configs[config.default_model]
             provider = get_provider(mc.provider)
             return provider, mc.model, mc.timeout
-        except KeyError:
-            pass
+        except KeyError as exc:
+            log.debug("default model %r not in provider registry: %s; falling through",
+                      config.default_model, exc)
 
     # Fall back to "default" provider in registry
     try:

--- a/src/decafclaw/mail.py
+++ b/src/decafclaw/mail.py
@@ -14,6 +14,7 @@ delivery.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import mimetypes
 from email.message import EmailMessage
@@ -83,8 +84,7 @@ async def send_mail(
         if ctype is None:
             ctype = "application/octet-stream"
         maintype, subtype = ctype.split("/", 1)
-        with path.open("rb") as f:
-            data = f.read()
+        data = await asyncio.to_thread(path.read_bytes)
         msg.add_attachment(
             data, maintype=maintype, subtype=subtype, filename=path.name,
         )

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -114,8 +114,8 @@ class MattermostClient:
             await self._http.post("/users/me/typing", json={
                 "channel_id": channel_id,
             })
-        except Exception:
-            pass  # typing indicators are best-effort
+        except Exception as exc:
+            log.debug("typing indicator failed (best-effort): %s", exc)
 
     async def listen(self, on_message, shutdown_event=None):
         """Listen for posted events via WebSocket. Calls on_message(post, channel_type)
@@ -613,8 +613,8 @@ class MattermostClient:
                             compaction_post_id,
                             f"\U0001f4e6 Conversation compacted ({details})",
                         )
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        log.debug("compaction post edit failed: %s", exc)
                     compaction_post_id = None
 
             elif event_type == "message_complete" and event.get("final"):
@@ -769,8 +769,8 @@ class MattermostClient:
                 resp = await self._http.get(f"/posts/{post_id}")
                 original_text = resp.json().get("message", "") if resp.status_code == 200 else ""
                 await self.edit_message(post_id, f"{original_text}\n\n**Result:** {label}")
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug("confirmation result edit failed for post %s: %s", post_id, exc)
 
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -823,8 +823,8 @@ class MattermostClient:
                             log.info(f"Agent turn cancelled by {user_id} via reaction")
                             cancel_event.set()
                             return
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug("reaction poll failed for post %s: %s", post_id, exc)
             await asyncio.sleep(poll_interval)
 
     async def close(self):

--- a/src/decafclaw/mcp_client.py
+++ b/src/decafclaw/mcp_client.py
@@ -576,8 +576,8 @@ class MCPRegistry:
             if state._exit_stack:
                 try:
                     await state._exit_stack.__aexit__(None, None, None)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    log.debug("MCP server %r exit-stack cleanup failed: %s", name, exc)
                 state._exit_stack = None
 
     async def _connect_stdio(self, exit_stack, server_config, message_handler=None):

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -61,7 +61,7 @@ async def retrieve_memory_context(config, user_message: str) -> list[dict]:
         results = _enrich_results(config, results)
 
         # Expand via wiki-link graph traversal (one hop)
-        relevance = getattr(config, "relevance", None)
+        relevance = config.relevance
         if relevance and relevance.graph_expansion_enabled:
             results = _expand_graph_links(
                 config, results,

--- a/src/decafclaw/notification_channels/__init__.py
+++ b/src/decafclaw/notification_channels/__init__.py
@@ -18,6 +18,19 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
+# Priority comparison shared by every channel adapter. Each channel filters
+# the bus on its own ``min_priority`` threshold, so the ordering and glyph
+# tables live here to keep the channel modules in sync.
+PRIORITY_ORDER = {"low": 0, "normal": 1, "high": 2}
+PRIORITY_GLYPH = {"low": "·", "normal": "🔔", "high": "⚠️"}
+
+
+def meets_priority(record_priority: str, min_priority: str) -> bool:
+    """True when ``record_priority`` is at or above ``min_priority``."""
+    return (PRIORITY_ORDER.get(record_priority, 1)
+            >= PRIORITY_ORDER.get(min_priority, 1))
+
+
 def init_notification_channels(
     config,
     event_bus,

--- a/src/decafclaw/notification_channels/email.py
+++ b/src/decafclaw/notification_channels/email.py
@@ -23,16 +23,9 @@ from typing import Any, Awaitable, Callable
 
 from decafclaw.notifications import NotificationRecord
 
+from . import PRIORITY_GLYPH, meets_priority
+
 log = logging.getLogger(__name__)
-
-
-_PRIORITY_ORDER = {"low": 0, "normal": 1, "high": 2}
-_PRIORITY_GLYPH = {"low": "·", "normal": "🔔", "high": "⚠️"}
-
-
-def _meets_priority(record_priority: str, min_priority: str) -> bool:
-    return (_PRIORITY_ORDER.get(record_priority, 1)
-            >= _PRIORITY_ORDER.get(min_priority, 1))
 
 
 def _format_body(record: NotificationRecord, base_url: str) -> str:
@@ -42,7 +35,7 @@ def _format_body(record: NotificationRecord, base_url: str) -> str:
     body + optional link line — but without any markdown escaping
     since email clients render plain text literally.
     """
-    glyph = _PRIORITY_GLYPH.get(record.priority, "🔔")
+    glyph = PRIORITY_GLYPH.get(record.priority, "🔔")
     parts = [f"{glyph} {record.title}"]
     if record.body:
         parts.append(record.body)
@@ -120,7 +113,7 @@ def make_email_adapter(
                 or not (email_cfg.sender_address or "").strip()):
             return
         record = NotificationRecord.from_dict(event["record"])
-        if not _meets_priority(record.priority, channel_cfg.min_priority):
+        if not meets_priority(record.priority, channel_cfg.min_priority):
             return
         base_url = config.http.base_url
         asyncio.create_task(_deliver(record, recipients, base_url))

--- a/src/decafclaw/notification_channels/mattermost_dm.py
+++ b/src/decafclaw/notification_channels/mattermost_dm.py
@@ -18,17 +18,9 @@ from typing import Any, Awaitable, Callable
 
 from decafclaw.notifications import NotificationRecord
 
+from . import PRIORITY_GLYPH, meets_priority
+
 log = logging.getLogger(__name__)
-
-
-_PRIORITY_ORDER = {"low": 0, "normal": 1, "high": 2}
-_PRIORITY_GLYPH = {"low": "·", "normal": "🔔", "high": "⚠️"}
-
-
-def _meets_priority(record_priority: str, min_priority: str) -> bool:
-    """True when ``record_priority`` is at or above ``min_priority``."""
-    return (_PRIORITY_ORDER.get(record_priority, 1)
-            >= _PRIORITY_ORDER.get(min_priority, 1))
 
 
 def _format_dm(record: NotificationRecord, base_url: str) -> str:
@@ -38,7 +30,7 @@ def _format_dm(record: NotificationRecord, base_url: str) -> str:
     lines, and an optional link if ``base_url`` is configured and the
     record carries a ``conv_id`` or explicit ``link``.
     """
-    glyph = _PRIORITY_GLYPH.get(record.priority, "🔔")
+    glyph = PRIORITY_GLYPH.get(record.priority, "🔔")
     parts = [f"{glyph} **{record.title}**"]
     if record.body:
         parts.append(record.body)
@@ -104,7 +96,7 @@ def make_mattermost_dm_adapter(
         if not cfg.enabled or not recipient:
             return
         record = NotificationRecord.from_dict(event["record"])
-        if not _meets_priority(record.priority, cfg.min_priority):
+        if not meets_priority(record.priority, cfg.min_priority):
             return
         base_url = config.http.base_url
         # Fire-and-forget — don't make notify() wait on Mattermost I/O.

--- a/src/decafclaw/notification_channels/vault_page.py
+++ b/src/decafclaw/notification_channels/vault_page.py
@@ -28,11 +28,9 @@ from typing import Any, Awaitable, Callable
 
 from decafclaw.notifications import NotificationRecord, _parse_iso
 
+from . import PRIORITY_GLYPH, meets_priority
+
 log = logging.getLogger(__name__)
-
-
-_PRIORITY_ORDER = {"low": 0, "normal": 1, "high": 2}
-_PRIORITY_GLYPH = {"low": "·", "normal": "🔔", "high": "⚠️"}
 
 
 # Per-path locks so concurrent appends to the same daily page serialize.
@@ -42,11 +40,6 @@ _locks: dict[str, asyncio.Lock] = {}
 # Folder paths we've already warned about, so a misconfigured folder
 # doesn't spam the log once per notification.
 _warned_bad_folders: set[str] = set()
-
-
-def _meets_priority(record_priority: str, min_priority: str) -> bool:
-    return (_PRIORITY_ORDER.get(record_priority, 1)
-            >= _PRIORITY_ORDER.get(min_priority, 1))
 
 
 def _get_lock(path: Path) -> asyncio.Lock:
@@ -134,7 +127,7 @@ def _format_entry(record: NotificationRecord, base_url: str) -> str:
     except (ValueError, TypeError):
         time_str = "??:?? UTC"
 
-    glyph = _PRIORITY_GLYPH.get(record.priority, "🔔")
+    glyph = PRIORITY_GLYPH.get(record.priority, "🔔")
     heading = (
         f"## {time_str} · {glyph} [{record.category}] {record.title}"
     )
@@ -203,7 +196,7 @@ def make_vault_page_adapter(
         if not ch.enabled:
             return
         record = NotificationRecord.from_dict(event["record"])
-        if not _meets_priority(record.priority, ch.min_priority):
+        if not meets_priority(record.priority, ch.min_priority):
             return
         # Folder validity (including emptiness) is checked inside
         # `_daily_page_path`, which emits a one-time warning per bad

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -260,7 +260,7 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask) -> d
         ctx.channel_name = channel
         # Pre-activate required skills
         if required_skills:
-            discovered = getattr(config, "discovered_skills", [])
+            discovered = config.discovered_skills
             skill_map = {s.name: s for s in discovered}
             from .tools.skill_tools import activate_skill_internal
             for skill_name in required_skills:

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -258,8 +258,8 @@ async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
                 reg = get_registry()
                 if reg:
                     candidates.update(reg.get_tools().keys())
-            except Exception:
-                pass
+            except Exception as exc:
+                log.debug("MCP registry probe failed while suggesting tools: %s", exc)
             suggestions = _suggest_tool_names(name, candidates)
             hint = _format_suggestions(suggestions)
             return ToolResult(

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -36,7 +36,7 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
 
     # Build child system prompt: base + activated skill bodies
     activated = parent_ctx.skills.activated
-    skill_map = {s.name: s for s in getattr(config, "discovered_skills", [])}
+    skill_map = {s.name: s for s in config.discovered_skills}
     prompt_parts = [DEFAULT_CHILD_SYSTEM_PROMPT]
     for name in sorted(activated):
         skill = skill_map.get(name)
@@ -53,18 +53,18 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
     # Children don't discover or activate skills — they inherit parent's
     child_config.discovered_skills = []
 
-    parent_conv = getattr(parent_ctx, "conv_id", "") or getattr(parent_ctx, "channel_id", "")
+    parent_conv = parent_ctx.conv_id or parent_ctx.channel_id
     # Per-call unique conv_id; short random suffix to avoid collisions.
     child_conv_id = f"{parent_conv}--child-{secrets.token_hex(4)}"
-    parent_event_id = getattr(parent_ctx, "event_context_id", "") or parent_ctx.context_id
+    parent_event_id = parent_ctx.event_context_id or parent_ctx.context_id
 
     def setup(child_ctx):
         # Swap in the child-specific config (smaller iteration budget + child
         # system prompt). Context was already built with parent's config by
         # Context.for_task, so we overwrite here.
         child_ctx.config = child_config
-        child_ctx.cancelled = getattr(parent_ctx, "cancelled", None)
-        child_ctx.request_confirmation = getattr(parent_ctx, "request_confirmation", None)
+        child_ctx.cancelled = parent_ctx.cancelled
+        child_ctx.request_confirmation = parent_ctx.request_confirmation
         # Route child events to the parent's UI subscriber so confirmations
         # and tool progress are visible in the parent conversation.
         child_ctx.event_context_id = parent_event_id

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -392,7 +392,7 @@ async def tool_health_status(ctx) -> str:
     try:
         sections.extend(_process_section())
         # Add model info (per-conversation state)
-        active_model = getattr(ctx, "active_model", "")
+        active_model = ctx.active_model
         if active_model:
             sections.append(f"- **Active model:** {active_model}")
         elif ctx.config.default_model:

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -96,7 +96,7 @@ async def restore_skills(ctx) -> None:
     skill_names = set(ctx.skills.activated)
     if not skill_names:
         return
-    discovered = getattr(ctx.config, "discovered_skills", [])
+    discovered = ctx.config.discovered_skills
     skill_map = {s.name: s for s in discovered}
     existing_tools = set(ctx.tools.extra.keys())
     for name in skill_names:
@@ -129,7 +129,7 @@ async def tool_activate_skill(ctx, name: str) -> str | ToolResult:
     log.info(f"[tool:activate_skill] name={name}")
 
     # Find the skill in discovered skills
-    discovered = getattr(ctx.config, "discovered_skills", [])
+    discovered = ctx.config.discovered_skills
     skill_info = None
     for s in discovered:
         if s.name == name:
@@ -202,16 +202,11 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
             result_parts.append(
                 f"\n\nThe following tools are now available: {', '.join(tool_names)}"
             )
-            shutdown_fn = getattr(module, "shutdown", None)
-            if shutdown_fn:
-                if not hasattr(ctx, "_skill_shutdown_hooks"):
-                    ctx._skill_shutdown_hooks = {}
-                ctx._skill_shutdown_hooks[name] = shutdown_fn
             log.info(f"Activated native skill '{name}' with tools: {tool_names}")
 
             # Cache tool names for always-loaded skills so tool_registry
             # can exempt them from deferral
-            if getattr(skill_info, "always_loaded", False):
+            if skill_info.always_loaded:
                 ctx.config.always_loaded_skill_tools = (
                     ctx.config.always_loaded_skill_tools | set(tool_names)
                 )

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -39,7 +39,7 @@ def get_critical_names(config) -> set[str]:
       first activation)
     """
     extra = set(config.agent.critical_tools)
-    for skill in getattr(config, "discovered_skills", []):
+    for skill in config.discovered_skills:
         if skill.always_loaded and skill.has_native_tools:
             extra |= config.always_loaded_skill_tools
     return extra

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -707,8 +707,8 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx,
     async def ws_send(msg):
         try:
             await websocket.send_json(msg)
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug("ws send failed (client likely disconnected): %s", exc)
 
     # Send available models immediately so the picker is visible before
     # any conversation is selected

--- a/src/decafclaw/widget_input.py
+++ b/src/decafclaw/widget_input.py
@@ -91,7 +91,7 @@ class WidgetResponseHandler:
             content = default_inject_message(response.data)
 
         # Write the synthetic user message so a subsequent turn sees it.
-        if ctx is not None and getattr(ctx, "conv_id", None):
+        if ctx is not None and ctx.conv_id:
             from .archive import append_message
             append_message(ctx.config, ctx.conv_id, {
                 "role": "user",

--- a/tests/test_notification_channels_email.py
+++ b/tests/test_notification_channels_email.py
@@ -9,10 +9,10 @@ import pytest
 
 from decafclaw import notifications as notifs
 from decafclaw.events import EventBus
+from decafclaw.notification_channels import meets_priority as _meets_priority
 from decafclaw.notification_channels.email import (
     _format_body,
     _format_subject,
-    _meets_priority,
     make_email_adapter,
 )
 

--- a/tests/test_notification_channels_mattermost.py
+++ b/tests/test_notification_channels_mattermost.py
@@ -9,9 +9,9 @@ import pytest
 
 from decafclaw import notifications as notifs
 from decafclaw.events import EventBus
+from decafclaw.notification_channels import meets_priority as _meets_priority
 from decafclaw.notification_channels.mattermost_dm import (
     _format_dm,
-    _meets_priority,
     _resolve_link,
     make_mattermost_dm_adapter,
 )

--- a/tests/test_notification_channels_vault_page.py
+++ b/tests/test_notification_channels_vault_page.py
@@ -10,12 +10,12 @@ import pytest
 
 from decafclaw import notifications as notifs
 from decafclaw.events import EventBus
+from decafclaw.notification_channels import meets_priority as _meets_priority
 from decafclaw.notification_channels import vault_page as vp_mod
 from decafclaw.notification_channels.vault_page import (
     _daily_page_path,
     _format_entry,
     _format_new_page_header,
-    _meets_priority,
     _resolve_link,
     make_vault_page_adapter,
 )

--- a/tests/test_widgets_input_flow.py
+++ b/tests/test_widgets_input_flow.py
@@ -28,11 +28,18 @@ def _make_manager(config):
 def _make_ctx(manager, conv_id):
     """Build a minimal ctx that has the manager-bound
     request_confirmation closure, mirroring how the ConversationManager
-    wires it in production."""
+    wires it in production — including the ``ctx.manager`` reference
+    that the cancel/cleanup path reads. ``cancelled`` defaults to None
+    to match the real ``Context`` initial state."""
     async def request_confirmation(request):
         return await manager.request_confirmation(conv_id, request)
 
-    return SimpleNamespace(request_confirmation=request_confirmation)
+    return SimpleNamespace(
+        request_confirmation=request_confirmation,
+        cancelled=None,
+        manager=manager,
+        conv_id=conv_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -163,7 +170,7 @@ async def test_ctx_without_request_confirmation_ends_turn(caplog):
     signal = WidgetInputPause(
         tool_call_id="tc-no-mgr",
         widget_payload={})
-    ctx = SimpleNamespace()  # no request_confirmation
+    ctx = SimpleNamespace(request_confirmation=None)  # mirrors Context default
 
     inject = await _handle_widget_input_pause(ctx, signal)
     assert inject is None
@@ -240,6 +247,8 @@ async def test_live_pause_clears_callback_even_on_exception(
                         {"tc-leak": lambda d: "unreached"})
 
     class _FailingCtx:
+        cancelled = None
+
         async def request_confirmation(self, _req):
             raise asyncio.CancelledError()
 


### PR DESCRIPTION
## Summary

Mechanical hygiene pass after a stretch of feature landings. Five categories of convention violations and small smells, verified against `CLAUDE.md`. No behavior changes.

- **Replace `getattr(obj, \"field\", default)` for declared fields** — 13 `discovered_skills` sites + a handful of others (`config.relevance`, `ctx.active_model`, `ctx.conv_id`, `ctx.channel_id`, `ctx.event_context_id`, `ctx.manager`, `ctx.cancelled`, `ctx.request_confirmation`, `skill_info.always_loaded`). CLAUDE.md flags this pattern as a maintenance trap; every site here was redundant.
- **Remove dead `_skill_shutdown_hooks` storage** — registered in `tools/skill_tools.py` but never read anywhere; deleting the 5-line block is cleaner than declaring an unused field on `Context`.
- **Replace `except: pass`** with `except Exception as exc: log.debug(...)` across 9 sites (`agent`, `mattermost` ×4, `mcp_client`, `web/websocket`, `llm/__init__`, `tools/__init__`). CLAUDE.md: \"never acceptable.\"
- **Extract duplicated priority helpers** — `_PRIORITY_ORDER` / `_PRIORITY_GLYPH` / `_meets_priority` were copy-pasted across `notification_channels/{email,mattermost_dm,vault_page}.py`. Now exported as `PRIORITY_ORDER` / `PRIORITY_GLYPH` / `meets_priority` from `notification_channels/__init__.py`.
- **Wrap `mail.py` attachment read** with `asyncio.to_thread(path.read_bytes)` to keep `send_mail` off the event loop.

Tests updated to import `meets_priority` from the new location and to declare the `Context`-default attributes that were missing on a few `SimpleNamespace` mocks.

Larger items surfaced during exploration but explicitly **out of scope** (documented in the dev-session `notes.md`): refactoring `run_agent_turn` / `_handle_reflection` / `http_server.create_app`, centralizing WebSocket message types, file-locking in `archive.append_message`, the `conversation_manager._save_conversation_state` field-list pattern.

Dev-session docs at `docs/dev-sessions/2026-04-26-1028-code-quality-sweep/`.

## Test plan

- [x] `make lint` clean (ruff)
- [x] `make typecheck` clean (pyright)
- [x] `make check-js` clean (tsc)
- [x] `make test` — 2027/2027 passing
- [ ] Smoke test live in Mattermost / web UI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)