### PR TITLE
Centralize WebSocket message types (#384)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui
 
 - **Mattermost concerns stay in `mattermost.py`.** Progress formatting, placeholders, threading.
 - **Web UI conversation management is REST-only.** WebSocket only for chat streaming, history loading, model changes, cancellation. Workspace files via `/api/workspace/*`. Conversation folders are metadata-only (per-user JSON index); archive files stay in place.
+- **WebSocket message types are centralized.** Add new wire types in `src/decafclaw/web/message_types.json` and run `make gen-message-types`. Code references `WSMessageType.X` in Python and `MESSAGE_TYPES.X` in JS — never bare string literals. The drift check (`make check-message-types`, wired into `make check`) catches manual edits to the generated files. See [docs/websocket-messages.md](docs/websocket-messages.md).
 - **Mattermost PATCH quirks.** Omitting `props` preserves existing props (including attachments) — to strip, send `props: {"attachments": []}`. Sending only `props` without `message` clears the text (shows "(message deleted)"). Always include the message text when patching props.
 - **Interactive button gotchas.** Button IDs must not contain underscores (callbacks silently dropped). `http_callback_base` must be reachable from MM server's network. Check `AllowedUntrustedInternalConnections` and laptop DHCP IP changes.
 - **One bot instance per Mattermost account.** A second silently misses websocket events.

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,19 @@ check-js: install-js
 	cd src/decafclaw/web/static && npx tsc --noEmit
 
 # Lint + type check (Python + JS)
-check: install-js
+check: install-js check-message-types
 	uv run ruff check src/ tests/
 	uv run pyright
 	cd src/decafclaw/web/static && npx tsc --noEmit
+
+# Regenerate the WebSocket message-type enum/JS/docs from the manifest
+gen-message-types:
+	uv run python scripts/gen_message_types.py
+
+# Verify generated WebSocket message-type files are in sync with the manifest
+check-message-types:
+	uv run python scripts/gen_message_types.py
+	git diff --exit-code -- src/decafclaw/web/message_types.py src/decafclaw/web/static/lib/message-types.js docs/websocket-messages.md
 
 # Auto-fix lint issues
 lint-fix:

--- a/docs/dev-sessions/2026-04-27-1732-ws-message-types/plan.md
+++ b/docs/dev-sessions/2026-04-27-1732-ws-message-types/plan.md
@@ -1,0 +1,772 @@
+# Centralize WebSocket message types — Implementation Plan
+
+**Goal:** Replace ~50 hand-written WS message-type literals across Python and JS with a manifest-driven, drift-checked, code-generated single source of truth.
+
+**Architecture:** A hand-edited JSON manifest (`src/decafclaw/web/message_types.json`) is the source of truth. A stdlib-only generator (`scripts/gen_message_types.py`) produces a `StrEnum` for Python, a frozen JS constants module, and a generated docs page. Make targets enforce drift detection in CI. Existing call sites in `web/websocket.py` and the JS client are migrated to the generated symbols. Runtime warnings on both sides catch any literal that slipped through during the migration.
+
+**Tech Stack:** Python 3.12 (`StrEnum`), vanilla JS (frozen `Object` + `Set`), GNU Make, pytest.
+
+**Branch:** `ws-message-types` (already created from `origin/main` + the two spec commits).
+
+---
+
+## Inventory (audit results)
+
+**Server → Client (22):**
+`background_event`, `canvas_update`, `chunk`, `command_ack`, `compaction_done`, `confirm_request`, `confirmation_response`, `conv_history`, `conv_selected`, `error`, `message_complete`, `model_changed`, `models_available`, `notification_created`, `notification_read`, `reflection_result`, `tool_end`, `tool_start`, `tool_status`, `turn_complete`, `turn_start`, `user_message`
+
+**Client → Server (8):**
+`cancel_turn`, `confirm_response`, `load_history`, `select_conv`, `send`, `set_effort` (deprecated alias for `set_model`), `set_model`, `widget_response`
+
+**Bidirectional:** none.
+
+`http_server.py`'s `tool_confirm_response` and `cancel_turn` are EventBus events, not WS wire messages — out of scope.
+
+---
+
+## Phase 1 — Manifest
+
+### Task 1.1: Create the JSON manifest
+
+**Files:**
+- Create: `src/decafclaw/web/message_types.json`
+
+The full manifest content (alphabetical within direction blocks for readability — generator sorts on output regardless):
+
+```json
+{
+  "$schema_version": 1,
+  "_doc_header": "WebSocket message types exchanged between the decafclaw server (`src/decafclaw/web/websocket.py`) and the in-browser client. This page is generated from `src/decafclaw/web/message_types.json` — edit the manifest and run `make gen-message-types` to regenerate.",
+  "messages": {
+    "background_event": {
+      "direction": "server_to_client",
+      "description": "Background-task lifecycle event surfaced into a conversation timeline (e.g. delegated task started/finished).",
+      "fields": {"conv_id": "string", "event": "object"}
+    },
+    "canvas_update": {
+      "direction": "server_to_client",
+      "description": "The conversation's canvas state changed; client should re-render the canvas panel.",
+      "fields": {"conv_id": "string", "state": "object"}
+    },
+    "chunk": {
+      "direction": "server_to_client",
+      "description": "Streaming text fragment of an in-flight assistant message.",
+      "fields": {"conv_id": "string", "text": "string"}
+    },
+    "command_ack": {
+      "direction": "server_to_client",
+      "description": "Acknowledgement that a slash-style user command was received and dispatched.",
+      "fields": {"conv_id": "string", "command": "string"}
+    },
+    "compaction_done": {
+      "direction": "server_to_client",
+      "description": "Conversation history compaction completed; client should reload history.",
+      "fields": {"conv_id": "string"}
+    },
+    "confirm_request": {
+      "direction": "server_to_client",
+      "description": "Server is asking the user to approve or deny a pending action (tool call, end-of-turn gate, widget input).",
+      "fields": {"conv_id": "string", "request_id": "string", "kind": "string", "payload": "object"}
+    },
+    "confirmation_response": {
+      "direction": "server_to_client",
+      "description": "Replay of a prior confirmation response, surfaced when reloading conversation history.",
+      "fields": {"conv_id": "string", "request_id": "string", "decision": "string"}
+    },
+    "conv_history": {
+      "direction": "server_to_client",
+      "description": "Page of historical messages for a conversation.",
+      "fields": {"conv_id": "string", "messages": "array of object", "before": "string | null"}
+    },
+    "conv_selected": {
+      "direction": "server_to_client",
+      "description": "Confirmation that a select_conv subscribed this socket to the named conversation. May include initial conversation state.",
+      "fields": {"conv_id": "string", "model": "string | null"}
+    },
+    "error": {
+      "direction": "server_to_client",
+      "description": "Generic error surfaced to the client (bad request, unknown conversation, internal error).",
+      "fields": {"message": "string", "conv_id": "string | null"}
+    },
+    "message_complete": {
+      "direction": "server_to_client",
+      "description": "Final form of an assistant message after streaming completed (or when replayed from history).",
+      "fields": {"conv_id": "string", "message": "object"}
+    },
+    "model_changed": {
+      "direction": "server_to_client",
+      "description": "The active model for a conversation changed (echoed back to all subscribers of that conversation).",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "models_available": {
+      "direction": "server_to_client",
+      "description": "List of model identifiers the user can select in the UI.",
+      "fields": {"models": "array of string"}
+    },
+    "notification_created": {
+      "direction": "server_to_client",
+      "description": "A new notification was added to the user's inbox (push from notification subsystem).",
+      "fields": {"notification": "object"}
+    },
+    "notification_read": {
+      "direction": "server_to_client",
+      "description": "A notification was marked read (push from notification subsystem).",
+      "fields": {"id": "string"}
+    },
+    "reflection_result": {
+      "direction": "server_to_client",
+      "description": "Output of the post-turn reflection step for a conversation.",
+      "fields": {"conv_id": "string", "result": "object"}
+    },
+    "tool_end": {
+      "direction": "server_to_client",
+      "description": "Final result of a tool call. Replaces the in-flight tool_status with terminal state.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "ok": "boolean", "result": "string | object"}
+    },
+    "tool_start": {
+      "direction": "server_to_client",
+      "description": "Tool call has begun execution.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "input": "object"}
+    },
+    "tool_status": {
+      "direction": "server_to_client",
+      "description": "Mid-flight progress update from a running tool.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "status": "string"}
+    },
+    "turn_complete": {
+      "direction": "server_to_client",
+      "description": "An agent turn finished (success, error, or cancellation).",
+      "fields": {"conv_id": "string"}
+    },
+    "turn_start": {
+      "direction": "server_to_client",
+      "description": "An agent turn has started; clients should clear any draft and show in-flight UI.",
+      "fields": {"conv_id": "string"}
+    },
+    "user_message": {
+      "direction": "server_to_client",
+      "description": "Echo of a user-authored message to all subscribers of the conversation (used for multi-tab sync).",
+      "fields": {"conv_id": "string", "message": "object"}
+    },
+
+    "cancel_turn": {
+      "direction": "client_to_server",
+      "description": "Request cancellation of the conversation's in-flight agent turn.",
+      "fields": {"conv_id": "string"}
+    },
+    "confirm_response": {
+      "direction": "client_to_server",
+      "description": "User's decision on a pending confirm_request.",
+      "fields": {"conv_id": "string", "request_id": "string", "decision": "string", "extras": "object"}
+    },
+    "load_history": {
+      "direction": "client_to_server",
+      "description": "Request a page of historical messages for a conversation.",
+      "fields": {"conv_id": "string", "limit": "number", "before": "string | null"}
+    },
+    "select_conv": {
+      "direction": "client_to_server",
+      "description": "Subscribe this socket to a conversation's event stream.",
+      "fields": {"conv_id": "string"}
+    },
+    "send": {
+      "direction": "client_to_server",
+      "description": "Send a user message (and/or attachments) to the conversation.",
+      "fields": {"conv_id": "string", "text": "string", "attachments": "array of object"}
+    },
+    "set_effort": {
+      "direction": "client_to_server",
+      "description": "Deprecated backward-compat alias for set_model used by older web clients.",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "set_model": {
+      "direction": "client_to_server",
+      "description": "Change the active model for a conversation.",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "widget_response": {
+      "direction": "client_to_server",
+      "description": "Submission of an interactive widget input.",
+      "fields": {"conv_id": "string", "request_id": "string", "value": "object"}
+    }
+  }
+}
+```
+
+- [ ] **Step 1.1.1 — Write the manifest.** Verbatim above.
+- [ ] **Step 1.1.2 — Sanity-check.** `python -c "import json; json.load(open('src/decafclaw/web/message_types.json'))"` — must exit 0.
+- [ ] **Step 1.1.3 — Coverage diff.** Re-run the audit greps from the spec and assert every literal appears as a manifest key:
+
+  ```bash
+  python - <<'PY'
+  import json, re, pathlib
+  manifest = json.loads(pathlib.Path("src/decafclaw/web/message_types.json").read_text())
+  keys = set(manifest["messages"])
+  py_lits = set(re.findall(r'"type":\s*"([a-z_][a-z0-9_]*)"', pathlib.Path("src/decafclaw/web/websocket.py").read_text()))
+  print("py only:", py_lits - keys)
+  print("missing in py (ok if c2s):", keys - py_lits)
+  PY
+  ```
+
+  Expected: `py only` set is empty. `missing in py` is the c2s-only set (those don't appear in `"type": "..."` outbound literals).
+
+- [ ] **Step 1.1.4 — Commit.**
+  ```bash
+  git add src/decafclaw/web/message_types.json
+  git commit -m "feat(ws): add message-type manifest (#384)"
+  ```
+
+---
+
+## Phase 2 — Generator + Make targets + first generated outputs
+
+### Task 2.1: Write the generator script
+
+**Files:**
+- Create: `scripts/gen_message_types.py`
+
+- [ ] **Step 2.1.1 — Write the generator.**
+
+```python
+#!/usr/bin/env python3
+"""Generate Python enum, JS constants, and Markdown docs for WebSocket message types.
+
+Source of truth: src/decafclaw/web/message_types.json
+Run via: make gen-message-types
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "src/decafclaw/web/message_types.json"
+PY_OUT = REPO_ROOT / "src/decafclaw/web/message_types.py"
+JS_OUT = REPO_ROOT / "src/decafclaw/web/static/lib/message-types.js"
+DOC_OUT = REPO_ROOT / "docs/websocket-messages.md"
+
+GEN_HEADER = "DO NOT EDIT — regenerate via 'make gen-message-types'"
+SOURCE_REL = MANIFEST_PATH.relative_to(REPO_ROOT).as_posix()
+
+VALID_DIRECTIONS = ("server_to_client", "client_to_server", "bidirectional")
+NAME_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def load_manifest() -> dict:
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if data.get("$schema_version") != 1:
+        sys.exit(f"unsupported $schema_version in {MANIFEST_PATH}")
+    msgs = data.get("messages")
+    if not isinstance(msgs, dict):
+        sys.exit("manifest 'messages' must be an object")
+    for name, entry in msgs.items():
+        if not NAME_RE.match(name):
+            sys.exit(f"invalid message name: {name!r}")
+        direction = entry.get("direction")
+        if direction not in VALID_DIRECTIONS:
+            sys.exit(f"{name}: invalid direction {direction!r}")
+        if not isinstance(entry.get("description"), str):
+            sys.exit(f"{name}: missing/non-string description")
+        if not isinstance(entry.get("fields"), dict):
+            sys.exit(f"{name}: 'fields' must be an object")
+    return data
+
+
+def sorted_messages(data: dict) -> list[tuple[str, dict]]:
+    direction_order = {d: i for i, d in enumerate(VALID_DIRECTIONS)}
+    return sorted(
+        data["messages"].items(),
+        key=lambda kv: (direction_order[kv[1]["direction"]], kv[0]),
+    )
+
+
+def render_python(data: dict) -> str:
+    items = sorted_messages(data)
+    out: list[str] = []
+    out.append(f'"""{GEN_HEADER}\n\nSource: {SOURCE_REL}\n"""')
+    out.append("")
+    out.append("from __future__ import annotations")
+    out.append("")
+    out.append("from enum import StrEnum")
+    out.append("")
+    out.append("")
+    out.append("class WSMessageType(StrEnum):")
+    out.append('    """WebSocket wire message types."""')
+    out.append("")
+    for name, _ in items:
+        out.append(f'    {name.upper()} = "{name}"')
+    out.append("")
+    out.append("")
+    out.append("KNOWN_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset(WSMessageType)")
+    out.append("")
+
+    def _emit_subset(var: str, names: list[str]) -> None:
+        if not names:
+            out.append(f"{var}: frozenset[WSMessageType] = frozenset()")
+            out.append("")
+            return
+        out.append(f"{var}: frozenset[WSMessageType] = frozenset({{")
+        for n in names:
+            out.append(f"    WSMessageType.{n.upper()},")
+        out.append("})")
+        out.append("")
+
+    s2c = [n for n, e in items if e["direction"] == "server_to_client"]
+    c2s = [n for n, e in items if e["direction"] == "client_to_server"]
+    bid = [n for n, e in items if e["direction"] == "bidirectional"]
+    _emit_subset("S2C_MESSAGE_TYPES", s2c)
+    _emit_subset("C2S_MESSAGE_TYPES", c2s)
+    _emit_subset("BIDIRECTIONAL_MESSAGE_TYPES", bid)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_js(data: dict) -> str:
+    items = sorted_messages(data)
+    out: list[str] = []
+    out.append(f"// {GEN_HEADER}")
+    out.append(f"// Source: {SOURCE_REL}")
+    out.append("")
+    out.append("export const MESSAGE_TYPES = Object.freeze({")
+    for name, _ in items:
+        out.append(f"  {name.upper()}: '{name}',")
+    out.append("});")
+    out.append("")
+    out.append("export const KNOWN_MESSAGE_TYPES = new Set(Object.values(MESSAGE_TYPES));")
+    return "\n".join(out) + "\n"
+
+
+def render_doc(data: dict) -> str:
+    out: list[str] = []
+    out.append(f"<!-- {GEN_HEADER} -->")
+    out.append(f"<!-- Source: {SOURCE_REL} -->")
+    out.append("")
+    out.append("# WebSocket Message Types")
+    out.append("")
+    header = (data.get("_doc_header") or "").strip()
+    if header:
+        out.append(header)
+        out.append("")
+    out.append(
+        "> **Future direction:** Field types are human-readable sketches today, not validators. "
+        "Future work could grow them into typed entries (`{type, optional, enum}`, "
+        "`{type: \"array\", items: ...}`) for runtime validation. Out of scope at present."
+    )
+    out.append("")
+    sections = (
+        ("Server → Client", "server_to_client"),
+        ("Client → Server", "client_to_server"),
+        ("Bidirectional", "bidirectional"),
+    )
+    for heading, direction in sections:
+        in_dir = sorted(
+            (n, e) for n, e in data["messages"].items() if e["direction"] == direction
+        )
+        if not in_dir:
+            continue
+        out.append(f"## {heading}")
+        out.append("")
+        for name, entry in in_dir:
+            out.append(f"### `{name}`")
+            out.append("")
+            out.append(entry["description"])
+            out.append("")
+            fields = entry.get("fields") or {}
+            if fields:
+                out.append("**Fields:**")
+                out.append("")
+                for fname, ftype in fields.items():
+                    out.append(f"- `{fname}` — {ftype}")
+                out.append("")
+            else:
+                out.append("(No payload fields.)")
+                out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    data = load_manifest()
+    PY_OUT.write_text(render_python(data), encoding="utf-8")
+    JS_OUT.write_text(render_js(data), encoding="utf-8")
+    DOC_OUT.write_text(render_doc(data), encoding="utf-8")
+    for p in (PY_OUT, JS_OUT, DOC_OUT):
+        print(f"wrote {p.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+### Task 2.2: Wire Make targets
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 2.2.1 — Add targets.** Add near the existing `vendor:`/`reindex:` group:
+
+  ```makefile
+  gen-message-types:
+  	python scripts/gen_message_types.py
+
+  check-message-types:
+  	python scripts/gen_message_types.py
+  	git diff --exit-code -- src/decafclaw/web/message_types.py src/decafclaw/web/static/lib/message-types.js docs/websocket-messages.md
+  ```
+
+- [ ] **Step 2.2.2 — Wire into `check`.** Modify the `check:` recipe to call `check-message-types` before `lint` and `typecheck`. Existing `check:` looks like:
+  ```makefile
+  check: install-js
+  	# existing lint + typecheck commands
+  ```
+  Update to invoke `check-message-types` as the first step inside `check` (or list it as a prerequisite alongside `install-js`). Inspect the actual `check:` body before editing — preserve all current commands.
+
+### Task 2.3: First generation pass
+
+- [ ] **Step 2.3.1 — Run generator twice and assert idempotence.**
+  ```bash
+  make gen-message-types
+  git status --short  # 3 new files
+  make gen-message-types
+  git diff --exit-code -- src/decafclaw/web/message_types.py src/decafclaw/web/static/lib/message-types.js docs/websocket-messages.md
+  ```
+  Expected: second run is a no-op.
+
+- [ ] **Step 2.3.2 — Skim generated outputs.**
+  - `src/decafclaw/web/message_types.py` — class `WSMessageType(StrEnum)` with all 30 members; three frozensets.
+  - `src/decafclaw/web/static/lib/message-types.js` — frozen object + Set.
+  - `docs/websocket-messages.md` — three sections, alphabetical entries.
+
+- [ ] **Step 2.3.3 — Type-check the new Python file.** `make typecheck` — must pass (no errors anywhere in the project).
+
+### Task 2.4: Unit test for handler/JS coverage
+
+**Files:**
+- Create: `tests/test_message_types.py`
+
+- [ ] **Step 2.4.1 — Write the test.**
+
+```python
+"""Tests for the WS message-type manifest, ensuring the generated artifacts
+stay aligned with the runtime call sites that consume them."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from decafclaw.web.message_types import KNOWN_MESSAGE_TYPES, WSMessageType
+from decafclaw.web.websocket import _HANDLERS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JS_PATH = REPO_ROOT / "src/decafclaw/web/static/lib/message-types.js"
+
+
+def test_all_handler_keys_are_known_types() -> None:
+    for key in _HANDLERS:
+        assert key in KNOWN_MESSAGE_TYPES, f"unknown handler key: {key!r}"
+
+
+def test_js_constants_match_python_enum() -> None:
+    text = JS_PATH.read_text(encoding="utf-8")
+    block = re.search(
+        r"export const MESSAGE_TYPES = Object\.freeze\(\{(.*?)\}\);",
+        text,
+        re.DOTALL,
+    )
+    assert block, "MESSAGE_TYPES literal block not found in generated JS"
+    js_values = set(re.findall(r"'([a-z_][a-z0-9_]*)'", block.group(1)))
+    py_values = {t.value for t in WSMessageType}
+    assert js_values == py_values
+```
+
+- [ ] **Step 2.4.2 — Run the test.**
+  ```bash
+  pytest tests/test_message_types.py -v
+  ```
+  Expected: 2 passing.
+
+### Task 2.5: Commit
+
+- [ ] **Step 2.5.1 — Lint + check-js + full test suite.**
+  ```bash
+  make lint && make check-js && make typecheck && make test
+  ```
+  All must pass. Address any failure before committing.
+
+- [ ] **Step 2.5.2 — Commit.**
+  ```bash
+  git add scripts/gen_message_types.py Makefile \
+          src/decafclaw/web/message_types.py \
+          src/decafclaw/web/static/lib/message-types.js \
+          docs/websocket-messages.md \
+          tests/test_message_types.py
+  git commit -m "feat(ws): generator + drift check for message types (#384)"
+  ```
+
+---
+
+## Phase 3 — Server flip + warning hardening
+
+### Task 3.1: Migrate `web/websocket.py` literals
+
+**Files:**
+- Modify: `src/decafclaw/web/websocket.py`
+
+- [ ] **Step 3.1.1 — Add the import.** Near the existing `from decafclaw.web.…` imports at the top of the file:
+  ```python
+  from decafclaw.web.message_types import WSMessageType
+  ```
+
+- [ ] **Step 3.1.2 — Replace outbound literals.** For each occurrence of `"type": "<wire>"` in the file (~40 sites — see grep below), replace with `"type": WSMessageType.<UPPER>`. Use repeat search-and-replace, one wire string at a time, to keep diffs reviewable.
+
+  Search-replace pairs (all server-to-client):
+  ```
+  "type": "background_event"      → "type": WSMessageType.BACKGROUND_EVENT
+  "type": "canvas_update"         → "type": WSMessageType.CANVAS_UPDATE
+  "type": "chunk"                 → "type": WSMessageType.CHUNK
+  "type": "command_ack"           → "type": WSMessageType.COMMAND_ACK
+  "type": "compaction_done"       → "type": WSMessageType.COMPACTION_DONE
+  "type": "confirm_request"       → "type": WSMessageType.CONFIRM_REQUEST
+  "type": "confirmation_response" → "type": WSMessageType.CONFIRMATION_RESPONSE
+  "type": "conv_history"          → "type": WSMessageType.CONV_HISTORY
+  "type": "conv_selected"         → "type": WSMessageType.CONV_SELECTED
+  "type": "error"                 → "type": WSMessageType.ERROR
+  "type": "message_complete"      → "type": WSMessageType.MESSAGE_COMPLETE
+  "type": "model_changed"         → "type": WSMessageType.MODEL_CHANGED
+  "type": "models_available"      → "type": WSMessageType.MODELS_AVAILABLE
+  "type": "notification_created"  → "type": WSMessageType.NOTIFICATION_CREATED
+  "type": "notification_read"     → "type": WSMessageType.NOTIFICATION_READ
+  "type": "reflection_result"     → "type": WSMessageType.REFLECTION_RESULT
+  "type": "tool_end"              → "type": WSMessageType.TOOL_END
+  "type": "tool_start"            → "type": WSMessageType.TOOL_START
+  "type": "tool_status"           → "type": WSMessageType.TOOL_STATUS
+  "type": "turn_complete"         → "type": WSMessageType.TURN_COMPLETE
+  "type": "turn_start"            → "type": WSMessageType.TURN_START
+  "type": "user_message"          → "type": WSMessageType.USER_MESSAGE
+  ```
+
+- [ ] **Step 3.1.3 — Migrate `_HANDLERS` keys.** Convert dict keys to enum members:
+  ```python
+  _HANDLERS = {
+      WSMessageType.SELECT_CONV: _handle_select_conv,
+      WSMessageType.LOAD_HISTORY: _handle_load_history,
+      WSMessageType.SEND: _handle_send,
+      WSMessageType.CANCEL_TURN: _handle_cancel_turn,
+      WSMessageType.SET_EFFORT: _handle_set_model,  # backward compat for old web UI
+      WSMessageType.SET_MODEL: _handle_set_model,
+      WSMessageType.CONFIRM_RESPONSE: _handle_confirm_response,
+      WSMessageType.WIDGET_RESPONSE: _handle_widget_response,
+  }
+  ```
+  String dispatch (`_HANDLERS.get(msg.get("type", ""))`) keeps working — `StrEnum` keys hash equal to their underlying string.
+
+- [ ] **Step 3.1.4 — Verify zero remaining `"type": "<wire>"` literals.**
+  ```bash
+  grep -nE '"type":\s*"[a-z_][a-z0-9_]*"' src/decafclaw/web/websocket.py
+  ```
+  Expected output: empty. (The error-message string `"Unknown message type: ..."` does not match this regex.)
+
+### Task 3.2: Server-side warning on inbound unknown types
+
+**Files:**
+- Modify: `src/decafclaw/web/websocket.py` around line 785–790
+
+- [ ] **Step 3.2.1 — Add `log.warning`.** Locate the inbound dispatch:
+  ```python
+  msg_type = msg.get("type", "")
+  handler = _HANDLERS.get(msg_type)
+  if handler:
+      await handler(ws_send, index, username, msg, state)
+  else:
+      await ws_send({"type": WSMessageType.ERROR, "message": f"Unknown message type: {msg_type}"})
+  ```
+  Add a `log.warning(...)` line in the `else` branch *before* the `ws_send`:
+  ```python
+  else:
+      log.warning("ws: unknown inbound message type from %s: %r", username, msg_type)
+      await ws_send({"type": WSMessageType.ERROR, "message": f"Unknown message type: {msg_type}"})
+  ```
+
+### Task 3.3: Verify and commit
+
+- [ ] **Step 3.3.1 — Lint + typecheck + tests.**
+  ```bash
+  make lint && make typecheck && make test
+  ```
+  All must pass.
+
+- [ ] **Step 3.3.2 — Commit.**
+  ```bash
+  git add src/decafclaw/web/websocket.py
+  git commit -m "refactor(ws): server uses WSMessageType enum (#384)"
+  ```
+
+---
+
+## Phase 4 — Client flip + warning
+
+### Task 4.1: Replace dispatch sites
+
+**Files:**
+- Modify: `src/decafclaw/web/static/lib/message-store.js`
+- Modify: `src/decafclaw/web/static/lib/conversation-store.js`
+- Modify: `src/decafclaw/web/static/lib/tool-status-store.js`
+- Modify: `src/decafclaw/web/static/app.js`
+- Modify: `src/decafclaw/web/static/canvas-page.js`
+
+- [ ] **Step 4.1.1 — Add imports.**
+
+  Top of each file (existing imports). Use the relative path appropriate to the file:
+  - `lib/*.js` files → `import { MESSAGE_TYPES } from './message-types.js';`
+  - `app.js`, `canvas-page.js` → `import { MESSAGE_TYPES, KNOWN_MESSAGE_TYPES } from './lib/message-types.js';`
+  - In `app.js` we'll also use `KNOWN_MESSAGE_TYPES` for the warning. Other files don't need the Set.
+
+- [ ] **Step 4.1.2 — `lib/message-store.js`.** Replace the `case '<wire>':` lines (around 135–230) with `case MESSAGE_TYPES.<UPPER>:`. Wire strings used: `conv_history`, `chunk`, `message_complete`, `user_message`, `command_ack`, `compaction_done`, `background_event`.
+
+- [ ] **Step 4.1.3 — `lib/conversation-store.js`.** Replace:
+  - Two `msg.type === 'conv_history'` and `msg.type === 'message_complete'` checks (~lines 534, 551) with `msg.type === MESSAGE_TYPES.CONV_HISTORY` / `MESSAGE_TYPES.MESSAGE_COMPLETE`.
+  - `case 'conv_selected':` / `'turn_start'` / `'model_changed'` / `'models_available'` / `'error'` (~lines 571–602) with the enum form.
+  - Outbound `ws.send({ type: 'select_conv', ... })` (line 430) with `MESSAGE_TYPES.SELECT_CONV`. Same for `'load_history'` (lines 431, 504), `'set_model'` (490), `'cancel_turn'` (497).
+
+- [ ] **Step 4.1.4 — `lib/tool-status-store.js`.** Replace:
+  - `case 'tool_start'` / `'tool_status'` / `'tool_end'` / `'confirm_request'` / `'confirmation_response'` / `'reflection_result'` (lines 130–227) with the enum form.
+  - Outbound `ws.send({ type: 'confirm_response', ... })` (line 71) and `'widget_response'` (line 109) with the enum form.
+
+- [ ] **Step 4.1.5 — `app.js`.** Replace the four `msg?.type === 'error' | 'turn_complete' | 'notification_created' | 'notification_read' | 'canvas_update'` checks (around lines 416–435).
+
+- [ ] **Step 4.1.6 — `canvas-page.js`.** Replace `ws.send(JSON.stringify({ type: 'select_conv', conv_id: convId }))` (line 74) with `MESSAGE_TYPES.SELECT_CONV`.
+
+- [ ] **Step 4.1.7 — Verify no remaining bare wire literals.**
+  ```bash
+  grep -rnE "(\\.type === ['\"][a-z_]+['\"]|case ['\"][a-z_]+['\"])" \
+    src/decafclaw/web/static/app.js \
+    src/decafclaw/web/static/canvas-page.js \
+    src/decafclaw/web/static/lib/conversation-store.js \
+    src/decafclaw/web/static/lib/message-store.js \
+    src/decafclaw/web/static/lib/tool-status-store.js
+  ```
+  Expected: empty (every remaining `.type ===` and `case` should reference `MESSAGE_TYPES.X`).
+
+### Task 4.2: Client-side warning on inbound unknown types
+
+**Files:**
+- Modify: `src/decafclaw/web/static/app.js`
+
+- [ ] **Step 4.2.1 — Locate the central WS message router.** Look in `app.js` for the `ws.addEventListener('message', ...)` or equivalent dispatcher. Add at the top of that handler, after JSON parse:
+  ```js
+  if (msg && typeof msg.type === 'string' && !KNOWN_MESSAGE_TYPES.has(msg.type)) {
+    console.warn('[ws] unknown message type from server:', msg.type, msg);
+  }
+  ```
+  Place the warning *before* the existing per-type dispatch, so it fires regardless of whether any branch handles the message. The warning is informational — do not return/skip on it.
+
+  If the central dispatch in `app.js` only sees a subset (because stores subscribe directly), put the warning at the WS-client subscribe site that sees every message. The grep that follows confirms.
+
+- [ ] **Step 4.2.2 — Verify the warning gets every message.** Skim `app.js`'s WS setup. If it forwards messages to multiple stores via separate listeners, the warning must hook in at the single point all messages flow through. Otherwise add a top-level forwarder.
+
+### Task 4.3: Verify and commit
+
+- [ ] **Step 4.3.1 — `make check-js`.** Must pass with no new errors.
+
+- [ ] **Step 4.3.2 — `make check && make test`.** All green.
+
+- [ ] **Step 4.3.3 — Manual smoke test (web UI).** Les will need to confirm `make dev` is OK to bounce, or just describe the steps. If we can't restart the running dev server, we describe the smoke-test steps in the PR body and ask Les to verify locally before merge.
+
+  Smoke checklist (when run): open the web UI, send a chat message that triggers a tool call, change models mid-conversation, cancel a turn, trigger a compaction, watch the browser console for any `[ws] unknown message type` warnings. None expected.
+
+- [ ] **Step 4.3.4 — Commit.**
+  ```bash
+  git add src/decafclaw/web/static/lib/message-store.js \
+          src/decafclaw/web/static/lib/conversation-store.js \
+          src/decafclaw/web/static/lib/tool-status-store.js \
+          src/decafclaw/web/static/app.js \
+          src/decafclaw/web/static/canvas-page.js
+  git commit -m "refactor(ws): client uses MESSAGE_TYPES constants (#384)"
+  ```
+
+---
+
+## Phase 5 — Docs index + CLAUDE.md note
+
+### Task 5.1: Link the generated docs page
+
+**Files:**
+- Modify: `docs/index.md`
+
+- [ ] **Step 5.1.1 — Add a link.** Locate the section that lists web-UI / transport docs (read the file first to find the right anchor). Add a bullet:
+  ```markdown
+  - [WebSocket message types](websocket-messages.md) — generated wire-protocol reference.
+  ```
+
+### Task 5.2: CLAUDE.md note
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 5.2.1 — Add a one-liner.** In the "Web-UI" / "Mattermost-specific" / "Conventions" section (read the file first), add a single bullet pointing future contributors at the manifest as the place to add new types:
+  ```markdown
+  - **WebSocket message types** are centralized — add new wire types in `src/decafclaw/web/message_types.json` and run `make gen-message-types`. The generated `WSMessageType` enum / `MESSAGE_TYPES` JS object are the only call-site references.
+  ```
+
+### Task 5.3: Verify and commit
+
+- [ ] **Step 5.3.1 — `make check && make test`.** Must pass.
+
+- [ ] **Step 5.3.2 — Commit.**
+  ```bash
+  git add docs/index.md CLAUDE.md
+  git commit -m "docs(ws): link generated reference + note manifest in CLAUDE.md (#384)"
+  ```
+
+---
+
+## Phase 6 — PR
+
+- [ ] **Step 6.1 — Final pre-PR checks.**
+  ```bash
+  make check && make test
+  git log --oneline origin/main..HEAD
+  ```
+  Expect 5 implementation commits + 2 spec commits = 7 total.
+
+- [ ] **Step 6.2 — Push the branch.**
+  ```bash
+  git push -u origin ws-message-types
+  ```
+
+- [ ] **Step 6.3 — Open the PR.** Title: `Centralize WebSocket message types (#384)`. Body should:
+  - Link to issue #384.
+  - Summarize the manifest → generator → drift-check architecture.
+  - List the call-site flips (server-side count, client-side files).
+  - Call out the smoke-test steps (the manual checklist from Step 4.3.3) for Les to verify.
+  - Note the `set_effort` deprecated alias is preserved (no client-facing change).
+  - Note the deferred future direction (stricter field schema).
+
+- [ ] **Step 6.4 — Add Copilot reviewer.**
+  ```bash
+  gh pr edit <PR#> --add-reviewer copilot-pull-request-reviewer
+  ```
+  Verify via:
+  ```bash
+  gh api repos/lmorchard/decafclaw/pulls/<PR#>/requested_reviewers
+  ```
+
+---
+
+## Spec Coverage Self-Review
+
+- ✅ Manifest source of truth (`message_types.json`) — Phase 1.
+- ✅ `StrEnum` Python output — Phase 2.1 (`render_python`).
+- ✅ Frozen-object JS output + `KNOWN_MESSAGE_TYPES` Set — Phase 2.1 (`render_js`).
+- ✅ Generated docs page with three sections + future-direction callout — Phase 2.1 (`render_doc`).
+- ✅ Make targets + drift check wired into `make check` — Phase 2.2.
+- ✅ Server-side migration of all literals + `_HANDLERS` keys — Phase 3.1.
+- ✅ Server-side `log.warning` on inbound unknown — Phase 3.2.
+- ✅ Client-side dispatch + outbound migration — Phase 4.1.
+- ✅ Client-side `console.warn` on inbound unknown — Phase 4.2.
+- ✅ Unit tests (handler coverage + JS↔Python value match) — Phase 2.4.
+- ✅ Drift CI test — Phase 2.5 via `make check`.
+- ✅ Docs index link + CLAUDE.md note — Phase 5.
+- ✅ Manual smoke test — Phase 4.3 (called out in PR body).
+- ✅ `http_server.py` correctly excluded — `_HANDLERS` migration in Phase 3.1 covers all server-side wire sites; `http_server.py` is documented as out of scope.

--- a/docs/dev-sessions/2026-04-27-1732-ws-message-types/spec.md
+++ b/docs/dev-sessions/2026-04-27-1732-ws-message-types/spec.md
@@ -4,7 +4,7 @@ Closes [#384](https://github.com/lmorchard/decafclaw/issues/384).
 
 ## Background
 
-WebSocket message-type strings (`"chunk"`, `"tool_end"`, `"select_conv"`, …) are scattered as ~50 string literals across `src/decafclaw/web/websocket.py`, `src/decafclaw/http_server.py`, and the JS client (`web/static/lib/*.js`, `web/static/app.js`, `web/static/canvas-page.js`). Risks:
+WebSocket message-type strings (`"chunk"`, `"tool_end"`, `"select_conv"`, …) are scattered as ~50 string literals across `src/decafclaw/web/websocket.py` and the JS client (`web/static/lib/*.js`, `web/static/app.js`, `web/static/canvas-page.js`). (Note: `http_server.py` contains a couple of `event_bus.publish(...)` calls that share names with WS wire types — `tool_confirm_response`, `cancel_turn` — but those are internal EventBus events, not wire messages, and stay as plain strings.) Risks:
 
 - Typos don't fail at compile time on either side.
 - Renames require grepping two languages.
@@ -123,11 +123,12 @@ Generated outputs:
 
 ### Migration of call sites
 
-**Server side** — `web/websocket.py` + `http_server.py`:
+**Server side** — `web/websocket.py`:
 
 - `from decafclaw.web.message_types import WSMessageType`.
-- Every `"type": "..."` literal becomes `"type": WSMessageType.X`. Works because `StrEnum` is a `str` subclass.
+- Every `"type": "..."` literal in WS-send paths becomes `"type": WSMessageType.X`. Works because `StrEnum` is a `str` subclass.
 - `_HANDLERS` dict keys become `WSMessageType.X`. Inbound dispatch keeps the existing `msg.get("type", "")` pattern (string lookup against StrEnum keys hashes correctly).
+- `http_server.py` is **not** modified: its two `event_bus.publish(...)` calls with `tool_confirm_response`/`cancel_turn` are internal pub/sub events, not WS wire messages.
 
 **Client side** — `web/static/`:
 
@@ -148,7 +149,7 @@ Generated outputs:
 
 1. **Manifest + audit** — add `web/message_types.json` populated from a complete grep of every `"type": "..."` literal on both sides. Data only; no imports yet.
 2. **Generator + Make targets + first generated outputs** — `scripts/gen_message_types.py`, `make gen-message-types`, `make check-message-types`, wired into `make check`. First run emits `web/message_types.py`, `web/static/lib/message-types.js`, `docs/websocket-messages.md`. Nothing imports the generated files yet.
-3. **Server flip + server-side warning hardening** — migrate `web/websocket.py` and the two sites in `http_server.py` to `WSMessageType.X`. Add `log.warning(...)` for inbound unknown types.
+3. **Server flip + server-side warning hardening** — migrate `web/websocket.py` to `WSMessageType.X`. Add `log.warning(...)` for inbound unknown types.
 4. **Client flip + client-side warning** — migrate dispatch and outbound sites in `lib/conversation-store.js`, `lib/message-store.js`, `lib/tool-status-store.js`, `app.js`, `canvas-page.js`. Add the `console.warn` for unknown inbound types.
 5. **Docs index + CLAUDE.md note** — link `docs/websocket-messages.md` from `docs/index.md`, add a one-line bullet to CLAUDE.md's web-UI section pointing future contributors at the manifest.
 

--- a/docs/dev-sessions/2026-04-27-1732-ws-message-types/spec.md
+++ b/docs/dev-sessions/2026-04-27-1732-ws-message-types/spec.md
@@ -1,0 +1,166 @@
+# Spec — Centralize WebSocket message types
+
+Closes [#384](https://github.com/lmorchard/decafclaw/issues/384).
+
+## Background
+
+WebSocket message-type strings (`"chunk"`, `"tool_end"`, `"select_conv"`, …) are scattered as ~50 string literals across `src/decafclaw/web/websocket.py`, `src/decafclaw/http_server.py`, and the JS client (`web/static/lib/*.js`, `web/static/app.js`, `web/static/canvas-page.js`). Risks:
+
+- Typos don't fail at compile time on either side.
+- Renames require grepping two languages.
+- New types ship without a place that documents the wire format.
+
+The bug class to prevent: a missed call site keeps using the old literal, so messages start dropping silently.
+
+## Goals
+
+1. Single source of truth for every WebSocket message type, owned by a hand-edited JSON manifest.
+2. Python and JS get generated, drift-checked enum / constants files. CI fails on drift.
+3. Pyright/eslint catch typos before runtime; runtime warnings catch drift during the migration.
+4. Wire format is documented in a single generated doc page, kept in lockstep with the manifest.
+
+## Non-goals
+
+- Centralizing internal `EventBus` event-type strings (`"confirmation_request"`, `"tool_status"`, etc.). Different domain (in-process pub/sub), different consumers, different lifecycle.
+- Centralizing archive-message `role` values.
+- Centralizing Mattermost-side message types.
+- Strict per-field runtime validation. Field types in the manifest are human-readable sketches, not validators. **Future direction:** if we ever want runtime validation, the manifest schema can grow into typed entries (`{"type": "string", "optional": true, "enum": [...]}`, `{"type": "array", "items": {...}}`, etc.). Out of scope here.
+
+## Design
+
+### Manifest (`src/decafclaw/web/message_types.json`)
+
+Hand-edited, source of truth. Top-level shape:
+
+```json
+{
+  "$schema_version": 1,
+  "_doc_header": "Prose intro that gets lifted into the top of docs/websocket-messages.md.",
+  "messages": {
+    "tool_end": {
+      "description": "Final result of a tool call. Replaces the in-flight tool_status with terminal state.",
+      "direction": "server_to_client",
+      "fields": {
+        "conv_id": "string",
+        "tool_call_id": "string",
+        "name": "string",
+        "ok": "boolean",
+        "result": "string | object"
+      }
+    },
+    "select_conv": {
+      "description": "Subscribe this socket to a conversation's event stream.",
+      "direction": "client_to_server",
+      "fields": { "conv_id": "string" }
+    }
+  }
+}
+```
+
+Rules:
+
+- Keys match `[a-z_][a-z0-9_]*`. Generator validates.
+- `direction` ∈ `server_to_client` | `client_to_server` | `bidirectional`. We don't enforce direction at runtime, but it's used for doc grouping and generated per-direction frozensets in case future work wants it.
+- `fields` is a flat dict from field name to a human-readable type sketch (`"string"`, `"boolean"`, `"string | object"`, `"array of string"`). Not a validator — see future direction above.
+- Manifest entry order is **not** significant. The generator sorts deterministically (by direction, then alphabetical) on the way to every output, so contributors can append new entries wherever's convenient.
+- `$schema_version` is reserved for future format evolution. Generator currently asserts it equals `1` and otherwise ignores it.
+
+### Generator (`scripts/gen_message_types.py`)
+
+- Single Python script, stdlib only, ~80 lines.
+- Reads the manifest, validates shape, emits three files. Each output starts with a `# DO NOT EDIT — regenerate via 'make gen-message-types'` header naming the manifest path.
+- Output must be byte-stable across runs (deterministic sort, fixed indentation, trailing newline). The drift check depends on this.
+
+Generated outputs:
+
+1. **`src/decafclaw/web/message_types.py`**
+   ```python
+   from enum import StrEnum
+
+   class WSMessageType(StrEnum):
+       CHUNK = "chunk"
+       TOOL_END = "tool_end"
+       # ...
+
+   KNOWN_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset(WSMessageType)
+   S2C_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset({WSMessageType.CHUNK, ...})
+   C2S_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset({WSMessageType.SELECT_CONV, ...})
+   ```
+   Member names are `SCREAMING_SNAKE` of the wire string.
+
+2. **`src/decafclaw/web/static/lib/message-types.js`**
+   ```js
+   export const MESSAGE_TYPES = Object.freeze({
+     CHUNK: 'chunk',
+     TOOL_END: 'tool_end',
+     // ...
+   });
+   export const KNOWN_MESSAGE_TYPES = new Set(Object.values(MESSAGE_TYPES));
+   ```
+
+3. **`docs/websocket-messages.md`** — see "Generated docs" below.
+
+### Make targets
+
+- `make gen-message-types` — runs the generator.
+- `make check-message-types` — runs the generator, then `git diff --exit-code -- <three output paths>`. Fails if any output is stale.
+- `check-message-types` is wired into the existing `make check` (between `lint` and `typecheck`), so CI catches drift.
+
+### Generated docs (`docs/websocket-messages.md`)
+
+- Header note: "This page is generated. Edit `src/decafclaw/web/message_types.json` and run `make gen-message-types`."
+- Lifts `_doc_header` prose from the manifest.
+- "Future direction" callout: stricter field schema as a deferred enhancement (so we don't re-debate it).
+- Three sections — **Server → Client**, **Client → Server**, **Bidirectional** — alphabetical within each.
+- Per type: literal in code voice, description prose, fields as a definition list.
+- Linked from `docs/index.md` under the web-UI / transport section.
+
+### Runtime safety
+
+- **Server inbound unknown** — `web/websocket.py` already returns `{"type": "error", "message": "Unknown message type: ..."}` to the client. Harden by also `log.warning(...)`-ing it on the server, so it shows in our logs.
+- **Client inbound unknown** — add to the central JS dispatcher (in `app.js`'s router) a single `if (!KNOWN_MESSAGE_TYPES.has(msg.type)) console.warn('[ws] unknown message type from server:', msg.type, msg);`.
+- **Outbound validation** — *not* added. Per design discussion, the enum + lint/pyright catches typos before runtime; outbound runtime validation is overkill. Direction frozensets are exported in case a future change wants to enforce.
+
+### Migration of call sites
+
+**Server side** — `web/websocket.py` + `http_server.py`:
+
+- `from decafclaw.web.message_types import WSMessageType`.
+- Every `"type": "..."` literal becomes `"type": WSMessageType.X`. Works because `StrEnum` is a `str` subclass.
+- `_HANDLERS` dict keys become `WSMessageType.X`. Inbound dispatch keeps the existing `msg.get("type", "")` pattern (string lookup against StrEnum keys hashes correctly).
+
+**Client side** — `web/static/`:
+
+- Every dispatch site (`case 'tool_end':` in `lib/conversation-store.js`, `lib/message-store.js`, `lib/tool-status-store.js`, `app.js`) becomes `case MESSAGE_TYPES.TOOL_END:`.
+- Every outbound `ws.send({ type: 'select_conv', ... })` (in `conversation-store.js` and `canvas-page.js`) becomes `ws.send({ type: MESSAGE_TYPES.SELECT_CONV, ... })`.
+- Add the inbound-unknown warning at the central dispatch in `app.js`.
+
+### Testing
+
+- **Drift test** — `make check` now runs `check-message-types`. CI catches manifest-vs-generated divergence.
+- **Unit test** (`tests/test_message_types.py`):
+  - Every key in `_HANDLERS` is a `WSMessageType` member.
+  - The generated JS file's `MESSAGE_TYPES` values match the Python enum's values exactly. Python-side parses the JS file with a small regex over the `MESSAGE_TYPES = Object.freeze({...})` block — no Node dependency.
+- **No new behavioral tests.** This is a pure rename; existing WS tests cover wire behavior.
+- **Manual verification** — `make dev`, exercise chat / tool confirmation / model change / cancel turn / canvas update in the web UI, watch console for `[ws] unknown message type` warnings.
+
+## Commit slicing (single PR)
+
+1. **Manifest + audit** — add `web/message_types.json` populated from a complete grep of every `"type": "..."` literal on both sides. Data only; no imports yet.
+2. **Generator + Make targets + first generated outputs** — `scripts/gen_message_types.py`, `make gen-message-types`, `make check-message-types`, wired into `make check`. First run emits `web/message_types.py`, `web/static/lib/message-types.js`, `docs/websocket-messages.md`. Nothing imports the generated files yet.
+3. **Server flip + server-side warning hardening** — migrate `web/websocket.py` and the two sites in `http_server.py` to `WSMessageType.X`. Add `log.warning(...)` for inbound unknown types.
+4. **Client flip + client-side warning** — migrate dispatch and outbound sites in `lib/conversation-store.js`, `lib/message-store.js`, `lib/tool-status-store.js`, `app.js`, `canvas-page.js`. Add the `console.warn` for unknown inbound types.
+5. **Docs index + CLAUDE.md note** — link `docs/websocket-messages.md` from `docs/index.md`, add a one-line bullet to CLAUDE.md's web-UI section pointing future contributors at the manifest.
+
+## Risk
+
+- **Wire-protocol churn between server and client.** Mitigated by: (a) the literals don't change, only how they're written in code; (b) drift CI; (c) runtime warnings on both sides during migration. If a literal is missed, the unknown-type warning fires loudly.
+- **`StrEnum` serialization.** `json.dumps(WSMessageType.CHUNK)` produces `"chunk"` — verified semantics. No custom encoder needed.
+- **Generator non-determinism.** Mitigated by deterministic sort + golden test (the drift check itself).
+
+## Out of scope (filed as follow-ups if needed)
+
+- Stricter manifest field schema (typed entries with optional/enum/array).
+- Centralizing internal `EventBus` event types.
+- Centralizing archive-message `role` values.
+- Centralizing Mattermost message types.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 - [Widgets](widgets.md) — Rich tool output in the web UI (Phase 1: `data_table`; extensible via admin tier)
 - [Streaming](streaming.md) — Stream LLM tokens as they arrive, configurable throttle
 - [HTTP Server & Interactive Buttons](http-server.md) — Mattermost button confirmations, HTTP callback server
+- [WebSocket Message Types](websocket-messages.md) — Generated wire-protocol reference for messages exchanged between server and browser
 
 ## Knowledge & Memory
 

--- a/docs/websocket-messages.md
+++ b/docs/websocket-messages.md
@@ -1,0 +1,289 @@
+<!-- DO NOT EDIT — regenerate via 'make gen-message-types' -->
+<!-- Source: src/decafclaw/web/message_types.json -->
+
+# WebSocket Message Types
+
+WebSocket message types exchanged between the decafclaw server (`src/decafclaw/web/websocket.py`) and the in-browser client. This page is generated from `src/decafclaw/web/message_types.json` — edit the manifest and run `make gen-message-types` to regenerate.
+
+> **Future direction:** Field types are human-readable sketches today, not validators. Future work could grow them into typed entries (`{type, optional, enum}`, `{type: "array", items: ...}`) for runtime validation. Out of scope at present.
+
+## Server → Client
+
+### `background_event`
+
+Background-task lifecycle event surfaced into a conversation timeline (e.g. delegated task started/finished).
+
+**Fields:**
+
+- `conv_id` — string
+- `event` — object
+
+### `canvas_update`
+
+The conversation's canvas state changed; client should re-render the canvas panel.
+
+**Fields:**
+
+- `conv_id` — string
+- `state` — object
+
+### `chunk`
+
+Streaming text fragment of an in-flight assistant message.
+
+**Fields:**
+
+- `conv_id` — string
+- `text` — string
+
+### `command_ack`
+
+Acknowledgement that a slash-style user command was received and dispatched.
+
+**Fields:**
+
+- `conv_id` — string
+- `command` — string
+
+### `compaction_done`
+
+Conversation history compaction completed; client should reload history.
+
+**Fields:**
+
+- `conv_id` — string
+
+### `confirm_request`
+
+Server is asking the user to approve or deny a pending action (tool call, end-of-turn gate, widget input).
+
+**Fields:**
+
+- `conv_id` — string
+- `request_id` — string
+- `kind` — string
+- `payload` — object
+
+### `confirmation_response`
+
+Replay of a prior confirmation response, surfaced when reloading conversation history.
+
+**Fields:**
+
+- `conv_id` — string
+- `request_id` — string
+- `decision` — string
+
+### `conv_history`
+
+Page of historical messages for a conversation.
+
+**Fields:**
+
+- `conv_id` — string
+- `messages` — array of object
+- `before` — string | null
+
+### `conv_selected`
+
+Confirmation that a select_conv subscribed this socket to the named conversation. May include initial conversation state.
+
+**Fields:**
+
+- `conv_id` — string
+- `model` — string | null
+
+### `error`
+
+Generic error surfaced to the client (bad request, unknown conversation, internal error).
+
+**Fields:**
+
+- `message` — string
+- `conv_id` — string | null
+
+### `message_complete`
+
+Final form of an assistant message after streaming completed (or when replayed from history).
+
+**Fields:**
+
+- `conv_id` — string
+- `message` — object
+
+### `model_changed`
+
+The active model for a conversation changed (echoed back to all subscribers of that conversation).
+
+**Fields:**
+
+- `conv_id` — string
+- `model` — string
+
+### `models_available`
+
+List of model identifiers the user can select in the UI.
+
+**Fields:**
+
+- `models` — array of string
+
+### `notification_created`
+
+A new notification was added to the user's inbox (push from notification subsystem).
+
+**Fields:**
+
+- `notification` — object
+
+### `notification_read`
+
+A notification was marked read (push from notification subsystem).
+
+**Fields:**
+
+- `id` — string
+
+### `reflection_result`
+
+Output of the post-turn reflection step for a conversation.
+
+**Fields:**
+
+- `conv_id` — string
+- `result` — object
+
+### `tool_end`
+
+Final result of a tool call. Replaces the in-flight tool_status with terminal state.
+
+**Fields:**
+
+- `conv_id` — string
+- `tool_call_id` — string
+- `name` — string
+- `ok` — boolean
+- `result` — string | object
+
+### `tool_start`
+
+Tool call has begun execution.
+
+**Fields:**
+
+- `conv_id` — string
+- `tool_call_id` — string
+- `name` — string
+- `input` — object
+
+### `tool_status`
+
+Mid-flight progress update from a running tool.
+
+**Fields:**
+
+- `conv_id` — string
+- `tool_call_id` — string
+- `status` — string
+
+### `turn_complete`
+
+An agent turn finished (success, error, or cancellation).
+
+**Fields:**
+
+- `conv_id` — string
+
+### `turn_start`
+
+An agent turn has started; clients should clear any draft and show in-flight UI.
+
+**Fields:**
+
+- `conv_id` — string
+
+### `user_message`
+
+Echo of a user-authored message to all subscribers of the conversation (used for multi-tab sync).
+
+**Fields:**
+
+- `conv_id` — string
+- `message` — object
+
+## Client → Server
+
+### `cancel_turn`
+
+Request cancellation of the conversation's in-flight agent turn.
+
+**Fields:**
+
+- `conv_id` — string
+
+### `confirm_response`
+
+User's decision on a pending confirm_request.
+
+**Fields:**
+
+- `conv_id` — string
+- `request_id` — string
+- `decision` — string
+- `extras` — object
+
+### `load_history`
+
+Request a page of historical messages for a conversation.
+
+**Fields:**
+
+- `conv_id` — string
+- `limit` — number
+- `before` — string | null
+
+### `select_conv`
+
+Subscribe this socket to a conversation's event stream.
+
+**Fields:**
+
+- `conv_id` — string
+
+### `send`
+
+Send a user message (and/or attachments) to the conversation.
+
+**Fields:**
+
+- `conv_id` — string
+- `text` — string
+- `attachments` — array of object
+
+### `set_effort`
+
+Deprecated backward-compat alias for set_model used by older web clients.
+
+**Fields:**
+
+- `conv_id` — string
+- `model` — string
+
+### `set_model`
+
+Change the active model for a conversation.
+
+**Fields:**
+
+- `conv_id` — string
+- `model` — string
+
+### `widget_response`
+
+Submission of an interactive widget input.
+
+**Fields:**
+
+- `conv_id` — string
+- `request_id` — string
+- `value` — object

--- a/scripts/gen_message_types.py
+++ b/scripts/gen_message_types.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Generate Python enum, JS constants, and Markdown docs for WebSocket message types.
+
+Source of truth: src/decafclaw/web/message_types.json
+Run via: make gen-message-types
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "src/decafclaw/web/message_types.json"
+PY_OUT = REPO_ROOT / "src/decafclaw/web/message_types.py"
+JS_OUT = REPO_ROOT / "src/decafclaw/web/static/lib/message-types.js"
+DOC_OUT = REPO_ROOT / "docs/websocket-messages.md"
+
+GEN_HEADER = "DO NOT EDIT — regenerate via 'make gen-message-types'"
+SOURCE_REL = MANIFEST_PATH.relative_to(REPO_ROOT).as_posix()
+
+VALID_DIRECTIONS = ("server_to_client", "client_to_server", "bidirectional")
+NAME_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def load_manifest() -> dict:
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if data.get("$schema_version") != 1:
+        sys.exit(f"unsupported $schema_version in {MANIFEST_PATH}")
+    msgs = data.get("messages")
+    if not isinstance(msgs, dict):
+        sys.exit("manifest 'messages' must be an object")
+    for name, entry in msgs.items():
+        if not NAME_RE.match(name):
+            sys.exit(f"invalid message name: {name!r}")
+        direction = entry.get("direction")
+        if direction not in VALID_DIRECTIONS:
+            sys.exit(f"{name}: invalid direction {direction!r}")
+        if not isinstance(entry.get("description"), str):
+            sys.exit(f"{name}: missing/non-string description")
+        if not isinstance(entry.get("fields"), dict):
+            sys.exit(f"{name}: 'fields' must be an object")
+    return data
+
+
+def sorted_messages(data: dict) -> list[tuple[str, dict]]:
+    direction_order = {d: i for i, d in enumerate(VALID_DIRECTIONS)}
+    return sorted(
+        data["messages"].items(),
+        key=lambda kv: (direction_order[kv[1]["direction"]], kv[0]),
+    )
+
+
+def render_python(data: dict) -> str:
+    items = sorted_messages(data)
+    out: list[str] = []
+    out.append(f'"""{GEN_HEADER}\n\nSource: {SOURCE_REL}\n"""')
+    out.append("")
+    out.append("from __future__ import annotations")
+    out.append("")
+    out.append("from enum import StrEnum")
+    out.append("")
+    out.append("")
+    out.append("class WSMessageType(StrEnum):")
+    out.append('    """WebSocket wire message types."""')
+    out.append("")
+    for name, _ in items:
+        out.append(f'    {name.upper()} = "{name}"')
+    out.append("")
+    out.append("")
+    out.append("KNOWN_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset(WSMessageType)")
+    out.append("")
+
+    def _emit_subset(var: str, names: list[str]) -> None:
+        if not names:
+            out.append(f"{var}: frozenset[WSMessageType] = frozenset()")
+            out.append("")
+            return
+        out.append(f"{var}: frozenset[WSMessageType] = frozenset({{")
+        for n in names:
+            out.append(f"    WSMessageType.{n.upper()},")
+        out.append("})")
+        out.append("")
+
+    s2c = [n for n, e in items if e["direction"] == "server_to_client"]
+    c2s = [n for n, e in items if e["direction"] == "client_to_server"]
+    bid = [n for n, e in items if e["direction"] == "bidirectional"]
+    _emit_subset("S2C_MESSAGE_TYPES", s2c)
+    _emit_subset("C2S_MESSAGE_TYPES", c2s)
+    _emit_subset("BIDIRECTIONAL_MESSAGE_TYPES", bid)
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_js(data: dict) -> str:
+    items = sorted_messages(data)
+    out: list[str] = []
+    out.append(f"// {GEN_HEADER}")
+    out.append(f"// Source: {SOURCE_REL}")
+    out.append("")
+    out.append("export const MESSAGE_TYPES = Object.freeze({")
+    for name, _ in items:
+        out.append(f"  {name.upper()}: '{name}',")
+    out.append("});")
+    out.append("")
+    out.append("export const KNOWN_MESSAGE_TYPES = new Set(Object.values(MESSAGE_TYPES));")
+    return "\n".join(out) + "\n"
+
+
+def render_doc(data: dict) -> str:
+    out: list[str] = []
+    out.append(f"<!-- {GEN_HEADER} -->")
+    out.append(f"<!-- Source: {SOURCE_REL} -->")
+    out.append("")
+    out.append("# WebSocket Message Types")
+    out.append("")
+    header = (data.get("_doc_header") or "").strip()
+    if header:
+        out.append(header)
+        out.append("")
+    out.append(
+        "> **Future direction:** Field types are human-readable sketches today, not validators. "
+        "Future work could grow them into typed entries (`{type, optional, enum}`, "
+        "`{type: \"array\", items: ...}`) for runtime validation. Out of scope at present."
+    )
+    out.append("")
+    sections = (
+        ("Server → Client", "server_to_client"),
+        ("Client → Server", "client_to_server"),
+        ("Bidirectional", "bidirectional"),
+    )
+    for heading, direction in sections:
+        in_dir = sorted(
+            (n, e) for n, e in data["messages"].items() if e["direction"] == direction
+        )
+        if not in_dir:
+            continue
+        out.append(f"## {heading}")
+        out.append("")
+        for name, entry in in_dir:
+            out.append(f"### `{name}`")
+            out.append("")
+            out.append(entry["description"])
+            out.append("")
+            fields = entry.get("fields") or {}
+            if fields:
+                out.append("**Fields:**")
+                out.append("")
+                for fname, ftype in fields.items():
+                    out.append(f"- `{fname}` — {ftype}")
+                out.append("")
+            else:
+                out.append("(No payload fields.)")
+                out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    data = load_manifest()
+    PY_OUT.write_text(render_python(data), encoding="utf-8")
+    JS_OUT.write_text(render_js(data), encoding="utf-8")
+    DOC_OUT.write_text(render_doc(data), encoding="utf-8")
+    for p in (PY_OUT, JS_OUT, DOC_OUT):
+        print(f"wrote {p.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/decafclaw/web/message_types.json
+++ b/src/decafclaw/web/message_types.json
@@ -1,0 +1,157 @@
+{
+  "$schema_version": 1,
+  "_doc_header": "WebSocket message types exchanged between the decafclaw server (`src/decafclaw/web/websocket.py`) and the in-browser client. This page is generated from `src/decafclaw/web/message_types.json` — edit the manifest and run `make gen-message-types` to regenerate.",
+  "messages": {
+    "background_event": {
+      "direction": "server_to_client",
+      "description": "Background-task lifecycle event surfaced into a conversation timeline (e.g. delegated task started/finished).",
+      "fields": {"conv_id": "string", "event": "object"}
+    },
+    "canvas_update": {
+      "direction": "server_to_client",
+      "description": "The conversation's canvas state changed; client should re-render the canvas panel.",
+      "fields": {"conv_id": "string", "state": "object"}
+    },
+    "chunk": {
+      "direction": "server_to_client",
+      "description": "Streaming text fragment of an in-flight assistant message.",
+      "fields": {"conv_id": "string", "text": "string"}
+    },
+    "command_ack": {
+      "direction": "server_to_client",
+      "description": "Acknowledgement that a slash-style user command was received and dispatched.",
+      "fields": {"conv_id": "string", "command": "string"}
+    },
+    "compaction_done": {
+      "direction": "server_to_client",
+      "description": "Conversation history compaction completed; client should reload history.",
+      "fields": {"conv_id": "string"}
+    },
+    "confirm_request": {
+      "direction": "server_to_client",
+      "description": "Server is asking the user to approve or deny a pending action (tool call, end-of-turn gate, widget input).",
+      "fields": {"conv_id": "string", "request_id": "string", "kind": "string", "payload": "object"}
+    },
+    "confirmation_response": {
+      "direction": "server_to_client",
+      "description": "Replay of a prior confirmation response, surfaced when reloading conversation history.",
+      "fields": {"conv_id": "string", "request_id": "string", "decision": "string"}
+    },
+    "conv_history": {
+      "direction": "server_to_client",
+      "description": "Page of historical messages for a conversation.",
+      "fields": {"conv_id": "string", "messages": "array of object", "before": "string | null"}
+    },
+    "conv_selected": {
+      "direction": "server_to_client",
+      "description": "Confirmation that a select_conv subscribed this socket to the named conversation. May include initial conversation state.",
+      "fields": {"conv_id": "string", "model": "string | null"}
+    },
+    "error": {
+      "direction": "server_to_client",
+      "description": "Generic error surfaced to the client (bad request, unknown conversation, internal error).",
+      "fields": {"message": "string", "conv_id": "string | null"}
+    },
+    "message_complete": {
+      "direction": "server_to_client",
+      "description": "Final form of an assistant message after streaming completed (or when replayed from history).",
+      "fields": {"conv_id": "string", "message": "object"}
+    },
+    "model_changed": {
+      "direction": "server_to_client",
+      "description": "The active model for a conversation changed (echoed back to all subscribers of that conversation).",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "models_available": {
+      "direction": "server_to_client",
+      "description": "List of model identifiers the user can select in the UI.",
+      "fields": {"models": "array of string"}
+    },
+    "notification_created": {
+      "direction": "server_to_client",
+      "description": "A new notification was added to the user's inbox (push from notification subsystem).",
+      "fields": {"notification": "object"}
+    },
+    "notification_read": {
+      "direction": "server_to_client",
+      "description": "A notification was marked read (push from notification subsystem).",
+      "fields": {"id": "string"}
+    },
+    "reflection_result": {
+      "direction": "server_to_client",
+      "description": "Output of the post-turn reflection step for a conversation.",
+      "fields": {"conv_id": "string", "result": "object"}
+    },
+    "tool_end": {
+      "direction": "server_to_client",
+      "description": "Final result of a tool call. Replaces the in-flight tool_status with terminal state.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "ok": "boolean", "result": "string | object"}
+    },
+    "tool_start": {
+      "direction": "server_to_client",
+      "description": "Tool call has begun execution.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "input": "object"}
+    },
+    "tool_status": {
+      "direction": "server_to_client",
+      "description": "Mid-flight progress update from a running tool.",
+      "fields": {"conv_id": "string", "tool_call_id": "string", "status": "string"}
+    },
+    "turn_complete": {
+      "direction": "server_to_client",
+      "description": "An agent turn finished (success, error, or cancellation).",
+      "fields": {"conv_id": "string"}
+    },
+    "turn_start": {
+      "direction": "server_to_client",
+      "description": "An agent turn has started; clients should clear any draft and show in-flight UI.",
+      "fields": {"conv_id": "string"}
+    },
+    "user_message": {
+      "direction": "server_to_client",
+      "description": "Echo of a user-authored message to all subscribers of the conversation (used for multi-tab sync).",
+      "fields": {"conv_id": "string", "message": "object"}
+    },
+
+    "cancel_turn": {
+      "direction": "client_to_server",
+      "description": "Request cancellation of the conversation's in-flight agent turn.",
+      "fields": {"conv_id": "string"}
+    },
+    "confirm_response": {
+      "direction": "client_to_server",
+      "description": "User's decision on a pending confirm_request.",
+      "fields": {"conv_id": "string", "request_id": "string", "decision": "string", "extras": "object"}
+    },
+    "load_history": {
+      "direction": "client_to_server",
+      "description": "Request a page of historical messages for a conversation.",
+      "fields": {"conv_id": "string", "limit": "number", "before": "string | null"}
+    },
+    "select_conv": {
+      "direction": "client_to_server",
+      "description": "Subscribe this socket to a conversation's event stream.",
+      "fields": {"conv_id": "string"}
+    },
+    "send": {
+      "direction": "client_to_server",
+      "description": "Send a user message (and/or attachments) to the conversation.",
+      "fields": {"conv_id": "string", "text": "string", "attachments": "array of object"}
+    },
+    "set_effort": {
+      "direction": "client_to_server",
+      "description": "Deprecated backward-compat alias for set_model used by older web clients.",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "set_model": {
+      "direction": "client_to_server",
+      "description": "Change the active model for a conversation.",
+      "fields": {"conv_id": "string", "model": "string"}
+    },
+    "widget_response": {
+      "direction": "client_to_server",
+      "description": "Submission of an interactive widget input.",
+      "fields": {"conv_id": "string", "request_id": "string", "value": "object"}
+    }
+  }
+}

--- a/src/decafclaw/web/message_types.py
+++ b/src/decafclaw/web/message_types.py
@@ -1,0 +1,84 @@
+"""DO NOT EDIT — regenerate via 'make gen-message-types'
+
+Source: src/decafclaw/web/message_types.json
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WSMessageType(StrEnum):
+    """WebSocket wire message types."""
+
+    BACKGROUND_EVENT = "background_event"
+    CANVAS_UPDATE = "canvas_update"
+    CHUNK = "chunk"
+    COMMAND_ACK = "command_ack"
+    COMPACTION_DONE = "compaction_done"
+    CONFIRM_REQUEST = "confirm_request"
+    CONFIRMATION_RESPONSE = "confirmation_response"
+    CONV_HISTORY = "conv_history"
+    CONV_SELECTED = "conv_selected"
+    ERROR = "error"
+    MESSAGE_COMPLETE = "message_complete"
+    MODEL_CHANGED = "model_changed"
+    MODELS_AVAILABLE = "models_available"
+    NOTIFICATION_CREATED = "notification_created"
+    NOTIFICATION_READ = "notification_read"
+    REFLECTION_RESULT = "reflection_result"
+    TOOL_END = "tool_end"
+    TOOL_START = "tool_start"
+    TOOL_STATUS = "tool_status"
+    TURN_COMPLETE = "turn_complete"
+    TURN_START = "turn_start"
+    USER_MESSAGE = "user_message"
+    CANCEL_TURN = "cancel_turn"
+    CONFIRM_RESPONSE = "confirm_response"
+    LOAD_HISTORY = "load_history"
+    SELECT_CONV = "select_conv"
+    SEND = "send"
+    SET_EFFORT = "set_effort"
+    SET_MODEL = "set_model"
+    WIDGET_RESPONSE = "widget_response"
+
+
+KNOWN_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset(WSMessageType)
+
+S2C_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset({
+    WSMessageType.BACKGROUND_EVENT,
+    WSMessageType.CANVAS_UPDATE,
+    WSMessageType.CHUNK,
+    WSMessageType.COMMAND_ACK,
+    WSMessageType.COMPACTION_DONE,
+    WSMessageType.CONFIRM_REQUEST,
+    WSMessageType.CONFIRMATION_RESPONSE,
+    WSMessageType.CONV_HISTORY,
+    WSMessageType.CONV_SELECTED,
+    WSMessageType.ERROR,
+    WSMessageType.MESSAGE_COMPLETE,
+    WSMessageType.MODEL_CHANGED,
+    WSMessageType.MODELS_AVAILABLE,
+    WSMessageType.NOTIFICATION_CREATED,
+    WSMessageType.NOTIFICATION_READ,
+    WSMessageType.REFLECTION_RESULT,
+    WSMessageType.TOOL_END,
+    WSMessageType.TOOL_START,
+    WSMessageType.TOOL_STATUS,
+    WSMessageType.TURN_COMPLETE,
+    WSMessageType.TURN_START,
+    WSMessageType.USER_MESSAGE,
+})
+
+C2S_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset({
+    WSMessageType.CANCEL_TURN,
+    WSMessageType.CONFIRM_RESPONSE,
+    WSMessageType.LOAD_HISTORY,
+    WSMessageType.SELECT_CONV,
+    WSMessageType.SEND,
+    WSMessageType.SET_EFFORT,
+    WSMessageType.SET_MODEL,
+    WSMessageType.WIDGET_RESPONSE,
+})
+
+BIDIRECTIONAL_MESSAGE_TYPES: frozenset[WSMessageType] = frozenset()

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -7,6 +7,7 @@
 import { AuthClient } from './lib/auth-client.js';
 import { WebSocketClient } from './lib/websocket-client.js';
 import { ConversationStore } from './lib/conversation-store.js';
+import { MESSAGE_TYPES, KNOWN_MESSAGE_TYPES } from './lib/message-types.js';
 import { setupResizeHandle } from './lib/utils.js';
 import {
   setActiveConv,
@@ -413,12 +414,15 @@ store.addEventListener('change', () => {
 // Listen for WebSocket error messages directly
 ws.addEventListener('message', (e) => {
   const msg = /** @type {CustomEvent} */ (e).detail;
-  if (msg?.type === 'error' && msg?.message) {
+  if (msg && typeof msg.type === 'string' && !KNOWN_MESSAGE_TYPES.has(msg.type)) {
+    console.warn('[ws] unknown message type from server:', msg.type, msg);
+  }
+  if (msg?.type === MESSAGE_TYPES.ERROR && msg?.message) {
     showToast(msg.message);
   }
   // Fan out turn-complete as a window event so sidebars can silently refresh
   // (e.g. files-sidebar auto-refetches so agent-written files appear).
-  if (msg?.type === 'turn_complete') {
+  if (msg?.type === MESSAGE_TYPES.TURN_COMPLETE) {
     window.dispatchEvent(new CustomEvent('turn-complete', {
       detail: { conv_id: msg.conv_id },
     }));
@@ -426,13 +430,13 @@ ws.addEventListener('message', (e) => {
   // Notification push events — the bell component listens at the window
   // level so we don't have to hand it the raw ws instance. Payloads mirror
   // the event bus shape (see docs/notifications.md).
-  if (msg?.type === 'notification_created') {
+  if (msg?.type === MESSAGE_TYPES.NOTIFICATION_CREATED) {
     window.dispatchEvent(new CustomEvent('notification-created', { detail: msg }));
   }
-  if (msg?.type === 'notification_read') {
+  if (msg?.type === MESSAGE_TYPES.NOTIFICATION_READ) {
     window.dispatchEvent(new CustomEvent('notification-read', { detail: msg }));
   }
-  if (msg?.type === 'canvas_update') {
+  if (msg?.type === MESSAGE_TYPES.CANVAS_UPDATE) {
     applyEvent(msg);
   }
 });

--- a/src/decafclaw/web/static/canvas-page.js
+++ b/src/decafclaw/web/static/canvas-page.js
@@ -6,6 +6,8 @@
  * canvas_update events over WebSocket for live updates.
  */
 
+import { MESSAGE_TYPES } from './lib/message-types.js';
+
 const PATH_RE = /^\/canvas\/([^/?#]+)/;
 const m = location.pathname.match(PATH_RE);
 let convId = '';
@@ -71,12 +73,12 @@ function openWebSocket() {
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   const ws = new WebSocket(`${proto}//${location.host}/ws/chat`);
   ws.addEventListener('open', () => {
-    ws.send(JSON.stringify({ type: 'select_conv', conv_id: convId }));
+    ws.send(JSON.stringify({ type: MESSAGE_TYPES.SELECT_CONV, conv_id: convId }));
   });
   ws.addEventListener('message', (ev) => {
     let msg;
     try { msg = JSON.parse(ev.data); } catch { return; }
-    if (msg.type !== 'canvas_update') return;
+    if (msg.type !== MESSAGE_TYPES.CANVAS_UPDATE) return;
     if (msg.conv_id && msg.conv_id !== convId) return;
     applyTab(msg.tab);
   });

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -1,3 +1,5 @@
+import { MESSAGE_TYPES } from './message-types.js';
+
 /**
  * @typedef {object} ConversationMeta
  * @property {string} conv_id
@@ -427,8 +429,8 @@ export class ConversationStore extends EventTarget {
     this.#contextLimit = 0;
     this.#activeModel = '';
     this.#readOnly = false;
-    this.#ws.send({ type: 'select_conv', conv_id: convId });
-    this.#ws.send({ type: 'load_history', conv_id: convId, limit: 50 });
+    this.#ws.send({ type: MESSAGE_TYPES.SELECT_CONV, conv_id: convId });
+    this.#ws.send({ type: MESSAGE_TYPES.LOAD_HISTORY, conv_id: convId, limit: 50 });
     this.#emitChange();
   }
 
@@ -452,7 +454,7 @@ export class ConversationStore extends EventTarget {
     this.#busy = true;
     this.#messageStore.clearStreamingText();
     this.#toolStatusStore.clearToolStatus();
-    const wsMsg = { type: 'send', conv_id: this.#currentConvId, text };
+    const wsMsg = { type: MESSAGE_TYPES.SEND, conv_id: this.#currentConvId, text };
     if (attachments.length) wsMsg.attachments = attachments;
     const wikiPage = /** @type {any} */ (window).getOpenWikiPage?.();
     if (wikiPage) wsMsg.wiki_page = wikiPage;
@@ -487,21 +489,21 @@ export class ConversationStore extends EventTarget {
   setModel(model) {
     this.#activeModel = model;
     if (this.#currentConvId) {
-      this.#ws.send({ type: 'set_model', conv_id: this.#currentConvId, model });
+      this.#ws.send({ type: MESSAGE_TYPES.SET_MODEL, conv_id: this.#currentConvId, model });
     }
     this.#emitChange();
   }
 
   cancelTurn() {
     if (!this.#currentConvId) return;
-    this.#ws.send({ type: 'cancel_turn', conv_id: this.#currentConvId });
+    this.#ws.send({ type: MESSAGE_TYPES.CANCEL_TURN, conv_id: this.#currentConvId });
   }
 
   /** @param {string} [before] timestamp cursor */
   loadMoreHistory(before = '') {
     if (!this.#currentConvId) return;
     const cursor = before || (this.#messageStore.currentMessages[0]?.timestamp || '');
-    this.#ws.send({ type: 'load_history', conv_id: this.#currentConvId, limit: 50, before: cursor });
+    this.#ws.send({ type: MESSAGE_TYPES.LOAD_HISTORY, conv_id: this.#currentConvId, limit: 50, before: cursor });
   }
 
   /**
@@ -531,7 +533,7 @@ export class ConversationStore extends EventTarget {
     // Delegate to sub-stores first
     if (this.#messageStore.handleMessage(msg, this.#currentConvId)) {
       // Handle side effects that live in ConversationStore
-      if (msg.type === 'conv_history' && msg.conv_id === this.#currentConvId) {
+      if (msg.type === MESSAGE_TYPES.CONV_HISTORY && msg.conv_id === this.#currentConvId) {
         if (msg.context_limit) this.#contextLimit = msg.context_limit;
         if (msg.estimated_tokens) this.#contextUsage = msg.estimated_tokens;
         if (msg.active_model) this.#activeModel = msg.active_model;
@@ -542,13 +544,13 @@ export class ConversationStore extends EventTarget {
         // Restore pending confirmation from server state (survives reload)
         if (msg.pending_confirmation) {
           this.#toolStatusStore.handleMessage({
-            type: 'confirm_request',
+            type: MESSAGE_TYPES.CONFIRM_REQUEST,
             conv_id: this.#currentConvId,
             ...msg.pending_confirmation,
           }, this.#currentConvId);
         }
       }
-      if (msg.type === 'message_complete' && msg.conv_id === this.#currentConvId) {
+      if (msg.type === MESSAGE_TYPES.MESSAGE_COMPLETE && msg.conv_id === this.#currentConvId) {
         this.#toolStatusStore.clearToolStatus();
         if (msg.final) {
           this.#busy = false;
@@ -568,19 +570,19 @@ export class ConversationStore extends EventTarget {
 
     // Messages handled directly by ConversationStore
     switch (msg.type) {
-      case 'conv_selected':
+      case MESSAGE_TYPES.CONV_SELECTED:
         if (msg.read_only) this.#readOnly = true;
         // Restore pending confirmation from server state (survives reload)
         if (msg.pending_confirmation) {
           this.#toolStatusStore.handleMessage({
-            type: 'confirm_request',
+            type: MESSAGE_TYPES.CONFIRM_REQUEST,
             conv_id: msg.conv_id || this.#currentConvId,
             ...msg.pending_confirmation,
           }, this.#currentConvId);
         }
         break;
 
-      case 'turn_start':
+      case MESSAGE_TYPES.TURN_START:
         if (!msg.conv_id || msg.conv_id === this.#currentConvId) {
           this.#busy = true;
           this.#messageStore.clearStreamingText();
@@ -588,18 +590,18 @@ export class ConversationStore extends EventTarget {
         }
         break;
 
-      case 'model_changed':
+      case MESSAGE_TYPES.MODEL_CHANGED:
         if (msg.conv_id === this.#currentConvId) {
           this.#activeModel = msg.model || '';
         }
         break;
 
-      case 'models_available':
+      case MESSAGE_TYPES.MODELS_AVAILABLE:
         if (msg.available_models) this.#availableModels = msg.available_models;
         if (msg.default_model) this.#defaultModel = msg.default_model;
         break;
 
-      case 'error':
+      case MESSAGE_TYPES.ERROR:
         console.error('Server error:', msg.message);
         if (!msg.conv_id || msg.conv_id === this.#currentConvId) {
           this.#busy = false;

--- a/src/decafclaw/web/static/lib/message-store.js
+++ b/src/decafclaw/web/static/lib/message-store.js
@@ -2,6 +2,8 @@
  * @typedef {import('./conversation-store.js').ChatMessage} ChatMessage
  */
 
+import { MESSAGE_TYPES } from './message-types.js';
+
 /**
  * Sub-store managing message state: history, streaming text, pagination.
  */
@@ -132,7 +134,7 @@ export class MessageStore {
    */
   handleMessage(msg, currentConvId) {
     switch (msg.type) {
-      case 'conv_history':
+      case MESSAGE_TYPES.CONV_HISTORY:
         if (msg.conv_id === currentConvId) {
           const existing = new Set(this.#currentMessages.map(m => m.timestamp));
           const newMsgs = (msg.messages || []).filter(
@@ -150,13 +152,13 @@ export class MessageStore {
         }
         return true;
 
-      case 'chunk':
+      case MESSAGE_TYPES.CHUNK:
         if (msg.conv_id === currentConvId) {
           this.#streamingText += msg.text;
         }
         return true;
 
-      case 'message_complete':
+      case MESSAGE_TYPES.MESSAGE_COMPLETE:
         if (msg.conv_id === currentConvId) {
           this.#currentMessages.push({
             role: msg.role || 'assistant',
@@ -168,7 +170,7 @@ export class MessageStore {
         }
         return true;
 
-      case 'user_message':
+      case MESSAGE_TYPES.USER_MESSAGE:
         // Multi-tab sync: add user message if not already present
         // (the originating tab adds it locally before the event arrives).
         //
@@ -198,7 +200,7 @@ export class MessageStore {
         }
         return true;
 
-      case 'command_ack':
+      case MESSAGE_TYPES.COMMAND_ACK:
         if (msg.conv_id === currentConvId) {
           this.#currentMessages.push({
             role: 'command',
@@ -208,7 +210,7 @@ export class MessageStore {
         }
         return true;
 
-      case 'compaction_done':
+      case MESSAGE_TYPES.COMPACTION_DONE:
         if (msg.conv_id === currentConvId) {
           this.#currentMessages.push({
             role: 'compaction',
@@ -218,7 +220,7 @@ export class MessageStore {
         }
         return true;
 
-      case 'background_event':
+      case MESSAGE_TYPES.BACKGROUND_EVENT:
         if (msg.conv_id === currentConvId) {
           const record = msg.record || {};
           this.#currentMessages.push({

--- a/src/decafclaw/web/static/lib/message-types.js
+++ b/src/decafclaw/web/static/lib/message-types.js
@@ -1,0 +1,37 @@
+// DO NOT EDIT — regenerate via 'make gen-message-types'
+// Source: src/decafclaw/web/message_types.json
+
+export const MESSAGE_TYPES = Object.freeze({
+  BACKGROUND_EVENT: 'background_event',
+  CANVAS_UPDATE: 'canvas_update',
+  CHUNK: 'chunk',
+  COMMAND_ACK: 'command_ack',
+  COMPACTION_DONE: 'compaction_done',
+  CONFIRM_REQUEST: 'confirm_request',
+  CONFIRMATION_RESPONSE: 'confirmation_response',
+  CONV_HISTORY: 'conv_history',
+  CONV_SELECTED: 'conv_selected',
+  ERROR: 'error',
+  MESSAGE_COMPLETE: 'message_complete',
+  MODEL_CHANGED: 'model_changed',
+  MODELS_AVAILABLE: 'models_available',
+  NOTIFICATION_CREATED: 'notification_created',
+  NOTIFICATION_READ: 'notification_read',
+  REFLECTION_RESULT: 'reflection_result',
+  TOOL_END: 'tool_end',
+  TOOL_START: 'tool_start',
+  TOOL_STATUS: 'tool_status',
+  TURN_COMPLETE: 'turn_complete',
+  TURN_START: 'turn_start',
+  USER_MESSAGE: 'user_message',
+  CANCEL_TURN: 'cancel_turn',
+  CONFIRM_RESPONSE: 'confirm_response',
+  LOAD_HISTORY: 'load_history',
+  SELECT_CONV: 'select_conv',
+  SEND: 'send',
+  SET_EFFORT: 'set_effort',
+  SET_MODEL: 'set_model',
+  WIDGET_RESPONSE: 'widget_response',
+});
+
+export const KNOWN_MESSAGE_TYPES = new Set(Object.values(MESSAGE_TYPES));

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -5,6 +5,8 @@
  * @typedef {import('./message-store.js').MessageStore} MessageStore
  */
 
+import { MESSAGE_TYPES } from './message-types.js';
+
 /**
  * Sub-store managing tool execution status and confirmation requests.
  */
@@ -68,7 +70,7 @@ export class ToolStatusStore {
     });
 
     this.#ws.send({
-      type: 'confirm_response',
+      type: MESSAGE_TYPES.CONFIRM_RESPONSE,
       context_id: contextId,
       tool,
       approved,
@@ -106,7 +108,7 @@ export class ToolStatusStore {
       return;
     }
     this.#ws.send({
-      type: 'widget_response',
+      type: MESSAGE_TYPES.WIDGET_RESPONSE,
       conv_id: confirm.conv_id,
       confirmation_id: confirm.confirmation_id,
       tool_call_id: toolCallId,
@@ -127,7 +129,7 @@ export class ToolStatusStore {
    */
   handleMessage(msg, currentConvId) {
     switch (msg.type) {
-      case 'tool_start': {
+      case MESSAGE_TYPES.TOOL_START: {
         const tcId = msg.tool_call_id || '';
         this.#activeTools.set(tcId, `Running ${msg.tool}...`);
         if (msg.conv_id === currentConvId) {
@@ -142,7 +144,7 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'tool_status': {
+      case MESSAGE_TYPES.TOOL_STATUS: {
         const tcId = msg.tool_call_id || '';
         this.#activeTools.set(tcId, `${msg.tool}: ${msg.message}`);
         if (msg.conv_id === currentConvId) {
@@ -159,7 +161,7 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'tool_end': {
+      case MESSAGE_TYPES.TOOL_END: {
         const tcId = msg.tool_call_id || '';
         this.#activeTools.delete(tcId);
         if (msg.conv_id === currentConvId) {
@@ -176,7 +178,7 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'confirm_request': {
+      case MESSAGE_TYPES.CONFIRM_REQUEST: {
         // Only show confirmations for the active conversation (#235)
         if (msg.conv_id && msg.conv_id !== currentConvId) return true;
         // Deduplicate by confirmation_id (can arrive via both conv_history and live event)
@@ -201,7 +203,7 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'confirmation_response': {
+      case MESSAGE_TYPES.CONFIRMATION_RESPONSE: {
         // Multi-tab sync: remove the resolved confirmation widget.
         // For widget responses, also flip the matching tool message to
         // submitted + carry the response data so the widget UI
@@ -224,7 +226,7 @@ export class ToolStatusStore {
         return true;
       }
 
-      case 'reflection_result':
+      case MESSAGE_TYPES.REFLECTION_RESULT:
         if (msg.conv_id === currentConvId) {
           const passed = msg.passed;
           const critique = msg.critique || '';

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -12,6 +12,8 @@ import re
 
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from decafclaw.web.message_types import WSMessageType
+
 log = logging.getLogger(__name__)
 
 # conv_id must be safe for use as a filename — alphanumeric, hyphens, dots, underscores only
@@ -36,7 +38,7 @@ def _project_tool_end(event: dict, conv_id: str) -> dict:
     compact.
     """
     payload = {
-        "type": "tool_end", "conv_id": conv_id,
+        "type": WSMessageType.TOOL_END, "conv_id": conv_id,
         "tool": event.get("tool", ""),
         "result_text": event.get("result_text", ""),
         "tool_call_id": event.get("tool_call_id", ""),
@@ -64,7 +66,7 @@ def _make_canvas_update_forwarder(state, conv_id):
         if event.get("conv_id") != conv_id:
             return
         await ws_send({
-            "type": "canvas_update",
+            "type": WSMessageType.CANVAS_UPDATE,
             "conv_id": conv_id,
             "kind": event.get("kind", "set"),
             "active_tab": event.get("active_tab"),
@@ -98,11 +100,11 @@ def _confirmation_to_dict(req) -> dict:
 async def _handle_select_conv(ws_send, index, username, msg, state):
     conv_id = msg.get("conv_id", "")
     if not _is_safe_conv_id(conv_id):
-        await ws_send({"type": "error", "message": "Invalid conversation ID"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "Invalid conversation ID"})
         return
     conv = index.get(conv_id)
     if conv and conv.user_id == username:
-        response = {"type": "conv_selected", "conv_id": conv_id}
+        response = {"type": WSMessageType.CONV_SELECTED, "conv_id": conv_id}
         # Check for pending confirmation via the manager
         manager = state.get("manager")
         if manager:
@@ -116,16 +118,16 @@ async def _handle_select_conv(ws_send, index, username, msg, state):
         # Check if it's a system conversation (archive exists on disk)
         # Reject other users' web conversations
         if conv_id.startswith("web-") and "--child-" not in conv_id:
-            await ws_send({"type": "error",
+            await ws_send({"type": WSMessageType.ERROR,
                            "message": f"Conversation not found: {conv_id}"})
             return
         from ..archive import archive_path
         if archive_path(state["config"], conv_id).exists():
-            await ws_send({"type": "conv_selected", "conv_id": conv_id,
+            await ws_send({"type": WSMessageType.CONV_SELECTED, "conv_id": conv_id,
                            "read_only": True})
             _subscribe_to_conv(state, conv_id)
         else:
-            await ws_send({"type": "error",
+            await ws_send({"type": WSMessageType.ERROR,
                            "message": f"Conversation not found: {conv_id}"})
 
 
@@ -180,19 +182,19 @@ async def _handle_load_history(ws_send, index, username, msg, state):
     config = state["config"]
     conv_id = msg.get("conv_id", "")
     if not _is_safe_conv_id(conv_id):
-        await ws_send({"type": "error", "message": "Invalid conversation ID"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "Invalid conversation ID"})
         return
     conv = index.get(conv_id)
     is_owner = conv and conv.user_id == username
     if not is_owner:
         # Reject other users' web conversations
         if conv_id.startswith("web-") and "--child-" not in conv_id:
-            await ws_send({"type": "error", "message": "Conversation not found"})
+            await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
             return
         # Allow read-only access if archive exists on disk (system conversations)
         from ..archive import archive_path
         if not archive_path(config, conv_id).exists():
-            await ws_send({"type": "error", "message": "Conversation not found"})
+            await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
             return
     try:
         limit = min(max(1, int(msg.get("limit", 50))), 500)
@@ -237,7 +239,7 @@ async def _handle_load_history(ws_send, index, username, msg, state):
                     break
 
     response = {
-        "type": "conv_history", "conv_id": conv_id,
+        "type": WSMessageType.CONV_HISTORY, "conv_id": conv_id,
         "messages": messages, "has_more": has_more,
         "context_limit": config.compaction.max_tokens,
     }
@@ -275,16 +277,16 @@ async def _handle_send(ws_send, index, username, msg, state):
     attachments = msg.get("attachments") or None
     wiki_page = msg.get("wiki_page") or None
     if not conv_id or (not text and not attachments):
-        await ws_send({"type": "error", "message": "conv_id and text (or attachments) required"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "conv_id and text (or attachments) required"})
         return
     conv = index.get(conv_id)
     if not conv or conv.user_id != username:
-        await ws_send({"type": "error", "message": "Conversation not found"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
         return
 
     manager = state.get("manager")
     if not manager:
-        await ws_send({"type": "error", "message": "Chat service unavailable"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "Chat service unavailable"})
         return
 
     # -- Command dispatch (centralized in commands.py) --
@@ -299,14 +301,14 @@ async def _handle_send(ws_send, index, username, msg, state):
 
     if cmd_result.mode in ("help", "unknown", "error"):
         await ws_send({
-            "type": "message_complete", "conv_id": conv_id,
+            "type": WSMessageType.MESSAGE_COMPLETE, "conv_id": conv_id,
             "role": "assistant", "text": cmd_result.text, "final": True,
         })
         return
 
     if cmd_result.mode == "fork":
         await ws_send({
-            "type": "message_complete", "conv_id": conv_id,
+            "type": WSMessageType.MESSAGE_COMPLETE, "conv_id": conv_id,
             "role": "assistant", "text": cmd_result.text, "final": True,
         })
         return
@@ -324,7 +326,7 @@ async def _handle_send(ws_send, index, username, msg, state):
         # Acknowledge the command so the user sees it was recognized
         skill_name = cmd_result.skill.name if cmd_result.skill else "unknown"
         await ws_send({
-            "type": "command_ack", "conv_id": conv_id,
+            "type": WSMessageType.COMMAND_ACK, "conv_id": conv_id,
             "command": cmd_result.display_text,
             "skill": skill_name,
         })
@@ -378,15 +380,15 @@ async def _handle_set_model(ws_send, index, username, msg, state):
     model_name = msg.get("model", msg.get("level", ""))
     conv = index.get(conv_id)
     if not conv or conv.user_id != username:
-        await ws_send({"type": "error", "message": "Conversation not found"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
         return
 
     config = state["config"]
     if not model_name:
-        await ws_send({"type": "error", "message": "No model specified"})
+        await ws_send({"type": WSMessageType.ERROR, "message": "No model specified"})
         return
     if model_name not in config.model_configs:
-        await ws_send({"type": "error", "message": f"Unknown model: {model_name}"})
+        await ws_send({"type": WSMessageType.ERROR, "message": f"Unknown model: {model_name}"})
         return
 
     # Record model change in archive
@@ -399,7 +401,7 @@ async def _handle_set_model(ws_send, index, username, msg, state):
         manager.set_flag(conv_id, "active_model", model_name)
 
     await ws_send({
-        "type": "model_changed", "conv_id": conv_id,
+        "type": WSMessageType.MODEL_CHANGED, "conv_id": conv_id,
         "model": model_name,
     })
 
@@ -496,14 +498,14 @@ def _subscribe_to_conv(state, conv_id):
             # Sent as distinct type so the client can deduplicate
             # (the originating tab already has the message locally).
             await ws_send({
-                "type": "user_message", "conv_id": event_conv_id,
+                "type": WSMessageType.USER_MESSAGE, "conv_id": event_conv_id,
                 "text": event.get("text", ""),
             })
 
         elif event_type == "chunk":
             streaming_buffer["text"] += event.get("text", "")
             await ws_send({
-                "type": "chunk", "conv_id": event_conv_id,
+                "type": WSMessageType.CHUNK, "conv_id": event_conv_id,
                 "text": event.get("text", ""),
             })
 
@@ -514,7 +516,7 @@ def _subscribe_to_conv(state, conv_id):
             iteration = event.get("iteration", 1)
             if iteration > 1 and streaming_buffer["text"]:
                 await ws_send({
-                    "type": "message_complete", "conv_id": event_conv_id,
+                    "type": WSMessageType.MESSAGE_COMPLETE, "conv_id": event_conv_id,
                     "role": "assistant", "text": streaming_buffer["text"],
                 })
                 streaming_buffer["text"] = ""
@@ -523,21 +525,21 @@ def _subscribe_to_conv(state, conv_id):
             text = streaming_buffer["text"] or event.get("text", "")
             if text:
                 await ws_send({
-                    "type": "message_complete", "conv_id": event_conv_id,
+                    "type": WSMessageType.MESSAGE_COMPLETE, "conv_id": event_conv_id,
                     "role": "assistant", "text": text,
                 })
                 streaming_buffer["text"] = ""
 
         elif event_type == "tool_start":
             await ws_send({
-                "type": "tool_start", "conv_id": event_conv_id,
+                "type": WSMessageType.TOOL_START, "conv_id": event_conv_id,
                 "tool": event.get("tool", ""),
                 "tool_call_id": event.get("tool_call_id", ""),
             })
 
         elif event_type == "tool_status":
             await ws_send({
-                "type": "tool_status", "conv_id": event_conv_id,
+                "type": WSMessageType.TOOL_STATUS, "conv_id": event_conv_id,
                 "tool": event.get("tool", ""),
                 "message": event.get("message", ""),
                 "tool_call_id": event.get("tool_call_id", ""),
@@ -549,7 +551,7 @@ def _subscribe_to_conv(state, conv_id):
         elif event_type == "canvas_update":
             if event_conv_id == conv_id:
                 await ws_send({
-                    "type": "canvas_update",
+                    "type": WSMessageType.CANVAS_UPDATE,
                     "conv_id": event_conv_id,
                     "kind": event.get("kind", "set"),
                     "active_tab": event.get("active_tab"),
@@ -560,7 +562,7 @@ def _subscribe_to_conv(state, conv_id):
             text = event.get("text", "")
             if text:
                 await ws_send({
-                    "type": "tool_status", "conv_id": event_conv_id,
+                    "type": WSMessageType.TOOL_STATUS, "conv_id": event_conv_id,
                     "tool": "vault_retrieval",
                     "message": text, "tool_call_id": "",
                 })
@@ -569,7 +571,7 @@ def _subscribe_to_conv(state, conv_id):
             text = event.get("text", "")
             if text:
                 await ws_send({
-                    "type": "tool_status", "conv_id": event_conv_id,
+                    "type": WSMessageType.TOOL_STATUS, "conv_id": event_conv_id,
                     "tool": "vault_references",
                     "message": text, "tool_call_id": "",
                 })
@@ -578,7 +580,7 @@ def _subscribe_to_conv(state, conv_id):
             # Flush any pending streamed text
             if streaming_buffer["text"]:
                 await ws_send({
-                    "type": "message_complete", "conv_id": event_conv_id,
+                    "type": WSMessageType.MESSAGE_COMPLETE, "conv_id": event_conv_id,
                     "role": "assistant", "text": streaming_buffer["text"],
                 })
                 streaming_buffer["text"] = ""
@@ -587,7 +589,7 @@ def _subscribe_to_conv(state, conv_id):
             log.info("Forwarding confirm request to web UI: %s",
                      action_type)
             await ws_send({
-                "type": "confirm_request", "conv_id": event_conv_id,
+                "type": WSMessageType.CONFIRM_REQUEST, "conv_id": event_conv_id,
                 "confirmation_id": event.get("confirmation_id", ""),
                 "action_type": action_type,
                 # Provide tool/command for backward compat with confirm-view
@@ -604,7 +606,7 @@ def _subscribe_to_conv(state, conv_id):
         elif event_type == "confirmation_response":
             # Forward to all tabs so non-originating tabs clear the widget
             payload = {
-                "type": "confirmation_response", "conv_id": event_conv_id,
+                "type": WSMessageType.CONFIRMATION_RESPONSE, "conv_id": event_conv_id,
                 "confirmation_id": event.get("confirmation_id", ""),
                 "approved": event.get("approved", False),
             }
@@ -623,15 +625,15 @@ def _subscribe_to_conv(state, conv_id):
             await ws_send(event)
 
         elif event_type == "turn_start":
-            await ws_send({"type": "turn_start", "conv_id": event_conv_id})
+            await ws_send({"type": WSMessageType.TURN_START, "conv_id": event_conv_id})
 
         elif event_type == "turn_complete":
             streaming_buffer["text"] = ""
-            await ws_send({"type": "turn_complete", "conv_id": event_conv_id})
+            await ws_send({"type": WSMessageType.TURN_COMPLETE, "conv_id": event_conv_id})
 
         elif event_type == "error":
             await ws_send({
-                "type": "error", "conv_id": event_conv_id,
+                "type": WSMessageType.ERROR, "conv_id": event_conv_id,
                 "message": event.get("message", ""),
             })
 
@@ -644,7 +646,7 @@ def _subscribe_to_conv(state, conv_id):
                 pass
             else:
                 await ws_send({
-                    "type": "reflection_result", "conv_id": event_conv_id,
+                    "type": WSMessageType.REFLECTION_RESULT, "conv_id": event_conv_id,
                     "passed": passed,
                     "critique": event.get("critique", ""),
                     "retry_number": event.get("retry_number", 0),
@@ -657,13 +659,13 @@ def _subscribe_to_conv(state, conv_id):
 
         elif event_type == "background_event":
             await ws_send({
-                "type": "background_event", "conv_id": event_conv_id,
+                "type": WSMessageType.BACKGROUND_EVENT, "conv_id": event_conv_id,
                 "record": event.get("record", {}),
             })
 
         elif event_type == "compaction_end":
             await ws_send({
-                "type": "compaction_done", "conv_id": event_conv_id,
+                "type": WSMessageType.COMPACTION_DONE, "conv_id": event_conv_id,
                 "before_messages": event.get("before_messages", 0),
                 "after_messages": event.get("after_messages", 0),
             })
@@ -684,14 +686,14 @@ def _unsubscribe_all(state):
 
 
 _HANDLERS = {
-    "select_conv": _handle_select_conv,
-    "load_history": _handle_load_history,
-    "send": _handle_send,
-    "cancel_turn": _handle_cancel_turn,
-    "set_effort": _handle_set_model,  # backward compat for old web UI
-    "set_model": _handle_set_model,
-    "confirm_response": _handle_confirm_response,
-    "widget_response": _handle_widget_response,
+    WSMessageType.SELECT_CONV: _handle_select_conv,
+    WSMessageType.LOAD_HISTORY: _handle_load_history,
+    WSMessageType.SEND: _handle_send,
+    WSMessageType.CANCEL_TURN: _handle_cancel_turn,
+    WSMessageType.SET_EFFORT: _handle_set_model,  # backward compat for old web UI
+    WSMessageType.SET_MODEL: _handle_set_model,
+    WSMessageType.CONFIRM_RESPONSE: _handle_confirm_response,
+    WSMessageType.WIDGET_RESPONSE: _handle_widget_response,
 }
 
 
@@ -710,13 +712,13 @@ def _make_notification_forwarder(ws_send):
         t = event.get("type")
         if t == "notification_created":
             await ws_send({
-                "type": "notification_created",
+                "type": WSMessageType.NOTIFICATION_CREATED,
                 "record": event["record"],
                 "unread_count": event["unread_count"],
             })
         elif t == "notification_read":
             await ws_send({
-                "type": "notification_read",
+                "type": WSMessageType.NOTIFICATION_READ,
                 "ids": event["ids"],
                 "unread_count": event["unread_count"],
             })
@@ -750,7 +752,7 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx,
     # any conversation is selected
     if config.model_configs:
         await ws_send({
-            "type": "models_available",
+            "type": WSMessageType.MODELS_AVAILABLE,
             "available_models": sorted(config.model_configs.keys()),
             "default_model": config.default_model,
         })
@@ -779,7 +781,7 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx,
             try:
                 msg = json.loads(raw)
             except json.JSONDecodeError:
-                await ws_send({"type": "error", "message": "Invalid JSON"})
+                await ws_send({"type": WSMessageType.ERROR, "message": "Invalid JSON"})
                 continue
 
             msg_type = msg.get("type", "")
@@ -787,7 +789,8 @@ async def websocket_chat(websocket: WebSocket, config, event_bus, app_ctx,
             if handler:
                 await handler(ws_send, index, username, msg, state)
             else:
-                await ws_send({"type": "error", "message": f"Unknown message type: {msg_type}"})
+                log.warning("ws: unknown inbound message type from %s: %r", username, msg_type)
+                await ws_send({"type": WSMessageType.ERROR, "message": f"Unknown message type: {msg_type}"})
 
     except WebSocketDisconnect:
         log.info(f"WebSocket disconnected: {username}")

--- a/tests/test_message_types.py
+++ b/tests/test_message_types.py
@@ -1,0 +1,33 @@
+"""Tests for the WS message-type manifest, ensuring the generated artifacts
+stay aligned with the runtime call sites that consume them."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from decafclaw.web.message_types import KNOWN_MESSAGE_TYPES, WSMessageType
+from decafclaw.web.websocket import _HANDLERS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JS_PATH = REPO_ROOT / "src/decafclaw/web/static/lib/message-types.js"
+
+
+def test_all_handler_keys_are_known_types() -> None:
+    for key in _HANDLERS:
+        assert key in KNOWN_MESSAGE_TYPES, f"unknown handler key: {key!r}"
+
+
+def test_js_constants_match_python_enum() -> None:
+    text = JS_PATH.read_text(encoding="utf-8")
+    block = re.search(
+        r"export const MESSAGE_TYPES = Object\.freeze\(\{(.*?)\}\);",
+        text,
+        re.DOTALL,
+    )
+    assert block, "MESSAGE_TYPES literal block not found in generated JS"
+    js_values = set(re.findall(r"'([a-z_][a-z0-9_]*)'", block.group(1)))
+    py_values = {t.value for t in WSMessageType}
+    assert js_values == py_values, (
+        f"JS↔Python mismatch — only in JS: {js_values - py_values}, "
+        f"only in Python: {py_values - js_values}"
+    )


### PR DESCRIPTION
## Summary

Replaces ~50 hand-written WebSocket message-type literals across Python and JS with a manifest-driven, drift-checked, code-generated single source of truth. Closes #384.

- **`src/decafclaw/web/message_types.json`** — hand-edited manifest, source of truth (30 wire types: 22 server-to-client, 8 client-to-server).
- **`scripts/gen_message_types.py`** — stdlib-only generator producing three artifacts from the manifest:
  - `src/decafclaw/web/message_types.py` — `class WSMessageType(StrEnum)` plus `KNOWN_MESSAGE_TYPES` / `S2C_MESSAGE_TYPES` / `C2S_MESSAGE_TYPES` frozensets.
  - `src/decafclaw/web/static/lib/message-types.js` — frozen `MESSAGE_TYPES` object plus `KNOWN_MESSAGE_TYPES` Set.
  - `docs/websocket-messages.md` — generated wire-protocol reference page.
- **`make gen-message-types`** regenerates; **`make check-message-types`** asserts no drift via `git diff --exit-code` and is wired into `make check`.
- **Server side** (`web/websocket.py`): every `"type": "..."` literal and every `_HANDLERS` key now references `WSMessageType.X`. `StrEnum` keeps the existing string-based dispatch pattern working.
- **Client side** (5 JS files): every `case '...'` and `ws.send({type: '...'})` now references `MESSAGE_TYPES.X`.
- **Migration safety net** — `log.warning` on the server and `console.warn` on the client when an unknown message type arrives. The issue's stated mitigation: catches any literal that slipped the migration.
- The two `event_bus.publish(...)` calls in `http_server.py` (`tool_confirm_response`, `cancel_turn`) are EventBus events, not WS wire messages, and intentionally stay as plain strings — out of scope.

## Commits

1. `feat(ws): add message-type manifest (#384)` — JSON source of truth.
2. `feat(ws): generator + drift check for message types (#384)` — generator script, Make targets, generated outputs, unit tests.
3. `refactor(ws): server uses WSMessageType enum (#384)` — all server-side flips + log.warning.
4. `refactor(ws): client uses MESSAGE_TYPES constants (#384)` — all client-side flips + console.warn.
5. `docs(ws): link generated reference + note manifest in CLAUDE.md (#384)` — docs index + CLAUDE.md hot-files note.

(Plus three dev-session docs commits: spec, spec correction, plan.)

## Future direction

The manifest's `fields` are human-readable type sketches today, not runtime validators. The generated docs page calls out a stricter typed-field schema as a deferred enhancement.

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes (0 errors)
- [x] `make check-js` passes (tsc --checkJs)
- [x] `make check-message-types` passes (drift check)
- [x] `make test` passes (2207 / 2207 including new `tests/test_message_types.py`)
- [ ] Manual smoke test in the web UI (`make dev`):
  - [ ] Send a chat message → streaming chunks render, `message_complete` finalizes
  - [ ] Trigger a tool that asks for confirmation → `confirm_request`/`confirm_response` round-trip works
  - [ ] Submit an interactive widget → `widget_response` round-trip works
  - [ ] Switch model mid-conversation → `set_model` / `model_changed` works
  - [ ] Cancel a turn → `cancel_turn` / `turn_complete` works
  - [ ] Trigger a compaction → `compaction_done` reload works
  - [ ] Open the standalone canvas page → `select_conv` + `canvas_update` works
  - [ ] Watch the browser console — no `[ws] unknown message type` warnings should appear
  - [ ] Watch server logs — no `ws: unknown inbound message type` warnings should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)