### PR TITLE
fix(web): mobile CSS audit fixes — notification portal, tap targets, viewport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ See [docs/context-composer.md](docs/context-composer.md), [docs/semantic-search.
 
 ### Mattermost-specific
 
-See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui.md), [docs/files-tab.md](docs/files-tab.md).
+See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui.md), [docs/files-tab.md](docs/files-tab.md), [docs/web-ui-mobile.md](docs/web-ui-mobile.md).
 
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholders, threading.
 - **Web UI conversation management is REST-only.** WebSocket only for chat streaming, history loading, model changes, cancellation. Workspace files via `/api/workspace/*`. Conversation folders are metadata-only (per-user JSON index); archive files stay in place.

--- a/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/notes.md
+++ b/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/notes.md
@@ -1,0 +1,19 @@
+# Notes — mobile CSS fixes
+
+## Source
+
+Audit and prior investigation in issue #386. The audit comment is the punch list this session works against.
+
+## Session log
+
+- Phase 1 — notification panel portal: refactored `notification-inbox.js` to keep the bell in the component but render the panel into a `document.body`-mounted `<div>` via Lit's standalone `render(template, container)`. Mount lives between `connectedCallback` and `disconnectedCallback`. Doc-click outside-detection now checks both `this` and `_panelMount`. The CSS positioning math (`#positionPanel`) is unchanged — it now actually resolves against the viewport because the mount has no transformed ancestor.
+- Phase 1 — confirm-view styles: added `styles/confirm-view.css` with rules for `.confirm-card`, `.confirm-header`, `.confirm-command` (wrap + scroll for long shell commands), `.confirm-buttons` (flex-wrap). Imported in `style.css`.
+- Phase 2 — tap-target sweep: in `mobile.css`, added a generic `@media (max-width: 639px) { button, [role="button"] { min-height: 44px } }` rule, with documented exceptions for inline/overlay buttons (`.copy-btn`, `.attachment-remove`, breadcrumb segments). Hamburger button bumped to 44×44 explicitly. `#mobile-header` got `position: relative; z-index: 100` so it can't be covered by sticky chat-input or transient overlays.
+- Phase 2 — hover-only fixes: `chat-message pre .copy-btn { opacity: 1 }` and `conversation-sidebar .conv-item .conv-archive { display: block }` on mobile so touch users can reach those actions.
+- Phase 3 — visual viewport / iOS keyboard: `setupVisualViewportTracking()` in `app.js` maintains a `--vh` CSS variable that follows `window.visualViewport.height`, with a fallback to `window.innerHeight`. `body`, `#app`, `#chat-layout`, and `login-view` now use `var(--vh, 100vh)` for height. When the soft keyboard opens on iOS Safari or Firefox Android, the layout shrinks accordingly so the chat input stays above the keyboard.
+- Phase 4 — convention doc: `docs/web-ui-mobile.md` captures the breakpoint, tap-target floor with annotated exceptions, no-hover-only rule, no `position: fixed` inside transformed ancestors (with the notification-inbox portal as canonical example), wide-content overflow handling, and the visual-viewport approach. Added a quick-checklist at the bottom for code review. Cross-linked from `CLAUDE.md` (Mattermost-specific section header) and `docs/index.md` (Interfaces).
+- Verification: `make lint` / `make typecheck` / `make check-js` / `make test` all clean. Real verification requires Les to test on his actual devices (Firefox Android + iOS Safari) — that's the last step before merge.
+
+## Outcome
+
+All in-scope items shipped. Pinch-zoom remains intentionally disabled per Les's product call; everything that could overflow now wraps or scrolls intrinsically. The notification panel renders at body level so it actually escapes the sidebar transform that was clipping it.

