### PR TITLE
refactor(conversation_manager): PersistedTurnState single source of truth

### DIFF
--- a/docs/dev-sessions/2026-04-27-1654-persisted-turn-state/spec.md
+++ b/docs/dev-sessions/2026-04-27-1654-persisted-turn-state/spec.md
@@ -1,0 +1,157 @@
+# PersistedTurnState — single source of truth for conversation persistence (#378)
+
+## Problem
+
+`ConversationManager._save_conversation_state` and `_restore_per_conv_state` are a save/restore pair (`conversation_manager.py:765-790`). They copy a deliberate subset of `Context` state onto `ConversationState` and back. The bug shape: **two parallel hand-maintained field lists** that drift out of sync silently — adding a persistent field requires both a save edit and a restore edit, with symmetry enforced only by code review.
+
+CLAUDE.md already bans the "hand-list fields when copying" pattern, but `_save`/`_restore` carved out an exception because not every ctx field should persist (per-call counters, per-call IDs, transient flags must NOT survive). The right fix isn't `vars()` iteration; it's a typed dataclass that names "what persists" plus a single binding table that walks fields symmetrically.
+
+## Why this isn't the same fix as #377
+
+The audit fixes that #377 addressed (`fork_for_tool_call`, notification round-trip, confirmation round-trip) all wanted *every* field to propagate — `vars()` / `dataclasses.fields()` iteration was the right idiom there.
+
+This pair wants only a *deliberate subset*. So `vars()` would be wrong; we need a structurally-enforced subset.
+
+## Design
+
+### `PersistedTurnState` dataclass
+
+```python
+@dataclass
+class PersistedTurnState:
+    """Per-conversation state that persists across turns.
+
+    Two field categories live here:
+    - Ctx-driven: written by `_save_conversation_state` from ctx,
+      read by `_restore_per_conv_state` onto ctx.
+    - Externally-driven: set by `manager.set_flag()` from web /
+      transport handlers, read by restore onto ctx; save never
+      overwrites these.
+    """
+    extra_tools: dict = field(default_factory=dict)
+    extra_tool_definitions: list = field(default_factory=list)
+    activated_skills: set = field(default_factory=set)
+    skip_vault_retrieval: bool = False
+    active_model: str = ""
+```
+
+Replaces the existing trio on `ConversationState`:
+- `skill_state: dict | None` (the dict shape that today bundles `extra_tools` / `extra_tool_definitions` / `activated_skills`)
+- `skip_vault_retrieval: bool`
+- `active_model: str`
+
+…with a single field `persisted: PersistedTurnState = field(default_factory=PersistedTurnState)`.
+
+### Binding table — single source of truth
+
+```python
+# Per-field reader/writer pair, exhaustive over PersistedTurnState
+# fields. Adding a field to PersistedTurnState requires adding an
+# entry here (the regression test in test_conversation_manager.py
+# enforces this).
+_PERSISTED_BINDINGS: dict[str, tuple[Callable, Callable]] = {
+    "extra_tools": (
+        lambda ctx: ctx.tools.extra,
+        lambda ctx, v: setattr(ctx.tools, "extra", v),
+    ),
+    "extra_tool_definitions": (
+        lambda ctx: ctx.tools.extra_definitions,
+        lambda ctx, v: setattr(ctx.tools, "extra_definitions", v),
+    ),
+    "activated_skills": (
+        lambda ctx: ctx.skills.activated,
+        lambda ctx, v: setattr(ctx.skills, "activated", v),
+    ),
+    "skip_vault_retrieval": (
+        lambda ctx: ctx.skip_vault_retrieval,
+        lambda ctx, v: setattr(ctx, "skip_vault_retrieval", v),
+    ),
+    "active_model": (
+        lambda ctx: ctx.active_model,
+        lambda ctx, v: setattr(ctx, "active_model", v),
+    ),
+}
+
+# Fields whose value flows ctx -> state on save. Others are
+# externally-driven and only flow state -> ctx on restore.
+_CTX_DRIVEN_FIELDS = frozenset({
+    "extra_tools",
+    "extra_tool_definitions",
+    "activated_skills",
+    "skip_vault_retrieval",
+})
+```
+
+### Save/restore become symmetric loops
+
+```python
+def _save_conversation_state(self, state, ctx):
+    for f in dc_fields(PersistedTurnState):
+        if f.name not in _CTX_DRIVEN_FIELDS:
+            continue
+        reader, _ = _PERSISTED_BINDINGS[f.name]
+        value = reader(ctx)
+        if value:  # truthy — preserves sticky-once-set semantics
+            setattr(state.persisted, f.name, value)
+
+def _restore_per_conv_state(self, state, ctx):
+    for f in dc_fields(PersistedTurnState):
+        _, writer = _PERSISTED_BINDINGS[f.name]
+        value = getattr(state.persisted, f.name)
+        if not value:
+            continue
+        writer(ctx, value)
+```
+
+The `if value:` truthiness guards preserve the existing "once-True/once-set, never clobber back to default" semantics that the inline conditionals have today (e.g. ctx.skip_vault_retrieval set via `set_flag` survives even if a turn's ctx is born False).
+
+### `set_flag` writes through
+
+Currently `set_flag(conv_id, key, value)` does `setattr(state, key, value)`. After the refactor, the persisted fields live on `state.persisted`. Update:
+
+```python
+def set_flag(self, conv_id, key, value):
+    state = self._get_or_create(conv_id)
+    if key in {f.name for f in dc_fields(PersistedTurnState)}:
+        setattr(state.persisted, key, value)
+        return
+    if hasattr(state, key):
+        setattr(state, key, value)
+        return
+    log.warning("Unknown conversation flag: %s", key)
+```
+
+### Read sites
+
+`mattermost.py:450` reads `conv_state.active_model` directly. Update to `conv_state.persisted.active_model`. Self-contained — only one external read site. Tests have one or two pokes at the old fields, also updated.
+
+### Regression test
+
+```python
+def test_persisted_field_bindings_exhaustive():
+    """Every PersistedTurnState field must have a binding entry —
+    so adding a future field can't silently drop out of save/restore."""
+    pf = {f.name for f in dc_fields(PersistedTurnState)}
+    bf = set(_PERSISTED_BINDINGS.keys())
+    assert pf == bf
+```
+
+Plus an end-to-end save→restore round-trip test with every field set to a non-default sentinel, verifying restore reproduces them all on a fresh ctx.
+
+## Files touched
+
+- `src/decafclaw/conversation_manager.py` — new dataclass, new bindings, rewritten save/restore + set_flag, `ConversationState` field swap.
+- `src/decafclaw/mattermost.py` — one read site.
+- `tests/test_conversation_manager.py` — update `test_enqueue_turn_wake_kind_restores_skill_state` to construct `PersistedTurnState`; add the binding-coverage test and a round-trip test.
+
+## Out of scope
+
+- Persisting any *new* fields. This is purely a structural refactor of what's there.
+- Changing the public API of `set_flag`. The transport-side callers (`web/websocket.py`) keep working.
+
+## Test plan
+
+1. `test_persisted_field_bindings_exhaustive` — fields set matches bindings set.
+2. `test_save_restore_round_trip` — set every PersistedTurnState field on ctx + state via `set_flag`/save, restore on a fresh ctx, assert all values flow through.
+3. Existing `test_enqueue_turn_wake_kind_restores_skill_state` updated to use `PersistedTurnState` directly — should pass without behavior change.
+4. Full pytest run — no regressions.

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
 from enum import Enum
 from typing import Any, Callable
 from uuid import uuid4
@@ -60,6 +61,83 @@ STATE_PERSIST_KINDS = {TurnKind.USER, TurnKind.WAKE}
 
 
 @dataclass
+class PersistedTurnState:
+    """Per-conversation state that persists across agent turns (#378).
+
+    Replaces the parallel save/restore field lists that used to live
+    inline on `ConversationState` (`skill_state` dict + ad-hoc
+    booleans/strings). Two field categories live here:
+
+    - **Ctx-driven** (listed in ``_CTX_DRIVEN_FIELDS`` below): written
+      by ``_save_conversation_state`` from the live ctx at turn end,
+      read by ``_restore_per_conv_state`` onto the next turn's ctx.
+    - **Externally-driven** (everything else in this dataclass): set
+      by ``ConversationManager.set_flag`` from web / transport
+      handlers; restore reads them onto ctx but save never touches
+      them.
+
+    Adding a field requires a matching entry in ``_PERSISTED_BINDINGS``
+    (the unit test ``test_persisted_field_bindings_exhaustive``
+    enforces this) and an explicit decision about which category it
+    belongs to.
+    """
+    extra_tools: dict = field(default_factory=dict)
+    extra_tool_definitions: list = field(default_factory=list)
+    activated_skills: set = field(default_factory=set)
+    skip_vault_retrieval: bool = False
+    active_model: str = ""
+
+
+# Per-field reader/writer bindings between PersistedTurnState and the
+# live Context. Exhaustive over PersistedTurnState fields — readers
+# fetch the current ctx value; writers apply a state value back onto
+# ctx. Save and restore both walk this table so adding a field can't
+# silently drop out of either side. The exhaustiveness check lives in
+# ``test_persisted_field_bindings_exhaustive``.
+_PERSISTED_BINDINGS: dict[str, tuple[Callable[[Any], Any], Callable[[Any, Any], None]]] = {
+    "extra_tools": (
+        lambda ctx: ctx.tools.extra,
+        lambda ctx, v: setattr(ctx.tools, "extra", v),
+    ),
+    "extra_tool_definitions": (
+        lambda ctx: ctx.tools.extra_definitions,
+        lambda ctx, v: setattr(ctx.tools, "extra_definitions", v),
+    ),
+    "activated_skills": (
+        lambda ctx: ctx.skills.activated,
+        lambda ctx, v: setattr(ctx.skills, "activated", v),
+    ),
+    "skip_vault_retrieval": (
+        lambda ctx: ctx.skip_vault_retrieval,
+        lambda ctx, v: setattr(ctx, "skip_vault_retrieval", v),
+    ),
+    "active_model": (
+        lambda ctx: ctx.active_model,
+        lambda ctx, v: setattr(ctx, "active_model", v),
+    ),
+}
+
+
+# Subset of PersistedTurnState fields whose value flows
+# ctx → state on save. Other fields are externally-driven (e.g. by
+# `set_flag` from a transport handler) and never overwritten by save.
+_CTX_DRIVEN_FIELDS: frozenset[str] = frozenset({
+    "extra_tools",
+    "extra_tool_definitions",
+    "activated_skills",
+    "skip_vault_retrieval",
+})
+
+
+# All declared PersistedTurnState field names — precomputed once at
+# module load so hot paths like ``set_flag`` don't reflect on every
+# call. Stays in sync with the dataclass automatically.
+_PERSISTED_FIELD_NAMES: frozenset[str] = frozenset(
+    f.name for f in dc_fields(PersistedTurnState)
+)
+
+
+@dataclass
 class ConversationState:
     """Per-conversation state managed by the ConversationManager."""
     conv_id: str = ""
@@ -74,10 +152,10 @@ class ConversationState:
     confirmation_event: asyncio.Event | None = None
     confirmation_response: ConfirmationResponse | None = None
 
-    # Per-conversation persistent state (survives across turns)
-    skill_state: dict | None = None
-    skip_vault_retrieval: bool = False
-    active_model: str = ""
+    # Per-conversation persistent state (survives across turns).
+    # See PersistedTurnState for what lives here and how save/restore
+    # interact with it.
+    persisted: PersistedTurnState = field(default_factory=PersistedTurnState)
 
     # Circuit breaker state (rate-limiting turns per conversation)
     turn_times: list = field(default_factory=list)
@@ -410,12 +488,20 @@ class ConversationManager:
             state.history = history
 
     def set_flag(self, conv_id: str, key: str, value) -> None:
-        """Set a per-conversation flag (e.g., skip_vault_retrieval, active_model)."""
+        """Set a per-conversation flag (e.g., skip_vault_retrieval, active_model).
+
+        Persisted-state fields (those declared on ``PersistedTurnState``)
+        are written through to ``state.persisted.<key>``; other keys
+        fall through to direct ``ConversationState`` attributes.
+        """
         state = self._get_or_create(conv_id)
+        if key in _PERSISTED_FIELD_NAMES:
+            setattr(state.persisted, key, value)
+            return
         if hasattr(state, key):
             setattr(state, key, value)
-        else:
-            log.warning("Unknown conversation flag: %s", key)
+            return
+        log.warning("Unknown conversation flag: %s", key)
 
     def subscribe(self, conv_id: str, callback: Callable) -> str:
         """Subscribe to a conversation's event stream. Returns subscription ID."""
@@ -763,31 +849,47 @@ class ConversationManager:
         state.agent_task = asyncio.create_task(run())
 
     def _restore_per_conv_state(self, state: ConversationState, ctx) -> None:
-        """Restore per-conversation state (skill activations, model, flags) onto ctx.
+        """Restore persisted per-conversation state onto ctx.
 
-        Called for USER and WAKE turns, which share the same live conversation.
+        Walks every ``PersistedTurnState`` field through
+        ``_PERSISTED_BINDINGS`` so adding a new persisted field can't
+        silently drop out of restore. Falsy persisted values are
+        skipped — preserves the sticky-once-set semantics that ctx
+        defaults rely on (e.g. a fresh ctx born with
+        ``skip_vault_retrieval=False`` shouldn't be clobbered by a
+        default-False persisted value).
+
+        Called for USER and WAKE turns — the kinds that share a live
+        conversation across turns.
         """
-        if state.skill_state:
-            ctx.tools.extra = state.skill_state.get("extra_tools", {})
-            ctx.tools.extra_definitions = state.skill_state.get(
-                "extra_tool_definitions", [])
-            ctx.skills.activated = state.skill_state.get(
-                "activated_skills", set())
-        if state.skip_vault_retrieval:
-            ctx.skip_vault_retrieval = True
-        if state.active_model:
-            ctx.active_model = state.active_model
+        persisted = state.persisted
+        for f in dc_fields(PersistedTurnState):
+            _, writer = _PERSISTED_BINDINGS[f.name]
+            value = getattr(persisted, f.name)
+            if not value:
+                continue
+            writer(ctx, value)
 
     def _save_conversation_state(self, state: ConversationState, ctx) -> None:
-        """Persist relevant context state back to conversation state."""
-        if ctx.skills.activated:
-            state.skill_state = {
-                "extra_tools": ctx.tools.extra,
-                "extra_tool_definitions": ctx.tools.extra_definitions,
-                "activated_skills": ctx.skills.activated,
-            }
-        if ctx.skip_vault_retrieval:
-            state.skip_vault_retrieval = True
+        """Persist ctx-driven state into ``state.persisted``.
+
+        Only fields listed in ``_CTX_DRIVEN_FIELDS`` flow this way —
+        externally-driven fields (e.g. ``active_model``, set via
+        ``set_flag`` from the web UI) are owned by their setters and
+        save never overwrites them.
+
+        Truthy-only writes preserve the sticky semantics that the
+        previous inline save logic had: once a ctx-driven flag becomes
+        True for a conversation, save never flips it back to False.
+        """
+        persisted = state.persisted
+        for f in dc_fields(PersistedTurnState):
+            if f.name not in _CTX_DRIVEN_FIELDS:
+                continue
+            reader, _ = _PERSISTED_BINDINGS[f.name]
+            value = reader(ctx)
+            if value:
+                setattr(persisted, f.name, value)
 
     async def _drain_pending(self, state: ConversationState) -> None:
         """Process queued entries one batch at a time.

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -447,7 +447,7 @@ class MattermostClient:
         def is_streaming():
             """Resolve streaming for the conversation's active model."""
             conv_state = manager.get_state(conv_id)
-            model = conv_state.active_model if conv_state else ""
+            model = conv_state.persisted.active_model if conv_state else ""
             return resolve_streaming(config, model)
         compaction_post_id = None
 

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -11,7 +11,14 @@ from decafclaw.confirmations import (
     ConfirmationRequest,
     ConfirmationResponse,
 )
-from decafclaw.conversation_manager import ConversationManager, ConversationState, TurnKind
+from decafclaw.conversation_manager import (
+    _CTX_DRIVEN_FIELDS,
+    _PERSISTED_BINDINGS,
+    ConversationManager,
+    ConversationState,
+    PersistedTurnState,
+    TurnKind,
+)
 from decafclaw.events import EventBus
 
 
@@ -645,13 +652,11 @@ async def test_enqueue_turn_wake_kind_restores_skill_state(
     monkeypatch.setattr("decafclaw.agent.run_agent_turn", fake_run_agent_turn)
 
     state = manager._get_or_create("c1")
-    state.skill_state = {
-        "extra_tools": {"tool_x": lambda ctx: None},
-        "extra_tool_definitions": [{"name": "tool_x"}],
-        "activated_skills": {"skill_x"},
-    }
-    state.skip_vault_retrieval = True
-    state.active_model = "fancy-model"
+    state.persisted.extra_tools = {"tool_x": lambda ctx: None}
+    state.persisted.extra_tool_definitions = [{"name": "tool_x"}]
+    state.persisted.activated_skills = {"skill_x"}
+    state.persisted.skip_vault_retrieval = True
+    state.persisted.active_model = "fancy-model"
 
     future = await manager.enqueue_turn(
         conv_id="c1",
@@ -1091,3 +1096,102 @@ async def test_wake_explicit_context_overrides_inherited(
 
     assert seen[1]["user_id"] == "explicit-wake-user"
     assert seen[1]["channel_name"] == "wake-channel"
+
+
+# -- PersistedTurnState — single source of truth (#378) -----------------------
+
+def test_persisted_field_bindings_exhaustive():
+    """Every PersistedTurnState field must have a binding entry — adding
+    a field without a binding would silently drop it from save/restore."""
+    from dataclasses import fields as dc_fields
+    declared = {f.name for f in dc_fields(PersistedTurnState)}
+    bound = set(_PERSISTED_BINDINGS.keys())
+    assert declared == bound, (
+        f"PersistedTurnState fields and _PERSISTED_BINDINGS keys disagree: "
+        f"declared-only={declared - bound}, bound-only={bound - declared}"
+    )
+
+
+def test_ctx_driven_fields_subset_of_persisted():
+    """_CTX_DRIVEN_FIELDS must reference only declared persisted fields —
+    catches typos that would otherwise silently misclassify a field."""
+    from dataclasses import fields as dc_fields
+    declared = {f.name for f in dc_fields(PersistedTurnState)}
+    assert _CTX_DRIVEN_FIELDS <= declared, (
+        f"_CTX_DRIVEN_FIELDS contains unknown field(s): "
+        f"{_CTX_DRIVEN_FIELDS - declared}"
+    )
+
+
+def test_save_restore_round_trip(manager, config):
+    """End-to-end: populate every persisted field, save from a ctx,
+    restore onto a fresh ctx, assert all values flow through."""
+    from decafclaw.context import Context
+
+    state = manager._get_or_create("rt-conv")
+
+    # Populate ctx with non-default sentinel values for every
+    # persisted field. Using `set_flag` for the externally-driven
+    # fields and direct ctx writes for the ctx-driven ones — same
+    # paths the real code uses.
+    save_ctx = Context(config=config, event_bus=manager.event_bus)
+    save_ctx.tools.extra = {"sentinel_tool": lambda c: None}
+    save_ctx.tools.extra_definitions = [{"name": "sentinel_tool"}]
+    save_ctx.skills.activated = {"sentinel_skill"}
+    save_ctx.skip_vault_retrieval = True
+    manager.set_flag("rt-conv", "active_model", "sentinel-model")
+
+    manager._save_conversation_state(state, save_ctx)
+
+    # Round-trip: a fresh ctx should pick up every field on restore.
+    restore_ctx = Context(config=config, event_bus=manager.event_bus)
+    manager._restore_per_conv_state(state, restore_ctx)
+
+    assert restore_ctx.tools.extra == {"sentinel_tool": save_ctx.tools.extra["sentinel_tool"]}
+    assert restore_ctx.tools.extra_definitions == [{"name": "sentinel_tool"}]
+    assert restore_ctx.skills.activated == {"sentinel_skill"}
+    assert restore_ctx.skip_vault_retrieval is True
+    assert restore_ctx.active_model == "sentinel-model"
+
+
+def test_save_does_not_overwrite_externally_driven_fields(manager, config):
+    """``active_model`` is set via ``set_flag`` from the web UI; save
+    runs at turn end and must not clobber it with whatever ctx happens
+    to carry."""
+    from decafclaw.context import Context
+
+    state = manager._get_or_create("ext-conv")
+    manager.set_flag("ext-conv", "active_model", "user-pinned-model")
+
+    # ctx happens to carry a different (or empty) active_model — save
+    # should leave the persisted value alone.
+    ctx = Context(config=config, event_bus=manager.event_bus)
+    ctx.active_model = "some-different-value"
+    manager._save_conversation_state(state, ctx)
+
+    assert state.persisted.active_model == "user-pinned-model"
+
+
+def test_set_flag_writes_through_to_persisted(manager):
+    """Persisted-state flags should land on ``state.persisted``, not on
+    ``ConversationState`` itself — confirms the new write-through."""
+    manager.set_flag("flag-conv", "active_model", "m1")
+    manager.set_flag("flag-conv", "skip_vault_retrieval", True)
+    state = manager.get_state("flag-conv")
+    assert state.persisted.active_model == "m1"
+    assert state.persisted.skip_vault_retrieval is True
+
+
+def test_save_truthy_only_preserves_sticky_semantics(manager, config):
+    """Once a ctx-driven flag is True in persisted state, a later save
+    with a False ctx value must not clobber it back to False."""
+    from decafclaw.context import Context
+
+    state = manager._get_or_create("sticky-conv")
+    state.persisted.skip_vault_retrieval = True
+
+    ctx = Context(config=config, event_bus=manager.event_bus)
+    ctx.skip_vault_retrieval = False  # ctx happens to be False this turn
+    manager._save_conversation_state(state, ctx)
+
+    assert state.persisted.skip_vault_retrieval is True


### PR DESCRIPTION
## Summary

- Adds `PersistedTurnState` dataclass + `_PERSISTED_BINDINGS` table as the single source of truth for what persists across agent turns.
- Replaces the previous trio (`skill_state: dict | None`, `skip_vault_retrieval: bool`, `active_model: str`) on `ConversationState` with one `persisted: PersistedTurnState` field.
- `_save_conversation_state` and `_restore_per_conv_state` walk the same binding table; adding a new persisted field can no longer silently drop out of either side.

## Why

`#378` flagged this pair as a different-shape bug from the laundry-list copy patterns we already fixed. CLAUDE.md says "never enumerate fields when copying" but that idiom assumes you want every field — here we want a deliberate subset, so `vars()` iteration would be wrong. The fix is a typed dataclass naming what persists plus a binding table walked symmetrically by both halves.

## Design notes

- `_CTX_DRIVEN_FIELDS` distinguishes fields whose value flows ctx → state on save (extra_tools / extra_tool_definitions / activated_skills / skip_vault_retrieval) from externally-driven ones (`active_model`, set via `set_flag` from web UI). Save never overwrites externally-driven fields.
- Truthy-only writes preserve the sticky-once-set semantics the inline conditionals had: a False ctx value never clobbers a True persisted value.
- `set_flag` write-through is automatic for any field that's a `PersistedTurnState` field name — keeps `web/websocket.py` callers (`set_flag("active_model", ...)`) working unchanged.

## Test plan

- [x] `test_persisted_field_bindings_exhaustive` — fields ↔ bindings symmetric
- [x] `test_ctx_driven_fields_subset_of_persisted` — typo guard on `_CTX_DRIVEN_FIELDS`
- [x] `test_save_restore_round_trip` — populate every field, save, restore on fresh ctx, all values flow through
- [x] `test_save_does_not_overwrite_externally_driven_fields` — `active_model` set via `set_flag` survives save with a different ctx value
- [x] `test_set_flag_writes_through_to_persisted` — write-through correctness
- [x] `test_save_truthy_only_preserves_sticky_semantics` — sticky-once-set guard
- [x] Existing `test_enqueue_turn_wake_kind_restores_skill_state` updated to construct `PersistedTurnState` directly — passes without behavior change
- [x] Full pytest run (2205 tests) clean

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)