### PR TITLE
docs(skills): document .agents/skills as another npx skills target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/
 evals/results/
 node_modules/
 .playwright-mcp/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ See [docs/web-ui-design.md](docs/web-ui-design.md) for the primitive catalog and
 See [docs/skills.md](docs/skills.md).
 
 - **Lazy-loaded by default.** Catalog (name + description) in system prompt; full body and tools load on `activate_skill`. `always-loaded: true` opts a skill out (auto-activated, exempt from deferral).
-- **Bundled in `src/decafclaw/skills/`**. Each: SKILL.md (required) + `tools.py` (optional). Scan order: workspace > agent-level > bundled > `extra_skill_paths` (configured external dirs, e.g. for `npx skills add`).
+- **Bundled in `src/decafclaw/skills/`**. Each: SKILL.md (required) + `tools.py` (optional). Scan order: workspace > agent-level > bundled > `extra_skill_paths` (configured external dirs — common targets are `~/.claude/skills` and `~/.agents/skills` from `npx skills add`).
 - **Skills must use absolute imports** (`from decafclaw.skills.X.Y import ...`). The loader uses `importlib.spec_from_file_location` without package context, so relative imports fail at runtime.
 - **Skill config via `SkillConfig` dataclass in `tools.py`.** Resolved at activation by `load_sub_config` (env + `config.skills[name]` + defaults). `init(config, skill_config)` receives both.
 - **User-invokable commands** (`user-invocable: true`) trigger via `!name` (Mattermost) / `/name` (web UI). Supports `$ARGUMENTS`/`$0`/`$1`, `context: fork`, `allowed-tools`.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -299,26 +299,36 @@ Example: the `weather` skill from ClawHub uses `curl` via the `shell` tool — n
 
 ### Installing skills via `npx skills`
 
-The [`vercel-labs/skills`](https://www.npmjs.com/package/skills) CLI installs skills from GitHub/GitLab/git URLs into per-agent paths. To wire it into decafclaw:
+The [`vercel-labs/skills`](https://www.npmjs.com/package/skills) CLI installs skills from GitHub/GitLab/git URLs into per-agent paths. `decafclaw` isn't in its built-in agent list, so install under one of the agent targets it knows about and point `extra_skill_paths` at the resulting directory.
 
-1. Install with any compatible agent target — `claude-code` is convenient since the path matches a common Claude Code setup:
+The CLI's path is `<scope>/<agent-dir>/skills/<skill>/`, where:
+
+- `<scope>` is `~/` with `-g` (global) or the current directory without it (project-local)
+- `<agent-dir>` is `.claude` for `-a claude-code`, otherwise `.agents` (used by `universal` and most other targets)
+
+So the four canonical install locations are `~/.claude/skills/`, `~/.agents/skills/`, `./.claude/skills/`, `./.agents/skills/`. Any of them can be added to `extra_skill_paths`.
+
+1. Install with a compatible agent target. `claude-code` and `universal` are both reasonable:
 
    ```bash
    npx skills add vercel-labs/agent-skills -a claude-code -g
    # skills land in ~/.claude/skills/<name>/
+
+   npx skills add vercel-labs/agent-skills -a universal -g
+   # skills land in ~/.agents/skills/<name>/
    ```
 
 2. Add the install location to the agent's `data/{agent_id}/config.json`:
 
    ```json
-   { "extra_skill_paths": ["~/.claude/skills"] }
+   { "extra_skill_paths": ["~/.claude/skills", "~/.agents/skills"] }
    ```
 
-   Or set `EXTRA_SKILL_PATHS=~/.claude/skills` in the environment. Multiple paths are supported (JSON array or comma-separated).
+   Or set `EXTRA_SKILL_PATHS=~/.claude/skills,~/.agents/skills` in the environment. Multiple paths are supported (JSON array or comma-separated).
 
 3. Restart decafclaw or run `refresh_skills`.
 
-Path entries support `~` and `$VAR` expansion. Relative paths resolve against `data/{agent_id}/`.
+Path entries support `~` and `$VAR` expansion. Relative paths resolve against `data/{agent_id}/` — useful for project-local installs (`.claude/skills`, `.agents/skills`) when you run decafclaw from a fixed working directory.
 
 **Trust posture for external skills.** External skills are treated identically to workspace skills:
 


### PR DESCRIPTION
## Summary
- `npx skills add` installs to `.agents/skills/` for any non-`claude-code` agent target (e.g. `-a universal`), in addition to the previously documented `.claude/skills/` for `-a claude-code`. Spell out the `<scope>/<agent-dir>/skills/` path layout, list the four canonical install locations (`~/.claude/skills`, `~/.agents/skills`, and project-local equivalents), and update the multi-path `extra_skill_paths` example.
- CLAUDE.md's bundled-skills bullet now names both `~/.claude/skills` and `~/.agents/skills` as common `npx skills` targets.
- Gitignore `.claude/` — local Claude Code state (settings.local.json, worktrees/, dev-sessions scratch) shouldn't be tracked. Canonical dev-session docs still live under `docs/dev-sessions/`.

No code change — `extra_skill_paths` already accepts arbitrary paths, so this is purely follow-up documentation to #427.

## Test plan
- [ ] Read through `docs/skills.md` § "Installing skills via `npx skills`" — paths and examples render cleanly
- [ ] Confirm `.claude/` no longer appears in `git status` after the gitignore change

🤖 Generated with [Claude Code](https://claude.com/claude-code)