### PR TITLE
Fix #393: separate history from current-turn injections in compose()

### DIFF
--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -88,6 +88,14 @@ compaction prompts.
 - Tool definitions are fixed overhead on every turn — [tool deferral](tool-search.md) keeps this in check
 - Vault context competes for remaining budget after fixed costs (see [Vault Retrieval](#vault-retrieval) below)
 
+#### History accounting
+
+`compose()` treats the input `history` list as read-only during all token-budget and diagnostics calculation. Fresh-this-turn injections (`vault_references`, `conversation_notes`, `vault_retrieval`, and the current user message) are each tracked via their own `SourceEntry` (`wiki_entry`, `notes_entry`, `memory_entry`, `user_msg_entry`). The `history` source entry counts everything archived from prior turns, including messages whose role is in `ROLE_REMAP` (auto-injected role messages archived from earlier turns) — they're sent to the LLM after remap, so they count.
+
+After all token accounting and message-list assembly, `compose()` appends this turn's injections to `history` so the caller (agent loop) sees the post-turn state on subsequent turns. The single mutation point at the end of `compose()` replaces a previous shape that mixed input and scratchpad uses of `history`.
+
+This contract closes a class of underreporting bugs (#393) where a role-based filter excluded archived auto-injected messages even though the LLM still sees them after remap.
+
 ## How it works
 
 ### Lifecycle

--- a/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/notes.md
+++ b/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/notes.md
@@ -1,0 +1,19 @@
+# Notes — Token accounting for archived role-remap messages
+
+## Session log
+
+- **2026-04-29 15:04** — Session started. Worktree at `.claude/worktrees/fix-token-accounting-393/`. Baseline `make test`: 2243 passed. Issue #393 seeded into `spec.md`.
+- **Phase 1** — `75fb428` adds failing regression test; `6c59e00` fixup adds tool/memory mock context managers to match sibling `TestCompose` pattern (responsive to code review).
+- **Phase 2** — `7207f0b` refactors `compose()`. Phase 1 test goes RED → GREEN. Full suite 2244/2244, `make check` clean. No existing tests required adjustment.
+- **Phase 2 smoke test (real data)** — Loaded `web-lmorchard-e5a17d78.jsonl` (46 archived messages including 8 auto-injected remap-role messages) into a fresh `compose()` call. `history_entry.tokens_estimated`: pre-fix would report 2623 (LLM_ROLES only); post-fix reports 9569 — the 6946-token archived remap-role contribution is now correctly counted. Live `make dev` + Playwright was attempted first but the agent's playwright MCP child grabbed the Chrome lock; CLI test against real archived data was equivalent and faster.
+- **Phase 2 fixup (`fb79e8d`)** — Phase 3's structural test surfaced a regression Phase 2 inadvertently introduced: the current-turn user message lost its accounting (pre-Phase 2 the role-based history filter happened to count it; post-Phase 2 the user_msg is appended past the diagnostics calc). Fixed by adding a `user_message` SourceEntry. Strictly additive — adds one entry to `composed.sources`, no schema change. Reviewer dispatch skipped for this 11-line additive change since Les approved the approach explicitly and the change is verified by a passing structural test against real production data flow.
+- **Phase 3 (`1955b3c`)** — Adds the structural no-double-count guard test. Passes within the planned 5%/50-token tolerance (observed gap is ~12 tokens for the self-referential `[Context: ...]` status line). Suite: 2245 passed. `make check` clean.
+- **Phase 4 (`630802c`)** — Adds the "History accounting" sub-section to `docs/context-composer.md` under "Token budget". Lint clean. Implementer audited the rest of the doc for contradictions; none.
+
+## Deferred — for PR self-review
+
+Code-review Minor nits on the Phase 2 commit, not blocking, can be picked up during PR self-review or skipped:
+
+1. `src/decafclaw/context_composer.py:426` — drop the trailing inline comment `# computed earlier, single source of truth` on the `tokens_estimated=history_tokens` field; the block comment three lines above already explains the rationale.
+2. Optional rename `combined` → `llm_messages` in compose() (around line 395). Reviewer noted churn cost vs marginal clarity gain — left as-is.
+3. compose() docstring (around lines 266-267) — add a blank line between the contract paragraph and the archival note for cleaner rendered formatting.

--- a/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/plan.md
+++ b/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/plan.md
@@ -1,0 +1,437 @@
+# History/Injection Separation Implementation Plan
+
+**Goal:** Refactor `ContextComposer.compose()` so `history` represents only archived past content during all calculation, eliminating the dual filter that produces #393's archived-remap-role under-counting.
+
+**Approach:** Move history-mutation to the end of `compose()`. Replace both filters (id-based at `:340-344`, role-based at `:413-414`) with a single role-allowlist sum over the input `history`. Build the LLM message list from an explicit `combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]`.
+
+**Tech stack:** Python (stdlib only — no new deps), pytest, existing `make` targets.
+
+---
+
+## Phase 1: Failing regression test for #393
+
+Add a test that constructs an input `history` containing one archived message of each remap role plus a user/assistant pair, calls `compose()` with no fresh injections, and asserts that `history_entry.tokens_estimated` reflects the archived remap-role content. The test will fail on the current code (role-based filter excludes them) and pass after Phase 2.
+
+**Files:**
+- Modify: `tests/test_context_composer.py` — add a new test class `TestHistoryArchivedRemap` (or single test method on `TestCompose`; choose the location adjacent to existing `TestCompose.test_includes_retrieved_context_text` for cohesion).
+
+**Key changes:**
+
+```python
+class TestHistoryArchivedRemap:
+    """Regression coverage for #393 — archived remap-role messages
+    must count toward history_entry.tokens_estimated."""
+
+    @pytest.mark.asyncio
+    async def test_archived_remap_messages_counted_in_history_entry(
+        self, ctx, config,
+    ):
+        """An archived vault_retrieval / vault_references / conversation_notes
+        message in history (loaded from the archive on a later turn) must
+        contribute to history_entry.tokens_estimated."""
+        composer = ContextComposer()
+        archived_user = {"role": "user", "content": "earlier user message"}
+        archived_assistant = {"role": "assistant", "content": "earlier reply"}
+        archived_vault_retrieval = {
+            "role": "vault_retrieval",
+            "content": "AAAA " * 100,  # ~ measurable token weight
+        }
+        archived_vault_references = {
+            "role": "vault_references",
+            "content": "BBBB " * 100,
+            "wiki_page": "Foo",
+        }
+        archived_notes = {
+            "role": "conversation_notes",
+            "content": "CCCC " * 100,
+        }
+        history = [
+            archived_user,
+            archived_assistant,
+            archived_vault_retrieval,
+            archived_vault_references,
+            archived_notes,
+        ]
+
+        composed = await composer.compose(
+            ctx, "current user message", history,
+            mode=ComposerMode.INTERACTIVE,
+        )
+
+        history_entries = [s for s in composed.sources if s.source == "history"]
+        assert len(history_entries) == 1
+        history_entry = history_entries[0]
+
+        # Sum of all five archived messages — naive estimate the same way
+        # compose() does it, to match the assertion to the implementation.
+        expected_min = sum(
+            estimate_tokens(str(m.get("content", "")))
+            for m in (
+                archived_user,
+                archived_assistant,
+                archived_vault_retrieval,
+                archived_vault_references,
+                archived_notes,
+            )
+        )
+        assert history_entry.tokens_estimated >= expected_min, (
+            f"history_entry.tokens_estimated={history_entry.tokens_estimated} "
+            f"expected >= {expected_min} (sum of all five archived messages)"
+        )
+```
+
+Imports to add at the top of the test file (if not already present): `estimate_tokens` from the same module the production code imports it from (verify with a grep on the existing test file). The test depends on the existing `ctx` and `config` fixtures from `tests/conftest.py`.
+
+**Verification — automated:**
+- [x] `make test PYTEST_ARGS='-x tests/test_context_composer.py::TestHistoryArchivedRemap'` runs the new test.
+- [x] The new test FAILS on this commit (assertion: `history_entry.tokens_estimated` is too low because the role-based filter at `context_composer.py:413-414` excludes the three archived remap messages). Verified output: `history_entry.tokens_estimated=13 expected >= 383`.
+- [x] All other tests in `tests/test_context_composer.py` still pass: `make test PYTEST_ARGS='tests/test_context_composer.py'`. Verified: 1 failed (the new test), 91 passed.
+
+**Verification — manual:**
+- [x] Eyeball the test — does the assertion clearly express what should be true after the fix? Does it fail for the right reason on the unmodified code? (Confirmed by Les.)
+
+---
+
+## Phase 2: Refactor `compose()` — defer history-mutation, single token calc
+
+The actual fix. Replace the dual filter with one role-allowlist sum over the input `history` (which now contains only archived past content during calculation). Build LLM message list from an explicit `combined`. Append fresh injections to `history` only at the end. The Phase 1 regression test passes after this commit. Existing tests that pass fresh-this-turn-shaped messages in the input `history` are audited and updated to the new shape.
+
+**Files:**
+- Modify: `src/decafclaw/context_composer.py` — see "Key changes" below for specific edits. No new files.
+- Modify: `tests/test_context_composer.py` — fixture updates as discovered by running the suite. Likely candidates: `TestCompose.test_message_ordering`, tests in `TestComposeMemoryContext`, tests in `TestRetrievalModes`. Document each adjustment with a one-line code comment if non-obvious.
+
+**Key changes:**
+
+### 2a. Lift `role_remap` to a module-level constant
+
+Currently defined as a local at `:383-387`. Promote it to module-level so it's reachable from the budget-side calculation and from any future caller. Place it just below the `LLM_ROLES` import at `:258` (or near the other module-level constants near the top of the file — pick the location adjacent to `_TASK_MODE_TO_COMPOSER` if it exists; otherwise at the top of the module).
+
+```python
+# Roles that are remapped to "user" before sending to the LLM.
+# These messages are auto-injected by the composer per-turn, then
+# archived under their internal role for accounting and dedupe.
+ROLE_REMAP: dict[str, str] = {
+    "vault_retrieval": "user",
+    "vault_references": "user",
+    "conversation_notes": "user",
+}
+```
+
+Drop the local `role_remap = {...}` in `compose()` and reference `ROLE_REMAP` instead.
+
+### 2b. Stop appending fresh injections to `history` mid-`compose()`
+
+At the wiki injection (`:288-290`):
+
+```python
+for wm in wiki_msgs:
+    to_archive.append(wm)
+    await ctx.publish("vault_references", text=wm["content"], page=wm.get("wiki_page"))
+```
+
+Drop the `history.append(wm)` line.
+
+At the notes injection (`:299-301`):
+
+```python
+for nm in notes_msgs:
+    to_archive.append(nm)
+```
+
+Drop the `history.append(nm)` line.
+
+At the memory injection (`:372-374`):
+
+```python
+for mm in memory_msgs:
+    to_archive.append(mm)
+```
+
+Drop the `history.append(mm)` line.
+
+At the user-message append (`:379-380`):
+
+```python
+to_archive.append(user_msg)
+```
+
+Drop the `history.append(user_msg)` line.
+
+### 2c. Replace the budget-side filter with a single role-allowlist sum
+
+Currently `:338-345`:
+
+```python
+injected_ids = {id(wm) for wm in wiki_msgs}
+injected_ids |= {id(nm) for nm in notes_msgs}
+existing_history_tokens = sum(
+    estimate_tokens(str(m.get("content", "")))
+    for m in history
+    if id(m) not in injected_ids
+)
+fixed_tokens += existing_history_tokens
+```
+
+Replace with:
+
+```python
+# History contains only archived prior-turn content at this point —
+# fresh wiki / notes / memory / user injections are appended after
+# all token accounting, at the end of compose(). Count messages whose
+# role is sent to the LLM either directly (LLM_ROLES) or after remap
+# (ROLE_REMAP keys). Other roles (e.g. confirmation_request, archive-only
+# bookkeeping) are not sent and don't count.
+countable_roles = LLM_ROLES | ROLE_REMAP.keys()
+history_tokens = sum(
+    estimate_tokens(str(m.get("content", "")))
+    for m in history
+    if m.get("role") in countable_roles
+)
+fixed_tokens += history_tokens
+```
+
+The variable name changes from `existing_history_tokens` to `history_tokens`. Both filters now collapse to this one value — no separate diagnostics-side calc.
+
+### 2d. Replace the diagnostics-side `history_entry` with the same value
+
+Currently `:410-429`:
+
+```python
+remapped_roles = set(role_remap.keys())
+history_only = [m for m in history if m.get("role") not in remapped_roles]
+history_tokens = sum(
+    estimate_tokens(str(m.get("content", "")))
+    for m in history_only
+    if m.get("role") in LLM_ROLES
+)
+history_msg_count = sum(
+    1 for m in history_only if m.get("role") in LLM_ROLES
+)
+history_entry = SourceEntry(
+    source="history",
+    tokens_estimated=history_tokens,
+    items_included=history_msg_count,
+    details={"total_llm_messages": len(llm_history)},
+)
+sources.append(history_entry)
+```
+
+Replace with:
+
+```python
+history_msg_count = sum(
+    1 for m in history if m.get("role") in countable_roles
+)
+history_entry = SourceEntry(
+    source="history",
+    tokens_estimated=history_tokens,  # computed earlier, single source of truth
+    items_included=history_msg_count,
+    details={"total_llm_messages": len(llm_history)},
+)
+sources.append(history_entry)
+```
+
+### 2e. Build LLM message list from explicit `combined`
+
+Currently `:388-399`:
+
+```python
+llm_history = []
+for m in history:
+    role = m.get("role")
+    if role == "background_event":
+        llm_history.extend(_expand_background_event(m))
+    elif role in LLM_ROLES:
+        llm_history.append(m)
+    elif role in role_remap:
+        llm_history.append({**m, "role": role_remap[role]})
+```
+
+Replace with:
+
+```python
+# Combine archived history with this turn's injections in the same
+# order they'll be archived: prior history → wiki → notes → memory →
+# user message. The combined list is what the LLM sees.
+combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]
+llm_history = []
+for m in combined:
+    role = m.get("role")
+    if role == "background_event":
+        llm_history.extend(_expand_background_event(m))
+    elif role in LLM_ROLES:
+        llm_history.append(m)
+    elif role in ROLE_REMAP:
+        llm_history.append({**m, "role": ROLE_REMAP[role]})
+```
+
+### 2f. Mutate `history` once, at the end, before returning
+
+After the sources list, llm_history, diagnostics, and `messages` are all built (after `:437` `messages.extend(llm_history)`), append the fresh injections to `history` so the caller's continued use of `self.history` is preserved. Place this immediately before the `return ComposedContext(...)` statement:
+
+```python
+# Preserve the load-bearing side effect: caller (agent.py) continues
+# to read self.history after compose() returns. Append this turn's
+# injections in the same order as `combined` above.
+history.extend(wiki_msgs)
+history.extend(notes_msgs)
+history.extend(memory_msgs)
+history.append(user_msg)
+```
+
+### 2g. Update the docstring at `:252`
+
+Currently:
+
+> Orchestrates all context sources, mutates history in place (appending …)
+
+Replace with (preserving the rest of the docstring; only the relevant sentence changes):
+
+> Orchestrates all context sources. Token accounting treats `history`
+> as read-only (archived prior turns); this turn's wiki / notes / memory
+> / user-message injections are appended to `history` once, at the end,
+> before returning. The caller's continued reads of `history` after
+> compose() returns see the post-turn state.
+
+### 2h. Audit and update existing tests
+
+After the production-code changes are in place, run `make test PYTEST_ARGS='tests/test_context_composer.py'`. For each failure:
+
+1. Read the test to determine if it was relying on `compose()`'s in-progress mutation of `history` (e.g., asserting on `history` membership before `compose()` finishes, or constructing an input `history` that includes objects shaped like fresh-this-turn injections).
+2. Adjust the test to either (a) construct injections through the production paths (memory/wiki fixtures) instead of by hand, or (b) accept that injections appear in `history` after `compose()` returns (matching the new contract).
+3. Do NOT broaden test changes beyond the minimum needed to express the same intent under the new contract.
+4. The Phase 1 regression test must still pass throughout.
+
+Likely candidates (audit before assuming):
+- `TestCompose.test_message_ordering` (`tests/test_context_composer.py:836-858`)
+- Tests in `TestComposeMemoryContext` (`:151-270`) — these construct memory candidates and may verify mutation.
+- Tests in `TestRetrievalModes` (`:275-366`) — same.
+
+**Verification — automated:**
+- [x] `make test PYTEST_ARGS='tests/test_context_composer.py::TestHistoryArchivedRemap'` — Phase 1 regression test now PASSES. Verified: 1 passed.
+- [x] `make test` — full suite passes (2244 passed, 0 failed; was 2243 + 1 failing in Phase 1).
+- [x] `make check` — lint + typecheck clean. Verified: 0 errors / 0 warnings / 0 informations.
+
+**Verification — manual:**
+- [ ] Read the diff for `compose()` end-to-end. Does `history` become read-only between the start of the function and the final `history.extend(...)` block?
+- [ ] Confirm no other call site or sub-method depends on mid-compose mutation of `history` (re-grep `history.append` / `history.extend` inside `context_composer.py` after edits — only the final block should remain).
+- [x] Run the worktree against a real conversation. CLI smoke test (substituted for live web-UI run because the agent's Playwright MCP held the Chrome lock when `make dev` was up). Loaded archived conversation `web-lmorchard-e5a17d78.jsonl` (46 messages, 8 of them auto-injected remap roles totaling 6946 tokens) as `history`, called `compose()`, inspected `history_entry.tokens_estimated`. Pre-fix would report 2623 tokens (LLM_ROLES only). Post-fix reports 9569 — the archived remap-role tokens are now correctly included.
+
+---
+
+## Phase 3: Structural test — no double-counting across `SourceEntry` totals
+
+Add a guard rail that catches future regressions where a fresh injection is double-counted (in `history_entry` AND its own SourceEntry) or dropped (in neither). This protects the architecture against drift if someone later re-introduces a filter or accidentally appends to `history` mid-compose.
+
+**Files:**
+- Modify: `tests/test_context_composer.py` — add a new test method to `TestHistoryArchivedRemap` (or a separate `TestSourceEntryNoDoubleCount` class).
+
+**Key changes:**
+
+```python
+@pytest.mark.asyncio
+async def test_source_entries_account_for_all_llm_content(
+    self, ctx, config, monkeypatch,
+):
+    """The sum of SourceEntry.tokens_estimated across all sources
+    should equal the sum of token estimates over llm_history (the
+    messages the model actually sees). Catches double-counting and
+    silent drops."""
+    composer = ContextComposer()
+    history = [
+        {"role": "user", "content": "prior user " * 50},
+        {"role": "assistant", "content": "prior assistant " * 50},
+        {"role": "vault_references", "content": "archived ref " * 50, "wiki_page": "Old"},
+    ]
+
+    composed = await composer.compose(
+        ctx, "fresh user message " * 20, history,
+        mode=ComposerMode.INTERACTIVE,
+    )
+
+    # Sum of all SourceEntry.tokens_estimated.
+    source_total = sum(s.tokens_estimated for s in composed.sources)
+
+    # Sum of token estimates over the actual LLM-bound message list.
+    # composed.messages includes the system prompt as the first entry;
+    # SourceEntry breakdown also includes "system_prompt" as a source,
+    # so this comparison is apples-to-apples.
+    llm_total = sum(
+        estimate_tokens(str(m.get("content", "")))
+        for m in composed.messages
+    )
+
+    # Allow small rounding drift from per-message estimate boundaries
+    # (estimate_tokens may use ceiling division). Tighten if the gap
+    # is larger than a few percent — that signals a real divergence.
+    assert abs(source_total - llm_total) <= max(50, llm_total * 0.05), (
+        f"SourceEntry sum {source_total} vs llm_history sum {llm_total} "
+        f"diverge by more than 5% / 50 tokens — token accounting is drifting."
+    )
+```
+
+The 5%/50-token tolerance is a guard against `estimate_tokens` ceiling/floor drift across many small messages. If the test reveals a tighter possible bound after Phase 2 lands, narrow it.
+
+**Verification — automated:**
+- [x] `make test PYTEST_ARGS='-x tests/test_context_composer.py::TestHistoryArchivedRemap::test_source_entries_account_for_all_llm_content'` passes. (After the Phase 2 fixup that added the `user_message` SourceEntry — see notes.md.)
+- [x] `make test` full suite green: 2245 passed (was 2244 before the structural test).
+- [x] `make check` clean.
+
+**Verification — manual:**
+- [ ] Confirm the 5%/50-token tolerance is the right ballpark — if Phase 2's actual implementation produces a tighter match, narrow the bound. Observed gap: ~12 tokens (self-referential `[Context: ...]` status line, by design). Floor of 50 absorbs it cleanly. Tightening the bound would couple the guard rail to the exact size of the status string — fragile. Recommend leaving as planned.
+
+---
+
+## Phase 4: Update `docs/context-composer.md`
+
+Per CLAUDE.md: "When changing a feature: update its `docs/` page **as part of the same PR**." The relevant section is `### Token budget` (line 84) and `### compose()` (line 97). Add a one-paragraph note clarifying the post-#393 contract: `history` is read-only during calculation, archived auto-injected role messages are counted in `history_entry`, fresh-this-turn injections are counted only in their per-source `SourceEntry`.
+
+**Files:**
+- Modify: `docs/context-composer.md` — extend the "Token budget" section with a "History accounting" sub-section. Suggested placement: after the existing bullets at `:84-89`.
+
+**Key changes:**
+
+Add a new sub-section after the existing "Token budget" bullets:
+
+```markdown
+#### History accounting
+
+`compose()` treats the input `history` list as read-only during all token-budget and diagnostics calculation. Fresh-this-turn injections (`vault_references`, `conversation_notes`, `vault_retrieval`, the user message) are accounted for via their own per-source `SourceEntry` — `wiki_entry`, `notes_entry`, `memory_entry`. The `history` source entry counts everything archived from prior turns, including messages whose role is in `ROLE_REMAP` (auto-injected role messages archived from earlier turns). After all token accounting and message-list assembly, `compose()` appends this turn's injections to `history` so the caller (agent loop) continues to see the post-turn state on subsequent turns.
+
+This contract closes a class of underreporting bugs (#393) where the diagnostics-side filter excluded archived auto-injected messages by role, even though the LLM still sees them after remap.
+```
+
+**Verification — automated:**
+- [x] `make lint` clean.
+- [x] No broken cross-links — implementer audited the rest of `docs/context-composer.md` for passages that contradict the new sub-section; none found. The "compose() steps" list at lines 99-109 describes step semantics without implying mid-compose mutation.
+
+**Verification — manual:**
+- [ ] Read the new sub-section in context. Does it explain enough to a future reader why `history` becoming read-only is the load-bearing property?
+- [x] Skim the full `docs/context-composer.md` page for any other passages that imply mid-compose history mutation; if found, reconcile. (Implementer audited; nothing else needs editing.)
+
+---
+
+## Plan self-review
+
+**Spec coverage:**
+- Spec Decision 1 (defer history-append to end) → Phase 2, items 2b + 2f.
+- Spec Decision 2 (one history-token calc, no filters) → Phase 2, items 2c + 2d.
+- Spec Decision 3 (explicit `combined` assembly) → Phase 2, item 2e.
+- Spec Decision 4 (`_get_already_injected_pages` unchanged) → no phase needed (no code change).
+- Spec Decision 5 (`compose()` still mutates at end, docstring updated) → Phase 2, items 2f + 2g.
+- Spec test plan: regression test → Phase 1; structural test → Phase 3; existing-test audit → Phase 2 item 2h.
+- Spec verification (`make test`, `make check`) → covered in each phase's automated checks.
+- Spec "What we're NOT doing" → no phase touches the listed exclusions (no schema bump, no role-remap removal, no formula change, etc.).
+
+**Placeholder scan:** No "TBD", "TODO", or "implement later" markers. Each phase has concrete file paths, code snippets, and verification commands. The two flexible spots — the precise location of `ROLE_REMAP` (Phase 2a) and which existing tests need fixture updates (Phase 2h) — are explicitly bounded and require runtime evidence to resolve, which is appropriate for `execute`.
+
+**Type/name consistency:**
+- `ROLE_REMAP` (module-level constant) is the only name introduced. It replaces the local `role_remap`. Both phases that reference it (2c, 2d, 2e) use the same name.
+- `countable_roles = LLM_ROLES | ROLE_REMAP.keys()` is reused as the role allowlist in 2c and 2d. Spelled consistently.
+- `combined` is the name of the assembled message list in 2e; consumed by the role-remap loop.
+- `history_tokens` (Phase 2c, single source of truth) is the name used in 2c, 2d. The previous `existing_history_tokens` is removed; nothing else in the codebase references it (verify with `grep existing_history_tokens` during execute).
+- `wiki_msgs`, `notes_msgs`, `memory_msgs`, `user_msg` are existing local names in `compose()` — no new names introduced for these.
+
+**Scope discipline check:** No drive-by refactors. The plan touches `compose()` mechanics, two test files, and one docs page. No adjacent code (other composer methods, agent loop, archive layer) is modified.
+
+Plan is ready for `execute`.

--- a/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/research.md
+++ b/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/research.md
@@ -1,0 +1,157 @@
+# Research — Token accounting in ContextComposer
+
+Documentarian-mode findings (Explore subagent). All `file:line` refs against this worktree's tree.
+
+## 1. Token-budget calculation in `ContextComposer.compose()`
+
+### `SourceEntry`
+
+- Defined at `src/decafclaw/context_composer.py:46-53` — dataclass with `source`, `tokens_estimated`, `items_included`, `items_truncated`, `details`.
+- Instances appended in `compose()` for every component:
+  - System prompt: `:280-281`
+  - Wiki references: `:285-293` (only when present)
+  - Conversation notes: `:298-303`
+  - Preemptive tool matches: `:308-312`
+  - Preemptive skill matches: `:317-321`
+  - Tools: `:324-325`
+  - Memory context: `:368-376`
+  - History: `:423-429`
+
+### `injected_ids`
+
+- Built at `:338-339` — `set` of Python `id()` values for current-turn `wiki_msgs` + `notes_msgs`.
+- Consulted only at `:340-344` (the `existing_history_tokens` filter).
+
+### "Existing history" token total used for budget
+
+- Computed at `:340-344`:
+  ```python
+  existing_history_tokens = sum(
+      estimate_tokens(str(m.get("content", "")))
+      for m in history
+      if id(m) not in injected_ids
+  )
+  ```
+- Filter is by Python object identity, so messages **loaded from the archive on prior turns** are NOT in `injected_ids` and therefore ARE counted.
+- Accumulated into `fixed_tokens` at `:345`.
+
+### `history_entry` (diagnostics-side accounting)
+
+- `history_only` filter at `:414` excludes messages whose role is in the remap dict (`vault_retrieval`, `vault_references`, `conversation_notes`).
+- `history_tokens` summed at `:415-419` over `history_only` (role in `LLM_ROLES`).
+- `history_entry = SourceEntry(source="history", tokens_estimated=history_tokens, ...)` at `:423-428`.
+- This entry is what the diagnostics sidecar reports and what `_build_context_status` totals.
+
+### Dynamic memory budget
+
+- `fixed_tokens` accumulates: system, wiki (if present), notes (if present), `existing_history_tokens`, user message, tools, preempt-skill matches (`:329-351`).
+- `window_size = self._get_context_window_size(config)` at `:357`; resolved at `:1047-1058` (prefers `config.llm.context_window_size`, else `config.compaction.max_tokens`).
+- `response_reserve = 4096` (hard-coded, `:354`).
+- `remaining_budget = max(0, window_size - fixed_tokens - response_reserve)` at `:358`.
+- Memory budget = `remaining_budget` if > 0 else `None` (`:362-365`); `None` falls back to `config.vault_retrieval.max_tokens` inside `_compose_vault_retrieval` (`:620`).
+
+## 2. Role remapping
+
+### Current `role_remap`
+
+`context_composer.py:383-387`:
+
+```python
+role_remap = {
+    "vault_retrieval": "user",
+    "vault_references": "user",
+    "conversation_notes": "user",
+}
+```
+
+### `vault_retrieval`
+
+- Created in `_compose_vault_retrieval()` at `:647`: `msg = {"role": "vault_retrieval", "content": formatted}`
+- Appended to `history` and to archive list at `:372-374`.
+- Reloaded from archive on subsequent turns into `history`.
+- Remapped to `"user"` at the LLM-history filter `:388-399`.
+
+### `vault_references`
+
+- Created in `_compose_vault_references()` at `:732-736` (carries extra `wiki_page` field).
+- Appended to history at `:289`, archive at `:290`.
+- Remapped to `"user"` at `:388-399`.
+
+### `conversation_notes`
+
+- Created in `_compose_notes()` at `:780`: `msg = {"role": "conversation_notes", "content": text}`
+- Appended to history at `:300`, archive at `:301`.
+- Remapped to `"user"` at `:388-399`.
+
+### Where remapping happens
+
+- Single loop at `:388-399`. Iterates `history`, includes messages whose role is in `LLM_ROLES` as-is, includes messages whose role is in `role_remap` with the remapped role, and expands `background_event` into a synthetic tool-call/tool-result pair (`:391-395`).
+
+## 3. Test coverage
+
+### Direct `compose()` tests in `tests/test_context_composer.py`
+
+- `TestCompose.test_produces_valid_composed_context` (`:817-834`) — basic shape: messages, token estimate > 0, `sources` populated.
+- `TestCompose.test_message_ordering` (`:836-858`) — system / deferred / user ordering and budget-pressure deferral.
+- `TestCompose.test_truncates_long_user_message` (`:860-875`) — `agent.max_message_length` truncation.
+- `TestCompose.test_stores_sources_on_state` (`:877-890`) — `composer.state.last_sources` and `last_total_tokens_estimated` updates.
+- `TestCompose.test_includes_retrieved_context_text` (`:892-909`) — memory text formatting.
+
+### Sub-component tests
+
+- `TestGetContextWindowSize` (`:134-145`) — window size resolution.
+- `TestComposeSystemPrompt` (`:111-131`) — system prompt token estimation.
+- `TestComposeMemoryContext` (`:151-270`) — memory retrieval / suppression / token budgeting.
+- `TestRetrievalModes` (`:275-366`) — dynamic budget per `vault_retrieval.mode`.
+- `TestComposeTools` (`:441-500`) — tool deferral under budget pressure.
+- `TestComposePreemptMatches` (`:506-631`) — preempt token addition.
+- `TestComposePreemptSkillMatches` (`:650-810`) — preempt skill token addition.
+
+### Adjacent
+
+- `TestScoreCandidates` (`:915-966`) — composite scoring.
+- `TestBuildDiagnostics` (`:973-1028`) — diagnostics dict shape.
+- `TestContextSidecar` (`:1031-1050`) — sidecar write/read, fail-open.
+- `TestBuildContextStatus` (`:1073-1096`) — status-line formatting.
+- `TestContextStatusInCompose` (`:1099-1135`) — context-status injection on/off.
+- `TestExpandBackgroundEvent` (`:1141-1263`) and `TestComposeExpandsBackgroundEvent` (`:1266-1356`) — background-event expansion.
+
+No test currently exercises the role-based `history_only` filter at `:414` against archived remap-role messages.
+
+### Helpers
+
+- `_make_tool_def()` at `:430-438`.
+- `_make_skill_info()` at `:637-647`.
+
+## 4. Diagnostics surface
+
+### `show_context_status`
+
+- Config: `config_types.py:178` — `show_context_status: bool = True`.
+- Consulted at `context_composer.py:449-455`. When on, appends a status line as a final `system` message inside `messages`.
+- Status string built by `_build_context_status` at `:1061-1077`:
+  ```
+  [Context: ~{total_tokens:,} / {context_window:,} tokens ({pct:.0f}%), {message_count} messages{hint}]
+  ```
+  Adds ` — consider being concise` above 70% utilization.
+
+### Sidecar
+
+- Path: `workspace/conversations/{conv_id}.context.json` resolved at `:98-107`.
+- Writer `write_context_sidecar` at `:110-117` — creates parent dir, JSON-dumps with `indent=2, default=str`, fail-open on exception.
+- Schema returned by `build_diagnostics` at `:1084-1126`:
+  - `timestamp`, `total_tokens_estimated`, `total_tokens_actual`, `context_window_size`, `compaction_threshold`
+  - `sources: [SourceEntry-shaped dicts]`
+  - `memory_candidates: [...]`
+  - `cleanup: {cleared_count, cleared_bytes}`
+- Call site for sidecar write: `agent.py:1410-1424` (`_write_diagnostics`).
+- REST endpoint `/api/conversations/{id}/context` at `http_server.py:1778`; handler `get_context_diagnostics` at `:557-570` reads via `read_context_sidecar`.
+
+## Summary of relevant divergence
+
+The bug surface has two filters that count history differently:
+
+- **Budget filter** (`:340-344`) — by `id()`. Archived remap-role messages from prior turns ARE counted here.
+- **Diagnostics filter** (`:414-419`) — by role. Archived remap-role messages from prior turns are NOT counted here. `history_entry.tokens_estimated` and the status-line totals therefore underreport.
+
+Issue #393's framing implies the budget side is also affected; the agent's reading of `:340-344` says the budget side already uses an id-based filter that does count archived messages. **This needs verification by direct read before designing a fix.**

--- a/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/spec.md
+++ b/docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/spec.md
@@ -1,0 +1,126 @@
+# Spec — Separate `history` from current-turn injections in `ContextComposer.compose()`
+
+Tracks: [#393](https://github.com/lmorchard/decafclaw/issues/393)
+
+## Goal
+
+Eliminate the design tension that produced #393's bug — `compose()` using `history` as both input (archived prior turns) and scratchpad (fresh-this-turn injections appended into it). Result: token accounting becomes structurally correct rather than maintained-by-convention via two filters that have to stay in sync.
+
+## Current state
+
+`ContextComposer.compose()` in `src/decafclaw/context_composer.py`:
+
+- Mutates the input `history` list in place by appending fresh-this-turn `vault_references`, `conversation_notes`, `vault_retrieval`, and the user message.
+- Has **two** filters that count "history tokens" with different semantics:
+  - **Budget filter** (`:338-344`) — id-based; excludes current-turn wiki+notes by Python object identity. Used to compute `existing_history_tokens` → `fixed_tokens` → `remaining_budget` → `memory_budget`. Correct today.
+  - **Diagnostics filter** (`:413-414`) — role-based; excludes ALL messages whose role is in `role_remap` (`vault_retrieval`, `vault_references`, `conversation_notes`), including those archived from prior turns. Feeds `history_entry.tokens_estimated`, the sidecar `total_tokens_estimated`, and the `[Context: ...]` status line. Underreports.
+- Sub-methods that read `history` (`_get_already_injected_pages` in `_compose_vault_references`, `extract_last_assistant_text` in `_compose_notes` / `_compose_preempt_*`) work correctly with prior-turn-only `history`; they don't depend on seeing this turn's injections.
+- After `compose()` returns, the caller (`agent.py:1050+`) continues to mutate `self.history` (tool results, assistant messages, etc.) and passes it back into `compose()` on the next turn — so the post-turn state of `history` MUST include this turn's injections.
+
+## Desired end state
+
+- `compose()` treats the input `history` list as **read-only during all calculation**. It still appends this turn's injections, but only **after** all token / budget / diagnostics work is finished, so the caller-visible side-effect is preserved.
+- The two history-token filters are gone. There is one calculation: `sum tokens in history` (with no exclusions) feeds both budget and diagnostics. Per-source `SourceEntry` instances (`wiki_entry`, `notes_entry`, `memory_entry`) account for fresh injections; `history_entry` accounts for everything archived (including archived remap-role messages).
+- Archived `vault_retrieval` / `vault_references` / `conversation_notes` messages from prior turns count toward `history_entry.tokens_estimated`, `total_tokens_estimated`, and the `[Context: ...]` status line — closing #393.
+- Final assembly builds `combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]` explicitly, runs role-remap / `_reorder_tool_results` / attachment resolution over `combined`, and returns it as `composed.messages`.
+- Tests cover the regression: archived remap-role messages in `history` produce the expected `history_entry.tokens_estimated`.
+
+## Design decisions
+
+### Decision 1 — Defer history-append to end of `compose()`
+
+**Chosen:** Append `wiki_msgs`, `notes_msgs`, `memory_msgs`, and `user_msg` to `history` at the **end** of `compose()`, after diagnostics are computed.
+
+**Reasoning:** `self.history` is load-bearing for the agent loop after `compose()` returns (tool-result appends, future turns). We can't drop the side-effect; we can move it past the calculation so during calculation `history` represents only archived past content. Single mutation point, clearly placed, easy to reason about.
+
+**Alternative considered:** Stop mutating `history` entirely and have the agent loop append injections itself from `composed.messages_to_archive`. Rejected — pushes a compose-internal concern into the caller.
+
+### Decision 2 — One history-token calculation, no filters
+
+**Chosen:** A single `history_tokens = sum(estimate_tokens(str(m.get("content", ""))) for m in history if m.get("role") in LLM_ROLES_OR_REMAP)` calculation (where `LLM_ROLES_OR_REMAP` is `LLM_ROLES | role_remap.keys()`). Use this value for both `existing_history_tokens` (budget) and `history_entry.tokens_estimated` (diagnostics).
+
+**Reasoning:** With (1) in place, `history` only contains archived prior-turn content during calculation. No injection-vs-archive disambiguation is needed. Remap-role messages should count (they're sent to the LLM after remap). Background-event records and other non-LLM-role internal messages should not. The role check enforces this without an id-based exclusion set.
+
+**Alternative considered:** Drop the role check entirely and count everything in `history`. Rejected — `history` may contain `confirmation_request` / `confirmation_response` records and similar archive-only entries that aren't sent to the LLM.
+
+### Decision 3 — Explicit `combined` assembly for LLM message list
+
+**Chosen:** Build `combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]` immediately before the role-remap loop, and iterate `combined` instead of `history` in the loop at `:388-399`.
+
+**Reasoning:** Replicates the existing LLM message ordering (archived → wiki → notes → memory → user) without relying on prior in-place appends. Explicit, single source of truth for ordering, easier to read.
+
+### Decision 4 — `_compose_vault_references` already-injected check still scans `history`
+
+**Chosen:** `_get_already_injected_pages(history)` continues to scan only `history`. `_compose_vault_references` is called once per turn before any current-turn injections happen, so within-turn dedupe is unnecessary; cross-turn dedupe works because prior turns' `vault_references` messages live in archived `history`.
+
+**Reasoning:** No code change needed. The function's premise — `history` contains archived prior-turn injections — is now structurally true throughout `compose()` rather than incidentally true.
+
+### Decision 5 — Compose still mutates `history` at the end (don't break the API)
+
+**Chosen:** `compose()` continues to mutate the caller's `history` list as the final step. Update the docstring at `:252` to reflect the new ordering ("calculates token accounting on the input history; appends this turn's injections at the end").
+
+**Reasoning:** The agent loop and tests rely on the post-compose state of `history` containing this turn's injections. Breaking that API would require touching every call site. Keep the side effect; just move it past the calculation.
+
+## Patterns to follow
+
+- **`SourceEntry`** for per-source token accounting, defined at `src/decafclaw/context_composer.py:46-53`. Each fresh injection (wiki, notes, memory) already produces one. `history_entry` continues to account for archived content. The sum of all `SourceEntry.tokens_estimated` should equal the total prompt-token estimate.
+- **Single mutation point** — match the existing pattern of `to_archive` (built incrementally, appended to once at the end). Apply the same to `history`.
+- **Role-remap dict** stays at `:383-387`. The dict's purpose narrows to "remap role names before sending to LLM"; it's no longer load-bearing for token-accounting filtering.
+- **`LLM_ROLES`** constant defined at `src/decafclaw/archive.py:13` as `{"system", "user", "assistant", "tool"}`. For the new history-token calculation, count messages whose role is in `LLM_ROLES | role_remap.keys()` so archived remap-role messages count.
+
+## What we're NOT doing
+
+- Not changing how `vault_retrieval` / `vault_references` / `conversation_notes` messages are produced, archived, or remapped to `user` role for the LLM. Only how their tokens are counted.
+- Not changing the `to_archive` flow or `composed.messages_to_archive`.
+- Not changing the dynamic memory-budget formula (`window_size - fixed_tokens - response_reserve`). Only the `existing_history_tokens` term that feeds it (which becomes structurally correct via this refactor).
+- Not changing the response-reserve constant (4096).
+- Not changing sidecar JSON schema. The numbers in `total_tokens_estimated` and `history` source entry change (become accurate), but field names stay.
+- Not changing context-window-size resolution.
+- Not changing the docs/architecture page beyond the relevant `docs/context-composer.md` section about history accounting (per CLAUDE.md "update its `docs/` page as part of the same PR").
+- Not adding new config knobs.
+- Not removing `role_remap` — it still drives LLM role remapping at `:398-399`. We just stop using its keys as a filter for token accounting.
+
+## Test plan
+
+### Regression test (the bug from #393)
+
+In `tests/test_context_composer.py`, add a test in `TestCompose` that:
+
+1. Constructs a `history` containing one archived message of each remap role (`vault_retrieval`, `vault_references`, `conversation_notes`) plus a normal `user` + `assistant` pair. None of these have `id()` matches with this turn's freshly-built injections (they're prior-turn loaded-from-archive).
+2. Calls `compose()` with no fresh wiki references, no fresh memory hits, notes empty (or otherwise verifies the test isn't accidentally re-injecting).
+3. Asserts `history_entry.tokens_estimated` is approximately the sum of token estimates for ALL five archived messages — not just the user/assistant pair.
+4. Asserts `composed.total_tokens_estimated` (or the equivalent that build_diagnostics returns) reflects the same total.
+
+### Structural test (no double-counting)
+
+Same test class, separate test:
+
+1. Constructs a `history` (some archived content), and a `compose()` call that triggers fresh wiki + notes + memory injection.
+2. Asserts that the sum of `SourceEntry.tokens_estimated` across `wiki_entry`, `notes_entry`, `memory_entry`, and `history_entry` equals the post-compose history-content token total **plus** the user message tokens (i.e., no message's tokens are counted twice and none are dropped).
+
+### Existing test impact
+
+Run the existing `tests/test_context_composer.py` suite. Tests that construct an input `history` containing fresh-this-turn-shaped injections (with `id()`s that won't be in `injected_ids` after the refactor since `injected_ids` is gone) — those tests will likely need adjustment to either:
+- Pass injections via the new path (let `compose()` produce them via its sub-methods, with appropriate fixtures), or
+- Pass them as archived-history-shaped (already remap-roled) entries the calculation should count.
+
+Audit candidates: `TestCompose.test_message_ordering`, `TestCompose.test_includes_retrieved_context_text`, `TestComposeMemoryContext.*`, `TestRetrievalModes.*`. Likely small edits, not rewrites.
+
+## Verification
+
+- `make test` — full suite passes (2243 baseline → still 2243+).
+- `make check` — lint + typecheck clean.
+- The sidecar diagnostics for a real multi-turn conversation now report a `total_tokens_estimated` that matches what compaction sees (no archived-remap drift). Manual smoke test in the web UI after the change is a nice-to-have but not blocking.
+
+## Open questions
+
+(None remaining at spec time. Spec is ready for `plan`.)
+
+## Related
+
+- #392 — added `conversation_notes` to `role_remap`.
+- `src/decafclaw/context_composer.py::compose` — primary edit site.
+- `src/decafclaw/context_composer.py::build_diagnostics` (`:1084-1126`) — consumer of `history_entry`.
+- `src/decafclaw/agent.py:1050` — caller of `compose()`.
+- `src/decafclaw/agent.py:944 _get_already_injected_pages` — sub-consumer of `history` mid-compose; unchanged.
+- `docs/context-composer.md` — to update as part of the same PR.

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -18,6 +18,15 @@ from decafclaw.skills.background.tools import format_status_text
 
 log = logging.getLogger(__name__)
 
+# Roles that are remapped to "user" before sending to the LLM.
+# These messages are auto-injected by the composer per-turn, then
+# archived under their internal role for accounting and dedupe.
+ROLE_REMAP: dict[str, str] = {
+    "vault_retrieval": "user",
+    "vault_references": "user",
+    "conversation_notes": "user",
+}
+
 
 # -- Enums --------------------------------------------------------------------
 
@@ -249,10 +258,13 @@ class ContextComposer:
     ) -> ComposedContext:
         """Assemble the complete context for this turn.
 
-        Orchestrates all context sources, mutates history in place (appending
-        wiki/memory/user messages), publishes events, and returns the
-        ready-to-send ComposedContext. Does NOT archive — the caller is
-        responsible for persisting messages via the messages_to_archive list.
+        Orchestrates all context sources. Token accounting treats ``history``
+        as read-only (archived prior turns); this turn's wiki / notes / memory
+        / user-message injections are appended to ``history`` once, at the end,
+        before returning. The caller's continued reads of ``history`` after
+        compose() returns see the post-turn state.
+        Does NOT archive — the caller is responsible for persisting messages
+        via the messages_to_archive list.
         """
         from .agent import _resolve_attachments
         from .archive import LLM_ROLES
@@ -286,7 +298,6 @@ class ContextComposer:
             ctx, config, user_message, history, mode,
         )
         for wm in wiki_msgs:
-            history.append(wm)
             to_archive.append(wm)
             await ctx.publish("vault_references", text=wm["content"], page=wm.get("wiki_page"))
         if wiki_entry:
@@ -297,7 +308,6 @@ class ContextComposer:
         # tool call per turn to read them.
         notes_msgs, notes_entry = self._compose_notes(ctx, config, mode)
         for nm in notes_msgs:
-            history.append(nm)
             to_archive.append(nm)
         if notes_entry:
             sources.append(notes_entry)
@@ -331,20 +341,30 @@ class ContextComposer:
             fixed_tokens += wiki_entry.tokens_estimated
         if notes_entry:
             fixed_tokens += notes_entry.tokens_estimated
-        # Estimate existing history (before this turn's additions)
-        # Exclude messages injected THIS turn (wiki, notes); their tokens
-        # are already counted via their respective SourceEntry. Prior
-        # turns' wiki/notes/memory are already in history and sent to the LLM.
-        injected_ids = {id(wm) for wm in wiki_msgs}
-        injected_ids |= {id(nm) for nm in notes_msgs}
-        existing_history_tokens = sum(
+        # History contains only archived prior-turn content at this point —
+        # fresh wiki / notes / memory / user injections are appended after
+        # all token accounting, at the end of compose(). Count messages whose
+        # role is sent to the LLM either directly (LLM_ROLES) or after remap
+        # (ROLE_REMAP keys). Other roles (e.g. confirmation_request, archive-only
+        # bookkeeping) are not sent and don't count.
+        countable_roles = LLM_ROLES | ROLE_REMAP.keys()
+        history_tokens = sum(
             estimate_tokens(str(m.get("content", "")))
             for m in history
-            if id(m) not in injected_ids
+            if m.get("role") in countable_roles
         )
-        fixed_tokens += existing_history_tokens
-        # User message
-        fixed_tokens += estimate_tokens(user_message)
+        fixed_tokens += history_tokens
+        # User message — has its own SourceEntry so the diagnostics
+        # waffle chart and [Context: ...] status line account for the
+        # current-turn user content alongside archived history.
+        user_msg_tokens = estimate_tokens(user_message)
+        user_msg_entry = SourceEntry(
+            source="user_message",
+            tokens_estimated=user_msg_tokens,
+            items_included=1,
+        )
+        sources.append(user_msg_entry)
+        fixed_tokens += user_msg_tokens
         # Tools (actual token cost, not estimate)
         fixed_tokens += tools_entry.tokens_estimated
         if preempt_skill_entry is not None:
@@ -370,23 +390,20 @@ class ContextComposer:
             token_budget=memory_budget,
         )
         for mm in memory_msgs:
-            history.append(mm)
             to_archive.append(mm)
         if memory_entry:
             sources.append(memory_entry)
 
-        # -- User message (added to history; caller archives with archive_text if needed) --
-        history.append(user_msg)
+        # -- User message (archived; appended to history at the end) --
         to_archive.append(user_msg)
 
         # -- Build LLM messages (filter + remap roles) --
-        role_remap = {
-            "vault_retrieval": "user",
-            "vault_references": "user",
-            "conversation_notes": "user",
-        }
+        # Combine archived history with this turn's injections in the same
+        # order they'll be archived: prior history → wiki → notes → memory →
+        # user message. The combined list is what the LLM sees.
+        combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]
         llm_history = []
-        for m in history:
+        for m in combined:
             role = m.get("role")
             if role == "background_event":
                 # Expand completion records into a synthetic poll pair so the
@@ -395,8 +412,8 @@ class ContextComposer:
                 llm_history.extend(_expand_background_event(m))
             elif role in LLM_ROLES:
                 llm_history.append(m)
-            elif role in role_remap:
-                llm_history.append({**m, "role": role_remap[role]})
+            elif role in ROLE_REMAP:
+                llm_history.append({**m, "role": ROLE_REMAP[role]})
         # Sanitize tool message ordering for LLM compatibility.
         # LiteLLM / Gemini require each tool result to immediately follow
         # the assistant message that issued its tool_call. After compaction
@@ -408,21 +425,14 @@ class ContextComposer:
         llm_history = [_resolve_attachments(config, m) for m in llm_history]
 
         # -- History source entry --
-        # Exclude wiki/memory messages — they have their own SourceEntry,
-        # so counting them here would double-count tokens in the total.
-        remapped_roles = set(role_remap.keys())
-        history_only = [m for m in history if m.get("role") not in remapped_roles]
-        history_tokens = sum(
-            estimate_tokens(str(m.get("content", "")))
-            for m in history_only
-            if m.get("role") in LLM_ROLES
-        )
+        # history_tokens was computed above (budget side); reuse the same value
+        # so budget and diagnostics are a single source of truth.
         history_msg_count = sum(
-            1 for m in history_only if m.get("role") in LLM_ROLES
+            1 for m in history if m.get("role") in countable_roles
         )
         history_entry = SourceEntry(
             source="history",
-            tokens_estimated=history_tokens,
+            tokens_estimated=history_tokens,  # computed earlier, single source of truth
             items_included=history_msg_count,
             details={"total_llm_messages": len(llm_history)},
         )
@@ -457,6 +467,14 @@ class ContextComposer:
         # -- Update state --
         self.state.last_sources = sources
         self.state.last_total_tokens_estimated = total_tokens
+
+        # Preserve the load-bearing side effect: caller (agent.py) continues
+        # to read self.history after compose() returns. Append this turn's
+        # injections in the same order as `combined` above.
+        history.extend(wiki_msgs)
+        history.extend(notes_msgs)
+        history.extend(memory_msgs)
+        history.append(user_msg)
 
         return ComposedContext(
             messages=messages,

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -13,6 +13,7 @@ from decafclaw.context_composer import (
     SourceEntry,
     _expand_background_event,
 )
+from decafclaw.util import estimate_tokens
 
 # -- Dataclass construction ---------------------------------------------------
 
@@ -907,6 +908,128 @@ class TestCompose:
             composer = ContextComposer()
             result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
             assert result.retrieved_context_text == "formatted memory"
+
+
+class TestHistoryArchivedRemap:
+    """Regression coverage for #393 — archived remap-role messages
+    must count toward history_entry.tokens_estimated."""
+
+    @pytest.mark.asyncio
+    async def test_archived_remap_messages_counted_in_history_entry(
+        self, ctx, config,
+    ):
+        """An archived vault_retrieval / vault_references / conversation_notes
+        message in history (loaded from the archive on a later turn) must
+        contribute to history_entry.tokens_estimated."""
+        composer = ContextComposer()
+        archived_user = {"role": "user", "content": "earlier user message"}
+        archived_assistant = {"role": "assistant", "content": "earlier reply"}
+        archived_vault_retrieval = {
+            "role": "vault_retrieval",
+            "content": "AAAA " * 100,  # ~ measurable token weight
+        }
+        archived_vault_references = {
+            "role": "vault_references",
+            "content": "BBBB " * 100,
+            "wiki_page": "Foo",
+        }
+        archived_notes = {
+            "role": "conversation_notes",
+            "content": "CCCC " * 100,
+        }
+        history = [
+            archived_user,
+            archived_assistant,
+            archived_vault_retrieval,
+            archived_vault_references,
+            archived_notes,
+        ]
+
+        with (
+            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composed = await composer.compose(
+                ctx, "current user message", history,
+                mode=ComposerMode.INTERACTIVE,
+            )
+
+        history_entries = [s for s in composed.sources if s.source == "history"]
+        assert len(history_entries) == 1
+        history_entry = history_entries[0]
+
+        # Sum of all five archived messages — naive estimate the same way
+        # compose() does it, to match the assertion to the implementation.
+        expected_min = sum(
+            estimate_tokens(str(m.get("content", "")))
+            for m in (
+                archived_user,
+                archived_assistant,
+                archived_vault_retrieval,
+                archived_vault_references,
+                archived_notes,
+            )
+        )
+        assert history_entry.tokens_estimated >= expected_min, (
+            f"history_entry.tokens_estimated={history_entry.tokens_estimated} "
+            f"expected >= {expected_min} (sum of all five archived messages)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_source_entries_account_for_all_llm_content(
+        self, ctx, config,
+    ):
+        """The sum of SourceEntry.tokens_estimated across all sources
+        should equal the sum of token estimates over llm_history (the
+        messages the model actually sees). Catches double-counting and
+        silent drops."""
+        composer = ContextComposer()
+        history = [
+            {"role": "user", "content": "prior user " * 50},
+            {"role": "assistant", "content": "prior assistant " * 50},
+            {"role": "vault_references", "content": "archived ref " * 50, "wiki_page": "Old"},
+        ]
+
+        with (
+            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composed = await composer.compose(
+                ctx, "fresh user message " * 20, history,
+                mode=ComposerMode.INTERACTIVE,
+            )
+
+        # Sum of SourceEntry.tokens_estimated for sources that map to
+        # entries in composed.messages. Tools are tracked via a SourceEntry
+        # but sent via the separate API `tools=` parameter, NOT in
+        # composed.messages — they have to be excluded from this sum or
+        # the comparison is not apples-to-apples. The test still patches
+        # _collect_all_tool_defs to [] to keep tools_entry near-zero, but
+        # excluding it explicitly makes the invariant robust to future
+        # changes that introduce non-empty default tool fixtures.
+        source_total = sum(
+            s.tokens_estimated for s in composed.sources if s.source != "tools"
+        )
+
+        # Sum of token estimates over the actual LLM-bound message list.
+        # composed.messages includes the system prompt as the first entry;
+        # SourceEntry breakdown also includes "system_prompt" as a source,
+        # so this comparison is apples-to-apples once tools is excluded.
+        llm_total = sum(
+            estimate_tokens(str(m.get("content", "")))
+            for m in composed.messages
+        )
+
+        # Allow small rounding drift from per-message estimate boundaries
+        # (estimate_tokens may use ceiling division). Tighten if the gap
+        # is larger than a few percent — that signals a real divergence.
+        assert abs(source_total - llm_total) <= max(50, llm_total * 0.05), (
+            f"SourceEntry sum {source_total} (excl tools) vs composed.messages "
+            f"sum {llm_total} diverge by more than 5% / 50 tokens — token "
+            f"accounting is drifting."
+        )
 
 
 # -- Relevance scoring ---------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes #393: archived `vault_retrieval` / `vault_references` / `conversation_notes` messages are now correctly counted in `history_entry.tokens_estimated`, the sidecar `total_tokens_estimated`, and the `[Context: ...]` status line.
- Restructures `ContextComposer.compose()` so the input `history` list is read-only during all token-budget and diagnostics calculation. Eliminates the dual filter (id-based + role-based) that produced the bug — the role-based filter quietly excluded archived auto-injected role messages even though the LLM still sees them after remap.

Real-data smoke against an archived 46-message conversation: pre-fix reported 2623 tokens for the history source entry; post-fix reports 9569 — a 6946-token (~73%) correction.

## Design Decisions

- **`history` is read-only during all calculation.** The four mid-compose `history.append` calls are replaced by a single block at the end (after diagnostics), preserving the load-bearing side effect that the agent loop relies on.
- **One history-token sum, no filters.** `countable_roles = LLM_ROLES | ROLE_REMAP.keys()`. The budget calc and `history_entry.tokens_estimated` reuse the same value — single source of truth.
- **Explicit `combined` for LLM assembly.** `combined = [*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]` is iterated to build the LLM message list, instead of mutating `history` and iterating it.
- **`ROLE_REMAP` lifted to module-level constant.** It's now referenced from both the LLM-remap loop and the countable-roles set.
- **`user_message` gets its own SourceEntry.** Pre-refactor the role-based filter incidentally counted the current-turn user message; the new role-allowlist filter doesn't (current-turn content isn't in `history` during the calc), so an explicit SourceEntry restores diagnostics parity.

The architectural property worth preserving: any future auto-injection role just needs its own SourceEntry. No filter to keep in sync; no double-counting risk.

## Changes

- `src/decafclaw/context_composer.py` — refactor compose(), lift `ROLE_REMAP` to module-level, add `user_msg_entry` SourceEntry, update docstring.
- `tests/test_context_composer.py` — two new tests in `TestHistoryArchivedRemap`:
  - `test_archived_remap_messages_counted_in_history_entry` — regression test for #393.
  - `test_source_entries_account_for_all_llm_content` — structural no-double-count guard rail with a 5% / 50-token tolerance. The 50-token floor absorbs the self-referential `[Context: ...]` status line that's appended after all SourceEntry computation by design.
- `docs/context-composer.md` — new "History accounting" sub-section under "Token budget".
- `docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/` — spec / plan / research / notes.

## Test Plan

- [x] `make test` — full suite: 2312 passed, 0 failed.
- [x] `make check` — lint + typecheck clean (ruff + pyright + tsc).
- [x] Real-data smoke: load an archived conversation with 8 auto-injected remap-role messages, call `compose()`, verify `history_entry.tokens_estimated` includes them. Pre-fix: 2623 tokens. Post-fix: 9569 tokens.

## References

- Spec: `docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/spec.md`
- Plan: `docs/dev-sessions/2026-04-29-1504-token-accounting-archived-remap-393/plan.md`
- Closes #393