### PR TITLE
delegate_task: default-deny vault access + opt-in flags

### DIFF
--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -32,12 +32,30 @@ Each call spawns an independent child agent that:
 |-------|----------|-------------|
 | `task` | Yes | Task description — becomes the child agent's user message |
 | `model` | No | Named model config for the subtask. Omit to inherit parent's model. See [Model Selection](model-selection.md). |
+| `allow_vault_retrieval` | No | Opt the child INTO proactive memory retrieval at turn start. Default `false`. See [Vault access](#vault-access). |
+| `allow_vault_read` | No | Opt the child INTO read-side vault tools (`vault_read`, `vault_search`, etc.). Default `false`. See [Vault access](#vault-access). |
+
+## Vault access
+
+By default, child agents have **no vault access at all** — no proactive retrieval, no read tools, no write tools. The parent opts the child in via flags on `delegate_task`:
+
+| Flag | Effect |
+|---|---|
+| `allow_vault_retrieval=True` | Child runs the proactive memory retrieval at turn start (`skip_vault_retrieval=False`). |
+| `allow_vault_read=True` | Child can call `vault_read`, `vault_search`, `vault_list`, `vault_backlinks`, `vault_show_sections`. |
+
+**Vault writes are categorically blocked** for children regardless of flags. The set is hardcoded in `_VAULT_WRITE_TOOLS` and includes `vault_write`, `vault_journal_append`, `vault_delete`, `vault_rename`, `vault_move_lines`, and `vault_section`. If the child's work should land in the vault, the parent does the write itself after the child returns — keeps the audit trail in the parent's conversation.
+
+The default-deny posture means the child gets isolated context: no auto-injected memory, no vault tools. Use the flags when the subtask genuinely needs them (e.g. "research X across the vault" → `allow_vault_read=True`; "summarize my last conversation about Y given my preferences" → both flags).
+
+This is a behavior tightening from earlier versions where children inherited every parent vault tool by default; see #396.
 
 ## Results
 
-- Returns the child's text response directly
-- Failures returned as error text — one child failing doesn't affect siblings
-- Timeouts return `[subtask timed out after Ns]`
+- Returns the child's text response wrapped in a `ToolResult`.
+- When `return_schema` is supplied (#395, separate PR), `ToolResult.data` carries the parsed JSON.
+- Failures returned as error text — one child failing doesn't affect siblings.
+- Timeouts return `[subtask timed out after Ns]`.
 
 ## Configuration
 

--- a/docs/dev-sessions/2026-04-27-1145-delegate-vault-access/plan.md
+++ b/docs/dev-sessions/2026-04-27-1145-delegate-vault-access/plan.md
@@ -1,0 +1,49 @@
+# Plan
+
+See `spec.md` for decisions.
+
+## Phase 1 — code + tests
+
+- `src/decafclaw/tools/delegate.py`:
+  - Module-level `_VAULT_READ_TOOLS` and `_VAULT_WRITE_TOOLS`
+    `frozenset`s.
+  - `_run_child_turn(..., allow_vault_retrieval=False,
+    allow_vault_read=False)` — wires both into the `setup`
+    closure.
+  - `setup` builds the excluded set: existing four + writes
+    (always) + reads (when not opted in). `skip_vault_retrieval`
+    becomes `not allow_vault_retrieval`.
+  - `tool_delegate_task(..., allow_vault_retrieval=False,
+    allow_vault_read=False)` — passes through.
+  - Tool-definition update: two new boolean parameters with
+    explicit-opt-in language in the descriptions.
+- `tests/test_delegate.py` extensions:
+  - Default flags → child's `allowed` set excludes all vault
+    tools; `skip_vault_retrieval=True`.
+  - `allow_vault_read=True` → read set in `allowed`, write set
+    not in `allowed`.
+  - `allow_vault_retrieval=True` → `skip_vault_retrieval=False`.
+  - Wrapper: parameters thread through to `_run_child_turn`.
+
+## Phase 2 — docs
+
+- `docs/delegation.md`: new "Vault access" section describing
+  the default-deny posture and when to opt in.
+
+## Phase 3 — squash, push, PR, request Copilot
+
+`Closes #396`. Note the behavior change in the PR description.
+
+## Risk register
+
+- **Behavior tightening.** Existing code paths that delegate
+  vault-using subtasks without opt-in flags will see those
+  subtasks lose vault access. The migration is a one-line param
+  add; documenting clearly in the PR description and in
+  `docs/delegation.md` covers the discovery path.
+- **Children writing to vault as part of legitimate flows.** I
+  haven't found any in the bundled skills — the dream/garden
+  paths run as scheduled tasks (not via `delegate_task`). If
+  anyone has a workspace skill that delegates "write a journal
+  entry" to a child, that breaks until they restructure to write
+  from the parent. Documented in the PR.

--- a/docs/dev-sessions/2026-04-27-1145-delegate-vault-access/spec.md
+++ b/docs/dev-sessions/2026-04-27-1145-delegate-vault-access/spec.md
@@ -1,0 +1,185 @@
+# delegate_task: read-only vault access for children
+
+Tracking issue: #396 (split out of #300).
+
+## Problem
+
+Today's `delegate_task` has a confused vault-access policy:
+
+- `_run_child_turn` sets `child_ctx.skip_vault_retrieval = True`,
+  so the proactive memory retrieval at turn start is suppressed.
+- But `child_ctx.tools.allowed` includes every vault tool — read
+  AND write — that the parent had access to. Children can
+  `vault_write`, `vault_delete`, `vault_journal_append`, etc.,
+  with no parental supervision.
+
+The issue body framed current state as "child can't call
+`vault_search` / `vault_read`," but the code shows children CAN
+call those (along with the write tools). The actual gap is:
+
+- **Children can write to the vault unsupervised.** Surprising
+  blast radius for a sub-agent the parent invoked for an isolated
+  task.
+- **No way to opt children INTO the proactive retrieval** when
+  the parent specifically wants them to benefit from memory.
+
+## Goal
+
+Replace today's all-or-nothing-implicit policy with an explicit
+opt-in model:
+
+- **Default**: child has no proactive retrieval, no vault read
+  tools, no vault write tools — total isolation from the vault.
+- **`allow_vault_retrieval: bool = False`**: opt the child INTO
+  the proactive retrieval at turn start.
+- **`allow_vault_read: bool = False`**: opt the child INTO
+  read-side vault tools (`vault_read`, `vault_search`,
+  `vault_list`, `vault_backlinks`, `vault_show_sections`).
+- **Vault writes are NEVER allowed** for children, regardless of
+  flags. If a parent needs the child's findings persisted to the
+  vault, the parent does the write itself after delegation
+  completes.
+
+## Decisions (autonomous brainstorm)
+
+1. **Two booleans, not a combined enum.** Easier to reason about
+   in tool descriptions and call sites for v1. A future
+   `vault_access: "none" | "read" | "retrieval+read"` enum is a
+   refactor we can do once usage patterns surface.
+2. **Writes are categorically blocked.** No "and also writes"
+   flag. If the child writes, that's a category of action the
+   parent should explicitly perform after the child returns —
+   keeps the audit trail in the parent's conversation.
+3. **This is a behavior tightening.** Children today can call
+   any vault tool the parent has; this PR removes that. Calls
+   that relied on the old behavior get a clear migration path:
+   add `allow_vault_read=True`. Calls that rely on writes need
+   to restructure (do the write in the parent).
+4. **Read-set membership is hardcoded** rather than computed.
+   The list of vault tools is small and stable; a hardcoded
+   read/write split is auditable in one read of `delegate.py`.
+   If new vault tools land, the author updates the set as part
+   of adding the tool.
+5. **Implementation via `ctx.tools.allowed` filtering**, not a
+   bespoke runtime gate. `tools.allowed` is the existing
+   mechanism; routing the new policy through it keeps tool
+   restriction in one place and works for both bundled vault
+   tools and any future vault-adjacent skills.
+
+## Architecture
+
+### Module-level tool sets
+
+```python
+_VAULT_READ_TOOLS = frozenset({
+    "vault_read",
+    "vault_search",
+    "vault_list",
+    "vault_backlinks",
+    "vault_show_sections",
+})
+
+_VAULT_WRITE_TOOLS = frozenset({
+    "vault_write",
+    "vault_delete",
+    "vault_rename",
+    "vault_journal_append",
+    "vault_move_lines",
+    "vault_section",
+})
+```
+
+### `_run_child_turn` change
+
+Adds `allow_vault_retrieval: bool = False` and `allow_vault_read:
+bool = False` parameters. Computes the excluded tool set:
+
+```python
+excluded = {"delegate_task", "activate_skill", "refresh_skills", "tool_search"}
+excluded |= _VAULT_WRITE_TOOLS  # always
+if not allow_vault_read:
+    excluded |= _VAULT_READ_TOOLS
+child_ctx.tools.allowed = (all_tools - excluded)
+```
+
+`skip_vault_retrieval` becomes `not allow_vault_retrieval` (was
+hardcoded `True`).
+
+### `tool_delegate_task` change
+
+Adds the two parameters to its signature and threads them through
+to `_run_child_turn`.
+
+### Tool definition
+
+Two new parameters with descriptions that explicitly describe the
+default-deny posture:
+
+```
+"allow_vault_retrieval": {
+    "type": "boolean",
+    "description": (
+        "When true, the child agent runs the proactive memory "
+        "retrieval at turn start. Default false — the child has "
+        "no auto-injected memory context unless you opt in. "
+        "Use when the child needs to draw on past conversations "
+        "or vault knowledge to do its task."
+    ),
+},
+"allow_vault_read": {
+    "type": "boolean",
+    "description": (
+        "When true, the child can call read-side vault tools "
+        "(vault_read, vault_search, vault_list, vault_backlinks, "
+        "vault_show_sections). Default false — the child can't "
+        "read the vault unless you opt in. Vault WRITE tools "
+        "(vault_write, vault_journal_append, vault_delete, etc.) "
+        "are NEVER available to children regardless of this flag; "
+        "if the child's work should land in the vault, do the "
+        "write yourself after the child returns."
+    ),
+},
+```
+
+## Out of scope
+
+- Read-write opt-in flag. Writes are always blocked.
+- Per-tool-set granularity (e.g. let the child read but not
+  search). Two flags is enough for v1.
+- Combined `vault_access` enum.
+- Auto-derived read/write split via tool metadata. Hardcoded
+  sets are simpler for v1.
+
+## Acceptance criteria
+
+- Default `delegate_task(...)` (no flags): child cannot call
+  `vault_read` / `vault_search` / `vault_list` /
+  `vault_backlinks` / `vault_show_sections` / any vault write
+  tool. No proactive retrieval.
+- `allow_vault_read=True`: child can call the read-set; cannot
+  call any write tool.
+- `allow_vault_retrieval=True`: child sees proactive retrieval at
+  turn start (`skip_vault_retrieval=False`).
+- Both flags can be combined.
+- The two boolean parameters appear in the tool definition with
+  the descriptions above.
+
+## Testing
+
+- Existing test: `_run_child_turn` already verifies basic flow.
+  Add new tests asserting `child_ctx.tools.allowed` after setup:
+  - default → write tools excluded, read tools excluded
+  - `allow_vault_read=True` → read tools included, write tools
+    still excluded
+  - `allow_vault_retrieval=True` → `skip_vault_retrieval=False`
+    on the child ctx
+- `tool_delegate_task` test: parameters thread through to
+  `_run_child_turn`.
+- No real-LLM CI test. Manual smoke after merge.
+
+## Files touched
+
+- `src/decafclaw/tools/delegate.py` — module-level sets + flag
+  threading + tool definition.
+- `tests/test_delegate.py` — new tests covering each flag.
+- `docs/delegation.md` — describe the policy.

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -17,15 +17,50 @@ DEFAULT_CHILD_SYSTEM_PROMPT = (
     "When a skill below shows bash/curl commands, run them with the shell tool."
 )
 
+# Vault-access policy for child agents (#396). Default is no-access;
+# the parent opts the child in via flags on ``delegate_task``. Vault
+# WRITE tools are categorically blocked — if a child's work should
+# land in the vault, the parent does the write itself after the child
+# returns. New vault tools should update these sets when added.
+_VAULT_READ_TOOLS = frozenset({
+    "vault_read",
+    "vault_search",
+    "vault_list",
+    "vault_backlinks",
+    "vault_show_sections",
+})
+
+_VAULT_WRITE_TOOLS = frozenset({
+    "vault_write",
+    "vault_delete",
+    "vault_rename",
+    "vault_journal_append",
+    "vault_move_lines",
+    "vault_section",
+})
+
 
 async def _run_child_turn(parent_ctx, task, model: str = "",
-                          max_iterations: int = 0):
+                          max_iterations: int = 0,
+                          *,
+                          allow_vault_retrieval: bool = False,
+                          allow_vault_read: bool = False):
     """Run a child agent turn via ConversationManager, preserving the
     parent's tools, skills, and event routing.
 
     Args:
         model: Override model for the child. Empty = inherit parent's.
         max_iterations: Override max tool iterations. 0 = use child_max_tool_iterations.
+        allow_vault_retrieval: When False (default), the child runs
+            with ``skip_vault_retrieval=True`` — no proactive memory
+            injection. Set True to opt the child INTO the parent's
+            retrieval pipeline. See #396.
+        allow_vault_read: When False (default), the child has no
+            access to vault read tools. Set True to opt INTO the
+            read set (``vault_read``, ``vault_search``,
+            ``vault_list``, ``vault_backlinks``,
+            ``vault_show_sections``). Vault WRITE tools are
+            categorically blocked regardless.
 
     Returns the child's text response, or an error string on failure.
     """
@@ -72,6 +107,11 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         # Child inherits parent's tools minus delegation/activation.
         # If parent has restricted allowed_tools, respect that restriction.
         excluded = {"delegate_task", "activate_skill", "refresh_skills", "tool_search"}
+        # Vault policy (#396): writes are categorically blocked for
+        # children regardless of flags; reads require explicit opt-in.
+        excluded |= _VAULT_WRITE_TOOLS
+        if not allow_vault_read:
+            excluded |= _VAULT_READ_TOOLS
         all_tools = set(TOOLS) | set(parent_ctx.tools.extra)
         parent_allowed = parent_ctx.tools.allowed
         if parent_allowed is not None:
@@ -93,7 +133,9 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         child_ctx.on_stream_chunk = None
         child_ctx.is_child = True
         child_ctx.skip_reflection = True
-        child_ctx.skip_vault_retrieval = True
+        # Default-deny vault retrieval (#396); the parent opts in via
+        # `allow_vault_retrieval=True` on `delegate_task`.
+        child_ctx.skip_vault_retrieval = not allow_vault_retrieval
 
         # Set active model: explicit override > parent's model
         child_ctx.active_model = model if model else parent_ctx.active_model
@@ -124,14 +166,38 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         return ToolResult(text=f"[error: subtask failed: {e}]")
 
 
-async def tool_delegate_task(ctx, task: str, model: str = "") -> str | ToolResult:
-    """Delegate a subtask to a child agent."""
-    log.info("[tool:delegate_task] model=%s %s...", model or "inherit", task[:80])
+async def tool_delegate_task(
+    ctx,
+    task: str,
+    model: str = "",
+    allow_vault_retrieval: bool = False,
+    allow_vault_read: bool = False,
+) -> str | ToolResult:
+    """Delegate a subtask to a child agent.
+
+    By default the child has NO vault access — no proactive
+    retrieval, no read tools, no write tools. Opt the child into
+    retrieval via ``allow_vault_retrieval=True`` and into the
+    read-side vault tools via ``allow_vault_read=True``. Write
+    tools are categorically blocked for children regardless. See
+    #396.
+    """
+    log.info(
+        "[tool:delegate_task] model=%s vault_retrieval=%s vault_read=%s %s...",
+        model or "inherit",
+        allow_vault_retrieval,
+        allow_vault_read,
+        task[:80],
+    )
 
     if not task or not task.strip():
         return ToolResult(text="[error: task description is required]")
 
-    return await _run_child_turn(ctx, task, model=model)
+    return await _run_child_turn(
+        ctx, task, model=model,
+        allow_vault_retrieval=allow_vault_retrieval,
+        allow_vault_read=allow_vault_read,
+    )
 
 
 DELEGATE_TOOLS = {
@@ -174,6 +240,32 @@ DELEGATE_TOOL_DEFINITIONS = [
                         "description": (
                             "Named model config for the subtask. "
                             "Omit to inherit parent's model."
+                        ),
+                    },
+                    "allow_vault_retrieval": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, the child runs the proactive memory "
+                            "retrieval at turn start. Default false — the "
+                            "child has no auto-injected memory context "
+                            "unless you opt in. Use when the child needs "
+                            "to draw on past conversations or vault "
+                            "knowledge to do its task."
+                        ),
+                    },
+                    "allow_vault_read": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, the child can call read-side vault "
+                            "tools (vault_read, vault_search, vault_list, "
+                            "vault_backlinks, vault_show_sections). Default "
+                            "false — the child can't read the vault unless "
+                            "you opt in. Vault WRITE tools (vault_write, "
+                            "vault_journal_append, vault_delete, etc.) are "
+                            "NEVER available to children regardless of this "
+                            "flag; if the child's work should land in the "
+                            "vault, do the write yourself after the child "
+                            "returns."
                         ),
                     },
                 },

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -90,8 +90,10 @@ class TestRunChildTurn:
 
     @pytest.mark.asyncio
     async def test_inherits_parent_extra_tools(self, ctx):
