### PR TITLE
Add text_input widget + ask_user_text tool; rename ask_user (#410)

### DIFF
--- a/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/notes.md
+++ b/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/notes.md
@@ -1,0 +1,25 @@
+# Notes: Widget — text_input
+
+## Session start — 2026-04-29
+
+- Issue: [#410](https://github.com/lmorchard/decafclaw/issues/410) — Widget: text_input — free-form text / multi-field form
+- Branch: `widget-text-input-410`
+- Worktree: `/Users/lorchard/devel/decafclaw/.claude/worktrees/widget-text-input-410`
+- Baseline: `make test` → 2243 passed (green)
+
+## Execute summary
+
+- **Phase 1** (rename): mechanical, all green.
+- **Phase 2** (widget files): `make check-js` initially flagged untyped `seeded` object; fixed with `@type` JSDoc annotation.
+- **Phase 3** (tool): ruff flagged un-sorted imports in the new test file; auto-fixed via `ruff check --fix`.
+- **Phase 4** (docs + eval): all 3 new `ask_user_*` disambiguation cases pass. Pre-existing `workspace-write-vs-canvas-save-blog-post` eval failure is unrelated to this PR (no canvas/workspace_write code touched).
+- Final test count: 2267 (was 2243).
+- Manual verification done via Playwright MCP against a local server on port 18881 (Mattermost dev token coexists with prod, per memory). Single-field, multi-field (`name` + multiline `bio`), renamed `ask_user_multiple_choice`, and page-refresh recovery all worked end-to-end.
+
+## Pre-existing bug found and fixed in this PR
+
+Live-tab `submitted` state didn't flip after submission. In `src/decafclaw/web/static/lib/tool-status-store.js`, `respondToWidget` removed the confirm from `#pendingConfirms` *before* the backend broadcast `CONFIRMATION_RESPONSE`. The `CONFIRMATION_RESPONSE` handler then looked the confirm up by id (`#pendingConfirms.find(...)`) and missed on the submitting tab, so `markToolWidgetSubmitted` never fired locally. Other tabs (which still had the confirm in their pending list) flipped correctly via the broadcast. Refresh-from-archive path always worked.
+
+Bug landed with #366 (the original `multiple_choice` widget). Affected `multiple_choice` and `text_input` equally.
+
+**Fix:** call `markToolWidgetSubmitted(toolCallId, data)` directly in `respondToWidget` right after sending the WS — we already have the data, no reason to wait for the broadcast on the submitting tab. Other tabs continue to use the broadcast path. Verified end-to-end via Playwright: both widgets now flip immediately on submit.

--- a/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/plan.md
+++ b/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/plan.md
@@ -1,0 +1,830 @@
+# Widget: text_input Implementation Plan
+
+**Goal:** Ship the `text_input` widget + `ask_user_text` tool, and rename `ask_user` → `ask_user_multiple_choice` as part of the same PR.
+
+**Approach:** Do the rename first (mechanical, isolates churn). Then add the widget files (front-end + CSS + registry tests). Then add the new tool and its tests. Finish with docs and eval fixtures so the LLM can disambiguate the two `ask_user_*` tools.
+
+**Tech stack:** Python (tools, widget registry), Lit + plain CSS (front-end), `jsonschema` for widget data validation, pytest for tests.
+
+---
+
+## Phase 1: Rename `ask_user` → `ask_user_multiple_choice`
+
+Hard rename of the existing tool, helpers, registry key, tool definition, tests, and docs. No alias. Establishes the `ask_user_*` family naming before the new tool lands.
+
+**Files:**
+
+- Modify: `src/decafclaw/tools/core.py`
+  - Module docstring (line 1) — update reference to `ask_user`.
+  - Rename `_normalize_ask_user_options` → `_normalize_multiple_choice_options` (line 138).
+  - Rename `_ask_user_default_on_response` → `_default_multiple_choice_callback` (line 168). Update docstring on line 170.
+  - Rename `tool_ask_user` → `tool_ask_user_multiple_choice` (line 195). Update log message (line 198), error strings (lines 201, 205–206).
+  - In `CORE_TOOLS` dict (line 313), key `"ask_user": tool_ask_user` → `"ask_user_multiple_choice": tool_ask_user_multiple_choice`.
+  - In `CORE_TOOL_DEFINITIONS` (line 403), update `"name": "ask_user"` → `"ask_user_multiple_choice"`. Tweak first sentence of description to land cleanly: `"Pause the turn and ask the user to pick from a fixed list of options."` (rest unchanged).
+
+- Rename: `tests/test_ask_user.py` → `tests/test_ask_user_multiple_choice.py`. Update imports (lines 6–10) and inline test names where the function is called.
+
+- Modify: `tests/test_reflection.py` — string literals `"ask_user"` → `"ask_user_multiple_choice"` at lines 57, 69, 82, 97, 98 (test fixtures and assertions). Update the comment on line 97.
+
+- Modify: `tests/test_web_widget_response_handler.py` — string literal `"ask_user"` → `"ask_user_multiple_choice"` at line 123.
+
+- Modify: `src/decafclaw/mattermost.py` — comment on line 520: `description for ask_user already discourages` → `description for ask_user_multiple_choice already discourages`.
+
+- Modify: `docs/widgets.md` — section heading `### The ask_user core tool` (line 150) → `### The ask_user_multiple_choice core tool`. Body references at lines 152, 153, 157 updated. Key files reference at line 434 updated.
+
+**Key changes:**
+
+```python
+# tools/core.py — rename signatures only; behavior unchanged.
+def _normalize_multiple_choice_options(options: list) -> list[dict] | None: ...
+def _default_multiple_choice_callback(options: list[dict],
+                                       allow_multiple: bool): ...
+async def tool_ask_user_multiple_choice(ctx, prompt: str, options: list,
+                                        allow_multiple: bool = False) -> ToolResult: ...
+
+CORE_TOOLS = {
+    # ...
+    "ask_user_multiple_choice": tool_ask_user_multiple_choice,
+}
+```
+
+**TDD note:** This is mechanical refactoring (no behavior change). Procedure: rename the test file first, run pytest to watch the import fail, then rename in `core.py`. The `make test` run after is the regression check.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+- [x] `grep` for stale `ask_user` references returns nothing.
+
+**Verification — manual:**
+- [ ] In the running app, the LLM still receives a tool named `ask_user_multiple_choice` and calling it pauses the turn for a user choice (test by triggering it through the web UI). _(deferred to Phase 4 manual block)_
+
+---
+
+## Phase 2: Add `text_input` widget files (front-end + CSS + registry tests)
+
+Build the widget itself: `widget.json` (schema for the agent's request), `widget.js` (Lit component), CSS. No tool yet — the registry alone gates rendering, and tests verify the schema accepts/rejects well-formed payloads.
+
+**Files:**
+
+- Create: `src/decafclaw/web/static/widgets/text_input/widget.json`
+- Create: `src/decafclaw/web/static/widgets/text_input/widget.js`
+- Modify: `src/decafclaw/web/static/styles/widgets.css` — append a `/* ---- text_input ---- */` block following the `multiple_choice` pattern at lines 138–215.
+- Create: `tests/test_text_input_widget.py` — registry-level validation tests (no tool yet).
+
+**Key changes:**
+
+`widget.json`:
+
+```json
+{
+  "name": "text_input",
+  "description": "Ask the user a free-form text question — single-line, multiline, or a small multi-field form. Pauses the agent turn until the user submits.",
+  "modes": ["inline"],
+  "accepts_input": true,
+  "data_schema": {
+    "type": "object",
+    "required": ["prompt", "fields"],
+    "properties": {
+      "prompt": { "type": "string", "minLength": 1 },
+      "fields": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["key", "label"],
+          "properties": {
+            "key": { "type": "string", "minLength": 1 },
+            "label": { "type": "string", "minLength": 1 },
+            "placeholder": { "type": "string" },
+            "default": { "type": "string" },
+            "multiline": { "type": "boolean" },
+            "required": { "type": "boolean" },
+            "max_length": { "type": "integer", "minimum": 1 }
+          }
+        }
+      },
+      "submit_label": { "type": "string", "minLength": 1 }
+    }
+  }
+}
+```
+
+`widget.js` — Lit component, light DOM (mirrors `multiple_choice/widget.js:24` pattern):
+
+```js
+import { LitElement, html, nothing } from 'lit';
+
+export class TextInputWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+    submitted: { type: Boolean },
+    response: { type: Object, attribute: false },
+    _values: { type: Object, state: true },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    this.data = null;
+    this.submitted = false;
+    this.response = null;
+    this._values = {};
+  }
+
+  updated(changed) {
+    // On reload, seed values from the archived response so the
+    // submitted UI shows what the user actually entered.
+    if ((changed.has('response') || changed.has('submitted'))
+        && this.submitted && this.response) {
+      this._values = { ...this.response };
+    }
+    // On first data, seed defaults.
+    if (changed.has('data') && this.data && !this.submitted) {
+      const seeded = {};
+      for (const f of (this.data.fields || [])) {
+        seeded[f.key] = (f.default ?? '');
+      }
+      this._values = seeded;
+    }
+  }
+
+  _onInput(key, e) {
+    this._values = { ...this._values, [key]: e.target.value };
+  }
+
+  _isSingleLineSingleField() {
+    const fields = this.data?.fields || [];
+    return fields.length === 1 && !fields[0].multiline;
+  }
+
+  _canSubmit() {
+    if (this.submitted) return false;
+    for (const f of (this.data?.fields || [])) {
+      const required = f.required !== false; // default true
+      if (required && !(this._values[f.key] || '').trim()) return false;
+    }
+    return true;
+  }
+
+  _onSubmit() {
+    if (!this._canSubmit()) return;
+    this.dispatchEvent(new CustomEvent('widget-response', {
+      detail: { ...this._values },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  _onKeyDown(e) {
+    // Enter submits ONLY when there's exactly one non-multiline field.
+    // Cmd/Ctrl+Enter submits in any shape.
+    if (e.key !== 'Enter') return;
+    if ((e.metaKey || e.ctrlKey) || this._isSingleLineSingleField()) {
+      e.preventDefault();
+      this._onSubmit();
+    }
+  }
+
+  _renderField(f) {
+    const value = this._values[f.key] ?? '';
+    const required = f.required !== false;
+    const common = {
+      id: `tf-${f.key}`,
+      placeholder: f.placeholder || '',
+      maxlength: f.max_length || undefined,
+      disabled: this.submitted,
+    };
+    const input = f.multiline
+      ? html`
+          <textarea
+            id=${common.id}
+            placeholder=${common.placeholder}
+            maxlength=${common.maxlength ?? nothing}
+            ?required=${required}
+            ?disabled=${common.disabled}
+            .value=${value}
+            @input=${(e) => this._onInput(f.key, e)}
+            @keydown=${this._onKeyDown}
+            rows="3"
+          ></textarea>`
+      : html`
+          <input
+            type="text"
+            id=${common.id}
+            placeholder=${common.placeholder}
+            maxlength=${common.maxlength ?? nothing}
+            ?required=${required}
+            ?disabled=${common.disabled}
+            .value=${value}
+            @input=${(e) => this._onInput(f.key, e)}
+            @keydown=${this._onKeyDown}
+          />`;
+    return html`
+      <label class="widget-text-input__field" for=${common.id}>
+        <span class="widget-text-input__label">${f.label}</span>
+        ${input}
+      </label>`;
+  }
+
+  render() {
+    const d = this.data;
+    if (!d || !Array.isArray(d.fields) || d.fields.length === 0) {
+      return html`<div class="widget-text-input widget-text-input--empty"><em>no fields</em></div>`;
+    }
+    const submitLabel = this.submitted
+      ? 'Submitted'
+      : (d.submit_label || 'Submit');
+    return html`
+      <div class="widget-text-input">
+        ${d.prompt ? html`<p class="widget-text-input__prompt">${d.prompt}</p>` : nothing}
+        <div class="widget-text-input__fields">
+          ${d.fields.map((f) => this._renderField(f))}
+        </div>
+        <div class="widget-text-input__actions">
+          <button
+            type="button"
+            class="widget-text-input__submit"
+            ?disabled=${!this._canSubmit()}
+            @click=${this._onSubmit}
+          >${submitLabel}</button>
+        </div>
+      </div>`;
+  }
+}
+
+customElements.define('dc-widget-text-input', TextInputWidget);
+```
+
+`widgets.css` (appended block):
+
+```css
+/* ---- text_input ---- */
+
+.widget-text-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.widget-text-input__prompt {
+  margin: 0 0 0.25rem 0;
+}
+
+.widget-text-input__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.widget-text-input__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.widget-text-input__label {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.widget-text-input__actions {
+  margin-top: 0.25rem;
+}
+
+.widget-text-input__submit {
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+}
+```
+
+`tests/test_text_input_widget.py`:
+
+```python
+"""Tests for the text_input widget's data_schema validation."""
+
+from decafclaw.widgets import load_widget_registry
+
+
+class _Cfg:
+    def __init__(self, agent_path):
+        self.agent_path = agent_path
+
+
+def _registry(tmp_path):
+    return load_widget_registry(_Cfg(tmp_path / "agent"))
+
+
+def test_text_input_registered(tmp_path):
+    reg = _registry(tmp_path)
+    desc = reg.get("text_input")
+    assert desc is not None
+    assert desc.accepts_input is True
+    assert desc.modes == ["inline"]
+
+
+def test_validate_single_field(tmp_path):
+    reg = _registry(tmp_path)
+    ok, err = reg.validate("text_input", {
+        "prompt": "What's your name?",
+        "fields": [{"key": "value", "label": "Name"}],
+    })
+    assert ok, err
+
+
+def test_validate_multi_field_with_optionals(tmp_path):
+    reg = _registry(tmp_path)
+    ok, err = reg.validate("text_input", {
+        "prompt": "Contact info",
+        "fields": [
+            {"key": "name", "label": "Name", "placeholder": "Les"},
+            {"key": "email", "label": "Email", "default": "x@y",
+             "max_length": 200, "required": False},
+            {"key": "bio", "label": "Bio", "multiline": True},
+        ],
+        "submit_label": "Send",
+    })
+    assert ok, err
+
+
+def test_validate_rejects_empty_fields(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "prompt": "x", "fields": [],
+    })
+    assert not ok
+
+
+def test_validate_rejects_missing_key(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "prompt": "x",
+        "fields": [{"label": "no key"}],
+    })
+    assert not ok
+
+
+def test_validate_rejects_missing_prompt(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "fields": [{"key": "v", "label": "V"}],
+    })
+    assert not ok
+```
+
+**TDD note:** Write `test_text_input_widget.py` first, watch the registry tests fail (`reg.get("text_input")` returns `None`), then add `widget.json` + `widget.js`. JS not unit-tested (no JS framework here); rely on registry tests + manual UI verification at the end of execute.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (new tests included)
+- [x] `make check` passes (Python + `make check-js` over the new `widget.js`)
+
+**Verification — manual:**
+- [ ] After Phase 3 lands, UI test in `make dev` confirms the widget renders correctly. (No standalone manual verification mid-phase — widget can't render without a tool to emit it.)
+
+---
+
+## Phase 3: Add `ask_user_text` tool
+
+The tool that emits the `text_input` widget. Mirrors the structure of `tool_ask_user_multiple_choice` (Phase 1's renamed tool): normalization helper, default-callback builder, async tool function, registry entries.
+
+**Files:**
+
+- Modify: `src/decafclaw/tools/core.py`
+  - Add `_normalize_text_input_fields(fields)` — accepts bare strings, `{key, label, ...}` dicts. Returns `None` on bad shape (mirrors `_normalize_multiple_choice_options`).
+  - Add `_default_text_input_callback(field_keys: list[str])` — returns a callback. Single-key: bare value. Multi-key: JSON object. Empty/missing: `"User did not respond."`.
+  - Add `tool_ask_user_text(ctx, prompt, fields=None, submit_label="Submit") -> ToolResult`.
+  - Register in `CORE_TOOLS`: `"ask_user_text": tool_ask_user_text`.
+  - Register in `CORE_TOOL_DEFINITIONS` with a description that explicitly contrasts with `ask_user_multiple_choice`.
+- Create: `tests/test_ask_user_text.py` — happy paths, normalization edge cases, callback formatting, integration with `WidgetRequest`/`ToolResult`.
+
+**Key changes:**
+
+```python
+# tools/core.py — appended below existing helpers and tool
+
+import json  # already imported at top
+
+def _normalize_text_input_fields(fields: list | None) -> list[dict] | None:
+    """Normalize the fields argument into the widget's data_schema shape.
+
+    Accepts None / [] (single-field default added by caller), bare
+    strings (used as both key and title-cased label), or dicts. Dict
+    form requires both ``key`` and ``label``. Returns None on any bad
+    entry; returns [] for an explicit empty list (caller decides).
+    """
+    if fields is None:
+        return None
+    out: list[dict] = []
+    seen_keys: set[str] = set()
+    for f in fields:
+        if isinstance(f, str):
+            key = f.strip()
+            if not key or key in seen_keys:
+                return None
+            entry = {"key": key, "label": key.replace("_", " ").title()}
+        elif isinstance(f, dict):
+            key = f.get("key")
+            label = f.get("label")
+            if not key or not label or key in seen_keys:
+                return None
+            entry = {"key": str(key), "label": str(label)}
+            for opt in ("placeholder", "default"):
+                v = f.get(opt)
+                if isinstance(v, str):
+                    entry[opt] = v
+            for opt in ("multiline", "required"):
+                v = f.get(opt)
+                if isinstance(v, bool):
+                    entry[opt] = v
+            ml = f.get("max_length")
+            if isinstance(ml, int) and ml > 0:
+                entry["max_length"] = ml
+        else:
+            return None
+        seen_keys.add(entry["key"])
+        out.append(entry)
+    return out
+
+
+def _default_text_input_callback(field_keys: list[str]):
+    """Build the default ``on_response`` callback for ask_user_text.
+
+    Single field: returns ``"User responded: <value>"``. Multi-field:
+    returns ``"User responded: {json}"``. Empty / no recognised data:
+    ``"User did not respond."``.
+    """
+    def _cb(data: dict) -> str:
+        if not isinstance(data, dict) or not data:
+            return "User did not respond."
+        if len(field_keys) == 1:
+            value = data.get(field_keys[0], "")
+            text = str(value).strip() if value is not None else ""
+            if not text:
+                return "User did not respond."
+            return f"User responded: {text}"
+        # Multi-field: emit a JSON object preserving field order.
+        ordered = {k: str(data.get(k, "")) for k in field_keys}
+        # Treat all-empty as "no response."
+        if not any(v.strip() for v in ordered.values()):
+            return "User did not respond."
+        return "User responded: " + json.dumps(ordered, ensure_ascii=False)
+    return _cb
+
+
+async def tool_ask_user_text(ctx, prompt: str, fields: list | None = None,
+                              submit_label: str = "Submit") -> ToolResult:
+    """Pause the turn and ask the user for free-form text input."""
+    log.info(f"[tool:ask_user_text] prompt={prompt!r} "
+             f"fields={len(fields) if fields else 0}")
+    if not prompt or not prompt.strip():
+        return ToolResult(
+            text="[error: ask_user_text requires a non-empty prompt]")
+    if not fields:
+        # Single-field default.
+        normalized = [{"key": "value", "label": prompt.strip()}]
+    else:
+        normalized = _normalize_text_input_fields(fields)
+        if normalized is None or not normalized:
+            return ToolResult(
+                text="[error: ask_user_text fields must each be a non-empty "
+                     "string or a {key, label, ...} dict with unique keys]")
+    widget_data: dict = {"prompt": prompt, "fields": normalized}
+    if submit_label and submit_label != "Submit":
+        widget_data["submit_label"] = submit_label
+    widget = WidgetRequest(
+        widget_type="text_input",
+        data=widget_data,
+        on_response=_default_text_input_callback(
+            [f["key"] for f in normalized]),
+    )
+    short = (f"ask: {len(normalized)} field"
+             + ("s" if len(normalized) != 1 else ""))
+    return ToolResult(
+        text=f"[awaiting user response: {prompt}]",
+        display_short_text=short,
+        widget=widget,
+        end_turn=True,
+    )
+```
+
+`CORE_TOOLS` addition:
+
+```python
+CORE_TOOLS = {
+    # ... existing entries ...
+    "ask_user_multiple_choice": tool_ask_user_multiple_choice,
+    "ask_user_text": tool_ask_user_text,
+}
+```
+
+`CORE_TOOL_DEFINITIONS` addition (paste below the existing `ask_user_multiple_choice` entry):
+
+```python
+{
+    "type": "function",
+    "priority": "low",
+    "function": {
+        "name": "ask_user_text",
+        "description": (
+            "Pause the turn and ask the user a free-form text question — "
+            "a single-line answer, a multiline blob, or a small multi-field "
+            "form. Use this when the answer is open-ended (a name, a URL, "
+            "a paragraph). For picking from a fixed list of options use "
+            "ask_user_multiple_choice instead. Use ONLY when the right "
+            "answer is genuinely ambiguous from context and you cannot make "
+            "a reasonable choice on your own. "
+            "Only works in the web UI; Mattermost / terminal render the "
+            "prompt as text and the turn ends without a response."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Question presented to the user.",
+                },
+                "fields": {
+                    "type": "array",
+                    "description": (
+                        "Optional. Each field is either a bare string "
+                        "(used as both key and title-cased label) or a "
+                        "{key, label, placeholder?, default?, multiline?, "
+                        "required?, max_length?} dict. Keys must be "
+                        "unique. Omit for a single-field text question "
+                        "keyed 'value'."
+                    ),
+                    "items": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "key": {"type": "string"},
+                                    "label": {"type": "string"},
+                                    "placeholder": {"type": "string"},
+                                    "default": {"type": "string"},
+                                    "multiline": {"type": "boolean"},
+                                    "required": {"type": "boolean"},
+                                    "max_length": {"type": "integer"},
+                                },
+                                "required": ["key", "label"],
+                            },
+                        ],
+                    },
+                },
+                "submit_label": {
+                    "type": "string",
+                    "description": "Optional submit button label (default 'Submit').",
+                },
+            },
+            "required": ["prompt"],
+        },
+    },
+},
+```
+
+`tests/test_ask_user_text.py`:
+
+```python
+"""Tests for the ask_user_text core tool."""
+
+import json
+
+import pytest
+
+from decafclaw.media import ToolResult, WidgetRequest
+from decafclaw.tools.core import (
+    _default_text_input_callback,
+    _normalize_text_input_fields,
+    tool_ask_user_text,
+)
+
+
+# ------------- field normalization -------------
+
+def test_normalize_bare_strings_title_cases_label():
+    out = _normalize_text_input_fields(["name", "email_address"])
+    assert out == [
+        {"key": "name", "label": "Name"},
+        {"key": "email_address", "label": "Email Address"},
+    ]
+
+
+def test_normalize_dicts_with_optionals():
+    out = _normalize_text_input_fields([
+        {"key": "bio", "label": "Bio", "multiline": True,
+         "max_length": 500, "required": False, "placeholder": "tell me",
+         "default": "x"},
+    ])
+    assert out == [{
+        "key": "bio", "label": "Bio", "multiline": True,
+        "max_length": 500, "required": False,
+        "placeholder": "tell me", "default": "x",
+    }]
+
+
+def test_normalize_dict_missing_key_or_label_is_rejected():
+    assert _normalize_text_input_fields([{"label": "no key"}]) is None
+    assert _normalize_text_input_fields([{"key": "v"}]) is None
+
+
+def test_normalize_duplicate_keys_rejected():
+    assert _normalize_text_input_fields([
+        {"key": "v", "label": "A"}, {"key": "v", "label": "B"},
+    ]) is None
+
+
+def test_normalize_bad_max_length_dropped():
+    out = _normalize_text_input_fields([
+        {"key": "v", "label": "V", "max_length": 0},
+    ])
+    assert out == [{"key": "v", "label": "V"}]
+
+
+def test_normalize_None_returns_None():
+    assert _normalize_text_input_fields(None) is None
+
+
+def test_normalize_bad_entry_returns_None():
+    assert _normalize_text_input_fields([123]) is None
+
+
+# ------------- default on_response -------------
+
+def test_default_callback_single_returns_bare_value():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": "Hello"}) == "User responded: Hello"
+
+
+def test_default_callback_single_strips_whitespace():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": "  Hi  "}) == "User responded: Hi"
+
+
+def test_default_callback_single_empty_says_no_response():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": ""}) == "User did not respond."
+    assert cb({}) == "User did not respond."
+
+
+def test_default_callback_multi_returns_json():
+    cb = _default_text_input_callback(["name", "email"])
+    out = cb({"name": "Les", "email": "x@y"})
+    assert out.startswith("User responded: ")
+    assert json.loads(out[len("User responded: "):]) == {
+        "name": "Les", "email": "x@y"}
+
+
+def test_default_callback_multi_preserves_field_order():
+    cb = _default_text_input_callback(["b", "a"])
+    out = cb({"a": "first", "b": "second"})
+    # Field-key order, not insertion order from the response.
+    body = out[len("User responded: "):]
+    assert body.index('"b"') < body.index('"a"')
+
+
+def test_default_callback_multi_all_empty_says_no_response():
+    cb = _default_text_input_callback(["a", "b"])
+    assert cb({"a": "", "b": "  "}) == "User did not respond."
+
+
+# ------------- tool integration -------------
+
+@pytest.mark.asyncio
+async def test_tool_happy_single_field_default():
+    ctx = object()
+    result = await tool_ask_user_text(ctx, prompt="Your name?")
+    assert isinstance(result, ToolResult)
+    assert result.end_turn is True
+    assert isinstance(result.widget, WidgetRequest)
+    assert result.widget.widget_type == "text_input"
+    fields = result.widget.data["fields"]
+    assert len(fields) == 1
+    assert fields[0] == {"key": "value", "label": "Your name?"}
+    assert "awaiting user response" in result.text
+
+
+@pytest.mark.asyncio
+async def test_tool_multi_field():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="Contact info?",
+        fields=[
+            {"key": "name", "label": "Name"},
+            {"key": "email", "label": "Email", "required": False},
+        ],
+        submit_label="Send",
+    )
+    assert result.widget.data["submit_label"] == "Send"
+    assert len(result.widget.data["fields"]) == 2
+    inject = result.widget.on_response({"name": "Les", "email": "x@y"})
+    assert json.loads(inject[len("User responded: "):]) == {
+        "name": "Les", "email": "x@y"}
+
+
+@pytest.mark.asyncio
+async def test_tool_blank_prompt_returns_error():
+    ctx = object()
+    result = await tool_ask_user_text(ctx, prompt="   ")
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_bad_fields_returns_error():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="?", fields=[{"label": "no key"}])
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_default_callback_wired():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="?", fields=["color"])
+    inject = result.widget.on_response({"color": "blue"})
+    assert inject == "User responded: blue"
+```
+
+**TDD note:** Write `test_ask_user_text.py` first, watch ImportError on `_default_text_input_callback`/`_normalize_text_input_fields`/`tool_ask_user_text`. Then add the helpers and tool. Then re-run.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+
+**Verification — manual:** (deferred to Phase 4 manual block)
+
+---
+
+## Phase 4: Docs + tool-disambiguation eval + UI verification
+
+Final slice: documentation update, eval fixture for the new tool pair, and live UI verification of single + multi-field flows.
+
+**Files:**
+
+- Modify: `docs/widgets.md` — add a new sub-section under "Input widgets" describing `text_input`. Update the example block at line 156–162 to also cover `ask_user_text`. Update the key-files list at line 434 if needed.
+- Modify: `evals/tool_choice/core_overlaps.yaml` — add cases that disambiguate `ask_user_multiple_choice` vs `ask_user_text`.
+  - `"Should I deploy to production or staging?"` → `ask_user_multiple_choice` (fixed list).
+  - `"What name would you like for the new project?"` → `ask_user_text` (free-form).
+  - `"Tell me your name, email, and a short bio."` → `ask_user_text` (multi-field).
+- TDD opt-out: docs are pure prose; eval is an evaluation, not a test. Both are verification surfaces, not implementation.
+
+**Key changes (docs/widgets.md, around line 150):**
+
+```markdown
+### Asking the user — `ask_user_multiple_choice` vs `ask_user_text`
+
+Two core tools wrap the input-widget infrastructure:
+
+- **`ask_user_multiple_choice(prompt, options, allow_multiple=False)`** —
+  pick one (or several) from a fixed list. Renders the `multiple_choice`
+  widget. Inject string: `"User selected: <label>"`.
+
+- **`ask_user_text(prompt, fields=None, submit_label="Submit")`** —
+  free-form text answer. Single-field by default (`fields` omitted), or
+  pass `fields=[...]` for a small multi-field form. Renders the
+  `text_input` widget. Inject string: bare value for single-field,
+  `{...}` JSON for multi-field.
+
+Both pause the turn until the user submits and only work in the web UI.
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+- [x] `make eval-tools` runs — all 3 new ask_user disambiguation cases pass; one pre-existing canvas/workspace_write failure unrelated to this PR.
+
+**Verification — manual:** (Playwright walkthrough against local `uv run decafclaw` on port 18881)
+- [x] Single-field default → single text input rendered with prompt as label, Enter submits, agent received `"User responded: Indigo"` and replied "Got it — your favorite color is indigo."
+- [x] Multi-field (`name` + multiline `bio`) → two fields rendered (input + textarea), Enter on the name field does NOT submit, button click does, agent received `User responded: {"name": "Les", "bio": ""}` JSON and correctly extracted both.
+- [ ] Multiline single-field Enter→newline path not separately exercised (covered indirectly: multi-field test confirmed Enter doesn't submit when multiline is present).
+- [x] Renamed `ask_user_multiple_choice` rendered three radios, picked "green", agent replied "Got it — you picked green."
+- [x] Page refresh after single-field submit → widget restored with `submitted: true`, `response: {value: "Indigo"}`, button "Submitted", input disabled, value preserved.
+
+**Found during walkthrough and fixed in this PR:** Live-tab `submitted` state didn't flip after submission — `tool-status-store.js` `respondToWidget` removed the confirm from `pendingConfirms` before the broadcast `CONFIRMATION_RESPONSE` arrived, so `markToolWidgetSubmitted` never fired on the submitting tab. Affected both `multiple_choice` and `text_input` (pre-existing, landed with #366). Fix: have `respondToWidget` call `markToolWidgetSubmitted` directly. Verified end-to-end via Playwright after the fix — both widgets now flip immediately on submit.
+
+---
+
+## Plan self-review
+
+- **Spec coverage:**
+  - Widget `text_input` files (json + js + css) → Phase 2.
+  - Tool `ask_user_text` with single-field default + multi-field signature → Phase 3.
+  - Smart-default inject string (bare for single, JSON for multi) → Phase 3 (`_default_text_input_callback`).
+  - Hard rename `ask_user` → `ask_user_multiple_choice` → Phase 1.
+  - Field schema `{key, label, placeholder?, default?, multiline?, required?, max_length?}` → Phase 2 (widget.json) + Phase 3 (normalize helper).
+  - Client-side `required` + `maxlength` only → Phase 2 (widget.js).
+  - Enter-submit only for single non-multiline field → Phase 2 (`_isSingleLineSingleField` + `_onKeyDown`).
+  - No alias for `ask_user` → Phase 1 (no shim added; `grep` check in verification).
+  - Inline-only mode → Phase 2 (widget.json `modes: ["inline"]`).
+  - Tool description disambiguation via `make eval-tools` → Phase 4.
+- **Placeholder scan:** no TBDs / TODOs / "implement later" / vague phrases.
+- **Type consistency:** `tool_ask_user_multiple_choice` (Phase 1) and `tool_ask_user_text` (Phase 3) match across all later references; `_default_multiple_choice_callback` and `_default_text_input_callback` symmetric and used consistently; widget name `text_input` consistent across `widget.json` `name`, `customElements.define('dc-widget-text-input', ...)`, CSS class prefix `.widget-text-input__`, registry tests.
+
+No gaps found.

--- a/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/research.md
+++ b/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/research.md
@@ -1,0 +1,110 @@
+# Research: Widget — text_input
+
+Documentarian findings on the existing widget infrastructure. Dense file:line refs over prose.
+
+## 1. Widget catalog and registration
+
+**On-disk layout** — bundled widgets at `src/decafclaw/web/static/widgets/{name}/widget.json` + `widget.js`. Existing widgets:
+
+| Widget | Purpose | accepts_input | modes |
+|---|---|---|---|
+| `data_table` | Sortable scrollable table | no | inline, canvas |
+| `multiple_choice` | Radio/checkbox; pauses agent | **yes** | inline |
+| `markdown_document` | Rendered markdown; canvas-capable | no | inline, canvas |
+| `code_block` | Syntax-highlighted code; canvas-capable | no | inline, canvas |
+| `iframe_sandbox` | Agent-authored HTML in CSP-locked sandbox | no | inline, canvas |
+
+**Python side** — `src/decafclaw/widgets.py`:
+- `_META_SCHEMA` (lines 23–37) — validates `widget.json`: `name`, `description`, `modes` (≥1 of `inline`/`canvas`), optional `accepts_input` (bool), `data_schema` (JSON Schema).
+- `WidgetDescriptor` dataclass (lines 165–177): `name`, `tier`, `description`, `modes`, `accepts_input`, `data_schema`, `js_path`, `tier_root`, `mtime`.
+- `WidgetRegistry` (lines 56–126): `.get`, `.list`, `.tier`, `.validate(name, data)`, `.normalize(name, data)`. `validate` runs `jsonschema` against widget's `data_schema` (lines 104–126).
+- `_scan_tier()` (lines 128–177), `load_widget_registry(config)` (lines 180–202): scans `_BUNDLED_DIR` (line 20: `Path(__file__).parent / "web" / "static" / "widgets"`) then `config.agent_path / "widgets"` (admin tier overrides bundled on collision, line 196).
+- `init_widgets(config)` (lines 214–218): startup singleton.
+
+**HTTP endpoints** — `src/decafclaw/http_server.py`:
+- `GET /api/widgets` (lines 1570–1588) — catalog with cache-busted `js_url` (mtime query param).
+- `GET /widgets/{tier}/{name}/widget.js` (lines 1591–1620) — serves widget JS with path/symlink validation.
+
+**No workspace tier yet** — agent-writable widget JS would be privilege escalation (#358).
+
+## 2. Widget protocol / schema
+
+**Tool returns `WidgetRequest`** — `src/decafclaw/media.py:37–51`:
+```
+WidgetRequest(widget_type, data, target="inline"|"canvas", on_response=callable, response_message=...)
+```
+Attached to `ToolResult.widget` alongside `text` (LLM-visible) and `end_turn` (lines 69–83).
+
+**Agent validates & resolves** — `src/decafclaw/agent.py:652–738` `_resolve_widget()`:
+- `registry.validate(widget_type, data)` (line 679); strips widget on fail (lines 681–684).
+- Target check: in `("inline", "canvas")` and in `descriptor.modes` (lines 687–700).
+- `registry.normalize(widget_type, data)` (lines 704–705) — idempotent, regenerates derived fields.
+- For `accepts_input=true`: registers `on_response` callback in `pending_callbacks[tool_call_id]` (lines 729–731), promotes `end_turn` to `WidgetInputPause(tool_call_id, widget_payload)` (lines 733–736).
+- Rule: input widget must have `end_turn=True` (or `EndTurnConfirm`, downgraded). Else widget stripped (lines 716–722).
+
+**Archive & dispatch** — payload `{widget_type, target, data}` archived in tool message; emitted via WebSocket (line 618).
+
+**Frontend rendering**:
+- `lib/widget-catalog.js:24–44` `getCatalog()` — fetches `/api/widgets` once, memoizes.
+- `components/widgets/widget-host.js:89–126` `<dc-widget-host>` — dynamic-imports `desc.js_url`, creates `<dc-widget-{type}>`, sets props `.data`, `.submitted`, `.response`, `.mode`.
+- All widgets use light DOM (`createRenderRoot() { return this; }`, line 24) so Pico CSS applies naturally.
+- Widgets dispatch `widget-response` CustomEvent on submit (bubbles + composed).
+
+## 3. `multiple_choice` end-to-end (the canonical input widget)
+
+**Schema** — `src/decafclaw/web/static/widgets/multiple_choice/widget.json`:
+- `prompt` (required), `options` (array of `{value, label, description?}`), optional `allow_multiple`.
+
+**Tool** — `src/decafclaw/tools/core.py:195–225` `tool_ask_user(ctx, prompt, options, allow_multiple=False)`:
+- Normalizes options (line 202; helper at lines 138–165) — bare strings/dicts → `{value, label, description?}`.
+- Builds default `on_response` (lines 215–216; helper at lines 168–192) returning string `"User selected: <label>"` (line 190) or comma-joined for multiple (line 186).
+- Returns `ToolResult(text="[awaiting user response: ...]", widget=WidgetRequest(...), end_turn=True)` (lines 220–225).
+
+**Render** — `multiple_choice/widget.js`:
+- Lit component, props `data`, `submitted`, `response`.
+- Render (lines 124–147): prompt + options (radios if `!allow_multiple`, checkboxes else, lines 99–100). Submit button disabled until selection (line 141–142).
+- Winner styling on `submitted + selected` (CSS lines 190–206).
+- On submit (lines 79–92): `widget-response` CustomEvent, `detail: {selected: string | string[]}`.
+
+**Response data shape**: `{selected: string | string[]}` — keyed string per `value`.
+
+## 4. `WidgetInputPause` & input flow
+
+**Pause initiation** — `agent.py:712–736` (covered in §2 above).
+
+**Pause detection** — `agent.py:1156–1171` after `_execute_tool_calls()`:
+- `isinstance(end_turn_signal, WidgetInputPause)` → `_handle_widget_input_pause(ctx, signal)` returns inject string or None.
+- If string: append synthetic `{"role": "user", "source": "widget_response", "content": inject}` to history+archive (lines 1163–1170), `_Continue()` loop.
+- If None (cancelled): set `end_turn_signal = True`, fall through to final no-tools LLM call.
+
+**Pause mechanics** — `agent.py:213–310` `_handle_widget_input_pause`:
+1. Build `ConfirmationRequest(action_type=WIDGET_RESPONSE, action_data=widget_payload, tool_call_id=signal.tool_call_id, timeout=None)` (lines 241–246).
+2. Race `ctx.request_confirmation(request)` against `cancel_event` (lines 257–292).
+3. Pop callback from `pending_callbacks[tool_call_id]` (line 297). Call `callback(response.data)` (line 304); fallback `default_inject_message(response.data)` (line 310; `widget_input.py:46`).
+
+**Persistence & recovery**:
+- Archived as `role: "confirmation_request"` / `"confirmation_response"` (`confirmations.py:40–97`).
+- On restart: `ConversationManager.recover_confirmation()` → `WidgetResponseHandler.on_approve()` (`widget_input.py:49–102`) writes synthetic user message directly to archive (lines 96–100). Falls back to default message if in-memory callback gone (lines 81–91).
+
+**What the LLM sees** — the inject string the callback returns. For `multiple_choice`: `"User selected: <label>"` or `"User selected: label1, label2, ..."`.
+
+## 5. Web UI form/input components
+
+**Foundation** — Pico CSS v2 + custom `--pico-*` variables in `styles/variables.css`. All widgets use light DOM so Pico applies.
+
+**Existing input components**:
+| Component | File | Notes |
+|---|---|---|
+| `chat-input` | `web/static/components/chat-input.js` | Textarea + attachments. Auto-resize (lines 71–75). File picker (129–131). Drag-drop (134–150). Dispatches `send` event (60–64). |
+| `multiple_choice` widget | `widgets/multiple_choice/widget.js` | Radios/checkboxes in 2-col grid (CSS `widgets.css:156–188`). |
+
+**Styling conventions**:
+- BEM-ish: `.widget-<name>__<part>--<state>` (e.g., `.widget-multiple-choice__option--winner`).
+- Pico var fallbacks: `var(--pico-muted-border-color, #ccc)` (widgets.css:64).
+- Compact submit button pattern: `padding: 0.35rem 0.9rem; font-size: 0.85rem` (widgets.css:212–215).
+- `--vh` tracking for mobile soft keyboard (variables.css:9–16).
+- No shared form-primitive library — each widget defines own markup. Validation is server-side via `jsonschema`.
+
+## Pico v2 gotcha
+
+From memory: Pico v2 re-scopes `--pico-color`/`--pico-background-color` inside `<button>`. For text/textarea inside the widget, Pico defaults are fine; for any custom button styling, tag-qualify rules (`button.foo`, not `.foo`).

--- a/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/spec.md
+++ b/docs/dev-sessions/2026-04-29-1459-widget-text-input-410/spec.md
@@ -1,0 +1,118 @@
+# Widget: text_input Spec
+
+**Goal:** Give the agent a way to ask the user for free-form text — a single-line answer, a multiline blob, or a small multi-field form — pausing the turn until the user submits.
+
+**Source:** [#410](https://github.com/lmorchard/decafclaw/issues/410)
+
+## Current state
+
+Input widgets today: only `multiple_choice` (radios/checkboxes). Tool surface: `ask_user(prompt, options, allow_multiple)` at `tools/core.py:195–225`. The widget infra (registry, schema validation, agent-loop pause via `WidgetInputPause`, persistence/recovery) is fully built and shared across input widgets — see `research.md` §1, §4. New input widgets only need: a `widget.json` + `widget.js` pair under `web/static/widgets/{name}/`, plus a tool that emits a `WidgetRequest` with `end_turn=True` and an `on_response` callback.
+
+## Desired end state
+
+### New widget — `text_input`
+
+Bundled at `src/decafclaw/web/static/widgets/text_input/{widget.json,widget.js}`.
+
+- `modes`: `["inline"]`
+- `accepts_input`: `true`
+- `data_schema` (validates the agent's request):
+  - `prompt` (string, required)
+  - `fields` (array, required, min 1): each `{key (string, required), label (string, required), placeholder? (string), default? (string), multiline? (boolean, default false), required? (boolean, default true), max_length? (integer)}`
+  - `submit_label` (string, optional, default `"Submit"`)
+- Response payload from JS to agent: object keyed by `key` — `{<key>: <string>, ...}`. Empty/unfilled non-required fields submit as empty string.
+
+### Render behavior
+
+- One `<input>` (or `<textarea>` if `multiline`) per field, labeled, with `placeholder` and `default` applied. `required` and `max_length` enforced via HTML attributes only — no client-side validation framework.
+- Submit button labeled `submit_label`, disabled until all `required` fields are non-empty.
+- **Keyboard:** Enter submits when the form has exactly one non-multiline field (single-field common case). In all other shapes (multiline field present, or ≥2 fields), Enter is normal newline/tab and submit requires a click or Cmd/Ctrl+Enter.
+- After submit: read-only display of submitted values (mirrors `multiple_choice` "winner" pattern).
+
+### New tool — `ask_user_text`
+
+In `tools/core.py`. Signature:
+
+```python
+async def tool_ask_user_text(
+    ctx,
+    prompt: str,
+    fields: list | None = None,
+    submit_label: str = "Submit",
+) -> ToolResult: ...
+```
+
+- If `fields` is `None` or empty, default to a single field `[{"key": "value", "label": prompt}]`. Fields can be passed as bare strings (`"name"` → `{key: "name", label: "Name"}` via title-casing) or full dicts.
+- Returns `ToolResult(text="[awaiting user response: ...]", widget=WidgetRequest(...), end_turn=True)`.
+- Default `on_response` callback shapes the inject string:
+  - **Single field:** `User responded: <value>` (matches `"User selected: <label>"` style of `multiple_choice`).
+  - **Multi-field:** `User responded: {"name": "Les", "email": "..."}` — JSON, compact.
+  - Empty / cancelled: `"User did not respond."` (matches the `multiple_choice` fallback shape).
+
+### Rename — `ask_user` → `ask_user_multiple_choice`
+
+Hard rename, no alias. Touches: tool definition (`tools/core.py`), tool registry (`tools/tool_registry.py`), system prompt / tool descriptions, eval fixtures (`evals/`), any bundled skill that calls it by name (`src/decafclaw/skills/*/`), docs (`docs/tools.md`, `docs/widgets*.md`), and tests.
+
+The two tools must be obviously different to the LLM: descriptions explicitly contrast "pick from a fixed list of options" vs. "free-form text answer." Validate via `make eval-tools`.
+
+## Design decisions
+
+- **Decision:** New widget `text_input`, separate from `multiple_choice`.
+  - **Why:** Different schemas, different render shapes, different keyboard behavior. The widget catalog already separates by widget type, not by tool.
+  - **Rejected:** Overloading `multiple_choice` with a "free-text" mode — it would balloon the schema and make tool descriptions harder.
+
+- **Decision:** Smart-default inject string — single-field unwraps to bare value, multi-field is JSON.
+  - **Why:** The single-field case is the dominant one and a bare string reads more naturally to the LLM. Mirrors `multiple_choice`'s `"User selected: <label>"` natural-language style. JSON is unambiguous when there are multiple keys.
+  - **Rejected:** Always JSON — uniform but verbose for the common case.
+
+- **Decision:** Two sibling tools (`ask_user_text`, `ask_user_multiple_choice`) instead of one polymorphic `ask_user`.
+  - **Why:** Tool descriptions are a control surface (CLAUDE.md). Two clean schemas with sharp descriptions disambiguate better than one tool with branching parameters. Sets up the `ask_user_*` family for future input widgets (date picker, slider, etc.).
+  - **Rejected:** Extending `ask_user` with `fields` (mutually exclusive with `options`); convenience tool `ask_user_input` with both flat and `fields=[...]` shapes.
+
+- **Decision:** Hard rename `ask_user` → `ask_user_multiple_choice` in this PR. No alias.
+  - **Why:** CLAUDE.md "no deprecated code for test compatibility." Symmetric naming pays off forever; the churn is contained to one PR.
+  - **Rejected:** Keeping `ask_user` as a deprecated alias.
+
+- **Decision:** v1 field schema = `{key, label, placeholder?, default?, multiline?, required?, max_length?}`.
+  - **Why:** All cheaply supported by HTML `<input>`/`<textarea>` with no extra code. Adding them in v1 costs nothing and avoids a follow-up.
+  - **Rejected:** Trimming to `{key, label, required}` for "minimal v1."
+
+- **Decision:** Client-side `required`/`maxlength` only; no server-side response validation.
+  - **Why:** Matches the trust model of `multiple_choice`, which doesn't validate response payloads server-side either. The widget `data_schema` validates the *agent's* request shape (so the LLM can't pass malformed `fields`).
+  - **Rejected:** Server-side enforcement on response data — adds plumbing without a clear threat model in v1.
+
+- **Decision:** Enter submits only for single non-multiline field. Multi-field or multiline: button only (Cmd/Ctrl+Enter shortcut).
+  - **Why:** Real-form convention. Tabbing between fields with Enter would feel wrong; accidental submit in field 1 of 3 is annoying.
+  - **Rejected:** Always-button (loses muscle memory for the common one-shot question); always-Enter-with-Shift-newline (chat-input style — wrong for forms).
+
+## Patterns to follow
+
+- Widget pair structure: `widget.json` + `widget.js` per `web/static/widgets/multiple_choice/` (`research.md` §3).
+- Tool emit pattern: `tools/core.py:195–225` (`tool_ask_user`) — option normalization helper, default `on_response` builder, `ToolResult(..., widget=WidgetRequest(...), end_turn=True)`.
+- Default callback signature: `widget_input.py:46` `default_inject_message(data)`.
+- Light-DOM Lit component with `createRenderRoot() { return this; }`: `multiple_choice/widget.js:24`.
+- BEM-ish class naming: `.widget-text-input__field--required`, `.widget-text-input__submit`.
+- Pico-var fallbacks for borders/colors: `widgets.css:64` style.
+- Submitted state styling pattern: `multiple_choice` "winner" CSS at `widgets.css:190–206`.
+- Pico v2 button gotcha: tag-qualify (`button.foo`) for any custom button rules — see memory `reference_pico_cascade_gotchas.md`.
+- Eval-driven tool disambiguation: run `make eval-tools` after the rename + new tool description (CLAUDE.md "Tools" section).
+- Per-conversation persistence/recovery is automatic via the existing `WidgetInputPause` infra — no new code path needed (`research.md` §4).
+
+## What we're NOT doing
+
+- **No richer validation in v1.** No regex, min_length, type=email/url/number, or cross-field rules. Punt to a follow-up.
+- **No server-side response validation.** Trust the WS payload like `multiple_choice` does.
+- **No canvas mode for `text_input`.** Inline only.
+- **No deprecated `ask_user` alias.** Hard rename only.
+- **No new input primitive library / shared form component.** Each widget keeps its own markup.
+- **No changes to `WidgetInputPause` / agent loop / confirmation infra.** Reuse as-is.
+- **No changes to other tools / skills beyond mechanical updates required by the rename.**
+- **No mobile-specific keyboard tweaks** (e.g., setting `inputmode`, `autocapitalize`). Default browser behavior is fine in v1.
+- **No accessibility audit beyond using semantic `<label for=...>` + native `<input>`/`<textarea>`.**
+
+## Open questions
+
+None blocking. Two minor defaults I'm proceeding with:
+
+- **Field key for the single-field default:** `"value"` (matches the issue's example).
+- **Default `required` per field:** `true`. Most asks expect an answer; opt out with `required: false`.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -147,24 +147,55 @@ To mark a widget as interactive, set `"accepts_input": true` in its
 `widget.json`. Tools that emit an input widget MUST also set
 `end_turn=True` on the `ToolResult`.
 
-### The `ask_user` core tool
+### Asking the user — `ask_user_multiple_choice` vs `ask_user_text`
 
-The agent can ask the user to pick from a list via the built-in
-`ask_user` tool:
+Two core tools wrap the input-widget infrastructure. Both pause the
+turn until the user submits and only work in the web UI.
+
+**`ask_user_multiple_choice(prompt, options, allow_multiple=False)`** —
+pick one (or several) from a fixed list. Renders the `multiple_choice`
+widget. Inject string: `"User selected: <label>"`.
 
 ```python
-# Inside the LLM's tool-calling loop
-await ask_user(
+await ask_user_multiple_choice(
     prompt="Which deploy target?",
     options=["production", "staging", "dev"],
     allow_multiple=False,  # radios; set True for checkboxes
 )
 ```
 
-The user sees a `multiple_choice` widget inline in the tool message;
-the agent pauses. When the user submits, the conversation continues
-with a synthetic `role: "user"` message like
-`"User selected: production"`.
+**`ask_user_text(prompt, fields=None, submit_label="Submit")`** —
+free-form text answer. Single-field by default (`fields` omitted), or
+pass `fields=[...]` for a small multi-field form. Renders the
+`text_input` widget. Inject string: bare value for a single field,
+JSON object for multi-field.
+
+```python
+# Single-field common case (keyed 'value'):
+await ask_user_text(prompt="What name would you like?")
+# → "User responded: Hello"
+
+# Multi-field form:
+await ask_user_text(
+    prompt="Contact info?",
+    fields=[
+        {"key": "name", "label": "Name"},
+        {"key": "email", "label": "Email", "required": False},
+        {"key": "bio", "label": "Bio", "multiline": True, "max_length": 500},
+    ],
+    submit_label="Send",
+)
+# → 'User responded: {"name": "Les", "email": "x@y", "bio": "..."}'
+```
+
+Per-field options on the dict form: `placeholder`, `default`,
+`multiline` (renders a `<textarea>`), `required` (default `true`),
+`max_length` (HTML `maxlength` attribute). Bare-string fields get
+title-cased labels (`"email_address"` → `"Email Address"`). Keys must
+be unique. Enter submits only when there's exactly one non-multiline
+field; otherwise Enter won't submit and the user must click the button
+(or use Cmd/Ctrl+Enter). Inside a multiline field, plain Enter inserts
+a newline as usual.
 
 ### Building your own input widget
 
@@ -431,12 +462,12 @@ check). Filed as a follow-up if/when needed.
 - `src/decafclaw/widgets.py` — registry scan + validation
 - `src/decafclaw/media.py` — `WidgetRequest`, `WidgetInputPause`, `ToolResult.widget`
 - `src/decafclaw/widget_input.py` — input-widget handler + callback map
-- `src/decafclaw/tools/core.py` — `ask_user` tool
+- `src/decafclaw/tools/core.py` — `ask_user_multiple_choice` tool
 - `src/decafclaw/canvas.py` — canvas state operations
 - `src/decafclaw/tools/canvas_tools.py` — canvas tools
 - `src/decafclaw/web/static/lib/canvas-state.js` — frontend state
 - `src/decafclaw/web/static/components/canvas-panel.js` — panel component
-- `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice, markdown_document, code_block)
+- `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice, text_input, markdown_document, code_block, iframe_sandbox)
 - `src/decafclaw/web/static/widgets/markdown_document/` — markdown_document widget descriptor + Lit component
 - `src/decafclaw/web/static/widgets/code_block/` — code_block widget descriptor + Lit component
 - `src/decafclaw/web/static/widgets/iframe_sandbox/` — iframe_sandbox widget descriptor + Lit component

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -125,3 +125,31 @@
     user explicitly asks to save to a file path is workspace_write.
     The "PREFER canvas_new_tab" guidance applies to interactive web
     content the user wants displayed, not to authoring file artifacts.
+
+# -- ask_user_multiple_choice vs ask_user_text -------------------------------
+
+- name: ask-text-vs-choice-free-form-name
+  scenario: "Ask the user what name they'd like for the new project."
+  expected: ask_user_text
+  near_miss: [ask_user_multiple_choice]
+  notes: |
+    Free-form question with no fixed options — "what name" is a
+    single-line text answer. ask_user_multiple_choice would be wrong
+    because there's no list to pick from.
+
+- name: ask-choice-vs-text-deploy-target
+  scenario: "Should I deploy to production or to staging?"
+  expected: ask_user_multiple_choice
+  near_miss: [ask_user_text]
+  notes: |
+    Two named choices presented in the prompt itself — that's the
+    canonical multiple_choice case. ask_user_text would dump a free
+    input on the user when the answer is one of two known values.
+
+- name: ask-text-vs-choice-multi-field-form
+  scenario: "Collect the user's name, email, and a short bio."
+  expected: ask_user_text
+  near_miss: [ask_user_multiple_choice]
+  notes: |
+    Multi-field form with free-form text per field — ask_user_text
+    with fields=[name, email, bio]. Nothing to pick from a list.

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -517,7 +517,7 @@ class MattermostClient:
                 # no widget surface here, and the buttons would resolve
                 # the confirmation with no data, producing an unhelpful
                 # "User responded with: {}" inject. The agent's tool
-                # description for ask_user already discourages calls
+                # description for ask_user_multiple_choice already discourages calls
                 # outside the web UI.
                 if action_type == "widget_response":
                     log.info(

--- a/src/decafclaw/tools/core.py
+++ b/src/decafclaw/tools/core.py
@@ -1,4 +1,4 @@
-"""Core tools — web fetch, debug, time, context stats, ask_user."""
+"""Core tools — web fetch, debug, time, context stats, ask_user_multiple_choice."""
 
 import json
 import logging
@@ -135,7 +135,7 @@ async def tool_wait(ctx, seconds: int = 30) -> str | ToolResult:
     return f"Waited {seconds} seconds."
 
 
-def _normalize_ask_user_options(options: list) -> list[dict] | None:
+def _normalize_multiple_choice_options(options: list) -> list[dict] | None:
     """Normalize mixed options into the widget's data_schema shape.
 
     Accepts each option as a bare string (used as both value and label)
@@ -165,9 +165,9 @@ def _normalize_ask_user_options(options: list) -> list[dict] | None:
     return out
 
 
-def _ask_user_default_on_response(options: list[dict],
-                                  allow_multiple: bool):
-    """Build the default ``on_response`` callback for ask_user.
+def _default_multiple_choice_callback(options: list[dict],
+                                       allow_multiple: bool):
+    """Build the default ``on_response`` callback for ask_user_multiple_choice.
 
     Single: returns ``"User selected: <label>"``; multi: comma-joins
     the labels of selected values. Looks up labels from the option list
@@ -192,17 +192,18 @@ def _ask_user_default_on_response(options: list[dict],
     return _cb
 
 
-async def tool_ask_user(ctx, prompt: str, options: list,
-                        allow_multiple: bool = False) -> ToolResult:
-    """Pause the turn and ask the user to pick from a list of options."""
-    log.info(f"[tool:ask_user] prompt={prompt!r} "
+async def tool_ask_user_multiple_choice(ctx, prompt: str, options: list,
+                                        allow_multiple: bool = False) -> ToolResult:
+    """Pause the turn and ask the user to pick from a fixed list of options."""
+    log.info(f"[tool:ask_user_multiple_choice] prompt={prompt!r} "
              f"options={len(options)} allow_multiple={allow_multiple}")
     if not prompt or not prompt.strip():
-        return ToolResult(text="[error: ask_user requires a non-empty prompt]")
-    normalized = _normalize_ask_user_options(options)
+        return ToolResult(
+            text="[error: ask_user_multiple_choice requires a non-empty prompt]")
+    normalized = _normalize_multiple_choice_options(options)
     if normalized is None:
         return ToolResult(
-            text="[error: ask_user needs at least one option; "
+            text="[error: ask_user_multiple_choice needs at least one option; "
                  "each must be a string or {value, label} dict]")
     widget_data = {
         "prompt": prompt,
@@ -212,11 +213,117 @@ async def tool_ask_user(ctx, prompt: str, options: list,
     widget = WidgetRequest(
         widget_type="multiple_choice",
         data=widget_data,
-        on_response=_ask_user_default_on_response(normalized,
-                                                  bool(allow_multiple)),
+        on_response=_default_multiple_choice_callback(normalized,
+                                                      bool(allow_multiple)),
     )
     short = (f"ask: {len(normalized)} option(s)"
              + (" (multi)" if allow_multiple else ""))
+    return ToolResult(
+        text=f"[awaiting user response: {prompt}]",
+        display_short_text=short,
+        widget=widget,
+        end_turn=True,
+    )
+
+
+def _normalize_text_input_fields(fields: list | None) -> list[dict] | None:
+    """Normalize the fields argument into the widget's data_schema shape.
+
+    Accepts None (caller provides default), bare strings (used as both
+    key and title-cased label), or dicts. Dict form requires both
+    ``key`` and ``label``. Returns None on any bad entry, on duplicate
+    keys, or when given None.
+    """
+    if fields is None:
+        return None
+    out: list[dict] = []
+    seen_keys: set[str] = set()
+    for f in fields:
+        if isinstance(f, str):
+            key = f.strip()
+            if not key or key in seen_keys:
+                return None
+            entry: dict = {"key": key, "label": key.replace("_", " ").title()}
+        elif isinstance(f, dict):
+            raw_key = f.get("key")
+            label = f.get("label")
+            if not raw_key or not label:
+                return None
+            key = str(raw_key).strip()
+            if not key or key in seen_keys:
+                return None
+            entry = {"key": key, "label": str(label)}
+            for opt in ("placeholder", "default"):
+                v = f.get(opt)
+                if isinstance(v, str):
+                    entry[opt] = v
+            for opt in ("multiline", "required"):
+                v = f.get(opt)
+                if isinstance(v, bool):
+                    entry[opt] = v
+            ml = f.get("max_length")
+            if isinstance(ml, int) and ml > 0:
+                entry["max_length"] = ml
+        else:
+            return None
+        seen_keys.add(entry["key"])
+        out.append(entry)
+    return out
+
+
+def _default_text_input_callback(field_keys: list[str]):
+    """Build the default ``on_response`` callback for ask_user_text.
+
+    Single field: returns ``"User responded: <value>"`` with the value
+    trimmed. Multi-field: returns ``"User responded: {json}"`` with
+    keys in the field-definition order. Empty / no recognised data:
+    ``"User did not respond."``.
+    """
+    def _cb(data: dict) -> str:
+        if not isinstance(data, dict) or not data:
+            return "User did not respond."
+        if len(field_keys) == 1:
+            value = data.get(field_keys[0], "")
+            text = str(value).strip() if value is not None else ""
+            if not text:
+                return "User did not respond."
+            return f"User responded: {text}"
+        ordered = {k: str(data.get(k, "")) for k in field_keys}
+        if not any(v.strip() for v in ordered.values()):
+            return "User did not respond."
+        return "User responded: " + json.dumps(ordered, ensure_ascii=False)
+
+    return _cb
+
+
+async def tool_ask_user_text(ctx, prompt: str, fields: list | None = None,
+                             submit_label: str = "Submit") -> ToolResult:
+    """Pause the turn and ask the user for free-form text input."""
+    log.info(f"[tool:ask_user_text] prompt={prompt!r} "
+             f"fields={len(fields) if fields else 0}")
+    if not prompt or not prompt.strip():
+        return ToolResult(
+            text="[error: ask_user_text requires a non-empty prompt]")
+    if not fields:
+        normalized: list[dict] = [{"key": "value", "label": prompt.strip()}]
+    else:
+        normalized_or_none = _normalize_text_input_fields(fields)
+        if normalized_or_none is None or not normalized_or_none:
+            return ToolResult(
+                text="[error: ask_user_text fields must each be a non-empty "
+                     "string or a {key, label, ...} dict with unique keys]")
+        normalized = normalized_or_none
+    widget_data: dict = {"prompt": prompt, "fields": normalized}
+    if submit_label and submit_label != "Submit":
+        widget_data["submit_label"] = submit_label
+    widget = WidgetRequest(
+        widget_type="text_input",
+        data=widget_data,
+        on_response=_default_text_input_callback(
+            [f["key"] for f in normalized]),
+    )
+    short = (f"ask: {len(normalized)} field"
+             + ("s" if len(normalized) != 1 else ""))
     return ToolResult(
         text=f"[awaiting user response: {prompt}]",
         display_short_text=short,
@@ -316,7 +423,8 @@ CORE_TOOLS = {
     "context_stats": tool_context_stats,
     "current_time": tool_current_time,
     "wait": tool_wait,
-    "ask_user": tool_ask_user,
+    "ask_user_multiple_choice": tool_ask_user_multiple_choice,
+    "ask_user_text": tool_ask_user_text,
 }
 
 CORE_TOOL_DEFINITIONS = [
@@ -404,10 +512,10 @@ CORE_TOOL_DEFINITIONS = [
         "type": "function",
         "priority": "low",
         "function": {
-            "name": "ask_user",
+            "name": "ask_user_multiple_choice",
             "description": (
-                "Pause the turn and ask the user to pick from a list of "
-                "options. Use ONLY when the right answer is genuinely "
+                "Pause the turn and ask the user to pick from a fixed list "
+                "of options. Use ONLY when the right answer is genuinely "
                 "ambiguous from context and you cannot make a reasonable "
                 "choice on your own. Prefer to act on your best judgment; "
                 "calling this tool is costly — it interrupts the user's "
@@ -452,6 +560,69 @@ CORE_TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["prompt", "options"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "priority": "low",
+        "function": {
+            "name": "ask_user_text",
+            "description": (
+                "Pause the turn and ask the user a free-form text question — "
+                "a single-line answer, a multiline blob, or a small "
+                "multi-field form. Use this when the answer is open-ended "
+                "(a name, a URL, a paragraph). For picking from a fixed "
+                "list of options use ask_user_multiple_choice instead. "
+                "Use ONLY when the right answer is genuinely ambiguous "
+                "from context and you cannot make a reasonable choice on "
+                "your own. Calling this tool is costly — it interrupts "
+                "the user's flow. "
+                "Only works in the web UI; Mattermost / terminal render "
+                "the prompt as text and the turn ends without a response."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Question presented to the user.",
+                    },
+                    "fields": {
+                        "type": "array",
+                        "description": (
+                            "Optional. Each field is either a bare string "
+                            "(used as both key and title-cased label) or a "
+                            "{key, label, placeholder?, default?, "
+                            "multiline?, required?, max_length?} dict. "
+                            "Keys must be unique. Omit for a single-field "
+                            "text question keyed 'value'."
+                        ),
+                        "items": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {"type": "string"},
+                                        "label": {"type": "string"},
+                                        "placeholder": {"type": "string"},
+                                        "default": {"type": "string"},
+                                        "multiline": {"type": "boolean"},
+                                        "required": {"type": "boolean"},
+                                        "max_length": {"type": "integer"},
+                                    },
+                                    "required": ["key", "label"],
+                                },
+                            ],
+                        },
+                    },
+                    "submit_label": {
+                        "type": "string",
+                        "description": "Optional submit button label (default 'Submit').",
+                    },
+                },
+                "required": ["prompt"],
             },
         },
     },

--- a/src/decafclaw/web/static/lib/tool-status-store.js
+++ b/src/decafclaw/web/static/lib/tool-status-store.js
@@ -114,8 +114,13 @@ export class ToolStatusStore {
       tool_call_id: toolCallId,
       data,
     });
-    // Remove this confirm from the pending list — the backend will
-    // broadcast confirmation_response which flips the widget UI state.
+    // Flip the local widget to its post-submit state immediately. The
+    // backend will broadcast confirmation_response which the
+    // CONFIRMATION_RESPONSE handler uses to flip OTHER tabs (their
+    // pendingConfirms still has this entry). On this tab the broadcast
+    // lookup misses (we pop below), so without this direct call the
+    // submitting widget would stay live until reload.
+    this.#messageStore.markToolWidgetSubmitted(toolCallId, data);
     this.#pendingConfirms = this.#pendingConfirms.filter(
       c => c.confirmation_id !== confirm.confirmation_id);
     this.#onChange();

--- a/src/decafclaw/web/static/styles/widgets.css
+++ b/src/decafclaw/web/static/styles/widgets.css
@@ -214,6 +214,44 @@ chat-message .tool-result-raw pre {
   font-size: 0.85rem;
 }
 
+/* ---- text_input ---- */
+
+.widget-text-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.widget-text-input__prompt {
+  margin: 0 0 0.25rem 0;
+}
+
+.widget-text-input__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.widget-text-input__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.widget-text-input__label {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.widget-text-input__actions {
+  margin-top: 0.25rem;
+}
+
+.widget-text-input__submit {
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+}
+
 /* ---- markdown_document ---- */
 
 .md-doc-inline.collapsed .md-doc-body {

--- a/src/decafclaw/web/static/widgets/text_input/widget.js
+++ b/src/decafclaw/web/static/widgets/text_input/widget.js
@@ -1,0 +1,170 @@
+import { LitElement, html, nothing } from 'lit';
+
+/**
+ * Free-form text input widget. Renders a single text input by default,
+ * a textarea when a field has `multiline: true`, or a small multi-field
+ * form when `fields` has more than one entry. Submit dispatches
+ * widget-response with the field values keyed by `key`.
+ *
+ * Props:
+ *   data      { prompt, fields: [{key, label, placeholder?, default?,
+ *                                  multiline?, required?, max_length?}],
+ *              submit_label? }
+ *   submitted boolean — true after the user submits or when reloaded
+ *   response  { [key]: string } — populated on reload
+ */
+export class TextInputWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+    submitted: { type: Boolean },
+    response: { type: Object, attribute: false },
+    _values: { type: Object, state: true },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    /** @type {{prompt: string, fields: Array<Object>, submit_label?: string}|null} */
+    this.data = null;
+    this.submitted = false;
+    /** @type {Object<string,string>|null} */
+    this.response = null;
+    /** @type {Object<string,string>} */
+    this._values = {};
+  }
+
+  /** @param {Map<string, any>} changed */
+  updated(changed) {
+    if ((changed.has('response') || changed.has('submitted'))
+        && this.submitted && this.response) {
+      this._values = { ...this.response };
+      return;
+    }
+    if (changed.has('data') && this.data && !this.submitted) {
+      /** @type {Object<string,string>} */
+      const seeded = {};
+      for (const f of (this.data.fields || [])) {
+        seeded[f.key] = (f.default ?? '');
+      }
+      this._values = seeded;
+    }
+  }
+
+  _onInput(key, e) {
+    const value = /** @type {HTMLInputElement | HTMLTextAreaElement} */ (e.target).value;
+    this._values = { ...this._values, [key]: value };
+  }
+
+  _isSingleLineSingleField() {
+    const fields = this.data?.fields || [];
+    return fields.length === 1 && !fields[0].multiline;
+  }
+
+  _canSubmit() {
+    if (this.submitted) return false;
+    for (const f of (this.data?.fields || [])) {
+      const required = f.required !== false;
+      if (required && !((this._values[f.key] || '').trim())) return false;
+    }
+    return true;
+  }
+
+  _onSubmit() {
+    if (!this._canSubmit()) return;
+    this.dispatchEvent(new CustomEvent('widget-response', {
+      detail: { ...this._values },
+      bubbles: true,
+      composed: true,
+    }));
+    // Don't flip submitted locally — the parent flips it via the
+    // broadcast confirmation_response event so all tabs stay in sync.
+  }
+
+  _onKeyDown(e) {
+    if (e.key !== 'Enter') return;
+    if ((e.metaKey || e.ctrlKey) || this._isSingleLineSingleField()) {
+      e.preventDefault();
+      this._onSubmit();
+    }
+  }
+
+  /** @param {string} key */
+  _fieldId(key) {
+    // HTML id can't contain whitespace and shouldn't contain arbitrary
+    // punctuation. Sanitize to [A-Za-z0-9_-]; collapse runs to a single
+    // dash. Empty after sanitize falls back to `tf-` so attribute is
+    // still present (validation upstream guarantees non-empty key).
+    const safe = String(key)
+      .trim()
+      .replace(/[^A-Za-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    return `tf-${safe || 'field'}`;
+  }
+
+  /** @param {{key: string, label: string, placeholder?: string, default?: string, multiline?: boolean, required?: boolean, max_length?: number}} f */
+  _renderField(f) {
+    const value = this._values[f.key] ?? '';
+    const required = f.required !== false;
+    const id = this._fieldId(f.key);
+    const placeholder = f.placeholder || '';
+    const maxlength = f.max_length || undefined;
+    const input = f.multiline
+      ? html`
+          <textarea
+            id=${id}
+            placeholder=${placeholder}
+            maxlength=${maxlength ?? nothing}
+            ?required=${required}
+            ?disabled=${this.submitted}
+            .value=${value}
+            @input=${(e) => this._onInput(f.key, e)}
+            @keydown=${(e) => this._onKeyDown(e)}
+            rows="3"
+          ></textarea>`
+      : html`
+          <input
+            type="text"
+            id=${id}
+            placeholder=${placeholder}
+            maxlength=${maxlength ?? nothing}
+            ?required=${required}
+            ?disabled=${this.submitted}
+            .value=${value}
+            @input=${(e) => this._onInput(f.key, e)}
+            @keydown=${(e) => this._onKeyDown(e)}
+          />`;
+    return html`
+      <label class="widget-text-input__field" for=${id}>
+        <span class="widget-text-input__label">${f.label}</span>
+        ${input}
+      </label>`;
+  }
+
+  render() {
+    const d = this.data;
+    if (!d || !Array.isArray(d.fields) || d.fields.length === 0) {
+      return html`<div class="widget-text-input widget-text-input--empty"><em>no fields</em></div>`;
+    }
+    const submitLabel = this.submitted
+      ? 'Submitted'
+      : (d.submit_label || 'Submit');
+    return html`
+      <div class="widget-text-input">
+        ${d.prompt ? html`<p class="widget-text-input__prompt">${d.prompt}</p>` : nothing}
+        <div class="widget-text-input__fields">
+          ${d.fields.map((f) => this._renderField(f))}
+        </div>
+        <div class="widget-text-input__actions">
+          <button
+            type="button"
+            class="widget-text-input__submit"
+            ?disabled=${!this._canSubmit()}
+            @click=${this._onSubmit}
+          >${submitLabel}</button>
+        </div>
+      </div>`;
+  }
+}
+
+customElements.define('dc-widget-text-input', TextInputWidget);

--- a/src/decafclaw/web/static/widgets/text_input/widget.json
+++ b/src/decafclaw/web/static/widgets/text_input/widget.json
@@ -1,0 +1,31 @@
+{
+  "name": "text_input",
+  "description": "Ask the user a free-form text question — single-line, multiline, or a small multi-field form. Pauses the agent turn until the user submits.",
+  "modes": ["inline"],
+  "accepts_input": true,
+  "data_schema": {
+    "type": "object",
+    "required": ["prompt", "fields"],
+    "properties": {
+      "prompt": { "type": "string", "minLength": 1 },
+      "fields": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "required": ["key", "label"],
+          "properties": {
+            "key": { "type": "string", "minLength": 1 },
+            "label": { "type": "string", "minLength": 1 },
+            "placeholder": { "type": "string" },
+            "default": { "type": "string" },
+            "multiline": { "type": "boolean" },
+            "required": { "type": "boolean" },
+            "max_length": { "type": "integer", "minimum": 1 }
+          }
+        }
+      },
+      "submit_label": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/tests/test_ask_user_multiple_choice.py
+++ b/tests/test_ask_user_multiple_choice.py
@@ -1,19 +1,19 @@
-"""Tests for the ask_user core tool."""
+"""Tests for the ask_user_multiple_choice core tool."""
 
 import pytest
 
 from decafclaw.media import ToolResult, WidgetRequest
 from decafclaw.tools.core import (
-    _ask_user_default_on_response,
-    _normalize_ask_user_options,
-    tool_ask_user,
+    _default_multiple_choice_callback,
+    _normalize_multiple_choice_options,
+    tool_ask_user_multiple_choice,
 )
 
 # ------------- option normalization -------------
 
 
 def test_normalize_bare_strings():
-    out = _normalize_ask_user_options(["alpha", "beta"])
+    out = _normalize_multiple_choice_options(["alpha", "beta"])
     assert out == [
         {"value": "alpha", "label": "alpha"},
         {"value": "beta", "label": "beta"},
@@ -21,7 +21,7 @@ def test_normalize_bare_strings():
 
 
 def test_normalize_dicts_with_description():
-    out = _normalize_ask_user_options([
+    out = _normalize_multiple_choice_options([
         {"value": "a", "label": "Alpha", "description": "first"},
         {"value": "b", "label": "Beta"},
     ])
@@ -35,23 +35,23 @@ def test_normalize_dict_missing_label_is_rejected():
     """Per the tool-definition schema, dict options require both value
     and label. A dict with only value is invalid input — callers should
     use the bare-string shortcut if they want value=label."""
-    assert _normalize_ask_user_options([{"value": "x"}]) is None
+    assert _normalize_multiple_choice_options([{"value": "x"}]) is None
 
 
 def test_normalize_mixed_strings_and_dicts():
-    out = _normalize_ask_user_options(
+    out = _normalize_multiple_choice_options(
         ["alpha", {"value": "b", "label": "Beta"}])
     assert out[0]["label"] == "alpha"
     assert out[1]["label"] == "Beta"
 
 
 def test_normalize_empty_returns_none():
-    assert _normalize_ask_user_options([]) is None
+    assert _normalize_multiple_choice_options([]) is None
 
 
 def test_normalize_bad_entry_returns_none():
-    assert _normalize_ask_user_options([123]) is None
-    assert _normalize_ask_user_options([{"label": "no value"}]) is None
+    assert _normalize_multiple_choice_options([123]) is None
+    assert _normalize_multiple_choice_options([{"label": "no value"}]) is None
 
 
 # ------------- default on_response -------------
@@ -60,19 +60,19 @@ def test_normalize_bad_entry_returns_none():
 def test_default_response_single_uses_label():
     options = [{"value": "a", "label": "Alpha"},
                {"value": "b", "label": "Beta"}]
-    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    cb = _default_multiple_choice_callback(options, allow_multiple=False)
     assert cb({"selected": "a"}) == "User selected: Alpha"
 
 
 def test_default_response_single_unknown_value_falls_back():
     options = [{"value": "a", "label": "Alpha"}]
-    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    cb = _default_multiple_choice_callback(options, allow_multiple=False)
     assert cb({"selected": "mystery"}) == "User selected: mystery"
 
 
 def test_default_response_single_missing_selection():
     options = [{"value": "a", "label": "Alpha"}]
-    cb = _ask_user_default_on_response(options, allow_multiple=False)
+    cb = _default_multiple_choice_callback(options, allow_multiple=False)
     assert "did not select" in cb({})
 
 
@@ -80,23 +80,23 @@ def test_default_response_multi_joins_labels():
     options = [{"value": "a", "label": "Alpha"},
                {"value": "b", "label": "Beta"},
                {"value": "c", "label": "Gamma"}]
-    cb = _ask_user_default_on_response(options, allow_multiple=True)
+    cb = _default_multiple_choice_callback(options, allow_multiple=True)
     assert cb({"selected": ["a", "c"]}) == "User selected: Alpha, Gamma"
 
 
 def test_default_response_multi_empty():
     options = [{"value": "a", "label": "Alpha"}]
-    cb = _ask_user_default_on_response(options, allow_multiple=True)
+    cb = _default_multiple_choice_callback(options, allow_multiple=True)
     assert "nothing" in cb({"selected": []})
 
 
-# ------------- tool_ask_user integration -------------
+# ------------- tool_ask_user_multiple_choice integration -------------
 
 
 @pytest.mark.asyncio
-async def test_ask_user_happy_path():
+async def test_ask_user_multiple_choice_happy_path():
     ctx = object()  # unused
-    result = await tool_ask_user(
+    result = await tool_ask_user_multiple_choice(
         ctx, prompt="Which deploy target?",
         options=["production", "staging"])
     assert isinstance(result, ToolResult)
@@ -111,9 +111,9 @@ async def test_ask_user_happy_path():
 
 
 @pytest.mark.asyncio
-async def test_ask_user_allow_multiple():
+async def test_ask_user_multiple_choice_allow_multiple():
     ctx = object()
-    result = await tool_ask_user(
+    result = await tool_ask_user_multiple_choice(
         ctx, prompt="Which?",
         options=["a", "b"], allow_multiple=True)
     assert result.widget.data["allow_multiple"] is True
@@ -123,27 +123,27 @@ async def test_ask_user_allow_multiple():
 
 
 @pytest.mark.asyncio
-async def test_ask_user_empty_options_returns_error():
+async def test_ask_user_multiple_choice_empty_options_returns_error():
     ctx = object()
-    result = await tool_ask_user(ctx, prompt="?", options=[])
+    result = await tool_ask_user_multiple_choice(ctx, prompt="?", options=[])
     assert result.widget is None
     assert "error" in result.text.lower()
 
 
 @pytest.mark.asyncio
-async def test_ask_user_blank_prompt_returns_error():
+async def test_ask_user_multiple_choice_blank_prompt_returns_error():
     ctx = object()
-    result = await tool_ask_user(ctx, prompt="   ", options=["a"])
+    result = await tool_ask_user_multiple_choice(ctx, prompt="   ", options=["a"])
     assert result.widget is None
     assert "error" in result.text.lower()
 
 
 @pytest.mark.asyncio
-async def test_ask_user_default_callback_wired_correctly():
+async def test_ask_user_multiple_choice_default_callback_wired_correctly():
     """The default callback formatting matches what tests would
     expect: integrates with the normalized options so label > value."""
     ctx = object()
-    result = await tool_ask_user(
+    result = await tool_ask_user_multiple_choice(
         ctx, prompt="?",
         options=[{"value": "v1", "label": "Nice Label"}])
     inject = result.widget.on_response({"selected": "v1"})

--- a/tests/test_ask_user_text.py
+++ b/tests/test_ask_user_text.py
@@ -1,0 +1,173 @@
+"""Tests for the ask_user_text core tool."""
+
+import json
+
+import pytest
+
+from decafclaw.media import ToolResult, WidgetRequest
+from decafclaw.tools.core import (
+    _default_text_input_callback,
+    _normalize_text_input_fields,
+    tool_ask_user_text,
+)
+
+# ------------- field normalization -------------
+
+def test_normalize_bare_strings_title_cases_label():
+    out = _normalize_text_input_fields(["name", "email_address"])
+    assert out == [
+        {"key": "name", "label": "Name"},
+        {"key": "email_address", "label": "Email Address"},
+    ]
+
+
+def test_normalize_dicts_with_optionals():
+    out = _normalize_text_input_fields([
+        {"key": "bio", "label": "Bio", "multiline": True,
+         "max_length": 500, "required": False, "placeholder": "tell me",
+         "default": "x"},
+    ])
+    assert out == [{
+        "key": "bio", "label": "Bio", "multiline": True,
+        "max_length": 500, "required": False,
+        "placeholder": "tell me", "default": "x",
+    }]
+
+
+def test_normalize_dict_missing_key_or_label_is_rejected():
+    assert _normalize_text_input_fields([{"label": "no key"}]) is None
+    assert _normalize_text_input_fields([{"key": "v"}]) is None
+
+
+def test_normalize_duplicate_keys_rejected():
+    assert _normalize_text_input_fields([
+        {"key": "v", "label": "A"}, {"key": "v", "label": "B"},
+    ]) is None
+
+
+def test_normalize_duplicate_keys_after_str_coercion_rejected():
+    """Catch the bug where dedup happened on the raw value before
+    coercing to str: int 1 vs str "1" must collide once normalized."""
+    assert _normalize_text_input_fields([
+        {"key": 1, "label": "A"}, {"key": "1", "label": "B"},
+    ]) is None
+
+
+def test_normalize_strips_whitespace_from_dict_key():
+    out = _normalize_text_input_fields([
+        {"key": "  v  ", "label": "V"},
+    ])
+    assert out == [{"key": "v", "label": "V"}]
+
+
+def test_normalize_bad_max_length_dropped():
+    out = _normalize_text_input_fields([
+        {"key": "v", "label": "V", "max_length": 0},
+    ])
+    assert out == [{"key": "v", "label": "V"}]
+
+
+def test_normalize_None_returns_None():
+    assert _normalize_text_input_fields(None) is None
+
+
+def test_normalize_bad_entry_returns_None():
+    assert _normalize_text_input_fields([123]) is None
+
+
+# ------------- default on_response -------------
+
+def test_default_callback_single_returns_bare_value():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": "Hello"}) == "User responded: Hello"
+
+
+def test_default_callback_single_strips_whitespace():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": "  Hi  "}) == "User responded: Hi"
+
+
+def test_default_callback_single_empty_says_no_response():
+    cb = _default_text_input_callback(["value"])
+    assert cb({"value": ""}) == "User did not respond."
+    assert cb({}) == "User did not respond."
+
+
+def test_default_callback_multi_returns_json():
+    cb = _default_text_input_callback(["name", "email"])
+    out = cb({"name": "Les", "email": "x@y"})
+    assert out.startswith("User responded: ")
+    assert json.loads(out[len("User responded: "):]) == {
+        "name": "Les", "email": "x@y"}
+
+
+def test_default_callback_multi_preserves_field_order():
+    cb = _default_text_input_callback(["b", "a"])
+    out = cb({"a": "first", "b": "second"})
+    body = out[len("User responded: "):]
+    assert body.index('"b"') < body.index('"a"')
+
+
+def test_default_callback_multi_all_empty_says_no_response():
+    cb = _default_text_input_callback(["a", "b"])
+    assert cb({"a": "", "b": "  "}) == "User did not respond."
+
+
+# ------------- tool integration -------------
+
+@pytest.mark.asyncio
+async def test_tool_happy_single_field_default():
+    ctx = object()
+    result = await tool_ask_user_text(ctx, prompt="Your name?")
+    assert isinstance(result, ToolResult)
+    assert result.end_turn is True
+    assert isinstance(result.widget, WidgetRequest)
+    assert result.widget.widget_type == "text_input"
+    fields = result.widget.data["fields"]
+    assert len(fields) == 1
+    assert fields[0] == {"key": "value", "label": "Your name?"}
+    assert "awaiting user response" in result.text
+
+
+@pytest.mark.asyncio
+async def test_tool_multi_field():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="Contact info?",
+        fields=[
+            {"key": "name", "label": "Name"},
+            {"key": "email", "label": "Email", "required": False},
+        ],
+        submit_label="Send",
+    )
+    assert result.widget.data["submit_label"] == "Send"
+    assert len(result.widget.data["fields"]) == 2
+    inject = result.widget.on_response({"name": "Les", "email": "x@y"})
+    assert json.loads(inject[len("User responded: "):]) == {
+        "name": "Les", "email": "x@y"}
+
+
+@pytest.mark.asyncio
+async def test_tool_blank_prompt_returns_error():
+    ctx = object()
+    result = await tool_ask_user_text(ctx, prompt="   ")
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_bad_fields_returns_error():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="?", fields=[{"label": "no key"}])
+    assert result.widget is None
+    assert "error" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_tool_default_callback_wired():
+    ctx = object()
+    result = await tool_ask_user_text(
+        ctx, prompt="?", fields=["color"])
+    inject = result.widget.on_response({"color": "blue"})
+    assert inject == "User responded: blue"

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -54,7 +54,7 @@ class TestBuildToolSummary:
             {"role": "user", "content": "ask me a question"},
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "tc1", "function": {
-                    "name": "ask_user",
+                    "name": "ask_user_multiple_choice",
                     "arguments": json.dumps(
                         {"prompt": "Pick one", "options": ["a", "b"]}),
                 }},
@@ -66,7 +66,7 @@ class TestBuildToolSummary:
             {"role": "assistant", "content": "You picked A."},
         ]
         result = build_tool_summary(history, 0)
-        assert "ask_user" in result
+        assert "ask_user_multiple_choice" in result
         assert "User responded to widget" in result
         assert "User selected: a" in result
 
@@ -79,7 +79,7 @@ class TestBuildToolSummary:
             {"role": "user", "content": "first turn"},
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "tc1", "function": {
-                    "name": "ask_user",
+                    "name": "ask_user_multiple_choice",
                     "arguments": json.dumps({"prompt": "x", "options": []}),
                 }},
             ]},
@@ -94,8 +94,8 @@ class TestBuildToolSummary:
         # first turn + synthetic. Synthetic must NOT be a turn boundary.
         result = build_prior_turn_summary(history, 5, max_turns=3)
         # Should have exactly one prior turn ("first turn"), with
-        # the ask_user call in its tool lines.
-        assert "ask_user" in result
+        # the ask_user_multiple_choice call in its tool lines.
+        assert "ask_user_multiple_choice" in result
         # The synthetic response is included as a tool-line entry;
         # there's no second "User selected" turn-boundary spawning a
         # second prior turn.

--- a/tests/test_text_input_widget.py
+++ b/tests/test_text_input_widget.py
@@ -1,0 +1,69 @@
+"""Tests for the text_input widget's data_schema validation."""
+
+from decafclaw.widgets import load_widget_registry
+
+
+class _Cfg:
+    def __init__(self, agent_path):
+        self.agent_path = agent_path
+
+
+def _registry(tmp_path):
+    return load_widget_registry(_Cfg(tmp_path / "agent"))
+
+
+def test_text_input_registered(tmp_path):
+    reg = _registry(tmp_path)
+    desc = reg.get("text_input")
+    assert desc is not None
+    assert desc.accepts_input is True
+    assert desc.modes == ["inline"]
+
+
+def test_validate_single_field(tmp_path):
+    reg = _registry(tmp_path)
+    ok, err = reg.validate("text_input", {
+        "prompt": "What's your name?",
+        "fields": [{"key": "value", "label": "Name"}],
+    })
+    assert ok, err
+
+
+def test_validate_multi_field_with_optionals(tmp_path):
+    reg = _registry(tmp_path)
+    ok, err = reg.validate("text_input", {
+        "prompt": "Contact info",
+        "fields": [
+            {"key": "name", "label": "Name", "placeholder": "Les"},
+            {"key": "email", "label": "Email", "default": "x@y",
+             "max_length": 200, "required": False},
+            {"key": "bio", "label": "Bio", "multiline": True},
+        ],
+        "submit_label": "Send",
+    })
+    assert ok, err
+
+
+def test_validate_rejects_empty_fields(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "prompt": "x", "fields": [],
+    })
+    assert not ok
+
+
+def test_validate_rejects_missing_key(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "prompt": "x",
+        "fields": [{"label": "no key"}],
+    })
+    assert not ok
+
+
+def test_validate_rejects_missing_prompt(tmp_path):
+    reg = _registry(tmp_path)
+    ok, _ = reg.validate("text_input", {
+        "fields": [{"key": "v", "label": "V"}],
+    })
+    assert not ok

--- a/tests/test_web_widget_response_handler.py
+++ b/tests/test_web_widget_response_handler.py
@@ -120,7 +120,7 @@ def test_annotate_pairs_widget_response_to_tool():
     archive = [
         {"role": "assistant", "content": "",
          "tool_calls": [{"id": "tc-1",
-                         "function": {"name": "ask_user", "arguments": "{}"}}]},
+                         "function": {"name": "ask_user_multiple_choice", "arguments": "{}"}}]},
         {"role": "tool", "tool_call_id": "tc-1", "content": "[awaiting]",
          "widget": {"widget_type": "multiple_choice",
                     "target": "inline", "data": {}}},


### PR DESCRIPTION
## Summary

- Adds the `text_input` widget — single-line, multiline, or small multi-field form — closing the biggest gap in the input widget catalog (previously only `multiple_choice`).
- Adds `ask_user_text(prompt, fields=None, submit_label="Submit")` core tool that emits the new widget.
- Hard-renames `ask_user` → `ask_user_multiple_choice` for symmetric naming with the new sibling. No alias (per CLAUDE.md).
- **Drive-by fix:** live-tab `submitted` state now flips immediately after submission. This was a pre-existing bug from #366 that affected `multiple_choice` (and would have affected `text_input` too) — surfaced during the Playwright walkthrough.

Closes #410.

## What's new

- **`src/decafclaw/web/static/widgets/text_input/{widget.json,widget.js}`** — inline-only, `accepts_input: true`. Per-field options: `placeholder`, `default`, `multiline` (renders `<textarea>`), `required` (default `true`), `max_length` (HTML `maxlength`). Keys must be unique. Keyboard: Enter submits only when there's exactly one non-multiline field; otherwise button (or Cmd/Ctrl+Enter).
- **`tool_ask_user_text`** — single-field default keys `'value'`; multi-field opt-in via `fields=[...]`. Bare-string fields auto-title-case labels. Default `on_response` shapes the inject string: `"User responded: <value>"` (single-field), JSON object (multi-field), `"User did not respond."` (empty).
- **`evals/tool_choice/core_overlaps.yaml`** — three new disambiguation cases between `ask_user_text` and `ask_user_multiple_choice`.
- **`docs/widgets.md`** — rewritten input-tools section with side-by-side examples.

## Bug fix (drive-by)

`src/decafclaw/web/static/lib/tool-status-store.js`: `respondToWidget` now calls `markToolWidgetSubmitted` directly on the submitting tab instead of relying on the `CONFIRMATION_RESPONSE` broadcast (which missed on the local tab because `respondToWidget` pops the confirm from `pendingConfirms` before the broadcast arrives). Other tabs continue to flip via the broadcast. Affected `multiple_choice` and would have affected `text_input` equally; landed with #366. See session notes for the full diagnosis.

## Renames

- `tool_ask_user` → `tool_ask_user_multiple_choice`
- `_normalize_ask_user_options` → `_normalize_multiple_choice_options`
- `_ask_user_default_on_response` → `_default_multiple_choice_callback`
- `tests/test_ask_user.py` → `tests/test_ask_user_multiple_choice.py`
- registry key, tool definition `name`, log + error messages updated

## Design decisions

See [`spec.md`](docs/dev-sessions/2026-04-29-1459-widget-text-input-410/spec.md). Key calls:

- **Smart-default inject string** — single-field unwraps to bare value, multi-field is JSON. Mirrors `multiple_choice`'s natural-language style for the common case, JSON when ambiguous.
- **Hard rename, no alias.** Symmetric naming pays off forever; churn is contained to one PR.
- **v1 fields:** `{key, label, placeholder?, default?, multiline?, required?, max_length?}`. All cheap to support; richer validation deferred.
- **Client-side enforcement only** for `required`/`maxlength` — matches `multiple_choice`'s trust model.
- **Enter-submit** only for the single non-multiline field shape — real-form convention.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (2269 tests, was 2243)
- [x] `make check` passes (Python + JS typecheck)
- [x] `make eval-tools` — all 3 new `ask_user_*` disambiguation cases pass
- [x] Playwright walkthrough: single-field default (Enter submits, agent received `User responded: Indigo`), multi-field with multiline (button-only submit, JSON inject parsed correctly), renamed `ask_user_multiple_choice` (radios, agent received selected label), page-refresh recovery (submitted state restored), live-tab `submitted` flip after the bug fix (verified for both `text_input` and `multiple_choice`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)