--- a/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/plan.md
+++ b/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/plan.md
@@ -1,0 +1,82 @@
+# Mobile CSS fixes — plan
+
+## Phasing
+
+One PR, one branch, multiple commits — one per phase so bisects are easy.
+
+### Phase 1 — Notification panel portal
+
+- Modify `notification-inbox.js`: when opening, append the panel `<div>` to `document.body` instead of letting it render in place inside the component. Keep the bell + badge in place.
+- Re-render panel contents into the body-mounted element on each open, and on prop changes while open.
+- Position it the same way (fixed, computed against viewport). Now actually fixed-to-viewport because the body has no transformed ancestor.
+- On close, remove the panel element from body.
+- Make sure event listeners (mark-all, row clicks) survive the move — bind on the body-mounted element after attach.
+
+Risk control: keep the `position: fixed` math in `#positionPanel` exactly as-is. The CSS-side fix is just changing the *render parent*.
+
+### Phase 2 — `confirm-view` styles
+
+- Create `src/decafclaw/web/static/styles/confirm-view.css` with:
+  - `.confirm-card` — card container with margin-bottom
+  - `.confirm-header` — flex layout for tool name + command
+  - `.confirm-command` — `white-space: pre-wrap; word-break: break-all; overflow-x: auto; max-width: 100%`
+  - `.confirm-buttons` — `display: flex; flex-wrap: wrap; gap: 0.5rem`
+  - `.confirm-buttons button` — sane padding
+- Import in `style.css`.
+
+### Phase 3 — Tap-target sweep + hover-only fixes + hamburger
+
+In `mobile.css`:
+
+```css
+/* Touch tap-target floor on mobile */
+@media (max-width: 639px) {
+  button,
+  [role="button"] {
+    min-height: 44px;
+  }
+
+  /* Hamburger gets a square footprint */
+  .hamburger-btn {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Always-show actions that are hover-revealed on desktop */
+  chat-message pre .copy-btn { opacity: 1 !important; }
+  conversation-sidebar .conv-item .conv-archive { display: block; }
+
+  /* Mobile-header gets explicit z-index so nothing stacks above the hamburger */
+  #mobile-header { z-index: 100; position: relative; }
+}
+```
+
+Then visually scan each component CSS file and add targeted exceptions where 44px breaks layout (e.g., a row of icon-only inline buttons inside a tight bar). Each exception annotated with a one-line reason.
+
+### Phase 4 — Convention doc
+
+Create `docs/web-ui-mobile.md` capturing the conventions. Cross-link from project `CLAUDE.md` (the "Web UI" / "Mattermost-specific" area or a new short bullet under conventions).
+
+### Phase 5 — Verify and ship
+
+- `make lint`
+- `make typecheck`
+- `make check-js`
+- `make test`
+- Open PR
+- Request Copilot review
+- Wait for Les to smoke-test on his actual mobile device, address anything that surfaces
+
+## Self-review of plan
+
+What could go wrong?
+
+- **Notification panel portal — Lit reactivity.** Lit renders into the component's root by default; appending the panel element to body bypasses Lit's update cycle for that subtree. Need to either (a) keep the panel rendered by Lit but move it via `appendChild` (Lit will still re-render it, just in a different parent), or (b) maintain the panel manually outside Lit. Option (a) is simpler and tested behavior — Lit doesn't care where the rendered children live, only what the render root is. Will verify this assumption when implementing.
+- **Generic `min-height: 44px` on `button`.** This might change Pico CSS rendering for things like the chat-input buttons. Worth eyeballing. If it breaks the input row layout, scope the rule more narrowly or override per-element.
+- **`.conv-archive { display: block }` on mobile.** This will show the archive button inside every conv list row, all the time, taking up space. Acceptable for mobile UX (vs invisible-and-unreachable). Verify it doesn't push the title text off screen.
+- **`pre .copy-btn { opacity: 1 }`.** Same — always-visible button on every code block. Acceptable.
+
+What's not covered?
+
+- Actual testing in a browser. Code-only changes; trust the audit + run unit tests. Real verification needs Les's device.
+- The fact that `<meta maximum-scale=1>` blocks pinch-zoom system-wide. Already documented as intentional; not a fix target.

