### PR TITLE
feat(delegate): parallel dispatch via delegate_tasks

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -325,6 +325,8 @@ Agent identity, loop limits, tool loading, and delegation.
 | `preemptive_search.max_matches` | int | `10` | *(no env var)* |
 | `child_max_tool_iterations` | int | `10` | `CHILD_MAX_TOOL_ITERATIONS` |
 | `child_timeout_sec` | int | `300` | `CHILD_TIMEOUT_SEC` |
+| `max_parallel_delegates` | int | `3` | `MAX_PARALLEL_DELEGATES` |
+| `max_tasks_per_delegate_call` | int | `10` | `MAX_TASKS_PER_DELEGATE_CALL` |
 
 `data_home` and `id` are resolved from env vars only (not from the config file) since they determine where the config file lives.
 

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -1,6 +1,6 @@
 # Sub-Agent Delegation
 
-The `delegate_task` tool lets the agent fork a child agent to handle a focused subtask. For parallel work, the agent calls `delegate_task` multiple times in the same response — the agent loop runs them concurrently.
+The `delegate_task` tool lets the agent fork a child agent to handle a focused subtask. For batches of similar subtasks, the `delegate_tasks` (plural) tool dispatches them in parallel under one tool call — see [Parallel dispatch](#parallel-dispatch-with-delegate_tasks).
 
 ## Usage
 
@@ -10,14 +10,7 @@ The agent calls `delegate_task` with a task description:
 {"task": "Look up the weather in Portland"}
 ```
 
-For parallel subtasks, the model emits multiple `delegate_task` calls in one response:
-
-```json
-// tool_call 1
-{"task": "Look up the weather in Portland"}
-// tool_call 2
-{"task": "Search my memories for cocktail recipes"}
-```
+For a batch of related subtasks, prefer `delegate_tasks` (plural) — see [Parallel dispatch](#parallel-dispatch-with-delegate_tasks). The agent can also emit multiple singular `delegate_task` calls in one response and they'll execute concurrently via the agent loop's tool semaphore, but the plural tool gives a single aggregated result and a fixed concurrency cap.
 
 Each call spawns an independent child agent that:
 - Gets a fresh, empty conversation history
@@ -86,16 +79,64 @@ The parent receives both halves:
 
 See #395 for the design rationale.
 
+## Parallel dispatch with `delegate_tasks`
+
+`delegate_tasks` (plural) takes a list of task descriptions and runs them as concurrent child agents under a single tool call. Use it when you have a known list of similar investigations — per page, per file, per topic — that don't need to talk to each other.
+
+```python
+# Example call (LLM-emitted tool call):
+delegate_tasks(
+    tasks=[
+        "Summarize the README in repo A",
+        "Summarize the README in repo B",
+        "Summarize the README in repo C",
+    ],
+    return_schema={"summary": "string", "main_topic": "string"},
+)
+```
+
+**Result shape:**
+
+```json
+{
+  "summary": {"total": 3, "ok": 2, "failed": 1},
+  "results": [
+    {"index": 0, "ok": true, "text": "...", "data": {"summary": "...", "main_topic": "..."}},
+    {"index": 1, "ok": true, "text": "...", "data": {"summary": "...", "main_topic": "..."}},
+    {"index": 2, "ok": false, "error": "[error: subtask timed out after 300s]"}
+  ]
+}
+```
+
+- `ToolResult.text` — one-line summary (e.g. `"3 subtasks: 2 succeeded, 1 failed"`).
+- `ToolResult.data.results` — per-task entries in input order, each with `index`, `ok`, and either `text`/`data` (success) or `error` (failure).
+- `ToolResult.data.summary` — total/ok/failed counts.
+
+**Shared params, not per-task.** `model`, `allow_vault_retrieval`, `allow_vault_read`, and `return_schema` all apply to every task in the batch. If you genuinely need per-task overrides, fall back to multiple singular `delegate_task` calls.
+
+**Concurrency cap.** At most `agent.max_parallel_delegates` children run at once (default 3). The remaining queue waits inside the gather. The total batch size is also capped at `agent.max_tasks_per_delegate_call` (default 10) to prevent fan-out blowup — over-cap requests fail fast with a clear error.
+
+**Failure isolation.** One child raising or timing out does not abort siblings. Each per-task entry carries its own `ok` flag and (on failure) an `error` string lifted from the child's `ToolResult.text`.
+
+**Per-child events are suppressed from the parent UI.** Each child publishes its tool-status events to a unique override id rather than the parent's subscriber, so you don't get N concurrent tool streams flooding the parent conversation. The parent emits one aggregate `tool_status` event per child completion (`"2/3 subtasks complete"`).
+
+**Cancellation.** The parent's cancel event flows through the gather — cancelling the parent turn cancels in-flight children too.
+
+See #397 for the design rationale.
+
 ## Configuration
 
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `CHILD_MAX_TOOL_ITERATIONS` | 10 | Max tool call rounds per child agent |
 | `CHILD_TIMEOUT_SEC` | 300 | Timeout in seconds per child agent |
-| `MAX_CONCURRENT_TOOLS` | 5 | Max parallel tool calls (applies to all tools, including concurrent delegate_task calls) |
+| `MAX_PARALLEL_DELEGATES` | 3 | Max children running simultaneously inside one `delegate_tasks` call |
+| `MAX_TASKS_PER_DELEGATE_CALL` | 10 | Max batch size accepted by `delegate_tasks` per call |
+| `MAX_CONCURRENT_TOOLS` | 5 | Max parallel tool calls at the agent loop's outer semaphore (applies to all tools) |
 
 ## Limitations
 
-- No nested delegation — children cannot call `delegate_task`
-- No streaming of child LLM text to the UI (tool progress and confirmations are visible)
+- No nested delegation — children cannot call `delegate_task` or `delegate_tasks`
+- No streaming of child LLM text to the UI (tool progress and confirmations are visible for singular `delegate_task`; suppressed for `delegate_tasks` per the parallel-dispatch event policy)
 - No persistent child conversations — results are ephemeral
+- `delegate_tasks` shares one set of params across the batch; per-task overrides require multiple singular `delegate_task` calls

--- a/docs/dev-sessions/2026-04-27-1631-delegate-parallel/plan.md
+++ b/docs/dev-sessions/2026-04-27-1631-delegate-parallel/plan.md
@@ -1,0 +1,83 @@
+# Plan — `delegate_tasks` parallel dispatch
+
+Single-commit PR. All work in one branch.
+
+## Step 1 — Config
+
+In `src/decafclaw/config_types.py`, add to `AgentConfig`:
+
+```python
+max_parallel_delegates: int = 3
+max_tasks_per_delegate_call: int = 10
+```
+
+No env aliases — autoresolved via the standard `AGENT_*` lift.
+
+## Step 2 — `delegate.py` — implement `tool_delegate_tasks`
+
+Add to `src/decafclaw/tools/delegate.py`:
+
+- New module-level helper `_run_one_delegated(ctx, task, idx, semaphore, progress_state, return_schema, ...)`:
+  - Acquires the semaphore.
+  - Calls `_run_child_turn` with `event_context_id_override=child_conv_id` (a new optional kwarg on `_run_child_turn`, defaulting to None which preserves the current behavior of routing to the parent's subscriber).
+  - Parses structured output if `return_schema` was supplied; mirrors the singular tool's split.
+  - On success returns `{"index": idx, "ok": True, "text": prose, "data": parsed}` (or `{"index": idx, "ok": True, "text": text}` if no schema).
+  - On error (the wrapper returns a `ToolResult(text="[error: ...]")`) returns `{"index": idx, "ok": False, "error": err_text}`.
+  - Bumps the shared progress counter (under an `asyncio.Lock` on `progress_state`) and publishes a `tool_status` event from the parent ctx.
+
+- New `tool_delegate_tasks(ctx, tasks, model, allow_vault_retrieval, allow_vault_read, return_schema)`:
+  - Validates `tasks` (non-empty list, all non-empty strings, length ≤ cap).
+  - Builds the semaphore, progress state.
+  - `await asyncio.gather(*[_run_one_delegated(...) for ...], return_exceptions=True)`.
+  - Replaces any unexpected `Exception` slot with `{"index": ..., "ok": False, "error": "delegate_tasks internal error: ..."}` and logs it.
+  - Sorts by index (gather preserves order, but be explicit since we may post-process).
+  - Builds `summary = {"total": N, "ok": ok_count, "failed": fail_count}`.
+  - Returns `ToolResult(text=summary_line, data={"summary": ..., "results": ...})`.
+
+- Add `tool_delegate_tasks` to `DELEGATE_TOOLS` and append a definition to `DELEGATE_TOOL_DEFINITIONS` with `priority: "critical"`, `timeout: None` (owns timeout per-child).
+
+- Tweak `delegate_task` definition's description: change "For parallel work, call delegate_task multiple times in the same response" → "For parallel work over a known list, prefer `delegate_tasks` (plural)."
+
+## Step 3 — Plumb optional event override into `_run_child_turn`
+
+The cleanest path: add a kwarg `event_context_id_override: str | None = None` to `_run_child_turn`. When non-None, the `setup` callback assigns it to `child_ctx.event_context_id` instead of `parent_event_id`. Default behavior unchanged.
+
+## Step 4 — Tests in `tests/test_delegate.py`
+
+Add `class TestDelegateTasks` with the cases from the spec test plan:
+
+1. `test_happy_path_three_tasks` — patch `_run_child_turn` to return per-task strings; assert results have ok=True, indices in order, summary counts right, three `tool_status` events emitted.
+2. `test_mixed_failures` — patch to raise on one task (or return a `ToolResult(text="[error: ...]")`); assert one entry has `ok: False`, others succeed.
+3. `test_empty_list_errors` — `tasks=[]` returns error `ToolResult`.
+4. `test_blank_entry_errors` — `tasks=["", "valid"]` returns error.
+5. `test_non_string_entry_errors` — `tasks=[42, "valid"]` returns error.
+6. `test_over_cap_errors` — N+1 tasks with cap N returns error mentioning cap.
+7. `test_concurrency_cap_honored` — cap 2, 4 tasks; patch `_run_child_turn` to record entry/exit timestamps; assert never more than 2 simultaneous.
+8. `test_structured_return_parses_per_task` — each child returns prose + JSON; per-entry `data` is parsed, `text` has the JSON stripped.
+9. `test_singular_unchanged` — keep existing tests; verify they pass without modification.
+10. `test_event_override_passed_through` — verify the new kwarg on `_run_child_turn` reaches the setup callback (mock `manager.enqueue_turn`, inspect `context_setup`).
+
+For (7), use a small `asyncio.Event` + counter pattern in the patched `_run_child_turn` instead of timestamps — more robust under pytest-xdist.
+
+## Step 5 — Docs
+
+- `docs/delegation.md`: add a section "Parallel dispatch with `delegate_tasks`". Show the params, the result shape, the cap config, the per-child event suppression, and a brief example.
+- `docs/config.md`: add the two new fields to the `agent` table with defaults + env-var names.
+
+## Step 6 — Verify
+
+- `make lint` — clean.
+- `make test` — all pass.
+- `pytest --durations=25` — the new tests should all be sub-second (no real LLM, no fixed sleeps).
+
+## Step 7 — Commit + push + PR
+
+- One commit: `feat(delegate): parallel dispatch via delegate_tasks (#397)`.
+- PR body: brief problem statement, summary of design decisions (shared params, suppress per-child events, cap on tasks), reference #397 with `Closes #397`.
+- Add Copilot reviewer.
+
+## Out of scope (future work, not in this PR)
+
+- Per-task model / schema / vault overrides — flagged in spec as "promote to dicts later".
+- Streaming child progress to parent UI — flagged in spec.
+- Retry-on-failure logic.

--- a/docs/dev-sessions/2026-04-27-1631-delegate-parallel/spec.md
+++ b/docs/dev-sessions/2026-04-27-1631-delegate-parallel/spec.md
@@ -1,0 +1,142 @@
+# Delegate parallel dispatch (`delegate_tasks`) — #397
+
+## Problem
+
+`delegate_task` (singular) runs one child agent at a time. Anthropic's *Effective Context Engineering for AI Agents* names parallel sub-agent fan-out as a primary benefit of the delegation pattern: multiple concurrent investigations whose results aggregate back to the parent without polluting its context. Today the agent has to sequence sibling explorations, paying latency it shouldn't have to pay.
+
+## Goal
+
+Add a sibling tool `delegate_tasks` (plural) that takes a list of subtask descriptions and dispatches them concurrently with a bounded gather. Each child runs in its own forked context; the parent receives an aggregated structured result.
+
+## Non-goals
+
+- Per-task model overrides, per-task vault flags, per-task return schemas. Batches of N similar investigations are the dominant use case; one shared set of params keeps the API tight. Promote to per-task dicts later if a real use case appears.
+- Streaming child progress to the parent UI. v1 emits one parent-side `tool_status` event per child completion (3/N done, etc.) — no individual tool/skill events per child.
+- A separate "join after N successes" / "abort on first failure" mode. Always wait for all, return per-task status.
+- Replacing `delegate_task`. Singular stays — clearer ergonomics for one-off cases and avoids forcing a list literal in the simple case.
+
+## Design
+
+### New tool: `delegate_tasks`
+
+**Signature:**
+
+```python
+tool_delegate_tasks(
+    ctx,
+    tasks: list[str],
+    model: str = "",
+    allow_vault_retrieval: bool = False,
+    allow_vault_read: bool = False,
+    return_schema: dict | None = None,
+) -> ToolResult
+```
+
+All non-`tasks` parameters are shared across the batch — same model, same vault flags, same schema. This matches the most common use case ("investigate these N pages and pull out X for each") without forcing the agent to specify N copies of the same params.
+
+**Validation:**
+
+- `tasks` must be a non-empty list of non-empty strings — empty list / non-string entries / blank entries → error result.
+- Length capped at `config.agent.max_tasks_per_delegate_call` (default 10) — over the cap → error result with the cap value in the message.
+
+### Concurrency
+
+- New config: `AgentConfig.max_parallel_delegates` (default 3).
+- Internal `asyncio.Semaphore(max_parallel_delegates)` in `tool_delegate_tasks` wraps each child dispatch so we cap simultaneous in-flight children regardless of `tasks` length.
+- `asyncio.gather(..., return_exceptions=True)` so one child's failure doesn't kill the rest.
+- Cancellation: if the parent's tool-call cancel event fires, the gather is cancelled — `asyncio.gather` propagates `CancelledError` to the in-flight children. Already wired through `parent_ctx.cancelled` on each child.
+
+### Refactor
+
+The existing `_run_child_turn` already encapsulates the per-task primitive. The plural tool calls it N times under the semaphore. No structural refactor of `_run_child_turn` itself.
+
+### Result shape
+
+```json
+{
+  "summary": {"total": 3, "ok": 2, "failed": 1},
+  "results": [
+    {"index": 0, "ok": true, "text": "...", "data": {...}},
+    {"index": 1, "ok": true, "text": "...", "data": {...}},
+    {"index": 2, "ok": false, "error": "subtask timed out after 300s"}
+  ]
+}
+```
+
+- `ToolResult.text` is a one-line human-readable summary (`"3 tasks complete: 2 succeeded, 1 failed"`).
+- `ToolResult.data` carries the structured breakdown (rendered as a fenced JSON block in the chat by the existing `ToolResult` rendering path).
+- `data` is keyed in task input order — `results[i]` corresponds to `tasks[i]`.
+- When `return_schema` is supplied, each successful entry's `data` field is the parsed JSON; `text` is the prose with the JSON block stripped (mirroring the singular tool's split).
+- Failed entries omit `text`/`data` and carry an `error` string.
+
+### Event routing
+
+- For parallel children, **don't** route per-child events to the parent UI subscriber — would flood the UI with N concurrent tool-status streams.
+- Implementation: in the per-task `setup` callback, set `child_ctx.event_context_id` to a unique per-child id (the child's own `child_conv_id`) instead of the parent's `event_context_id`. Each child still publishes events, but they don't land in the parent's subscriber.
+- Parent emits ONE `tool_status` event per child completion: `"delegate_tasks: 2/3 complete"`. This gives the user visible progress without per-child noise. Aggregated by a small counter inside `tool_delegate_tasks` — the gather waits on `asyncio.as_completed` so we publish in the order children finish, not the order they were dispatched.
+
+### Failure isolation
+
+`asyncio.gather(return_exceptions=True)` treats `CancelledError` like any other exception — bad for parent-cancellation propagation. Use `asyncio.gather(*coros, return_exceptions=True)` only for non-cancel exceptions: catch `CancelledError` from the children and re-raise from the parent. In practice: each child task already returns a `ToolResult` on failure (the existing wrapper around `_run_child_turn` catches everything), so the gather mostly just sees clean returns. Use `return_exceptions=True` defensively for any unexpected raise.
+
+### Backwards compat
+
+`delegate_task` (singular) is unchanged. `delegate_tasks` (plural) is purely additive. Both registered, both deferred-discoverable, both `priority: critical`.
+
+## Configuration
+
+```python
+class AgentConfig:
+    max_parallel_delegates: int = 3
+    max_tasks_per_delegate_call: int = 10
+```
+
+Standard env aliases: `MAX_PARALLEL_DELEGATES`, `MAX_TASKS_PER_DELEGATE_CALL`.
+
+## Tool description
+
+The agent picks between singular and plural; the descriptions need to disambiguate. Singular description already nudges "for parallel work, call delegate_task multiple times" — change that line to point at `delegate_tasks` for ≥2-task fan-outs.
+
+Plural description leads with "Dispatch a batch of N independent subtasks concurrently. Use when you have a known list of similar investigations (per-page, per-file, per-topic) where the children don't need to talk to each other." Mentions the cap.
+
+## Files touched
+
+- `src/decafclaw/tools/delegate.py` — new `tool_delegate_tasks` + definition; minor description tweak on `delegate_task`.
+- `src/decafclaw/config_types.py` — `AgentConfig` adds two fields.
+- `tests/test_delegate.py` — new test class for parallel dispatch (success batch, mixed-failure batch, cap enforcement, concurrency cap, structured-return parsing, cancellation propagation).
+- `docs/delegation.md` — new section on `delegate_tasks` + cap config.
+- `docs/config.md` — add the two fields to `agent` table.
+- `CLAUDE.md` — no mention needed beyond what's there (tool already covered).
+
+## Test plan
+
+1. **Happy path:** 3 tasks all succeed; result shows `ok: 2/3` worth of `True` entries, indices 0/1/2 in input order, parent emits 3 progress events.
+2. **Mixed failures:** 1 of 3 children raises (mock `_run_child_turn`); failed entry has `error` string, others succeed unchanged.
+3. **Empty list:** error result.
+4. **Over cap:** N+1 tasks where cap is N → error result mentioning the cap.
+5. **Concurrency cap honored:** Patch `_run_child_turn` to register start/end timestamps; with cap 2 and 4 tasks, max simultaneous in-flight is 2.
+6. **Structured return parses:** Each child returns prose + JSON block; per-entry `data` has the parsed object, `text` has prose stripped.
+7. **Cancellation propagates:** Set the parent cancel event mid-flight; gather raises, in-flight children see the cancel signal.
+8. **Singular tool unchanged:** Existing `delegate_task` test class still passes without modification.
+
+## Historical context: Gemini schema compatibility (#71)
+
+A previous attempt at multi-delegation was unwound in [`2026-03-18-1017-concurrent-tools-delegate`](../2026-03-18-1017-concurrent-tools-delegate/spec.md). The original `delegate` tool used an **array-of-objects-with-properties** schema:
+
+```
+tasks: array → items: object → { task: string, tools: array, system_prompt: string }
+```
+
+This caused Gemini 2.5 Flash to emit `finish_reason: malformed_function_call` (0 completion tokens). The fix was to drop the array entirely, ship a flat singular `delegate_task(task: str)`, and push concurrency to the agent loop's `max_concurrent_tools` semaphore (the model emits N singular tool calls in one response).
+
+This PR re-introduces multi-delegation with a deliberately simpler schema: **array-of-strings only**, no per-item objects. That pattern is already used successfully by `checklist_create.steps`, `vault_write.tags`, `email_send.to`, `vault_show_sections.sections`, and others — all on Gemini in production. The failure mode from #71 is sidestepped by construction.
+
+If `malformed_function_call` reappears in logs after this lands, the fallback is the existing pattern: agents emit N singular `delegate_task` calls in one response. The plural tool's incremental value (structured aggregation, single-tool-call mental model, independent concurrency cap) doesn't justify keeping it on if Gemini chokes.
+
+## Open questions resolved
+
+- **Share or suppress events?** Suppress per-child events from the parent UI; emit aggregate progress from the parent. (Issue's preferred direction.)
+- **Failure isolation?** Yes — `return_exceptions=True`, per-task status in result.
+- **Circuit-breaker accounting?** One tool call from parent's perspective.
+- **Per-task params?** No — shared across the batch in v1. Revisit if a real need surfaces.
+- **`max_tokens` per call?** No explicit total cap — relies on per-child `child_max_tool_iterations` and the `max_tasks_per_delegate_call` length cap. Add later if real use surfaces blowup.

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -164,6 +164,12 @@ class AgentConfig:
     critical_tools: list[str] = field(default_factory=list)
     child_max_tool_iterations: int = 10
     child_timeout_sec: int = 300
+    # Parallel sub-agent dispatch via `delegate_tasks` (#397). The
+    # plural tool runs up to `max_parallel_delegates` children
+    # concurrently; the total batch size is capped at
+    # `max_tasks_per_delegate_call` to prevent fan-out blowup.
+    max_parallel_delegates: int = 3
+    max_tasks_per_delegate_call: int = 10
     # Wall-clock timeout applied to each non-MCP tool call in execute_tool.
     # `<= 0` disables the wrapper globally. Per-tool overrides live on
     # TOOL_DEFINITIONS entries via the `timeout` key.

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -114,7 +114,8 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
                           *,
                           allow_vault_retrieval: bool = False,
                           allow_vault_read: bool = False,
-                          return_schema: dict | None = None):
+                          return_schema: dict | None = None,
+                          event_context_id_override: str | None = None):
     """Run a child agent turn via ConversationManager, preserving the
     parent's tools, skills, and event routing.
 
@@ -136,6 +137,11 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
             instructing it to emit a fenced JSON block matching the
             shape after any prose. The caller is responsible for
             parsing the JSON out of the response.
+        event_context_id_override: When non-None, the child's
+            ``event_context_id`` is set to this value instead of
+            inheriting the parent's subscriber id. Used by
+            ``delegate_tasks`` (#397) to suppress per-child progress
+            events from the parent UI.
 
     Returns the child's text response, or an error string on failure.
     """
@@ -182,7 +188,13 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         child_ctx.request_confirmation = parent_ctx.request_confirmation
         # Route child events to the parent's UI subscriber so confirmations
         # and tool progress are visible in the parent conversation.
-        child_ctx.event_context_id = parent_event_id
+        # `event_context_id_override` lets `delegate_tasks` (#397) point
+        # children at a separate id so per-child progress doesn't flood
+        # the parent UI when running batches in parallel.
+        child_ctx.event_context_id = (
+            event_context_id_override if event_context_id_override is not None
+            else parent_event_id
+        )
 
         # Child inherits parent's tools minus delegation/activation.
         # If parent has restricted allowed_tools, respect that restriction.
@@ -306,8 +318,206 @@ async def tool_delegate_task(
     return ToolResult(text=prose or raw_text, data=parsed)
 
 
+async def _run_one_delegated(
+    parent_ctx,
+    *,
+    task: str,
+    idx: int,
+    semaphore: asyncio.Semaphore,
+    progress: dict,
+    progress_lock: asyncio.Lock,
+    total: int,
+    model: str,
+    allow_vault_retrieval: bool,
+    allow_vault_read: bool,
+    return_schema: dict | None,
+) -> dict:
+    """Run one child of a `delegate_tasks` batch under a semaphore.
+
+    Returns a dict matching the per-task entry shape on
+    ``ToolResult.data["results"]``: index + ok + (text/data | error).
+
+    Per-child events are routed to a dedicated id (the child's own
+    conv id) so they don't flood the parent UI; the parent emits one
+    aggregate ``tool_status`` event per completion via this helper.
+    """
+    async with semaphore:
+        try:
+            raw = await _run_child_turn(
+                parent_ctx, task, model=model,
+                allow_vault_retrieval=allow_vault_retrieval,
+                allow_vault_read=allow_vault_read,
+                return_schema=return_schema,
+                event_context_id_override=f"delegate-tasks-child-{idx}",
+            )
+        except Exception as exc:
+            log.warning(
+                "delegate_tasks: child %d raised unexpectedly: %s",
+                idx, exc, exc_info=True,
+            )
+            entry: dict = {
+                "index": idx,
+                "ok": False,
+                "error": f"delegate_tasks internal error: {exc}",
+            }
+        else:
+            if isinstance(raw, ToolResult):
+                # _run_child_turn surfaces failure as a ToolResult with
+                # an "[error: ...]" prefix; preserve it as the error
+                # field so callers can inspect it.
+                entry = {"index": idx, "ok": False, "error": raw.text or ""}
+            else:
+                raw_text = raw or ""
+                if return_schema is None:
+                    entry = {"index": idx, "ok": True, "text": raw_text}
+                else:
+                    parsed, prose = _parse_structured_output(raw_text)
+                    if parsed is None:
+                        log.debug(
+                            "delegate_tasks: child %d had no parseable "
+                            "JSON block; falling back to prose-only.",
+                            idx,
+                        )
+                        entry = {"index": idx, "ok": True, "text": raw_text}
+                    else:
+                        entry = {
+                            "index": idx,
+                            "ok": True,
+                            "text": prose or raw_text,
+                            "data": parsed,
+                        }
+
+        async with progress_lock:
+            progress["done"] += 1
+            done = progress["done"]
+        try:
+            await parent_ctx.publish("tool_status", {
+                "tool": "delegate_tasks",
+                "message": f"{done}/{total} subtasks complete",
+            })
+        except Exception:
+            log.debug(
+                "delegate_tasks: failed to publish progress event "
+                "(child %d)", idx, exc_info=True,
+            )
+        return entry
+
+
+async def tool_delegate_tasks(
+    ctx,
+    tasks: list[str],
+    model: str = "",
+    allow_vault_retrieval: bool = False,
+    allow_vault_read: bool = False,
+    return_schema: dict | None = None,
+) -> ToolResult:
+    """Delegate a batch of subtasks to child agents in parallel (#397).
+
+    Each task in ``tasks`` runs as its own forked child agent with
+    the parent's tools and activated skills. Children run
+    concurrently, capped by ``config.agent.max_parallel_delegates``.
+    The total batch size is capped at
+    ``config.agent.max_tasks_per_delegate_call``.
+
+    All non-``tasks`` parameters are shared across the batch — same
+    model, same vault flags, same return schema. (For per-task
+    overrides, fall back to multiple ``delegate_task`` calls.)
+
+    Per-child progress events are NOT routed to the parent UI; the
+    parent emits one aggregate ``tool_status`` event per completion.
+
+    Returns ``ToolResult(text=summary_line, data={"summary": ...,
+    "results": [...]})``. Each per-task entry carries ``index``,
+    ``ok``, and either ``text``/``data`` (success) or ``error``
+    (failure). Results are ordered by input index.
+    """
+    config = ctx.config
+    cap_count = config.agent.max_tasks_per_delegate_call
+    cap_parallel = config.agent.max_parallel_delegates
+
+    if not isinstance(tasks, list) or not tasks:
+        return ToolResult(text="[error: tasks must be a non-empty list]")
+    for i, t in enumerate(tasks):
+        if not isinstance(t, str) or not t.strip():
+            return ToolResult(text=(
+                f"[error: tasks[{i}] must be a non-empty string]"
+            ))
+    if cap_count > 0 and len(tasks) > cap_count:
+        return ToolResult(text=(
+            f"[error: too many tasks ({len(tasks)}); cap is "
+            f"{cap_count} per call. Split the batch or raise "
+            "config.agent.max_tasks_per_delegate_call.]"
+        ))
+
+    log.info(
+        "[tool:delegate_tasks] count=%d parallel<=%d model=%s "
+        "vault_retrieval=%s vault_read=%s schema=%s",
+        len(tasks), cap_parallel, model or "inherit",
+        allow_vault_retrieval, allow_vault_read,
+        "yes" if return_schema else "no",
+    )
+
+    semaphore = asyncio.Semaphore(max(1, cap_parallel))
+    progress: dict = {"done": 0}
+    progress_lock = asyncio.Lock()
+    total = len(tasks)
+
+    coros = [
+        _run_one_delegated(
+            ctx,
+            task=t,
+            idx=i,
+            semaphore=semaphore,
+            progress=progress,
+            progress_lock=progress_lock,
+            total=total,
+            model=model,
+            allow_vault_retrieval=allow_vault_retrieval,
+            allow_vault_read=allow_vault_read,
+            return_schema=return_schema,
+        )
+        for i, t in enumerate(tasks)
+    ]
+    raw_results = await asyncio.gather(*coros, return_exceptions=True)
+
+    # Replace any leaked exception with a structured failure entry.
+    # `_run_one_delegated` already swallows child errors, so this is
+    # purely defensive against bugs in the gather/setup path.
+    results: list[dict] = []
+    for i, r in enumerate(raw_results):
+        if isinstance(r, BaseException):
+            log.warning(
+                "delegate_tasks: gather slot %d raised unexpectedly: %s",
+                i, r, exc_info=r,
+            )
+            results.append({
+                "index": i,
+                "ok": False,
+                "error": f"delegate_tasks internal error: {r}",
+            })
+        else:
+            results.append(r)
+
+    results.sort(key=lambda e: e["index"])
+    ok_count = sum(1 for e in results if e["ok"])
+    fail_count = total - ok_count
+    summary_line = (
+        f"{total} subtasks: {ok_count} succeeded, {fail_count} failed"
+    )
+    return ToolResult(
+        text=summary_line,
+        data={
+            "summary": {
+                "total": total, "ok": ok_count, "failed": fail_count,
+            },
+            "results": results,
+        },
+    )
+
+
 DELEGATE_TOOLS = {
     "delegate_task": tool_delegate_task,
+    "delegate_tasks": tool_delegate_tasks,
 }
 
 DELEGATE_TOOL_DEFINITIONS = [
@@ -319,15 +529,15 @@ DELEGATE_TOOL_DEFINITIONS = [
         "function": {
             "name": "delegate_task",
             "description": (
-                "Delegate a subtask to a child agent (a separate sub-agent / "
+                "Delegate a SINGLE subtask to a child agent (a separate sub-agent / "
                 "fork) that runs as an independent agent turn with access to "
                 "the same tools and skills. **Use this whenever the user asks "
                 "you to spin up, fork off, or hand off a task to a sub-agent, "
                 "child agent, or separate agent**, and whenever a request has "
                 "an independent part that benefits from running in its own "
                 "context (e.g. exploration / summarization that would clutter "
-                "the main conversation). For parallel work, call "
-                "delegate_task multiple times in the same response. "
+                "the main conversation). For parallel work over a known list "
+                "of similar subtasks, prefer `delegate_tasks` (plural). "
                 "**Do not just do the work yourself with workspace_read / "
                 "vault_read** when the user explicitly asked for a sub-agent."
             ),
@@ -391,6 +601,83 @@ DELEGATE_TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["task"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "priority": "critical",
+        # Owns child timeouts internally; gather-bounded fan-out.
+        "timeout": None,
+        "function": {
+            "name": "delegate_tasks",
+            "description": (
+                "Dispatch a BATCH of independent subtasks to child agents "
+                "in PARALLEL. Use this when you have a known list of "
+                "similar investigations (per-page, per-file, per-topic) "
+                "where the children don't need to talk to each other and "
+                "can run concurrently. Each task runs as its own forked "
+                "child with the same tools and skills. Returns one "
+                "structured result containing per-task status (ok/error) "
+                "in input order. Concurrency is capped by config; the "
+                "batch size is also capped per call. For a single "
+                "subtask, use `delegate_task` (singular) instead — the "
+                "ergonomics are simpler."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tasks": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "List of task descriptions, one per child. "
+                            "Each description should be self-contained "
+                            "with enough context to work independently. "
+                            "All tasks share the same model, vault flags, "
+                            "and return schema — for per-task overrides, "
+                            "fall back to multiple `delegate_task` calls."
+                        ),
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": (
+                            "Named model config for every subtask in the "
+                            "batch. Omit to inherit parent's model."
+                        ),
+                    },
+                    "allow_vault_retrieval": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, every child runs the proactive "
+                            "memory retrieval at turn start. Default "
+                            "false. Same semantics as `delegate_task`."
+                        ),
+                    },
+                    "allow_vault_read": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, every child can call read-side "
+                            "vault tools (vault_read, vault_search, "
+                            "vault_list, vault_backlinks, "
+                            "vault_show_sections). Default false. Vault "
+                            "WRITE tools are categorically blocked. "
+                            "Same semantics as `delegate_task`."
+                        ),
+                    },
+                    "return_schema": {
+                        "type": "object",
+                        "description": (
+                            "Optional JSON-schema-shaped object applied "
+                            "to every child in the batch. Each successful "
+                            "per-task entry's `data` field will be the "
+                            "parsed JSON; `text` will be the prose with "
+                            "the JSON block stripped. Treat as a hint — "
+                            "no validation is performed."
+                        ),
+                    },
+                },
+                "required": ["tasks"],
             },
         },
     },

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -12,6 +12,7 @@ from decafclaw.tools.delegate import (
     DEFAULT_CHILD_SYSTEM_PROMPT,
     _run_child_turn,
     tool_delegate_task,
+    tool_delegate_tasks,
 )
 
 
