### PR TITLE
refactor(agent): TurnRunner + reflection split (#382)

### DIFF
--- a/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/notes.md
+++ b/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/notes.md
@@ -1,0 +1,13 @@
+# Refactor `run_agent_turn` and `_handle_reflection` — session notes
+
+## Status
+
+In progress.
+
+## Live verification results
+
+(Filled in after PR opened; track LV1-LV10 from plan.md.)
+
+## Surprises and follow-ups
+
+(Anything that didn't fit the plan, or new issues to file.)

--- a/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/plan.md
+++ b/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/plan.md
@@ -1,0 +1,1380 @@
+# Refactor `run_agent_turn` and `_handle_reflection` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `run_agent_turn` a thin shim over a `TurnRunner` class, replace the 200-line iteration-loop body with an `IterationOutcome` dispatcher, and split `_handle_reflection`'s 4-tuple into a `ReflectionOutcome` + three small methods. No behavior change.
+
+**Architecture:** Single `agent.py` file. Class-based turn lifecycle. Tagged-union return types replace control-flow magic numbers. Existing free-function helpers (`_check_cancelled`, `_archive`, `_setup_turn_state`, `_refresh_dynamic_tools`, `_build_tool_list`, `_call_llm_with_events`, `_execute_tool_calls`, `_handle_widget_input_pause`, `_handle_end_turn_confirm`, `_maybe_compact`) stay where they are.
+
+**Tech Stack:** Python 3.12, `dataclasses`, `pytest` + `pytest-xdist`, `make` for lint/typecheck/test.
+
+---
+
+## Reference paths
+
+- Code under refactor: `src/decafclaw/agent.py`
+  - `_handle_reflection`: lines 195-310
+  - `run_agent_turn`: lines 1053-1384
+- Tests: `tests/test_agent*.py` (any test file matching this prefix)
+- Spec: `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/spec.md`
+- Lint+typecheck: `make check`
+- Tests: `make test` (parallel via `pytest-xdist`)
+
+## Workflow notes
+
+- This is a **no-behavior-change refactor**. The bar at every step is "all
+  existing tests pass." If a test starts failing, the extraction was wrong —
+  back out, narrow the change, retry.
+- TDD does not apply in the usual "write a failing test first" sense.
+  Existing tests are the safety net. The one new test
+  (`test_run_agent_turn_public_surface_unchanged`) goes in early in commit 2
+  to lock the wrapper contract.
+- Run `make check` after each task that touches code (cheap, ~10s).
+- Run `make test` only at the end of each commit's tasks (slow, ~21s; saves
+  time vs running it after every task).
+- Commit only at the end of each commit's task group, per the spec.
+
+---
+
+# Task 0: Branch setup and baseline
+
+**Files:**
+- None modified — environment prep only.
+
+- [ ] **Step 0.1: Verify working tree is clean**
+
+Run: `git status`
+Expected: clean (or only untracked files unrelated to this work).
+
+If dirty, stash or commit unrelated changes before proceeding.
+
+- [ ] **Step 0.2: Sync with `origin/main`**
+
+Run: `git fetch origin && git log --oneline main..origin/main`
+Expected: empty output (local main is up to date).
+
+If remote main has new commits, fast-forward: `git checkout main && git pull --ff-only`.
+
+- [ ] **Step 0.3: Create the work branch**
+
+Run: `git checkout -b refactor/agent-turn-runner`
+Expected: branch created, you're now on it.
+
+- [ ] **Step 0.4: Verify the baseline tests pass**
+
+Run: `make check && make test`
+Expected: PASS (lint clean, typecheck clean, ~2200 tests passing in ~21s).
+
+If anything fails on the baseline, stop and fix before starting the
+refactor — we need a green starting point to attribute regressions.
+
+- [ ] **Step 0.5: Initialize dev session notes**
+
+Create `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/notes.md`:
+
+```markdown
+# Refactor `run_agent_turn` and `_handle_reflection` — session notes
+
+## Status
+
+In progress.
+
+## Live verification results
+
+(Filled in after PR opened; track LV1-LV10 from plan.md.)
+
+## Surprises and follow-ups
+
+(Anything that didn't fit the plan, or new issues to file.)
+```
+
+---
+
+# Commit 1: Split `_handle_reflection` into orchestrator + free-function helpers
+
+## Task 1: Add `ReflectionOutcome` dataclass
+
+**Files:**
+- Modify: `src/decafclaw/agent.py` (add new class near `_handle_reflection`,
+  around line 195)
+
+- [ ] **Step 1.1: Add the dataclass**
+
+Insert immediately above `def _should_reflect(...)` at line 180:
+
+```python
+@dataclass(frozen=True)
+class ReflectionOutcome:
+    """Result of evaluating a candidate final response.
+
+    Replaces the 4-tuple return shape of the old _handle_reflection.
+    `text` is None when the caller should retry (critique already
+    injected into history/messages by the helper). When `should_retry`
+    is False, `text` is the response to deliver (with optional
+    exhaustion-escalation suffix appended in the skip path).
+
+    `reflection_retries` and `last_reflection` are mutated on the call
+    sites' state directly — they don't appear in this return type.
+    """
+    text: str | None
+    should_retry: bool
+```
+
+`@dataclass` is already imported (used by `ReflectionResult` etc.). If not, add `from dataclasses import dataclass` at the top of the file.
+
+- [ ] **Step 1.2: Compile-check**
+
+Run: `make check`
+Expected: PASS (no callers yet — the class is unused).
+
+## Task 2: Extract `_reflection_skip` free function
+
+**Files:**
+- Modify: `src/decafclaw/agent.py` (add new free function above
+  `_handle_reflection`)
+
+- [ ] **Step 2.1: Add the function**
+
+Insert above `_handle_reflection` (line 195):
+
+```python
+def _reflection_skip(
+    ctx, config, final_text: str,
+    reflection_retries: int,
+    last_reflection: "ReflectionResult | None",
+) -> tuple[str, "ReflectionResult | None"]:
+    """The 'reflection did not run' branch. Returns (final_text_maybe_with_escalation,
+    cleared_last_reflection).
+
+    Mirrors the early-return block at agent.py:215-229. Appends the
+    'I'm not confident' suffix when retries are exhausted; clears
+    last_reflection so it won't get archived against this new response.
+    """
+    reflection_exhausted = (
+        reflection_retries >= config.reflection.max_retries
+        and last_reflection is not None
+        and not last_reflection.passed
+    )
+    if reflection_exhausted:
+        final_text += (
+            "\n\n---\n*I'm not confident in this answer. "
+            "Try switching to a more capable model in the web UI model picker.*"
+        )
+    return final_text, None
+```
+
+- [ ] **Step 2.2: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+## Task 3: Extract `_reflection_evaluate` free function
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 3.1: Add the function**
+
+Insert below `_reflection_skip`:
+
+```python
+async def _reflection_evaluate(
+    ctx, config, history: list,
+    final_text: str, user_message: str,
+    attachments: list[dict] | None,
+    retrieved_context_text: str,
+    turn_start_index: int,
+    reflection_retries: int,
+    accumulated_text_parts: list[str] | None,
+) -> "ReflectionResult":
+    """Build summaries, annotate user message, call evaluate_response,
+    publish reflection_result event.
+
+    Mirrors agent.py:231-279 in the original _handle_reflection.
+    Returns the ReflectionResult; caller stores it on its own state
+    and decides what to do with the verdict.
+    """
+    from .reflection import (
+        build_prior_turn_summary,
+        build_tool_summary,
+        evaluate_response,
+    )
+
+    tool_summary = build_tool_summary(
+        history, turn_start_index,
+        max_result_len=config.reflection.max_tool_result_len,
+    )
+    prior_turn_summary = build_prior_turn_summary(
+        history, turn_start_index - 1,
+        max_turns=3,
+        max_result_len=200,
+    )
+    judge_user_message = user_message
+    if attachments:
+        att_desc = ", ".join(
+            f"{a.get('filename', '?')} ({a.get('mime_type', '?')})"
+            for a in attachments
+        )
+        judge_user_message += f"\n\n[User attached files: {att_desc}]"
+    judge_agent_response = "\n\n".join(
+        part for part in [*(accumulated_text_parts or []), final_text]
+        if part and part.strip()
+    ) or final_text
+    result = await evaluate_response(
+        config, judge_user_message, judge_agent_response, tool_summary,
+        prior_turn_summary=prior_turn_summary,
+        retrieved_context=retrieved_context_text,
+    )
+
+    log.info("Reflection result: passed=%s, critique=%s, error=%s",
+             result.passed, result.critique[:200] if result.critique else "",
+             result.error[:100] if result.error else "")
+    await ctx.publish("reflection_result",
+        passed=result.passed,
+        critique=result.critique,
+        raw_response=result.raw_response,
+        retry_number=reflection_retries + 1,
+        error=result.error)
+    return result
+```
+
+- [ ] **Step 3.2: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+## Task 4: Extract `_reflection_apply_verdict` free function
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 4.1: Add the function**
+
+Insert below `_reflection_evaluate`:
+
+```python
+def _reflection_apply_verdict(
+    ctx, history: list, messages: list,
+    final_text: str, result: "ReflectionResult",
+    reflection_retries: int,
+    config,
+) -> tuple[ReflectionOutcome, int]:
+    """Apply the judge's verdict. On fail-with-real-critique, append
+    failed_msg + critique_msg to history/messages, archive both, and
+    bump retries. Returns (outcome, new_retries).
+
+    Mirrors agent.py:281-310 in the original _handle_reflection. The
+    fail-open path (result.error set) is treated as PASS so the user
+    still gets a response when the judge LLM itself fails.
+    """
+    if not result.passed and not result.error:
+        log.info("Reflection failed (retry %d/%d): %s",
+                 reflection_retries + 1,
+                 config.reflection.max_retries,
+                 result.critique[:200])
+        failed_msg = {"role": "assistant", "content": final_text}
+        history.append(failed_msg)
+        messages.append(failed_msg)
+        _archive(ctx, failed_msg)
+
+        critique_msg = {
+            "role": "user",
+            "content": (
+                "[reflection] Your previous response may not fully "
+                "address the user's request.\n"
+                f"Feedback: {result.critique}\n"
+                "Please try again, addressing the feedback above."
+            ),
+        }
+        history.append(critique_msg)
+        messages.append(critique_msg)
+        _archive(ctx, critique_msg)
+
+        return ReflectionOutcome(text=None, should_retry=True), reflection_retries + 1
+
+    return ReflectionOutcome(text=final_text, should_retry=False), reflection_retries
+```
+
+- [ ] **Step 4.2: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+## Task 5: Rewrite `_handle_reflection` as orchestrator + update call site
+
+**Files:**
+- Modify: `src/decafclaw/agent.py:195-310` (replace the whole function body)
+- Modify: `src/decafclaw/agent.py:1308-1315` (the single call site in
+  `run_agent_turn`)
+
+- [ ] **Step 5.1: Replace `_handle_reflection`**
+
+Replace the existing function body (lines 195-310) with this thin orchestrator:
+
+```python
+async def _handle_reflection(
+    ctx, config, messages, history, final_text,
+    user_message, attachments, retrieved_context_text,
+    turn_start_index, reflection_retries, last_reflection,
+    accumulated_text_parts=None,
+) -> tuple[ReflectionOutcome, int, "ReflectionResult | None"]:
+    """Run the reflection phase on a candidate final response.
+
+    Returns (outcome, new_reflection_retries, new_last_reflection):
+    - Skipped: outcome wraps possibly-suffixed text; last_reflection cleared
+    - Evaluated and passed: outcome wraps text; last_reflection set to result
+    - Evaluated and failed (retries left): outcome.should_retry=True;
+      critique already injected into messages/history
+    - Evaluated and failed (no retries left, fail-open error): treated as pass
+
+    `accumulated_text_parts` collects text from earlier iterations of
+    this turn (skill-style "report + tool call" patterns) so the judge
+    sees the full visible response, not just the trailer.
+    """
+    if not _should_reflect(ctx, config, final_text, reflection_retries):
+        text, cleared = _reflection_skip(
+            ctx, config, final_text, reflection_retries, last_reflection,
+        )
+        return ReflectionOutcome(text=text, should_retry=False), reflection_retries, cleared
+
+    result = await _reflection_evaluate(
+        ctx, config, history, final_text, user_message, attachments,
+        retrieved_context_text, turn_start_index, reflection_retries,
+        accumulated_text_parts,
+    )
+    last_reflection = result
+
+    outcome, new_retries = _reflection_apply_verdict(
+        ctx, history, messages, final_text, result, reflection_retries, config,
+    )
+    return outcome, new_retries, last_reflection
+```
+
+- [ ] **Step 5.2: Update the single call site in `run_agent_turn`**
+
+Find the call at agent.py:1308-1315:
+
+```python
+content, should_retry, reflection_retries, last_reflection = (
+    await _handle_reflection(
+        ctx, config, messages, history, content,
+        user_message, attachments, retrieved_context_text,
+        turn_start_index, reflection_retries, last_reflection,
+        accumulated_text_parts=accumulated_text_parts,
+    )
+)
+if should_retry:
+    continue
+```
+
+Replace with:
+
+```python
+outcome, reflection_retries, last_reflection = await _handle_reflection(
+    ctx, config, messages, history, content,
+    user_message, attachments, retrieved_context_text,
+    turn_start_index, reflection_retries, last_reflection,
+    accumulated_text_parts=accumulated_text_parts,
+)
+if outcome.should_retry:
+    continue
+content = outcome.text
+```
+
+- [ ] **Step 5.3: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+## Task 6: Verify and commit commit 1
+
+- [ ] **Step 6.1: Run the full test suite**
+
+Run: `make test`
+Expected: PASS (2200+ tests, ~21s).
+
+If anything fails, the reflection split changed behavior — investigate the
+failing test (likely `tests/test_agent_reflection*.py`), revert the relevant
+extraction, narrow the change.
+
+- [ ] **Step 6.2: Commit**
+
+```bash
+git add src/decafclaw/agent.py
+git commit -m "$(cat <<'EOF'
+refactor(agent): split _handle_reflection into orchestrator + helpers
+
+Replace the 117-line _handle_reflection 4-tuple return with a
+ReflectionOutcome dataclass + three free-function helpers
+(_reflection_skip, _reflection_evaluate, _reflection_apply_verdict).
+The orchestrator is now ~25 lines; each helper has a single
+responsibility.
+
+No behavior change. Existing tests pass unchanged.
+
+Refs #382.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Commit 2: Introduce `TurnRunner` and `IterationOutcome`; fold reflection helpers onto class
+
+## Task 7: Add `IterationOutcome` types
+
+**Files:**
+- Modify: `src/decafclaw/agent.py` (add near `_handle_reflection` / above
+  `run_agent_turn`)
+
+- [ ] **Step 7.1: Add the types**
+
+Insert immediately above `async def run_agent_turn(...)` (line 1053):
+
+```python
+class IterationOutcome:
+    """Tagged-union return type from TurnRunner._run_iteration.
+
+    Two variants: _Continue (loop again) and _Final (return this
+    ToolResult from the turn). Cancellation collapses into _Final
+    since the outer loop treats it identically.
+    """
+
+
+@dataclass(frozen=True)
+class _Continue(IterationOutcome):
+    """Loop again — used for tool-call iterations, retries, widget
+    injection, EndTurnConfirm-approved continuation."""
+
+
+@dataclass(frozen=True)
+class _Final(IterationOutcome):
+    """Turn is done; return this ToolResult."""
+    result: "ToolResult"
+```
+
+- [ ] **Step 7.2: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+## Task 8: Add the wrapper-contract test (locks the public surface)
+
+**Files:**
+- Create or modify: `tests/test_agent.py` (add at end)
+
+- [ ] **Step 8.1: Find or pick a test file**
+
+Run: `ls tests/test_agent*.py`
+
+Add the test to `tests/test_agent.py` if it exists, or create
+`tests/test_agent_public_surface.py` if it doesn't.
+
+- [ ] **Step 8.2: Add the test**
+
+```python
+import inspect
+from decafclaw.agent import run_agent_turn
+
+
+def test_run_agent_turn_public_surface_unchanged():
+    """Lock the public signature so future refactors don't drift the
+    contract callers depend on (conversation_manager.py, eval/runner,
+    etc.)."""
+    sig = inspect.signature(run_agent_turn)
+    params = sig.parameters
+
+    assert list(params.keys()) == [
+        "ctx", "user_message", "history", "archive_text", "attachments",
+    ], "Positional/keyword arg order changed"
+    assert params["archive_text"].default == "", \
+        "archive_text default changed"
+    assert params["attachments"].default is None, \
+        "attachments default changed"
+    assert inspect.iscoroutinefunction(run_agent_turn), \
+        "run_agent_turn must remain async"
+```
+
+- [ ] **Step 8.3: Run the test**
+
+Run: `pytest tests/test_agent.py::test_run_agent_turn_public_surface_unchanged -v`
+(Or the equivalent path if you created a new file.)
+
+Expected: PASS.
+
+## Task 9: Add `TurnRunner` skeleton; move `run_agent_turn` body verbatim
+
+**Files:**
+- Modify: `src/decafclaw/agent.py:1053-1384` (entire `run_agent_turn` body
+  moves to `TurnRunner.run`)
+
+- [ ] **Step 9.1: Insert `TurnRunner` class above `run_agent_turn`**
+
+Insert this skeleton above `async def run_agent_turn(...)`:
+
+```python
+@dataclass
+class TurnRunner:
+    """Owns the mutable state of a single agent turn.
+
+    State that was local variables in the original run_agent_turn
+    becomes fields here. State written through ctx helpers
+    (ctx.tokens, ctx.skills, ctx.history) stays on ctx.
+    """
+    ctx: Any
+    config: Any
+    history: list
+    user_message: str
+    archive_text: str
+    attachments: list[dict] | None
+
+    messages: list = field(default_factory=list)
+    deferred_msg: dict | None = None
+    prompt_tokens: int = 0
+    empty_retries: int = 0
+    reflection_retries: int = 0
+    last_reflection: "ReflectionResult | None" = None
+    turn_start_index: int = 0
+    accumulated_text_parts: list[str] = field(default_factory=list)
+    model_override: dict[str, str] = field(default_factory=dict)
+    retrieved_context_text: str = ""
+    composed: "ComposedContext | None" = None
+    composer: "ContextComposer | None" = None
+
+    async def run(self) -> "ToolResult":
+        # Body filled in step 9.2.
+        raise NotImplementedError
+```
+
+**Imports check** — before adding the class, verify `agent.py`'s top-of-file imports include:
+
+```python
+from dataclasses import dataclass, field
+from typing import Any
+```
+
+Run: `grep -n "from dataclasses\|from typing" src/decafclaw/agent.py | head -5`
+
+Add any missing imports.
+
+- [ ] **Step 9.2: Move the entire body of `run_agent_turn` into `TurnRunner.run()`**
+
+This is a mechanical translation: every `local_var` in `run_agent_turn`
+becomes `self.local_var`; every reference to function-arg `ctx`, `config`,
+`history`, `user_message`, `archive_text`, `attachments` becomes
+`self.ctx`, `self.config`, etc.
+
+Some inline detail to watch for:
+
+- `model_override = await _setup_turn_state(...)` → `self.model_override = await _setup_turn_state(self.ctx, self.config, self.history)`
+- `composed = None; composer = None` → already fields, just assign `self.composed = None; self.composer = None` at top of method
+- `messages = composed.messages; ctx.messages = messages` →
+  `self.messages = self.composed.messages; self.ctx.messages = self.messages`
+- `retrieved_context_text = composed.retrieved_context_text` →
+  `self.retrieved_context_text = self.composed.retrieved_context_text`
+- `prompt_tokens = 0; empty_retries = 0; ...` → already fields, just
+  initialize via `__post_init__` or skip (defaults already cover them).
+- `for iteration in range(config.agent.max_tool_iterations)` →
+  `for iteration in range(self.config.agent.max_tool_iterations)`
+- All inner `ctx`/`config`/`history`/`messages` refs → `self.ctx`/`self.config`/etc.
+- The `**model_override` kwargs spread → `**self.model_override`
+- `accumulated_text_parts.append(...)` → `self.accumulated_text_parts.append(...)`
+- The reflection call site (updated in commit 1) becomes:
+  ```python
+  outcome, self.reflection_retries, self.last_reflection = await _handle_reflection(
+      self.ctx, self.config, self.messages, self.history, content,
+      self.user_message, self.attachments, self.retrieved_context_text,
+      self.turn_start_index, self.reflection_retries, self.last_reflection,
+      accumulated_text_parts=self.accumulated_text_parts,
+  )
+  if outcome.should_retry:
+      continue
+  content = outcome.text
+  ```
+- The `finally` block keeps the same `try` boundary — the whole `try: ...
+  finally: ...` structure moves intact.
+
+The method body should otherwise be a line-for-line copy.
+
+- [ ] **Step 9.3: Replace `run_agent_turn` body with the wrapper**
+
+After the `TurnRunner` class, leave `run_agent_turn` defined as:
+
+```python
+async def run_agent_turn(ctx, user_message: str, history: list,
+                         archive_text: str = "",
+                         attachments: list[dict] | None = None) -> "ToolResult":
+    """Process a single user message through the agent loop.
+
+    Public entry point. Constructs a TurnRunner and runs it.
+    """
+    runner = TurnRunner(
+        ctx=ctx, config=ctx.config, history=history,
+        user_message=user_message, archive_text=archive_text,
+        attachments=attachments,
+    )
+    return await runner.run()
+```
+
+- [ ] **Step 9.4: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+- [ ] **Step 9.5: Run the full test suite**
+
+Run: `make test`
+Expected: PASS (no behavior change yet — just moved code).
+
+If a test fails: most likely a `self.` rename was missed, or a closure
+captured `ctx` instead of `self.ctx`. `git diff` and look for any
+non-`self.` reference to a local that should be on the runner.
+
+## Task 10: Extract `_compose` method
+
+**Files:**
+- Modify: `src/decafclaw/agent.py` (`TurnRunner` class)
+
+- [ ] **Step 10.1: Add `_compose` method**
+
+The compose phase covers everything from the start of `try:` through the
+`# Track the deferred tools system message...` block (lines ~1079-1124 in
+the original). Cut that block out of `run()` and paste into a new method:
+
+```python
+async def _compose(self) -> None:
+    """Build the composed context, archive composer-added messages,
+    initialize message-tracking state on self."""
+    if self.ctx.is_child:
+        composer_mode = ComposerMode.CHILD_AGENT
+    elif self.ctx.task_mode in _TASK_MODE_TO_COMPOSER:
+        composer_mode = _TASK_MODE_TO_COMPOSER[self.ctx.task_mode]
+    else:
+        composer_mode = ComposerMode.INTERACTIVE
+
+    self.composer = ContextComposer(state=self.ctx.composer)
+    self.composed = await self.composer.compose(
+        self.ctx, self.user_message, self.history,
+        mode=composer_mode, attachments=self.attachments,
+    )
+    self.messages = self.composed.messages
+    self.ctx.messages = self.messages
+    self.retrieved_context_text = self.composed.retrieved_context_text
+
+    for msg in self.composed.messages_to_archive:
+        if self.ctx.task_mode == "background_wake" and msg.get("role") == "user":
+            archive_msg: dict = {
+                "role": "wake_trigger",
+                "content": msg.get("content", ""),
+            }
+            _archive(self.ctx, archive_msg)
+        elif self.archive_text and msg.get("role") == "user":
+            archive_msg = {"role": "user", "content": self.archive_text}
+            if msg.get("attachments"):
+                archive_msg["attachments"] = msg["attachments"]
+            _archive(self.ctx, archive_msg)
+        else:
+            _archive(self.ctx, msg)
+
+    if (len(self.messages) > 1
+            and self.messages[1].get("role") == "system"
+            and self.composed.deferred_tools):
+        self.deferred_msg = self.messages[1]
+    else:
+        self.deferred_msg = None
+
+    self.turn_start_index = len(self.history)
+```
+
+In `run()`, replace the moved block with `await self._compose()` immediately
+after `self.model_override = await _setup_turn_state(...)`.
+
+- [ ] **Step 10.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+## Task 11: Extract `_write_diagnostics` method
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 11.1: Add `_write_diagnostics` method**
+
+The `finally` block (lines ~1367-1384 in the original) becomes:
+
+```python
+async def _write_diagnostics(self) -> None:
+    """Persist context diagnostics + skill state on any turn-exit path.
+
+    Fail-open: any failure logs at DEBUG and is swallowed so the
+    finally block never raises through to callers.
+    """
+    conv_id = self.ctx.conv_id or self.ctx.channel_id
+
+    if self.composed is not None and self.composer is not None and conv_id:
+        try:
+            from .context_composer import write_context_sidecar
+            diagnostics = self.composer.build_diagnostics(self.config, self.composed)
+            write_context_sidecar(self.config, conv_id, diagnostics)
+        except Exception as exc:
+            log.debug("context sidecar write failed for %s: %s", conv_id, exc)
+
+    if conv_id:
+        activated = self.ctx.skills.activated
+        if activated:
+            write_skills_state(self.config, conv_id, activated)
+        skill_data = self.ctx.skills.data
+        if skill_data:
+            write_skill_data(self.config, conv_id, skill_data)
+```
+
+In `run()`, replace the entire `finally:` body with `await self._write_diagnostics()`.
+
+- [ ] **Step 11.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+## Task 12: Extract `_handle_tool_calls` method
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 12.1: Add `_handle_tool_calls` method**
+
+This handles the entire `if tool_calls:` branch in the iteration body
+(lines ~1174-1291 in the original). Cut that block from `run()` and paste
+as:
+
+```python
+async def _handle_tool_calls(
+    self, response: dict, tool_calls: list,
+) -> IterationOutcome:
+    """Append assistant tool-call message, execute tools, dispatch
+    on end-turn signals (widget pause, EndTurnConfirm, end_turn=True).
+
+    Returns _Continue to loop again, or _Final(result) to end the turn.
+    """
+    iter_content = response.get("content")
+    assistant_msg = {"role": "assistant", "content": iter_content}
+    assistant_msg["tool_calls"] = tool_calls
+    self.history.append(assistant_msg)
+    self.messages.append(assistant_msg)
+    _archive(self.ctx, assistant_msg)
+
+    if iter_content:
+        self.accumulated_text_parts.append(iter_content)
+        await self.ctx.publish("text_before_tools", text=iter_content)
+
+    cancelled, end_turn_signal = await _execute_tool_calls(
+        self.ctx, tool_calls, self.history, self.messages,
+    )
+    if cancelled:
+        return _Final(result=cancelled)
+
+    if isinstance(end_turn_signal, WidgetInputPause):
+        inject_content = await _handle_widget_input_pause(
+            self.ctx, end_turn_signal,
+        )
+        if inject_content is None:
+            end_turn_signal = True
+        else:
+            synthetic = {
+                "role": "user",
+                "source": "widget_response",
+                "content": inject_content,
+            }
+            self.history.append(synthetic)
+            self.messages.append(synthetic)
+            _archive(self.ctx, synthetic)
+            return _Continue()
+
+    if isinstance(end_turn_signal, EndTurnConfirm):
+        log.info("EndTurnConfirm — making presentation LLM call before confirmation")
+        present_response = await _call_llm_with_events(
+            self.ctx, self.config, self.messages, [],
+            **self.model_override,
+        )
+        present_content = present_response.get("content") or ""
+        present_msg = {"role": "assistant", "content": present_content}
+        self.history.append(present_msg)
+        self.messages.append(present_msg)
+        _archive(self.ctx, present_msg)
+
+        log.info("EndTurnConfirm — requesting confirmation")
+        approved = await _handle_end_turn_confirm(self.ctx, end_turn_signal)
+        if approved:
+            log.info("EndTurnConfirm approved — continuing agent loop")
+            if end_turn_signal.on_approve:
+                if asyncio.iscoroutinefunction(end_turn_signal.on_approve):
+                    await end_turn_signal.on_approve()
+                else:
+                    end_turn_signal.on_approve()
+            note = f"[User approved: {end_turn_signal.message or 'review'}]"
+            self.history.append({"role": "user", "content": note})
+            self.messages.append({"role": "user", "content": note})
+            return _Continue()
+        else:
+            log.info("EndTurnConfirm denied — ending turn")
+            if end_turn_signal.on_deny:
+                if asyncio.iscoroutinefunction(end_turn_signal.on_deny):
+                    await end_turn_signal.on_deny()
+                else:
+                    end_turn_signal.on_deny()
+            deny_label = end_turn_signal.deny_label or "denied"
+            note = f"[User selected '{deny_label}'. Ask what they'd like changed.]"
+            self.history.append({"role": "user", "content": note})
+            self.messages.append({"role": "user", "content": note})
+            end_turn_signal = True
+
+    if end_turn_signal:
+        log.info("Tool signalled end_turn — making final no-tools LLM call")
+        final_response = await _call_llm_with_events(
+            self.ctx, self.config, self.messages, [],
+            **self.model_override,
+        )
+        content = final_response.get("content") or ""
+        final_msg = {"role": "assistant", "content": content}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+
+        return _Final(result=self._extract_workspace_media(content))
+
+    return _Continue()
+```
+
+This method also references a small helper `_extract_workspace_media`.
+Add it as a method on `TurnRunner`:
+
+```python
+def _extract_workspace_media(self, content: str) -> "ToolResult":
+    """Extract workspace:// refs only for channels that need it.
+
+    Mattermost strips refs and uploads files; web/terminal render them
+    in-place. Returns ToolResult with media when extraction applies,
+    otherwise just text.
+    """
+    handler = self.ctx.media_handler
+    should_extract = (handler is None or handler.strips_workspace_refs)
+    if should_extract:
+        cleaned_text, workspace_media = extract_workspace_media(
+            content or "", self.config.workspace_path,
+        )
+        if workspace_media:
+            return ToolResult(text=cleaned_text, media=workspace_media)
+    return ToolResult(text=content or "")
+```
+
+In `run()`, the `if tool_calls:` block is replaced with:
+
+```python
+if tool_calls:
+    outcome = await self._handle_tool_calls(response, tool_calls)
+    if isinstance(outcome, _Final):
+        return outcome.result
+    continue
+```
+
+- [ ] **Step 12.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+This is the highest-risk extraction. If any of `tests/test_agent_widget_input*.py`,
+`tests/test_agent_end_turn_confirm*.py`, or `tests/test_agent.py` start
+failing, suspect: a dropped `self.`, or fall-through ordering changed
+(approved → `continue` vs denied → fall through to `if end_turn_signal:`).
+
+## Task 13: Extract `_handle_no_tool_calls` method
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 13.1: Add `_handle_no_tool_calls` method**
+
+This handles the `# No tool calls — final response` block in the iteration
+body (lines ~1294-1354 in the original). Cut that block from `run()` and
+paste as:
+
+```python
+async def _handle_no_tool_calls(self, response: dict) -> IterationOutcome:
+    """Process a no-tool-calls LLM response. Handles empty-retry,
+    reflection, archive of last_reflection, and compaction trigger.
+    Returns _Continue (retry) or _Final(result) (deliver response)."""
+    content = response.get("content") or ""
+    if not content:
+        if self.empty_retries < 1:
+            self.empty_retries += 1
+            log.warning("LLM returned empty response, retrying")
+            return _Continue()
+        log.warning("LLM returned empty content with no tool calls (after retry)")
+
+    log.debug("Reflection check: enabled=%s, retries=%d/%d, skip=%s, has_content=%s",
+               self.config.reflection.enabled, self.reflection_retries,
+               self.config.reflection.max_retries, self.ctx.skip_reflection, bool(content))
+    outcome, self.reflection_retries, self.last_reflection = await _handle_reflection(
+        self.ctx, self.config, self.messages, self.history, content,
+        self.user_message, self.attachments, self.retrieved_context_text,
+        self.turn_start_index, self.reflection_retries, self.last_reflection,
+        accumulated_text_parts=self.accumulated_text_parts,
+    )
+    if outcome.should_retry:
+        return _Continue()
+    content = outcome.text
+
+    final_msg = {"role": "assistant", "content": content}
+    self.history.append(final_msg)
+    _archive(self.ctx, final_msg)
+
+    if self.last_reflection is not None:
+        visibility = self.config.reflection.visibility
+        r = self.last_reflection
+        should_archive = (
+            visibility == "debug"
+            or (visibility == "visible" and not r.passed)
+        )
+        if should_archive:
+            detail = r.raw_response or r.critique or (
+                "Response passed evaluation" if r.passed else "No details")
+            label = ("reflection: PASS" if r.passed
+                     else f"reflection: retry {self.reflection_retries}")
+            _archive(self.ctx, {"role": "reflection", "tool": label,
+                                "content": detail})
+
+    await _maybe_compact(self.ctx, self.config, self.history, self.prompt_tokens)
+    return _Final(result=self._extract_workspace_media(content))
+```
+
+In `run()`, the `# No tool calls — final response` block becomes:
+
+```python
+outcome = await self._handle_no_tool_calls(response)
+if isinstance(outcome, _Final):
+    return outcome.result
+continue
+```
+
+- [ ] **Step 13.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+If `tests/test_agent_reflection*.py` fails, suspect: `self.last_reflection`
+not preserved across the `_handle_reflection` call (the orchestrator returns
+the new value; we must reassign).
+
+## Task 14: Extract `_finalize_max_iterations` method
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 14.1: Add `_finalize_max_iterations` method**
+
+The post-loop block (lines ~1357-1365 in the original) becomes:
+
+```python
+async def _finalize_max_iterations(self) -> "ToolResult":
+    """Hit max iterations without a final response. Preserve any
+    accumulated text from tool-call iterations and append a notice."""
+    limit_note = (
+        f"\n\n[Agent reached max tool iterations "
+        f"({self.config.agent.max_tool_iterations}) without a final response]"
+    )
+    accumulated = "\n\n".join(self.accumulated_text_parts)
+    msg = accumulated + limit_note if accumulated else limit_note.strip()
+    final_msg = {"role": "assistant", "content": msg}
+    self.history.append(final_msg)
+    _archive(self.ctx, final_msg)
+    await _maybe_compact(
+        self.ctx, self.config, self.history, self.prompt_tokens,
+    )
+    return ToolResult(text=msg)
+```
+
+In `run()`, the post-loop block becomes:
+
+```python
+return await self._finalize_max_iterations()
+```
+
+- [ ] **Step 14.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+## Task 15: Extract `_run_iteration` dispatcher
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 15.1: Add `_run_iteration` method**
+
+After the previous extractions, the `for iteration in range(...)` body in
+`run()` should look approximately like:
+
+```python
+for iteration in range(self.config.agent.max_tool_iterations):
+    cancelled = _check_cancelled(self.ctx, self.history)
+    if cancelled:
+        return cancelled
+
+    log.debug(f"Agent iteration {iteration + 1}")
+    self.ctx._current_iteration = iteration + 1
+
+    _refresh_dynamic_tools(self.ctx)
+    all_tools, deferred_text = _build_tool_list(self.ctx)
+
+    # Inject/update deferred tool list...  (about 12 lines)
+
+    response = await _call_llm_with_events(...)
+
+    # Token usage tracking...
+
+    tool_calls = response.get("tool_calls")
+    if tool_calls:
+        outcome = await self._handle_tool_calls(response, tool_calls)
+        if isinstance(outcome, _Final):
+            return outcome.result
+        continue
+
+    outcome = await self._handle_no_tool_calls(response)
+    if isinstance(outcome, _Final):
+        return outcome.result
+    continue
+```
+
+Extract everything inside the `for` body into:
+
+```python
+async def _run_iteration(self, iteration: int) -> IterationOutcome:
+    """Run one LLM iteration: cancel-check, tool refresh, deferred-list
+    injection, the LLM call, and dispatch to tool-calls or no-tool-calls
+    handler. Returns _Continue or _Final."""
+    cancelled = _check_cancelled(self.ctx, self.history)
+    if cancelled:
+        return _Final(result=cancelled)
+
+    log.debug(f"Agent iteration {iteration + 1}")
+    self.ctx._current_iteration = iteration + 1
+
+    _refresh_dynamic_tools(self.ctx)
+    all_tools, deferred_text = _build_tool_list(self.ctx)
+
+    if deferred_text:
+        new_msg = {"role": "system", "content": deferred_text}
+        if self.deferred_msg is not None and self.deferred_msg in self.messages:
+            idx = self.messages.index(self.deferred_msg)
+            self.messages[idx] = new_msg
+        else:
+            self.messages.insert(1, new_msg)
+        self.deferred_msg = new_msg
+    elif self.deferred_msg is not None and self.deferred_msg in self.messages:
+        self.messages.remove(self.deferred_msg)
+        self.deferred_msg = None
+
+    response = await _call_llm_with_events(
+        self.ctx, self.config, self.messages, all_tools,
+        **self.model_override,
+    )
+
+    usage = response.get("usage")
+    if usage:
+        prompt_tokens = usage.get("prompt_tokens", 0)
+        completion_tokens = usage.get("completion_tokens", 0)
+        self.ctx.tokens.total_prompt += prompt_tokens
+        self.ctx.tokens.total_completion += completion_tokens
+        self.ctx.tokens.last_prompt = prompt_tokens
+        self.prompt_tokens = prompt_tokens
+        self.composer.record_actuals(prompt_tokens, completion_tokens)
+
+    tool_calls = response.get("tool_calls")
+    if tool_calls:
+        return await self._handle_tool_calls(response, tool_calls)
+
+    return await self._handle_no_tool_calls(response)
+```
+
+The `for` body in `run()` becomes:
+
+```python
+for iteration in range(self.config.agent.max_tool_iterations):
+    outcome = await self._run_iteration(iteration)
+    if isinstance(outcome, _Final):
+        return outcome.result
+return await self._finalize_max_iterations()
+```
+
+- [ ] **Step 15.2: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+## Task 16: Move reflection helpers onto `TurnRunner`
+
+**Files:**
+- Modify: `src/decafclaw/agent.py`
+
+- [ ] **Step 16.1: Convert `_handle_reflection`, `_reflection_skip`,
+  `_reflection_evaluate`, `_reflection_apply_verdict` to `TurnRunner` methods**
+
+These were free functions in commit 1. Move them onto `TurnRunner`:
+
+```python
+class TurnRunner:
+    # ... existing methods ...
+
+    async def _handle_reflection(self, content: str) -> ReflectionOutcome:
+        """Thin orchestrator. Mutates self.reflection_retries and
+        self.last_reflection; returns ReflectionOutcome."""
+        if not _should_reflect(
+            self.ctx, self.config, content, self.reflection_retries,
+        ):
+            return self._reflection_skip(content)
+        result = await self._reflection_evaluate(content)
+        self.last_reflection = result
+        return self._reflection_apply_verdict(content, result)
+
+    def _reflection_skip(self, content: str) -> ReflectionOutcome:
+        """Reflection-did-not-run branch. Appends escalation suffix
+        on exhaustion; clears self.last_reflection."""
+        reflection_exhausted = (
+            self.reflection_retries >= self.config.reflection.max_retries
+            and self.last_reflection is not None
+            and not self.last_reflection.passed
+        )
+        self.last_reflection = None
+        if reflection_exhausted:
+            content += (
+                "\n\n---\n*I'm not confident in this answer. "
+                "Try switching to a more capable model in the web UI model picker.*"
+            )
+        return ReflectionOutcome(text=content, should_retry=False)
+
+    async def _reflection_evaluate(self, content: str) -> "ReflectionResult":
+        """Build summaries + attachment annotation + accumulated-text
+        concat, call evaluate_response, publish reflection_result event."""
+        from .reflection import (
+            build_prior_turn_summary,
+            build_tool_summary,
+            evaluate_response,
+        )
+
+        tool_summary = build_tool_summary(
+            self.history, self.turn_start_index,
+            max_result_len=self.config.reflection.max_tool_result_len,
+        )
+        prior_turn_summary = build_prior_turn_summary(
+            self.history, self.turn_start_index - 1,
+            max_turns=3,
+            max_result_len=200,
+        )
+        judge_user_message = self.user_message
+        if self.attachments:
+            att_desc = ", ".join(
+                f"{a.get('filename', '?')} ({a.get('mime_type', '?')})"
+                for a in self.attachments
+            )
+            judge_user_message += f"\n\n[User attached files: {att_desc}]"
+        judge_agent_response = "\n\n".join(
+            part for part in [*self.accumulated_text_parts, content]
+            if part and part.strip()
+        ) or content
+        result = await evaluate_response(
+            self.config, judge_user_message, judge_agent_response, tool_summary,
+            prior_turn_summary=prior_turn_summary,
+            retrieved_context=self.retrieved_context_text,
+        )
+
+        log.info("Reflection result: passed=%s, critique=%s, error=%s",
+                 result.passed, result.critique[:200] if result.critique else "",
+                 result.error[:100] if result.error else "")
+        await self.ctx.publish("reflection_result",
+            passed=result.passed,
+            critique=result.critique,
+            raw_response=result.raw_response,
+            retry_number=self.reflection_retries + 1,
+            error=result.error)
+        return result
+
+    def _reflection_apply_verdict(
+        self, content: str, result: "ReflectionResult",
+    ) -> ReflectionOutcome:
+        """Apply the judge's verdict. On fail-with-real-critique,
+        append failed_msg + critique_msg, archive, bump retries.
+        Fail-open errors treated as PASS."""
+        if not result.passed and not result.error:
+            log.info("Reflection failed (retry %d/%d): %s",
+                     self.reflection_retries + 1,
+                     self.config.reflection.max_retries,
+                     result.critique[:200])
+            failed_msg = {"role": "assistant", "content": content}
+            self.history.append(failed_msg)
+            self.messages.append(failed_msg)
+            _archive(self.ctx, failed_msg)
+
+            critique_msg = {
+                "role": "user",
+                "content": (
+                    "[reflection] Your previous response may not fully "
+                    "address the user's request.\n"
+                    f"Feedback: {result.critique}\n"
+                    "Please try again, addressing the feedback above."
+                ),
+            }
+            self.history.append(critique_msg)
+            self.messages.append(critique_msg)
+            _archive(self.ctx, critique_msg)
+
+            self.reflection_retries += 1
+            return ReflectionOutcome(text=None, should_retry=True)
+
+        return ReflectionOutcome(text=content, should_retry=False)
+```
+
+- [ ] **Step 16.2: Update the call site in `_handle_no_tool_calls`**
+
+Replace the existing call to the free-function `_handle_reflection`:
+
+```python
+# OLD
+outcome, self.reflection_retries, self.last_reflection = await _handle_reflection(
+    self.ctx, self.config, self.messages, self.history, content,
+    self.user_message, self.attachments, self.retrieved_context_text,
+    self.turn_start_index, self.reflection_retries, self.last_reflection,
+    accumulated_text_parts=self.accumulated_text_parts,
+)
+```
+
+```python
+# NEW
+outcome = await self._handle_reflection(content)
+```
+
+- [ ] **Step 16.3: Delete the free-function copies**
+
+Delete the four free functions added in commit 1: `_handle_reflection`,
+`_reflection_skip`, `_reflection_evaluate`, `_reflection_apply_verdict`.
+
+`_should_reflect` stays as a free function — it's pure and stateless.
+
+- [ ] **Step 16.4: Compile-check**
+
+Run: `make check`
+Expected: PASS.
+
+- [ ] **Step 16.5: Run the full test suite**
+
+Run: `make test`
+Expected: PASS.
+
+If reflection tests fail, suspect: `self.last_reflection` reassignment
+order in `_handle_reflection` — `self.last_reflection = result` must run
+*before* `_reflection_apply_verdict` (which doesn't read it but relies
+on it being the canonical store for archiving downstream).
+
+## Task 17: Final verification and commit commit 2
+
+- [ ] **Step 17.1: Run lint, typecheck, and full test suite**
+
+Run: `make check && make test`
+Expected: PASS.
+
+- [ ] **Step 17.2: Sanity-check `run_agent_turn` is now a thin shim**
+
+Open `src/decafclaw/agent.py`, find `async def run_agent_turn(`. The body
+should be ≤ 10 lines (just the `TurnRunner(...)` construction + `return
+await runner.run()`).
+
+If it's longer, something didn't get extracted into `TurnRunner` — go
+back and finish the extraction.
+
+- [ ] **Step 17.3: Sanity-check the iteration loop is now a thin dispatcher**
+
+Find `TurnRunner.run()`. The `for iteration in range(...)` block should
+be ≤ 4 lines (call `_run_iteration`, branch on `_Final`, fall through
+on `_Continue`).
+
+- [ ] **Step 17.4: Commit**
+
+```bash
+git add src/decafclaw/agent.py tests/test_agent.py
+git commit -m "$(cat <<'EOF'
+refactor(agent): introduce TurnRunner for run_agent_turn iteration loop
+
+Replace the 314-line run_agent_turn function with a thin wrapper over
+a TurnRunner class that owns the per-turn mutable state. The 200-line
+iteration-loop body becomes a top-level loop calling _run_iteration,
+which dispatches on a tagged-union IterationOutcome. EndTurnConfirm
+fall-through stays inside _handle_tool_calls so method boundaries
+never split a fall-through.
+
+Folds the reflection helpers from commit 1 onto TurnRunner methods
+since they all mutate turn state (history, messages, retries,
+last_reflection). The free-function copies are removed.
+
+Adds test_run_agent_turn_public_surface_unchanged to lock the wrapper
+contract callers depend on.
+
+No behavior change. Existing tests pass unchanged.
+
+Closes #382.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Live verification (after PR is opened, before merge)
+
+These exercises confirm no per-mode regression. Capture results in
+`docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/notes.md`.
+
+- [ ] **LV1: Web UI normal turn** — Open web UI, send "what's 2+2?" — verify
+  text-only response, model selection persists across reload.
+- [ ] **LV2: Web UI tool-using turn** — Send a request that triggers
+  `tool_search` then a follow-up tool call. Verify `text_before_tools`
+  events flush before tool rows in the UI.
+- [ ] **LV3: Web UI widget input** — Trigger a widget tool that pauses
+  (e.g. a canvas widget). Submit the widget; verify the synthetic user
+  message is injected and the loop resumes.
+- [ ] **LV4: Web UI EndTurnConfirm — approve path** — Trigger a tool
+  returning `EndTurnConfirm`, click Approve, verify the agent continues.
+- [ ] **LV5: Web UI EndTurnConfirm — deny path** — Same setup, click Deny,
+  verify the agent ends turn with a "what would you like changed?" message.
+- [ ] **LV6: Mattermost normal turn** — Send a message in Mattermost, verify
+  placeholder + final message appear correctly with attachment upload.
+- [ ] **LV7: Heartbeat / scheduled task** — Wait for or trigger a scheduled
+  skill (e.g. `dream`); verify it runs to completion.
+- [ ] **LV8: Cancellation mid-turn** — Click stop while a long-running tool
+  executes. Verify `[cancelled]` archive entry and clean shutdown.
+- [ ] **LV9: Reflection retry** — Set `config.reflection.enabled = true`
+  with a low-quality model in test config; trigger a response that fails
+  judging; verify critique injection + escalation suffix on exhaustion.
+- [ ] **LV10: Compaction trigger** — Have a long conversation that crosses
+  `compaction.max_tokens`; verify `_maybe_compact` runs and the next
+  turn sees the compacted history.
+
+---
+
+# Self-review checklist
+
+After all tasks complete:
+
+- [ ] **Spec coverage:** Every item in
+  `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/spec.md`
+  Section "Goals" maps to a task above.
+- [ ] **Public surface:** `run_agent_turn` signature unchanged (Task 8
+  test enforces this).
+- [ ] **All existing tests pass unchanged** (Tasks 6, 9.5, 10.2, 11.2,
+  12.2, 13.2, 14.2, 15.2, 16.5, 17.1).
+- [ ] **No new tests added except `test_run_agent_turn_public_surface_unchanged`**
+  (per spec non-goal: don't unit-test TurnRunner internals).
+- [ ] **`agent.py` is the only file modified** (plus the one test file in
+  Task 8).
+- [ ] **Two commits** on the branch: reflection split, then TurnRunner.
+- [ ] **`make check && make test` clean before each commit**.

--- a/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/spec.md
+++ b/docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/spec.md
@@ -1,0 +1,278 @@
+# Refactor: split `run_agent_turn` and `_handle_reflection`
+
+Tracking issue: [#382](https://github.com/lmorchard/decafclaw/issues/382)
+
+## Background
+
+`agent.run_agent_turn` is ~314 lines and `_handle_reflection` is ~117 lines. Both
+mix multiple concerns and are review/onboarding friction whenever turn behavior
+changes. This refactor preserves behavior — no observable change to any
+transport, tool, or persisted artifact — and reorganizes the code so each phase
+of the turn is independently legible and the iteration-loop branching is
+visible at a glance.
+
+The work is explicitly out of scope for the PR #381 hygiene sweep, which kept
+the "no behavior changes" property by deferring this. This dev session picks it
+up as a focused effort.
+
+## Goals
+
+- `run_agent_turn` becomes a thin wrapper that constructs a `TurnRunner` and
+  calls `.run()`. Public signature unchanged.
+- The 200-line iteration-loop body is replaced by a top-level loop that calls
+  `_run_iteration` and dispatches on a tagged-union `IterationOutcome`.
+- `_handle_reflection`'s 4-tuple return is replaced by a `ReflectionOutcome`
+  dataclass; the function splits into three small methods on `TurnRunner`
+  (orchestrator, evaluator, verdict-applier).
+- All existing tests pass unchanged. Existing live behavior in Mattermost, the
+  web UI, terminal, heartbeat, and scheduled tasks is preserved.
+
+## Non-goals
+
+- No new abstractions beyond `TurnRunner`, `IterationOutcome`, and
+  `ReflectionOutcome`.
+- No move of `agent.py` helpers into separate modules. They stay where they
+  are.
+- No changes to `reflection.py` (the `build_*` and `evaluate_response` helpers
+  stay put).
+- No new unit tests for `TurnRunner` internals — existing end-to-end coverage
+  exercises every method.
+
+## Architecture
+
+### `TurnRunner`
+
+A class that owns the mutable per-turn state. State that was local variables
+in `run_agent_turn` becomes fields. State written through the existing context
+helpers (`ctx.tokens`, `ctx.skills`, etc.) stays on `ctx`.
+
+```python
+@dataclass
+class TurnRunner:
+    ctx: Any
+    config: Any
+    history: list
+    user_message: str
+    archive_text: str
+    attachments: list[dict] | None
+
+    # Mutable turn state (was local vars in run_agent_turn)
+    messages: list = field(default_factory=list)
+    deferred_msg: dict | None = None
+    prompt_tokens: int = 0
+    empty_retries: int = 0
+    reflection_retries: int = 0
+    last_reflection: "ReflectionResult | None" = None
+    turn_start_index: int = 0
+    accumulated_text_parts: list[str] = field(default_factory=list)
+    model_override: dict[str, str] = field(default_factory=dict)
+    retrieved_context_text: str = ""
+
+    # Composition products kept for finally-block diagnostics
+    composed: "ComposedContext | None" = None
+    composer: "ContextComposer | None" = None
+
+    async def run(self) -> ToolResult: ...
+    async def _compose(self) -> None: ...
+    async def _run_iteration(self, iteration: int) -> "IterationOutcome": ...
+    async def _handle_tool_calls(self, response, tool_calls) -> "IterationOutcome": ...
+    async def _handle_no_tool_calls(self, response) -> "IterationOutcome": ...
+    async def _handle_reflection(self, content: str) -> "ReflectionOutcome": ...
+    async def _finalize_normal_return(self, content: str) -> ToolResult: ...
+    async def _finalize_max_iterations(self) -> ToolResult: ...
+    async def _write_diagnostics(self) -> None: ...
+```
+
+`run_agent_turn` becomes:
+
+```python
+async def run_agent_turn(ctx, user_message: str, history: list,
+                         archive_text: str = "",
+                         attachments: list[dict] | None = None) -> "ToolResult":
+    runner = TurnRunner(
+        ctx=ctx, config=ctx.config, history=history,
+        user_message=user_message, archive_text=archive_text,
+        attachments=attachments,
+    )
+    return await runner.run()
+```
+
+The wrapper is intentionally trivial. Reverting the refactor is a single
+function-body swap.
+
+### `IterationOutcome`
+
+Tagged union expressing the three exits from one iteration:
+
+```python
+class IterationOutcome:
+    """Tagged-union return type from _run_iteration."""
+
+@dataclass(frozen=True)
+class _Continue(IterationOutcome):
+    """Loop again — used for tool-call iterations, retries, widget injection,
+    EndTurnConfirm-approved continuation."""
+
+@dataclass(frozen=True)
+class _Final(IterationOutcome):
+    """Turn is done; return this ToolResult.
+    Cancellation collapses into _Final since the outer loop treats it
+    identically."""
+    result: ToolResult
+```
+
+The outer loop:
+
+```python
+for iteration in range(self.config.agent.max_tool_iterations):
+    outcome = await self._run_iteration(iteration)
+    if isinstance(outcome, _Final):
+        return outcome.result
+    # _Continue → next iteration
+return await self._finalize_max_iterations()
+```
+
+`_run_iteration` does cancel-check, dynamic-tool refresh, deferred-tool
+injection, the LLM call, then dispatches to `_handle_tool_calls` or
+`_handle_no_tool_calls`.
+
+### Critical invariant: no fall-through across method boundaries
+
+Today's `EndTurnConfirm` denial path sets `end_turn_signal = True` and falls
+through to the `if end_turn_signal:` block in the same iteration. The refactor
+preserves this by keeping the denial → final-no-tools-call sequence inside
+`_handle_tool_calls`. Method boundaries never split a fall-through.
+
+### Reflection split
+
+`_handle_reflection` becomes three methods on `TurnRunner`:
+
+```python
+@dataclass(frozen=True)
+class ReflectionOutcome:
+    """Result of evaluating a candidate final response."""
+    text: str | None        # None when caller should retry
+    should_retry: bool      # True → critique was injected, loop again
+
+class TurnRunner:
+    async def _handle_reflection(self, content: str) -> ReflectionOutcome:
+        """Thin orchestrator. Decides skip vs evaluate vs inject-critique."""
+        if not _should_reflect(self.ctx, self.config, content, self.reflection_retries):
+            return self._reflection_skip(content)
+        result = await self._reflection_evaluate(content)
+        return self._reflection_apply_verdict(content, result)
+
+    def _reflection_skip(self, content: str) -> ReflectionOutcome:
+        """Exhaustion-escalation suffix logic; clears self.last_reflection."""
+
+    async def _reflection_evaluate(self, content: str) -> ReflectionResult:
+        """Build summaries + attachment annotation + accumulated-text concat,
+        call evaluate_response, publish reflection_result event, store on
+        self.last_reflection."""
+
+    def _reflection_apply_verdict(self, content: str,
+                                  result: ReflectionResult) -> ReflectionOutcome:
+        """On fail: append failed_msg + critique_msg to history/messages,
+        archive both, bump self.reflection_retries, return (None, True).
+        On pass / fail-open error: return (content, False)."""
+```
+
+The 4-tuple return goes away because state lives on `self`. Only `text` and
+`should_retry` are needed at the call site.
+
+## File layout
+
+Everything stays in `agent.py`. The class lives next to `run_agent_turn` and
+uses the existing private free-function helpers (`_check_cancelled`,
+`_archive`, `_setup_turn_state`, `_refresh_dynamic_tools`, `_build_tool_list`,
+`_call_llm_with_events`, `_execute_tool_calls`, `_handle_widget_input_pause`,
+`_handle_end_turn_confirm`, `_maybe_compact`) without absorbing them onto the
+class — they're called from `TurnRunner` only and a new file would just create
+circular-import surface.
+
+Lazy imports in the existing code stay lazy:
+
+- `from .reflection import ...` stays inside `_reflection_evaluate` (avoids
+  loading reflection eagerly when `config.reflection.enabled = false`).
+- `from .context_composer import write_context_sidecar` stays inside
+  `_write_diagnostics`.
+
+The `finally` block (sidecar write + skill-state persistence) moves into
+`TurnRunner.run()`'s own `try/finally`. Same fail-open `try/except log.debug`
+semantics.
+
+## Public surface
+
+Unchanged. `conversation_manager.py:776`'s `from .agent import run_agent_turn`
+and any other callers stay identical.
+
+## Test strategy
+
+This is a no-behavior-change refactor. The bar is "all existing tests pass
+unchanged."
+
+- All existing `tests/test_agent*.py` tests must pass without edits. If any
+  need editing, that's a red flag we changed behavior. Notable suites:
+  - `test_agent.py` — turn-level coverage
+  - `test_agent_reflection*.py` — reflection retry, exhaustion, escalation
+  - `test_agent_widget_input*.py` — widget pause / resume
+  - `test_agent_end_turn_confirm*.py` — approve / deny paths
+  - `test_agent_compaction*.py` — `_maybe_compact` integration
+- **One new test:** `test_run_agent_turn_public_surface_unchanged` — sanity
+  check the wrapper preserves positional/keyword signature and return type.
+- **No new tests for `TurnRunner` internals.** The class is an implementation
+  detail; existing end-to-end coverage exercises every method indirectly.
+
+## Commits and PR
+
+Single PR, two commits:
+
+1. **`refactor(agent): split _handle_reflection into orchestrator + helpers`**
+   — `ReflectionOutcome` dataclass, three helper functions still as
+   free functions in this commit (folded onto `TurnRunner` in commit 2).
+   Tests pass.
+2. **`refactor(agent): introduce TurnRunner for run_agent_turn iteration loop`**
+   — `TurnRunner` class, `IterationOutcome` tagged union, fold reflection
+   helpers into methods. `run_agent_turn` becomes the thin shim. Tests pass.
+
+Reflection-split first lets a bisect pinpoint which half broke things if a
+regression slips in. Single PR because the two are conceptually one refactor
+and partial state on `main` would be confusing.
+
+`make test` + `make check` run on each commit, not just the squash, per
+existing workflow.
+
+## Live verification
+
+`run_agent_turn` is the hot path for every conversation turn. Per CLAUDE.md,
+exercise the following on a branch before merging to `main`:
+
+1. Web UI normal turn — text-only, model selection persists.
+2. Web UI tool-using turn — e.g. `tool_search` then act on result; verify
+   `text_before_tools` events still flush before tool rows.
+3. Web UI widget input — fire a widget tool that pauses; verify pause + resume
+   injects the synthetic user message correctly.
+4. Web UI `EndTurnConfirm` — both approve and deny paths.
+5. Mattermost normal turn — placeholder behavior, attachment upload.
+6. Heartbeat / scheduled task — exercises `task_mode` composer branching.
+7. Cancellation mid-turn — click stop while a tool runs; verify `[cancelled]`
+   archive entry and clean shutdown.
+8. Reflection retry — exercise critique injection + escalation suffix on
+   exhaustion.
+9. Compaction trigger — long conversation that crosses the threshold; verify
+   `_maybe_compact` runs after the final response.
+
+Capture results in `notes.md`.
+
+## Risks and mitigations
+
+- **Per-mode regression possible if branching invariants aren't preserved.**
+  The fall-through invariant (above) is the highest-risk transformation;
+  `EndTurnConfirm` deny is the most likely place to break.
+  *Mitigation:* live-verification list explicitly covers approve and deny.
+- **Wrapper public surface drift.**
+  *Mitigation:* `test_run_agent_turn_public_surface_unchanged`.
+- **Hot-path regression in production.**
+  *Mitigation:* wrapper-preserving public surface means revert is a single
+  function-body swap; two-commit split lets `git bisect` pinpoint
+  reflection vs iteration-loop bugs.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -16,7 +16,7 @@ import functools
 import json
 import logging
 import re as _re
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -177,6 +177,23 @@ def _check_cancelled(ctx, history):
     return None
 
 
+@dataclass(frozen=True)
+class ReflectionOutcome:
+    """Result of evaluating a candidate final response.
+
+    Replaces the 4-tuple return shape of the old _handle_reflection.
+    `text` is None when the caller should retry (critique already
+    injected into history/messages by the helper). When `should_retry`
+    is False, `text` is the response to deliver (with optional
+    exhaustion-escalation suffix appended in the skip path).
+
+    `reflection_retries` and `last_reflection` are mutated on the call
+    sites' state directly — they don't appear in this return type.
+    """
+    text: str | None
+    should_retry: bool
+
+
 def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
     """Check whether reflection should run on this response."""
     if not config.reflection.enabled:
@@ -192,42 +209,45 @@ def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
     return True
 
 
-async def _handle_reflection(
-    ctx, config, messages, history, final_text,
-    user_message, attachments, retrieved_context_text,
-    turn_start_index, reflection_retries, last_reflection,
-    accumulated_text_parts=None,
-) -> tuple[str | None, bool, int, "ReflectionResult | None"]:
-    """Run the reflection phase on a candidate final response.
+def _reflection_skip(
+    config, final_text: str,
+    reflection_retries: int,
+    last_reflection: "ReflectionResult | None",
+) -> tuple[str, "ReflectionResult | None"]:
+    """The 'reflection did not run' branch. Returns (final_text_maybe_with_escalation,
+    cleared_last_reflection).
 
-    Returns (text, should_retry, reflection_retries, last_reflection):
-    - Reflection skipped or passed: (final_text, False, retries, result)
-    - Reflection failed with retries left: (None, True, retries+1, result)
-      — critique has been injected into messages/history before returning
-    - Reflection failed, no retries left: (text_with_escalation, False, retries, result)
-
-    `accumulated_text_parts` collects text the model emitted in earlier
-    iterations of this turn alongside tool calls (e.g. a skill that writes
-    a full report and then calls vault_write in the same LLM response). The
-    judge evaluates the concatenation so it sees the full user-visible
-    response, not just the final no-tools trailer.
+    Appends the 'I'm not confident' suffix when retries are exhausted; clears
+    last_reflection so it won't get archived against this new response.
     """
-    if not _should_reflect(ctx, config, final_text, reflection_retries):
-        reflection_exhausted = (
-            reflection_retries >= config.reflection.max_retries
-            and last_reflection is not None
-            and not last_reflection.passed
+    reflection_exhausted = (
+        reflection_retries >= config.reflection.max_retries
+        and last_reflection is not None
+        and not last_reflection.passed
+    )
+    if reflection_exhausted:
+        final_text += (
+            "\n\n---\n*I'm not confident in this answer. "
+            "Try switching to a more capable model in the web UI model picker.*"
         )
-        last_reflection = None  # clear stale result from prior retry
+    return final_text, None
 
-        # Suggest model escalation if reflection retries exhausted
-        if reflection_exhausted:
-            final_text += (
-                "\n\n---\n*I'm not confident in this answer. "
-                "Try switching to a more capable model in the web UI model picker.*"
-            )
-        return final_text, False, reflection_retries, last_reflection
 
+async def _reflection_evaluate(
+    ctx, config, history: list,
+    final_text: str, user_message: str,
+    attachments: list[dict] | None,
+    retrieved_context_text: str,
+    turn_start_index: int,
+    reflection_retries: int,
+    accumulated_text_parts: list[str] | None,
+) -> "ReflectionResult":
+    """Build summaries, annotate user message, call evaluate_response,
+    publish reflection_result event.
+
+    Returns the ReflectionResult; caller stores it on its own state
+    and decides what to do with the verdict.
+    """
     from .reflection import (
         build_prior_turn_summary,
         build_tool_summary,
@@ -238,15 +258,11 @@ async def _handle_reflection(
         history, turn_start_index,
         max_result_len=config.reflection.max_tool_result_len,
     )
-    # turn_start_index points past the current user message;
-    # use turn_start_index - 1 to exclude it from prior turns
     prior_turn_summary = build_prior_turn_summary(
         history, turn_start_index - 1,
         max_turns=3,
         max_result_len=200,
     )
-    # Annotate user message with attachment info for the judge —
-    # it can't see the actual files but needs to know they exist
     judge_user_message = user_message
     if attachments:
         att_desc = ", ".join(
@@ -254,8 +270,6 @@ async def _handle_reflection(
             for a in attachments
         )
         judge_user_message += f"\n\n[User attached files: {att_desc}]"
-    # Combine text from tool-call iterations with the current final text so
-    # the judge sees the full visible response, not just the trailer.
     judge_agent_response = "\n\n".join(
         part for part in [*(accumulated_text_parts or []), final_text]
         if part and part.strip()
@@ -266,30 +280,41 @@ async def _handle_reflection(
         retrieved_context=retrieved_context_text,
     )
 
-    last_reflection = result
     log.info("Reflection result: passed=%s, critique=%s, error=%s",
              result.passed, result.critique[:200] if result.critique else "",
              result.error[:100] if result.error else "")
-
     await ctx.publish("reflection_result",
         passed=result.passed,
         critique=result.critique,
         raw_response=result.raw_response,
         retry_number=reflection_retries + 1,
         error=result.error)
+    return result
 
+
+def _reflection_apply_verdict(
+    ctx, history: list, messages: list,
+    final_text: str, result: "ReflectionResult",
+    reflection_retries: int,
+    config,
+) -> tuple[ReflectionOutcome, int]:
+    """Apply the judge's verdict. On fail-with-real-critique, append
+    failed_msg + critique_msg to history/messages, archive both, and
+    bump retries. Returns (outcome, new_retries).
+
+    The fail-open path (result.error set) is treated as PASS so the user
+    still gets a response when the judge LLM itself fails.
+    """
     if not result.passed and not result.error:
         log.info("Reflection failed (retry %d/%d): %s",
                  reflection_retries + 1,
                  config.reflection.max_retries,
                  result.critique[:200])
-        # Add the failed response to history
         failed_msg = {"role": "assistant", "content": final_text}
         history.append(failed_msg)
         messages.append(failed_msg)
         _archive(ctx, failed_msg)
 
-        # Add critique as user message for retry
         critique_msg = {
             "role": "user",
             "content": (
@@ -303,11 +328,47 @@ async def _handle_reflection(
         messages.append(critique_msg)
         _archive(ctx, critique_msg)
 
-        reflection_retries += 1
-        return None, True, reflection_retries, last_reflection
+        return ReflectionOutcome(text=None, should_retry=True), reflection_retries + 1
 
-    # Reflection passed (or errored out — fail-open)
-    return final_text, False, reflection_retries, last_reflection
+    return ReflectionOutcome(text=final_text, should_retry=False), reflection_retries
+
+
+async def _handle_reflection(
+    ctx, config, messages, history, final_text,
+    user_message, attachments, retrieved_context_text,
+    turn_start_index, reflection_retries, last_reflection,
+    accumulated_text_parts=None,
+) -> tuple[ReflectionOutcome, int, "ReflectionResult | None"]:
+    """Run the reflection phase on a candidate final response.
+
+    Returns (outcome, new_reflection_retries, new_last_reflection):
+    - Skipped: outcome wraps possibly-suffixed text; last_reflection cleared
+    - Evaluated and passed: outcome wraps text; last_reflection set to result
+    - Evaluated and failed (retries left): outcome.should_retry=True;
+      critique already injected into messages/history
+    - Evaluated and failed (no retries left, fail-open error): treated as pass
+
+    `accumulated_text_parts` collects text from earlier iterations of
+    this turn (skill-style "report + tool call" patterns) so the judge
+    sees the full visible response, not just the trailer.
+    """
+    if not _should_reflect(ctx, config, final_text, reflection_retries):
+        text, cleared = _reflection_skip(
+            config, final_text, reflection_retries, last_reflection,
+        )
+        return ReflectionOutcome(text=text, should_retry=False), reflection_retries, cleared
+
+    result = await _reflection_evaluate(
+        ctx, config, history, final_text, user_message, attachments,
+        retrieved_context_text, turn_start_index, reflection_retries,
+        accumulated_text_parts,
+    )
+    last_reflection = result
+
+    outcome, new_retries = _reflection_apply_verdict(
+        ctx, history, messages, final_text, result, reflection_retries, config,
+    )
+    return outcome, new_retries, last_reflection
 
 
 async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
@@ -1305,16 +1366,15 @@ async def run_agent_turn(ctx, user_message: str, history: list,
             log.debug("Reflection check: enabled=%s, retries=%d/%d, skip=%s, has_content=%s",
                        config.reflection.enabled, reflection_retries,
                        config.reflection.max_retries, ctx.skip_reflection, bool(content))
-            content, should_retry, reflection_retries, last_reflection = (
-                await _handle_reflection(
-                    ctx, config, messages, history, content,
-                    user_message, attachments, retrieved_context_text,
-                    turn_start_index, reflection_retries, last_reflection,
-                    accumulated_text_parts=accumulated_text_parts,
-                )
+            outcome, reflection_retries, last_reflection = await _handle_reflection(
+                ctx, config, messages, history, content,
+                user_message, attachments, retrieved_context_text,
+                turn_start_index, reflection_retries, last_reflection,
+                accumulated_text_parts=accumulated_text_parts,
             )
-            if should_retry:
+            if outcome.should_retry:
                 continue
+            content = outcome.text
 
             final_msg = {"role": "assistant", "content": content}
             history.append(final_msg)

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -16,11 +16,12 @@ import functools
 import json
 import logging
 import re as _re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .context_composer import ComposedContext
     from .reflection import ReflectionResult
 
 from .archive import append_message
@@ -207,168 +208,6 @@ def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
     if ctx.cancelled and ctx.cancelled.is_set():
         return False
     return True
-
-
-def _reflection_skip(
-    config, final_text: str,
-    reflection_retries: int,
-    last_reflection: "ReflectionResult | None",
-) -> tuple[str, "ReflectionResult | None"]:
-    """The 'reflection did not run' branch. Returns (final_text_maybe_with_escalation,
-    cleared_last_reflection).
-
-    Appends the 'I'm not confident' suffix when retries are exhausted; clears
-    last_reflection so it won't get archived against this new response.
-    """
-    reflection_exhausted = (
-        reflection_retries >= config.reflection.max_retries
-        and last_reflection is not None
-        and not last_reflection.passed
-    )
-    if reflection_exhausted:
-        final_text += (
-            "\n\n---\n*I'm not confident in this answer. "
-            "Try switching to a more capable model in the web UI model picker.*"
-        )
-    return final_text, None
-
-
-async def _reflection_evaluate(
-    ctx, config, history: list,
-    final_text: str, user_message: str,
-    attachments: list[dict] | None,
-    retrieved_context_text: str,
-    turn_start_index: int,
-    reflection_retries: int,
-    accumulated_text_parts: list[str] | None,
-) -> "ReflectionResult":
-    """Build summaries, annotate user message, call evaluate_response,
-    publish reflection_result event.
-
-    Returns the ReflectionResult; caller stores it on its own state
-    and decides what to do with the verdict.
-    """
-    from .reflection import (
-        build_prior_turn_summary,
-        build_tool_summary,
-        evaluate_response,
-    )
-
-    tool_summary = build_tool_summary(
-        history, turn_start_index,
-        max_result_len=config.reflection.max_tool_result_len,
-    )
-    prior_turn_summary = build_prior_turn_summary(
-        history, turn_start_index - 1,
-        max_turns=3,
-        max_result_len=200,
-    )
-    judge_user_message = user_message
-    if attachments:
-        att_desc = ", ".join(
-            f"{a.get('filename', '?')} ({a.get('mime_type', '?')})"
-            for a in attachments
-        )
-        judge_user_message += f"\n\n[User attached files: {att_desc}]"
-    judge_agent_response = "\n\n".join(
-        part for part in [*(accumulated_text_parts or []), final_text]
-        if part and part.strip()
-    ) or final_text
-    result = await evaluate_response(
-        config, judge_user_message, judge_agent_response, tool_summary,
-        prior_turn_summary=prior_turn_summary,
-        retrieved_context=retrieved_context_text,
-    )
-
-    log.info("Reflection result: passed=%s, critique=%s, error=%s",
-             result.passed, result.critique[:200] if result.critique else "",
-             result.error[:100] if result.error else "")
-    await ctx.publish("reflection_result",
-        passed=result.passed,
-        critique=result.critique,
-        raw_response=result.raw_response,
-        retry_number=reflection_retries + 1,
-        error=result.error)
-    return result
-
-
-def _reflection_apply_verdict(
-    ctx, history: list, messages: list,
-    final_text: str, result: "ReflectionResult",
-    reflection_retries: int,
-    config,
-) -> tuple[ReflectionOutcome, int]:
-    """Apply the judge's verdict. On fail-with-real-critique, append
-    failed_msg + critique_msg to history/messages, archive both, and
-    bump retries. Returns (outcome, new_retries).
-
-    The fail-open path (result.error set) is treated as PASS so the user
-    still gets a response when the judge LLM itself fails.
-    """
-    if not result.passed and not result.error:
-        log.info("Reflection failed (retry %d/%d): %s",
-                 reflection_retries + 1,
-                 config.reflection.max_retries,
-                 result.critique[:200])
-        failed_msg = {"role": "assistant", "content": final_text}
-        history.append(failed_msg)
-        messages.append(failed_msg)
-        _archive(ctx, failed_msg)
-
-        critique_msg = {
-            "role": "user",
-            "content": (
-                "[reflection] Your previous response may not fully "
-                "address the user's request.\n"
-                f"Feedback: {result.critique}\n"
-                "Please try again, addressing the feedback above."
-            ),
-        }
-        history.append(critique_msg)
-        messages.append(critique_msg)
-        _archive(ctx, critique_msg)
-
-        return ReflectionOutcome(text=None, should_retry=True), reflection_retries + 1
-
-    return ReflectionOutcome(text=final_text, should_retry=False), reflection_retries
-
-
-async def _handle_reflection(
-    ctx, config, messages, history, final_text,
-    user_message, attachments, retrieved_context_text,
-    turn_start_index, reflection_retries, last_reflection,
-    accumulated_text_parts=None,
-) -> tuple[ReflectionOutcome, int, "ReflectionResult | None"]:
-    """Run the reflection phase on a candidate final response.
-
-    Returns (outcome, new_reflection_retries, new_last_reflection):
-    - Skipped: outcome wraps possibly-suffixed text; last_reflection cleared
-    - Evaluated and passed: outcome wraps text; last_reflection set to result
-    - Evaluated and failed (retries left): outcome.should_retry=True;
-      critique already injected into messages/history
-    - Evaluated and failed (no retries left, fail-open error): treated as pass
-
-    `accumulated_text_parts` collects text from earlier iterations of
-    this turn (skill-style "report + tool call" patterns) so the judge
-    sees the full visible response, not just the trailer.
-    """
-    if not _should_reflect(ctx, config, final_text, reflection_retries):
-        text, cleared = _reflection_skip(
-            config, final_text, reflection_retries, last_reflection,
-        )
-        return ReflectionOutcome(text=text, should_retry=False), reflection_retries, cleared
-
-    result = await _reflection_evaluate(
-        ctx, config, history, final_text, user_message, attachments,
-        retrieved_context_text, turn_start_index, reflection_retries,
-        accumulated_text_parts,
-    )
-    last_reflection = result
-
-    outcome, new_retries = _reflection_apply_verdict(
-        ctx, history, messages, final_text, result, reflection_retries, config,
-    )
-    return outcome, new_retries, last_reflection
 
 
 async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
@@ -1108,7 +947,487 @@ def _get_already_injected_pages(history: list) -> set[str]:
     return pages
 
 
+class IterationOutcome:
+    """Tagged-union return type from TurnRunner._run_iteration.
+
+    Two variants: _Continue (loop again) and _Final (return this
+    ToolResult from the turn). Cancellation collapses into _Final
+    since the outer loop treats it identically.
+    """
+
+
+@dataclass(frozen=True)
+class _Continue(IterationOutcome):
+    """Loop again — used for tool-call iterations, retries, widget
+    injection, EndTurnConfirm-approved continuation."""
+
+
+@dataclass(frozen=True)
+class _Final(IterationOutcome):
+    """Turn is done; return this ToolResult."""
+    result: "ToolResult"
+
+
 # -- Main agent turn -----------------------------------------------------------
+
+
+@dataclass
+class TurnRunner:
+    """Owns the mutable state of a single agent turn.
+
+    State that was local variables in the original run_agent_turn
+    becomes fields here. State written through ctx helpers
+    (ctx.tokens, ctx.skills, ctx.history) stays on ctx.
+
+    Single-use: do not call run() twice on the same instance.
+    """
+    ctx: Any
+    config: Any
+    history: list
+    user_message: str
+    archive_text: str
+    attachments: list[dict] | None
+
+    messages: list = field(default_factory=list)
+    deferred_msg: dict | None = None
+    prompt_tokens: int = 0
+    empty_retries: int = 0
+    reflection_retries: int = 0
+    last_reflection: "ReflectionResult | None" = None
+    turn_start_index: int = 0
+    accumulated_text_parts: list[str] = field(default_factory=list)
+    model_override: dict[str, str] = field(default_factory=dict)
+    retrieved_context_text: str = ""
+    composed: "ComposedContext | None" = None
+    composer: "ContextComposer | None" = None
+
+    async def run(self) -> "ToolResult":
+        """Process a single user message through the agent loop."""
+        self.ctx.history = self.history
+
+        self.model_override = await _setup_turn_state(self.ctx, self.config, self.history)
+
+        try:
+            await self._compose()
+
+            self.prompt_tokens = 0
+            self.empty_retries = 0
+            self.reflection_retries = 0
+            self.last_reflection = None  # last ReflectionResult, for archiving after final response
+
+            self.accumulated_text_parts = []  # text from iterations that also had tool calls
+
+            for iteration in range(self.config.agent.max_tool_iterations):
+                outcome = await self._run_iteration(iteration)
+                if isinstance(outcome, _Final):
+                    return outcome.result
+            return await self._finalize_max_iterations()
+
+        finally:
+            await self._write_diagnostics()
+
+    async def _compose(self) -> None:
+        """Build the composed context, archive composer-added messages,
+        initialize message-tracking state on self.
+
+        Note: ``skip_vault_retrieval`` is handled directly by the composer,
+        not via mode — HEARTBEAT/SCHEDULED skip wiki too, which isn't
+        always desired when only memory should be skipped.
+        """
+        if self.ctx.is_child:
+            composer_mode = ComposerMode.CHILD_AGENT
+        elif self.ctx.task_mode in _TASK_MODE_TO_COMPOSER:
+            composer_mode = _TASK_MODE_TO_COMPOSER[self.ctx.task_mode]
+        else:
+            composer_mode = ComposerMode.INTERACTIVE
+
+        self.composer = ContextComposer(state=self.ctx.composer)
+        self.composed = await self.composer.compose(
+            self.ctx, self.user_message, self.history,
+            mode=composer_mode, attachments=self.attachments,
+        )
+        self.messages = self.composed.messages
+        self.ctx.messages = self.messages
+        self.retrieved_context_text = self.composed.retrieved_context_text
+
+        for msg in self.composed.messages_to_archive:
+            if self.ctx.task_mode == "background_wake" and msg.get("role") == "user":
+                archive_msg: dict = {
+                    "role": "wake_trigger",
+                    "content": msg.get("content", ""),
+                }
+                _archive(self.ctx, archive_msg)
+            elif self.archive_text and msg.get("role") == "user":
+                archive_msg = {"role": "user", "content": self.archive_text}
+                if msg.get("attachments"):
+                    archive_msg["attachments"] = msg["attachments"]
+                _archive(self.ctx, archive_msg)
+            else:
+                _archive(self.ctx, msg)
+
+        if (len(self.messages) > 1
+                and self.messages[1].get("role") == "system"
+                and self.composed.deferred_tools):
+            self.deferred_msg = self.messages[1]
+        else:
+            self.deferred_msg = None
+
+        self.turn_start_index = len(self.history)
+
+    async def _run_iteration(self, iteration: int) -> IterationOutcome:
+        """Run one LLM iteration: cancel-check, tool refresh, deferred-list
+        injection, the LLM call, and dispatch to tool-calls or no-tool-calls
+        handler. Returns _Continue or _Final."""
+        cancelled = _check_cancelled(self.ctx, self.history)
+        if cancelled:
+            return _Final(result=cancelled)
+
+        log.debug(f"Agent iteration {iteration + 1}")
+        self.ctx._current_iteration = iteration + 1
+
+        _refresh_dynamic_tools(self.ctx)
+        all_tools, deferred_text = _build_tool_list(self.ctx)
+
+        if deferred_text:
+            new_msg = {"role": "system", "content": deferred_text}
+            if self.deferred_msg is not None and self.deferred_msg in self.messages:
+                idx = self.messages.index(self.deferred_msg)
+                self.messages[idx] = new_msg
+            else:
+                self.messages.insert(1, new_msg)
+            self.deferred_msg = new_msg
+        elif self.deferred_msg is not None and self.deferred_msg in self.messages:
+            self.messages.remove(self.deferred_msg)
+            self.deferred_msg = None
+
+        response = await _call_llm_with_events(
+            self.ctx, self.config, self.messages, all_tools,
+            **self.model_override,
+        )
+
+        usage = response.get("usage")
+        if usage:
+            prompt_tokens = usage.get("prompt_tokens", 0)
+            completion_tokens = usage.get("completion_tokens", 0)
+            self.ctx.tokens.total_prompt += prompt_tokens
+            self.ctx.tokens.total_completion += completion_tokens
+            self.ctx.tokens.last_prompt = prompt_tokens
+            self.prompt_tokens = prompt_tokens
+            # composer is set by _compose() before the loop; guard is for the type checker
+            if self.composer is not None:
+                self.composer.record_actuals(prompt_tokens, completion_tokens)
+
+        tool_calls = response.get("tool_calls")
+        if tool_calls:
+            return await self._handle_tool_calls(response, tool_calls)
+
+        return await self._handle_no_tool_calls(response)
+
+    async def _handle_tool_calls(
+        self, response: dict, tool_calls: list,
+    ) -> IterationOutcome:
+        """Append assistant tool-call message, execute tools, dispatch
+        on end-turn signals (widget pause, EndTurnConfirm, end_turn=True).
+
+        Returns _Continue to loop again, or _Final(result) to end the turn.
+        """
+        iter_content = response.get("content")
+        assistant_msg = {"role": "assistant", "content": iter_content}
+        assistant_msg["tool_calls"] = tool_calls
+        self.history.append(assistant_msg)
+        self.messages.append(assistant_msg)
+        _archive(self.ctx, assistant_msg)
+
+        if iter_content:
+            self.accumulated_text_parts.append(iter_content)
+            await self.ctx.publish("text_before_tools", text=iter_content)
+
+        cancelled, end_turn_signal = await _execute_tool_calls(
+            self.ctx, tool_calls, self.history, self.messages,
+        )
+        if cancelled:
+            return _Final(result=cancelled)
+
+        if isinstance(end_turn_signal, WidgetInputPause):
+            inject_content = await _handle_widget_input_pause(
+                self.ctx, end_turn_signal,
+            )
+            if inject_content is None:
+                end_turn_signal = True
+            else:
+                synthetic = {
+                    "role": "user",
+                    "source": "widget_response",
+                    "content": inject_content,
+                }
+                self.history.append(synthetic)
+                self.messages.append(synthetic)
+                _archive(self.ctx, synthetic)
+                return _Continue()
+
+        if isinstance(end_turn_signal, EndTurnConfirm):
+            log.info("EndTurnConfirm — making presentation LLM call before confirmation")
+            present_response = await _call_llm_with_events(
+                self.ctx, self.config, self.messages, [],
+                **self.model_override,
+            )
+            present_content = present_response.get("content") or ""
+            present_msg = {"role": "assistant", "content": present_content}
+            self.history.append(present_msg)
+            self.messages.append(present_msg)
+            _archive(self.ctx, present_msg)
+
+            log.info("EndTurnConfirm — requesting confirmation")
+            approved = await _handle_end_turn_confirm(self.ctx, end_turn_signal)
+            if approved:
+                log.info("EndTurnConfirm approved — continuing agent loop")
+                if end_turn_signal.on_approve:
+                    if asyncio.iscoroutinefunction(end_turn_signal.on_approve):
+                        await end_turn_signal.on_approve()
+                    else:
+                        end_turn_signal.on_approve()
+                note = f"[User approved: {end_turn_signal.message or 'review'}]"
+                self.history.append({"role": "user", "content": note})
+                self.messages.append({"role": "user", "content": note})
+                return _Continue()
+            else:
+                log.info("EndTurnConfirm denied — ending turn")
+                if end_turn_signal.on_deny:
+                    if asyncio.iscoroutinefunction(end_turn_signal.on_deny):
+                        await end_turn_signal.on_deny()
+                    else:
+                        end_turn_signal.on_deny()
+                deny_label = end_turn_signal.deny_label or "denied"
+                note = f"[User selected '{deny_label}'. Ask what they'd like changed.]"
+                self.history.append({"role": "user", "content": note})
+                self.messages.append({"role": "user", "content": note})
+                end_turn_signal = True
+
+        if end_turn_signal:
+            log.info("Tool signalled end_turn — making final no-tools LLM call")
+            final_response = await _call_llm_with_events(
+                self.ctx, self.config, self.messages, [],
+                **self.model_override,
+            )
+            content = final_response.get("content") or ""
+            final_msg = {"role": "assistant", "content": content}
+            self.history.append(final_msg)
+            _archive(self.ctx, final_msg)
+
+            return _Final(result=self._extract_workspace_media(content))
+
+        return _Continue()
+
+    async def _handle_no_tool_calls(self, response: dict) -> IterationOutcome:
+        """Process a no-tool-calls LLM response. Handles empty-retry,
+        reflection, archive of last_reflection, and compaction trigger.
+        Returns _Continue (retry) or _Final(result) (deliver response)."""
+        content = response.get("content") or ""
+        if not content:
+            if self.empty_retries < 1:
+                self.empty_retries += 1
+                log.warning("LLM returned empty response, retrying")
+                return _Continue()
+            log.warning("LLM returned empty content with no tool calls (after retry)")
+
+        log.debug("Reflection check: enabled=%s, retries=%d/%d, skip=%s, has_content=%s",
+                   self.config.reflection.enabled, self.reflection_retries,
+                   self.config.reflection.max_retries, self.ctx.skip_reflection, bool(content))
+        outcome = await self._handle_reflection(content)
+        if outcome.should_retry:
+            return _Continue()
+        assert outcome.text is not None  # invariant: should_retry=False implies text is not None
+        content = outcome.text
+
+        final_msg = {"role": "assistant", "content": content}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+
+        if self.last_reflection is not None:
+            visibility = self.config.reflection.visibility
+            r = self.last_reflection
+            should_archive = (
+                visibility == "debug"
+                or (visibility == "visible" and not r.passed)
+            )
+            if should_archive:
+                detail = r.raw_response or r.critique or (
+                    "Response passed evaluation" if r.passed else "No details")
+                label = ("reflection: PASS" if r.passed
+                         else f"reflection: retry {self.reflection_retries}")
+                _archive(self.ctx, {"role": "reflection", "tool": label,
+                                    "content": detail})
+
+        await _maybe_compact(self.ctx, self.config, self.history, self.prompt_tokens)
+        return _Final(result=self._extract_workspace_media(content))
+
+    async def _handle_reflection(self, content: str) -> ReflectionOutcome:
+        """Thin orchestrator. Mutates self.reflection_retries and
+        self.last_reflection; returns ReflectionOutcome."""
+        if not _should_reflect(
+            self.ctx, self.config, content, self.reflection_retries,
+        ):
+            return self._reflection_skip(content)
+        result = await self._reflection_evaluate(content)
+        self.last_reflection = result
+        return self._reflection_apply_verdict(content, result)
+
+    def _reflection_skip(self, content: str) -> ReflectionOutcome:
+        """Reflection-did-not-run branch. Appends escalation suffix
+        on exhaustion; clears self.last_reflection."""
+        reflection_exhausted = (
+            self.reflection_retries >= self.config.reflection.max_retries
+            and self.last_reflection is not None
+            and not self.last_reflection.passed
+        )
+        self.last_reflection = None
+        if reflection_exhausted:
+            content += (
+                "\n\n---\n*I'm not confident in this answer. "
+                "Try switching to a more capable model in the web UI model picker.*"
+            )
+        return ReflectionOutcome(text=content, should_retry=False)
+
+    async def _reflection_evaluate(self, content: str) -> "ReflectionResult":
+        """Build summaries + attachment annotation + accumulated-text
+        concat, call evaluate_response, publish reflection_result event."""
+        from .reflection import (
+            build_prior_turn_summary,
+            build_tool_summary,
+            evaluate_response,
+        )
+
+        tool_summary = build_tool_summary(
+            self.history, self.turn_start_index,
+            max_result_len=self.config.reflection.max_tool_result_len,
+        )
+        prior_turn_summary = build_prior_turn_summary(
+            self.history, self.turn_start_index - 1,
+            max_turns=3,
+            max_result_len=200,
+        )
+        judge_user_message = self.user_message
+        if self.attachments:
+            att_desc = ", ".join(
+                f"{a.get('filename', '?')} ({a.get('mime_type', '?')})"
+                for a in self.attachments
+            )
+            judge_user_message += f"\n\n[User attached files: {att_desc}]"
+        judge_agent_response = "\n\n".join(
+            part for part in [*self.accumulated_text_parts, content]
+            if part and part.strip()
+        ) or content
+        result = await evaluate_response(
+            self.config, judge_user_message, judge_agent_response, tool_summary,
+            prior_turn_summary=prior_turn_summary,
+            retrieved_context=self.retrieved_context_text,
+        )
+
+        log.info("Reflection result: passed=%s, critique=%s, error=%s",
+                 result.passed, result.critique[:200] if result.critique else "",
+                 result.error[:100] if result.error else "")
+        await self.ctx.publish("reflection_result",
+            passed=result.passed,
+            critique=result.critique,
+            raw_response=result.raw_response,
+            retry_number=self.reflection_retries + 1,
+            error=result.error)
+        return result
+
+    def _reflection_apply_verdict(
+        self, content: str, result: "ReflectionResult",
+    ) -> ReflectionOutcome:
+        """Apply the judge's verdict. On fail-with-real-critique,
+        append failed_msg + critique_msg, archive, bump retries.
+        Fail-open errors treated as PASS."""
+        if not result.passed and not result.error:
+            log.info("Reflection failed (retry %d/%d): %s",
+                     self.reflection_retries + 1,
+                     self.config.reflection.max_retries,
+                     result.critique[:200])
+            failed_msg = {"role": "assistant", "content": content}
+            self.history.append(failed_msg)
+            self.messages.append(failed_msg)
+            _archive(self.ctx, failed_msg)
+
+            critique_msg = {
+                "role": "user",
+                "content": (
+                    "[reflection] Your previous response may not fully "
+                    "address the user's request.\n"
+                    f"Feedback: {result.critique}\n"
+                    "Please try again, addressing the feedback above."
+                ),
+            }
+            self.history.append(critique_msg)
+            self.messages.append(critique_msg)
+            _archive(self.ctx, critique_msg)
+
+            self.reflection_retries += 1
+            return ReflectionOutcome(text=None, should_retry=True)
+
+        return ReflectionOutcome(text=content, should_retry=False)
+
+    async def _finalize_max_iterations(self) -> "ToolResult":
+        """Hit max iterations without a final response. Preserve any
+        accumulated text from tool-call iterations and append a notice."""
+        limit_note = (
+            f"\n\n[Agent reached max tool iterations "
+            f"({self.config.agent.max_tool_iterations}) without a final response]"
+        )
+        accumulated = "\n\n".join(self.accumulated_text_parts)
+        msg = accumulated + limit_note if accumulated else limit_note.strip()
+        final_msg = {"role": "assistant", "content": msg}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+        await _maybe_compact(
+            self.ctx, self.config, self.history, self.prompt_tokens,
+        )
+        return ToolResult(text=msg)
+
+    def _extract_workspace_media(self, content: str) -> "ToolResult":
+        """Extract workspace:// refs only for channels that need it.
+
+        Mattermost strips refs and uploads files; web/terminal render them
+        in-place. Returns ToolResult with media when extraction applies,
+        otherwise just text.
+        """
+        handler = self.ctx.media_handler
+        should_extract = (handler is None or handler.strips_workspace_refs)
+        if should_extract:
+            cleaned_text, workspace_media = extract_workspace_media(
+                content or "", self.config.workspace_path,
+            )
+            if workspace_media:
+                return ToolResult(text=cleaned_text, media=workspace_media)
+        return ToolResult(text=content or "")
+
+    async def _write_diagnostics(self) -> None:
+        """Persist context diagnostics + skill state on any turn-exit path.
+
+        Fail-open: any failure logs at DEBUG and is swallowed so the
+        finally block never raises through to callers.
+        """
+        conv_id = self.ctx.conv_id or self.ctx.channel_id
+
+        if self.composed is not None and self.composer is not None and conv_id:
+            try:
+                from .context_composer import write_context_sidecar
+                diagnostics = self.composer.build_diagnostics(self.config, self.composed)
+                write_context_sidecar(self.config, conv_id, diagnostics)
+            except Exception as exc:
+                log.debug("context sidecar write failed for %s: %s", conv_id, exc)
+
+        if conv_id:
+            try:
+                activated = self.ctx.skills.activated
+                if activated:
+                    write_skills_state(self.config, conv_id, activated)
+                skill_data = self.ctx.skills.data
+                if skill_data:
+                    write_skill_data(self.config, conv_id, skill_data)
+            except Exception as exc:
+                log.debug("skill state persistence failed for %s: %s", conv_id, exc)
 
 
 async def run_agent_turn(ctx, user_message: str, history: list,
@@ -1116,330 +1435,12 @@ async def run_agent_turn(ctx, user_message: str, history: list,
                          attachments: list[dict] | None = None) -> "ToolResult":
     """Process a single user message through the agent loop.
 
-    Args:
-        ctx: Runtime context (carries config, event bus, etc.)
-        user_message: The user's message text
-        archive_text: If set, archive this instead of user_message (for inline
-                      commands where the full body is the LLM prompt but the
-                      archive should show the short command)
-        history: Conversation history (list of message dicts, mutated in place)
-
-    Returns:
-        ToolResult with the agent's text response and any accumulated media.
+    Public entry point. Constructs a TurnRunner and runs it.
     """
-    config = ctx.config
-    ctx.history = history
-
-    model_override = await _setup_turn_state(ctx, config, history)
-
-    conv_id = ctx.conv_id or ctx.channel_id
-
-    composed = None
-    composer = None
-
-    try:
-        # Determine composer mode from context flags.
-        # Note: skip_vault_retrieval is handled directly by the composer,
-        # not via mode — HEARTBEAT/SCHEDULED skip wiki too, which isn't
-        # always desired when only memory should be skipped.
-        if ctx.is_child:
-            composer_mode = ComposerMode.CHILD_AGENT
-        elif ctx.task_mode in _TASK_MODE_TO_COMPOSER:
-            composer_mode = _TASK_MODE_TO_COMPOSER[ctx.task_mode]
-        else:
-            composer_mode = ComposerMode.INTERACTIVE
-
-        composer = ContextComposer(state=ctx.composer)
-        composed = await composer.compose(
-            ctx, user_message, history,
-            mode=composer_mode, attachments=attachments,
-        )
-        messages = composed.messages
-        ctx.messages = messages
-        retrieved_context_text = composed.retrieved_context_text
-
-        # Archive messages the composer added (wiki, memory, user).
-        # For inline commands, swap the user message with the short display version.
-        for msg in composed.messages_to_archive:
-            if ctx.task_mode == "background_wake" and msg.get("role") == "user":
-                # Wake turn's synthetic trigger prompt — archive under a distinct
-                # role so the UI doesn't render it as a real user message.
-                archive_msg: dict = {
-                    "role": "wake_trigger",
-                    "content": msg.get("content", ""),
-                }
-                _archive(ctx, archive_msg)
-            elif archive_text and msg.get("role") == "user":
-                archive_msg = {"role": "user", "content": archive_text}
-                if msg.get("attachments"):
-                    archive_msg["attachments"] = msg["attachments"]
-                _archive(ctx, archive_msg)
-            else:
-                _archive(ctx, msg)
-
-        # Track the deferred tools system message (replaced each iteration).
-        # If compose() already inserted one, reference it so the loop can update it.
-        if len(messages) > 1 and messages[1].get("role") == "system" and composed.deferred_tools:
-            deferred_msg: dict | None = messages[1]
-        else:
-            deferred_msg = None
-
-        prompt_tokens = 0
-        empty_retries = 0
-        reflection_retries = 0
-        last_reflection = None  # last ReflectionResult, for archiving after final response
-        turn_start_index = len(history)  # start of this turn's tool/assistant activity (after user message)
-
-        accumulated_text_parts = []  # text from iterations that also had tool calls
-
-        for iteration in range(config.agent.max_tool_iterations):
-            cancelled = _check_cancelled(ctx, history)
-            if cancelled:
-                return cancelled
-
-            log.debug(f"Agent iteration {iteration + 1}")
-            ctx._current_iteration = iteration + 1
-
-            _refresh_dynamic_tools(ctx)
-            all_tools, deferred_text = _build_tool_list(ctx)
-
-            # Inject/update deferred tool list in messages
-            if deferred_text:
-                new_msg = {"role": "system", "content": deferred_text}
-                if deferred_msg is not None and deferred_msg in messages:
-                    idx = messages.index(deferred_msg)
-                    messages[idx] = new_msg
-                else:
-                    # Insert after the first system message
-                    messages.insert(1, new_msg)
-                deferred_msg = new_msg
-            elif deferred_msg is not None and deferred_msg in messages:
-                # No longer in deferred mode — remove the block
-                messages.remove(deferred_msg)
-                deferred_msg = None
-
-            response = await _call_llm_with_events(ctx, config, messages, all_tools,
-                                                     **model_override)
-
-            # Track token usage
-            usage = response.get("usage")
-            if usage:
-                prompt_tokens = usage.get("prompt_tokens", 0)
-                completion_tokens = usage.get("completion_tokens", 0)
-                ctx.tokens.total_prompt += prompt_tokens
-                ctx.tokens.total_completion += completion_tokens
-                ctx.tokens.last_prompt = prompt_tokens
-                composer.record_actuals(prompt_tokens, completion_tokens)
-
-            tool_calls = response.get("tool_calls")
-            if tool_calls:
-                # Add the assistant's tool-call message to history
-                iter_content = response.get("content")
-                assistant_msg = {"role": "assistant", "content": iter_content}
-                assistant_msg["tool_calls"] = tool_calls
-                history.append(assistant_msg)
-                messages.append(assistant_msg)
-                _archive(ctx, assistant_msg)
-
-                # Flush any text content to the UI before starting tool execution.
-                # Without this, text like "Let me check the weather..." appears
-                # after tool results instead of before.
-                if iter_content:
-                    accumulated_text_parts.append(iter_content)
-                    await ctx.publish("text_before_tools", text=iter_content)
-
-                cancelled, end_turn_signal = await _execute_tool_calls(
-                    ctx, tool_calls, history, messages
-                )
-                if cancelled:
-                    return cancelled
-
-                if isinstance(end_turn_signal, WidgetInputPause):
-                    # Input-widget pause: route through the confirmation
-                    # infra, await user submit, call the tool's
-                    # on_response callback (if any), inject the returned
-                    # string as a synthetic user message, and continue
-                    # the loop for the next LLM iteration.
-                    inject_content = await _handle_widget_input_pause(
-                        ctx, end_turn_signal)
-                    if inject_content is None:
-                        # request_confirmation not available (unusual —
-                        # no manager wired); strip the pause and end
-                        # the turn gracefully.
-                        end_turn_signal = True
-                    else:
-                        synthetic = {
-                            "role": "user",
-                            "source": "widget_response",
-                            "content": inject_content,
-                        }
-                        history.append(synthetic)
-                        messages.append(synthetic)
-                        _archive(ctx, synthetic)
-                        continue  # next LLM iteration sees the answer
-
-                if isinstance(end_turn_signal, EndTurnConfirm):
-                    # Confirmation gate: present the artifact, show buttons, wait.
-                    # 1. No-tools LLM call so model presents the artifact
-                    # 2. Show confirmation buttons
-                    # 3. Approved → continue loop. Denied → fall through to
-                    #    end_turn handler which makes another LLM call for
-                    #    the feedback-request message (two messages total on
-                    #    denial: presentation + "what would you like changed?").
-                    log.info("EndTurnConfirm — making presentation LLM call before confirmation")
-                    present_response = await _call_llm_with_events(
-                        ctx, config, messages, [],  # no tools
-                        **model_override
-                    )
-                    present_content = present_response.get("content") or ""
-                    present_msg = {"role": "assistant", "content": present_content}
-                    history.append(present_msg)
-                    messages.append(present_msg)
-                    _archive(ctx, present_msg)
-
-                    log.info("EndTurnConfirm — requesting confirmation")
-                    approved = await _handle_end_turn_confirm(
-                        ctx, end_turn_signal
-                    )
-                    if approved:
-                        log.info("EndTurnConfirm approved — continuing agent loop")
-                        if end_turn_signal.on_approve:
-                            if asyncio.iscoroutinefunction(end_turn_signal.on_approve):
-                                await end_turn_signal.on_approve()
-                            else:
-                                end_turn_signal.on_approve()
-                        note = f"[User approved: {end_turn_signal.message or 'review'}]"
-                        history.append({"role": "user", "content": note})
-                        messages.append({"role": "user", "content": note})
-                        continue  # Next iteration — model sees approval and continues
-                    else:
-                        log.info("EndTurnConfirm denied — ending turn")
-                        if end_turn_signal.on_deny:
-                            if asyncio.iscoroutinefunction(end_turn_signal.on_deny):
-                                await end_turn_signal.on_deny()
-                            else:
-                                end_turn_signal.on_deny()
-                        # Inject denial note and make one more LLM call for feedback request
-                        deny_label = end_turn_signal.deny_label or "denied"
-                        note = f"[User selected '{deny_label}'. Ask what they'd like changed.]"
-                        history.append({"role": "user", "content": note})
-                        messages.append({"role": "user", "content": note})
-                        end_turn_signal = True  # Fall through to end-turn handling
-
-                if end_turn_signal:
-                    # end_turn=True: make one final LLM call with no tools
-                    # to produce a text response, then return.
-                    log.info("Tool signalled end_turn — making final no-tools LLM call")
-                    final_response = await _call_llm_with_events(
-                        ctx, config, messages, [],  # empty tool list
-                        **model_override
-                    )
-                    content = final_response.get("content") or ""
-                    final_msg = {"role": "assistant", "content": content}
-                    history.append(final_msg)
-                    _archive(ctx, final_msg)
-
-                    handler = ctx.media_handler
-                    should_extract = (handler is None or handler.strips_workspace_refs)
-                    if should_extract:
-                        cleaned_text, workspace_media = extract_workspace_media(
-                            content or "", config.workspace_path
-                        )
-                        if workspace_media:
-                            return ToolResult(text=cleaned_text, media=workspace_media)
-                    return ToolResult(text=content or "")
-
-                continue
-
-            # No tool calls — final response
-            content = response.get("content") or ""
-            if not content:
-                # Retry once on empty response — Gemini sometimes returns
-                # 0 completion tokens, especially after tool list changes.
-                if empty_retries < 1:
-                    empty_retries += 1
-                    log.warning("LLM returned empty response, retrying")
-                    continue
-                log.warning("LLM returned empty content with no tool calls (after retry)")
-
-            # Reflection check — evaluate before delivering
-            log.debug("Reflection check: enabled=%s, retries=%d/%d, skip=%s, has_content=%s",
-                       config.reflection.enabled, reflection_retries,
-                       config.reflection.max_retries, ctx.skip_reflection, bool(content))
-            outcome, reflection_retries, last_reflection = await _handle_reflection(
-                ctx, config, messages, history, content,
-                user_message, attachments, retrieved_context_text,
-                turn_start_index, reflection_retries, last_reflection,
-                accumulated_text_parts=accumulated_text_parts,
-            )
-            if outcome.should_retry:
-                continue
-            content = outcome.text
-
-            final_msg = {"role": "assistant", "content": content}
-            history.append(final_msg)
-            _archive(ctx, final_msg)
-
-            # Archive reflection result after the final response (correct ordering)
-            # Only archive if reflection ran for this specific response
-            # (last_reflection is cleared when reflection is skipped)
-            if last_reflection is not None:
-                visibility = config.reflection.visibility
-                r = last_reflection
-                # Match visibility filtering: hidden=none, visible=failures, debug=all
-                should_archive = (
-                    visibility == "debug"
-                    or (visibility == "visible" and not r.passed)
-                )
-                if should_archive:
-                    detail = r.raw_response or r.critique or (
-                        "Response passed evaluation" if r.passed else "No details")
-                    label = ("reflection: PASS" if r.passed
-                             else f"reflection: retry {reflection_retries}")
-                    _archive(ctx, {"role": "reflection", "tool": label,
-                                   "content": detail})
-
-            await _maybe_compact(ctx, config, history, prompt_tokens)
-
-            # Extract workspace:// refs only for channels that need it
-            # (Mattermost strips refs and uploads files; web/terminal render them in-place)
-            handler = ctx.media_handler
-            should_extract = (handler is None or handler.strips_workspace_refs)
-            if should_extract:
-                cleaned_text, workspace_media = extract_workspace_media(
-                    content or "", config.workspace_path
-                )
-                if workspace_media:
-                    return ToolResult(text=cleaned_text, media=workspace_media)
-            return ToolResult(text=content or "")
-
-        # Hit max iterations — preserve accumulated text from tool-call iterations
-        limit_note = (f"\n\n[Agent reached max tool iterations "
-                      f"({config.agent.max_tool_iterations}) without a final response]")
-        accumulated = "\n\n".join(accumulated_text_parts)
-        msg = accumulated + limit_note if accumulated else limit_note.strip()
-        final_msg = {"role": "assistant", "content": msg}
-        history.append(final_msg)
-        _archive(ctx, final_msg)
-        await _maybe_compact(ctx, config, history, prompt_tokens)
-        return ToolResult(text=msg)
-
-    finally:
-        # Write context diagnostics on any exit path
-        if composed is not None and composer is not None and conv_id:
-            try:
-                from .context_composer import write_context_sidecar
-                diagnostics = composer.build_diagnostics(config, composed)
-                write_context_sidecar(config, conv_id, diagnostics)
-            except Exception as exc:
-                log.debug("context sidecar write failed for %s: %s", conv_id, exc)
-
-        # Persist activated skills and skill_data after every turn
-        if conv_id:
-            activated = ctx.skills.activated
-            if activated:
-                write_skills_state(config, conv_id, activated)
-            skill_data = ctx.skills.data
-            if skill_data:
-                write_skill_data(config, conv_id, skill_data)
+    runner = TurnRunner(
+        ctx=ctx, config=ctx.config, history=history,
+        user_message=user_message, archive_text=archive_text,
+        attachments=attachments,
+    )
+    return await runner.run()
 

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -879,3 +879,25 @@ async def test_wake_turn_archives_nudge_as_wake_trigger_not_user(ctx, config):
     wake_trigger_msgs = [m for m in all_msgs if m.get("role") == "wake_trigger"]
     assert len(wake_trigger_msgs) == 1
     assert "background job" in wake_trigger_msgs[0]["content"].lower()
+
+
+# -- Public surface contract test ----------------------------------------------
+
+
+def test_run_agent_turn_public_surface_unchanged():
+    """Lock the public signature so future refactors don't drift the
+    contract callers depend on (conversation_manager.py, eval/runner,
+    etc.)."""
+    import inspect
+    sig = inspect.signature(run_agent_turn)
+    params = sig.parameters
+
+    assert list(params.keys()) == [
+        "ctx", "user_message", "history", "archive_text", "attachments",
+    ], "Positional/keyword arg order changed"
+    assert params["archive_text"].default == "", \
+        "archive_text default changed"
+    assert params["attachments"].default is None, \
+        "attachments default changed"
+    assert inspect.iscoroutinefunction(run_agent_turn), \
+        "run_agent_turn must remain async"


### PR DESCRIPTION
## Summary

Implements #382. Two-commit refactor of `agent.run_agent_turn` (~314 lines) and `_handle_reflection` (~117 lines, 4-tuple return).

- **Commit 1** splits `_handle_reflection` into a thin orchestrator + three free-function helpers, replacing the 4-tuple with a `ReflectionOutcome` dataclass.
- **Commit 2** introduces a `TurnRunner` dataclass owning per-turn mutable state. The 200-line iteration-loop body becomes a 4-line dispatcher on `IterationOutcome` (`_Continue` / `_Final`). The reflection helpers fold onto `TurnRunner` as methods. `run_agent_turn` becomes a 6-line wrapper.

`run_agent_turn`'s public signature is unchanged; `test_run_agent_turn_public_surface_unchanged` locks the contract.

## No-behavior-change with one minor hardening

This is a no-behavior-change refactor: 2206 tests pass (was 2205 + the new wrapper-contract test). The one observable difference is `_write_diagnostics` now wraps `write_skills_state` / `write_skill_data` in the same fail-open `try/except log.debug` as the sidecar write — the original code didn't, so a skill-persistence failure would have propagated through the `finally` block and clobbered the turn's return value. This is a strict tightening, not a regression.

## Spec / plan / notes

- Spec: `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/spec.md`
- Plan: `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/plan.md`
- Session notes: `docs/dev-sessions/2026-04-27-1731-refactor-run-agent-turn/notes.md`

## Test plan

- [x] \`make check\` clean
- [x] \`make test\` (2206 tests passing)
- [ ] LV1 Web UI normal turn
- [ ] LV2 Web UI tool-using turn (verify \`text_before_tools\` flush)
- [ ] LV3 Web UI widget input pause/resume
- [ ] LV4 Web UI EndTurnConfirm — approve
- [ ] LV5 Web UI EndTurnConfirm — deny
- [ ] LV6 Mattermost normal turn + attachment upload
- [ ] LV7 Heartbeat / scheduled task
- [ ] LV8 Cancellation mid-turn
- [ ] LV9 Reflection retry + escalation suffix
- [ ] LV10 Compaction trigger

Closes #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)