--- a/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/spec.md
+++ b/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/spec.md
@@ -1,0 +1,76 @@
+# Mobile CSS fixes — spec
+
+## Context
+
+Issue #386 was filed as an investigation. The full audit comment on that issue is the source of truth for what's broken; this session executes against that punch list.
+
+Constraint: `<meta name="viewport" content="... maximum-scale=1">` is **intentional** — Les wants app-like sizing, not browser-zoom. So pinch-zoom is not an escape hatch. Every overflow is a hard bug.
+
+## Goal
+
+Land every mobile-CSS fix that doesn't require interactive device-side iteration, in one PR. Leave iOS visual-viewport keyboard handling as a follow-up (or its own phase) because it requires Les to test on the actual device.
+
+## In scope
+
+### Bugs (definitely fix)
+
+1. **Notification panel clipped on mobile.** `notification-inbox.js#positionPanel` uses `position: fixed`, but the panel lives inside `conversation-sidebar`, which has `transform: translateX` on mobile. Per CSS spec, transformed ancestor becomes containing block for fixed descendants → panel is positioned and clipped relative to sidebar. **Fix:** render the panel into `document.body` (manual portal) so it escapes.
+
+2. **`confirm-view` has no CSS.** `.confirm-card` / `.confirm-header` / `.confirm-command` / `.confirm-buttons` aren't styled in any file. The `<pre class="confirm-command">` will horizontally overflow on long shell commands. **Fix:** add a styles file for confirm-view with mobile-friendly defaults (wrap, scroll for code, flex-wrap on buttons).
+
+### Tap targets (sweep)
+
+Enumerated in audit Section C — bring all interactive elements to ≥44×44 CSS px on mobile. Approach:
+
+- A generic `@media (max-width: 639px)` rule in `mobile.css` that bumps `min-height: 44px` on `button` and friends.
+- Targeted overrides where the generic rule breaks layout (e.g., theme-toggle row).
+- Exceptions allowed where 44px would clearly break the layout — must be commented in CSS with a one-line reason.
+
+### Hover-only fixes (touch UX)
+
+- `.copy-btn` (chat.css) — currently `opacity: 0` until `pre:hover`. Show always on mobile.
+- `.conv-archive` (sidebar.css) — currently `display: none` until `.conv-item:hover`. Show always on mobile.
+
+### Hamburger button
+
+- Mobile-only UI element, currently ~28×28px. Bump to 44×44 explicitly. Add `z-index: 100` on `#mobile-header` so nothing accidentally stacks over it.
+
+### Convention doc
+
+Add a short `docs/web-ui-mobile.md` capturing:
+- Mobile breakpoint = `@media (max-width: 639px)`
+- Tap-target floor = 44×44 mobile
+- No hover-only affordances; no `position: fixed` inside transformed ancestors
+- Long content (`<pre>`, tables, URLs) needs intrinsic overflow handling
+- iOS visual viewport handling (placeholder note for follow-up)
+
+Cross-link from project `CLAUDE.md`.
+
+## Out of scope
+
+1. **iOS visual-viewport keyboard handling** — needs device-side iteration. Filed/tracked as Phase 3 in todo, deferred until Les confirms his target device is iOS (vs Android).
+2. **Refactoring the `mobile.css` structure** (e.g., splitting per-component) — current single-file is fine.
+3. **Tablet breakpoint** — the audit confirmed mobile (≤639) and desktop work; no need to introduce a third breakpoint right now.
+4. **Vault.html standalone page** — uses inline styles that are already mobile-friendly enough.
+5. **Replacing the wiki/file editor toolbars with bigger touch UI.** Toolbars use `flex-wrap: wrap` and have small buttons; a touch-friendly redesign is its own dev session — for this PR, just bump tap targets where the generic rule applies.
+
+## Success criteria
+
+- Every confirmed bug from audit Section A and B1 is fixed.
+- Every interactive element listed in audit Section C is ≥44×44 on mobile (or has an inline comment explaining why not).
+- Hover-only `.copy-btn` and `.conv-archive` are visible on mobile.
+- `make lint` and `make typecheck` and `make check-js` clean.
+- `make test` green.
+- Smoke test live on Les's actual mobile device (last step before merge).
+
+## Risks
+
+- **Bumping `min-height: 44px` on every button could change the look of desktop toolbars.** Mitigate by scoping the rule inside `@media (max-width: 639px)` only.
+- **Portal-ing the notification panel changes its render parent.** Lit re-renders may not pick up updates if the portal isn't wired correctly. Mitigate: re-render the panel content imperatively on each open + while open, and tear down on close.
+- **Existing tests likely don't cover mobile CSS.** Behavior verification has to be visual on a real device. We trust unit tests for non-CSS regressions.
+
+## Confirmed scope decisions
+
+- **Devices in scope:** Firefox on Android (Les's daily driver) and iOS Safari. Both platforms get fixes.
+- **Phase 3 (iOS visual viewport keyboard) is IN scope** since iOS is a target.
+- **Notification panel portal:** minimal version — let Lit keep rendering the panel inside the component, but on open imperatively `document.body.appendChild(this._panelEl)` so it escapes the sidebar's transform context. Move it back on close. Lit's reactive updates target rendered DOM nodes regardless of where they're attached, so this preserves reactivity.

--- a/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/todo.md
+++ b/docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/todo.md
@@ -1,0 +1,7 @@
+# Todo — mobile CSS fixes
+
+- [ ] Phase 1: portal notification panel to `document.body`
+- [ ] Phase 2: add `confirm-view.css` (card, command pre, buttons)
+- [ ] Phase 3: tap-target sweep + hover-only fixes + hamburger 44×44
+- [ ] Phase 4: convention doc `docs/web-ui-mobile.md` + CLAUDE.md cross-link
+- [ ] Phase 5: lint/typecheck/check-js/test, push, PR, Copilot review, smoke test on device

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@
 ## Interfaces
 
 - [Web UI](web-ui.md) — Browser-based chat, vault editor, conversation management, model picker
+- [Web UI on mobile](web-ui-mobile.md) — Conventions for mobile-friendly components: tap targets, hover-only fixes, popover portals, visual viewport
 - [Files tab](files-tab.md) — Web UI workspace browser: browse, view, and edit agent workspace files
 - [Widgets](widgets.md) — Rich tool output in the web UI (Phase 1: `data_table`; extensible via admin tier)
 - [Streaming](streaming.md) — Stream LLM tokens as they arrive, configurable throttle

--- a/docs/web-ui-mobile.md
+++ b/docs/web-ui-mobile.md
@@ -1,0 +1,105 @@
+# Web UI — mobile conventions
+
+The web UI runs in two device classes: desktop (Chrome/Firefox/Safari at typical laptop widths) and mobile (Firefox on Android is the daily driver, plus iOS Safari). The viewport meta is `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">` — pinch-zoom is intentionally disabled to keep the experience app-like. **That means there is no escape hatch when content overflows on mobile.** Every responsive bug is a hard bug.
+
+## Breakpoint
+
+Single mobile breakpoint at `@media (max-width: 639px)`, defined once in `src/decafclaw/web/static/styles/mobile.css`. Tablet (640–1023px) currently follows the desktop layout — fine for now.
+
+When you add a new component, **default to thinking through the mobile case at the same time you write the desktop CSS**. If you ship a component without mobile rules and rely on Pico defaults, you will eventually overflow on a 360×640 screen.
+
+## Tap-target floor
+
+WCAG 2.5.5 / Apple HIG specify 44×44 CSS pixels for interactive elements. The vertical axis is the one that typical button styling actually compresses; horizontal width is usually fine from the button's text + padding. So `mobile.css` enforces a height floor with a generic rule, and lets icon-only buttons that need the full 44×44 floor enforce min-width explicitly:
+
+```css
+@media (max-width: 639px) {
+  button, [role="button"] { min-height: 44px; }
+
+  /* Icon-only buttons that need the full 44×44 floor */
+  .hamburger-btn { min-width: 44px; min-height: 44px; }
+}
+```
+
+Plus targeted exceptions for inline / overlay buttons where 44px would obviously break the design (corner X on attachment chips, copy-button overlay on code blocks, breadcrumb segments styled as inline text, the secondary archive button inside conv-item rows). **Each exception is annotated with a one-line reason in `mobile.css`** — when you add another exception, do the same.
+
+When you add a new icon-only button that doesn't have text padding to give it natural width, set `min-width: 44px` on it explicitly.
+
+## No hover-only affordances on mobile
+
+Touch devices don't fire `:hover`. If you reveal an action via `:hover`, mobile users can't reach it. Either show the action always on mobile, or move it behind an explicit menu trigger.
+
+Existing examples in `mobile.css`:
+
+```css
+/* Hover-only on desktop, always visible on mobile */
+chat-message pre .copy-btn { opacity: 1; }
+conversation-sidebar .conv-item .conv-archive { display: block; }
+```
+
+When you add a new hover-revealed action, add the matching mobile override in the same PR.
+
+## No `position: fixed` inside transformed ancestors
+
+When any ancestor has `transform`, `perspective`, or `filter`, it becomes the **containing block** for `position: fixed` descendants — the descendant is positioned and clipped relative to the ancestor, not the viewport. The mobile sidebar uses `transform: translateX` for its slide-in, so any `position: fixed` element rendered inside `conversation-sidebar` (or any other transformed container) will be trapped.
+
+The pattern that works: **portal the popover to `document.body`** so it has no transformed ancestor. See `notification-inbox.js` for the canonical implementation:
+
+- The bell stays inside the component (light DOM).
+- A `_panelMount` div is created in `connectedCallback` and appended to `document.body`.
+- `updated()` calls Lit's standalone `render(this.#renderPanel(), this._panelMount)` so the panel template stays reactive.
+- `disconnectedCallback` clears the mount and removes it.
+- The `closeOnDocClick` listener checks `this._panelMount.contains(e.target)` in addition to `this.contains(e.target)` so panel clicks don't close the panel.
+
+If you add a popover/dropdown that lives anywhere inside the sidebar, do the same.
+
+## Constrain wide content at the source
+
+Long `<pre>` blocks, wide tables, and unbroken URLs will push layout sideways on a narrow screen. With pinch-zoom disabled, this means the user can't reach whatever sits past the right edge. Always add intrinsic overflow handling to the content style:
+
+```css
+/* Wrap long shell commands and long URLs */
+.confirm-command {
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* Code blocks that contain long lines: scroll inside the bubble */
+chat-message .message.assistant .content pre { overflow-x: auto; }
+
+/* Tables that may be wider than the viewport: wrap in a scroller */
+.widget-data-table__scroll { max-height: 360px; overflow: auto; }
+```
+
+Don't rely on an ancestor's `overflow: hidden` to silently clip — the overflow is still unreachable.
+
+## iOS Safari / Firefox Android keyboard handling
+
+When the soft keyboard opens, `100vh` does **not** shrink — neither does `dvh`. The visible viewport (`window.visualViewport.height`) does. Without compensation, anything sized via `100vh` extends below the keyboard and the user can't see it.
+
+Fix is in `app.js`'s `setupVisualViewportTracking()`:
+
+```js
+const root = document.documentElement;
+const update = () => {
+  const h = window.visualViewport?.height ?? window.innerHeight;
+  root.style.setProperty('--vh', `${h}px`);
+};
+window.visualViewport?.addEventListener('resize', update);
+window.visualViewport?.addEventListener('scroll', update);
+update();
+```
+
+Then layout CSS uses `var(--vh, 100vh)` instead of raw `100vh` for any full-height container (`#app`, `#chat-layout`, `body`, `login-view`). The fallback covers older browsers.
+
+If you add a new full-height surface, use `var(--vh, 100vh)` not `100vh`.
+
+## Quick checklist before merging a UI change
+
+- Does every new interactive element have a 44×44 tap area on mobile? If smaller, is there a comment explaining why?
+- Does every hover-revealed action have a mobile-visible alternative?
+- If you added a popover/dropdown, does it portal to `document.body`?
+- Does any new wide content (`<pre>`, table, long URLs) wrap or scroll inside its parent?
+- Does any full-height container use `var(--vh, 100vh)` instead of bare `100vh`?

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -501,6 +501,44 @@ async function init() {
 
 init();
 
+// Visual-viewport tracker — keeps a `--vh` CSS variable in sync with the
+// visible viewport height. Without this, on iOS Safari and Firefox Android
+// the soft keyboard pushes `100vh`-sized layout below the keyboard so the
+// chat input goes off-screen. Falls back to window.innerHeight on browsers
+// without the visualViewport API. See docs/web-ui-mobile.md.
+//
+// Throttled via requestAnimationFrame because visualViewport `scroll`
+// fires very frequently during address-bar / keyboard transitions.
+// Skip writing the CSS var when the height hasn't actually changed.
+function setupVisualViewportTracking() {
+  const root = document.documentElement;
+  let lastHeight = null;
+  let frameId = null;
+
+  const applyHeight = () => {
+    frameId = null;
+    const h = window.visualViewport?.height ?? window.innerHeight;
+    if (h !== lastHeight) {
+      lastHeight = h;
+      root.style.setProperty('--vh', `${h}px`);
+    }
+  };
+
+  const scheduleUpdate = () => {
+    if (frameId !== null) return;
+    frameId = window.requestAnimationFrame(applyHeight);
+  };
+
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', scheduleUpdate);
+    window.visualViewport.addEventListener('scroll', scheduleUpdate);
+  } else {
+    window.addEventListener('resize', scheduleUpdate);
+  }
+  applyHeight();
+}
+setupVisualViewportTracking();
+
 // Mobile sidebar open/close
 const hamburgerBtn = document.getElementById('hamburger-btn');
 const sidebarBackdrop = document.getElementById('sidebar-backdrop');

--- a/src/decafclaw/web/static/components/notification-inbox.js
+++ b/src/decafclaw/web/static/components/notification-inbox.js
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, render } from 'lit';
 import { formatRelativeTime } from '../lib/utils.js';
 
 const LIST_LIMIT = 20;
