### PR TITLE
Add extra_skill_paths config for externally-installed skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ See [docs/tools.md](docs/tools.md), [docs/tool-priority.md](docs/tool-priority.m
 See [docs/skills.md](docs/skills.md).
 
 - **Lazy-loaded by default.** Catalog (name + description) in system prompt; full body and tools load on `activate_skill`. `always-loaded: true` opts a skill out (auto-activated, exempt from deferral).
-- **Bundled in `src/decafclaw/skills/`**. Each: SKILL.md (required) + `tools.py` (optional). Scan order: workspace > agent-level > bundled.
+- **Bundled in `src/decafclaw/skills/`**. Each: SKILL.md (required) + `tools.py` (optional). Scan order: workspace > agent-level > bundled > `extra_skill_paths` (configured external dirs, e.g. for `npx skills add`).
 - **Skills must use absolute imports** (`from decafclaw.skills.X.Y import ...`). The loader uses `importlib.spec_from_file_location` without package context, so relative imports fail at runtime.
 - **Skill config via `SkillConfig` dataclass in `tools.py`.** Resolved at activation by `load_sub_config` (env + `config.skills[name]` + defaults). `init(config, skill_config)` receives both.
 - **User-invokable commands** (`user-invocable: true`) trigger via `!name` (Mattermost) / `/name` (web UI). Supports `$ARGUMENTS`/`$0`/`$1`, `context: fork`, `allowed-tools`.

--- a/docs/dev-sessions/2026-04-29-1448-external-skill-paths/notes.md
+++ b/docs/dev-sessions/2026-04-29-1448-external-skill-paths/notes.md
@@ -1,0 +1,53 @@
+# External Skill Paths — Retro
+
+## What shipped
+
+A top-level `Config.extra_skill_paths: list[str]` with `EXTRA_SKILL_PATHS` env override, resolved via `~`/`$VAR` expansion + `agent_path` anchoring for relatives, appended to `discover_skills`' `scan_paths` after bundled. Externals never shadow bundled skills. Empty env vars now fall through to `config.json` (matched the module's "first non-empty wins" docstring after Copilot caught the gap).
+
+13 new tests across `tests/test_skills.py` and `tests/test_config.py`. New `docs/skills.md` subsection ("Installing skills via `npx skills`"), updated scan-order table, extended `CLAUDE.md` skills bullet.
+
+PR #427 — squashed feature commit + separate session-docs commit.
+
+## Scope drift
+
+- **`always_loaded` discovery-time stripping** was added for ALL non-bundled skills (workspace + agent + external), not just externals. The spec claimed "trust boundary unchanged — falls out of the existing `is_relative_to(_BUNDLED_SKILLS_DIR)` check," but only `auto_approve` was actually stripped at discovery; `always_loaded` was filtered only in the catalog text builder. Copilot's first review comment caught it: a non-bundled skill with `always-loaded: true` was still getting its tools registered as critical at `activate_skill_internal`. Mirrored the existing `auto_approve` pattern; bundled skills (`vault`, `background`, `mcp`) are exempt and verified to retain the flag.
+
+- **Manual verification via `make config`** turned out to be impossible without an unrelated change. `decafclaw config show` only iterates nested-dataclass groups, so top-level scalar/list fields (`default_model`, `providers`, `model_configs`, `extra_skill_paths`) silently don't appear. Documented as a known pre-existing gap in the PR body; substituted a `python -c "load_config().extra_skill_paths"` check.
+
+## Surprises
+
+- **Pre-existing inconsistency in `discover_skills`**: `auto_approve` stripped at discovery (line 215-223 pre-change), `always_loaded` only filtered later in `build_catalog_text`. Two enforcement sites for what should be one trust boundary. Spec/research didn't surface this because the documentarian's question framing (well-meaning) traced the auto_approve path as the canonical example without asking "what other flags share this trust posture, and is enforcement uniform?"
+
+- **`vercel-labs/skills`** already includes an `openclaw` agent target in its hardcoded registry (with `~/.openclaw/skills` global and fallback to `~/.clawdbot`/`~/.moltbot`). Not relevant to this session — but a curious neighbor in the namespace.
+
+- **No `--path` flag** in the `npx skills` CLI. The agent registry is fully hardcoded; the only env-based redirection is per-known-agent (`CLAUDE_CONFIG_DIR` for `claude-code`, etc.). Confirmed there's no pure-config integration path without modifying decafclaw.
+
+## Workflow friction
+
+- **Documentarian research substep was very valuable.** The 5 neutral questions produced precise `file:line` refs that grounded both the spec and plan. Saved redundant lookups during execute.
+
+- **TDD signal partially diluted.** 4 of 7 Phase 1 tests genuinely failed before implementation; 3 "passed" because they were regression nets (negative checks that succeed when externals are simply ignored). The 4 real failures were enough to validate the test setup; the 3 passers became valuable on their own merits as protection against future regressions. Net: TDD discipline still produced first-run-pass on the implementation.
+
+- **Plan self-review caught 3 spec gaps** before execute: missing `$VAR` test, missing "workspace+agent shadow external" test, env-var tests didn't match `tests/test_config.py`'s actual class/fixture pattern. Self-review wasn't theatre.
+
+- **Express mode worked well.** Brainstorm + plan stayed interactive (good — Les's intent capture); execute + branch self-review + PR + Copilot cycle ran autonomously. Copilot's two comments were both real bugs and both fixable in <30 minutes. Force-push with `--force-with-lease` per Les's standing rule.
+
+## Misses
+
+- **Should have asked one more research question:** "Where else does the bundled-only trust boundary get enforced beyond `discover_skills`?" That would have surfaced `activate_skill_internal`'s `always_loaded_skill_tools` caching, and the spec/test would have stripped `always_loaded` from the start instead of needing a Copilot comment to catch it.
+
+- **Should have spot-checked `make config`** during planning. The manual verification item rested on an untested assumption.
+
+## Memory candidates
+
+- **`decafclaw config show` limitation:** only prints nested-dataclass groups. Top-level scalar/list fields on `Config` silently skip. Relevant whenever adding a top-level config field — you can't smoke-test the value via `make config` without first patching `cmd_show`. Save as a project/reference memory.
+
+- **Trust boundary canonical pattern:** `is_relative_to(_BUNDLED_SKILLS_DIR)` is the bundled-only check used by `auto_approve` and now `always_loaded`. Any future flag that should be bundled-only follows the same pattern in `discover_skills` (strip + warn for non-bundled). Save as a project memory — relevant whenever adding new skill frontmatter flags with trust implications.
+
+- **`vercel-labs/skills` agent install paths:** for `claude-code` it's `~/.claude/skills/` global and `.claude/skills` project-local, controlled by `CLAUDE_CONFIG_DIR` env if set. Already documented in `docs/skills.md` now, so doesn't need a separate memory — but worth a reference if anyone asks again.
+
+## Skill candidates
+
+- **Documentarian prompt could nudge toward "enforcement-site enumeration."** Today the framing is good for tracing flow; less good for "find ALL places where X is enforced." Adding a question template like "for each behavior: list every enforcement site, not just the most obvious one" might catch latent inconsistencies before code review does. But this might be too narrow to formalize — the existing prompt's negation rules already discourage solution-shaped questions, which is the deeper safeguard.
+
+- **Dev-session retro pattern: capture latent codebase inconsistencies surfaced during a session** as a separate output channel (not just memory). When Copilot/branch self-review surfaces "this thing was already wrong," that's worth a follow-up issue, not just a fix-in-place. This session didn't open one because the fix was tightly coupled to the new feature, but in general it's worth a reflex.

--- a/docs/dev-sessions/2026-04-29-1448-external-skill-paths/plan.md
+++ b/docs/dev-sessions/2026-04-29-1448-external-skill-paths/plan.md
@@ -1,0 +1,365 @@
+# External Skill Paths Implementation Plan
+
+**Goal:** Add a `extra_skill_paths` config field that appends user-configured directories to the skill discovery scan list, so `npx skills add … -a claude-code -g` output (or any other source) can be picked up by decafclaw without code or upstream changes.
+
+**Approach:** Top-level `Config.extra_skill_paths: list[str]` with an `EXTRA_SKILL_PATHS` env override. Each path is `expanduser()`/`expandvars()`-resolved and anchored to `agent_path` if relative. Resolved paths are appended to `discover_skills`' scan list **after** bundled, so externals can never shadow first-party skills. Trust posture follows the existing non-bundled rules — `auto-approve` stripped, `always-loaded` stripped, scheduling excluded — automatically via the existing `is_relative_to(_BUNDLED_SKILLS_DIR)` check.
+
+**Tech stack:** Python stdlib (`pathlib`, `os.path.expandvars`), existing `_parse_list` helper.
+
+---
+
+## Phase 1: Config field, env override, and discovery splice
+
+End-to-end: a skill directory listed in `extra_skill_paths` is discovered and appears alongside bundled/admin/workspace skills. Bundled skills with the same name win.
+
+**Files:**
+- Modify: `src/decafclaw/config.py` — add `extra_skill_paths: list[str]` field to `Config` dataclass; populate it in `load_config()` with env-override + JSON read; pass to constructor
+- Modify: `src/decafclaw/skills/__init__.py` — add `_resolve_extra_skill_paths(config)` helper; extend `discover_skills` `scan_paths` list
+- Test: `tests/test_skills.py` — new tests in the discover_skills section
+
+**Key changes:**
+
+In `src/decafclaw/config.py`, after `default_model: str = ""` (line 166):
+
+```python
+extra_skill_paths: list[str] = field(default_factory=list)
+```
+
+In `load_config()`, after the `default_model = file_data.get(...)` block (around line 447):
+
+```python
+if "EXTRA_SKILL_PATHS" in os.environ:
+    extra_skill_paths = _parse_list(os.environ["EXTRA_SKILL_PATHS"])
+else:
+    raw = file_data.get("extra_skill_paths", [])
+    extra_skill_paths = [str(p) for p in raw] if isinstance(raw, list) else []
+```
+
+Add `extra_skill_paths=extra_skill_paths,` to the `Config(...)` constructor call (around line 474-497).
+
+In `src/decafclaw/skills/__init__.py`, add a module-level helper above `discover_skills`:
+
+```python
+def _resolve_extra_skill_paths(config) -> list[Path]:
+    """Resolve user-configured external skill paths.
+
+    For each entry: expand $VARS and ~, then anchor relative paths to
+    config.agent_path (matching vault_root). Order is preserved.
+    """
+    resolved: list[Path] = []
+    for raw in config.extra_skill_paths:
+        expanded = os.path.expandvars(str(raw))
+        p = Path(expanded).expanduser()
+        if not p.is_absolute():
+            p = config.agent_path / p
+        resolved.append(p)
+    return resolved
+```
+
+In `discover_skills`, change `scan_paths` (lines 186-190) to:
+
+```python
+scan_paths = [
+    config.workspace_path / "skills",
+    config.agent_path / "skills",
+    _BUNDLED_SKILLS_DIR,
+    *_resolve_extra_skill_paths(config),
+]
+```
+
+Update the docstring (lines 179-185) to mention the 4th tier and that externals slot below bundled.
+
+**Tests to add** in `tests/test_skills.py` (in the `discover_skills` section, after `test_discover_honors_auto_approve_on_bundled`):
+
+```python
+def test_discover_includes_extra_skill_path(tmp_path, config):
+    """A skill in extra_skill_paths is discovered."""
+    extra = tmp_path / "external"
+    _write_skill(extra / "ext-only", "name: ext-only\ndescription: External skill.")
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    assert any(s.name == "ext-only" for s in skills)
+
+
+def test_discover_extra_path_does_not_shadow_bundled(tmp_path, config):
+    """An external skill named the same as a bundled skill loses to bundled."""
+    extra = tmp_path / "external"
+    # `vault` is a real bundled skill — confirm via discover_skills output below.
+    _write_skill(extra / "vault", "name: vault\ndescription: Imposter vault.")
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    vaults = [s for s in skills if s.name == "vault"]
+    assert len(vaults) == 1
+    assert vaults[0].description != "Imposter vault."  # bundled wins
+
+
+def test_discover_extra_path_relative_anchored_to_agent(tmp_path, config):
+    """A relative entry resolves under config.agent_path."""
+    rel_dir = config.agent_path / "external"
+    _write_skill(rel_dir / "rel-skill", "name: rel-skill\ndescription: Relative.")
+    config.extra_skill_paths = ["external"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "rel-skill" for s in skills)
+
+
+def test_discover_extra_path_expands_user(tmp_path, config, monkeypatch):
+    """A leading ~ expands to $HOME."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    extra = tmp_path / "shared-skills"
+    _write_skill(extra / "homed", "name: homed\ndescription: Tilde skill.")
+    config.extra_skill_paths = ["~/shared-skills"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "homed" for s in skills)
+
+
+def test_discover_extra_path_expands_envvar(tmp_path, config, monkeypatch):
+    """$VAR substrings are expanded via os.path.expandvars."""
+    monkeypatch.setenv("MY_SKILLS_ROOT", str(tmp_path / "myroot"))
+    extra = tmp_path / "myroot" / "skills"
+    _write_skill(extra / "expanded", "name: expanded\ndescription: Var skill.")
+    config.extra_skill_paths = ["$MY_SKILLS_ROOT/skills"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "expanded" for s in skills)
+
+
+def test_discover_workspace_and_agent_shadow_extra_path(tmp_path, config):
+    """Workspace and admin skills both override same-named external skills."""
+    extra = tmp_path / "external"
+    _write_skill(extra / "shared", "name: shared\ndescription: External version.")
+    _write_skill(
+        config.agent_path / "skills" / "shared",
+        "name: shared\ndescription: Admin version.",
+    )
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "shared"]
+    assert len(matching) == 1
+    assert matching[0].description == "Admin version."
+
+    # Now also add a workspace version — it should beat the admin version.
+    _write_skill(
+        config.workspace_path / "skills" / "shared",
+        "name: shared\ndescription: Workspace version.",
+    )
+    skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "shared"]
+    assert len(matching) == 1
+    assert matching[0].description == "Workspace version."
+
+
+def test_discover_extra_path_skipped_when_missing(tmp_path, config, caplog):
+    """A non-existent extra path is silently skipped (no error)."""
+    config.extra_skill_paths = [str(tmp_path / "does-not-exist")]
+    skills = discover_skills(config)  # must not raise
+    # Should not log a warning for the missing path
+    assert all("does-not-exist" not in r.message for r in caplog.records
+               if r.levelname == "WARNING")
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2250 passed)
+- [x] `make check` passes
+- [x] `uv run pytest tests/test_skills.py -v -k "extra"` shows the 7 new tests passing
+
+**Verification — manual:**
+- [x] Field loads from defaults: `uv run python -c "from decafclaw.config import load_config; print(load_config().extra_skill_paths)"` prints `[]`
+- [x] Env override works: `EXTRA_SKILL_PATHS=/tmp/decaf-ext-test uv run python -c "from decafclaw.config import load_config; print(load_config().extra_skill_paths)"` prints `['/tmp/decaf-ext-test']`
+- [ ] (Out of scope, not blocking) `config show` doesn't print top-level scalar/list fields (pre-existing limitation — `default_model`, `providers`, etc. are also absent). Documented as a known gap if it matters; no fix in this PR.
+
+---
+
+## Phase 2: Trust posture + env var format coverage
+
+End-to-end: external skills inherit the workspace trust posture exactly, and the env-var override accepts both JSON and comma-separated forms.
+
+**Files:**
+- Test: `tests/test_skills.py` — add tests; no production code changes (this phase verifies Phase 1's design relies on existing trust enforcement and the existing `_parse_list` helper)
+- Test: `tests/test_config.py` (or wherever `load_config` env tests live — locate during execute and pick the closest existing pattern)
+
+**Key changes:** None to production code. This phase is pure verification of the trust-and-parsing surface that Phase 1 inherits.
+
+**Tests to add** in `tests/test_skills.py`:
+
+```python
+def test_discover_strips_auto_approve_from_extra_path_skill(tmp_path, config, caplog):
+    """auto-approve on an external-path skill is stripped, same as workspace."""
+    extra = tmp_path / "external"
+    _write_skill(
+        extra / "ext-auto",
+        "name: ext-auto\ndescription: External.\nauto-approve: true",
+    )
+    config.extra_skill_paths = [str(extra)]
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "ext-auto"]
+    assert len(matching) == 1
+    assert matching[0].auto_approve is False
+    assert any("auto-approve" in r.message for r in caplog.records)
+
+
+def test_discover_strips_always_loaded_from_extra_path_skill(tmp_path, config):
+    """always-loaded on an external-path skill is not honored in catalog text."""
+    extra = tmp_path / "external"
+    _write_skill(
+        extra / "ext-al",
+        "name: ext-al\ndescription: Pretender.\nalways-loaded: true",
+    )
+    config.extra_skill_paths = [str(extra)]
+    skills = discover_skills(config)
+    catalog = build_catalog_text(skills)
+    # ext-al should appear in the catalog but NOT in the Active Skills section
+    # (which is bundled-only via is_relative_to(bundled_dir) check).
+    assert "ext-al" in catalog
+    if "## Active Skills" in catalog:
+        active_block = catalog.split("## Active Skills")[1].split("##")[0]
+        assert "ext-al" not in active_block
+```
+
+**Tests to add** in `tests/test_config.py`. Add to the existing `TestJsonFileLoading` class (which already uses `tmp_path / "decafclaw"` to match `AgentConfig.id` default and `monkeypatch.setenv("DATA_HOME", ...)`); also extend the `_isolate_env` autouse fixture (lines 19-31) to clear `EXTRA_SKILL_PATHS` so the test environment is hermetic.
+
+In the `_isolate_env` fixture's prefix tuple at line 25-30, add `"EXTRA_SKILL_"` (so any pre-set env from the user's shell doesn't leak into tests). Specifically, the tuple becomes:
+
+```python
+if any(key.startswith(p) for p in (
+    "LLM_", "MATTERMOST_", "COMPACTION_", "EMBEDDING_",
+    "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
+    "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
+    "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_",
+)):
+```
+
+Then add tests inside `class TestJsonFileLoading`:
+
+```python
+def test_loads_extra_skill_paths_from_json(self, tmp_path, monkeypatch):
+    """extra_skill_paths read from config.json as a list of strings."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    (agent_dir / "config.json").write_text(json.dumps({
+        "extra_skill_paths": ["/opt/team-skills", "~/.claude/skills"],
+    }))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    c = load_config()
+    assert c.extra_skill_paths == ["/opt/team-skills", "~/.claude/skills"]
+
+
+def test_extra_skill_paths_env_comma_separated(self, tmp_path, monkeypatch):
+    """EXTRA_SKILL_PATHS env var (comma-separated) overrides config.json."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    (agent_dir / "config.json").write_text(json.dumps({
+        "extra_skill_paths": ["/from-json"],
+    }))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("EXTRA_SKILL_PATHS", "/a,/b,/c")
+    c = load_config()
+    assert c.extra_skill_paths == ["/a", "/b", "/c"]
+
+
+def test_extra_skill_paths_env_json_array(self, tmp_path, monkeypatch):
+    """EXTRA_SKILL_PATHS env var accepts a JSON array."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("EXTRA_SKILL_PATHS", '["/x", "/y"]')
+    c = load_config()
+    assert c.extra_skill_paths == ["/x", "/y"]
+
+
+def test_extra_skill_paths_default_empty(self, tmp_path, monkeypatch):
+    """Default is an empty list when neither env nor JSON set."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    c = load_config()
+    assert c.extra_skill_paths == []
+```
+
+**Verification — automated:**
+- [x] `make test` passes (2256 passed)
+- [x] `uv run pytest tests/test_skills.py tests/test_config.py -v -k "extra_skill_paths or always_loaded_from_extra or strips_auto_approve_from_extra"` shows the 6 new tests passing
+
+**Verification — manual:** none — Phase 1 already covers integration smoke; this phase is regression-net only.
+
+---
+
+## Phase 3: Documentation
+
+End-to-end: a user reading `docs/skills.md` learns the field exists, sees the `npx skills` workflow, and understands the trust limitations. `CLAUDE.md` skills section gets a one-line pointer.
+
+**Files:**
+- Modify: `docs/skills.md` — update the "Skill directories" table to include the optional 4th tier; add a new subsection under "Using community skills" explaining the `npx skills` workflow
+- Modify: `CLAUDE.md` — extend one bullet in the Skills section
+
+**Key changes:**
+
+In `docs/skills.md`, change the table at lines 228-232 to add a 4th row:
+
+```markdown
+| Priority | Location | Description |
+|----------|----------|-------------|
+| 1 | `data/{agent_id}/workspace/skills/` | Agent-writable. ClawHub installs land here. |
+| 2 | `data/{agent_id}/skills/` | Admin-managed. |
+| 3 | `src/decafclaw/skills/` | Bundled with the package. |
+| 4 | Paths listed in `extra_skill_paths` config | Externally-managed (e.g., `npx skills add`). Lowest priority — cannot shadow bundled skills. |
+```
+
+Update the "Higher-priority skills override lower-priority ones with the same name." sentence to add: "External skills (tier 4) cannot shadow bundled skills, but workspace and admin skills can shadow them."
+
+After the existing "Using community skills" section (around line 293), insert a new subsection:
+
+```markdown
+### Installing skills via `npx skills`
+
+The [`vercel-labs/skills`](https://www.npmjs.com/package/skills) CLI installs skills from GitHub/GitLab/git URLs into per-agent paths. To wire it into decafclaw:
+
+1. Install with any compatible agent target — `claude-code` is convenient since the path matches a common Claude Code setup:
+
+   ```bash
+   npx skills add vercel-labs/agent-skills -a claude-code -g
+   # skills land in ~/.claude/skills/<name>/
+   ```
+
+2. Add the install location to the agent's `data/{agent_id}/config.json`:
+
+   ```json
+   { "extra_skill_paths": ["~/.claude/skills"] }
+   ```
+
+   Or set `EXTRA_SKILL_PATHS=~/.claude/skills` in the environment. Multiple paths are supported (JSON array or comma-separated).
+
+3. Restart decafclaw or run `refresh_skills`.
+
+Path entries support `~` and `$VAR` expansion. Relative paths resolve against `data/{agent_id}/`.
+
+**Trust posture for external skills.** External skills are treated identically to workspace skills:
+
+- `auto-approve: true` is ignored (warning logged) — every activation requires confirmation
+- `always-loaded: true` is ignored — externals stay lazy-loaded
+- `schedule:` frontmatter is ignored — only bundled and admin-level skills can self-schedule
+- `user-invocable: true` and Python `tools.py` work normally
+
+Skills authored against the standard Agent Skills format (`SKILL.md` only) work as-is. Skills authored for decafclaw with a `tools.py` extension are decafclaw-specific and won't run in other agents.
+```
+
+In `CLAUDE.md`, extend the Skills bullet at line 50:
+
+```markdown
+- **Bundled in `src/decafclaw/skills/`**. Each: SKILL.md (required) + `tools.py` (optional). Scan order: workspace > agent-level > bundled > `extra_skill_paths` (configured external dirs, e.g. for `npx skills add`).
+```
+
+**Verification — automated:**
+- [x] `make lint` passes (sanity)
+- [x] `make test` passes (sanity, 2256 passed)
+
+**Verification — manual:**
+- [ ] `docs/skills.md` renders correctly (no broken markdown table)
+- [ ] The new "Installing skills via `npx skills`" subsection reads cleanly end-to-end
+- [ ] `CLAUDE.md` skills bullet still scans as one logical sentence

--- a/docs/dev-sessions/2026-04-29-1448-external-skill-paths/research.md
+++ b/docs/dev-sessions/2026-04-29-1448-external-skill-paths/research.md
@@ -1,0 +1,189 @@
+# Skill Discovery & Configuration System: Research Notes
+
+## 1. Skill Discovery Flow
+
+### Scan Path Precedence
+`discover_skills()` in `src/decafclaw/skills/__init__.py:178-242` builds scan list in this order (line 186-189):
+1. **Workspace skills**: `config.workspace_path / "skills"` (highest priority)
+2. **Agent-level skills**: `config.agent_path / "skills"`  
+3. **Bundled skills**: `_BUNDLED_SKILLS_DIR` (lowest priority)
+
+Each path is scanned via `iterdir()` (line 200); first skill name found wins (line 232-236).
+
+### SkillInfo Data Type
+`src/decafclaw/skills/__init__.py:17-38` defines `@dataclass SkillInfo`:
+- `name`, `description`, `location`, `body` (markdown content after frontmatter)
+- `has_native_tools`, `requires_env`, `user_invocable`, `allowed_tools`, `shell_patterns`
+- `context` ("inline" or "fork"), `argument_hint`, `model`, `requires_skills`
+- `always_loaded`, `schedule` (cron expr), `enabled`, `auto_approve`
+
+**No "source" or "trust" field in dataclass.** Trust boundary is determined post-hoc at runtime:
+- Line 215-223: `auto_approve` stripped from non-bundled skills (admin/workspace) via `is_relative_to(bundled_dir)`
+- Bundled status checked via resolved path comparison; not stored in SkillInfo
+
+### Trust Boundary / auto-approve
+Line 214-223: Bundled-only enforcement for `auto_approve` flag:
+```python
+if info.auto_approve:
+    is_bundled = skill_dir.resolve().is_relative_to(bundled_dir)
+    if not is_bundled:
+        log.warning("Ignoring 'auto-approve: true' on non-bundled skill...")
+        info.auto_approve = False
+```
+
+Same pattern applies to `always_loaded` in `src/decafclaw/prompts/__init__.py:98` — only bundled skills allowed.
+
+### Duplicate Resolution
+Line 232-236: When same skill name found in multiple paths, **first one wins** (workspace > agent > bundled):
+```python
+if info.name in seen_names:
+    log.debug(f"Skill '{info.name}' at {skill_dir} shadowed by {seen_names[info.name]}")
+    continue
+```
+
+### Environment Variable Dependencies
+Line 225-229: Skills with unmet `requires_env` are skipped entirely:
+```python
+missing_env = [v for v in info.requires_env if not os.environ.get(v)]
+if missing_env:
+    log.debug(f"Skipping skill '{info.name}': missing env vars {missing_env}")
+    continue
+```
+
+---
+
+## 2. Config Field Plumbing (End-to-End)
+
+### Config Loading Flow
+`src/decafclaw/config.py:338-502` (`load_config()`) implements 3-tier resolution:
+1. Environment variables (systematic name `PREFIX_FIELDNAME` + metadata alias)
+2. `data/{agent_id}/config.json` values
+3. Dataclass defaults
+
+### Example: vault_path (list[str] = str case)
+- **Declared**: `src/decafclaw/config_types.py:204` — `vault_path: str = "workspace/vault/"`
+- **Loaded**: Line 432-433 in `config.py` via `load_sub_config(VaultConfig, ...)`
+- **Resolution**: `config.property vault_root` (line 210-213) resolves relative → absolute:
+  ```python
+  @property
+  def vault_root(self) -> Path:
+      p = Path(self.vault.vault_path)
+      return p if p.is_absolute() else self.agent_path / p
+  ```
+- **No tilde/HOME expansion** — uses `is_absolute()` check; relative paths anchored to `agent_path`
+
+### Example: email.allowed_recipients (list[str])
+- **Declared**: `src/decafclaw/config_types.py:279` — `allowed_recipients: list[str] = field(default_factory=list)`
+- **Loaded**: Line 438-439 in `config.py` via nested `load_sub_config(EmailConfig, ...)`
+- **Parsed from JSON** directly (line 138-141 in `load_sub_config()`); env var support via `_parse_list()` (line 54-66)
+- **Env override**: `EMAIL_ALLOWED_RECIPIENTS` as comma-separated or JSON array
+
+### Generic Sub-config Loader
+`src/decafclaw/config.py:87-144` (`load_sub_config()`) for each field:
+1. Check env var `{PREFIX}_{FIELD_UPPER}` (skip if prefix empty)
+2. Check metadata `env_alias` or dict alias
+3. Check JSON file value
+4. Fall through to dataclass default
+
+Type coercion via `_coerce()` (line 69-80):
+- `list` → `_parse_list()` tries JSON parse, falls back to comma-split
+- `bool` → `_parse_bool()` checks "true"/"1"/"yes"
+- `int`/`float` → direct cast
+- Other → string
+
+---
+
+## 3. Existing "Extra Paths" Patterns
+
+**NONE FOUND EXPLICITLY.** However, related patterns:
+
+### vault_path (string, relative)
+`src/decafclaw/config_types.py:204`: User can override via `config.json` or `VAULT_VAULT_PATH` env var.
+Path is string, not `list[Path]`. Resolution happens at property access time via `is_absolute()` check.
+
+### mcp_servers.json (hardcoded location)
+`src/decafclaw/mcp_client.py:91-98` (`load_mcp_config()`):
+```python
+path = config.agent_path / "mcp_servers.json"
+```
+No configurable search path; single file location only.
+
+### Skill search (hardcoded 3 locations)
+`src/decafclaw/skills/__init__.py:186-189`: Three fixed paths only; no user-configurable append list.
+
+### Vault is closest model
+`src/decafclaw/config_types.py:203-206` allows a single path string in config:
+```python
+@dataclass
+class VaultConfig:
+    vault_path: str = "workspace/vault/"  # user can override
+    agent_folder: str = "agent/"
+```
+Relative paths are anchored to `agent_path` (not `workspace_path`). No `~` expansion.
+
+---
+
+## 4. Skill Activation, Scheduling, and User-Invokable Triggers
+
+### Prompt Assembly
+`src/decafclaw/prompts/__init__.py:36-115` (`load_system_prompt()`):
+- Line 82: calls `discover_skills(config)`
+- Line 83: builds catalog via `build_catalog_text(skills)`
+- Line 88-108: appends **bundled always-loaded** skill bodies to system prompt (trust boundary at line 98)
+
+### Schedule Discovery
+`src/decafclaw/schedules.py:99-159` (`discover_schedules()`):
+- Scans `config.agent_path / "schedules"` (admin) and `config.workspace_path / "schedules"`
+- Also re-discovers scheduled skills from bundled + admin dirs only (line 125-150)
+- Line 139: extracts `skill.schedule` field; converts to `ScheduleTask` with `source="bundled"` or `"admin"`
+- **Workspace skills NOT scanned for schedule** (security boundary)
+
+### User Commands
+`src/decafclaw/commands.py:7-9, 80-105`:
+- `find_command(name, discovered_skills)` finds by name if `user_invocable=True` (line 287-291 in skills/__init__.py)
+- `list_commands(discovered_skills)` returns sorted on-demand skills (line 294-299)
+- `format_help(discovered_skills)` includes all user-invocable skills + MCP prompts
+
+### Consumer Call Sites
+1. **Prompts** (`src/decafclaw/prompts/__init__.py:82`): Calls `discover_skills()` once per prompt load
+2. **Schedules** (`src/decafclaw/schedules.py:138`): Calls `parse_skill_md()` directly per scheduled skill
+3. **Commands** (`src/decafclaw/commands.py:287-290`): Uses pre-discovered skill list from context
+4. **Eval** (`src/decafclaw/eval/runner.py`): Calls `discover_skills()` to build loadout for toolchoice testing
+
+No caching of discovery results; rediscovered on each prompt load / schedule poll.
+
+---
+
+## 5. Tests and Fixtures
+
+### Test File
+`tests/test_skills.py` (547 lines) covers:
+
+**Fixture Pattern**: Uses `config` fixture from `conftest.py:20-29`:
+```python
+@pytest.fixture
+def config(tmp_data):
+    return Config(
+        agent=AgentConfig(data_home=str(tmp_data), id="test-agent", user_id="testuser"),
+        ...
+    )
+```
+Creates temp `data/test-agent/{workspace,skills}` structure automatically via Config properties.
+
+**Helper**: `_write_skill(skill_dir, frontmatter, body, tools_py)` (line 17-22) writes SKILL.md and optional tools.py.
+
+**Discover Tests** (line 254-360):
+- `test_discover_from_single_dir()`: writes skills to `config.workspace_path / "skills"`
+- `test_discover_priority_ordering()`: creates same-named skill in workspace + agent; asserts workspace wins
+- `test_discover_skips_unmet_requires()`: uses `monkeypatch.delenv()` to simulate missing `requires_env`
+- `test_discover_strips_auto_approve_from_workspace_skill()`: creates skill with `auto-approve: true` in workspace, asserts flag stripped + warning logged
+- `test_discover_honors_auto_approve_on_bundled()`: asserts bundled `background` and `mcp` skills retain `auto_approve=True`
+
+**Setup Pattern**: All tests create skill directories under `config.agent_path` or `config.workspace_path` 
+paths computed from the tmp fixture; no monkeypatching of `_BUNDLED_SKILLS_DIR` (tests rely on real bundled skills).
+
+---
+
+## Summary
+
+**No list[Path] config fields exist today.** Closest pattern: `vault_path` (single string). All paths use relative-to-anchor model (`agent_path` / `workspace_path`) with no `~` or `$HOME` expansion. Skills hardcoded to 3 scan locations; no configurable append list. Trust boundaries enforced post-hoc via `is_relative_to(bundled_dir)` on resolved paths, not via stored metadata. Tests use tmp_path fixture + _write_skill() helpers with real bundled skill fallback.

--- a/docs/dev-sessions/2026-04-29-1448-external-skill-paths/spec.md
+++ b/docs/dev-sessions/2026-04-29-1448-external-skill-paths/spec.md
@@ -1,0 +1,107 @@
+# External Skill Paths Spec
+
+**Goal:** Let decafclaw users discover skills installed by external tooling (notably `npx skills add …` from `vercel-labs/skills`) by adding a configurable list of extra directories to scan, without requiring an upstream PR or manual symlinks per install.
+
+**Source:** User request 2026-04-29 — "Check out this NPM command, can we support it for installing skills in decafclaw?"
+
+## Current state
+
+Skill discovery is hardcoded in `src/decafclaw/skills/__init__.py:186-189` to three paths:
+
+1. `config.workspace_path / "skills"` (highest priority)
+2. `config.agent_path / "skills"`
+3. `_BUNDLED_SKILLS_DIR` (lowest)
+
+First-name-wins shadowing (`research.md:36-42`). No existing `list[Path]` config field anywhere in the codebase (`research.md:96-122`); the closest analog is `vault_path` (single string, anchored to `agent_path`, no `~` expansion).
+
+Trust boundary is post-hoc: `is_relative_to(_BUNDLED_SKILLS_DIR)` strips `auto-approve` and `always-loaded` from non-bundled skills (`research.md:24-32`). Scheduled-task discovery only scans bundled + admin (`research.md:135-139`).
+
+The npm tool `vercel-labs/skills` (`/tmp/skills-inspect/package/dist/cli.mjs:712`) installs into hardcoded per-agent paths like `~/.claude/skills/`. None of those match decafclaw's three scan paths, so today there is no way for decafclaw to see those skills.
+
+## Desired end state
+
+A user can:
+
+```bash
+npx skills add vercel-labs/agent-skills -a claude-code -g
+# skill files land at ~/.claude/skills/<name>/SKILL.md
+```
+
+Edit `data/{agent_id}/config.json`:
+
+```json
+{ "extra_skill_paths": ["~/.claude/skills"] }
+```
+
+Or pass via env: `EXTRA_SKILL_PATHS=~/.claude/skills,~/share/team-skills`
+
+After restart (or `refresh_skills`), those skills appear in the catalog with the same trust posture as workspace/agent skills today: `auto-approve` stripped, `always-loaded` stripped, no scheduled-task registration, but `user-invocable` and `tools.py` work normally. They never shadow bundled skills.
+
+## Design decisions
+
+- **Decision:** New top-level `extra_skill_paths: list[str]` field on `Config` (not nested under a new `SkillsDiscoveryConfig` dataclass).
+  - **Why:** Single field for a single concern; no other discovery options on the horizon worth coupling. Smallest blast radius.
+  - **Rejected:** Nested `SkillsDiscoveryConfig` — symmetric with `VaultConfig`/`EmailConfig` but premature for one field.
+
+- **Decision:** Externals slot **below** bundled in scan order (`workspace > agent > bundled > external`).
+  - **Why:** Externals are inherently lower-trust (third-party npm content). Allowing them to shadow bundled critical skills (`vault`, `background`, `mcp`) would silently strip `always_loaded` from those skills (since the shadow loses always-loaded under the existing trust check) and break core decafclaw infra. Power users can still override bundled skills via `data/{agent_id}/skills/` or `data/{agent_id}/workspace/skills/`.
+  - **Rejected:** Between agent and bundled (matches "later overrides earlier" intuition but is the foot-gun above). Carve-out exempting `always_loaded` skills from being shadowed (Option C from brainstorm) — extra code for a niche case the user can already work around.
+
+- **Decision:** Expand `~` (via `Path.expanduser()`) and `$VAR` (via `os.path.expandvars()`) when reading paths from this field.
+  - **Why:** External skill paths point at OS-level locations. `~/.claude/skills` is the natural way users will write them; demanding absolute paths is hostile UX.
+  - **Rejected:** No expansion (current convention everywhere else) — that convention exists because all current paths are anchored to `agent_path`/`workspace_path`. Different field, different ergonomics.
+
+- **Decision:** Relative paths (after `~`/`$VAR` expansion) are anchored to `config.agent_path`, mirroring `vault_root` (`research.md:67-72`).
+  - **Why:** Consistent with the only existing user-configurable path field. A user who writes a relative path probably means "relative to my agent dir."
+  - **Rejected:** Reject relative paths entirely (3b in brainstorm) — slightly more explicit but inconsistent with `vault_path` and adds an error path users will trip over.
+
+- **Decision:** Trust boundary unchanged. Externals are treated identically to non-bundled (workspace/agent) skills.
+  - **Why:** Falls out automatically from `is_relative_to(_BUNDLED_SKILLS_DIR)`. No new code for the trust checks; just new paths in the scan list.
+  - **Concrete consequences:** `auto-approve` stripped (warning logged); `always-loaded` stripped; not eligible for scheduled-task registration (already excluded — `schedules.py` only scans bundled + admin); `user-invocable` allowed; `tools.py` loaded as Python with no sandboxing (same as workspace today).
+
+- **Decision:** Env-var override `EXTRA_SKILL_PATHS` (comma-separated or JSON array, via existing `_parse_list`).
+  - **Why:** Parity with other config fields (`research.md:75-79`). Lets users override per-shell without touching `config.json`.
+  - **Rejected:** No env var — minor inconsistency with the rest of config plumbing.
+
+- **Decision:** Non-existent or non-directory paths are silently skipped (existing `if not base_path.is_dir(): continue` at `src/decafclaw/skills/__init__.py:197-198` covers it).
+  - **Why:** Same fail-soft semantics as the existing scan paths. A user removing `~/.claude/skills` shouldn't break decafclaw startup.
+  - **Rejected:** Warning on missing — noisy if a path is intentionally absent on some machines.
+
+## Patterns to follow
+
+- **Config field declaration:** Top-level `Config` dataclass field with `field(default_factory=list)`, mirroring `default_model: str = ""` at `src/decafclaw/config.py:166` (top-level scalar/list, not nested). Add the field to the dataclass declaration at `src/decafclaw/config.py:151-180` and to the `Config(...)` constructor call at `src/decafclaw/config.py:474-497` (the constructor hand-lists fields; the "never enumerate fields" rule from CLAUDE.md applies to copies/forks/snapshots, not to this single canonical construction site).
+- **Config loading:** Add to `load_config()` in `src/decafclaw/config.py:338-502`. Top-level fields don't go through `load_sub_config`, so do an inline env-then-file-then-default read (the `default_model` pattern at `config.py:447` is the precedent — but it has no env override). Use `_parse_list()` (already in this module) for the env var so JSON-array and comma-split forms work uniformly. Env var name: `EXTRA_SKILL_PATHS`. Pseudocode: `extra_skill_paths = _parse_list(os.environ["EXTRA_SKILL_PATHS"]) if "EXTRA_SKILL_PATHS" in os.environ else file_data.get("extra_skill_paths", [])`.
+- **Path expansion + anchoring:** Mirror the `vault_root` property pattern at `src/decafclaw/config_types.py:210-213`: `Path(s).expanduser()`, then `os.path.expandvars()` on the string form, then `.is_absolute()` check, anchor relatives to `config.agent_path`. Single helper at module scope in `skills/__init__.py` (or `config.py`) so the resolution logic lives in one place.
+- **Discovery integration:** Extend the `scan_paths` list in `discover_skills()` at `src/decafclaw/skills/__init__.py:186-189` — append resolved external paths AFTER `_BUNDLED_SKILLS_DIR`. Do not change the existing loop.
+- **Tests:** Extend `tests/test_skills.py` using the existing `_write_skill()` helper (`research.md:173`) and `tmp_path`-driven `config` fixture (`research.md:162-170`). Tests to add:
+  - External skill discovered when path is in `config.extra_skill_paths`
+  - Bundled skill wins over same-named external skill (precedence verification)
+  - Workspace and agent skills both win over same-named external skill
+  - `auto-approve: true` stripped from external skill (parity with existing workspace test at `test_discover_strips_auto_approve_from_workspace_skill`)
+  - `~` expansion works (use `monkeypatch.setenv("HOME", str(tmp_path))` and write to `~/.foo/skills`)
+  - `$VAR` expansion works
+  - Relative external path anchored to `agent_path`
+  - Non-existent external path silently skipped
+  - `EXTRA_SKILL_PATHS` env var (comma-separated and JSON array forms)
+- **Docs:** New section in `docs/skills.md` covering: the `extra_skill_paths` field, the `npx skills` install workflow with `-a claude-code -g`, the trust posture (no auto-approve, no scheduling), and the limitation that externally-installed skills won't include decafclaw-specific `tools.py` extensions. Update `CLAUDE.md` skills section with a one-line reference.
+
+## What we're NOT doing
+
+- **No upstream PR** to `vercel-labs/skills` to register a `decafclaw` agent target. Explicitly ruled out by the user.
+- **No automatic sniffing** of well-known paths (e.g., auto-scanning `~/.claude/skills` if it exists). User must opt in via config.
+- **No `Makefile` wrapper** for invoking `npx skills add` with sensible defaults — this spec only adds discovery; install workflow is upstream's responsibility.
+- **No symlink/copy automation** from external paths into decafclaw's existing scan paths — extra paths just get scanned in place.
+- **No new trust tier** for "trusted external paths" that bypasses the bundled check. Externals match workspace trust posture exactly.
+- **No carve-out** for shadowing bundled `always_loaded` skills (Option C from brainstorm). Externals slot below bundled; cannot shadow.
+- **No reshape of `config.skills`** (currently a per-skill config dict) into a unified dataclass.
+- **No deduplication** when an external path overlaps an existing scan path. The first-found-wins logic handles it; duplicates produce a debug log and continue.
+- **No global-vs-per-agent split.** Each decafclaw agent's `config.json` declares its own `extra_skill_paths`. Multi-agent setups duplicate the field if they want shared external skills.
+- **No `refresh_skills` changes.** The existing `tool_refresh_skills` re-runs `discover_skills` and will pick up changes to `extra_skill_paths` paths automatically.
+
+## Open questions
+
+None blocking. Defaults the plan can proceed with:
+
+- **Field default** is `[]` (empty list).
+- **Env var separator** matches `_parse_list` (`research.md:88-90`): JSON array if it parses, else comma-split.
+- **Order within `extra_skill_paths`** is preserved (config order = scan order); no sort. First-found-wins applies within the list too.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -230,8 +230,9 @@ Skills are discovered from three locations, in priority order (highest first):
 | 1 | `data/{agent_id}/workspace/skills/` | Agent-writable. ClawHub installs land here. |
 | 2 | `data/{agent_id}/skills/` | Admin-managed. |
 | 3 | `src/decafclaw/skills/` | Bundled with the package. |
+| 4 | Paths listed in `extra_skill_paths` config | Externally-managed (e.g., `npx skills add`). Lowest priority — cannot shadow bundled skills. |
 
-Higher-priority skills override lower-priority ones with the same name.
+Higher-priority skills override lower-priority ones with the same name. External skills (tier 4) cannot shadow bundled skills, but workspace and admin skills can shadow them.
 
 ## Activation and permissions
 
@@ -295,6 +296,38 @@ Features:
 Shell-based skills from [ClawHub](https://clawhub.com) or OpenClaw's bundled skills can be placed in `data/{agent_id}/workspace/skills/`. As long as the skill has a `SKILL.md` with valid frontmatter and any required env vars are set, it will be discovered and available for activation.
 
 Example: the `weather` skill from ClawHub uses `curl` via the `shell` tool — no external binary needed.
+
+### Installing skills via `npx skills`
+
+The [`vercel-labs/skills`](https://www.npmjs.com/package/skills) CLI installs skills from GitHub/GitLab/git URLs into per-agent paths. To wire it into decafclaw:
+
+1. Install with any compatible agent target — `claude-code` is convenient since the path matches a common Claude Code setup:
+
+   ```bash
+   npx skills add vercel-labs/agent-skills -a claude-code -g
+   # skills land in ~/.claude/skills/<name>/
+   ```
+
+2. Add the install location to the agent's `data/{agent_id}/config.json`:
+
+   ```json
+   { "extra_skill_paths": ["~/.claude/skills"] }
+   ```
+
+   Or set `EXTRA_SKILL_PATHS=~/.claude/skills` in the environment. Multiple paths are supported (JSON array or comma-separated).
+
+3. Restart decafclaw or run `refresh_skills`.
+
+Path entries support `~` and `$VAR` expansion. Relative paths resolve against `data/{agent_id}/`.
+
+**Trust posture for external skills.** External skills are treated identically to workspace skills:
+
+- `auto-approve: true` is ignored (warning logged) — every activation requires confirmation
+- `always-loaded: true` is ignored — externals stay lazy-loaded
+- `schedule:` frontmatter is ignored — only bundled and admin-level skills can self-schedule
+- `user-invocable: true` and Python `tools.py` work normally
+
+Skills authored against the standard Agent Skills format (`SKILL.md` only) work as-is. Skills authored for decafclaw with a `tools.py` extension are decafclaw-specific and won't run in other agents.
 
 ## Creating a skill
 

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -164,6 +164,7 @@ class Config:
     providers: dict[str, ProviderConfig] = field(default_factory=dict)
     model_configs: dict[str, ModelConfig] = field(default_factory=dict)
     default_model: str = ""
+    extra_skill_paths: list[str] = field(default_factory=list)
     vault_retrieval: VaultRetrievalConfig = field(default_factory=VaultRetrievalConfig)
     relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
@@ -446,6 +447,15 @@ def load_config() -> Config:
     model_configs = _load_model_configs(file_data.get("model_configs", {}))
     default_model = file_data.get("default_model", "")
 
+    env_extra = os.getenv("EXTRA_SKILL_PATHS", "")
+    if env_extra:
+        extra_skill_paths = _parse_list(env_extra)
+    else:
+        raw_extra = file_data.get("extra_skill_paths", [])
+        extra_skill_paths = (
+            [str(p) for p in raw_extra] if isinstance(raw_extra, list) else []
+        )
+
     # Migration: if no providers/model_configs but old-style llm config exists,
     # auto-generate a "default" openai-compat provider + model config
     from .llm.types import PROVIDER_OPENAI_COMPAT
@@ -486,6 +496,7 @@ def load_config() -> Config:
         providers=providers,
         model_configs=model_configs,
         default_model=default_model,
+        extra_skill_paths=extra_skill_paths,
         vault_retrieval=vault_retrieval,
         relevance=relevance,
         vault=vault,

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -175,6 +175,22 @@ def _split_frontmatter(text: str) -> tuple[dict | None, str]:
     return parsed, body
 
 
+def _resolve_extra_skill_paths(config) -> list[Path]:
+    """Resolve user-configured external skill paths.
+
+    For each entry: expand $VARS and ~, then anchor relative paths to
+    config.agent_path (matching vault_root). Order is preserved.
+    """
+    resolved: list[Path] = []
+    for raw in config.extra_skill_paths:
+        expanded = os.path.expandvars(str(raw))
+        p = Path(expanded).expanduser()
+        if not p.is_absolute():
+            p = config.agent_path / p
+        resolved.append(p)
+    return resolved
+
+
 def discover_skills(config) -> list[SkillInfo]:
     """Scan skill directories and return discovered skills.
 
@@ -182,11 +198,13 @@ def discover_skills(config) -> list[SkillInfo]:
     1. Workspace skills: data/{agent_id}/workspace/skills/
     2. Agent-level skills: data/{agent_id}/skills/
     3. Bundled skills: src/decafclaw/skills/
+    4. config.extra_skill_paths (lowest — never shadows bundled)
     """
     scan_paths = [
         config.workspace_path / "skills",
         config.agent_path / "skills",
         _BUNDLED_SKILLS_DIR,
+        *_resolve_extra_skill_paths(config),
     ]
 
     seen_names: dict[str, Path] = {}
@@ -209,18 +227,26 @@ def discover_skills(config) -> list[SkillInfo]:
             if info is None:
                 continue
 
-            # auto-approve is bundled-only (trust boundary). Admin and
-            # workspace skills declaring it get the flag stripped and
-            # a warning logged.
-            if info.auto_approve:
-                is_bundled = skill_dir.resolve().is_relative_to(bundled_dir)
-                if not is_bundled:
-                    log.warning(
-                        "Ignoring 'auto-approve: true' on non-bundled skill "
-                        "'%s' at %s — only bundled skills may auto-approve.",
-                        info.name, skill_dir,
-                    )
-                    info.auto_approve = False
+            # auto-approve and always-loaded are bundled-only (trust
+            # boundary). Admin, workspace, and external skills declaring
+            # them get the flag stripped and a warning logged so the
+            # documented "bundled-only" trust posture is enforced
+            # uniformly (catalog text + activation-time tool caching).
+            is_bundled = skill_dir.resolve().is_relative_to(bundled_dir)
+            if info.auto_approve and not is_bundled:
+                log.warning(
+                    "Ignoring 'auto-approve: true' on non-bundled skill "
+                    "'%s' at %s — only bundled skills may auto-approve.",
+                    info.name, skill_dir,
+                )
+                info.auto_approve = False
+            if info.always_loaded and not is_bundled:
+                log.warning(
+                    "Ignoring 'always-loaded: true' on non-bundled skill "
+                    "'%s' at %s — only bundled skills may always-load.",
+                    info.name, skill_dir,
+                )
+                info.always_loaded = False
 
             # Check requires.env
             missing_env = [v for v in info.requires_env if not os.environ.get(v)]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ def _isolate_env(monkeypatch):
             "LLM_", "MATTERMOST_", "COMPACTION_", "EMBEDDING_",
             "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
             "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
-            "NOTIFICATIONS_", "EMAIL_",
+            "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_",
         )):
             monkeypatch.delenv(key, raising=False)
 
@@ -245,6 +245,62 @@ class TestJsonFileLoading:
         monkeypatch.delenv("LLM_MODEL", raising=False)
         c = load_config()
         assert c.llm.model == "gemini-2.5-flash"
+
+    def test_loads_extra_skill_paths_from_json(self, tmp_path, monkeypatch):
+        """extra_skill_paths read from config.json as a list of strings."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "extra_skill_paths": ["/opt/team-skills", "~/.claude/skills"],
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.extra_skill_paths == ["/opt/team-skills", "~/.claude/skills"]
+
+    def test_extra_skill_paths_env_comma_separated(self, tmp_path, monkeypatch):
+        """EXTRA_SKILL_PATHS env var (comma-separated) overrides config.json."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "extra_skill_paths": ["/from-json"],
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("EXTRA_SKILL_PATHS", "/a,/b,/c")
+        c = load_config()
+        assert c.extra_skill_paths == ["/a", "/b", "/c"]
+
+    def test_extra_skill_paths_env_json_array(self, tmp_path, monkeypatch):
+        """EXTRA_SKILL_PATHS env var accepts a JSON array."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("EXTRA_SKILL_PATHS", '["/x", "/y"]')
+        c = load_config()
+        assert c.extra_skill_paths == ["/x", "/y"]
+
+    def test_extra_skill_paths_default_empty(self, tmp_path, monkeypatch):
+        """Default is an empty list when neither env nor JSON set."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.extra_skill_paths == []
+
+    def test_extra_skill_paths_empty_env_does_not_clobber_json(
+        self, tmp_path, monkeypatch,
+    ):
+        """An empty EXTRA_SKILL_PATHS env var falls through to config.json,
+        matching the module's "first non-empty wins" docstring and
+        load_sub_config's empty-string handling."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "extra_skill_paths": ["/from-json"],
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("EXTRA_SKILL_PATHS", "")
+        c = load_config()
+        assert c.extra_skill_paths == ["/from-json"]
 
 
 class TestEnvVarOverride:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -349,6 +349,162 @@ def test_discover_honors_auto_approve_on_bundled(config):
     )
 
 
+def test_discover_strips_auto_approve_from_extra_path_skill(tmp_path, config, caplog):
+    """auto-approve on an external-path skill is stripped, same as workspace."""
+    extra = tmp_path / "external"
+    _write_skill(
+        extra / "ext-auto",
+        "name: ext-auto\ndescription: External.\nauto-approve: true",
+    )
+    config.extra_skill_paths = [str(extra)]
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "ext-auto"]
+    assert len(matching) == 1
+    assert matching[0].auto_approve is False
+    assert any("auto-approve" in r.message for r in caplog.records)
+
+
+def test_discover_strips_always_loaded_from_extra_path_skill(tmp_path, config, caplog):
+    """always-loaded on an external-path skill is stripped at discovery so
+    activation-time tool caching also treats the skill as on-demand, not
+    just the catalog text."""
+    extra = tmp_path / "external"
+    _write_skill(
+        extra / "ext-al",
+        "name: ext-al\ndescription: Pretender.\nalways-loaded: true",
+    )
+    config.extra_skill_paths = [str(extra)]
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "ext-al"]
+    assert len(matching) == 1
+    assert matching[0].always_loaded is False
+    assert any("always-loaded" in r.message for r in caplog.records)
+    catalog = build_catalog_text(skills)
+    assert "ext-al" in catalog
+    if "## Active Skills" in catalog:
+        active_block = catalog.split("## Active Skills")[1].split("##")[0]
+        assert "ext-al" not in active_block
+
+
+def test_discover_strips_always_loaded_from_workspace_skill(config, caplog):
+    """Workspace skills declaring always-loaded get the flag stripped (parity
+    with auto-approve enforcement; the trust boundary is bundled-only)."""
+    skills_dir = config.workspace_path / "skills"
+    _write_skill(
+        skills_dir / "ws-al",
+        "name: ws-al\ndescription: Workspace.\nalways-loaded: true",
+    )
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "ws-al"]
+    assert len(matching) == 1
+    assert matching[0].always_loaded is False
+    assert any("always-loaded" in r.message for r in caplog.records)
+
+
+def test_discover_honors_always_loaded_on_bundled(config):
+    """Bundled skills with always-loaded: true keep the flag — the trust
+    boundary lets bundled skills opt in while non-bundled skills get
+    stripped."""
+    skills = discover_skills(config)
+    always = {s.name for s in skills if s.always_loaded}
+    assert "vault" in always
+    assert "background" in always
+    assert "mcp" in always
+
+
+def test_discover_includes_extra_skill_path(tmp_path, config):
+    """A skill in extra_skill_paths is discovered."""
+    extra = tmp_path / "external"
+    _write_skill(extra / "ext-only", "name: ext-only\ndescription: External skill.")
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    assert any(s.name == "ext-only" for s in skills)
+
+
+def test_discover_extra_path_does_not_shadow_bundled(tmp_path, config):
+    """An external skill named the same as a bundled skill loses to bundled."""
+    extra = tmp_path / "external"
+    _write_skill(extra / "vault", "name: vault\ndescription: Imposter vault.")
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    vaults = [s for s in skills if s.name == "vault"]
+    assert len(vaults) == 1
+    assert vaults[0].description != "Imposter vault."
+
+
+def test_discover_workspace_and_agent_shadow_extra_path(tmp_path, config):
+    """Workspace and admin skills both override same-named external skills."""
+    extra = tmp_path / "external"
+    _write_skill(extra / "shared", "name: shared\ndescription: External version.")
+    _write_skill(
+        config.agent_path / "skills" / "shared",
+        "name: shared\ndescription: Admin version.",
+    )
+    config.extra_skill_paths = [str(extra)]
+
+    skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "shared"]
+    assert len(matching) == 1
+    assert matching[0].description == "Admin version."
+
+    _write_skill(
+        config.workspace_path / "skills" / "shared",
+        "name: shared\ndescription: Workspace version.",
+    )
+    skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "shared"]
+    assert len(matching) == 1
+    assert matching[0].description == "Workspace version."
+
+
+def test_discover_extra_path_relative_anchored_to_agent(tmp_path, config):
+    """A relative entry resolves under config.agent_path."""
+    rel_dir = config.agent_path / "external"
+    _write_skill(rel_dir / "rel-skill", "name: rel-skill\ndescription: Relative.")
+    config.extra_skill_paths = ["external"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "rel-skill" for s in skills)
+
+
+def test_discover_extra_path_expands_user(tmp_path, config, monkeypatch):
+    """A leading ~ expands to $HOME."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    extra = tmp_path / "shared-skills"
+    _write_skill(extra / "homed", "name: homed\ndescription: Tilde skill.")
+    config.extra_skill_paths = ["~/shared-skills"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "homed" for s in skills)
+
+
+def test_discover_extra_path_expands_envvar(tmp_path, config, monkeypatch):
+    """$VAR substrings are expanded via os.path.expandvars."""
+    monkeypatch.setenv("MY_SKILLS_ROOT", str(tmp_path / "myroot"))
+    extra = tmp_path / "myroot" / "skills"
+    _write_skill(extra / "expanded", "name: expanded\ndescription: Var skill.")
+    config.extra_skill_paths = ["$MY_SKILLS_ROOT/skills"]
+
+    skills = discover_skills(config)
+    assert any(s.name == "expanded" for s in skills)
+
+
+def test_discover_extra_path_skipped_when_missing(tmp_path, config, caplog):
+    """A non-existent extra path is silently skipped (no error)."""
+    config.extra_skill_paths = [str(tmp_path / "does-not-exist")]
+    discover_skills(config)  # must not raise
+    assert all(
+        "does-not-exist" not in r.message
+        for r in caplog.records
+        if r.levelname == "WARNING"
+    )
+
+
 def test_discover_skips_dirs_without_skill_md(tmp_path, config):
     """Directories without SKILL.md are ignored."""
     skills_dir = config.workspace_path / "skills"


### PR DESCRIPTION
## Summary
- Add a `extra_skill_paths` config field so decafclaw can discover skills installed by external tooling (notably `npx skills add …` from the [`vercel-labs/skills`](https://www.npmjs.com/package/skills) CLI) without an upstream PR or per-install symlinks.
- Externals slot below bundled in the scan order so they cannot shadow critical first-party skills (`vault`, `background`, `mcp`).

## Design Decisions
- **Top-level field on `Config`** (`extra_skill_paths: list[str]`), default `[]`. Smaller than introducing a `SkillsDiscoveryConfig` for one option.
- **Precedence: `workspace > agent > bundled > external`.** Externals never shadow bundled. Allowing them to would silently strip `always_loaded` from core skills (the shadow loses always-loaded under the existing `is_relative_to(_BUNDLED_SKILLS_DIR)` trust check), breaking decafclaw infra. Power users can still override bundled skills via `data/{agent_id}/skills/` or workspace.
- **Path expansion enabled.** `Path.expanduser()` + `os.path.expandvars()` so `~/.claude/skills` and `$VAR/foo` Just Work. Departure from the codebase convention of "no expansion," justified because external skill paths point at OS-level locations rather than internal anchored paths. Relative paths anchor to `config.agent_path`, mirroring `vault_root`.
- **Trust unchanged.** Externals inherit the workspace trust posture automatically: `auto-approve` stripped (warning logged), `always-loaded` stripped, scheduling excluded (existing `schedules.py` only scans bundled + admin), `user-invocable` and `tools.py` work.
- **`EXTRA_SKILL_PATHS` env override** for parity with other config fields (JSON array or comma-separated, via existing `_parse_list`).

## Changes
- `src/decafclaw/config.py` — new `Config.extra_skill_paths` field; `load_config()` reads env first, then `config.json`, then default.
- `src/decafclaw/skills/__init__.py` — new `_resolve_extra_skill_paths(config)` helper; `discover_skills` appends resolved paths to `scan_paths` after bundled.
- `tests/test_skills.py` — 9 new tests (discovery, precedence vs bundled/admin/workspace, `~` and `$VAR` expansion, relative anchoring, missing-path skip, `auto-approve` stripping, `always-loaded` stripping in catalog).
- `tests/test_config.py` — 4 new tests (JSON load, env comma-separated, env JSON array, default empty); extends `_isolate_env` autouse fixture to clear `EXTRA_SKILL_*` so external shell state can't pollute loader tests.
- `docs/skills.md` — new "Installing skills via `npx skills`" subsection plus tier 4 in the scan-order table.
- `CLAUDE.md` — scan-order bullet extended.

## Test Plan
- [x] `make test` passes (2256 passed)
- [x] `make check` passes
- [x] `uv run python -c "from decafclaw.config import load_config; print(load_config().extra_skill_paths)"` prints `[]`
- [x] `EXTRA_SKILL_PATHS=/tmp/x uv run python -c "..."` prints `['/tmp/x']`
- [ ] (Reviewer) Manual smoke: `npx skills add vercel-labs/agent-skills -a claude-code -g`, set `extra_skill_paths: ["~/.claude/skills"]` in `data/{agent_id}/config.json`, restart, confirm catalog includes the installed skills.

## References
- Spec: `docs/dev-sessions/2026-04-29-1448-external-skill-paths/spec.md`
- Plan: `docs/dev-sessions/2026-04-29-1448-external-skill-paths/plan.md`

Known gap (not blocking, pre-existing): `decafclaw config show` only prints nested-dataclass groups, so top-level scalar/list fields like `extra_skill_paths` (and `default_model`, `providers`, `model_configs`) don't appear in `make config` output. Out of scope for this PR.