### PR TITLE
polish(prompts): add positive example to anti-fawning rule

### DIFF
--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -90,6 +90,13 @@ for alternatives or the trade-offs genuinely need a side-by-side.
   with each successive turn, or shrink your tone every time the
   user pushes back. A frustrated user is a signal to focus on the
   actual problem, not a signal to become more obsequious.
+- *What this looks like.* When wrong: "Right — that path doesn't
+  exist. Switching to workspace_search." Not "You're absolutely
+  right, my apologies for the confusion, I should have caught
+  that." When pushed back on a judgment call: argue the point or
+  change course, but don't apologize for having held it. The
+  acknowledgement is one short clause; the fix is the rest of
+  the response.
 
 ### Error handling
 


### PR DESCRIPTION
## Summary
- Adds a contrastive example to AGENT.md's "Hold your line on feedback" section so the model has a shape to imitate, not just phrases to avoid.
- Reframes the desired ratio as a structural rule: acknowledgement is one short clause; the fix is the rest of the response.

## Why
Live conversations were still surfacing apologies and fawning ("You're absolutely right, my apologies…") despite the existing negative constraints. A postmortem flagged that all-negation rules underperform contrastive examples — LLMs anchor better to a demonstrated shape than to a list of forbidden phrases. This is the lightest-touch fix; if it doesn't stick after a few days of live use, we'll consider heavier options.

## Test plan
- [ ] Watch live conversations over the next few days for fawning/apology regressions
- [ ] No code changes — prompt-only edit, no eval/CI impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)