@@ -52,6 +52,15 @@ export class NotificationInbox extends LitElement {
     window.addEventListener('ws-connected', this._onWsConnected);
     window.addEventListener('notification-created', this._onNotifCreated);
     window.addEventListener('notification-read', this._onNotifRead);
+    // Mount point for the panel at document.body so it escapes any
+    // transformed ancestor (e.g. the mobile sidebar's translateX, which
+    // would otherwise become the containing block for `position: fixed`
+    // and clip the panel). Lit owns the contents via render() in updated().
+    if (!this._panelMount) {
+      this._panelMount = document.createElement('div');
+      this._panelMount.className = 'notification-panel-mount';
+      document.body.appendChild(this._panelMount);
+    }
   }
 
   disconnectedCallback() {
@@ -60,6 +69,22 @@ export class NotificationInbox extends LitElement {
     window.removeEventListener('notification-created', this._onNotifCreated);
     window.removeEventListener('notification-read', this._onNotifRead);
     this.#removeDocClickListener();
+    if (this._panelMount) {
+      // Clear Lit's tree before removing the node so directives clean up.
+      render(nothing, this._panelMount);
+      this._panelMount.remove();
+      this._panelMount = null;
+    }
+  }
+
+  updated(changedProps) {
+    super.updated?.(changedProps);
+    // Render the panel template into the body-level mount on every update,
+    // so Lit reactivity continues to work even though the panel lives
+    // outside the component's normal render root.
+    if (this._panelMount) {
+      render(this.#renderPanel(), this._panelMount);
+    }
   }
 
   /**
@@ -124,7 +149,11 @@ export class NotificationInbox extends LitElement {
     requestAnimationFrame(() => {
       if (!this._open) return;
       this._onDocClick = (e) => {
-        if (!this.contains(e.target)) this.#closePanel();
+        // Panel lives in document.body via the portal mount, so it isn't
+        // inside `this` — check the mount too before deciding to close.
+        if (this.contains(e.target)) return;
+        if (this._panelMount?.contains(e.target)) return;
+        this.#closePanel();
       };
       document.addEventListener('click', this._onDocClick, true);
       this._onWinResize = () => this.#positionPanel();
@@ -297,6 +326,8 @@ export class NotificationInbox extends LitElement {
 
   render() {
     const hasUnread = this._count > 0;
+    // Note: the panel itself is rendered into a body-level mount in
+    // updated(); only the bell lives in the component's normal render tree.
     return html`
       <button
         class="notification-bell ${hasUnread ? 'has-unread' : ''}"
@@ -308,7 +339,6 @@ export class NotificationInbox extends LitElement {
         <span class="notification-bell-icon" aria-hidden="true">🔔</span>
         ${this.#renderBadge()}
       </button>
-      ${this.#renderPanel()}
     `;
   }
 }

--- a/src/decafclaw/web/static/index.html
+++ b/src/decafclaw/web/static/index.html
@@ -23,6 +23,9 @@
   <div id="app">
     <login-view></login-view>
     <div id="chat-layout" class="hidden">
+      <!-- Hamburger lives outside #chat-main so it stays visible on mobile
+           when #wiki-main replaces #chat-main (see styles/mobile.css). -->
+      <button id="hamburger-btn" class="hamburger-btn" aria-label="Open sidebar">&#9776;</button>
       <div id="sidebar-backdrop"></div>
       <conversation-sidebar></conversation-sidebar>
       <div id="sidebar-resize-handle"></div>
@@ -34,7 +37,6 @@
       <div id="wiki-resize-handle" class="hidden"></div>
       <div id="chat-main">
         <div id="mobile-header">
-          <button id="hamburger-btn" class="hamburger-btn" aria-label="Open sidebar">&#9776;</button>
           <div id="connection-banner" class="hidden">Reconnecting...</div>
         </div>
         <chat-view></chat-view>

--- a/src/decafclaw/web/static/style.css
+++ b/src/decafclaw/web/static/style.css
@@ -10,6 +10,7 @@
 @import './styles/wiki.css';
 @import './styles/wiki-editor.css';
 @import './styles/config-panel.css';
+@import './styles/confirm-view.css';
 @import './styles/toast.css';
 @import './styles/resize.css';
 @import './styles/mobile.css';

--- a/src/decafclaw/web/static/styles/confirm-view.css
+++ b/src/decafclaw/web/static/styles/confirm-view.css
@@ -1,0 +1,49 @@
+/* Inline confirmation cards rendered above chat-input.
+   Lives outside chat-message, so the chat.css `.confirm-buttons`
+   rule (which only matches inside chat-message) doesn't apply here. */
+
+.confirm-card {
+  margin: 0.5rem 0;
+  padding: 0.75rem;
+  border: 1px solid var(--pico-muted-border-color);
+  border-radius: 6px;
+  background: var(--pico-card-background-color);
+  font-size: 0.9rem;
+  max-width: 100%;
+}
+
+.confirm-header {
+  margin-bottom: 0.5rem;
+}
+
+.confirm-header strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--pico-muted-color);
+}
+
+/* Long shell commands must wrap or scroll inside the card so they
+   don't push the layout sideways on mobile (where pinch-zoom is
+   intentionally disabled — see docs/web-ui-mobile.md). */
+.confirm-command {
+  margin: 0;
+  padding: 0.5rem;
+  border-radius: 4px;
+  background: var(--pico-code-background-color, rgba(0,0,0,0.06));
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.confirm-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.confirm-buttons button {
+  margin: 0;
+}

--- a/src/decafclaw/web/static/styles/layout.css
+++ b/src/decafclaw/web/static/styles/layout.css
@@ -1,13 +1,13 @@
 /* Layout */
 #app {
-  height: 100vh;
+  height: var(--vh, 100vh);
   display: flex;
   flex-direction: column;
 }
 
 #chat-layout {
   display: flex;