@@ -515,3 +516,214 @@ class TestVaultAccessPolicy:
             "allow_vault_retrieval": True,
             "allow_vault_read": True,
         }
+
+
+class TestDelegateTasks:
+    """Parallel batch dispatch via `delegate_tasks` (#397).
+
+    These tests patch ``_run_child_turn`` so we can control per-task
+    return values, simulate failures, and observe concurrency without
+    spinning up real child agents.
+    """
+
+    @pytest.mark.asyncio
+    async def test_happy_path_three_tasks(self, ctx):
+        """Three tasks all return prose; result has ok entries in
+        input order, summary counts match, and the parent emits one
+        progress event per child."""
+        published: list[tuple] = []
+
+        async def fake_publish(event_type, payload):
+            published.append((event_type, payload))
+
+        ctx.publish = fake_publish
+
+        async def fake_run(parent_ctx, task, **kwargs):
+            return f"result for {task}"
+
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+        ):
+            result = await tool_delegate_tasks(ctx, ["a", "b", "c"])
+
+        assert isinstance(result, ToolResult)
+        assert result.data["summary"] == {"total": 3, "ok": 3, "failed": 0}
+        results = result.data["results"]
+        assert [r["index"] for r in results] == [0, 1, 2]
+        assert all(r["ok"] for r in results)
+        assert results[0]["text"] == "result for a"
+        assert results[1]["text"] == "result for b"
+        assert results[2]["text"] == "result for c"
+        assert "3 subtasks" in result.text
+        # One progress event per completion.
+        statuses = [p for p in published if p[0] == "tool_status"]
+        assert len(statuses) == 3
+        assert all(p[1]["tool"] == "delegate_tasks" for p in statuses)
+
+    @pytest.mark.asyncio
+    async def test_mixed_failures(self, ctx):
+        """One child returns an error ToolResult, another raises;
+        siblings still complete and the result reflects per-task
+        status."""
+        async def fake_run(parent_ctx, task, **kwargs):
+            if task == "boom":
+                raise RuntimeError("kaboom")
+            if task == "softfail":
+                return ToolResult(text="[error: subtask timed out]")
+            return f"ok for {task}"
+
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+        ):
+            result = await tool_delegate_tasks(
+                ctx, ["fine", "softfail", "boom", "alsofine"],
+            )
+
+        assert result.data["summary"] == {
+            "total": 4, "ok": 2, "failed": 2,
+        }
+        results = result.data["results"]
+        assert results[0] == {"index": 0, "ok": True, "text": "ok for fine"}
+        assert results[1]["ok"] is False
+        assert "[error: subtask timed out]" in results[1]["error"]
+        assert results[2]["ok"] is False
+        assert "kaboom" in results[2]["error"]
+        assert results[3] == {
+            "index": 3, "ok": True, "text": "ok for alsofine",
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_list_errors(self, ctx):
+        result = await tool_delegate_tasks(ctx, [])
+        assert isinstance(result, ToolResult)
+        assert result.text.startswith("[error:")
+        assert "non-empty list" in result.text
+
+    @pytest.mark.asyncio
+    async def test_blank_entry_errors(self, ctx):
+        result = await tool_delegate_tasks(ctx, ["valid", "  "])
+        assert result.text.startswith("[error:")
+        assert "tasks[1]" in result.text
+
+    @pytest.mark.asyncio
+    async def test_non_string_entry_errors(self, ctx):
+        result = await tool_delegate_tasks(ctx, ["valid", 42])  # type: ignore[list-item]
+        assert result.text.startswith("[error:")
+        assert "tasks[1]" in result.text
+
+    @pytest.mark.asyncio
+    async def test_over_cap_errors(self, ctx):
+        ctx.config.agent.max_tasks_per_delegate_call = 2
+        result = await tool_delegate_tasks(ctx, ["a", "b", "c"])
+        assert result.text.startswith("[error:")
+        assert "cap is 2" in result.text
+
+    @pytest.mark.asyncio
+    async def test_concurrency_cap_honored(self, ctx):
+        """With cap=2 and 4 tasks, never more than 2 children are
+        in-flight simultaneously."""
+        ctx.config.agent.max_parallel_delegates = 2
+        ctx.config.agent.max_tasks_per_delegate_call = 10
+
+        state = {"in_flight": 0, "max_observed": 0}
+        state_lock = asyncio.Lock()
+        cap_full = asyncio.Event()
+
+        async def fake_run(parent_ctx, task, **kwargs):
+            async with state_lock:
+                state["in_flight"] += 1
+                if state["in_flight"] > state["max_observed"]:
+                    state["max_observed"] = state["in_flight"]
+                if state["in_flight"] >= 2:
+                    cap_full.set()
+            # Wait until both slots are occupied before any one releases,
+            # so a buggy implementation that allowed 3+ would visibly
+            # exceed the cap.
+            await cap_full.wait()
+            async with state_lock:
+                state["in_flight"] -= 1
+            return f"done {task}"
+
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+        ):
+            result = await tool_delegate_tasks(
+                ctx, ["a", "b", "c", "d"],
+            )
+
+        assert state["max_observed"] == 2
+        assert result.data["summary"]["ok"] == 4
+
+    @pytest.mark.asyncio
+    async def test_structured_return_parses_per_task(self, ctx):
+        """When return_schema is supplied, each successful entry's
+        data is the parsed JSON and text is the prose."""
+        async def fake_run(parent_ctx, task, **kwargs):
+            return (
+                f"prose for {task}\n\n"
+                "```json\n"
+                f'{{"task": "{task}", "score": 7}}\n'
+                "```\n"
+            )
+
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+        ):
+            result = await tool_delegate_tasks(
+                ctx, ["x", "y"], return_schema={"task": "string", "score": 0},
+            )
+
+        results = result.data["results"]
+        assert results[0]["data"] == {"task": "x", "score": 7}
+        assert results[0]["text"] == "prose for x"
+        assert results[1]["data"] == {"task": "y", "score": 7}
+        assert results[1]["text"] == "prose for y"
+
+    @pytest.mark.asyncio
+    async def test_event_override_routed_to_child_id(self, ctx):
+        """Each child's _run_child_turn call gets a unique override
+        for `event_context_id`, so parent UI doesn't get flooded."""
+        seen_overrides: list[str | None] = []
+
+        async def fake_run(parent_ctx, task, **kwargs):
+            seen_overrides.append(kwargs.get("event_context_id_override"))
+            return f"ok {task}"
+
+        with patch(
+            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+        ):
+            await tool_delegate_tasks(ctx, ["a", "b", "c"])
+
+        assert all(o is not None for o in seen_overrides)
+        assert len(set(seen_overrides)) == 3  # all distinct
+        assert all("delegate-tasks-child-" in o for o in seen_overrides)
+
+    @pytest.mark.asyncio
+    async def test_run_child_turn_event_override_kwarg(self, ctx):
+        """The new `event_context_id_override` kwarg on
+        `_run_child_turn` reaches the setup callback that
+        `enqueue_turn` invokes — so the singular path stays unaffected
+        and the plural override actually lands on the child ctx."""
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+
+            await _run_child_turn(
+                ctx, "task",
+                event_context_id_override="custom-override-id",
+            )
+
+        child_ctx = mock_run.call_args[0][0]
+        assert child_ctx.event_context_id == "custom-override-id"
+
+    @pytest.mark.asyncio
+    async def test_singular_event_routing_unchanged(self, ctx):
+        """When the override is omitted (singular case), the child
+        still routes events to the parent's subscriber id."""
+        ctx.event_context_id = "parent-subscriber-id"
+        with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = ToolResult(text="ok")
+
+            await _run_child_turn(ctx, "task")
+
+        child_ctx = mock_run.call_args[0][0]
+        assert child_ctx.event_context_id == "parent-subscriber-id"


