### PR TITLE
Eval harness: expect_tool / expect_no_tool / expect_tool_count_by_name

### DIFF
--- a/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/notes.md
+++ b/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/notes.md
@@ -1,0 +1,23 @@
+# Session notes: eval-expect-tool-assertions
+
+**Issue:** [#349](https://github.com/lmorchard/decafclaw/issues/349) — Eval harness: expect_tool / expect_no_tool / expect_tool_count_by_name assertions
+**Branch:** `eval-expect-tool-assertions`
+**Worktree:** `.claude/worktrees/eval-expect-tool-assertions/`
+**Started:** 2026-04-29 15:01
+
+## Context
+
+Split from #240. Audit doc in #338 (`docs/dev-sessions/2026-04-24-0941-eval-coverage/evals-audit.md`) flagged that `docs/eval-loop.md` originally claimed `expect_tool` support but the runner never implemented it. Row was removed from doc table. Real feature still needed — load-bearing for tool-deferral evals.
+
+## Scope (from issue)
+
+Implement three assertions in `src/decafclaw/eval/runner.py::_check_assertions`:
+- `expect.expect_tool: <name>` — fail if agent did NOT call named tool
+- `expect.expect_no_tool: <name>` — fail if agent DID call named tool
+- `expect.expect_tool_count_by_name: {name: count}` — exact match (consider min/max later)
+
+Update `docs/eval-loop.md` to re-add to field table.
+
+## Open questions / observations
+
+(filled during brainstorm)

--- a/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/plan.md
+++ b/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/plan.md
@@ -1,0 +1,178 @@
+# Eval tool-name assertions Implementation Plan
+
+**Goal:** Add `expect_tool`, `expect_no_tool`, and `expect_tool_count_by_name` assertion fields to the eval runner so tests can rigorously assert which tools the agent invoked.
+
+**Approach:** Add a `_collect_tool_names(history) -> list[str]` helper that walks `role: assistant` messages and extracts `function.name` from `tool_calls`. Thread per-turn tool-name lists through `_check_assertions` as a new kwarg. Two phases — phase 1 ships presence/absence assertions with their unit tests and doc rows; phase 2 ships the count assertion with its unit tests and doc row.
+
+**Tech stack:** Python (existing), pytest (existing). No new dependencies.
+
+---
+
+## Phase 1: Presence and absence — `expect_tool` / `expect_no_tool`
+
+Adds the helper, extends `_check_assertions`, ships the two str-or-list assertions with OR/AND semantics, plus their docs.
+
+**Files:**
+- Modify: `src/decafclaw/eval/runner.py` — add `_collect_tool_names` helper near `_count_tool_calls` (~line 105); extend `_check_assertions` signature and body; thread per-turn tool names through both call sites.
+- Modify: `docs/eval-loop.md` — add two new rows to the expect-fields table at lines 52-57; update the "list uses OR semantics" note at line 59 to mention the new `expect_tool` / `expect_no_tool` pair.
+- Create: `tests/test_eval_runner_assertions.py` — direct unit tests for `_check_assertions` covering all existing fields (regression) and the two new fields.
+
+**Key changes:**
+
+New helper in `runner.py` (placed after `_count_tool_calls` and before `_count_tool_errors`):
+
+```python
+def _collect_tool_names(history: list) -> list[str]:
+    """List tool names called in the (slice of) history, in call order, including duplicates."""
+    names = []
+    for msg in history:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            name = (call.get("function") or {}).get("name")
+            if name:
+                names.append(name)
+    return names
+```
+
+Extended `_check_assertions` signature (`runner.py:133-134`):
+
+```python
+def _check_assertions(test_case: dict, response: str, tool_calls: int,
+                      tool_errors: int = 0,
+                      tool_names: list[str] | None = None) -> tuple[bool, str]:
+```
+
+New body branches (after the existing `max_tool_errors` branch at `runner.py:171-173`, before `return True, ""`):
+
+```python
+    names = tool_names or []
+    called_repr = f"[{', '.join(names)}]" if names else "no tools were called"
+
+    expect_tool = expect.get("expect_tool")
+    if expect_tool is not None:
+        wanted = [expect_tool] if isinstance(expect_tool, str) else list(expect_tool)
+        if not any(w in names for w in wanted):
+            return False, f"Expected one of {wanted} to be called, but tools called were {called_repr}"
+
+    expect_no_tool = expect.get("expect_no_tool")
+    if expect_no_tool is not None:
+        forbidden = [expect_no_tool] if isinstance(expect_no_tool, str) else list(expect_no_tool)
+        for f in forbidden:
+            if f in names:
+                return False, f"Unexpected tool called: '{f}' (called tools: {called_repr})"
+```
+
+Call-site updates in `run_test`:
+- Line 271 (help/fork-mode early assertion check): pass `tool_names=[]` (no tools ran).
+- Line 302-303 (per-turn check): compute `tool_names = _collect_tool_names(history[pre_turn_history_len:])` and pass it as the new kwarg.
+
+Test scaffolding pattern:
+
+```python
+def _assistant(tool_calls):
+    """Build a synthetic assistant message with the given tool calls."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": f"call_{i}", "function": {"name": n, "arguments": "{}"}}
+            for i, n in enumerate(tool_calls)
+        ],
+    }
+
+def _tool_result(call_id="call_0", content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+```
+
+Required unit tests in `tests/test_eval_runner_assertions.py`:
+1. `test_expect_tool_string_match_passes` — `expect_tool: "vault_search"` with history containing one `vault_search` call → passes.
+2. `test_expect_tool_string_no_match_fails` — `expect_tool: "vault_search"` with history calling only `web_fetch` → fails, message names both expected list and called list.
+3. `test_expect_tool_list_or_semantics_passes` — `expect_tool: ["a", "b"]` with `b` called → passes.
+4. `test_expect_tool_no_tools_called_fails` — `expect_tool: "x"` with empty history → fails, message says "no tools were called".
+5. `test_expect_no_tool_string_blocks_match` — `expect_no_tool: "web_fetch"` with `web_fetch` called → fails.
+6. `test_expect_no_tool_string_passes_when_absent` — `expect_no_tool: "web_fetch"` with `vault_search` called → passes.
+7. `test_expect_no_tool_list_and_semantics` — `expect_no_tool: [a, b]` with `c` called → passes; with `b` called → fails.
+8. Regression tests: one each for `response_contains`, `response_not_contains`, `max_tool_calls`, `max_tool_errors` (so the new kwarg threading doesn't silently break existing fields).
+
+Helpers in tests should call `_collect_tool_names` to convert a synthetic history into the kwarg, exercising the helper too.
+
+Doc rows added to `docs/eval-loop.md:52-57` table (preserving existing rows):
+
+```
+| `expect_tool` | str / list[str] | **OR semantics.** Fail if none of the listed tools were called this turn. |
+| `expect_no_tool` | str / list[str] | **AND semantics.** Fail if any of the listed tools were called this turn. |
+```
+
+Plus, after the table (around line 59), add a one-line note: `Tool-name assertions see only parent-agent tool calls; tools invoked inside child agents (via delegate_task) are not visible.`
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2260 passed)
+- [x] `make check` passes (0 errors / warnings)
+- [x] `uv run pytest tests/test_eval_runner_assertions.py -v` — 17 passed; both new fields and the four regression tests covered.
+
+**Verification — manual:**
+- [x] Spec compliance review: ✅ all 8 numbered requirements satisfied, no extras.
+- [x] Code quality review: ✅ approved, no critical / important issues; helper style matches existing idioms; Phase-2 reusability of `names` / `called_repr` confirmed.
+
+---
+
+## Phase 2: Counts — `expect_tool_count_by_name`
+
+Adds the dict-valued count assertion using the same per-turn `tool_names` already threaded through in phase 1.
+
+**Files:**
+- Modify: `src/decafclaw/eval/runner.py` — add one branch in `_check_assertions` after the `expect_no_tool` branch from phase 1.
+- Modify: `docs/eval-loop.md` — add the third row to the field table.
+- Modify: `tests/test_eval_runner_assertions.py` — add count-assertion tests.
+
+**Key changes:**
+
+New branch (placed after the `expect_no_tool` branch from phase 1, before `return True, ""`):
+
+```python
+    count_by_name = expect.get("expect_tool_count_by_name")
+    if count_by_name is not None:
+        for name, want in count_by_name.items():
+            got = sum(1 for n in names if n == name)
+            if got != want:
+                return False, (
+                    f"Tool count mismatch for '{name}': expected {want}, got {got} "
+                    f"(called tools: {called_repr})"
+                )
+```
+
+Required unit tests added to `tests/test_eval_runner_assertions.py`:
+1. `test_count_exact_match_passes` — `expect_tool_count_by_name: {a: 2, b: 1}` with history `[a, b, a]` → passes.
+2. `test_count_too_few_fails` — `{a: 2}` with history `[a]` → fails, message names tool, expected, got.
+3. `test_count_too_many_fails` — `{a: 1}` with history `[a, a]` → fails.
+4. `test_count_zero_means_not_called` — `{web_fetch: 0}` with history `[vault_search]` → passes; with `[web_fetch]` → fails.
+5. `test_count_unlisted_tool_unconstrained` — `{a: 1}` with history `[a, b, b, b]` → passes (b unconstrained).
+6. `test_count_with_other_assertions_combine` — same `expect` block has `expect_tool: x` and `expect_tool_count_by_name: {x: 2}`; both pass when satisfied; one failing fails the whole check.
+
+Doc row added to the field table at `docs/eval-loop.md`:
+
+```
+| `expect_tool_count_by_name` | dict[str, int] | Fail if any listed tool's call count this turn does not equal the mapped int. Tools not listed are unconstrained. Count `0` is allowed (overlaps `expect_no_tool`). |
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2268 passed)
+- [x] `make check` passes (0 errors / warnings)
+- [x] `uv run pytest tests/test_eval_runner_assertions.py -v` — 25 passed (17 from Phase 1 + 8 new).
+
+**Verification — manual:**
+- [x] Spec compliance review: ✅ all requirements satisfied; only the three planned files changed.
+- [x] Code quality review: ✅ approved, no critical / important issues; reuses Phase 1 locals cleanly. Minor (deferred, ship-it): `names.count(name)` over `sum(1 for ...)`; first-mismatch-order test.
+
+---
+
+## Out of scope (locked by spec)
+
+- Min/max range form for counts.
+- Order or argument assertions.
+- Recursing into child-agent histories.
+- Touching `__main__.py` or YAML loading.
+- Refactoring existing assertion branches.

--- a/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/research.md
+++ b/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/research.md
@@ -1,0 +1,123 @@
+# Eval Runner Architecture Research
+
+## 1. Runner Structure & Assertions
+
+**Location:** `src/decafclaw/eval/runner.py:133-175`
+
+Function `_check_assertions(test_case: dict, response: str, tool_calls: int, tool_errors: int = 0) -> tuple[bool, str]` receives:
+- `test_case`: Full test case dict containing `expect` field
+- `response`: Final assistant text response (string)
+- `tool_calls`: Integer count of tool calls in this turn
+- `tool_errors`: Integer count of tool results containing `[error` (default 0)
+
+Returns `(passed: bool, failure_reason: str)`.
+
+**Caller signature** (`run_test`, line 178-341):
+- Single-turn format: `{"input": "...", "expect": {...}}`
+- Multi-turn format: `{"turns": [{input, expect}, ...]}`
+- Per-turn assertion check at line 303: `passed, reason = _check_assertions(turn, response, tool_calls, tool_errors)`
+
+**Current assertion fields** (lines 142-173):
+- `response_contains`: str/list/regex (`"re:"` prefix). OR semantics: matches if any string found (case-insensitive) or regex matches (line 149: `re.search(c[3:], response, re.IGNORECASE)`).
+- `response_not_contains`: str/list. AND semantics: fails if any listed string is present (line 164).
+- `max_tool_calls`: int. Fails if `tool_calls > max_tools` (line 168-169).
+- `max_tool_errors`: int. Fails if `tool_errors > max_errors` (line 171-173).
+
+**Failure reporting** (lines 309-311): Constructs `f"Turn {turn_idx + 1}: {reason}"` with optional error details appended: `f"\n         Errors: {detail_str}"`.
+
+## 2. Tool Call Data Shape
+
+**Assistant message with tool calls** (`src/decafclaw/agent.py:1133-1147`):
+```python
+assistant_msg = {"role": "assistant", "content": iter_content}
+assistant_msg["tool_calls"] = tool_calls
+```
+
+**Tool call structure** (from `src/decafclaw/llm/providers/openai_compat.py:113-123`):
+Each tool call has: `{"id": "...", "function": {"name": "...", "arguments": "..."}, ...}`
+- `id`: Tool call ID (sanitized at line 116 to strip `__thought__` data)
+- `function.name`: Tool function name
+- `function.arguments`: JSON string of arguments
+
+**Tool result message** (`src/decafclaw/agent.py:802-808`):
+```python
+tool_msg = {
+    "role": "tool",
+    "tool_call_id": tool_calls[i]["id"],  # Matches assistant's tool_call["id"]
+    "content": "[error: ...]" or actual result
+}
+```
+
+**Provider format** (OpenAI-compatible): Returns `{"content", "tool_calls", "role": "assistant", "usage"}` — internal normalized format across all providers (Vertex, OpenAI, OpenAI-compat).
+
+## 3. Eval Test Format
+
+**Location:** `evals/` (YAML files)
+
+**Single-turn example** (`evals/memory.yaml:1-9`):
+```yaml
+- name: "finds preference by direct term"
+  setup:
+    memories:
+      - tags: [preference, cocktail]
+        content: "Favorite cocktails are Boulevardier and Old Fashioned"
+  input: "What are my favorite cocktails?"
+  expect:
+    response_contains: "Boulevardier"
+    max_tool_calls: 8
+```
+
+**Multi-turn example** (`evals/memory-multi-turn.yaml:1-8`):
+```yaml
+- name: "save then recall hobby"
+  turns:
+    - input: "Remember that I play guitar on weekends"
+      expect:
+        response_contains: "guitar"
+    - input: "What are my hobbies?"
+      expect:
+        response_contains: "guitar"
+```
+
+**Loading** (`src/decafclaw/eval/__main__.py:38-51`):
+- Lines 39-42: Discover YAML files in directory or use single file
+- Lines 47-50: Load via `yaml.safe_load()` and extend `all_cases` list
+- Each case dict is passed to `run_test(config, test_case)` at line 379
+
+## 4. Failure Reporting
+
+**Format strings**:
+- `runner.py:156`: `f"Expected one of {contains} in response"`
+- `runner.py:165`: `f"Response should not contain '{nc}'"`
+- `runner.py:169`: `f"Too many tool calls: {tool_calls} > {max_tools}"`
+- `runner.py:173`: `f"Too many tool errors: {tool_errors} > {max_errors}"`
+- `runner.py:309`: `f"Turn {turn_idx + 1}: {reason}"`
+- `runner.py:311` (with errors): `f"\n         Errors: {detail_str}"` (errors truncated to 200 chars per line 129)
+
+**Surfacing** (`src/decafclaw/eval/__main__.py:81-104`):
+- Results dict saved to JSON at line 98: `bundle_dir / "results.json"`
+- Failures printed to stdout at lines 425-426: `print(f"         {result.get('failure_reason', '')}")`
+- Full history appended to result dict if failed (line 339: `result["history"] = history`)
+
+## 5. Existing Tests for Assertions
+
+**No direct unit tests for `_check_assertions` found.**
+
+Tests for tool-choice eval runner (`tests/test_eval_tool_choice_runner.py`) test a *different* eval harness (tool disambiguation, line 1-2: "tool-choice eval runner (#303)"). The main `run_test` and `_check_assertions` functions in `runner.py` have no corresponding test file — testing relies on end-to-end eval runs with real YAML test cases and mock tools.
+
+## 6. Doc State
+
+**File:** `docs/eval-loop.md:52-57`
+
+Current expect field table:
+
+```
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `response_contains` | str / list[str] / `"re:pattern"` | **OR semantics.** Matches if any listed string/regex is in the response. Case-insensitive for non-regex; regex uses `re:` prefix. |
+| `response_not_contains` | str / list[str] | **AND semantics.** Fails if any listed string is in the response. Case-insensitive. |
+| `max_tool_calls` | int | Fail if tool calls in this turn exceed the bound |
+| `max_tool_errors` | int | Fail if tool results containing `[error` in this turn exceed the bound |
+```
+
+No other doc page explicitly describes eval assertions; the table at line 52-57 is the authoritative reference.

--- a/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/spec.md
+++ b/docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/spec.md
@@ -1,0 +1,99 @@
+# Eval tool-name assertions Spec
+
+**Goal:** Let eval YAML files assert *which* tools the agent called (or didn't), and how many times — strengthening tool-deferral evals and replacing today's indirect "tool count + response text" approximation.
+
+**Source:** [#349](https://github.com/lmorchard/decafclaw/issues/349) (split from #240; missing-feature flagged in audit doc on #338).
+
+## Current state
+
+- `_check_assertions` (`src/decafclaw/eval/runner.py:133-175`) inspects `expect.response_contains`, `expect.response_not_contains`, `expect.max_tool_calls`, `expect.max_tool_errors`. It receives counts only — no tool-name visibility.
+- Per-turn slicing already works: `run_test` takes a snapshot at `pre_turn_history_len` (`runner.py:246`) and uses it to compute deltas (lines 290, 302) and to slice errors (line 307). Same approach can deliver per-turn tool names.
+- Tool-call data lives on `assistant.tool_calls[i].function.name` (research §2 — `agent.py:1133-1147`, `openai_compat.py:113-123`). `role: tool` messages only have `tool_call_id`/`content`, so a name-extraction helper must walk **assistant** messages, not tool messages.
+- Failure messages flow through `runner.py:309-311`: `f"Turn {turn_idx + 1}: {reason}"`, optionally with appended error details.
+- No unit tests exist for `_check_assertions` today (research §5). `tests/test_eval_tool_choice_runner.py` covers a different harness.
+- `docs/eval-loop.md:52-57` has the canonical `expect` field table — three rows to add.
+
+## Desired end state
+
+Three new fields, all nested inside `expect:`:
+
+```yaml
+expect:
+  expect_tool: vault_search                 # str OR list[str]; OR semantics
+  expect_no_tool: [web_fetch, shell_exec]   # str OR list[str]; AND semantics
+  expect_tool_count_by_name:                # dict[str, int]; exact match
+    vault_search: 2
+    web_fetch: 0
+```
+
+**Semantics**
+
+- `expect_tool`: fail if **none** of the listed tools were called this turn. Single string is treated as a one-element list.
+- `expect_no_tool`: fail if **any** of the listed tools were called this turn. Single string is treated as a one-element list.
+- `expect_tool_count_by_name`: fail if any listed tool's call count this turn does not equal its mapped int. Tools not listed are unconstrained. Count of 0 is allowed (overlaps `expect_no_tool` — tolerant input).
+
+**Scope** (matches existing `max_tool_calls` semantics): parent-agent tool calls only. Tool calls inside child agents spawned by `delegate_task` are not visible here — they live in the child's separate history. Documented in `docs/eval-loop.md`.
+
+**Failure messages** are specific and list what was actually called this turn:
+
+- `expect_tool`: `"expected one of [vault_search] but tools called were [web_fetch]"` (or `"... but no tools were called"` if empty)
+- `expect_no_tool`: `"unexpected tool called: web_fetch (called tools: [web_fetch, vault_read])"`
+- `expect_tool_count_by_name`: `"tool count mismatch for 'vault_search': expected 2, got 1 (called tools: [vault_search, web_fetch])"`
+
+These flow through the existing `Turn N: {reason}` wrapper unchanged.
+
+**Doc update.** `docs/eval-loop.md:52-57` table gets three new rows describing the assertions.
+
+## Design decisions
+
+- **Decision:** Field names match the issue text verbatim (`expect_tool`, `expect_no_tool`, `expect_tool_count_by_name`).
+  - **Why:** Issue is explicit; the `expect_` prefix on tool-name assertions reads naturally as "I expect this tool to be called" and disambiguates from response assertions. Honors author intent.
+  - **Rejected:** `tool_called` / `tool_not_called` / `tool_call_counts` (drop redundant prefix). Read more like state assertions than expectations and didn't match the issue.
+
+- **Decision:** `expect_tool` and `expect_no_tool` accept str OR list[str], with OR / AND semantics respectively.
+  - **Why:** Symmetry with `response_contains` (str/list, OR) and `response_not_contains` (str/list, AND) — users already know this shape. List-of-one collapses to the singular form, so we never lose expressiveness.
+  - **Rejected:** Singular-only (per issue text). Forces splitting into separate eval cases or waiting on count-by-name for any "either of these" assertion.
+  - **Rejected:** AND semantics on `expect_tool` (every listed tool must be called). Different from `response_contains` precedent; `expect_tool_count_by_name: {a: 1, b: 1}` covers this case once it lands.
+
+- **Decision:** `expect_tool_count_by_name` is exact-match only (`{name: int}`), no min/max range form yet.
+  - **Why:** Issue's acceptance criteria explicitly defer min/max. Exact form is sufficient for the tool-deferral evals that prompted this work. Polymorphic value (int vs `{min, max}`) opens a YAML-schema design question better answered when a real test needs it.
+  - **Rejected:** Polymorphic value now. Premature — no concrete use case yet, and `count: 0` already covers the most common range case ("must not be called").
+
+- **Decision:** Count of 0 is allowed in `expect_tool_count_by_name`, even though it overlaps with `expect_no_tool`.
+  - **Why:** Tolerant input. Users pick whichever reads better in context. No validation cost.
+  - **Rejected:** Reject 0 with an error. Adds friction without preventing any real bug.
+
+- **Decision:** Tool-name extraction walks assistant messages and reads `function.name` from `tool_calls`.
+  - **Why:** That's where names live (research §2). `role: tool` messages only carry `tool_call_id`.
+  - **Rejected:** Reverse-resolving from `tool_call_id` back to the assistant message. More work, no benefit.
+
+- **Decision:** Scope is parent-level only — child-agent tool calls inside `delegate_task` are invisible to these assertions.
+  - **Why:** Matches existing `max_tool_calls` semantics. Child-agent histories are separate; surfacing them would require deeper plumbing and wasn't requested. Documented in `eval-loop.md`.
+  - **Rejected:** Recursing into child histories. Out of scope; can be added later if needed.
+
+- **Decision:** Failure messages list the called-tools set so the reader sees what *did* happen.
+  - **Why:** Acceptance criterion ("Test failure messages are specific"). Mirrors `response_contains` failure that quotes the expected list.
+  - **Rejected:** Bare `"expected_tool not called"`. Less actionable; user has to dig into history.
+
+## Patterns to follow
+
+- **Per-turn delta extraction:** mirror the snapshot-then-subtract pattern at `runner.py:246-302`. Add a `_collect_tool_names(history) -> list[str]` helper next to `_count_tool_calls` (`runner.py:103-105`); slice with `pre_turn_history_len` like the existing error collector at `runner.py:120-130`.
+- **Helper signatures:** keep top-level module-private functions returning plain types (cf. `_count_tool_calls`, `_collect_tool_errors`). New helper returns `list[str]` (one entry per tool call, in call order, including duplicates).
+- **`_check_assertions` extension:** add one new keyword argument carrying the per-turn tool-name list. Existing call sites at `runner.py:271, 303` get the new arg threaded through.
+- **Failure-message style:** match the existing format strings at `runner.py:156, 165, 169, 173` — short, parenthetical context, no log-level prefixes.
+- **Test pattern:** add `tests/test_eval_runner_assertions.py` (or similar) that calls `_check_assertions` directly with synthetic histories. Follow the pattern in `tests/test_eval_tool_choice_runner.py` for synthetic-message construction. No end-to-end YAML loading needed.
+
+## What we're NOT doing
+
+- **No min/max range form** for `expect_tool_count_by_name`. Defer until a concrete eval needs it.
+- **No order assertions** (e.g. "tool A before tool B"). Out of scope.
+- **No call-argument assertions** (e.g. "vault_search called with `query: foo`"). Out of scope.
+- **No recursion into child-agent histories** from `delegate_task`. Parent-level only.
+- **No new MCP-tool special-casing.** MCP tool names (`mcp__server__tool`) are matched as exact strings.
+- **No refactor of existing assertions** (`response_contains`, `max_tool_calls`, etc.). Touch them only if the new arg threading requires it.
+- **No changes to eval discovery / loading** (`__main__.py`). All changes are inside `runner.py` plus tests plus docs.
+- **No new YAML schema validation pass.** Tolerant input — bad shapes (e.g. `expect_tool_count_by_name: 5`) raise a TypeError at runtime; that's fine.
+
+## Open questions
+
+None blocking the plan.

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -55,8 +55,13 @@ Tests are YAML files with a list of test cases. Single-turn form:
 | `response_not_contains` | str / list[str] | **AND semantics.** Fails if any listed string is in the response. Case-insensitive. |
 | `max_tool_calls` | int | Fail if tool calls in this turn exceed the bound |
 | `max_tool_errors` | int | Fail if tool results containing `[error` in this turn exceed the bound |
+| `expect_tool` | str / list[str] | **OR semantics.** Fail if none of the listed tools were called this turn. |
+| `expect_no_tool` | str / list[str] | **AND semantics.** Fail if any of the listed tools were called this turn. |
+| `expect_tool_count_by_name` | dict[str, int] | Fail if any listed tool's call count this turn does not equal the mapped int. Tools not listed are unconstrained. Count `0` is allowed (overlaps `expect_no_tool`). |
 
 Note that `response_contains` with a list uses OR semantics — to require several strings, use a single `re:(?s).*foo.*bar.*` regex, or use multiple assertions by splitting into separate test cases.
+
+Tool-name assertions see only parent-agent tool calls; tools invoked inside child agents (via `delegate_task`) are not visible.
 
 ### Multi-turn tests
 

--- a/evals/memory.yaml
+++ b/evals/memory.yaml
@@ -41,6 +41,8 @@
   expect:
     response_contains: "Python"
     max_tool_calls: 5
+    expect_tool: vault_journal_append
+    expect_no_tool: [shell, shell_patterns]
 
 - name: "connects related memories"
   setup:

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -105,6 +105,19 @@ def _count_tool_calls(history: list) -> int:
     return sum(1 for msg in history if msg.get("role") == "tool")
 
 
+def _collect_tool_names(history: list) -> list[str]:
+    """List tool names called in the (slice of) history, in call order, including duplicates."""
+    names = []
+    for msg in history:
+        if msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            name = (call.get("function") or {}).get("name")
+            if name:
+                names.append(name)
+    return names
+
+
 def _count_tool_errors(history: list) -> int:
     """Count tool results that contain error indicators."""
     count = 0
@@ -131,7 +144,8 @@ def _collect_tool_errors(history: list) -> list[str]:
 
 
 def _check_assertions(test_case: dict, response: str, tool_calls: int,
-                      tool_errors: int = 0) -> tuple[bool, str]:
+                      tool_errors: int = 0,
+                      tool_names: list[str] | None = None) -> tuple[bool, str]:
     """Check test assertions. Returns (passed, failure_reason)."""
     import re
 
@@ -171,6 +185,33 @@ def _check_assertions(test_case: dict, response: str, tool_calls: int,
     max_errors = expect.get("max_tool_errors")
     if max_errors is not None and tool_errors > max_errors:
         return False, f"Too many tool errors: {tool_errors} > {max_errors}"
+
+    names = tool_names or []
+    called_list = f"[{', '.join(names)}]"
+
+    expect_tool = expect.get("expect_tool")
+    if expect_tool is not None:
+        wanted = [expect_tool] if isinstance(expect_tool, str) else list(expect_tool)
+        if not any(w in names for w in wanted):
+            tail = f"tools called were {called_list}" if names else "no tools were called"
+            return False, f"Expected one of {wanted} to be called, but {tail}"
+
+    expect_no_tool = expect.get("expect_no_tool")
+    if expect_no_tool is not None:
+        forbidden = [expect_no_tool] if isinstance(expect_no_tool, str) else list(expect_no_tool)
+        for f in forbidden:
+            if f in names:
+                return False, f"Unexpected tool called: '{f}' (called tools: {called_list})"
+
+    count_by_name = expect.get("expect_tool_count_by_name")
+    if count_by_name is not None:
+        for name, want in count_by_name.items():
+            got = sum(1 for n in names if n == name)
+            if got != want:
+                paren = f"called tools: {called_list}" if names else "no tools were called"
+                return False, (
+                    f"Tool count mismatch for '{name}': expected {want}, got {got} ({paren})"
+                )
 
     return True, ""
 
@@ -268,7 +309,7 @@ async def run_test(config: Config, test_case: dict) -> dict:
             })
             expect = turn.get("expect", {})
             if expect:
-                passed, reason = _check_assertions(turn, response, 0, 0)
+                passed, reason = _check_assertions(turn, response, 0, 0, tool_names=[])
                 if not passed:
                     overall_passed = False
                     failure_reason = f"Turn {turn_idx + 1}: {reason}"
@@ -300,7 +341,9 @@ async def run_test(config: Config, test_case: dict) -> dict:
         expect = turn.get("expect", {})
         if expect:
             tool_errors = _count_tool_errors(history) - pre_turn_tool_errors
-            passed, reason = _check_assertions(turn, response, tool_calls, tool_errors)
+            tool_names = _collect_tool_names(history[pre_turn_history_len:])
+            passed, reason = _check_assertions(turn, response, tool_calls, tool_errors,
+                                               tool_names=tool_names)
             if not passed:
                 overall_passed = False
                 # Collect errors from this turn's messages only

--- a/tests/test_eval_runner_assertions.py
+++ b/tests/test_eval_runner_assertions.py
@@ -1,0 +1,278 @@
+"""Direct unit tests for `_check_assertions` and `_collect_tool_names`.
+
+Covers existing assertion fields (regression) and the three new tool-name
+assertions added for issue #349: `expect_tool`, `expect_no_tool`, and
+`expect_tool_count_by_name`.
+"""
+
+from decafclaw.eval.runner import _check_assertions, _collect_tool_names
+
+
+def _assistant(tool_names):
+    """Build a synthetic assistant message with the given tool calls."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": f"call_{i}", "function": {"name": n, "arguments": "{}"}}
+            for i, n in enumerate(tool_names)
+        ],
+    }
+
+
+def _tool_result(call_id="call_0", content="ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _check(test_case, history, response="response text", tool_calls=0,
+           tool_errors=0):
+    """Convenience wrapper: derive tool_names from history and call _check_assertions."""
+    tool_names = _collect_tool_names(history)
+    return _check_assertions(
+        test_case, response, tool_calls,
+        tool_errors=tool_errors, tool_names=tool_names,
+    )
+
+
+# --- _collect_tool_names sanity ---
+
+def test_collect_tool_names_empty_history():
+    assert _collect_tool_names([]) == []
+
+
+def test_collect_tool_names_collects_in_call_order():
+    history = [
+        {"role": "user", "content": "hi"},
+        _assistant(["a", "b"]),
+        _tool_result("call_0"),
+        _tool_result("call_1"),
+        _assistant(["c"]),
+        _tool_result("call_0"),
+    ]
+    assert _collect_tool_names(history) == ["a", "b", "c"]
+
+
+def test_collect_tool_names_skips_non_assistant_and_handles_missing():
+    history = [
+        {"role": "user", "content": "hi"},
+        # Assistant with no tool_calls key
+        {"role": "assistant", "content": "thinking"},
+        # Assistant with tool_calls=None
+        {"role": "assistant", "content": "", "tool_calls": None},
+        # Tool message — should be skipped even if it had a function name
+        {"role": "tool", "tool_call_id": "x", "content": "y"},
+        _assistant(["a"]),
+    ]
+    assert _collect_tool_names(history) == ["a"]
+
+
+# --- expect_tool ---
+
+def test_expect_tool_string_match_passes():
+    test_case = {"expect": {"expect_tool": "vault_search"}}
+    history = [_assistant(["vault_search"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_expect_tool_string_no_match_fails():
+    test_case = {"expect": {"expect_tool": "vault_search"}}
+    history = [_assistant(["web_fetch"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    # Message should name the expected list and the called tools
+    assert "vault_search" in reason
+    assert "web_fetch" in reason
+
+
+def test_expect_tool_list_or_semantics_passes():
+    test_case = {"expect": {"expect_tool": ["a", "b"]}}
+    history = [_assistant(["b"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_expect_tool_list_no_match_fails():
+    test_case = {"expect": {"expect_tool": ["a", "b"]}}
+    history = [_assistant(["c"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "a" in reason and "b" in reason
+    assert "c" in reason
+
+
+def test_expect_tool_no_tools_called_fails():
+    test_case = {"expect": {"expect_tool": "x"}}
+    passed, reason = _check(test_case, [])
+    assert not passed
+    assert "no tools were called" in reason
+
+
+# --- expect_no_tool ---
+
+def test_expect_no_tool_string_blocks_match():
+    test_case = {"expect": {"expect_no_tool": "web_fetch"}}
+    history = [_assistant(["web_fetch"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "web_fetch" in reason
+
+
+def test_expect_no_tool_string_passes_when_absent():
+    test_case = {"expect": {"expect_no_tool": "web_fetch"}}
+    history = [_assistant(["vault_search"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_expect_no_tool_list_and_semantics_passes_when_none_called():
+    test_case = {"expect": {"expect_no_tool": ["a", "b"]}}
+    history = [_assistant(["c"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_expect_no_tool_list_and_semantics_fails_when_one_called():
+    test_case = {"expect": {"expect_no_tool": ["a", "b"]}}
+    history = [_assistant(["b"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "b" in reason
+
+
+# --- expect_tool_count_by_name ---
+
+def test_count_exact_match_passes():
+    test_case = {"expect": {"expect_tool_count_by_name": {"a": 2, "b": 1}}}
+    history = [_assistant(["a", "b", "a"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_count_too_few_fails():
+    test_case = {"expect": {"expect_tool_count_by_name": {"a": 2}}}
+    history = [_assistant(["a"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "a" in reason
+    assert "2" in reason  # expected
+    assert "1" in reason  # got
+
+
+def test_count_too_many_fails():
+    test_case = {"expect": {"expect_tool_count_by_name": {"a": 1}}}
+    history = [_assistant(["a", "a"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "a" in reason
+    assert "1" in reason  # expected
+    assert "2" in reason  # got
+
+
+def test_count_zero_means_not_called_passes_when_absent():
+    test_case = {"expect": {"expect_tool_count_by_name": {"web_fetch": 0}}}
+    history = [_assistant(["vault_search"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_count_zero_means_not_called_fails_when_called():
+    test_case = {"expect": {"expect_tool_count_by_name": {"web_fetch": 0}}}
+    history = [_assistant(["web_fetch"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "web_fetch" in reason
+
+
+def test_count_unlisted_tool_unconstrained():
+    test_case = {"expect": {"expect_tool_count_by_name": {"a": 1}}}
+    history = [_assistant(["a", "b", "b", "b"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_count_with_other_assertions_combine_passes():
+    test_case = {
+        "expect": {
+            "expect_tool": "x",
+            "expect_tool_count_by_name": {"x": 2},
+        }
+    }
+    history = [_assistant(["x", "x"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert passed, reason
+
+
+def test_count_with_other_assertions_combine_fails_on_count():
+    test_case = {
+        "expect": {
+            "expect_tool": "x",
+            "expect_tool_count_by_name": {"x": 2},
+        }
+    }
+    # expect_tool passes (x was called), but count is wrong
+    history = [_assistant(["x"]), _tool_result()]
+    passed, reason = _check(test_case, history)
+    assert not passed
+    assert "x" in reason
+    assert "2" in reason
+    assert "1" in reason
+
+
+# --- Regression tests for existing fields with new kwarg threading ---
+
+def test_response_contains_regression():
+    test_case = {"expect": {"response_contains": "hello"}}
+    passed, reason = _check(test_case, [], response="well, Hello there")
+    assert passed, reason
+
+    test_case = {"expect": {"response_contains": "hello"}}
+    passed, reason = _check(test_case, [], response="goodbye")
+    assert not passed
+    assert "hello" in reason
+
+
+def test_response_not_contains_regression():
+    test_case = {"expect": {"response_not_contains": "secret"}}
+    passed, reason = _check(test_case, [], response="all clear here")
+    assert passed, reason
+
+    test_case = {"expect": {"response_not_contains": "secret"}}
+    passed, reason = _check(test_case, [], response="The Secret password is...")
+    assert not passed
+    assert "secret" in reason.lower()
+
+
+def test_max_tool_calls_regression():
+    test_case = {"expect": {"max_tool_calls": 2}}
+    # Within budget
+    passed, _ = _check(test_case, [], tool_calls=2)
+    assert passed
+    # Over budget
+    passed, reason = _check(test_case, [], tool_calls=3)
+    assert not passed
+    assert "3" in reason and "2" in reason
+
+
+def test_max_tool_errors_regression():
+    test_case = {"expect": {"max_tool_errors": 1}}
+    passed, _ = _check(test_case, [], tool_errors=1)
+    assert passed
+    passed, reason = _check(test_case, [], tool_errors=2)
+    assert not passed
+    assert "2" in reason and "1" in reason
+
+
+# --- Default kwarg behavior (call without tool_names) ---
+
+def test_check_assertions_defaults_when_tool_names_omitted():
+    """`tool_names=None` default should still let non-tool-name asserts work."""
+    test_case = {"expect": {"response_contains": "ok"}}
+    passed, _ = _check_assertions(test_case, "ok", 0)
+    assert passed
+
+    # And expect_tool with no tool_names → fails with "no tools were called"
+    test_case = {"expect": {"expect_tool": "x"}}
+    passed, reason = _check_assertions(test_case, "ok", 0)
+    assert not passed
+    assert "no tools were called" in reason


### PR DESCRIPTION
## Summary
- Adds three tool-name assertion fields to the eval runner so test cases can rigorously assert which tools the agent invoked, replacing the indirect "tool count + response text" approximation in use today.
- Unblocks the tool-deferral evals and strengthens nearly every other eval file — the load-bearing missing piece called out in the eval-coverage audit on #338.

## Design Decisions
- **Field names match the issue verbatim** (`expect_tool` / `expect_no_tool` / `expect_tool_count_by_name`). The `expect_` prefix on tool-name fields reads naturally as "I expect this tool to be called" and disambiguates from response assertions.
- **Symmetry with `response_contains` / `response_not_contains`**: the singular fields accept str OR list[str], with OR / AND semantics respectively. List-of-one collapses to the singular form, so no expressiveness is lost.
- **Exact-match counts only.** `{name: int}` form per the issue; min/max range form deferred until a real eval needs it.
- **Count `0` allowed**, even though it overlaps `expect_no_tool` — tolerant input, users pick whichever reads better.
- **Parent-level scope only**, matching existing `max_tool_calls`. Tools invoked inside child agents via `delegate_task` are not visible. Documented inline in `docs/eval-loop.md`.
- **Failure messages list the called-tools set** so the reader sees what actually happened (`"... but tools called were [web_fetch]"`).

## Changes
- `src/decafclaw/eval/runner.py` — new `_collect_tool_names(history)` helper; extended `_check_assertions` with a `tool_names: list[str] | None = None` kwarg; three new branches; threaded per-turn names through both call sites.
- `tests/test_eval_runner_assertions.py` (new) — 25 unit tests covering all three new fields and regression coverage for the four pre-existing `expect` fields.
- `evals/memory.yaml` — smoke-test exercising the new assertions on the existing "saves memory when asked" case (`expect_tool: vault_journal_append`, `expect_no_tool: [shell, shell_patterns]`). Broader tool-deferral coverage tracked in #430.
- `docs/eval-loop.md` — three new rows in the expect-fields table plus a parent-only scope note after the table.

## Test Plan
- [x] `make lint` (clean)
- [x] `make check` (0 errors / warnings; lint + pyright + JS tsc)
- [x] `make test` (2268 passed in 12.5s)
- [x] `uv run pytest tests/test_eval_runner_assertions.py -v` (25 passed)
- [ ] Sanity: open `docs/eval-loop.md` rendered, confirm the three new table rows + scope note look right.
- [ ] Run `uv run python -m decafclaw.eval evals/memory.yaml` against a configured agent to verify the smoke-test assertion fires correctly end-to-end.
- Follow-up: #430 — write the actual tool-deferral evals using these assertions.

## References
- Spec: `docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/spec.md`
- Plan: `docs/dev-sessions/2026-04-29-1501-eval-expect-tool-assertions/plan.md`
- Closes #349