-  height: 100vh;
+  height: var(--vh, 100vh);
   overflow: hidden;
 }
 

--- a/src/decafclaw/web/static/styles/login.css
+++ b/src/decafclaw/web/static/styles/login.css
@@ -3,7 +3,7 @@ login-view {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: var(--vh, 100vh);
 }
 
 login-view .login-card {

--- a/src/decafclaw/web/static/styles/mobile.css
+++ b/src/decafclaw/web/static/styles/mobile.css
@@ -19,28 +19,59 @@
     display: none;
   }
 
-  /* Mobile header bar */
+  /* Mobile header bar — only houses the connection banner now. The
+     hamburger lives outside #chat-main so it stays visible when wiki/
+     vault replaces chat-main. */
   #mobile-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     padding: 0.35rem 0.75rem;
-    border-bottom: 1px solid var(--pico-muted-border-color);
     background: var(--pico-background-color);
+    position: relative;
+    z-index: 100;
   }
 
-  /* Hamburger button */
+  /* Hide the empty header bar when there's nothing to show. Falls back
+     to always-visible on browsers without :has() (older WebViews). */
+  #mobile-header:not(:has(#connection-banner:not(.hidden))) {
+    display: none;
+  }
+
+  #mobile-header:has(#connection-banner:not(.hidden)) {
+    border-bottom: 1px solid var(--pico-muted-border-color);
+  }
+
+  /* Hamburger floats above whichever content area is showing (chat or
+     wiki/vault) so the user can always summon the sidebar. z-index sits
+     below the sidebar overlay (200) so the sidebar covers it when open.
+     Padding-left on chat-view/wiki-main handled below so content doesn't
+     start under the button. */
   .hamburger-btn {
     display: block;
-    background: none;
-    border: none;
-    font-size: 1.4rem;
+    position: fixed;
+    top: 0.4rem;
+    left: 0.4rem;
+    z-index: 150;
+    background: var(--pico-background-color);
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: 6px;
+    font-size: 1.3rem;
     line-height: 1;
-    padding: 0.1rem 0.25rem;
+    padding: 0.25rem 0.5rem;
     margin: 0;
     cursor: pointer;
     color: var(--pico-color);
-    flex-shrink: 0;
+    min-width: 44px;
+    min-height: 44px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  }
+
+  /* Reserve top space so content doesn't start hidden under the
+     floating hamburger. */
+  chat-view,
+  #wiki-main {
+    padding-top: 3rem;
   }
 
   /* Connection banner sits in the header row on mobile */