-        """Child inherits parent's extra_tools from activated skills."""
-        ctx.tools.extra = {"vault_read": lambda ctx, **kw: "data"}
+        """Child inherits parent's extra_tools from activated skills.
+        Uses a non-vault example since vault tools have their own
+        allowlist policy (see TestVaultAccessPolicy)."""
+        ctx.tools.extra = {"some_skill_tool": lambda ctx, **kw: "data"}
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
@@ -99,8 +101,8 @@ class TestRunChildTurn:
             await _run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
-        assert "vault_read" in child_ctx.tools.extra
-        assert "vault_read" in child_ctx.tools.allowed
+        assert "some_skill_tool" in child_ctx.tools.extra
+        assert "some_skill_tool" in child_ctx.tools.allowed
 
     @pytest.mark.asyncio
     async def test_timeout(self, ctx):
@@ -241,3 +243,119 @@ class TestDelegateRoutingThroughManager:
         assert seen_conv_ids[1].startswith("test-conv--child-")
         # They should be different (random suffix)
         assert seen_conv_ids[0] != seen_conv_ids[1]
+
+
+# -- Vault access policy (#396) -----------------------------------------------
+
+
+class TestVaultAccessPolicy:
+    """Children get NO vault access by default; parent opts in via flags."""
+
+    @pytest.mark.asyncio
+    async def test_default_blocks_all_vault_tools(self, ctx):
+        """No flags → child can't call any vault tool, read or write."""
+        from decafclaw.tools.delegate import (
+            _VAULT_READ_TOOLS,
+            _VAULT_WRITE_TOOLS,
+        )
+
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+            await _run_child_turn(ctx, "task")
+
+        child_ctx = mock_run.call_args[0][0]
+        for tool in _VAULT_READ_TOOLS:
+            assert tool not in child_ctx.tools.allowed, (
+                f"{tool} should be excluded by default"
+            )
+        for tool in _VAULT_WRITE_TOOLS:
+            assert tool not in child_ctx.tools.allowed, (
+                f"{tool} should always be excluded for children"
+            )
+        # Default also disables proactive retrieval.
+        assert child_ctx.skip_vault_retrieval is True
+
+    @pytest.mark.asyncio
+    async def test_allow_vault_read_lets_in_read_set_only(self, ctx):
+        """Opt-in for read tools; writes still excluded."""
+        from decafclaw.tools.delegate import (
+            _VAULT_READ_TOOLS,
+            _VAULT_WRITE_TOOLS,
+        )
+        # Seed parent with the vault tools as activated-skill tools so
+        # the inheritance path actually has something to keep/exclude.
+        ctx.tools.extra = {
+            tool: (lambda ctx, **kw: "x") for tool in _VAULT_READ_TOOLS | _VAULT_WRITE_TOOLS
+        }
+
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+            await _run_child_turn(ctx, "task", allow_vault_read=True)
+
+        child_ctx = mock_run.call_args[0][0]
+        for tool in _VAULT_READ_TOOLS:
+            assert tool in child_ctx.tools.allowed, (
+                f"{tool} should be allowed when allow_vault_read=True"
+            )
+        for tool in _VAULT_WRITE_TOOLS:
+            assert tool not in child_ctx.tools.allowed, (
+                f"{tool} should never be allowed for children"
+            )
+
+    @pytest.mark.asyncio
+    async def test_allow_vault_retrieval_enables_proactive_retrieval(self, ctx):
+        """Opt-in for proactive retrieval flips skip_vault_retrieval off."""
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+            await _run_child_turn(ctx, "task", allow_vault_retrieval=True)
+
+        child_ctx = mock_run.call_args[0][0]
+        assert child_ctx.skip_vault_retrieval is False
+
+    @pytest.mark.asyncio
+    async def test_flags_combine(self, ctx):
+        """Both flags can be set together."""
+        from decafclaw.tools.delegate import (
+            _VAULT_READ_TOOLS,
+            _VAULT_WRITE_TOOLS,
+        )
+        ctx.tools.extra = {
+            tool: (lambda ctx, **kw: "x") for tool in _VAULT_READ_TOOLS | _VAULT_WRITE_TOOLS
+        }
+
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+            await _run_child_turn(
+                ctx, "task",
+                allow_vault_retrieval=True, allow_vault_read=True,
+            )
+
+        child_ctx = mock_run.call_args[0][0]
+        assert child_ctx.skip_vault_retrieval is False
+        for tool in _VAULT_READ_TOOLS:
+            assert tool in child_ctx.tools.allowed
+        for tool in _VAULT_WRITE_TOOLS:
+            assert tool not in child_ctx.tools.allowed
+
+    @pytest.mark.asyncio
+    async def test_tool_wrapper_threads_flags_through(self, ctx):
+        """`tool_delegate_task` parameters reach `_run_child_turn`."""
+        seen = {}
+
+        async def fake_run(parent_ctx, task, model="", max_iterations=0,
+                           allow_vault_retrieval=False, allow_vault_read=False):
+            seen["allow_vault_retrieval"] = allow_vault_retrieval
+            seen["allow_vault_read"] = allow_vault_read
+            return ToolResult(text="ok")
+
+        with patch("decafclaw.tools.delegate._run_child_turn", side_effect=fake_run):
+            await tool_delegate_task(
+                ctx, "task",
+                allow_vault_retrieval=True,
+                allow_vault_read=True,
+            )
+
+        assert seen == {
+            "allow_vault_retrieval": True,
+            "allow_vault_read": True,
+        }


