### PR TITLE
fix(web-ui): a11y aria-labels + tag-qualify follow-up to #432

### DIFF
--- a/src/decafclaw/web/static/components/config-panel.js
+++ b/src/decafclaw/web/static/components/config-panel.js
@@ -86,7 +86,7 @@ export class ConfigPanel extends LitElement {
       return html`
         <div class="config-panel">
           <div class="config-panel-header">
-            <button class="config-back-btn dc-icon-btn" @click=${() => this.#backToList()} title="Back to list">&larr;</button>
+            <button class="config-back-btn dc-icon-btn" @click=${() => this.#backToList()} title="Back to list" aria-label="Back to list">&larr;</button>
             <span class="config-panel-title">${this._selectedFile.name}</span>
             <span class="config-scope-badge ${this._selectedFile.scope}">${this._selectedFile.scope}</span>
           </div>
@@ -109,7 +109,7 @@ export class ConfigPanel extends LitElement {
       <div class="config-panel">
         <div class="config-panel-header">
           <span class="config-panel-title">Agent Config</span>
-          <button class="config-close-btn dc-icon-btn" @click=${() => this.close()} title="Close">&#10005;</button>
+          <button class="config-close-btn dc-icon-btn" @click=${() => this.close()} title="Close config panel" aria-label="Close config panel">&#10005;</button>
         </div>
         <div class="config-file-list">
           ${this._files.map(f => html`

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -457,7 +457,7 @@ export class ConversationSidebar extends LitElement {
     if (this._collapsed && !this._mobileOpen) {
       return html`
         <div class="sidebar-header">
-          <button class="collapse-btn dc-icon-btn" @click=${this.#toggleCollapse} title="Expand sidebar">›</button>
+          <button class="collapse-btn dc-icon-btn" @click=${this.#toggleCollapse} title="Expand sidebar" aria-label="Expand sidebar">›</button>
         </div>
       `;
     }
@@ -473,7 +473,7 @@ export class ConversationSidebar extends LitElement {
             @click=${() => this.#switchTab('files')}>Files</button>
         </div>
         <button class="mobile-close-btn dc-overlay-close-x" @click=${() => this.closeMobile()} title="Close sidebar">×</button>
-        <button class="collapse-btn dc-icon-btn" @click=${this.#toggleCollapse} title="Collapse sidebar">‹</button>
+        <button class="collapse-btn dc-icon-btn" @click=${this.#toggleCollapse} title="Collapse sidebar" aria-label="Collapse sidebar">‹</button>
       </div>
       <vault-sidebar
         .active=${this._sidebarTab === 'wiki'}

--- a/src/decafclaw/web/static/components/file-page.js
+++ b/src/decafclaw/web/static/components/file-page.js
@@ -365,7 +365,7 @@ export class FilePage extends LitElement {
     const modeIcon = this._editing ? '\u{1f441}' : '\u{270e}';
     const modeTitle = this._editing ? 'Switch to view mode' : 'Switch to edit mode';
     const toggleBtn = canToggle
-      ? html`<button class="file-edit-btn dc-icon-btn" @click=${() => this.#toggleMode()} title=${modeTitle}>${modeIcon}</button>`
+      ? html`<button class="file-edit-btn dc-icon-btn" @click=${() => this.#toggleMode()} title=${modeTitle} aria-label=${modeTitle}>${modeIcon}</button>`
       : nothing;
 
     const canDelete = !this.readonly;

--- a/src/decafclaw/web/static/components/wiki-page.js
+++ b/src/decafclaw/web/static/components/wiki-page.js
@@ -247,9 +247,9 @@ export class WikiPage extends LitElement {
       <button class="wiki-close-btn dc-icon-btn" @click=${() => this._close()} title="Close wiki pane" aria-label="Close wiki pane">&times;</button>
     `;
     const rightButtons = html`
-      <button class="wiki-edit-btn dc-icon-btn" @click=${() => this._toggleMode()} title=${modeTitle}>${modeIcon}</button>
+      <button class="wiki-edit-btn dc-icon-btn" @click=${() => this._toggleMode()} title=${modeTitle} aria-label=${modeTitle}>${modeIcon}</button>
       <button class="wiki-delete-btn dc-icon-btn" @click=${() => this.#deletePage()} title="Delete page" aria-label="Delete page">\u{1F5D1}</button>
-      <a href=${newTabUrl} target="_blank" rel="noopener" class="wiki-open-tab dc-icon-btn" title="Open in new tab">&#8599;</a>
+      <a href=${newTabUrl} target="_blank" rel="noopener" class="wiki-open-tab dc-icon-btn" title="Open in new tab" aria-label="Open in new tab">&#8599;</a>
       ${closeBtn}
     `;
 

--- a/src/decafclaw/web/static/styles/context-inspector.css
+++ b/src/decafclaw/web/static/styles/context-inspector.css
@@ -41,8 +41,9 @@ context-inspector .inspector-header h3 {
 /* Structural rules from .dc-icon-btn in primitives.css. Per-site
    overrides: tighter inline padding, larger font. The hover state
    comes from the primitive (was previously missing here — now
-   intentionally surfaces on hover). */
-context-inspector .close-btn {
+   intentionally surfaces on hover). Tag-qualified per cascade rule §1
+   for robustness against future refactors. */
+context-inspector button.close-btn {
   font-size: 1.2rem;
   padding: 0 0.25rem;
 }

--- a/src/decafclaw/web/static/styles/mobile.css
+++ b/src/decafclaw/web/static/styles/mobile.css
@@ -111,7 +111,7 @@
   /* On mobile, swap collapse → close. Hamburger handles open; the
      close button (× tap-target) handles dismiss. Collapse-to-narrow
      doesn't make sense in a fullscreen overlay. */
-  conversation-sidebar .collapse-btn { display: none; }
+  conversation-sidebar button.collapse-btn { display: none; }
   conversation-sidebar .mobile-close-btn { display: block; }
 
 /* On mobile, wiki takes over — hide chat when wiki is visible */

--- a/src/decafclaw/web/static/styles/sidebar.css
+++ b/src/decafclaw/web/static/styles/sidebar.css
@@ -305,8 +305,12 @@ conversation-sidebar[collapsed] .sidebar-header {
 }
 
 /* Structural rules from .dc-icon-btn in primitives.css. Per-site
-   overrides: tighter padding than primitive default, larger font. */
-conversation-sidebar .collapse-btn {
+   overrides: tighter padding than primitive default, larger font.
+   Tag-qualified per the documented cascade rule §1 — the descendant
+   selector already ties primitive specificity (0,1,1) on its own,
+   but tag-qualifying makes the rule robust against future refactors
+   that might drop the descendant ancestor. */
+conversation-sidebar button.collapse-btn {
   padding: 0.15rem 0.3rem;
   font-size: 1.1rem;
 }


### PR DESCRIPTION
## Summary

Round 4 of Copilot review on #432 surfaced after that PR's polling window timed out (review submitted 23:06:17Z, final poll ended ~23:05Z), so these fixes ride in a follow-up.

- **a11y**: 6 icon-only controls were missing `aria-label` attributes — screen readers fell back to announcing the glyph (☓, ›, ‹, etc.) which isn't a meaningful control name.
- **CSS consistency**: 2 `.dc-icon-btn` consumer overrides used class-only selectors inside descendant context. They currently work (the descendant ancestor ties primitive specificity via its tag-selector point), but they violate the cascade rule §1 codified in `docs/web-ui-design.md` requiring per-component overrides on `.dc-icon-btn` consumers to be explicitly tag-qualified.

## Changes

**a11y additions** (`aria-label` on each):
- `config-panel.js:89` — `config-back-btn` → "Back to list"
- `config-panel.js:112` — `config-close-btn` → "Close config panel" (also more specific than the previous "Close" `title`)
- `conversation-sidebar.js:460,476` — both `.collapse-btn` render sites → "Expand sidebar" / "Collapse sidebar"
- `wiki-page.js:250` — `wiki-edit-btn` → uses dynamic `${modeTitle}` (matches the `title` attribute)
- `wiki-page.js:252` — `wiki-open-tab` `<a>` → "Open in new tab"
- `file-page.js:368` — `file-edit-btn` → uses `${modeTitle}`

**CSS tag-qualify**:
- `sidebar.css:309` — `conversation-sidebar .collapse-btn` → `conversation-sidebar button.collapse-btn`
- `context-inspector.css:45` — `context-inspector .close-btn` → `context-inspector button.close-btn`

## Not addressed

One Copilot suggestion claimed the token-vocabulary table at `docs/web-ui-design.md:184` had "leading double pipes" causing rendering issues. The table uses standard single-pipe Markdown syntax and renders correctly on GitHub. Intentionally skipped as a false positive.

## Test plan

- [x] `make check` (lint + typecheck Python + JS) green
- [x] `make test` green (2284 tests — gained 41 since #432 from intervening main commits)
- [ ] Reviewer manual: keyboard-tab through the icon-only controls (config back/close, sidebar collapse, wiki edit/delete/open-tab, file edit/close, inspector close); verify screen-reader announces the aria-label rather than the glyph

## References

- Follow-up to: #432
- Closes the round-4 Copilot comments not addressed in #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)