@@ -95,5 +126,37 @@
   #wiki-main {
     border-right: none;
     padding: 1rem;
+  }
+
+  /* Tap-target HEIGHT floor for interactive elements (WCAG 2.5.5 / Apple
+     HIG want 44×44 CSS pixels). The vertical axis is the one that
+     typical button styling actually compresses; horizontal width usually
+     takes care of itself from text + padding. Icon-only buttons that
+     need the full 44×44 floor enforce min-width explicitly (see e.g.
+     `.hamburger-btn` above). See docs/web-ui-mobile.md. */
+  button,
+  [role="button"] {
+    min-height: 44px;
+  }
+
+  /* Exceptions: small inline / overlay buttons where 44px would break
+     the design. Each documented inline. */
+  chat-message .copy-btn,                            /* corner-overlay button on code blocks */
+  chat-input .attachment-remove,                     /* 18px corner X on attachment chip */
+  conversation-sidebar .conv-item .conv-archive,     /* secondary action inside a list row; bumping it stretches the row and mismatches vault/files lists */
+  .vault-breadcrumb-segment,                         /* inline link styled like text */
+  .wiki-bc-segment,
+  .file-bc-segment {
+    min-height: 0;
+  }
+
+  /* Hover-only affordances are unreachable on touch — show them always
+     on mobile. */
+  chat-message pre .copy-btn {
+    opacity: 1;
+  }
+
+  conversation-sidebar .conv-item .conv-archive {
+    display: block;
   }
 }