### PR DESCRIPTION
## Summary

Today `_run_child_turn` sets `skip_vault_retrieval=True` (no proactive memory injection) **but inherits every vault tool from the parent** — children can call `vault_write`, `vault_delete`, `vault_journal_append` etc. unsupervised. This PR replaces the implicit policy with an explicit opt-in model:

- **Default**: child has no proactive retrieval, no vault read tools, no vault write tools — total isolation from the vault.
- **`allow_vault_retrieval=True`**: opt the child INTO the proactive retrieval at turn start.
- **`allow_vault_read=True`**: opt the child INTO read-side vault tools (`vault_read`, `vault_search`, `vault_list`, `vault_backlinks`, `vault_show_sections`).
- **Writes are categorically blocked** for children regardless of flags. If a child's work should land in the vault, the parent does the write itself after the child returns — keeps the audit trail in the parent's conversation.

This is the second split of #300; #395 (structured returns) is in PR #398 and #397 (parallel dispatch) follows.

## ⚠️ Behavior change

This is a **tightening** from current. Calls that relied on the old behavior need to migrate:

- **Children reading vault content** (`vault_read`/`vault_search`/etc.): add `allow_vault_read=True` to the `delegate_task` call.
- **Children writing to vault** (`vault_write`/`vault_journal_append`/etc.): no opt-in — restructure so the parent does the write after the child returns.