### PR DESCRIPTION
## Summary

- New tool `delegate_tasks` (plural) dispatches a batch of subtasks as concurrent child agents under a single tool call.
- Concurrency capped by `agent.max_parallel_delegates` (default 3); batch size capped by `agent.max_tasks_per_delegate_call` (default 10).
- All non-`tasks` params (`model`, `allow_vault_retrieval`, `allow_vault_read`, `return_schema`) are shared across the batch; per-task overrides require fall-back to singular `delegate_task` calls.
- Per-child events suppressed from the parent UI — one aggregate `tool_status` event fires per completion. Failure isolation via `asyncio.gather(return_exceptions=True)`.

## Design decisions

- **Shared params over per-task dicts.** v1 keeps the API tight for the dominant fan-out shape (similar investigations). Promote to per-task dicts later if a real use case appears.
- **Suppress per-child events.** Routes each child's event_context_id to a unique override id; the parent emits one aggregate progress event per completion. Avoids flooding the parent UI with N concurrent tool streams.
- **Cap on batch size.** Hard limit at the tool boundary so a runaway prompt can't fan out 1000 children.
- **Singular tool unchanged.** `delegate_task` keeps its current shape; description tweaked to point agents at the plural form for batched work.

## Note on Gemini schema compatibility (#71)