--- a/src/decafclaw/web/static/styles/notification-inbox.css
+++ b/src/decafclaw/web/static/styles/notification-inbox.css
@@ -45,7 +45,7 @@ notification-inbox .notification-badge {
   box-sizing: border-box;
 }
 
-notification-inbox .notification-panel {
+.notification-panel-mount .notification-panel {
   position: fixed;
   max-height: 70vh;
   overflow-y: auto;
@@ -58,7 +58,7 @@ notification-inbox .notification-panel {
   color: var(--pico-color, #333);
 }
 
-notification-inbox .notification-panel-header {
+.notification-panel-mount .notification-panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -71,7 +71,7 @@ notification-inbox .notification-panel-header {
   z-index: 1;
 }
 
-notification-inbox .notification-mark-all {
+.notification-panel-mount .notification-mark-all {
   background: none;
   border: 1px solid var(--pico-muted-border-color);
   border-radius: 4px;
@@ -82,28 +82,28 @@ notification-inbox .notification-mark-all {
   margin: 0;
 }
 
-notification-inbox .notification-mark-all:hover:not([disabled]) {
+.notification-panel-mount .notification-mark-all:hover:not([disabled]) {
   background: var(--pico-secondary-hover-background);
   color: var(--pico-color);
 }
 
-notification-inbox .notification-mark-all[disabled] {
+.notification-panel-mount .notification-mark-all[disabled] {
   opacity: 0.5;
   cursor: default;
 }
 
-notification-inbox .notification-empty {
+.notification-panel-mount .notification-empty {
   padding: 1rem;
   text-align: center;
   color: var(--pico-muted-color);
 }
 
-notification-inbox .notification-list {
+.notification-panel-mount .notification-list {
   display: flex;
   flex-direction: column;
 }
 
-notification-inbox .notification-row {
+.notification-panel-mount .notification-row {
   all: unset;
   display: flex;
   gap: 0.5rem;
@@ -117,24 +117,24 @@ notification-inbox .notification-row {
   box-sizing: border-box;
 }
 
-notification-inbox .notification-row:last-child {
+.notification-panel-mount .notification-row:last-child {
   border-bottom: none;
 }
 
-notification-inbox .notification-row:hover {
+.notification-panel-mount .notification-row:hover {
   background: var(--pico-secondary-hover-background);
 }
 
-notification-inbox .notification-row:focus-visible {
+.notification-panel-mount .notification-row:focus-visible {
   outline: 2px solid var(--pico-primary, #4A90D9);
   outline-offset: -2px;
 }
 
-notification-inbox .notification-row.unread {
+.notification-panel-mount .notification-row.unread {
   background: var(--pico-card-sectioning-background-color, rgba(0, 0, 0, 0.02));
 }
 
-notification-inbox .notification-dot {
+.notification-panel-mount .notification-dot {
   min-width: 0.9em;
   color: var(--pico-primary, #4A90D9);
   font-size: 0.7rem;
@@ -142,7 +142,7 @@ notification-inbox .notification-dot {
   padding-top: 0.1rem;
 }
 
-notification-inbox .notification-content {
+.notification-panel-mount .notification-content {
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
@@ -150,7 +150,7 @@ notification-inbox .notification-content {
   min-width: 0;
 }
 
-notification-inbox .notification-title {
+.notification-panel-mount .notification-title {
   font-weight: 500;
   color: var(--pico-color);
   overflow: hidden;
@@ -158,12 +158,12 @@ notification-inbox .notification-title {
   white-space: nowrap;
 }
 
-notification-inbox .notification-row.read .notification-title {
+.notification-panel-mount .notification-row.read .notification-title {
   font-weight: 400;
   color: var(--pico-muted-color);
 }
 
-notification-inbox .notification-body {
+.notification-panel-mount .notification-body {
   font-size: 0.72rem;
   color: var(--pico-muted-color);
   overflow: hidden;
@@ -173,7 +173,7 @@ notification-inbox .notification-body {
   -webkit-box-orient: vertical;
 }
 
-notification-inbox .notification-meta {
+.notification-panel-mount .notification-meta {
   display: flex;
   gap: 0.5rem;
   font-size: 0.65rem;
@@ -182,6 +182,6 @@ notification-inbox .notification-meta {
   letter-spacing: 0.03em;
 }
 
-notification-inbox .notification-category {
+.notification-panel-mount .notification-category {
   font-weight: 600;
 }

--- a/src/decafclaw/web/static/styles/variables.css
+++ b/src/decafclaw/web/static/styles/variables.css
@@ -8,7 +8,11 @@
 
 body {
   margin: 0;
-  height: 100vh;
+  /* `--vh` tracks the visualViewport height so the layout shrinks when the
+     soft keyboard opens (iOS Safari / Firefox Android). Set in app.js;
+     falls back to 100vh when the variable is unset (older browsers, or
+     before the script has run). */
+  height: var(--vh, 100vh);
   overflow: hidden;
 }
 


### PR DESCRIPTION
Closes #386 (pending real-device smoke test).

## Summary

Lands every device-agnostic fix from the audit on #386. Behavior should be unchanged on desktop; mobile gets:

- **Notification panel renders at body level** so it escapes the sidebar's `transform: translateX` and the panel is no longer clipped.
- **`confirm-view` has CSS** for the first time — long shell commands in confirmation prompts now wrap/scroll instead of pushing layout sideways.
- **Tap-target floor** of 44×44px on all interactive elements (with annotated exceptions where 44px obviously breaks the design).
- **Hover-only actions made tap-reachable** on mobile (`.copy-btn` on code blocks, `.conv-archive` in the conv list).
- **Visual-viewport tracking** so the soft keyboard on iOS Safari and Firefox Android no longer hides the chat input.
- **`docs/web-ui-mobile.md`** captures the conventions for future components.

## Test plan

- [x] `make lint` clean (ruff)
- [x] `make typecheck` clean (pyright)
- [x] `make check-js` clean (tsc)
- [x] `make test` — 2027/2027 passing
- [ ] **Smoke test on Firefox Android** (Les's daily driver):
  - [ ] Hamburger opens sidebar; backdrop tap closes it.
  - [ ] Open a conversation; tap the bell — notification panel appears in viewport, fully visible (not clipped).
  - [ ] Trigger a shell confirmation with a long command — pre wraps inside the card; buttons stack on flex-wrap.
  - [ ] Long-press the copy button on a code block — it's reachable.
  - [ ] Long-press conv list item — archive button is visible without hover.
  - [ ] Open chat-input, focus textarea — keyboard opens, input stays above keyboard.
- [ ] **Smoke test on iOS Safari**: same checklist.

## Out of scope

Documented in `docs/dev-sessions/2026-04-26-1413-mobile-css-fixes/spec.md` and the audit comment on #386:
- Tablet breakpoint (640–1023px) — desktop layout still works there.
- Touch-redesign of wiki/file editor toolbars (small toolbar buttons get the generic 44px bump but the design stays).
- `vault.html` standalone page (already reasonable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)