### PR TITLE
feat(tools): redirect 'show me HTML' from workspace_write to canvas_new_tab

### DIFF
--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -93,3 +93,35 @@
     "Search the convo" + specific question → conversation_search.
     conversation_compact is for proactively shrinking history before
     context fills up — never invoked because the user has a question.
+
+# -- canvas_new_tab vs workspace_write ---------------------------------------
+
+- name: canvas-vs-workspace-write-show-html-demo
+  scenario: "Show me a rotating 3D cube in HTML — keep it simple."
+  expected: canvas_new_tab
+  near_miss: [workspace_write]
+  notes: |
+    "Show me" + interactive HTML content → canvas_new_tab with
+    widget_type='iframe_sandbox', which renders the page directly in
+    the user's UI. workspace_write would force them to open a saved
+    file. Real-session miss (postmortem 2026-04-29): the agent reached
+    for workspace_write and produced an .html artifact instead of
+    rendering inline.
+
+- name: canvas-vs-workspace-write-display-chart
+  scenario: "Display a quick interactive bar chart of [10, 20, 35, 14]."
+  expected: canvas_new_tab
+  near_miss: [workspace_write]
+  notes: |
+    "Display" + interactive viz → iframe_sandbox in the canvas. The
+    user wants to see it now, not get a path to an HTML file.
+
+- name: workspace-write-vs-canvas-save-blog-post
+  scenario: "Write a draft blog post about my weekend project to blog/weekend.md."
+  expected: workspace_write
+  near_miss: [canvas_new_tab]
+  notes: |
+    Negative case for the canvas redirect: a markdown blog post the
+    user explicitly asks to save to a file path is workspace_write.
+    The "PREFER canvas_new_tab" guidance applies to interactive web
+    content the user wants displayed, not to authoring file artifacts.

--- a/src/decafclaw/tools/canvas_tools.py
+++ b/src/decafclaw/tools/canvas_tools.py
@@ -127,16 +127,20 @@ CANVAS_TOOL_DEFINITIONS = [
             "description": (
                 "Create a new tab on the conversation's canvas and make it the "
                 "active tab. The canvas is a persistent display surface in the "
-                "user's web UI — use it for documents, plans, or visualizations "
-                "you intend to revise across multiple turns. Returns a tab_id "
-                "you MUST keep to target this tab in subsequent canvas_update "
-                "or canvas_close_tab calls. Currently supports widget_type='markdown_document' "
+                "user's web UI — use it for documents, plans, visualizations, "
+                "or interactive demos you intend to revise across multiple "
+                "turns. Returns a tab_id you MUST keep to target this tab in "
+                "subsequent canvas_update or canvas_close_tab calls. "
+                "Currently supports widget_type='markdown_document' "
                 "with data={content: <markdown>}, widget_type='code_block' "
                 "with data={code: <string>, language?: <string>, filename?: <string>}, "
-                "and widget_type='iframe_sandbox' with data={body: <html>, title?: <string>} "
-                "for arbitrary HTML/CSS/JS demos in a CSP-locked sandboxed iframe "
-                "(no network access — fetch, external scripts, remote images/fonts all blocked; "
-                "inline <style> and <script> are allowed)."
+                "and widget_type='iframe_sandbox' with data={body: <html>, title?: <string>} — "
+                "PREFER this over workspace_write whenever the user asks you to 'show', "
+                "'display', 'render', or 'demo' interactive HTML/CSS/JS content (3D demos, "
+                "charts, visualizations, mini-apps, animations); it renders the page directly "
+                "in their UI instead of producing a file they have to open. Runs in a "
+                "CSP-locked sandboxed iframe (no network access — fetch, external scripts, "
+                "remote images/fonts all blocked; inline <style> and <script> are allowed)."
             ),
             "parameters": {
                 "type": "object",

--- a/src/decafclaw/tools/workspace_tools.py
+++ b/src/decafclaw/tools/workspace_tools.py
@@ -595,7 +595,7 @@ WORKSPACE_TOOL_DEFINITIONS = [
         "priority": "critical",
         "function": {
             "name": "workspace_write",
-            "description": "Write content to a file in your workspace filesystem. Use this for blog posts, code, configs, scripts, and any project files. NOT for vault knowledge pages (use vault_write for those). Creates parent directories as needed. Paths are relative to the workspace root — do NOT prefix with 'workspace/' (use 'blog/post.md' not 'workspace/blog/post.md').",
+            "description": "Write content to a file in your workspace filesystem. Use this for blog posts, code, configs, scripts, and any project files. NOT for vault knowledge pages (use vault_write for those). NOT for HTML/CSS/JS demos the user wants to SEE — when the user asks you to 'show', 'display', 'render', or 'demo' interactive web content, use canvas_new_tab with widget_type='iframe_sandbox' so it renders directly in their UI instead of forcing them to open a saved file. Creates parent directories as needed. Paths are relative to the workspace root — do NOT prefix with 'workspace/' (use 'blog/post.md' not 'workspace/blog/post.md').",
             "parameters": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Postmortem follow-up: in a recent session, asking the agent to "show" a 3D rotating cube ended in a `workspace_write` of an .html file rather than `canvas_new_tab(iframe_sandbox)` rendering inline. The agent had canvas available; it just never considered it at decision time.

## Summary

- Tightened `workspace_write` description with a negative clause that names the redirect — "NOT for HTML/CSS/JS demos the user wants to SEE — when the user asks to 'show', 'display', 'render', or 'demo' interactive web content, use `canvas_new_tab` with `widget_type='iframe_sandbox'`...". Catching the redirect at the tool the LLM was actually considering is what flips the outcome.
- Strengthened `canvas_new_tab`'s iframe_sandbox blurb to lead with user-intent verbs (`PREFER this over workspace_write whenever the user asks you to 'show', 'display', 'render', or 'demo'...`) and added "interactive demos" to the canvas-as-surface intro line.
- Three new cases in `evals/tool_choice/core_overlaps.yaml`:
  - `canvas-vs-workspace-write-show-html-demo` — replays the real session miss verbatim.
  - `canvas-vs-workspace-write-display-chart` — different verb / domain to catch overfitting on "rotating cube".
  - `workspace-write-vs-canvas-save-blog-post` — negative case: file-save framing for a markdown post stays on workspace_write so the redirect doesn't over-correct.

## Why not AGENT.md (yet)

The postmortem proposed a guideline in AGENT.md too. Holding that until we see whether tool descriptions alone move the eval. AGENT.md adds context cost on every turn; tool descriptions only fire when the LLM is already considering one of these tools — more targeted, and the redirect lands at decision time.

## Test plan

- [x] `make check` clean (ruff + pyright + tsc).
- [x] `make test` clean (2243 passing).
- [x] YAML eval cases parse and load.
- [ ] `make eval-tools` — run after merge to confirm the three new cases pass at the chosen model.
- [ ] Live smoke: re-run the failing prompt ("show me a rotating 3D cube in HTML, keep it simple") and confirm canvas_new_tab is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)