I checked the bundled skills; none of them currently use `delegate_task` to write to the vault. Workspace-level skills that do will surface immediately as failed tool calls.

## What ships

- Module-level `_VAULT_READ_TOOLS` / `_VAULT_WRITE_TOOLS` frozensets in `tools/delegate.py`. Hardcoded sets are auditable in one read; new vault tools should update them when added.
- `_run_child_turn(..., *, allow_vault_retrieval=False, allow_vault_read=False)` extends the existing `excluded` set with writes (always) and reads (when not opted in). `skip_vault_retrieval` becomes `not allow_vault_retrieval` (was hardcoded `True`).
- `tool_delegate_task` threads the two new boolean parameters; tool definition gets explicit-opt-in language in the descriptions, with a clear callout that writes are always off.
- `docs/delegation.md` gains a "Vault access" section.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 2033 passed (+5 new)
- [x] Default-deny: no vault tool reaches `child_ctx.tools.allowed`; `skip_vault_retrieval` is `True`.
- [x] `allow_vault_read=True`: read set in `allowed`, write set never in `allowed`.
- [x] `allow_vault_retrieval=True`: `skip_vault_retrieval=False`.
- [x] Both flags combine correctly.
- [x] `tool_delegate_task` parameters thread through to `_run_child_turn`.
- [x] Existing `test_inherits_parent_extra_tools` updated to use a non-vault example tool (the inheritance mechanism still works for non-vault skill tools).
- [ ] **Manual smoke after merge** — call `delegate_task` from the agent UI without flags, verify the child can't `vault_search`; with `allow_vault_read=True`, verify it can.

## Out of scope (the other splits of #300)

- **#395** — structured return schema (PR #398, in review).
- **#397** — parallel dispatch (`delegate_tasks` plural). Depends on #395.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)