### PR TITLE
feat(widgets): iframe_sandbox — agent-authored content (#358)

### DIFF
--- a/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/notes.md
+++ b/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/notes.md
@@ -1,0 +1,38 @@
+# iframe_sandbox session — notes
+
+## What shipped
+
+Closes #358 part B. Part A (workspace-tier widgets with first-use approval) stays deferred.
+
+A bundled `iframe_sandbox` widget that renders agent-authored HTML/CSS/JS in a CSP-locked, sandboxed iframe with no network access. Same WidgetRequest plumbing as existing widgets — no new tool needed; the agent uses `canvas_new_tab(widget_type="iframe_sandbox", data={"body": "...", "title": "..."})`.
+
+## Design decisions worth remembering
+
+- **Two layers of defense.** `sandbox="allow-scripts"` (NOT `allow-same-origin`) on the iframe + `<meta http-equiv="Content-Security-Policy">` injected backend-side. Either alone wouldn't be enough: sandbox without CSP allows network, CSP without sandbox allows storage/cookie access from inside the frame.
+- **CSP injection lives in Python.** `_normalize_iframe_sandbox` in `widgets.py` produces the wrapped doc. The backend sends the wrapped HTML over WS; widget.js just sets `iframe.srcdoc`. This means even a buggy or malicious admin/workspace-tier `widget.js` can't drop the CSP — by the time wrapped HTML reaches the browser the meta is already in the document.
+- **Per-widget normalization hook on the registry.** Added `WidgetRegistry.normalize(name, data)` + a module-level `_NORMALIZERS` dispatch dict. Pure functions, idempotent. Currently only `iframe_sandbox` registers one. Easy to extend later without touching the class.
+- **Idempotent normalization.** A stale `html` field in input is overwritten by re-wrapping from `body`, so a `canvas_read` → `canvas_update` round-trip can't compound or replay a poisoned document. Verified by `test_iframe_sandbox_normalize_idempotent`.
+- **Data shape diverges between input and stored.** Input: `{body, title?}`. Stored/transmitted: `{body, title?, html}`. The schema lists `html` in `properties` (so round-trip doesn't fail validation under `additionalProperties: false`) but doesn't require it. The schema validates input shape; widget.js consumes the post-normalization shape.
+- **256 KB body cap.** Enforced via `maxLength` in the data_schema. Big enough for non-trivial demos (small p5.js sketches, charts) without unbounded archive growth.
+- **No widget-response in v1.** `accepts_input: false`. To add later: validate `event.source === iframe.contentWindow` in a postMessage handler — origin will be `null` for sandboxed-without-same-origin so source-equality is the trust check.
+
+## Gotchas hit
+
+- **Multiple fake registries.** Three test files define their own registry stand-ins (`tests/test_canvas.py`, `tests/test_canvas_tools.py`, `tests/test_web_canvas.py`). All three needed a `normalize(name, data) -> data` shim added when canvas.py started calling `registry.normalize`. First test run failed with `AttributeError: '_Reg' object has no attribute 'normalize'` — fixed by adding the no-op shim to each. Worth a note: when adding a new method to the registry interface, grep for fakes.
+
+## Files touched
+
+- `src/decafclaw/widgets.py` — `WidgetRegistry.normalize()`, `_NORMALIZERS` dispatch, `_normalize_iframe_sandbox`.
+- `src/decafclaw/agent.py` — `_resolve_widget` calls `registry.normalize` after validate.
+- `src/decafclaw/canvas.py` — `new_tab` and `update_tab` call `registry.normalize` after validate.
+- `src/decafclaw/web/static/widgets/iframe_sandbox/widget.json` (new)
+- `src/decafclaw/web/static/widgets/iframe_sandbox/widget.js` (new)
+- `src/decafclaw/tools/canvas_tools.py` — `canvas_new_tab` description enumerates iframe_sandbox.
+- `tests/test_widgets.py`, `tests/test_canvas.py`, `tests/test_canvas_tools.py`, `tests/test_web_canvas.py` — new tests + fake-registry shims.
+- `docs/widgets.md` — full iframe_sandbox section + updated out-of-scope notes.
+
+## Smoke testing
+
+`make check` clean (ruff, pyright, tsc). `make test` clean (2240 passed). New tests at top of `--durations=25` but all under 0.05s.
+
+Browser smoke test: pending — needs a running web UI session. Ask agent to drop a small demo into the canvas via `canvas_new_tab(widget_type="iframe_sandbox", data={"body": "<h1>hi</h1><script>document.body.style.background='lime'</script>", "title": "demo"})` and verify (a) it renders, (b) the script runs, (c) `fetch('https://example.com')` from inside the iframe is blocked by CSP, (d) `parent.location` from inside the iframe throws (sandbox null-origin).

--- a/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/spec.md
+++ b/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/spec.md
@@ -50,7 +50,7 @@ The CSP meta is **prepended on the backend** as part of normalization — fronte
 
 `body` and `title` round-trip back to the agent (so re-reading state via `canvas_read` is intelligible). `html` is what `widget.js` sets as `srcdoc`. Normalization is idempotent: re-normalizing data that already has `html` regenerates it from `body` and `title` (so a stale `html` from a round-trip can't mislead).
 
-`data_schema` declares only `body` (required) and `title` (optional). `additionalProperties` is allowed so a round-tripped `html` doesn't fail re-validation.
+`data_schema` declares `body` (required), plus optional `title` and `html`, and keeps `additionalProperties: false` so a round-tripped `html` doesn't fail re-validation while arbitrary extra fields are still rejected. `html` carries its own `maxLength` cap (512 KB, 2x the body cap) to bound the validation payload even though normalize will overwrite it.
 
 ## Backend normalization hook
 

--- a/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/spec.md
+++ b/docs/dev-sessions/2026-04-28-2236-iframe-sandbox-widget/spec.md
@@ -1,0 +1,131 @@
+# iframe_sandbox widget — spec
+
+Closes part B of #358. Part A (workspace-tier widgets with first-use approval) stays deferred.
+
+## Goal
+
+Ship a single bundled widget, `iframe_sandbox`, that lets the agent render arbitrary HTML/JS/CSS inside a CSP-locked, sandboxed iframe. Same WidgetRequest protocol, just a different renderer. Once shipped, the agent can drop interactive demos into the canvas via `canvas_new_tab(widget_type="iframe_sandbox", data={...})` — no new tool needed.
+
+## Non-goals (v1)
+
+- postMessage→widget-response (input widgets in iframes). Doable later.
+- Workspace-tier widget catalog with first-use approval. Tracked separately in #358 part A.
+- Network-permitted variants (`fetch`, external scripts). Out of scope; default CSP blocks all network.
+- Hot-reload of widget catalog.
+
+## Trust model
+
+The agent supplies HTML; we treat it as untrusted. Two layers of defense:
+
+1. **iframe sandbox attribute.** `sandbox="allow-scripts"`. Critically NOT `allow-same-origin` — that combination would let scripts in the iframe break the sandbox by removing the attr from the parent. Without `allow-same-origin`, the iframe's origin is the special "null" origin: no access to parent's cookies, localStorage, or same-origin XHR. We also omit `allow-forms`, `allow-top-navigation`, `allow-popups`, `allow-modals`.
+2. **Content Security Policy meta tag.** `default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:;`. Blocks all network (no fetch, no remote scripts/images/fonts). Permits inline `<script>` and `<style>` so the agent's content can be self-contained.
+
+The CSP meta is **prepended on the backend** as part of normalization — frontend receives the already-wrapped HTML and just sets it as `srcdoc`. This is the safer split: even a buggy or malicious widget.js can't drop the CSP, because by the time wrapped HTML reaches the browser the meta is already in the document.
+
+## Data shape
+
+**Input** (what the agent provides on `WidgetRequest.data` or `canvas_new_tab(data=...)`):
+
+```json
+{
+  "body": "<h1>Hello</h1><script>document.body.style.background='lime'</script>",
+  "title": "Optional title"
+}
+```
+
+- `body` (required, string, maxLength 262144 / 256 KB) — HTML body content. Inline `<style>` and `<script>` allowed.
+- `title` (optional, string, maxLength 200) — sets `<title>`.
+
+256 KB cap leaves headroom for non-trivial interactive demos (small p5.js sketches, charts, etc.) while bounding archive/canvas-state size.
+
+**Stored / transmitted** (post-normalization — what flows over WS, gets archived, persists in `canvas.json`):
+
+```json
+{
+  "body": "<h1>Hello</h1>...",
+  "title": "Optional title",
+  "html": "<!doctype html><html><head><meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:;\"><meta charset=\"utf-8\"><title>Optional title</title><style>html,body{margin:0;padding:0;...}</style></head><body><h1>Hello</h1>...</body></html>"
+}
+```
+
+`body` and `title` round-trip back to the agent (so re-reading state via `canvas_read` is intelligible). `html` is what `widget.js` sets as `srcdoc`. Normalization is idempotent: re-normalizing data that already has `html` regenerates it from `body` and `title` (so a stale `html` from a round-trip can't mislead).
+
+`data_schema` declares only `body` (required) and `title` (optional). `additionalProperties` is allowed so a round-tripped `html` doesn't fail re-validation.
+
+## Backend normalization hook
+
+Add a per-widget normalizer dispatch to `widgets.py`:
+
+```python
+_NORMALIZERS: dict[str, Callable[[dict], dict]] = {}
+
+class WidgetRegistry:
+    def normalize(self, name: str, data: dict) -> dict:
+        fn = _NORMALIZERS.get(name)
+        return fn(data) if fn else data
+```
+
+Register `_normalize_iframe_sandbox` at module load. Call sites that should invoke `normalize` (after successful `validate`):
+
+- `_resolve_widget` in `agent.py` (post-validate, pre-`payload` build, replaces `widget.data` and the payload's `data` field).
+- `canvas.new_tab` (post-validate, pre-state-write).
+- `canvas.update_tab` (post-validate, pre-state-write).
+
+The normalizer is pure: takes data, returns a new dict with `html` key added.
+
+## Frontend widget
+
+`src/decafclaw/web/static/widgets/iframe_sandbox/`:
+
+- `widget.json` — descriptor: `modes: ["inline", "canvas"]`, `accepts_input: false`, schema as above.
+- `widget.js` — Lit component `<dc-widget-iframe-sandbox>`. Light DOM. Renders `<iframe sandbox="allow-scripts" srcdoc=...>` plus a thin header with the title (when present). Inline mode constrains height to 24rem with vertical scroll fallback; canvas mode fills available space.
+
+The widget.js does NOT inject CSP — it trusts the backend wrapper. (Defense-in-depth: we could double-inject as a sanity check, but for v1 we keep one canonical wrapper to avoid divergence.)
+
+## canvas_new_tab tool description
+
+Update the description to enumerate `iframe_sandbox` as a supported widget_type with its data shape, and call out the security stance:
+
+> `widget_type='iframe_sandbox'` with `data={body: <html>, title?: <string>}` — renders arbitrary HTML/JS/CSS in a sandboxed iframe with no network access (CSP blocks fetch, external scripts, images, fonts). Use for interactive demos, charts, small visualizations.
+
+## Tests
+
+`tests/test_widgets.py` (extend):
+- `test_bundled_iframe_sandbox_is_registered` — descriptor parses, modes are `inline` + `canvas`, `accepts_input: false`.
+- Schema validation: rejects missing `body`, accepts body-only, accepts body+title, rejects oversized body.
+- Schema permits `html` round-trip without rejecting.
+
+New file `tests/test_widget_normalize.py` (or extend existing):
+- `test_iframe_sandbox_normalize_injects_csp` — wrapped html starts with doctype, contains exact CSP meta tag, contains body content, contains title when supplied.
+- `test_iframe_sandbox_normalize_idempotent` — normalize(normalize(data)) == normalize(data) for same inputs (regenerates html from body, doesn't compound).
+- `test_iframe_sandbox_normalize_no_title` — works without title.
+- `test_iframe_sandbox_normalize_escapes_title` — title with `</title>` doesn't break the doc (HTML-escape).
+
+`tests/test_canvas.py` (extend):
+- `test_new_tab_iframe_sandbox_normalizes` — adding an iframe_sandbox tab stores normalized data with `html` populated.
+
+JS-side: no automated DOM tests (no browser harness in CI). Smoke-test in browser before merge.
+
+## Files touched
+
+- `src/decafclaw/widgets.py` — add `_NORMALIZERS` dispatch + `WidgetRegistry.normalize()`. Register `_normalize_iframe_sandbox`.
+- `src/decafclaw/agent.py` — `_resolve_widget` calls `registry.normalize` after validate.
+- `src/decafclaw/canvas.py` — `new_tab` and `update_tab` call `registry.normalize` after `_validate_widget_for_canvas`.
+- `src/decafclaw/web/static/widgets/iframe_sandbox/widget.json` (new)
+- `src/decafclaw/web/static/widgets/iframe_sandbox/widget.js` (new)
+- `src/decafclaw/tools/canvas_tools.py` — extend `canvas_new_tab` description.
+- `tests/test_widgets.py`, `tests/test_canvas.py` — extend.
+- `docs/widgets.md` — document iframe_sandbox section.
+- `docs/dev-sessions/.../notes.md` — retro at end.
+
+## Phasing
+
+Single phase, single commit. ~1 hour of work.
+
+## Risks
+
+- **CSP-meta sandbox interaction.** `<meta http-equiv="CSP">` only applies to subresources fetched after the meta is parsed. Inline scripts run after parsing the meta if it appears in `<head>` before any `<script>`. Wrapper places CSP first in `<head>`, before any other element.
+- **`allow-same-origin` accidentally added.** Tests assert the exact `sandbox` attr value.
+- **HTML injection via title.** Backend escapes title before injecting into `<title>`.
+- **Size DoS.** 256 KB hard cap via JSON schema `maxLength`.
+- **Future postMessage support.** When we add input-widget mode, we'll validate `event.source === iframe.contentWindow` (origin is `null` for sandboxed-without-same-origin iframes, so we can't use origin checks).

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -62,6 +62,10 @@ Phase 4:
 
 - **`code_block`** — syntax-highlighted code; inline (collapsed) + canvas modes. Data shape: `{code: string, language?, filename?}`. See [Phase 4](#phase-4--code_block-and-canvas-tabs).
 
+Post-Phase 4 (#358 part B):
+
+- **`iframe_sandbox`** — agent-authored HTML/CSS/JS rendered in a CSP-locked sandboxed iframe; inline + canvas modes. Data shape (input): `{body: string, title?: string}`. See [iframe_sandbox](#iframe_sandbox-widget).
+
 ## Adding a new widget
 
 Widgets are extensible by admins without changing DecafClaw's core. Each
@@ -316,6 +320,97 @@ tools — the implicit active-tab model from Phase 3 is gone. See
 - `canvas_read()` — return `{active_tab, tabs: [{id, label,
   widget_type, data}, ...]}` via `ToolResult.data`.
 
+## `iframe_sandbox` widget
+
+Bundled at `src/decafclaw/web/static/widgets/iframe_sandbox/`. Renders
+agent-authored HTML/CSS/JS in a sandboxed iframe with **no network
+access**. Use for interactive demos, charts, small visualizations, or
+anywhere text alone won't do.
+
+### Trust model
+
+Two layers of defense, applied independently:
+
+**1. iframe `sandbox` attribute** (set by `widget.js`):
+`sandbox="allow-scripts"`. Critically NOT `allow-same-origin` — that
+combination would defeat the sandbox by letting iframe scripts touch
+the parent's storage and origin. Without it, the iframe runs in the
+"null" origin: scripts can run, but they cannot reach parent cookies,
+localStorage, or same-origin XHR. We also omit `allow-forms`,
+`allow-top-navigation`, `allow-popups`, `allow-modals`.
+
+**2. CSP `<meta>` tag** (injected backend-side during normalization):
+
+```
+default-src 'none';
+style-src 'unsafe-inline';
+script-src 'unsafe-inline';
+img-src data:;
+font-src data:;
+```
+
+Blocks all network — no `fetch`, no remote scripts, no remote images
+or fonts. Permits inline `<style>` and `<script>` so demos can be
+self-contained. Permits data-URI images and fonts so demos can embed
+small assets.
+
+The CSP is injected in Python (`widgets.py::_normalize_iframe_sandbox`)
+before the wrapped HTML reaches the browser. The frontend just sets
+the wrapped string as `iframe.srcdoc`. Even a buggy or malicious
+admin/workspace-tier `widget.js` cannot drop the CSP, because by the
+time wrapped HTML reaches the iframe the meta is already in the
+document.
+
+### Data shape
+
+**Input** (what tools and the agent provide):
+
+- `body` (required, string, max 256 KB) — HTML body content. Inline
+  `<style>` and `<script>` allowed.
+- `title` (optional, string, max 200 chars) — populates `<title>`;
+  HTML-escaped before injection.
+
+**Stored / transmitted** (post-normalization):
+
+- `body`, `title` preserved (so `canvas_read` round-trips meaningfully).
+- `html` — server-generated wrapped document with CSP meta + base
+  styles + body content. The Lit widget consumes only `html` for the
+  iframe's `srcdoc`.
+
+Normalization is idempotent: a stale `html` field in the input is
+overwritten by re-wrapping from `body`, so a `canvas_read` →
+`canvas_update` round-trip can't compound or replay a poisoned
+document.
+
+### Usage
+
+Any tool can emit one:
+
+```python
+return ToolResult(
+    text="Rendered demo on canvas",
+    widget=WidgetRequest(
+        widget_type="iframe_sandbox",
+        data={
+            "body": "<h1>Live demo</h1><script>document.body.style.background='lime'</script>",
+            "title": "Lime demo",
+        },
+        target="canvas",
+    ),
+)
+```
+
+Or the agent can use `canvas_new_tab(widget_type="iframe_sandbox", data={"body": "..."})`
+to drop a demo straight into the canvas with no tool plumbing.
+
+### Future: input widgets
+
+`accepts_input: false` for v1. To support widget-response from inside
+the iframe, add a `postMessage` handler in `widget.js` that validates
+`event.source === iframe.contentWindow` (origin will be `null` for
+sandboxed-without-same-origin iframes, so source-equality is the trust
+check). Filed as a follow-up if/when needed.
+
 ## Out-of-scope
 
 - Diff view, line numbers/highlighting for `code_block` — follow-on issues.
@@ -324,7 +419,11 @@ tools — the implicit active-tab model from Phase 3 is gone. See
 - Multi-tab in standalone view — current standalone is single-tab focus by design.
 - Collapsing `EndTurnConfirm` into a widget with a Mattermost-buttons
   adapter — filed as a follow-up issue.
-- Agent-authored widget JS (workspace tier + iframe sandbox) — #358.
+- Workspace-tier widget catalog (`workspace/widgets/` with first-use
+  approval) — #358 part A, still deferred. Agent-writable widget JS is
+  a privilege-escalation surface; iframe_sandbox covers the
+  agent-authored-content case without that risk.
+- postMessage→widget-response from inside iframe_sandbox — future.
 - Hot-reload of widget catalog without server restart — future.
 
 ## Related files
@@ -340,6 +439,7 @@ tools — the implicit active-tab model from Phase 3 is gone. See
 - `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice, markdown_document, code_block)
 - `src/decafclaw/web/static/widgets/markdown_document/` — markdown_document widget descriptor + Lit component
 - `src/decafclaw/web/static/widgets/code_block/` — code_block widget descriptor + Lit component
+- `src/decafclaw/web/static/widgets/iframe_sandbox/` — iframe_sandbox widget descriptor + Lit component
 - `vendor/bundle/highlight.js` — bundled hljs core + ~20 languages + dual themes
 - `src/decafclaw/web/static/components/widgets/widget-host.js` — frontend host
 - `src/decafclaw/web/static/lib/widget-catalog.js` — catalog client

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -698,10 +698,15 @@ def _resolve_widget(fn_name: str, result: ToolResult,
             fn_name, widget.widget_type, target, desc.modes)
         result.widget = None
         return None
+    # Apply per-widget server-side normalization (e.g. iframe_sandbox CSP
+    # wrapping). Mutate widget.data so downstream consumers — archive,
+    # canvas state, WS event — all see the same normalized shape.
+    normalized = registry.normalize(widget.widget_type, widget.data)
+    widget.data = normalized
     payload = {
         "widget_type": widget.widget_type,
         "target": target,
-        "data": widget.data,
+        "data": normalized,
     }
 
     # Phase 2: input-widget enforcement + pause-signal promotion.

--- a/src/decafclaw/canvas.py
+++ b/src/decafclaw/canvas.py
@@ -233,6 +233,9 @@ async def new_tab(config,
     err = _validate_widget_for_canvas(widget_type, data)
     if err:
         return CanvasOpResult(ok=False, error=err)
+    registry = get_widget_registry()
+    if registry is not None:
+        data = registry.normalize(widget_type, data)
     state = read_canvas_state(config, conv_id)
     next_n = state.get("next_tab_id", 1)
     tab_id = f"canvas_{next_n}"
@@ -266,6 +269,9 @@ async def update_tab(config,
             err = _validate_widget_for_canvas(tab["widget_type"], data)
             if err:
                 return CanvasOpResult(ok=False, error=err)
+            registry = get_widget_registry()
+            if registry is not None:
+                data = registry.normalize(tab["widget_type"], data)
             tab["data"] = data
             if not write_canvas_state(config, conv_id, state):
                 return CanvasOpResult(ok=False,

--- a/src/decafclaw/tools/canvas_tools.py
+++ b/src/decafclaw/tools/canvas_tools.py
@@ -131,8 +131,12 @@ CANVAS_TOOL_DEFINITIONS = [
                 "you intend to revise across multiple turns. Returns a tab_id "
                 "you MUST keep to target this tab in subsequent canvas_update "
                 "or canvas_close_tab calls. Currently supports widget_type='markdown_document' "
-                "with data={content: <markdown>} and widget_type='code_block' "
-                "with data={code: <string>, language?: <string>, filename?: <string>}."
+                "with data={content: <markdown>}, widget_type='code_block' "
+                "with data={code: <string>, language?: <string>, filename?: <string>}, "
+                "and widget_type='iframe_sandbox' with data={body: <html>, title?: <string>} "
+                "for arbitrary HTML/CSS/JS demos in a CSP-locked sandboxed iframe "
+                "(no network access — fetch, external scripts, remote images/fonts all blocked; "
+                "inline <style> and <script> are allowed)."
             ),
             "parameters": {
                 "type": "object",

--- a/src/decafclaw/web/static/styles/canvas.css
+++ b/src/decafclaw/web/static/styles/canvas.css
@@ -68,10 +68,17 @@ canvas-panel {
   min-width: 2.5rem; min-height: 2.5rem;
 }
 .canvas-body { flex: 1; overflow: hidden; position: relative; display: flex; flex-direction: column; min-height: 0; }
-/* Stretch the widget-host chain so canvas-mode widgets get the full canvas-body height. */
+/* Stretch the widget-host chain so canvas-mode widgets get the full
+   surrounding height. Applied to both the embedded panel (`.canvas-body`)
+   and the standalone canvas page (`#canvas-standalone-body`) so any
+   canvas-mode widget fills the available space the same way in both
+   surfaces. */
 .canvas-body > dc-widget-host,
 .canvas-body > dc-widget-host > .widget-host,
-.canvas-body dc-widget-host > .widget-host > * {
+.canvas-body dc-widget-host > .widget-host > *,
+#canvas-standalone-body > dc-widget-host,
+#canvas-standalone-body > dc-widget-host > .widget-host,
+#canvas-standalone-body dc-widget-host > .widget-host > * {
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/src/decafclaw/web/static/widgets/iframe_sandbox/widget.js
+++ b/src/decafclaw/web/static/widgets/iframe_sandbox/widget.js
@@ -1,0 +1,72 @@
+import { LitElement, html } from 'lit';
+
+const INLINE_HEIGHT = '24rem';
+
+/**
+ * iframe_sandbox widget. Renders agent-authored HTML inside a sandboxed
+ * iframe via `srcdoc`. The backend has already wrapped `data.body` into a
+ * full HTML document with a locked-down CSP meta tag (see
+ * `widgets.py::_normalize_iframe_sandbox`); this component is a dumb
+ * renderer.
+ *
+ * Sandbox attributes:
+ *   - `allow-scripts`           — required for the agent's inline scripts
+ *   - NO `allow-same-origin`    — denies access to parent origin's storage
+ *                                  and prevents the iframe from removing its
+ *                                  own sandbox attribute
+ *   - NO `allow-forms`, `allow-top-navigation`, `allow-popups`, `allow-modals`
+ *
+ * The combination forces the iframe into the "null" origin: scripts run,
+ * but cannot reach parent cookies/storage, cannot make same-origin
+ * requests, and cannot navigate the top frame.
+ *
+ * Modes set by the host via `mode`:
+ *   inline → fixed height (24rem)
+ *   canvas → fills available height
+ *
+ * Data shape (after backend normalization): { html: string, body?, title? }
+ */
+export class IframeSandboxWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+    mode: { type: String },
+  };
+
+  constructor() {
+    super();
+    this.data = {};
+    this.mode = 'inline';
+  }
+
+  createRenderRoot() { return this; }
+
+  render() {
+    const srcdoc = (this.data && typeof this.data.html === 'string')
+      ? this.data.html
+      : '';
+    const isCanvas = this.mode === 'canvas';
+    const heightStyle = isCanvas
+      ? 'height: 100%; min-height: 12rem;'
+      : `height: ${INLINE_HEIGHT};`;
+    const wrapperClass = isCanvas
+      ? 'iframe-sandbox iframe-sandbox-canvas'
+      : 'iframe-sandbox iframe-sandbox-inline';
+    const title = this.data?.title;
+    return html`
+      <div class=${wrapperClass} style=${`display:flex; flex-direction:column; ${isCanvas ? 'height:100%;' : ''}`}>
+        ${title ? html`<header class="iframe-sandbox-header"><span class="iframe-sandbox-title">${title}</span></header>` : ''}
+        <iframe
+          class="iframe-sandbox-frame"
+          sandbox="allow-scripts"
+          referrerpolicy="no-referrer"
+          loading="lazy"
+          .srcdoc=${srcdoc}
+          style=${`${heightStyle} width: 100%; border: 1px solid var(--border-color, #ccc); border-radius: 4px; background: white;`}
+          title=${title || 'sandboxed widget'}>
+        </iframe>
+      </div>
+    `;
+  }
+}
+
+customElements.define('dc-widget-iframe-sandbox', IframeSandboxWidget);

--- a/src/decafclaw/web/static/widgets/iframe_sandbox/widget.js
+++ b/src/decafclaw/web/static/widgets/iframe_sandbox/widget.js
@@ -45,23 +45,30 @@ export class IframeSandboxWidget extends LitElement {
       ? this.data.html
       : '';
     const isCanvas = this.mode === 'canvas';
-    const heightStyle = isCanvas
-      ? 'height: 100%; min-height: 12rem;'
-      : `height: ${INLINE_HEIGHT};`;
+    // Canvas mode: iframe flexes to fill remaining height after the title
+    // header (if any), so it always reaches the bottom of whatever surface
+    // hosts it (embedded canvas panel or standalone /canvas/{id} page).
+    // Inline mode: fixed height — keeps the widget compact in chat bubbles.
+    const iframeStyle = isCanvas
+      ? 'flex: 1 1 auto; min-height: 12rem; width: 100%; border: 1px solid var(--border-color, #ccc); border-radius: 4px; background: white;'
+      : `height: ${INLINE_HEIGHT}; width: 100%; border: 1px solid var(--border-color, #ccc); border-radius: 4px; background: white;`;
     const wrapperClass = isCanvas
       ? 'iframe-sandbox iframe-sandbox-canvas'
       : 'iframe-sandbox iframe-sandbox-inline';
+    const wrapperStyle = isCanvas
+      ? 'display:flex; flex-direction:column; flex:1 1 auto; min-height:0; height:100%;'
+      : 'display:flex; flex-direction:column;';
     const title = this.data?.title;
     return html`
-      <div class=${wrapperClass} style=${`display:flex; flex-direction:column; ${isCanvas ? 'height:100%;' : ''}`}>
-        ${title ? html`<header class="iframe-sandbox-header"><span class="iframe-sandbox-title">${title}</span></header>` : ''}
+      <div class=${wrapperClass} style=${wrapperStyle}>
+        ${title ? html`<header class="iframe-sandbox-header" style="flex: 0 0 auto;"><span class="iframe-sandbox-title">${title}</span></header>` : ''}
         <iframe
           class="iframe-sandbox-frame"
           sandbox="allow-scripts"
           referrerpolicy="no-referrer"
           loading="lazy"
           .srcdoc=${srcdoc}
-          style=${`${heightStyle} width: 100%; border: 1px solid var(--border-color, #ccc); border-radius: 4px; background: white;`}
+          style=${iframeStyle}
           title=${title || 'sandboxed widget'}>
         </iframe>
       </div>

--- a/src/decafclaw/web/static/widgets/iframe_sandbox/widget.json
+++ b/src/decafclaw/web/static/widgets/iframe_sandbox/widget.json
@@ -1,0 +1,27 @@
+{
+  "name": "iframe_sandbox",
+  "description": "Renders agent-authored HTML/CSS/JS inside a sandboxed iframe with no network access. Use for interactive demos, charts, small visualizations, or any UI where text alone won't do. The agent supplies HTML body content; the backend wraps it in a CSP-locked document. Inline `<style>` and `<script>` are permitted; external scripts, fetch, and remote images/fonts are blocked. Sandbox attributes deny same-origin access, top-navigation, forms, popups, and modals.",
+  "modes": ["inline", "canvas"],
+  "accepts_input": false,
+  "data_schema": {
+    "type": "object",
+    "required": ["body"],
+    "properties": {
+      "body": {
+        "type": "string",
+        "maxLength": 262144,
+        "description": "HTML body content. Inline <style> and <script> tags are allowed."
+      },
+      "title": {
+        "type": "string",
+        "maxLength": 200,
+        "description": "Optional title; populates <title>."
+      },
+      "html": {
+        "type": "string",
+        "description": "Server-controlled wrapped document. Set by backend normalization; agent should not provide this."
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/decafclaw/web/static/widgets/iframe_sandbox/widget.json
+++ b/src/decafclaw/web/static/widgets/iframe_sandbox/widget.json
@@ -19,7 +19,8 @@
       },
       "html": {
         "type": "string",
-        "description": "Server-controlled wrapped document. Set by backend normalization; agent should not provide this."
+        "maxLength": 524288,
+        "description": "Server-controlled wrapped document. Set by backend normalization; agent should not provide this. Capped at 512 KB (2x body cap) to bound payload size when round-tripped — normalize regenerates from body anyway."
       }
     },
     "additionalProperties": false

--- a/src/decafclaw/widgets.py
+++ b/src/decafclaw/widgets.py
@@ -86,9 +86,20 @@ class WidgetRegistry:
         wrapped CSP-locked HTML document). Returns ``data`` unchanged when
         no normalizer is registered for ``name``. Idempotent — normalizers
         regenerate derived fields rather than compounding them.
+
+        Normalizers are bundled-tier only: admin-tier widgets may
+        intentionally override bundled widgets on name collision (see
+        ``load_widget_registry``), and an admin-defined widget should not
+        silently inherit a bundled-only normalizer just because the name
+        matches — its data shape may be entirely different.
         """
         fn = _NORMALIZERS.get(name)
-        return fn(data) if fn else data
+        if fn is None:
+            return data
+        desc = self._descriptors.get(name)
+        if desc is not None and desc.tier != "bundled":
+            return data
+        return fn(data)
 
     def validate(self, name: str, data: dict) -> tuple[bool, str | None]:
         """Validate widget payload against the widget's data_schema.

--- a/src/decafclaw/widgets.py
+++ b/src/decafclaw/widgets.py
@@ -3,8 +3,10 @@
 See docs/widgets.md for the admin-facing guide.
 """
 
+import html as html_lib
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -76,6 +78,17 @@ class WidgetRegistry:
         if d is None:
             raise KeyError(f"unknown widget: {name!r}")
         return d.js_path
+
+    def normalize(self, name: str, data: dict) -> dict:
+        """Apply per-widget post-validate normalization, if registered.
+
+        Used to inject server-controlled fields (e.g. iframe_sandbox's
+        wrapped CSP-locked HTML document). Returns ``data`` unchanged when
+        no normalizer is registered for ``name``. Idempotent — normalizers
+        regenerate derived fields rather than compounding them.
+        """
+        fn = _NORMALIZERS.get(name)
+        return fn(data) if fn else data
 
     def validate(self, name: str, data: dict) -> tuple[bool, str | None]:
         """Validate widget payload against the widget's data_schema.
@@ -198,3 +211,84 @@ def _reset_registry_for_tests() -> None:
     """Test helper — clears the module-level singleton."""
     global _registry
     _registry = None
+
+
+# ---------------------------------------------------------------------------
+# Per-widget normalizers
+#
+# A normalizer is a pure function ``(input_data) -> normalized_data`` invoked
+# AFTER successful schema validation. Used for server-controlled fields the
+# agent shouldn't be trusted to author. iframe_sandbox uses it to wrap
+# agent-supplied body content into a CSP-locked HTML document.
+#
+# Normalizers must be idempotent: ``normalize(normalize(d))`` should equal
+# ``normalize(d)`` for the same input. They typically achieve this by
+# regenerating derived fields from canonical source fields rather than
+# preserving prior derived state.
+# ---------------------------------------------------------------------------
+
+_NORMALIZERS: dict[str, Callable[[dict], dict]] = {}
+
+
+# Locked CSP for iframe_sandbox documents. ``default-src 'none'`` blocks all
+# network and resource loading; ``script-src 'unsafe-inline'`` and
+# ``style-src 'unsafe-inline'`` permit the agent's self-contained inline
+# scripts and styles; ``img-src data:`` and ``font-src data:`` permit
+# data-URI images and fonts so demos can embed assets without network.
+_IFRAME_SANDBOX_CSP = (
+    "default-src 'none'; "
+    "style-src 'unsafe-inline'; "
+    "script-src 'unsafe-inline'; "
+    "img-src data:; "
+    "font-src data:;"
+)
+
+_IFRAME_SANDBOX_BASE_STYLE = (
+    "html,body{margin:0;padding:0;"
+    "font-family:system-ui,-apple-system,Segoe UI,sans-serif;}"
+)
+
+
+def _normalize_iframe_sandbox(data: dict) -> dict:
+    """Wrap agent-provided body into a CSP-locked HTML document.
+
+    Input shape: ``{body: str, title?: str}`` (validated by the data_schema
+    before this is called). Output shape: ``{body, title?, html}`` where
+    ``html`` is the wrapped document the iframe consumes via ``srcdoc``.
+
+    Idempotent: a stale ``html`` key in the input is overwritten by the
+    regenerated wrapper, so a round-tripped value (e.g. via canvas_read →
+    canvas_update) doesn't compound.
+    """
+    body = data.get("body", "")
+    if not isinstance(body, str):
+        body = ""
+    title = data.get("title")
+    title_tag = ""
+    if isinstance(title, str) and title:
+        # html.escape handles `<`, `>`, `&`, and quotes — sufficient inside
+        # a <title> element where the only parser-meaningful sequence is
+        # ``</title>``.
+        title_tag = f"<title>{html_lib.escape(title)}</title>"
+    wrapped = (
+        '<!doctype html>'
+        '<html>'
+        '<head>'
+        f'<meta http-equiv="Content-Security-Policy" content="{_IFRAME_SANDBOX_CSP}">'
+        '<meta charset="utf-8">'
+        f'<meta name="viewport" content="width=device-width, initial-scale=1">'
+        f'{title_tag}'
+        f'<style>{_IFRAME_SANDBOX_BASE_STYLE}</style>'
+        '</head>'
+        '<body>'
+        f'{body}'
+        '</body>'
+        '</html>'
+    )
+    out = {"body": body, "html": wrapped}
+    if isinstance(title, str) and title:
+        out["title"] = title
+    return out
+
+
+_NORMALIZERS["iframe_sandbox"] = _normalize_iframe_sandbox

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -86,6 +86,10 @@ class _FakeRegistry:
                 return False, f"missing required field '{r}'"
         return True, None
 
+    def normalize(self, name, data):
+        # No registered normalizers in tests — pass through.
+        return data
+
 
 @pytest.fixture
 def md_doc_registry(monkeypatch):
@@ -291,6 +295,86 @@ async def test_update_tab_invalid_data(config, md_doc_registry, emit_recorder):
     )
     assert not result.ok
     assert "schema validation failed" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Per-widget normalization (e.g. iframe_sandbox CSP wrapping)
+# ---------------------------------------------------------------------------
+
+class _NormalizingFakeRegistry(_FakeRegistry):
+    """Fake registry that runs a normalize hook by widget name."""
+
+    def __init__(self, descriptors, normalizers):
+        super().__init__(descriptors)
+        self._normalizers = normalizers
+
+    def normalize(self, name, data):
+        fn = self._normalizers.get(name)
+        return fn(data) if fn else data
+
+
+@pytest.mark.asyncio
+async def test_new_tab_runs_normalize(config, monkeypatch, emit_recorder):
+    """new_tab should invoke registry.normalize after validate, so widgets
+    like iframe_sandbox get their server-controlled fields injected before
+    state is persisted or events are emitted."""
+    def normalize_iframe(data):
+        return {**data, "html": f"WRAPPED:{data.get('body', '')}"}
+
+    reg = _NormalizingFakeRegistry(
+        descriptors={
+            "iframe_sandbox": SimpleNamespace(modes=["inline", "canvas"],
+                                              required=["body"]),
+        },
+        normalizers={"iframe_sandbox": normalize_iframe},
+    )
+    monkeypatch.setattr(canvas, "get_widget_registry", lambda: reg)
+
+    result = await canvas.new_tab(
+        config, "c", "iframe_sandbox",
+        {"body": "<p>hi</p>"}, emit=emit_recorder,
+    )
+    assert result.ok
+    state = canvas.read_canvas_state(config, "c")
+    stored = state["tabs"][0]["data"]
+    # Normalized form: original body preserved, html field added.
+    assert stored["body"] == "<p>hi</p>"
+    assert stored["html"] == "WRAPPED:<p>hi</p>"
+    # Emitted event also carries the normalized data.
+    _, event = emit_recorder.events[0]
+    assert event["tab"]["data"]["html"] == "WRAPPED:<p>hi</p>"
+
+
+@pytest.mark.asyncio
+async def test_update_tab_runs_normalize(config, monkeypatch, emit_recorder):
+    """update_tab must re-run normalize so a stale html field can't survive
+    a round-trip."""
+    def normalize_iframe(data):
+        return {**data, "html": f"WRAPPED:{data.get('body', '')}"}
+
+    reg = _NormalizingFakeRegistry(
+        descriptors={
+            "iframe_sandbox": SimpleNamespace(modes=["inline", "canvas"],
+                                              required=["body"]),
+        },
+        normalizers={"iframe_sandbox": normalize_iframe},
+    )
+    monkeypatch.setattr(canvas, "get_widget_registry", lambda: reg)
+
+    r = await canvas.new_tab(config, "c", "iframe_sandbox",
+                             {"body": "v1"}, emit=emit_recorder)
+    emit_recorder.events.clear()
+    result = await canvas.update_tab(
+        config, "c", r.tab_id,
+        # Agent passes a stale html alongside fresh body — normalize should overwrite it.
+        {"body": "v2", "html": "STALE"},
+        emit=emit_recorder,
+    )
+    assert result.ok
+    state = canvas.read_canvas_state(config, "c")
+    stored = state["tabs"][0]["data"]
+    assert stored["body"] == "v2"
+    assert stored["html"] == "WRAPPED:v2"
 
 
 @pytest.mark.asyncio

--- a/tests/test_canvas_tools.py
+++ b/tests/test_canvas_tools.py
@@ -47,6 +47,9 @@ def md_doc_registry(monkeypatch):
                     return False, f"missing {r}"
             return True, None
 
+        def normalize(self, name, data):
+            return data
+
     monkeypatch.setattr(canvas_mod, "get_widget_registry", lambda: _Reg())
 
 

--- a/tests/test_web_canvas.py
+++ b/tests/test_web_canvas.py
@@ -48,6 +48,9 @@ def md_doc_registry(tmp_path, monkeypatch):
                     return False, f"missing {r}"
             return True, None
 
+        def normalize(self, name, data):
+            return data
+
     reg = _Reg()
     monkeypatch.setattr(widgets_module, "_registry", reg)
     # Also patch the canvas module's import of get_widget_registry

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -295,6 +295,129 @@ def test_bundled_markdown_document_is_registered(fake_config):
     assert not bad_ok
 
 
+def test_bundled_iframe_sandbox_is_registered(fake_config):
+    """Fresh registry scan finds the bundled iframe_sandbox widget descriptor."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    desc = reg.get("iframe_sandbox")
+    assert desc is not None
+    assert desc.tier == "bundled"
+    assert "inline" in desc.modes
+    assert "canvas" in desc.modes
+    assert desc.accepts_input is False
+
+    # body alone is valid
+    ok, err = reg.validate("iframe_sandbox", {"body": "<h1>Hi</h1>"})
+    assert ok is True, err
+    # body + title is valid
+    ok, err = reg.validate("iframe_sandbox",
+                           {"body": "<p>x</p>", "title": "demo"})
+    assert ok is True, err
+    # missing body rejected
+    bad, _ = reg.validate("iframe_sandbox", {"title": "no body"})
+    assert not bad
+    # body must be string, not other types
+    bad, _ = reg.validate("iframe_sandbox", {"body": 42})
+    assert not bad
+    # additionalProperties: false rejects unknown keys (safety against
+    # agent confusion). The server-injected `html` key is in `properties`,
+    # so it's allowed for round-trips.
+    bad, _ = reg.validate("iframe_sandbox",
+                          {"body": "x", "unexpected": "no"})
+    assert not bad
+    # Round-trip with html field is permitted (allowed on input so
+    # canvas_read → canvas_update doesn't fail; normalization regenerates).
+    ok, _ = reg.validate("iframe_sandbox",
+                         {"body": "x", "html": "<stale-doc>"})
+    assert ok is True
+    # Oversized body rejected (256 KB cap)
+    big = "a" * (262144 + 1)
+    bad, err = reg.validate("iframe_sandbox", {"body": big})
+    assert not bad
+
+
+def test_iframe_sandbox_normalize_injects_csp(fake_config):
+    """Normalization wraps body into a CSP-locked HTML document."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    out = reg.normalize("iframe_sandbox",
+                        {"body": "<h1>Hello</h1>", "title": "Demo"})
+    assert "html" in out
+    wrapped = out["html"]
+    # Doctype first
+    assert wrapped.startswith("<!doctype html>")
+    # CSP meta with the exact policy
+    assert 'http-equiv="Content-Security-Policy"' in wrapped
+    assert "default-src 'none'" in wrapped
+    assert "script-src 'unsafe-inline'" in wrapped
+    assert "style-src 'unsafe-inline'" in wrapped
+    # No allow-* network sources
+    assert "fetch-src" not in wrapped
+    assert "https:" not in wrapped or "https://" not in wrapped  # no remote scheme allowance
+    # Title is escaped and present
+    assert "<title>Demo</title>" in wrapped
+    # Body content is present verbatim
+    assert "<h1>Hello</h1>" in wrapped
+    # Original body and title preserved alongside html
+    assert out["body"] == "<h1>Hello</h1>"
+    assert out["title"] == "Demo"
+
+
+def test_iframe_sandbox_normalize_no_title(fake_config):
+    """Normalization works without title — no <title> tag emitted."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    out = reg.normalize("iframe_sandbox", {"body": "<p>x</p>"})
+    assert "<title>" not in out["html"]
+    assert "title" not in out
+
+
+def test_iframe_sandbox_normalize_escapes_title(fake_config):
+    """Adversarial title can't break out of the <title> element."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    out = reg.normalize("iframe_sandbox", {
+        "body": "<p>safe</p>",
+        "title": "</title><script>alert(1)</script>",
+    })
+    wrapped = out["html"]
+    # Literal `</title>` must not appear unescaped — html.escape converts
+    # `<` and `>` to entities, so the dangerous closing tag is neutralized.
+    # The escaped form contains `&lt;/title&gt;`.
+    assert "&lt;/title&gt;" in wrapped
+    # There's still exactly one literal closing </title> — the one we emit
+    # to close the element we opened.
+    assert wrapped.count("</title>") == 1
+
+
+def test_iframe_sandbox_normalize_idempotent(fake_config):
+    """Normalize regenerates html from body — re-normalizing same input
+    produces identical output, and a stale html field gets overwritten."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    once = reg.normalize("iframe_sandbox",
+                         {"body": "<p>same</p>", "title": "T"})
+    twice = reg.normalize("iframe_sandbox", once)
+    assert once == twice
+
+    # Stale html in input must not survive — should be regenerated from body.
+    poisoned = reg.normalize("iframe_sandbox", {
+        "body": "<p>fresh</p>",
+        "html": "<!doctype html><html>STALE</html>",
+    })
+    assert "STALE" not in poisoned["html"]
+    assert "<p>fresh</p>" in poisoned["html"]
+
+
+def test_normalize_passes_through_for_non_iframe_widgets(fake_config):
+    """Widgets without a registered normalizer get their data unchanged."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    data = {"content": "# hi"}
+    out = reg.normalize("markdown_document", data)
+    assert out is data  # exact same object — no copy, no mutation
+
+
 def test_bundled_code_block_is_registered(fake_config):
     """Fresh registry scan finds the bundled code_block widget descriptor."""
     reg = load_widget_registry(fake_config,

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -334,6 +334,47 @@ def test_bundled_iframe_sandbox_is_registered(fake_config):
     big = "a" * (262144 + 1)
     bad, err = reg.validate("iframe_sandbox", {"body": big})
     assert not bad
+    # Oversized html on input also rejected (512 KB cap on the round-trip
+    # field) — closes the loophole where a tiny body + huge html would
+    # otherwise pass validation before normalize wipes html.
+    huge_html = "a" * (524288 + 1)
+    bad, err = reg.validate("iframe_sandbox",
+                            {"body": "x", "html": huge_html})
+    assert not bad
+
+
+def test_iframe_sandbox_normalizer_skips_admin_override(tmp_path, fake_config):
+    """Admin-tier widgets that share a bundled name must not inherit the
+    bundled normalizer — their data shape may be entirely different.
+
+    Build a registry where the admin tier defines its own iframe_sandbox
+    with a different schema; verify normalize returns input unchanged
+    instead of wrapping (which would crash or corrupt admin-tier data).
+    """
+    admin = tmp_path / "admin"
+    _write_widget(admin, "iframe_sandbox",
+                  description="admin override with different shape",
+                  modes=["inline"],
+                  schema={
+                      "type": "object",
+                      "required": ["payload"],
+                      "properties": {"payload": {"type": "string"}},
+                      "additionalProperties": False,
+                  })
+    reg = load_widget_registry(fake_config,
+                               admin_dir=admin)
+    desc = reg.get("iframe_sandbox")
+    assert desc is not None
+    assert desc.tier == "admin"
+    # Validate with the admin schema (different from bundled).
+    ok, err = reg.validate("iframe_sandbox", {"payload": "hi"})
+    assert ok, err
+    # Normalize must NOT apply the bundled wrapper — admin shape lacks
+    # `body`, so the bundled normalizer would either crash or silently
+    # produce wrapped html with empty body. Verify it's a clean passthrough.
+    out = reg.normalize("iframe_sandbox", {"payload": "hi"})
+    assert out == {"payload": "hi"}
+    assert "html" not in out
 
 
 def test_iframe_sandbox_normalize_injects_csp(fake_config):
@@ -346,14 +387,18 @@ def test_iframe_sandbox_normalize_injects_csp(fake_config):
     wrapped = out["html"]
     # Doctype first
     assert wrapped.startswith("<!doctype html>")
-    # CSP meta with the exact policy
-    assert 'http-equiv="Content-Security-Policy"' in wrapped
-    assert "default-src 'none'" in wrapped
-    assert "script-src 'unsafe-inline'" in wrapped
-    assert "style-src 'unsafe-inline'" in wrapped
-    # No allow-* network sources
-    assert "fetch-src" not in wrapped
-    assert "https:" not in wrapped or "https://" not in wrapped  # no remote scheme allowance
+    # CSP meta with the exact policy. Scope assertions to the CSP tag
+    # itself so body text can't accidentally satisfy them.
+    csp_start = wrapped.index('http-equiv="Content-Security-Policy"')
+    csp_end = wrapped.index(">", csp_start)
+    csp_tag = wrapped[csp_start:csp_end]
+    assert "default-src 'none'" in csp_tag
+    assert "script-src 'unsafe-inline'" in csp_tag
+    assert "style-src 'unsafe-inline'" in csp_tag
+    # No remote-network allowances inside the CSP itself.
+    assert "https:" not in csp_tag
+    assert "https://" not in csp_tag
+    assert "fetch-src" not in csp_tag
     # Title is escaped and present
     assert "<title>Demo</title>" in wrapped
     # Body content is present verbatim


### PR DESCRIPTION
Closes part B of #358. Part A (workspace-tier widgets with first-use approval) stays deferred.

## Summary

- Bundled `iframe_sandbox` widget renders agent-authored HTML/CSS/JS in a CSP-locked, sandboxed iframe with no network access.
- Two layers of defense: `sandbox=\"allow-scripts\"` (NOT `allow-same-origin` — null origin denies parent storage/cookies) + backend-injected CSP meta (`default-src 'none'`, blocking all network).
- Agent supplies `{body, title?}`; backend `_normalize_iframe_sandbox` wraps it into a full document with the CSP meta. Frontend just sets `iframe.srcdoc`.
- No new tool — agent emits via existing `canvas_new_tab(widget_type=\"iframe_sandbox\", data={...})` or any tool returning a `WidgetRequest`.
- Adds a per-widget `normalize(name, data)` hook on `WidgetRegistry` (module-level `_NORMALIZERS` dispatch). Pure, idempotent functions. Currently only `iframe_sandbox` registers one; easy to extend.

## Why backend normalization (vs frontend wrap)

Discussed up front: even a buggy or future malicious admin/workspace-tier `widget.js` cannot drop the CSP, because by the time wrapped HTML reaches the browser the meta is already in the document. Single canonical wrapper, no divergence.

## Idempotence

Re-normalizing the same data produces identical output, and a stale `html` field in input is overwritten by re-wrapping from `body`. Verified by `test_iframe_sandbox_normalize_idempotent`. Matters because `canvas_read` returns the wrapped form; if the agent round-trips that into `canvas_update`, normalization regenerates `html` from `body` rather than replaying the (potentially poisoned) prior `html`.

## Caps

256 KB hard cap on `body` via JSON Schema `maxLength`. Title 200 chars, HTML-escaped before injection (`</title>` neutralized).

## Out of scope (filed as future)

- Workspace-tier widgets with first-use approval — #358 part A still open.
- postMessage→widget-response from inside iframe_sandbox — future. Trust check at that point: `event.source === iframe.contentWindow` (origin is `null` for sandboxed-without-same-origin iframes, so we can't use origin).

## Test plan

- [x] Unit: registry parses descriptor; modes inline+canvas; accepts_input false.
- [x] Unit: schema rejects missing/oversized body; permits round-trip with `html` field.
- [x] Unit: normalize injects CSP meta, escapes title, preserves body+title alongside html.
- [x] Unit: normalize is idempotent; stale html overwritten.
- [x] Unit: canvas `new_tab` and `update_tab` invoke normalize after validate (verified with a fake normalizer).
- [x] `make check` clean (ruff, pyright, tsc).
- [x] `make test` clean (2240 passed, ~19s).
- [ ] **Browser smoke** — pending. Drop a small interactive demo via `canvas_new_tab(widget_type=\"iframe_sandbox\", data={\"body\": \"<h1>hi</h1><script>document.body.style.background='lime'</script>\", \"title\": \"demo\"})` and verify: (1) renders, (2) script runs, (3) `fetch('https://example.com')` blocked by CSP, (4) `parent.location` throws (sandbox null-origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)