A previous attempt at multi-delegation hit Gemini 2.5 Flash's `finish_reason: malformed_function_call` and was unwound in [`2026-03-18-1017-concurrent-tools-delegate`](docs/dev-sessions/2026-03-18-1017-concurrent-tools-delegate/spec.md). **That failed schema was specifically array-of-objects-with-properties** (`tasks → items → object → { task, tools, system_prompt }`) — two levels of nesting and per-item required fields.

This PR's schema is **array-of-strings only** (`tasks → items → string`), which is the pattern used successfully today by `checklist_create.steps`, `vault_write.tags`, `email_send.to`, `vault_show_sections.sections`, etc. — all of which work on Gemini. So the failure mode from #71 is sidestepped by construction.

**If `malformed_function_call` reappears** in logs after this lands, the fallback is the existing pattern: agents emit N singular `delegate_task` calls in one response and the agent loop runs them concurrently via `max_concurrent_tools=5`. The plural tool's incremental value is structured aggregation + single-tool-call mental model + an independent concurrency cap; reverting it isn't catastrophic.

## Test plan

- [x] Three-task happy path — results in input order, one progress event per completion
- [x] Mixed failures (one ToolResult error, one exception) — siblings still complete
- [x] Empty list / blank entries / non-string entries — fail-fast errors with clear messages
- [x] Over-cap batch — fail-fast error mentioning the cap
- [x] Concurrency cap honored — 4 tasks with cap=2 never exceeds 2 in-flight
- [x] Per-task structured returns parse correctly
- [x] Each child gets a unique `event_context_id` override
- [x] `_run_child_turn`'s new `event_context_id_override` kwarg reaches the setup callback
- [x] Singular path's event routing unchanged
- [x] Full test suite (2199 tests) passes

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)