### PR TITLE
Vault user-page writes via confirmation gate

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -132,6 +132,21 @@ Tool-result clearing — a lightweight pre-compaction tier that replaces large o
 
 `min_turn_age: 2` means tool messages from the current and previous user turn stay intact; older results are eligible for clearing. `min_size_bytes: 1024` is a floor — messages smaller than the stub itself wouldn't be worth clearing. `preserve_tools` is a hard allowlist for tools whose output is fundamentally load-bearing (e.g. `activate_skill` announces the tools the agent will use; `checklist_*` carries the per-conversation execution-loop state).
 
+### `vault`
+
+Vault location and write-gate settings. See [vault.md](vault.md).
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `vault_path` | str | `workspace/vault/` | `VAULT_VAULT_PATH` |
+| `agent_folder` | str | `agent/` | `VAULT_AGENT_FOLDER` |
+| `recent_changes_limit` | int | `50` | `VAULT_RECENT_CHANGES_LIMIT` |
+| `user_writable_paths` | list[str] | `[]` | `VAULT_USER_WRITABLE_PATHS` |
+
+`agent_folder` is resolved relative to `vault_path`. Set `vault_path` to an absolute path to point the agent at an existing Obsidian vault.
+
+`user_writable_paths` lists vault-relative folder paths that bypass the user-page write confirmation. Prefix match (no globs); leading `/` is stripped and a trailing `/` is enforced, so `creative` and `creative/` are equivalent. Entries containing `..` are skipped with a warning. Empty by default — opt-in. Example: `["creative/", "notes/"]`.
+
 ### `vault_retrieval`
 
 Controls auto-retrieval injection at turn start. See [context-composer.md#memory-retrieval-modes](context-composer.md#memory-retrieval-modes) and #301.

--- a/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/notes.md
+++ b/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/notes.md
@@ -1,0 +1,111 @@
+# Session notes
+
+## Status
+
+Shipped to PR #443 (https://github.com/lmorchard/decafclaw/pull/443). All 5 phases plus 3 polish commits plus Copilot-review fixes squashed to a single commit. 2387 tests passing, `make check` clean. Awaiting merge after live `make dev` smoke.
+
+## Commits
+
+```
+2899e1b Phase 5 polish: dedup test helpers, validate reason, expand docs
+b7d753f Phase 5: vault_grant_folder tool + SKILL.md + docs
+38f5861 Phase 4 polish: extract _run_gate_or_confirm shared helper
+6abb91a Phase 4: wire vault_rename to confirmation gate
+c7612d0 Phase 3: wire vault_delete to confirmation gate
+3f308d9 Phase 2: wire vault_write to confirmation gate
+527cc62 Phase 1 polish: consolidate normalize_folder, move warning to load time
+65c4541 Phase 1: vault user-write gate helper, config, grant sidecar
+```
+
+Base: `0af4d4a` (origin/main).
+
+## Test summary
+
+- Full suite: 2385 passed in 158.86s.
+- Vault subset: 124 passed (test_vault_grants.py + test_vault_tools.py).
+- `make check` clean (ruff, pyright, tsc, message-types drift).
+
+## Key files
+
+- `src/decafclaw/skills/vault/_grants.py` (new) — sidecar I/O.
+- `src/decafclaw/skills/vault/tools.py` — gate helper, `_run_gate_or_confirm`, `vault_grant_folder` tool, three updated tools.
+- `src/decafclaw/config_types.py` — `VaultConfig.user_writable_paths`.
+- `src/decafclaw/config.py` — load-time allowlist validation.
+- `src/decafclaw/skills/vault/SKILL.md` — Boundaries section rewrite.
+- `docs/vault.md` — "Writing to user pages" section + tool table updates.
+- `docs/config.md` — vault config field docs.
+- `tests/test_vault_grants.py` (new) + `tests/test_vault_tools.py` extended.
+
+## Refactors during execution
+
+- **Phase 1 polish** (post-quality-review): consolidated `_normalize` and `_normalize_allowlist_entry` into a single `normalize_folder(folder, *, warn_on_invalid=False)` in `_grants.py`. Moved allowlist warning out of the per-call hot path into `load_config()` so misconfigured entries surface once at startup rather than on every write.
+- **Phase 4 polish** (post-quality-review): extracted `_run_gate_or_confirm` shared helper after three near-identical 8-line gate-flow blocks emerged across write/delete/rename. Phase 5's grant tool was the fourth call site. Behavior-preserving refactor; all tests still pass.
+- **Phase 5 polish**: deduplicated `_dummy_request_confirmation` test helper across 6 test classes; added `reason` validation to `vault_grant_folder`; expanded the tool docstring; simplified the inside-agent guard now that `Path.is_relative_to` self-equality is verified.
+
+## Deferred items (manual smoke / retro)
+
+These were left unchecked in plan.md for end-of-feature manual verification:
+
+- `make config` showing `vault.user_writable_paths: []` in the resolved config dump.
+- Live `make dev` smoke for each gate path (write/delete/rename), including: confirmation message renders correctly in web UI, approve/deny outcomes, allowlist bypass, grant-then-batch flow.
+- `make eval-tools` re-run if vault evals exist (report at retro).
+- Cross-conversation isolation (open new conversation, verify grants don't leak).
+- Reload-resilience: confirm grant sidecar persists across page reload + server restart via the existing ConversationManager confirmation infrastructure.
+
+## Known minor follow-ups (from final review, not blocking)
+
+1. **Theoretical race in `add_grant`** under concurrent calls in the same conversation. Mitigated in practice by `await request_confirmation(...)` blocking on human approval, which serializes calls. Same pattern as canvas/notes sidecars (no lock). Not a fix.
+2. **Allowlist mention asymmetry in `docs/vault.md`** — table cell says "Pages outside `agent/` trigger a user confirmation"; the fuller "Writing to user pages" section adds the allowlist + grant short-circuits below. Could tighten the table cell to "see Writing to user pages".
+
+## Code reviewer feedback themes (across phases)
+
+The reviewers consistently flagged:
+
+- **Cross-phase consistency** as a strength — same gate flow shape across write/delete/rename, same preview helper signature, same error format.
+- **Sentinel test patterns** as a strength — `AsyncMock(side_effect=AssertionError(...))` for "must not be called" guards is more rigorous than `assert mock.not_called`.
+- **Duplication** flagged early (Phase 1) and again (Phase 3) before being acted on (Phase 4 polish for the gate helper, Phase 5 polish for the test helper). Lesson: act on quality-review duplication flags sooner, especially when a reviewer specifically frames it as "the moment to extract is now."
+
+## Retrospective
+
+### Recap
+
+Replaced the hard-refuse on vault writes outside `agent/` with a three-tier gate (config allowlist → per-conversation grants → user confirmation). Added `vault_grant_folder` for batch trust. Surfaced as PR #443. The original ask was just `vault_write`; the brainstorm broadened to all three of write/delete/rename and added the grant tool.
+
+### Scope drift (during brainstorm)
+
+- **Q1** (scope): "loosen all three" instead of just `write`, since the same `_is_in_agent_dir` boundary gates write, delete, and rename. Symmetric design beats partial.
+- **Q2** (mechanism): static config allowlist + per-conversation grants (rather than pure per-call confirmation). Friction concern was concrete enough to design for upfront — Les routinely batch-edits creative pages.
+- **Q3** (grant shape): separate `vault_grant_folder` tool over a `grant_folder=true` flag on the existing tools. Cleaner mental model.
+
+No drift between spec and ship. The plan's vertical slices held; phases 1-5 each delivered exactly what the slice promised.
+
+### Surprises
+
+- **SKILL.md and runtime were already misaligned.** SKILL.md told the LLM "only write outside `agent/` when the user explicitly asks," but the runtime hard-refused regardless. The session existed to close that pre-existing gap, which made the framing crisp: align runtime with documented policy.
+- **Spec self-review caught a load-bearing API mistake.** Initial spec used `EndTurnConfirm`, but the LLM-facing precedent for "block on user approval, then return outcome" is `await request_confirmation(...)` (the email pattern). Caught and corrected before plan, which would have been hard to unwind later.
+- **Empty-string normalization → wildcard prefix** was a real bug. Phase 1 quality reviewer flagged it: if `_normalize` returned `""` for malformed input and the empty string landed in the grant set, `rel.startswith("")` would let any path through. Filter added at read time. The kind of thing that would be a security concern if anyone could write to the sidecar directly.
+- **`Path.is_relative_to(self)` is True.** The inside-agent guard had a redundant `==` check alongside `is_relative_to`. Verified at REPL during Phase 5 polish; simplified.
+
+### Workflow friction
+
+- **Brainstorm converged in 3 questions.** Could have been 4 (config shape, message format) but those were tactical enough to default-with-best-judgment in the spec for review. Right call.
+- **Plan was detailed enough that no Phase 1-5 implementer asked clarifying questions.** Sign of right specificity — when implementer subagents don't need to ask, the plan is doing its job.
+- **`_dummy_request_confirmation` duplication was flagged 3 times before being acted on** (Phase 1 quality review, Phase 4 quality review minor, Phase 5 quality review minor — finally fixed in Phase 5 polish). Should have acted on the second flag, not the third. Reviewer-flagged duplication is signal, not noise.
+- **`_run_gate_or_confirm` extraction was timed right.** Phase 4 polish, after three call sites existed, before Phase 5 added a fourth. "Three call sites is the threshold to extract" generalizes.
+- **Subagent-driven workflow stayed clean.** Per-phase fresh context + 2-stage review (spec compliance + code quality) caught real bugs early without polluting the controller. Final whole-feature review was confirmatory rather than discovering anything new — sign the per-phase reviews were doing their job.
+
+### Misses
+
+- **Race-condition note on `add_grant` wasn't in the spec.** Concurrent grant tool calls in the same conversation could race (read-modify-write on the sidecar). In practice impossible — `await request_confirmation` serializes by waiting on a human. But the spec / docs should have acknowledged it. Final reviewer surfaced it.
+- **No `schema_version` field on the grant sidecar.** Phase 1 quality review flagged this as a minor; we deferred. canvas.py has a "Phase 3 migration: synthesize next_tab_id" comment showing this kind of thing always matters eventually. Cheap to add now while there are zero deployed sidecars; expensive to retrofit later. **Actionable follow-up.**
+- **Behavioral surface change: `vault_grant_folder` no longer rejects leading-slash inputs.** After Copilot's normalize-don't-reject suggestion, `/creative` strips to `creative/` and proceeds; `/etc/passwd` strips to `etc/passwd/` and lands inside the vault as a folder name. Harmless (containment check still holds), but a watch-for-it if anyone reports oddities.
+
+### Memory candidates
+
+- **`request_confirmation` vs `EndTurnConfirm` decision frame.** When the LLM cares about the actual outcome (write succeeded? email sent?), use `await request_confirmation(...)` — blocks the tool, returns outcome as the tool result. When "I asked the user for review" is itself the meaningful state transition (project skill review gates), use `EndTurnConfirm` with on_approve/on_deny callbacks. CLAUDE.md mentions both but doesn't explicitly contrast the choice.
+- **Three-call-site rule for extraction.** Two call sites is premature; four is too late. Three is the sweet spot.
+
+### Skill candidates
+
+- **Maybe a "duplication flagged twice = act on it" guideline** for subagent-driven-development reviewer loops. Could go in the skill's red-flags section. Borderline — could also just be experience.
+

--- a/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/plan.md
+++ b/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/plan.md
@@ -1,0 +1,804 @@
+# Vault user-page writes — Implementation Plan
+
+**Goal:** Replace the hard-refuse on vault writes outside `agent/` with a three-tier gate: static config allowlist → per-conversation folder grants → user confirmation. Add a `vault_grant_folder` tool for batch-trust grants.
+
+**Approach:** Build the gate helper + grant sidecar first (Phase 1), then wire each of `vault_write`/`vault_delete`/`vault_rename` to use it (Phases 2–4), then ship the grant tool plus user-facing docs (Phase 5). Each phase mirrors the `send_email` allowlist+confirmation precedent at `src/decafclaw/tools/email_tools.py:133-219`.
+
+**Tech stack:** Python 3, dataclasses, `asyncio`, `pytest` + `unittest.mock`, JSON sidecars.
+
+---
+
+## Phase 1: Gate helper, config field, grant sidecar
+
+Foundation slice. Adds the config field, the per-conversation grant sidecar I/O, and the `_check_user_write_allowed` helper. **No tool wiring yet** — this phase is purely additive plumbing with full unit-test coverage.
+
+**Files:**
+- Modify: `src/decafclaw/config_types.py` — add `user_writable_paths: list[str] = field(default_factory=list)` to `VaultConfig` (line 203). Use `field(default_factory=list)`.
+- Create: `src/decafclaw/skills/vault/_grants.py` — sidecar I/O + path normalization helpers.
+- Modify: `src/decafclaw/skills/vault/tools.py` — add `_check_user_write_allowed(ctx, path) -> GateOutcome` helper, the `GateOutcome` enum, `_is_in_user_writable_paths(config, path)`, and `_normalize_allowlist_entry(entry)` near the existing path helpers (around `tools.py:114`, after `_is_in_agent_dir`).
+- Create: `tests/test_vault_grants.py` — unit tests for `_grants.py` (read/write/dedup, path safety, atomic write).
+- Modify: `tests/test_vault_tools.py` — add `TestCheckUserWriteAllowed` class testing the gate logic against allowlist, grants, agent dir, non-interactive context. Reuse existing `ctx` and `vault_dir` fixtures; extend with `conv_id` where needed.
+- Modify: `docs/config.md` — add `vault.user_writable_paths` row to the Vault config section.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/vault/_grants.py
+"""Per-conversation vault folder grants — sidecar persistence.
+
+Each conversation that has been granted folder trust gets a JSON sidecar at
+{workspace}/conversations/{conv_id}.vault_grants.json. Stored as a sorted,
+deduped list of folder paths (vault-relative, trailing slash enforced).
+"""
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _grants_sidecar_path(config, conv_id: str) -> Path:
+    """Path to the grants JSON sidecar; guarded against directory traversal.
+
+    Mirrors `_canvas_sidecar_path` in src/decafclaw/canvas.py:41-50.
+    """
+    base_dir = (config.workspace_path / "conversations").resolve()
+    if not conv_id or "/" in conv_id or "\\" in conv_id or ".." in conv_id:
+        return base_dir / "_invalid.vault_grants.json"
+    path = (base_dir / f"{conv_id}.vault_grants.json").resolve()
+    if not path.is_relative_to(base_dir):
+        return base_dir / "_invalid.vault_grants.json"
+    return path
+
+
+def read_grants(config, conv_id: str) -> set[str]:
+    """Read the grant set; fail-open with empty set on any error."""
+    if not conv_id:
+        return set()
+    path = _grants_sidecar_path(config, conv_id)
+    if not path.exists():
+        return set()
+    try:
+        data = json.loads(path.read_text())
+        folders = data.get("folders", [])
+        # Filter out invalid (normalized to "") entries — they would act as
+        # a wildcard prefix in is_path_in_grants and let everything through.
+        result: set[str] = set()
+        for f in folders:
+            if isinstance(f, str):
+                norm = _normalize(f)
+                if norm:
+                    result.add(norm)
+        return result
+    except (json.JSONDecodeError, OSError):
+        log.warning("Failed to read vault grants for %s; treating as empty",
+                    conv_id, exc_info=True)
+        return set()
+
+
+def add_grant(config, conv_id: str, folder: str) -> bool:
+    """Append a folder grant atomically. Returns True on success."""
+    if not conv_id:
+        return False
+    folder = _normalize(folder)
+    if not folder:
+        return False
+    grants = read_grants(config, conv_id)
+    grants.add(folder)
+    path = _grants_sidecar_path(config, conv_id)
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"folders": sorted(grants)}
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp.replace(path)
+        return True
+    except OSError:
+        log.warning("Failed to write vault grants for %s", conv_id, exc_info=True)
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError as cleanup_exc:
+            log.debug("vault_grants tmp cleanup failed: %s", cleanup_exc)
+        return False
+
+
+def _normalize(folder: str) -> str:
+    """Normalize a folder path: strip leading /, enforce trailing /, reject ..
+
+    Returns "" for invalid inputs (caller should treat as no-grant).
+    """
+    if not isinstance(folder, str):
+        return ""
+    folder = folder.strip()
+    if not folder or ".." in folder:
+        return ""
+    if folder.startswith("/"):
+        folder = folder.lstrip("/")
+    if not folder.endswith("/"):
+        folder = folder + "/"
+    return folder
+
+
+def is_path_in_grants(config, conv_id: str, path: Path) -> bool:
+    """Check if a vault-relative path is under any granted folder."""
+    grants = read_grants(config, conv_id)
+    if not grants:
+        return False
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except (ValueError, OSError):
+        return False
+    rel = rel.replace("\\", "/")
+    return any(rel.startswith(g) for g in grants)
+```
+
+```python
+# src/decafclaw/skills/vault/tools.py — added near _is_in_agent_dir (line ~114)
+from enum import Enum
+
+class GateOutcome(Enum):
+    ALLOW = "allow"
+    NEEDS_CONFIRMATION = "needs_confirmation"
+    NON_INTERACTIVE_ERROR = "non_interactive_error"
+
+
+def _is_in_user_writable_paths(config, path: Path) -> bool:
+    """Check if a vault-relative path is under any configured allowlist entry."""
+    paths = getattr(config.vault, "user_writable_paths", []) or []
+    if not paths:
+        return False
+    try:
+        rel = str(path.resolve().relative_to(_vault_root(config).resolve()))
+    except (ValueError, OSError):
+        return False
+    rel = rel.replace("\\", "/")
+    for entry in paths:
+        norm = _normalize_allowlist_entry(entry)
+        if norm and rel.startswith(norm):
+            return True
+    return False
+
+
+def _normalize_allowlist_entry(entry: str) -> str:
+    """Normalize an allowlist entry; return '' for invalid (caller skips)."""
+    if not isinstance(entry, str):
+        return ""
+    e = entry.strip()
+    if not e or ".." in e:
+        if e:
+            log.warning("Skipping invalid vault.user_writable_paths entry: %r", entry)
+        return ""
+    if e.startswith("/"):
+        e = e.lstrip("/")
+    if not e.endswith("/"):
+        e = e + "/"
+    return e
+
+
+def _check_user_write_allowed(ctx, path: Path) -> GateOutcome:
+    """Decide how to handle a vault write/delete/rename for the given path.
+
+    Returns:
+        GateOutcome.ALLOW — write directly (path is in agent/, allowlist, or grants)
+        GateOutcome.NEEDS_CONFIRMATION — caller must call request_confirmation()
+        GateOutcome.NON_INTERACTIVE_ERROR — no UI available; caller returns error
+    """
+    if _is_in_agent_dir(ctx.config, path):
+        return GateOutcome.ALLOW
+    if _is_in_user_writable_paths(ctx.config, path):
+        return GateOutcome.ALLOW
+    from decafclaw.skills.vault._grants import is_path_in_grants
+    if is_path_in_grants(ctx.config, ctx.conv_id, path):
+        return GateOutcome.ALLOW
+    if ctx.request_confirmation is None:
+        return GateOutcome.NON_INTERACTIVE_ERROR
+    return GateOutcome.NEEDS_CONFIRMATION
+```
+
+**Test outline (TDD — write these tests first; they should fail before the helpers exist):**
+
+```python
+# tests/test_vault_grants.py — new file
+class TestNormalizeFolder:
+    def test_strips_leading_slash(self): ...
+    def test_enforces_trailing_slash(self): ...
+    def test_rejects_dotdot(self): ...
+    def test_rejects_empty(self): ...
+
+class TestGrantsSidecarPath:
+    def test_rejects_path_traversal_in_conv_id(self, config): ...
+    def test_returns_invalid_path_for_empty_conv_id(self, config): ...
+
+class TestReadAddGrants:
+    def test_empty_when_no_sidecar(self, config): ...
+    def test_add_then_read_roundtrip(self, config, tmp_path): ...
+    def test_add_dedup(self, config): ...
+    def test_corrupt_sidecar_treated_as_empty(self, config): ...
+    def test_atomic_write_no_partial_on_failure(self, config): ...
+
+class TestIsPathInGrants:
+    def test_path_under_granted_folder(self, config): ...
+    def test_path_not_under_any_grant(self, config): ...
+    def test_no_grants_returns_false(self, config): ...
+
+# tests/test_vault_tools.py — new class
+class TestCheckUserWriteAllowed:
+    async def test_agent_dir_allows(self, ctx, agent_pages): ...
+    async def test_allowlist_allows(self, ctx, vault_dir):
+        # Configure ctx.config.vault.user_writable_paths = ["creative/"]
+        # Expect ALLOW for creative/foo.md
+        ...
+    async def test_grants_allow(self, ctx, vault_dir):
+        # Pre-populate sidecar with "creative/foo/"
+        # Expect ALLOW for creative/foo/bar.md
+        ...
+    async def test_outside_agent_with_request_conf_yields_needs_confirmation(self, ctx, vault_dir): ...
+    async def test_no_request_conf_yields_non_interactive_error(self, ctx, vault_dir):
+        # ctx.request_confirmation = None
+        ...
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2356 passed)
+- [x] `make check` passes
+- [x] `pytest tests/test_vault_grants.py -v` — all new tests green
+- [x] `pytest tests/test_vault_tools.py::TestCheckUserWriteAllowed -v` — all green
+
+**Verification — manual:**
+- [ ] `make config` output includes `vault.user_writable_paths: []` (resolved config dump shows the new field). _Deferred to end-of-feature manual smoke._
+
+---
+
+## Phase 2: Wire `vault_write` to use the gate
+
+Replaces the hard-refuse at `src/decafclaw/skills/vault/tools.py:171` with the three-tier check from Phase 1. After this phase, `vault_write` to user pages works (with confirmation) and the `vault_write` tool description teaches the LLM the new affordance.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` —
+  - Replace lines 171-174 (the hard-refuse block in `tool_vault_write`) with the gate-driven flow.
+  - Add `_format_vault_write_preview(config, path, content, exists)` near the existing helpers.
+  - Update the `vault_write` entry in `TOOL_DEFINITIONS` (lines 833-844): replace the "Writes are restricted ..." sentence.
+  - Add module-level import: `from decafclaw.tools.confirmation import request_confirmation`.
+- Modify: `tests/test_vault_tools.py` — extend `TestVaultWrite` class with new tests for the gate paths.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/vault/tools.py — tool_vault_write rewritten gate logic
+async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
+    log.info(f"[tool:vault_write] page={page}")
+    path = _safe_write_path(ctx.config, page)
+    if path is None:
+        return ToolResult(
+            text=f"[error: invalid page name '{page}' — must be within vault directory]")
+    if not content or not content.strip():
+        return ToolResult(text=f"[error: refusing to write empty vault page '{page}']")
+
+    outcome = _check_user_write_allowed(ctx, path)
+    if outcome == GateOutcome.NON_INTERACTIVE_ERROR:
+        return ToolResult(
+            text=f"[error: vault_write to '{page}' outside agent folder "
+                 f"requires interactive confirmation; not available from this context]")
+    if outcome == GateOutcome.NEEDS_CONFIRMATION:
+        msg = _format_vault_write_preview(ctx.config, path, content, path.exists())
+        approval = await request_confirmation(
+            ctx, tool_name="vault_write",
+            command=f"vault_write to '{page}'",
+            message=msg,
+        )
+        if not approval.get("approved"):
+            return ToolResult(text=f"[error: vault_write to '{page}' was denied by user]")
+    # outcome == ALLOW or approved confirmation — proceed
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    # ... existing indexing block unchanged ...
+    return f"Vault page '{page}' saved."
+
+
+def _format_vault_write_preview(config, path: Path, content: str, exists: bool) -> str:
+    """Confirmation preview for vault_write. Mirrors _format_confirmation_message."""
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except ValueError:
+        rel = path.name
+    state = "(overwrites existing page)" if exists else "(new page)"
+    size_kb = len(content.encode("utf-8")) / 1024
+    preview = content[:200] + ("..." if len(content) > 200 else "")
+    return "\n".join([
+        f"Vault write to: {rel}",
+        state,
+        f"Content: {size_kb:.1f} KB",
+        "---",
+        preview,
+    ])
+```
+
+```python
+# TOOL_DEFINITIONS entry for vault_write — replace the "Writes are restricted ..." sentence
+"description": (
+    "Create or overwrite a vault page (knowledge base). ONLY for "
+    "vault knowledge pages — NOT for workspace files, blog posts, "
+    "code, configs, or any file in a project directory. Use "
+    "workspace_write for those. ALWAYS vault_read first if "
+    "updating an existing page to preserve content you want to keep. "
+    "Use [[Page Name]] syntax to link to other pages. Include a "
+    "## Sources section. Pages outside the agent folder (agent/pages/, "
+    "agent/journal/) require user confirmation per call. For batch "
+    "operations on user folders, request folder trust via "
+    "vault_grant_folder first."
+),
+```
+
+**Test outline:**
+```python
+# tests/test_vault_tools.py — extend TestVaultWrite
+class TestVaultWriteUserFolders:
+    async def test_allowlist_bypass_writes_directly(self, ctx, vault_dir):
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        result = await tool_vault_write(ctx, "creative/foo", "content")
+        assert "saved" in str(result)
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    async def test_grant_bypass_writes_directly(self, ctx, vault_dir):
+        from decafclaw.skills.vault._grants import add_grant
+        ctx.conv_id = "conv-123"
+        add_grant(ctx.config, "conv-123", "creative/")
+        result = await tool_vault_write(ctx, "creative/foo", "content")
+        assert "saved" in str(result)
+
+    async def test_no_allowlist_or_grant_confirms_then_writes(self, ctx, vault_dir):
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": True})):
+            result = await tool_vault_write(ctx, "creative/foo", "content")
+        assert "saved" in str(result)
+
+    async def test_denied_returns_error_no_write(self, ctx, vault_dir):
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_write(ctx, "creative/foo", "content")
+        assert "denied by user" in str(result.text)
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    async def test_non_interactive_context_errors(self, ctx, vault_dir):
+        ctx.request_confirmation = None
+        result = await tool_vault_write(ctx, "creative/foo", "content")
+        assert "interactive confirmation" in str(result.text)
+
+    async def test_existing_test_rejects_outside_still_relevant(self, ...):
+        # The original test_rejects_write_outside_agent_folder at line 149
+        # MUST be updated — outside-agent no longer rejects unconditionally.
+        # Replace with: agent_dir writes still work, no confirmation prompt.
+```
+
+**Critical:** the original test `test_rejects_write_outside_agent_folder` at `tests/test_vault_tools.py:149` asserts the old behavior and will fail under the new design. Rewrite it (don't delete) to assert the new contract:
+- Write outside agent dir, no confirmation handler → error message about "interactive confirmation".
+- Write outside agent dir, mocked approve → succeeds.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2362 passed; rewritten `test_rejects_write_outside_agent_folder` green)
+- [x] `make check` passes
+- [x] `pytest tests/test_vault_tools.py::TestVaultWriteUserFolders -v` — 6 new tests green
+- [ ] `make eval-tools 2>&1 | grep -A2 vault_write` — _deferred to end-of-feature; vault tools may not have an eval. Report at retro._
+
+**Verification — manual:**
+- [ ] In a live `make dev` session: ask the agent to write to a page like `creative/test.md` — confirmation should appear in the web UI with the path, size, and content preview. Approve → write succeeds. _Deferred to end-of-feature manual smoke._
+- [ ] Same flow, click Deny → tool returns the denied error and no file appears in the vault. _Deferred._
+- [ ] With `vault.user_writable_paths: ["test/"]` in `data/{agent_id}/config.json`, ask agent to write `test/foo.md` — no confirmation prompted, write happens. _Deferred._
+
+---
+
+## Phase 3: Wire `vault_delete` to use the gate
+
+Same shape as Phase 2, applied to `tool_vault_delete` at `src/decafclaw/skills/vault/tools.py:195`. Adds delete-specific preview and updates the tool description.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` —
+  - Replace lines 204-206 (the hard-refuse in `tool_vault_delete`) with gate-driven flow.
+  - Add `_format_vault_delete_preview(config, path)`.
+  - Update the `vault_delete` entry in `TOOL_DEFINITIONS` (lines 868-876).
+- Modify: `tests/test_vault_tools.py` — add a `TestVaultDeleteUserFolders` class parallel to Phase 2's `TestVaultWriteUserFolders`. Rewrite the existing `test_rejects_page_outside_agent_dir` at line 202 to assert the new contract.
+
+**Key changes:**
+
+```python
+# tool_vault_delete after the path-exists check:
+outcome = _check_user_write_allowed(ctx, path)
+if outcome == GateOutcome.NON_INTERACTIVE_ERROR:
+    return ToolResult(
+        text=f"[error: vault_delete of '{page}' outside agent folder "
+             f"requires interactive confirmation; not available from this context]")
+if outcome == GateOutcome.NEEDS_CONFIRMATION:
+    msg = _format_vault_delete_preview(ctx.config, path)
+    approval = await request_confirmation(
+        ctx, tool_name="vault_delete",
+        command=f"vault_delete '{page}'",
+        message=msg,
+    )
+    if not approval.get("approved"):
+        return ToolResult(text=f"[error: vault_delete of '{page}' was denied by user]")
+# proceed with delete (existing logic at lines 208-228 unchanged)
+
+
+def _format_vault_delete_preview(config, path: Path) -> str:
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except ValueError:
+        rel = path.name
+    return (
+        f"Vault delete: {rel}\n"
+        f"(cannot be undone — page and embeddings will be removed)"
+    )
+```
+
+```python
+# vault_delete TOOL_DEFINITIONS description
+"description": (
+    "DESTRUCTIVE — permanently delete a vault page and its embedding "
+    "entries. Pages outside the agent folder (agent/pages/, "
+    "agent/journal/) require user confirmation per call. For batch "
+    "operations, request folder trust via vault_grant_folder first. "
+    "Prefer vault_write with updated content to retire or mark pages "
+    "superseded; use delete only when the page is definitively wrong, "
+    "duplicate, or no longer reachable."
+),
+```
+
+**Test outline:** identical structure to Phase 2's `TestVaultWriteUserFolders`, adapted for delete (e.g., pre-create file in `creative/foo.md`, assert it's removed on approve / preserved on deny).
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2368 passed; rewritten `test_rejects_page_outside_agent_dir` green)
+- [x] `make check` passes
+- [x] `pytest tests/test_vault_tools.py::TestVaultDeleteUserFolders -v` — 6 new tests green
+
+**Verification — manual:**
+- [ ] In `make dev`: have agent delete a user-folder page → confirmation message clearly says "(cannot be undone)". Approve → page gone. Deny → page preserved. _Deferred to end-of-feature manual smoke._
+
+---
+
+## Phase 4: Wire `vault_rename` to use the gate
+
+`vault_rename` has TWO paths to gate (old_path + new_path). The single confirmation message must cover both. If either path requires confirmation, the operation requires confirmation.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` —
+  - Replace lines 248-253 (the two hard-refuse blocks in `tool_vault_rename`) with combined gate check.
+  - Add `_format_vault_rename_preview(config, old_path, new_path)`.
+  - Update the `vault_rename` entry in `TOOL_DEFINITIONS` (lines 894-902).
+- Modify: `tests/test_vault_tools.py` — add a `TestVaultRenameUserFolders` class. Rewrite the existing `test_rejects_rename_outside_agent_dir` at line 293.
+
+**Key changes:**
+
+```python
+# In tool_vault_rename after both paths are resolved + existence checks pass:
+old_outcome = _check_user_write_allowed(ctx, old_path)
+new_outcome = _check_user_write_allowed(ctx, new_path)
+
+# If EITHER path is non-interactive-error, the whole op fails.
+if (old_outcome == GateOutcome.NON_INTERACTIVE_ERROR
+        or new_outcome == GateOutcome.NON_INTERACTIVE_ERROR):
+    return ToolResult(
+        text=f"[error: vault_rename '{page}' -> '{rename_to}' touches a path "
+             f"outside the agent folder and requires interactive confirmation; "
+             f"not available from this context]")
+
+# If EITHER path needs confirmation (and neither is non-interactive), confirm.
+if (old_outcome == GateOutcome.NEEDS_CONFIRMATION
+        or new_outcome == GateOutcome.NEEDS_CONFIRMATION):
+    msg = _format_vault_rename_preview(ctx.config, old_path, new_path)
+    approval = await request_confirmation(
+        ctx, tool_name="vault_rename",
+        command=f"vault_rename '{page}' -> '{rename_to}'",
+        message=msg,
+    )
+    if not approval.get("approved"):
+        return ToolResult(
+            text=f"[error: vault_rename '{page}' -> '{rename_to}' was denied by user]")
+# proceed with rename (existing logic at lines 255-285 unchanged)
+
+
+def _format_vault_rename_preview(config, old_path: Path, new_path: Path) -> str:
+    def _rel(p):
+        try:
+            return str(p.resolve().relative_to(config.vault_root.resolve()))
+        except ValueError:
+            return p.name
+    return f"Vault rename: {_rel(old_path)} → {_rel(new_path)}"
+```
+
+```python
+# vault_rename TOOL_DEFINITIONS description
+"description": (
+    "Rename or move a vault page. Updates the embedding index so "
+    "search results stay consistent. Pages outside the agent folder "
+    "(agent/pages/, agent/journal/) require user confirmation per "
+    "call. For batch operations, request folder trust via "
+    "vault_grant_folder first. Use this to reorganize or refine page "
+    "names — prefer it over delete + rewrite when the content stays "
+    "the same. Target must not already exist."
+),
+```
+
+**Test outline:**
+```python
+class TestVaultRenameUserFolders:
+    async def test_old_in_agent_new_in_user_confirms(self, ctx, agent_pages):
+        # Rename agent/pages/X to creative/X — confirms (because new_path is outside)
+        ...
+    async def test_both_in_user_confirms_once(self, ctx, vault_dir):
+        # Rename creative/A to creative/B — single confirmation
+        ...
+    async def test_both_in_user_with_grant_no_confirm(self, ctx, vault_dir):
+        # Pre-grant "creative/" — rename within creative/ no confirmation
+        ...
+    async def test_old_in_grant_new_outside_grant_confirms(self, ctx, vault_dir):
+        # Grant covers creative/ but rename target is notes/X — needs confirmation
+        ...
+    async def test_denied_no_rename(self, ctx, vault_dir):
+        # Deny → original file remains, target doesn't exist
+        ...
+    async def test_non_interactive_errors(self, ctx, vault_dir):
+        ctx.request_confirmation = None
+        ...
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2375 passed)
+- [x] `make check` passes
+- [x] `pytest tests/test_vault_tools.py::TestVaultRenameUserFolders -v` green (7 tests)
+
+**Verification — manual:**
+- [ ] In `make dev`: rename a user page within `creative/` — single confirmation. Approve → renamed. _Deferred to end-of-feature manual smoke._
+- [ ] Rename across folder boundary (e.g., `creative/X` → `notes/X`) — single confirmation showing both paths. Approve → renamed. _Deferred._
+
+---
+
+## Phase 5: `vault_grant_folder` tool + SKILL.md + user docs
+
+New tool that requests a per-conversation folder trust grant. After approval, future writes/deletes/renames under the folder skip the per-call confirmation. Also rewrites the SKILL.md "Boundaries" section and updates `docs/vault.md` to document the new permission model.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` —
+  - Add `tool_vault_grant_folder(ctx, folder, reason)`.
+  - Register in the `TOOLS` dict (line ~789): `"vault_grant_folder": tool_vault_grant_folder`.
+  - Add `vault_grant_folder` entry to `TOOL_DEFINITIONS`.
+- Modify: `src/decafclaw/skills/vault/SKILL.md` —
+  - Rewrite the `vault_delete` bullet in "Boundaries".
+  - Replace the "user files are readable but not yours to modify autonomously" bullet.
+  - Add a sentence about `vault_grant_folder` to the "Boundaries" section.
+- Modify: `docs/vault.md` — add a section "Writing to user pages" describing the gate, allowlist, and grant tool.
+- Modify: `tests/test_vault_tools.py` — add `TestVaultGrantFolder` class.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/vault/tools.py
+async def tool_vault_grant_folder(ctx, folder: str, reason: str) -> ToolResult:
+    """Request per-conversation trust for a vault folder."""
+    log.info(f"[tool:vault_grant_folder] folder={folder!r}")
+
+    # Path safety: reject .., absolute, must resolve under vault root.
+    if not isinstance(folder, str) or not folder.strip():
+        return ToolResult(text="[error: folder is required]")
+    f = folder.strip()
+    if ".." in f or f.startswith("/"):
+        return ToolResult(text=f"[error: invalid folder '{folder}']")
+
+    vault = _vault_root(ctx.config).resolve()
+    candidate = (vault / f).resolve()
+    if not candidate.is_relative_to(vault):
+        return ToolResult(text=f"[error: folder '{folder}' escapes the vault]")
+
+    # Reject if folder is inside agent/ (no grant needed)
+    try:
+        agent = _agent_dir(ctx.config).resolve()
+        if candidate == agent or candidate.is_relative_to(agent):
+            return ToolResult(
+                text=f"[error: '{folder}' is inside the agent folder; no grant needed]")
+    except (ValueError, OSError):
+        pass
+
+    if ctx.request_confirmation is None:
+        return ToolResult(
+            text=f"[error: vault_grant_folder requires interactive confirmation; "
+                 f"not available from this context]")
+
+    if not ctx.conv_id:
+        return ToolResult(
+            text="[error: vault_grant_folder requires a conversation context]")
+
+    rel = str(candidate.relative_to(vault)).replace("\\", "/")
+    if not rel.endswith("/"):
+        rel = rel + "/"
+
+    msg = (
+        f"Grant vault write/delete/rename trust for folder '{rel}' "
+        f"for the rest of this conversation?\n\nReason: {reason}"
+    )
+    approval = await request_confirmation(
+        ctx, tool_name="vault_grant_folder",
+        command=f"trust folder '{rel}'",
+        message=msg,
+    )
+    if not approval.get("approved"):
+        return ToolResult(text=f"[error: folder grant for '{rel}' was denied by user]")
+
+    from decafclaw.skills.vault._grants import add_grant
+    if not add_grant(ctx.config, ctx.conv_id, rel):
+        return ToolResult(
+            text=f"[error: failed to persist folder grant for '{rel}']")
+    return ToolResult(text=f"Folder '{rel}' trusted for this conversation.")
+```
+
+```python
+# TOOL_DEFINITIONS entry — add after vault_rename
+{
+    "type": "function",
+    "function": {
+        "name": "vault_grant_folder",
+        "description": (
+            "Request user trust for a vault folder for the rest of this "
+            "conversation. Use this BEFORE a batch operation on user-owned "
+            "folders (3+ writes/deletes/renames in the same area) to avoid "
+            "per-page confirmations. After approval, vault_write, "
+            "vault_delete, and vault_rename under the folder skip "
+            "confirmation. For one-off operations, the regular tools handle "
+            "confirmation per-call — don't call this for a single page."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "folder": {
+                    "type": "string",
+                    "description": (
+                        "Vault-relative folder path "
+                        "(e.g. 'creative/in-progress/fungal-world')."
+                    ),
+                },
+                "reason": {
+                    "type": "string",
+                    "description": (
+                        "Short user-facing reason. Shown in the confirmation "
+                        "message so the user knows why the grant is being "
+                        "requested."
+                    ),
+                },
+            },
+            "required": ["folder", "reason"],
+        },
+    },
+},
+```
+
+**SKILL.md edits — replace the two bullets in the "Boundaries" section:**
+
+Original (around lines 50-52):
+```
+- `vault_delete` permanently removes a page. Only for pages you own (under `agent/`) that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged.
+- The user's files are readable but not yours to modify autonomously. Only edit user files when asked.
+```
+
+Replace with:
+```
+- `vault_delete` permanently removes a page. Only for pages that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged. Pages outside `agent/` will trigger a user confirmation.
+- User pages outside `agent/` are writable on explicit user request. Each `vault_write` / `vault_delete` / `vault_rename` triggers a user confirmation. For batch operations (3+ pages in the same folder), call `vault_grant_folder` first to trust the folder for the rest of the conversation and skip per-page confirmations.
+```
+
+**docs/vault.md addition:**
+
+Add a section between existing sections (location: after the tool list, before the indexing notes — confirm placement when reading the file):
+
+```markdown
+## Writing to user pages
+
+Writes/deletes/renames under the agent folder (`agent/`) execute directly. Operations on pages outside `agent/` go through a three-tier gate:
+
+1. **Static allowlist.** Folders listed in `vault.user_writable_paths` are pre-approved. Path matching is prefix-based on vault-relative paths (no globs). Example: `["creative/", "notes/"]`.
+2. **Per-conversation grants.** The agent can call `vault_grant_folder(folder, reason)` to request trust for a folder. After user approval, all writes/deletes/renames under that folder skip confirmation for the rest of the conversation. Grants persist as a sidecar at `{workspace}/conversations/{conv_id}.vault_grants.json` and reset between conversations.
+3. **Per-call confirmation.** Anything else triggers a confirmation request showing the operation and a content preview. Approve to proceed; deny returns an error and no change is made.
+
+Heartbeat / scheduled / child-agent contexts can't display confirmations, so writes outside the agent folder fail with an error in those contexts.
+```
+
+**Test outline:**
+
+```python
+class TestVaultGrantFolder:
+    async def test_approves_and_persists(self, ctx, vault_dir):
+        ctx.conv_id = "conv-X"
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": True})):
+            result = await tool_vault_grant_folder(ctx, "creative", "batch rename")
+        assert "trusted" in str(result.text)
+        from decafclaw.skills.vault._grants import read_grants
+        assert "creative/" in read_grants(ctx.config, "conv-X")
+
+    async def test_denied_returns_error_no_persist(self, ctx, vault_dir):
+        ctx.conv_id = "conv-X"
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_grant_folder(ctx, "creative", "...")
+        assert "denied by user" in str(result.text)
+
+    async def test_rejects_dotdot(self, ctx, vault_dir):
+        result = await tool_vault_grant_folder(ctx, "../etc", "escape")
+        assert "invalid folder" in str(result.text)
+
+    async def test_rejects_absolute(self, ctx, vault_dir):
+        result = await tool_vault_grant_folder(ctx, "/etc/passwd", "escape")
+        assert "invalid folder" in str(result.text)
+
+    async def test_rejects_inside_agent(self, ctx, vault_dir):
+        result = await tool_vault_grant_folder(ctx, "agent/pages", "...")
+        assert "no grant needed" in str(result.text)
+
+    async def test_rejects_no_conv_id(self, ctx, vault_dir):
+        ctx.conv_id = ""
+        result = await tool_vault_grant_folder(ctx, "creative", "...")
+        assert "conversation context" in str(result.text)
+
+    async def test_rejects_non_interactive(self, ctx, vault_dir):
+        ctx.request_confirmation = None
+        result = await tool_vault_grant_folder(ctx, "creative", "...")
+        assert "interactive confirmation" in str(result.text)
+
+    async def test_grant_then_write_skips_confirmation(self, ctx, vault_dir):
+        """Integration: grant a folder, then write — no second confirmation."""
+        ctx.conv_id = "conv-X"
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": True})) as mock_conf:
+            await tool_vault_grant_folder(ctx, "creative", "batch")
+        # Now write — should NOT call request_confirmation again
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock()) as mock_conf2:
+            result = await tool_vault_write(ctx, "creative/foo", "content")
+        mock_conf2.assert_not_called()
+        assert "saved" in str(result)
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2385 passed)
+- [x] `make check` passes
+- [x] `pytest tests/test_vault_tools.py::TestVaultGrantFolder -v` green (10 tests)
+- [ ] `make eval-tools 2>&1 | grep -A2 vault_grant_folder` if a vault eval exists; report findings. _Deferred to end-of-feature; report at retro._
+
+**Verification — manual:**
+- [ ] `make dev`: ask agent to "rename three pages in `creative/foo/` to kebab-case." Expect: agent calls `vault_grant_folder("creative/foo", "...")` first → confirmation → approve. Then three `vault_rename` calls execute silently. _Deferred to end-of-feature manual smoke._
+- [ ] Reload the page; the grant survives (the JSON sidecar exists at `{workspace}/conversations/{conv_id}.vault_grants.json` and the agent can still rename without re-confirmation). _Deferred._
+- [ ] Open a NEW conversation and ask the agent to write to `creative/foo/X.md` — confirmation prompts again (grants don't leak across conversations). _Deferred._
+- [ ] `cat docs/vault.md | grep -A2 "Writing to user pages"` — section is present and accurate.
+
+---
+
+## What this plan does NOT do
+
+(Mirrors `spec.md`'s "What we're NOT doing" — for plan reviewer reference.)
+
+- No `vault_revoke_folder` tool.
+- No glob/regex matching in allowlist.
+- No persistent grants across conversations.
+- No "always trust" UI button on confirmations.
+- No changes to `vault_journal_append` or read-only tools.
+- No admin folder integration.
+- No drive-by refactoring of vault tool internals.
+
+## Plan self-review notes
+
+- **Spec coverage:** every requirement in `spec.md` is covered:
+  - Three-tier gate logic → Phase 1 (helper) + Phases 2–4 (per-tool wiring).
+  - `vault_grant_folder` tool → Phase 5.
+  - Static allowlist config → Phase 1 (config field), Phase 5 (docs).
+  - Sidecar persistence → Phase 1 (`_grants.py`), Phase 5 (manual verification of reload).
+  - Tool description updates → Phases 2, 3, 4, 5.
+  - SKILL.md edits → Phase 5.
+  - Docs updates → Phase 1 (`config.md`), Phase 5 (`vault.md`).
+  - Non-interactive context handling → Phase 1 (gate returns `NON_INTERACTIVE_ERROR`), Phases 2–5 (each tool returns the error message).
+  - Confirmation message formats → Phases 2, 3, 4 (per-op preview formatters).
+- **Type consistency:** `GateOutcome` enum is defined in Phase 1 and used in Phases 2–4 with consistent member names. `_check_user_write_allowed`, `_format_vault_*_preview`, `request_confirmation` signatures match across phases.
+- **No placeholders:** all phases have concrete code snippets, signatures, and tests. No "TBD" / "implement later" / "similar to phase N".

--- a/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/research.md
+++ b/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/research.md
@@ -1,0 +1,92 @@
+# Codebase research: vault write boundary + confirmation patterns
+
+## 1. Vault write/delete/rename boundary
+
+**Helpers** (`src/decafclaw/skills/vault/tools.py`):
+- `_vault_root(config)` → `config.vault_root` — line 22
+- `_agent_dir(config)` → `config.vault_agent_dir` — line 26
+- `_is_in_agent_dir(config, path)` — line 114, returns `path.is_relative_to(config.vault_agent_dir)`
+- `_safe_write_path(config, page)` — line 86, strips `.md`, rejects `..` / absolute prefixes, resolves under vault root
+
+**Boundary enforcement (current behavior — hard refuse outside agent dir):**
+- `tool_vault_write` line 162; refusal at line 171: `"only pages under the agent folder may be written"`
+- `tool_vault_delete` line 195; refusal at line 204: `"only pages under the agent folder may be deleted"`
+- `tool_vault_rename` line 233; refusals at lines 248 and 251
+
+**Config:**
+- `config.vault_root` from `config.vault.vault_path` (default `workspace/vault/`)
+- `config.vault_agent_dir` from `config.vault.agent_folder` (default `vault_root/agent/`)
+- `vault_agent_journal_dir = vault_agent_dir/journal/`
+- `vault_agent_pages_dir = vault_agent_dir/pages/`
+
+## 2. Vault skill self-description
+
+**SKILL.md (`src/decafclaw/skills/vault/SKILL.md`):**
+- Frontmatter: `always-loaded: true` (lines 1-4)
+- "Your Home Folder" section (lines 11-18) — `agent/pages/` and `agent/journal/`
+- Line 18 (verbatim): "Write to `agent/` by default. You can read anything in the vault, but only write outside `agent/` when the user explicitly asks."
+- Boundaries section (lines 46-52): line 52: "The user's files are readable but not yours to modify autonomously. Only edit user files when asked."
+
+**SKILL.md says one thing; runtime says another.** SKILL.md tells the LLM "write outside `agent/` when the user explicitly asks." The runtime in `tools.py:171` hard-refuses regardless of user request. This is the observable mismatch the session targets.
+
+**Tool descriptions (`src/decafclaw/skills/vault/tools.py`):**
+- `vault_write` description (lines 834-843): "Writes are restricted to the agent folder (agent/pages/, agent/journal/); admin and user pages are off-limits."
+- `vault_delete` description (lines 869-875): "Only pages under the agent folder ... may be deleted; admin and user pages are off-limits."
+- `vault_rename` description (lines 896-902): "Agent-owned pages only ... target must also land under the agent folder."
+
+## 3. EndTurnConfirm pattern
+
+**Definition (`src/decafclaw/media.py:18-33`):**
+```python
+@dataclass
+class EndTurnConfirm:
+    message: str = ""
+    approve_label: str = "Approve"
+    deny_label: str = "Deny"
+    on_approve: Callable[[], Any] | None = None
+    on_deny: Callable[[], Any] | None = None
+```
+
+**Tool returns it on `ToolResult.end_turn`.** Agent loop:
+1. Collects `end_turn_signal` after tool execution (`agent.py:814-819`)
+2. Final no-tools LLM "presentation" call to render reasoning (`agent.py:1175-1183`)
+3. `_handle_end_turn_confirm()` calls `request_confirmation()` (`agent.py:1186`)
+4. `on_approve` / `on_deny` callback invoked — sync or async (`agent.py:1189-1204`)
+5. History gets injected user note: `[User approved: ...]` or `[User denied: ...]` (`agent.py:1194-1196`)
+6. Loop continues (approved) or ends (denied)
+
+**Persistence (`src/decafclaw/confirmations.py`):**
+- `ConfirmationRequest` (lines 24-38): `action_type`, `action_data`, `message`, `approve_label`, `deny_label`, `tool_call_id`, `timeout`, `confirmation_id`, `timestamp`
+- `ConfirmationResponse` (lines 64-76): `confirmation_id`, `approved`, `always`, `add_pattern`, `data`, `timestamp`
+- `to_archive_message()` / `from_archive_message()` serialize as `role: "confirmation_request"` / `role: "confirmation_response"` — survives page reload + server restart
+
+## 4. Email allowlist + confirmation fallthrough
+
+**`src/decafclaw/tools/email_tools.py`:**
+- `_recipient_allowed(addr, allowlist)` (lines 31-58) — exact match or `@domain.com` suffix
+- `_all_recipients_allowed(recipients, allowlist)` — all-or-nothing
+- `check_email_approval(ctx, recipients, subject, body, ...)` (lines 133-158):
+  - All recipients allowlisted → auto-approve, no confirmation
+  - Otherwise → builds preview message, calls `request_confirmation()`
+- Preview format (lines 116-130):
+  ```
+  Email to: alice@example.com, bob@example.com
+  Subject: Meeting Notes
+  2 attachment(s) (512.5 KB)
+  ---
+  <body preview, first 200 chars>
+  ```
+- On denial: `return ToolResult(text="[error: email send was denied by user]")`
+
+**Allowlist sources unioned:** `ctx.config.email.allowed_recipients + ctx.tools.preapproved_email_recipients` (per-task frontmatter).
+
+## 5. Tool parameter conventions
+
+- `TOOL_DEFINITIONS` is OpenAI-shape JSON schema. Required args in `required: []`; optional via omission.
+- **No `force=true` / opt-in bypass flag pattern in the codebase today.** Boundary checks are server-side.
+- Closest precedent for "user explicitly opting in": email's per-task `email-recipients` frontmatter (config-level), not a per-call arg.
+- Enum-style discriminator pattern for action variants exists (`tool_shell_patterns(action="list"|"add"|"remove")` at `shell_tools.py:162`).
+
+## Class-of-bug analogues (per brainstorm framing)
+
+The user's prompt names `vault_write`. The same boundary in the same file gates `vault_delete` and `vault_rename`. Whatever the design here is, those two are in scope to consider — even if the decision is "leave them as hard-refuse".

--- a/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/spec.md
+++ b/docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/spec.md
@@ -1,0 +1,159 @@
+# Vault user-page writes via confirmation gate
+
+**Goal:** Let the agent write/delete/rename pages outside its `agent/` folder when the user explicitly asks, gated by user confirmation. Add a static config allowlist for trusted folders and a per-conversation grant tool for batch operations.
+
+**Source:** User request from 2026-05-07 (chat session).
+
+## Current state
+
+The vault has three write-class tools that hard-refuse any path outside `config.vault_agent_dir`:
+
+- `tool_vault_write` — refuses at `src/decafclaw/skills/vault/tools.py:171` with `"only pages under the agent folder may be written"`.
+- `tool_vault_delete` — refuses at `src/decafclaw/skills/vault/tools.py:204`.
+- `tool_vault_rename` — refuses at `src/decafclaw/skills/vault/tools.py:248` and `:251`.
+
+All three use the helper `_is_in_agent_dir(config, path)` (`tools.py:114`).
+
+`SKILL.md` already tells the LLM "only write outside `agent/` when the user explicitly asks" (`src/decafclaw/skills/vault/SKILL.md:18`), but the runtime ignores that affordance. This session aligns runtime with the documented policy.
+
+The codebase already has the confirmation infrastructure we need:
+
+- `request_confirmation(ctx, tool_name, command, message, timeout=60, **extra)` wrapper at `src/decafclaw/tools/confirmation.py:106` — async-await primitive. Returns a dict with at least `{"approved": bool}`. Routes through ConversationManager when available (persisted, per-conversation scoped); falls back to legacy event-bus path otherwise. Persistence: request/response pair archives as `confirmation_request` / `confirmation_response` messages — survives page reload + server restart.
+- `send_email` (`src/decafclaw/tools/email_tools.py:133-158`) is the closest precedent: build allowlist → if all recipients allowed return `{"approved": True}`; otherwise call `await request_confirmation(ctx, tool_name=..., command=..., message=...)` and use the dict result.
+- Per-tool short-circuit at `confirmation.py:124-126`: if `tool_name in ctx.tools.preapproved`, the wrapper returns approved without prompting. We don't need to add this check ourselves — it's inside `request_confirmation()`.
+- `EndTurnConfirm` (`src/decafclaw/media.py:18-33`) is a separate "review gate" pattern where the tool returns *"I asked for review"* as the result. **Not what we want here** — the LLM cares about the write outcome, not "I asked." We use the email pattern.
+
+See `research.md` for full file:line refs.
+
+## Desired end state
+
+### Behavior
+
+For `vault_write`, `vault_delete`, `vault_rename`, when the resolved target path is **outside** `config.vault_agent_dir`:
+
+1. **Path matches `vault.user_writable_paths`** (static config allowlist, prefix match against vault-relative path) → execute directly, no confirmation. Mirrors email's allowlist short-circuit.
+2. **Path is under a folder granted in this conversation** (in-memory grant set, persisted to a per-conversation sidecar) → execute directly.
+3. **Otherwise** → `await request_confirmation(ctx, tool_name="vault_write", command=..., message=...)` with a preview of the operation. The tool blocks until the user responds. On `{"approved": True}`: execute the op and return the normal success message. On `{"approved": False}`: return `ToolResult(text="[error: vault_<op> to '<page>' was denied by user]")`. Mirrors `send_email` (`email_tools.py:166-219`).
+
+**Non-interactive contexts (heartbeat / scheduled / child agent):** `request_confirmation()` documents (`confirmation.py:130-141`) that calls from non-ConversationManager contexts fall back to a legacy event-bus path the comment flags as "unexpected." For the vault gate, we short-circuit explicitly: if `ctx.request_confirmation is None`, return `ToolResult(text="[error: vault_<op> outside agent folder requires interactive confirmation; not available from this context]")` instead of calling the wrapper. This keeps scheduled tasks / heartbeats from blocking on a UI that isn't there. Same short-circuit for `vault_grant_folder`.
+
+### New tool: `vault_grant_folder(folder, reason)`
+
+- Always-loaded under the vault skill (the skill itself is `always-loaded: true`).
+- `folder` parameter: vault-relative folder path. Same path-safety as `_safe_write_path` (no `..`, no absolute prefixes; resolved must stay under `vault_root`). Reject if the folder resolves inside `agent/` (no grant needed) or escapes the vault.
+- Calls `await request_confirmation(ctx, tool_name="vault_grant_folder", command=f"trust folder '{folder}'", message=...)` with a preview like:
+  ```
+  Grant vault write/delete/rename trust for folder 'creative/in-progress/fungal-world/' for the rest of this conversation?
+
+  Reason: <agent-supplied reason>
+  ```
+- On approve: append the folder to the conversation grant sidecar (atomic write, deduped); return `ToolResult(text="Folder 'X' trusted for this conversation.")`.
+- On deny: return `ToolResult(text="[error: folder grant for '<folder>' was denied by user]")`.
+- Tool description teaches the agent: "Use this **before** a batch operation on user-owned folders to avoid per-page confirmations. For one-off writes, the regular vault_write/delete/rename tools handle confirmation per-call."
+
+### Config
+
+Add to `VaultConfig` at `src/decafclaw/config_types.py:203`:
+
+```python
+user_writable_paths: list[str] = field(default_factory=list)
+```
+
+Path semantics: vault-relative folder paths. Prefix match — if `user_writable_paths = ["creative/", "notes/"]`, then any page whose vault-relative path starts with one of those prefixes is auto-approved. Both ends of the comparison are normalized: leading `/` stripped, trailing `/` enforced, `..` rejected (skip the entry with a warning at config-load time rather than fail). An entry like `creative` matches `creative/` and everything under it. Empty by default — opt-in.
+
+Documented in `docs/vault.md` and `docs/config.md` (the "Vault" config section).
+
+### Per-conversation grant persistence
+
+Sidecar at `{config.workspace_path}/conversations/{conv_id}.vault_grants.json` (same convention and safety checks as `_canvas_sidecar_path` in `src/decafclaw/canvas.py:41-50`):
+
+```json
+{"folders": ["creative/in-progress/fungal-world/"]}
+```
+
+- `conv_id` comes from `ctx.conv_id` (set on every Context fork; see `src/decafclaw/context.py:78`).
+- Created on first grant; rewritten on each grant (atomic write, dedup on append).
+- Per-conversation scope — does not leak across conversations.
+- Survives page reload and server restart (the grant tool writes the sidecar after `await request_confirmation()` returns approved; the gate functions read it on each call).
+- Clearable by deleting the file (manual user action; not exposed as a tool in v1 — see "What we're NOT doing").
+- If `ctx.conv_id` is empty (rare — non-conversation contexts), the grant path is unavailable; falls through as if no grants exist.
+
+### Tool description and SKILL.md updates
+
+- **`vault_write` / `vault_delete` / `vault_rename` descriptions** in `tools.py` `TOOL_DEFINITIONS`: replace the "admin and user pages are off-limits" / "Agent-owned pages only" sentences with: "Pages outside the agent folder require user confirmation per call. For batch operations, request folder trust via `vault_grant_folder` first." Apply consistent wording across all three.
+- **New tool entry** in `TOOL_DEFINITIONS` for `vault_grant_folder` with `folder` (string, required, vault-relative folder path) and `reason` (string, required, short user-facing explanation).
+- **`SKILL.md` "Boundaries" section** (the bulleted list before "Editing Sections") needs two edits:
+  - The `vault_delete` bullet ("Only for pages you own (under `agent/`) ...") — generalize to "Only delete pages that are definitively wrong, duplicate, or no longer reachable. For pages outside `agent/`, the deletion will trigger a user confirmation."
+  - The "user files are readable but not yours to modify autonomously" bullet — replace with: "User pages outside `agent/` are writable on explicit user request. Each write/delete/rename triggers a user confirmation; for batches, call `vault_grant_folder` first to trust a folder for the rest of the conversation."
+- **`SKILL.md` "Your Home Folder" section** ("Write to `agent/` by default. ... only write outside `agent/` when the user explicitly asks.") — keep as-is. This affordance is already correct; the runtime now honors it.
+
+### Confirmation message formats
+
+Mirror the email_tools preview style (`email_tools.py:116-130`):
+
+- **vault_write:**
+  ```
+  Vault write to: creative/foo/bar.md
+  <"(overwrites existing page)" if file exists, else "(new page)">
+  Content: 1.4 KB
+  ---
+  <first 200 chars of content>
+  ```
+- **vault_delete:**
+  ```
+  Vault delete: creative/foo/bar.md
+  (cannot be undone — page and embeddings will be removed)
+  ```
+- **vault_rename:**
+  ```
+  Vault rename: creative/foo/bar.md → creative/foo/baz.md
+  ```
+
+## Design decisions
+
+- **Decision:** Loosen all three of `vault_write`, `vault_delete`, `vault_rename` symmetrically.
+  - **Why:** Same boundary, same code path (`_is_in_agent_dir`). User wants to "work in my area" — that includes moving and removing pages, not just creating.
+  - **Rejected:** "Loosen `write` only." Would leave the agent unable to fully manage user pages, defeating the use case.
+
+- **Decision:** Static config allowlist (`vault.user_writable_paths`) + per-conversation folder grant tool, both feeding the same gate logic.
+  - **Why:** Allowlist handles stable trust ("I always let the agent edit creative/"); per-conversation grant handles ad-hoc batches without permanent config edits. Each addresses a different friction surface.
+  - **Rejected:** Pure per-call confirmation. High friction for batch ops. Pure config allowlist. Forces premature decision about which folders are "trusted" globally; doesn't help one-off batch sessions.
+
+- **Decision:** Per-conversation grants live in `{workspace}/conversations/{conv_id}.vault_grants.json` sidecar.
+  - **Why:** Matches the codebase convention for per-conversation state (`canvas`, `notes`, `decisions`). Crash-recoverable, debuggable, clearable. No new schema in conversation archive.
+  - **Rejected:** Replay from `confirmation_response` archive entries. Adds coupling between confirmation infrastructure and vault gate logic; harder to inspect or clear.
+
+- **Decision:** Separate tool `vault_grant_folder(folder, reason)` for batch trust, distinct from `vault_write/delete/rename`.
+  - **Why:** Granting trust is its own deliberate action — keeping it separate makes the user-facing confirmation message clear and avoids overloading existing tool params with mode flags.
+  - **Rejected:** Boolean `grant_folder` param on each write tool. Conflates two semantics in one parameter; tool description gets harder to write.
+
+- **Decision:** Allowlist matching is prefix-based on vault-relative paths (folder paths only, no globs).
+  - **Why:** Simplest model; matches the user's mental model of "trust this folder." Globs are a rabbit hole (escaping, performance, edge cases) and the use case doesn't need them.
+  - **Rejected:** Glob/fnmatch matching. Adds complexity without clear demand.
+
+- **Decision:** Admin folder concerns (SOUL.md, AGENT.md, etc.) are **out of scope** because admin lives at `data/{agent_id}/`, not in the vault. Vault gate doesn't touch admin files.
+  - **Why:** Confirmed in `research.md` — admin is a separate filesystem location with its own access path. The vault has `agent/` and "everything else" (user pages); the gate is binary.
+
+## Patterns to follow
+
+- **Confirmation fallthrough:** `check_email_approval` at `src/decafclaw/tools/email_tools.py:133-158`. Allowlist short-circuit, then `await request_confirmation(...)`, then denied-message return on `{"approved": False}`. **This is the load-bearing pattern** — copy the shape.
+- **Confirmation preview message:** `_format_confirmation_message` at `src/decafclaw/tools/email_tools.py:116-130`.
+- **Persisted confirmations:** `src/decafclaw/confirmations.py:24-90`. Survives reload via archive replay — we don't need to extend this; existing flow handles us automatically when we use `request_confirmation()`.
+- **Per-conversation sidecar:** `src/decafclaw/notes.py` and `src/decafclaw/canvas.py` (especially `_canvas_sidecar_path` at `canvas.py:41-50`) — `{config.workspace_path}/conversations/{conv_id}.<kind>.json` filename, with directory-traversal guards on `conv_id`.
+- **Tool description as control surface:** CLAUDE.md "Tools" section — wording changes ("MUST", "NEVER") measurably change LLM behavior. Run `make eval-tools` if it covers vault.
+
+## What we're NOT doing
+
+- **No `vault_revoke_folder` tool.** Grants reset between conversations; manual sidecar deletion is the escape hatch. Don't ship a tool for a need that hasn't been demonstrated.
+- **No glob/regex matching in `user_writable_paths`.** Prefix match only.
+- **No persistent grants across conversations.** That's what the static config is for.
+- **No "always trust" UI button on the per-call confirmation.** The grant tool is the way to expand scope; we're not extending the confirmation UI to add a third action.
+- **No changes to `vault_journal_append` or read-only vault tools.** The boundary is unchanged for those — journal stays in `agent/`, reads are unrestricted.
+- **No admin folder integration.** Admin files live outside the vault; this session doesn't touch their access controls.
+- **No special-case for admin-style files inside the vault** (e.g., a hypothetical `vault/admin/`). If someone creates one, it's just another user folder under this design.
+- **No bulk migration / cleanup of existing tool descriptions for unrelated vault tools.** Touch only the three changed tools and the new grant tool.
+
+## Open questions
+
+- **Should the confirmation auto-skip for very small files (e.g., empty stub pages)?** Default answer: **no.** Confirmation is cheap; auto-skipping by size adds policy surface. Reconsider if friction shows up.
+- **Does the grant tool need a TTL within the conversation (e.g., expires after N writes)?** Default answer: **no.** Conversation lifetime is the natural scope; the user can always start a new conversation to reset.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -75,8 +75,9 @@ The vault skill is **always loaded** — its tools are available in every conver
 |------|-------------|
 | `vault_read(page)` | Read a page by name or path. Searches subdirectories. |
 | `vault_write(page, content)` | Create or overwrite a page. Indexes in semantic search. |
-| `vault_delete(page)` | Delete an agent-owned page. |
-| `vault_rename(from_page, to_page)` | Rename/move an agent-owned page (preserves links). |
+| `vault_delete(page)` | Delete a page. Pages outside `agent/` trigger a user confirmation. |
+| `vault_rename(from_page, to_page)` | Rename/move a page (preserves links). Pages outside `agent/` trigger a user confirmation. |
+| `vault_grant_folder(folder, reason)` | Request per-conversation trust for a folder. After approval, vault_write/delete/rename under the folder skip confirmation. |
 | `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. |
 | `vault_search(query, source_type?, days?, folder?)` | Semantic + substring search across the vault. |
 | `vault_list(folder?, pattern?)` | List pages with last-modified dates. |
@@ -95,6 +96,16 @@ The vault skill is **always loaded** — its tools are available in every conver
 ### Path Safety
 
 All vault tools validate that paths stay within the vault root. Path traversal attempts are rejected.
+
+## Writing to user pages
+
+Writes/deletes/renames under the agent folder (`agent/`) execute directly. Operations on pages outside `agent/` go through a three-tier gate:
+
+1. **Static allowlist.** Folders listed in `vault.user_writable_paths` are pre-approved. Path matching is prefix-based on vault-relative paths (no globs). Example: `["creative/", "notes/"]`.
+2. **Per-conversation grants.** The agent can call `vault_grant_folder(folder, reason)` to request trust for a folder. After user approval, all writes/deletes/renames under that folder skip confirmation for the rest of the conversation. Grants persist as a sidecar at `{workspace}/conversations/{conv_id}.vault_grants.json` and reset between conversations.
+3. **Per-call confirmation.** Anything else triggers a confirmation request showing the operation and a content preview. Approve to proceed; deny returns an error and no change is made.
+
+Heartbeat / scheduled / child-agent contexts can't display confirmations, so writes outside the agent folder fail with an error in those contexts.
 
 ## Vault Gardening
 

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -36,6 +36,7 @@ from .config_types import (
     VaultConfig,
     VaultRetrievalConfig,
 )
+from .skills.vault._grants import normalize_folder
 
 log = logging.getLogger(__name__)
 
@@ -509,6 +510,22 @@ def load_config() -> Config:
 
     # Apply custom env vars (only sets those not already in environment)
     config.apply_env()
+
+    # Validate vault.user_writable_paths once at load time so misconfigured
+    # entries surface in the logs without spamming per-call (the gate runs
+    # this check on every vault write/delete/rename). load_sub_config does
+    # not coerce types from JSON, so a malformed value (e.g. null, or a
+    # string) would otherwise blow up here at startup or iterate characters.
+    paths = config.vault.user_writable_paths
+    if not isinstance(paths, list):
+        log.warning(
+            "vault.user_writable_paths must be a list; got %s. Treating as empty.",
+            type(paths).__name__,
+        )
+        config.vault.user_writable_paths = []
+    else:
+        for entry in paths:
+            normalize_folder(entry, warn_on_invalid=True)
 
     return config
 

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -204,6 +204,9 @@ class VaultConfig:
     vault_path: str = "workspace/vault/"
     agent_folder: str = "agent/"
     recent_changes_limit: int = 50
+    # Vault-relative folder paths that bypass the user-page write
+    # confirmation. Prefix match (no globs). Empty by default — opt-in.
+    user_writable_paths: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/decafclaw/skills/vault/SKILL.md
+++ b/src/decafclaw/skills/vault/SKILL.md
@@ -48,8 +48,8 @@ Your files live under `agent/` in the vault:
 - `vault_write` modifies files in the vault. Default to writing in `agent/pages/`.
 - Use `vault_read` before `vault_write` when updating existing pages — `vault_write` overwrites the entire page.
 - `vault_rename` renames or moves an existing page (updates the embedding index). Prefer it over delete + rewrite when the content stays the same.
-- `vault_delete` permanently removes a page. Only for pages you own (under `agent/`) that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged.
-- The user's files are readable but not yours to modify autonomously. Only edit user files when asked.
+- `vault_delete` permanently removes a page. Only for pages that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged. Pages outside `agent/` will trigger a user confirmation.
+- User pages outside `agent/` are writable on explicit user request. Each `vault_write` / `vault_delete` / `vault_rename` triggers a user confirmation. For batch operations (3+ pages in the same folder), call `vault_grant_folder` first to trust the folder for the rest of the conversation and skip per-page confirmations.
 
 ## Editing Sections
 

--- a/src/decafclaw/skills/vault/_grants.py
+++ b/src/decafclaw/skills/vault/_grants.py
@@ -1,0 +1,127 @@
+"""Per-conversation vault folder grants — sidecar persistence.
+
+Each conversation that has been granted folder trust gets a JSON sidecar at
+{workspace}/conversations/{conv_id}.vault_grants.json. Stored as a sorted,
+deduped list of folder paths (vault-relative, trailing slash enforced).
+
+Sidecar shape:
+
+    {"schema_version": 1, "folders": ["creative/foo/", ...]}
+
+`schema_version` is written for forward compatibility — readers may key off
+it to migrate older shapes. The current reader ignores the field and reads
+`folders` directly, so older sidecars (no `schema_version` field) load
+unchanged.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _grants_sidecar_path(config, conv_id: str) -> Path:
+    """Path to the grants JSON sidecar; guarded against directory traversal.
+
+    Mirrors `_canvas_sidecar_path` in src/decafclaw/canvas.py:41-50.
+    """
+    base_dir = (config.workspace_path / "conversations").resolve()
+    if not conv_id or "/" in conv_id or "\\" in conv_id or ".." in conv_id:
+        return base_dir / "_invalid.vault_grants.json"
+    path = (base_dir / f"{conv_id}.vault_grants.json").resolve()
+    if not path.is_relative_to(base_dir):
+        return base_dir / "_invalid.vault_grants.json"
+    return path
+
+
+def normalize_folder(folder: str, *, warn_on_invalid: bool = False) -> str:
+    """Normalize a vault-relative folder path.
+
+    Strips leading `/`, enforces trailing `/`, rejects `..` substrings and
+    non-string/empty inputs. Returns "" for invalid inputs (caller treats
+    as no-match).
+
+    Args:
+        folder: The folder path to normalize.
+        warn_on_invalid: If True, log a warning when a non-empty entry is
+            rejected (used by the allowlist config-load path so users see
+            misconfigured entries).
+    """
+    if not isinstance(folder, str):
+        return ""
+    f = folder.strip()
+    if not f or ".." in f:
+        if f and warn_on_invalid:
+            log.warning("Skipping invalid vault folder entry: %r", folder)
+        return ""
+    if f.startswith("/"):
+        f = f.lstrip("/")
+    if not f.endswith("/"):
+        f = f + "/"
+    return f
+
+
+def read_grants(config, conv_id: str) -> set[str]:
+    """Read the grant set; fail-open with empty set on any error."""
+    if not conv_id:
+        return set()
+    path = _grants_sidecar_path(config, conv_id)
+    if not path.exists():
+        return set()
+    try:
+        data = json.loads(path.read_text())
+        folders = data.get("folders", [])
+        # Filter out invalid (normalized to "") entries — they would act as
+        # a wildcard prefix in is_path_in_grants and let everything through.
+        result: set[str] = set()
+        for f in folders:
+            if isinstance(f, str):
+                norm = normalize_folder(f)
+                if norm:
+                    result.add(norm)
+        return result
+    except (json.JSONDecodeError, OSError):
+        log.warning("Failed to read vault grants for %s; treating as empty",
+                    conv_id, exc_info=True)
+        return set()
+
+
+def add_grant(config, conv_id: str, folder: str) -> bool:
+    """Append a folder grant atomically. Returns True on success."""
+    if not conv_id:
+        return False
+    folder = normalize_folder(folder)
+    if not folder:
+        return False
+    grants = read_grants(config, conv_id)
+    grants.add(folder)
+    path = _grants_sidecar_path(config, conv_id)
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"schema_version": 1, "folders": sorted(grants)}
+        tmp.write_text(json.dumps(payload, indent=2) + "\n")
+        tmp.replace(path)
+        return True
+    except OSError:
+        log.warning("Failed to write vault grants for %s", conv_id, exc_info=True)
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError as cleanup_exc:
+            log.debug("vault_grants tmp cleanup failed: %s", cleanup_exc)
+        return False
+
+
+def is_path_in_grants(config, conv_id: str, path: Path) -> bool:
+    """Check if a vault-relative path is under any granted folder."""
+    grants = read_grants(config, conv_id)
+    if not grants:
+        return False
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except (ValueError, OSError):
+        return False
+    rel = rel.replace("\\", "/")
+    return any(rel.startswith(g) for g in grants)

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -7,10 +7,17 @@ that supports curated pages, daily journal entries, and user content.
 import logging
 import re
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 from decafclaw.media import ToolResult, WidgetRequest
+from decafclaw.skills.vault._grants import (
+    add_grant,
+    is_path_in_grants,
+    normalize_folder,
+)
 from decafclaw.skills.vault._sections import Document, _insert_into_doc
+from decafclaw.tools.confirmation import request_confirmation
 
 log = logging.getLogger(__name__)
 
@@ -120,6 +127,127 @@ def _is_in_agent_dir(config, path: Path) -> bool:
         return False
 
 
+class GateOutcome(Enum):
+    """Outcome of the user-page write gate. See `_check_user_write_allowed`."""
+
+    ALLOW = "allow"
+    NEEDS_CONFIRMATION = "needs_confirmation"
+    NON_INTERACTIVE_ERROR = "non_interactive_error"
+
+
+def _is_in_user_writable_paths(config, path: Path) -> bool:
+    """Check if a vault-relative path is under any configured allowlist entry.
+
+    Per-call: silent on invalid entries. The allowlist is validated once at
+    config-load time (see `load_config` in `decafclaw.config`), which surfaces
+    misconfigured entries without spamming logs on every write attempt.
+    """
+    paths = config.vault.user_writable_paths or []
+    if not paths:
+        return False
+    try:
+        rel = str(path.resolve().relative_to(_vault_root(config).resolve()))
+    except (ValueError, OSError):
+        return False
+    rel = rel.replace("\\", "/")
+    for entry in paths:
+        norm = normalize_folder(entry)
+        if norm and rel.startswith(norm):
+            return True
+    return False
+
+
+def _check_user_write_allowed(ctx, path: Path) -> GateOutcome:
+    """Decide how to handle a vault write/delete/rename for the given path.
+
+    Returns:
+        GateOutcome.ALLOW — write directly (path is in agent/, allowlist, or grants)
+        GateOutcome.NEEDS_CONFIRMATION — caller must call request_confirmation()
+        GateOutcome.NON_INTERACTIVE_ERROR — no UI available; caller returns error
+    """
+    if _is_in_agent_dir(ctx.config, path):
+        return GateOutcome.ALLOW
+    if _is_in_user_writable_paths(ctx.config, path):
+        return GateOutcome.ALLOW
+    if is_path_in_grants(ctx.config, ctx.conv_id, path):
+        return GateOutcome.ALLOW
+    if ctx.request_confirmation is None:
+        return GateOutcome.NON_INTERACTIVE_ERROR
+    return GateOutcome.NEEDS_CONFIRMATION
+
+
+async def _run_gate_or_confirm(
+    ctx,
+    outcomes: list[GateOutcome],
+    *,
+    tool_name: str,
+    command: str,
+    preview: str,
+    non_interactive_error: str,
+    denied_error: str,
+) -> ToolResult | None:
+    """Run the user-write gate flow shared by vault_write/delete/rename.
+
+    Pass one or more `GateOutcome` values (write/delete take one path; rename
+    takes both old and new). Returns:
+        - ToolResult with the appropriate error message if any outcome is
+          NON_INTERACTIVE_ERROR or if the user denies confirmation.
+        - None if the operation should proceed (all outcomes are ALLOW, or the
+          user approved confirmation).
+    """
+    if any(o == GateOutcome.NON_INTERACTIVE_ERROR for o in outcomes):
+        return ToolResult(text=non_interactive_error)
+    if any(o == GateOutcome.NEEDS_CONFIRMATION for o in outcomes):
+        approval = await request_confirmation(
+            ctx, tool_name=tool_name, command=command, message=preview,
+        )
+        if not approval.get("approved"):
+            return ToolResult(text=denied_error)
+    return None
+
+
+def _format_vault_write_preview(
+    config, path: Path, content: str, exists: bool
+) -> str:
+    """Confirmation preview for vault_write. Mirrors email's preview helper."""
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except ValueError:
+        rel = path.name
+    state = "(overwrites existing page)" if exists else "(new page)"
+    size_kb = len(content.encode("utf-8")) / 1024
+    preview = content[:200] + ("..." if len(content) > 200 else "")
+    return "\n".join([
+        f"Vault write to: {rel}",
+        state,
+        f"Content: {size_kb:.1f} KB",
+        "---",
+        preview,
+    ])
+
+
+def _format_vault_delete_preview(config, path: Path) -> str:
+    """Confirmation preview for vault_delete."""
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except ValueError:
+        rel = path.name
+    return (
+        f"Vault delete: {rel}\n"
+        f"(cannot be undone — page and embeddings will be removed)"
+    )
+
+
+def _format_vault_rename_preview(config, old_path: Path, new_path: Path) -> str:
+    """Confirmation preview for vault_rename. Shows both paths."""
+    def _rel(p: Path) -> str:
+        try:
+            return str(p.resolve().relative_to(config.vault_root.resolve()))
+        except ValueError:
+            return p.name
+    return f"Vault rename: {_rel(old_path)} → {_rel(new_path)}"
+
+
 def _safe_folder(config, folder: str) -> Path | None:
     """Validate a folder path within the vault. Returns resolved path or None."""
     if not folder:
@@ -168,10 +296,24 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
             text=f"[error: invalid page name '{page}' — must be within vault directory]")
     if not content or not content.strip():
         return ToolResult(text=f"[error: refusing to write empty vault page '{page}']")
-    if not _is_in_agent_dir(ctx.config, path):
-        return ToolResult(
-            text=f"[error: refusing to write '{page}' — "
-                 f"only pages under the agent folder may be written]")
+
+    outcome = _check_user_write_allowed(ctx, path)
+    gate_result = await _run_gate_or_confirm(
+        ctx,
+        [outcome],
+        tool_name="vault_write",
+        command=f"vault_write to '{page}'",
+        preview=_format_vault_write_preview(
+            ctx.config, path, content, path.exists()
+        ),
+        non_interactive_error=(
+            f"[error: vault_write to '{page}' outside agent folder "
+            f"requires interactive confirmation; not available from this context]"
+        ),
+        denied_error=f"[error: vault_write to '{page}' was denied by user]",
+    )
+    if gate_result is not None:
+        return gate_result
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
@@ -193,7 +335,8 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
 
 
 async def tool_vault_delete(ctx, page: str) -> ToolResult:
-    """Delete a vault page. Agent-owned pages only (under the agent folder)."""
+    """Delete a vault page. Agent pages allow direct delete; user pages
+    require confirmation per call (or grant/allowlist short-circuit)."""
     log.info(f"[tool:vault_delete] page={page}")
     path = _safe_write_path(ctx.config, page)
     if path is None:
@@ -201,9 +344,22 @@ async def tool_vault_delete(ctx, page: str) -> ToolResult:
             text=f"[error: invalid page name '{page}' — must be within vault directory]")
     if not path.exists():
         return ToolResult(text=f"[error: vault page '{page}' not found]")
-    if not _is_in_agent_dir(ctx.config, path):
-        return ToolResult(
-            text=f"[error: refusing to delete '{page}' — only pages under the agent folder may be deleted]")
+
+    outcome = _check_user_write_allowed(ctx, path)
+    gate_result = await _run_gate_or_confirm(
+        ctx,
+        [outcome],
+        tool_name="vault_delete",
+        command=f"vault_delete '{page}'",
+        preview=_format_vault_delete_preview(ctx.config, path),
+        non_interactive_error=(
+            f"[error: vault_delete of '{page}' outside agent folder "
+            f"requires interactive confirmation; not available from this context]"
+        ),
+        denied_error=f"[error: vault_delete of '{page}' was denied by user]",
+    )
+    if gate_result is not None:
+        return gate_result
 
     vault_resolved = _vault_root(ctx.config).resolve()
     rel_path = str(path.resolve().relative_to(vault_resolved))
@@ -231,7 +387,9 @@ async def tool_vault_delete(ctx, page: str) -> ToolResult:
 
 
 async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
-    """Rename or move a vault page. Agent-owned pages only."""
+    """Rename or move a vault page. Agent pages allow direct rename; user pages
+    require confirmation per call (or grant/allowlist short-circuit). A single
+    confirmation covers both source and target paths."""
     log.info(f"[tool:vault_rename] {page} -> {rename_to}")
     old_path = _safe_write_path(ctx.config, page)
     if old_path is None:
@@ -245,12 +403,27 @@ async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
         return ToolResult(text=f"[error: vault page '{page}' not found]")
     if new_path.exists():
         return ToolResult(text=f"[error: target '{rename_to}' already exists]")
-    if not _is_in_agent_dir(ctx.config, old_path):
-        return ToolResult(
-            text=f"[error: refusing to rename '{page}' — only pages under the agent folder may be renamed]")
-    if not _is_in_agent_dir(ctx.config, new_path):
-        return ToolResult(
-            text=f"[error: refusing to move '{page}' outside the agent folder]")
+
+    # Combined gate: a single confirmation must cover BOTH paths.
+    # If either path is non-interactive-error, the whole op fails.
+    # If either needs confirmation (and neither errors), confirm once.
+    old_outcome = _check_user_write_allowed(ctx, old_path)
+    new_outcome = _check_user_write_allowed(ctx, new_path)
+    gate_result = await _run_gate_or_confirm(
+        ctx,
+        [old_outcome, new_outcome],
+        tool_name="vault_rename",
+        command=f"vault_rename '{page}' -> '{rename_to}'",
+        preview=_format_vault_rename_preview(ctx.config, old_path, new_path),
+        non_interactive_error=(
+            f"[error: vault_rename '{page}' -> '{rename_to}' touches a path "
+            f"outside the agent folder and requires interactive confirmation; "
+            f"not available from this context]"
+        ),
+        denied_error=f"[error: vault_rename '{page}' -> '{rename_to}' was denied by user]",
+    )
+    if gate_result is not None:
+        return gate_result
 
     vault_resolved = _vault_root(ctx.config).resolve()
     old_rel = str(old_path.resolve().relative_to(vault_resolved))
@@ -283,6 +456,86 @@ async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
         log.warning(f"Failed to re-index after rename '{page}' -> '{rename_to}': {e}")
 
     return ToolResult(text=f"Vault page '{page}' renamed to '{rename_to}'.")
+
+
+async def tool_vault_grant_folder(ctx, folder: str, reason: str) -> ToolResult:
+    """Request per-conversation trust for a vault folder.
+
+    The folder is normalized via `normalize_folder` (leading `/` stripped,
+    trailing `/` enforced, `..` rejected) so inputs are accepted on the same
+    terms as `vault.user_writable_paths` config entries.
+
+    After user approval, vault_write/delete/rename under the granted folder
+    skip per-call confirmation for the rest of the conversation. The grant is
+    persisted as a sidecar at workspace/conversations/{conv_id}.vault_grants.json.
+    """
+    log.info(f"[tool:vault_grant_folder] folder={folder!r}")
+
+    # Path safety: empty / .. / vault-escape are rejected up front. Leading
+    # `/` is stripped by normalize_folder for consistency with the allowlist
+    # config (which also strips it), so /etc/passwd lands as etc/passwd/ and
+    # is then evaluated by the vault-containment check below.
+    if not isinstance(folder, str) or not folder.strip():
+        return ToolResult(text="[error: folder is required]")
+    if not isinstance(reason, str) or not reason.strip():
+        return ToolResult(text="[error: reason is required]")
+
+    normalized = normalize_folder(folder)
+    if not normalized:
+        return ToolResult(text=f"[error: invalid folder '{folder}']")
+
+    vault = _vault_root(ctx.config).resolve()
+    candidate = (vault / normalized.rstrip("/")).resolve()
+    if not candidate.is_relative_to(vault):
+        return ToolResult(text=f"[error: folder '{folder}' escapes the vault]")
+
+    # Reject if folder is inside agent/ (no grant needed — direct write allowed).
+    # `is_relative_to` returns True when the path equals itself, so it covers
+    # both the equality and subtree cases.
+    try:
+        agent = _agent_dir(ctx.config).resolve()
+        if candidate.is_relative_to(agent):
+            return ToolResult(
+                text=f"[error: '{folder}' is inside the agent folder; no grant needed]"
+            )
+    except (ValueError, OSError):
+        pass
+
+    # Validate context BEFORE prompting, so we never ask for a doomed grant.
+    if ctx.request_confirmation is None:
+        return ToolResult(
+            text=(
+                "[error: vault_grant_folder requires interactive confirmation; "
+                "not available from this context]"
+            )
+        )
+    if not ctx.conv_id:
+        return ToolResult(
+            text="[error: vault_grant_folder requires a conversation context]"
+        )
+
+    rel = str(candidate.relative_to(vault)).replace("\\", "/")
+    if not rel.endswith("/"):
+        rel = rel + "/"
+
+    msg = (
+        f"Grant vault write/delete/rename trust for folder '{rel}' "
+        f"for the rest of this conversation?\n\nReason: {reason}"
+    )
+    approval = await request_confirmation(
+        ctx,
+        tool_name="vault_grant_folder",
+        command=f"trust folder '{rel}'",
+        message=msg,
+    )
+    if not approval.get("approved"):
+        return ToolResult(text=f"[error: folder grant for '{rel}' was denied by user]")
+
+    if not add_grant(ctx.config, ctx.conv_id, rel):
+        return ToolResult(
+            text=f"[error: failed to persist folder grant for '{rel}']"
+        )
+    return ToolResult(text=f"Folder '{rel}' trusted for this conversation.")
 
 
 async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> str:
@@ -791,6 +1044,7 @@ TOOLS = {
     "vault_write": tool_vault_write,
     "vault_delete": tool_vault_delete,
     "vault_rename": tool_vault_rename,
+    "vault_grant_folder": tool_vault_grant_folder,
     "vault_journal_append": tool_vault_journal_append,
     "vault_search": tool_vault_search,
     "vault_list": tool_vault_list,
@@ -838,9 +1092,10 @@ TOOL_DEFINITIONS = [
                 "workspace_write for those. ALWAYS vault_read first if "
                 "updating an existing page to preserve content you want to keep. "
                 "Use [[Page Name]] syntax to link to other pages. Include a "
-                "## Sources section. Writes are restricted to the agent folder "
-                "(agent/pages/, agent/journal/); admin and user pages are "
-                "off-limits."
+                "## Sources section. Pages outside the agent folder (agent/pages/, "
+                "agent/journal/) require user confirmation per call. For batch "
+                "operations on user folders, request folder trust via "
+                "vault_grant_folder first."
             ),
             "parameters": {
                 "type": "object",
@@ -868,11 +1123,12 @@ TOOL_DEFINITIONS = [
             "name": "vault_delete",
             "description": (
                 "DESTRUCTIVE — permanently delete a vault page and its embedding "
-                "entries. Only pages under the agent folder (agent/pages/, "
-                "agent/journal/) may be deleted; admin and user pages are "
-                "off-limits. Prefer vault_write with updated content to retire "
-                "or mark pages superseded; use delete only when the page is "
-                "definitively wrong, duplicate, or no longer reachable."
+                "entries. Pages outside the agent folder (agent/pages/, "
+                "agent/journal/) require user confirmation per call. For batch "
+                "operations, request folder trust via vault_grant_folder first. "
+                "Prefer vault_write with updated content to retire or mark pages "
+                "superseded; use delete only when the page is definitively wrong, "
+                "duplicate, or no longer reachable."
             ),
             "parameters": {
                 "type": "object",
@@ -895,11 +1151,12 @@ TOOL_DEFINITIONS = [
             "name": "vault_rename",
             "description": (
                 "Rename or move a vault page. Updates the embedding index so "
-                "search results stay consistent. Agent-owned pages only (under "
-                "the agent folder); target must also land under the agent "
-                "folder and must not already exist. Use this to reorganize or "
-                "refine page names — prefer it over delete + rewrite when the "
-                "content stays the same."
+                "search results stay consistent. Pages outside the agent folder "
+                "(agent/pages/, agent/journal/) require user confirmation per "
+                "call. For batch operations, request folder trust via "
+                "vault_grant_folder first. Use this to reorganize or refine page "
+                "names — prefer it over delete + rewrite when the content stays "
+                "the same. Target must not already exist."
             ),
             "parameters": {
                 "type": "object",
@@ -921,6 +1178,42 @@ TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["page", "rename_to"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_grant_folder",
+            "description": (
+                "Request user trust for a vault folder for the rest of this "
+                "conversation. Use this BEFORE a batch operation on user-owned "
+                "folders (3+ writes/deletes/renames in the same area) to avoid "
+                "per-page confirmations. After approval, vault_write, "
+                "vault_delete, and vault_rename under the folder skip "
+                "confirmation. For one-off operations, the regular tools handle "
+                "confirmation per-call — don't call this for a single page."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Vault-relative folder path "
+                            "(e.g. 'creative/in-progress/fungal-world')."
+                        ),
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": (
+                            "Short user-facing reason. Shown in the confirmation "
+                            "message so the user knows why the grant is being "
+                            "requested."
+                        ),
+                    },
+                },
+                "required": ["folder", "reason"],
             },
         },
     },

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -355,6 +355,43 @@ class TestListFields:
         assert c.mattermost.channel_blocklist == ["id1", "id2"]
 
 
+class TestVaultUserWritablePathsTypeGuard:
+    """Misconfigured `vault.user_writable_paths` should not crash load_config."""
+
+    def test_null_value_coerced_to_empty(self, tmp_path, monkeypatch, caplog):
+        """`null` in JSON arrives as None — must not crash the validation loop."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "vault": {"user_writable_paths": None},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        with caplog.at_level("WARNING", logger="decafclaw.config"):
+            c = load_config()
+        assert c.vault.user_writable_paths == []
+        assert any(
+            "user_writable_paths must be a list" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_dict_value_coerced_to_empty(self, tmp_path, monkeypatch, caplog):
+        """A non-list/non-None value (e.g. a dict) would silently iterate keys
+        in the validation loop — guard catches it and warns."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "vault": {"user_writable_paths": {"creative": True}},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        with caplog.at_level("WARNING", logger="decafclaw.config"):
+            c = load_config()
+        assert c.vault.user_writable_paths == []
+        assert any(
+            "user_writable_paths must be a list" in rec.message
+            for rec in caplog.records
+        )
+
+
 class TestFallbackResolution:
     def test_compaction_resolved(self):
         """CompactionConfig.resolved() fills from llm."""

--- a/tests/test_vault_grants.py
+++ b/tests/test_vault_grants.py
@@ -1,0 +1,211 @@
+"""Tests for vault grant sidecar I/O — `decafclaw.skills.vault._grants`."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.skills.vault import _grants
+
+
+@pytest.fixture
+def grants_config(tmp_path):
+    """Minimal config with a workspace_path and vault_root for grants tests.
+
+    Uses SimpleNamespace rather than the full Config to keep tests fast and
+    independent of other config concerns. Mirrors the canvas test fixture.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    vault_root = workspace / "vault"
+    vault_root.mkdir()
+    return SimpleNamespace(
+        workspace_path=workspace,
+        vault_root=vault_root,
+    )
+
+
+class TestNormalizeFolder:
+    def test_strips_leading_slash(self):
+        assert _grants.normalize_folder("/creative") == "creative/"
+
+    def test_enforces_trailing_slash(self):
+        assert _grants.normalize_folder("creative") == "creative/"
+        assert _grants.normalize_folder("creative/") == "creative/"
+
+    def test_rejects_dotdot(self):
+        assert _grants.normalize_folder("../etc") == ""
+        assert _grants.normalize_folder("foo/../bar") == ""
+
+    def test_rejects_empty(self):
+        assert _grants.normalize_folder("") == ""
+        assert _grants.normalize_folder("   ") == ""
+
+    def test_rejects_non_string(self):
+        assert _grants.normalize_folder(None) == ""  # type: ignore[arg-type]
+        assert _grants.normalize_folder(42) == ""  # type: ignore[arg-type]
+
+    def test_preserves_nested_path(self):
+        assert _grants.normalize_folder("creative/in-progress") == "creative/in-progress/"
+
+    def test_warn_on_invalid_logs_for_non_empty(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="decafclaw.skills.vault._grants"):
+            assert _grants.normalize_folder("../etc", warn_on_invalid=True) == ""
+        assert any("Skipping invalid vault folder entry" in r.message
+                   for r in caplog.records)
+
+    def test_warn_on_invalid_silent_for_empty(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="decafclaw.skills.vault._grants"):
+            assert _grants.normalize_folder("", warn_on_invalid=True) == ""
+            assert _grants.normalize_folder("   ", warn_on_invalid=True) == ""
+        assert not any("Skipping invalid vault folder entry" in r.message
+                       for r in caplog.records)
+
+    def test_warn_off_silent_for_invalid(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="decafclaw.skills.vault._grants"):
+            assert _grants.normalize_folder("../etc") == ""
+        assert not any("Skipping invalid vault folder entry" in r.message
+                       for r in caplog.records)
+
+
+class TestGrantsSidecarPath:
+    def test_basic(self, grants_config):
+        path = _grants._grants_sidecar_path(grants_config, "abc123")
+        expected = grants_config.workspace_path / "conversations" / "abc123.vault_grants.json"
+        assert path == expected.resolve()
+
+    def test_rejects_path_traversal_in_conv_id(self, grants_config):
+        bad = _grants._grants_sidecar_path(grants_config, "../etc/passwd")
+        assert bad.name == "_invalid.vault_grants.json"
+
+    def test_rejects_slash_in_conv_id(self, grants_config):
+        bad = _grants._grants_sidecar_path(grants_config, "foo/bar")
+        assert bad.name == "_invalid.vault_grants.json"
+
+    def test_rejects_backslash_in_conv_id(self, grants_config):
+        bad = _grants._grants_sidecar_path(grants_config, "foo\\bar")
+        assert bad.name == "_invalid.vault_grants.json"
+
+    def test_returns_invalid_path_for_empty_conv_id(self, grants_config):
+        bad = _grants._grants_sidecar_path(grants_config, "")
+        assert bad.name == "_invalid.vault_grants.json"
+
+
+class TestReadAddGrants:
+    def test_empty_when_no_sidecar(self, grants_config):
+        assert _grants.read_grants(grants_config, "nope") == set()
+
+    def test_empty_when_conv_id_blank(self, grants_config):
+        assert _grants.read_grants(grants_config, "") == set()
+
+    def test_add_then_read_roundtrip(self, grants_config):
+        assert _grants.add_grant(grants_config, "conv1", "creative") is True
+        assert _grants.read_grants(grants_config, "conv1") == {"creative/"}
+
+    def test_add_normalizes_input(self, grants_config):
+        # Leading slash + missing trailing slash both get normalized.
+        assert _grants.add_grant(grants_config, "conv1", "/foo") is True
+        assert _grants.read_grants(grants_config, "conv1") == {"foo/"}
+
+    def test_add_dedup(self, grants_config):
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        _grants.add_grant(grants_config, "conv1", "creative")
+        _grants.add_grant(grants_config, "conv1", "/creative/")
+        assert _grants.read_grants(grants_config, "conv1") == {"creative/"}
+
+    def test_add_multiple_grants(self, grants_config):
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        _grants.add_grant(grants_config, "conv1", "notes/")
+        assert _grants.read_grants(grants_config, "conv1") == {"creative/", "notes/"}
+
+    def test_add_blank_conv_id_returns_false(self, grants_config):
+        assert _grants.add_grant(grants_config, "", "creative") is False
+
+    def test_add_invalid_folder_returns_false(self, grants_config):
+        assert _grants.add_grant(grants_config, "conv1", "../etc") is False
+        assert _grants.read_grants(grants_config, "conv1") == set()
+
+    def test_add_empty_folder_returns_false(self, grants_config):
+        assert _grants.add_grant(grants_config, "conv1", "") is False
+        assert _grants.read_grants(grants_config, "conv1") == set()
+
+    def test_corrupt_sidecar_treated_as_empty(self, grants_config):
+        path = _grants._grants_sidecar_path(grants_config, "corrupt")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not valid json")
+        assert _grants.read_grants(grants_config, "corrupt") == set()
+
+    def test_filters_invalid_entries_on_read(self, grants_config):
+        """Manually written sidecars with malformed entries are filtered out.
+
+        Critical: an empty-string entry would normalize to "" and act as a
+        wildcard prefix in is_path_in_grants, allowing every path through.
+        """
+        path = _grants._grants_sidecar_path(grants_config, "manual")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "folders": ["", "..", "../escape", "good/", 42, None],
+        }))
+        assert _grants.read_grants(grants_config, "manual") == {"good/"}
+
+    def test_atomic_write_no_partial_tmp(self, grants_config):
+        """Successful write goes through tmp file + rename — no leftover .tmp."""
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        path = _grants._grants_sidecar_path(grants_config, "conv1")
+        assert not path.with_suffix(".json.tmp").exists()
+        # Verify the JSON payload shape on disk.
+        data = json.loads(path.read_text())
+        assert data == {"schema_version": 1, "folders": ["creative/"]}
+
+    def test_legacy_sidecar_without_schema_version_still_reads(self, grants_config):
+        """Sidecars written before schema_version was added should still load."""
+        path = _grants._grants_sidecar_path(grants_config, "conv-legacy")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"folders": ["creative/"]}))
+        assert _grants.read_grants(grants_config, "conv-legacy") == {"creative/"}
+
+
+class TestIsPathInGrants:
+    def test_path_under_granted_folder(self, grants_config):
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        target = grants_config.vault_root / "creative" / "foo.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "conv1", target) is True
+
+    def test_path_under_nested_grant(self, grants_config):
+        _grants.add_grant(grants_config, "conv1", "creative/in-progress/")
+        target = grants_config.vault_root / "creative" / "in-progress" / "bar.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "conv1", target) is True
+
+    def test_path_not_under_any_grant(self, grants_config):
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        target = grants_config.vault_root / "notes" / "bar.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "conv1", target) is False
+
+    def test_no_grants_returns_false(self, grants_config):
+        target = grants_config.vault_root / "creative" / "foo.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "conv1", target) is False
+
+    def test_path_outside_vault_returns_false(self, grants_config, tmp_path):
+        _grants.add_grant(grants_config, "conv1", "creative/")
+        outside = tmp_path / "elsewhere" / "foo.md"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "conv1", outside) is False
+
+    def test_blank_conv_id_returns_false(self, grants_config):
+        target = grants_config.vault_root / "creative" / "foo.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x")
+        assert _grants.is_path_in_grants(grants_config, "", target) is False

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -4,10 +4,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from decafclaw.skills.vault._grants import add_grant
 from decafclaw.skills.vault.tools import (
+    GateOutcome,
+    _check_user_write_allowed,
     resolve_page,
     tool_vault_backlinks,
     tool_vault_delete,
+    tool_vault_grant_folder,
     tool_vault_journal_append,
     tool_vault_list,
     tool_vault_read,
@@ -39,6 +43,15 @@ def agent_journal(config):
     d = config.vault_agent_journal_dir
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def _dummy_request_confirmation(*args, **kwargs):
+    """Module-level stand-in callable so the gate sees a non-None
+    ctx.request_confirmation. Tests that exercise the gate patch
+    `request_confirmation` (the module-level helper) directly, so this
+    sentinel should never actually be invoked.
+    """
+    raise AssertionError("ctx.request_confirmation should not be invoked directly")
 
 
 class TestResolvePage:
@@ -147,11 +160,14 @@ class TestVaultWrite:
 
     @pytest.mark.asyncio
     async def test_rejects_write_outside_agent_folder(self, ctx, vault_dir):
-        """vault_write must refuse paths outside the agent folder, mirroring
-        vault_delete / vault_rename behavior."""
+        """In a non-interactive context (no request_confirmation), vault_write
+        to a path outside the agent folder must error rather than write.
+        With Phase 2, the message names interactive confirmation as the
+        missing prerequisite."""
+        ctx.request_confirmation = None
         result = await tool_vault_write(ctx, "StrayRootPage", "# Stray")
         assert "error" in result.text.lower()
-        assert "agent folder" in result.text.lower()
+        assert "interactive confirmation" in result.text.lower()
         assert not (vault_dir / "StrayRootPage.md").exists()
 
     @pytest.mark.asyncio
@@ -173,6 +189,81 @@ class TestVaultWrite:
         assert "saved" in result.lower() or "saved" in str(result).lower()
         assert (vault_dir / "agent" / "pages" / "Test.md").exists()
         assert not (vault_dir / "agent" / "pages" / "Test.md.md").exists()
+
+
+class TestVaultWriteUserFolders:
+    """Phase 2: vault_write to user folders via the three-tier gate.
+
+    Allowlist and grants short-circuit to direct write; otherwise the tool
+    requests user confirmation; non-interactive contexts error out.
+    """
+
+    @pytest.mark.asyncio
+    async def test_allowlist_bypass_writes_directly(self, ctx, vault_dir):
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            result = await tool_vault_write(ctx, "creative/foo", "content body")
+        assert "saved" in str(result).lower()
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_grant_bypass_writes_directly(self, ctx, vault_dir):
+        ctx.conv_id = "conv-123"
+        add_grant(ctx.config, "conv-123", "creative/")
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            result = await tool_vault_write(ctx, "creative/foo", "content body")
+        assert "saved" in str(result).lower()
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_or_grant_confirms_then_writes(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_write(ctx, "creative/foo", "content body")
+        assert "saved" in str(result).lower()
+        assert mock_conf.called
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_denied_returns_error_no_write(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_write(ctx, "creative/foo", "content body")
+        text = result.text if hasattr(result, "text") else str(result)
+        assert "denied by user" in text
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_context_errors(self, ctx, vault_dir):
+        ctx.request_confirmation = None
+        result = await tool_vault_write(ctx, "creative/foo", "content body")
+        text = result.text if hasattr(result, "text") else str(result)
+        assert "interactive confirmation" in text
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_confirmation_preview_includes_path_and_content(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        captured: dict = {}
+
+        async def capture_request(ctx_, **kwargs):
+            captured.update(kwargs)
+            return {"approved": True}
+
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  side_effect=capture_request),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            await tool_vault_write(ctx, "creative/foo", "hello world content")
+        assert "creative/foo.md" in captured["message"]
+        assert "hello world" in captured["message"]
+        assert "(new page)" in captured["message"]
 
 
 class TestVaultDelete:
@@ -200,11 +291,15 @@ class TestVaultDelete:
 
     @pytest.mark.asyncio
     async def test_rejects_page_outside_agent_dir(self, ctx, vault_dir):
-        # A page directly at the vault root is outside agent/
+        """In a non-interactive context (no request_confirmation), vault_delete
+        of a path outside the agent folder must error rather than delete.
+        With Phase 3, the message names interactive confirmation as the
+        missing prerequisite."""
+        ctx.request_confirmation = None
         (vault_dir / "User Notes.md").write_text("mine")
         result = await tool_vault_delete(ctx, "User Notes")
         assert "error" in result.text.lower()
-        assert "agent folder" in result.text.lower()
+        assert "interactive confirmation" in result.text.lower()
         assert (vault_dir / "User Notes.md").exists()
 
     @pytest.mark.asyncio
@@ -235,6 +330,92 @@ class TestVaultDelete:
             result = await tool_vault_delete(ctx, bad)
             assert "error" in result.text.lower(), f"bad input {bad!r} was accepted"
         assert (vault_dir / ".md").exists()
+
+
+class TestVaultDeleteUserFolders:
+    """Phase 3: vault_delete on user folders via the three-tier gate.
+
+    Allowlist and grants short-circuit to direct delete; otherwise the tool
+    requests user confirmation; non-interactive contexts error out.
+    """
+
+    @pytest.mark.asyncio
+    async def test_allowlist_bypass_deletes_directly(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        with patch("decafclaw.embeddings.delete_entries"):
+            result = await tool_vault_delete(ctx, "creative/foo")
+        assert "deleted" in result.text.lower()
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_grant_bypass_deletes_directly(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.conv_id = "conv-123"
+        add_grant(ctx.config, "conv-123", "creative/")
+        with patch("decafclaw.embeddings.delete_entries"):
+            result = await tool_vault_delete(ctx, "creative/foo")
+        assert "deleted" in result.text.lower()
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_no_allowlist_or_grant_confirms_then_deletes(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.embeddings.delete_entries"),
+        ):
+            result = await tool_vault_delete(ctx, "creative/foo")
+        assert "deleted" in result.text.lower()
+        assert mock_conf.called
+        assert not (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_denied_returns_error_no_delete(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_delete(ctx, "creative/foo")
+        text = result.text if hasattr(result, "text") else str(result)
+        assert "denied by user" in text
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_context_errors(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.request_confirmation = None
+        result = await tool_vault_delete(ctx, "creative/foo")
+        text = result.text if hasattr(result, "text") else str(result)
+        assert "interactive confirmation" in text
+        assert (vault_dir / "creative" / "foo.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_confirmation_preview_includes_path(self, ctx, vault_dir):
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "foo.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        captured: dict = {}
+
+        async def capture_request(ctx_, **kwargs):
+            captured.update(kwargs)
+            return {"approved": True}
+
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  side_effect=capture_request),
+            patch("decafclaw.embeddings.delete_entries"),
+        ):
+            await tool_vault_delete(ctx, "creative/foo")
+        assert "creative/foo.md" in captured["message"]
+        assert "(cannot be undone" in captured["message"]
 
 
 class TestVaultRename:
@@ -291,12 +472,14 @@ class TestVaultRename:
 
     @pytest.mark.asyncio
     async def test_rejects_rename_outside_agent_dir(self, ctx, vault_dir, agent_pages):
+        """Non-interactive context + new path outside agent → error, no rename."""
         (agent_pages / "Inside.md").write_text("x")
+        ctx.request_confirmation = None
         result = await tool_vault_rename(
             ctx, "agent/pages/Inside", "Escaped"
         )
         assert "error" in result.text.lower()
-        assert "agent folder" in result.text.lower()
+        assert "interactive confirmation" in result.text.lower()
         assert (agent_pages / "Inside.md").exists()
         assert not (vault_dir / "Escaped.md").exists()
 
@@ -339,6 +522,137 @@ class TestVaultRename:
             result = await tool_vault_rename(ctx, "agent/pages/Doc", bad)
             assert "error" in result.text.lower(), f"bad target {bad!r} accepted"
         assert (agent_pages / "Doc.md").exists()
+
+
+class TestVaultRenameUserFolders:
+    """Phase 4: vault_rename across user folders via the three-tier gate.
+
+    A single confirmation must cover BOTH source and target paths. If either
+    needs confirmation, the whole op confirms once. If either is non-interactive
+    error, the whole op fails.
+    """
+
+    @pytest.mark.asyncio
+    async def test_old_in_agent_new_in_user_confirms(self, ctx, agent_pages, vault_dir):
+        """Rename agent/pages/X to creative/X — confirms (new path is outside)."""
+        (agent_pages / "X.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.embeddings.delete_entries"),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_rename(ctx, "agent/pages/X", "creative/X")
+        assert "renamed" in result.text.lower()
+        assert mock_conf.called
+        assert not (agent_pages / "X.md").exists()
+        assert (vault_dir / "creative" / "X.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_both_in_user_confirms_once(self, ctx, vault_dir):
+        """Rename creative/A to creative/B — single confirmation covers both."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.embeddings.delete_entries"),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_rename(ctx, "creative/A", "creative/B")
+        assert "renamed" in result.text.lower()
+        assert mock_conf.call_count == 1
+        assert not (vault_dir / "creative" / "A.md").exists()
+        assert (vault_dir / "creative" / "B.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_both_in_user_with_grant_no_confirm(self, ctx, vault_dir):
+        """Pre-grant 'creative/' — rename within creative/ requires no confirm."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.conv_id = "conv-rename-grant"
+        add_grant(ctx.config, "conv-rename-grant", "creative/")
+        # If request_confirmation gets called, this AsyncMock asserts loudly.
+        sentinel = AsyncMock(side_effect=AssertionError(
+            "request_confirmation must not be invoked when grant covers both paths"))
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation", sentinel),
+            patch("decafclaw.embeddings.delete_entries"),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_rename(ctx, "creative/A", "creative/B")
+        assert "renamed" in result.text.lower()
+        assert not sentinel.called
+        assert not (vault_dir / "creative" / "A.md").exists()
+        assert (vault_dir / "creative" / "B.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_old_in_grant_new_outside_grant_confirms(self, ctx, vault_dir):
+        """Grant covers creative/ but target is notes/ — needs confirmation."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.conv_id = "conv-rename-partial"
+        add_grant(ctx.config, "conv-rename-partial", "creative/")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.embeddings.delete_entries"),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_rename(ctx, "creative/A", "notes/B")
+        assert "renamed" in result.text.lower()
+        assert mock_conf.called
+        assert not (vault_dir / "creative" / "A.md").exists()
+        assert (vault_dir / "notes" / "B.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_denied_no_rename(self, ctx, vault_dir):
+        """Deny → original file remains, target doesn't exist."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_rename(ctx, "creative/A", "creative/B")
+        assert "denied by user" in result.text
+        assert (vault_dir / "creative" / "A.md").exists()
+        assert not (vault_dir / "creative" / "B.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_errors(self, ctx, vault_dir):
+        """ctx.request_confirmation = None → error, no rename."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.request_confirmation = None
+        result = await tool_vault_rename(ctx, "creative/A", "creative/B")
+        assert "interactive confirmation" in result.text
+        assert (vault_dir / "creative" / "A.md").exists()
+        assert not (vault_dir / "creative" / "B.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_confirmation_preview_includes_both_paths(self, ctx, vault_dir):
+        """Capture confirmation kwargs; assert message has both old and new paths."""
+        (vault_dir / "creative").mkdir(parents=True, exist_ok=True)
+        (vault_dir / "creative" / "A.md").write_text("body")
+        ctx.request_confirmation = _dummy_request_confirmation
+        captured: dict = {}
+
+        async def capture_request(ctx_, **kwargs):
+            captured.update(kwargs)
+            return {"approved": True}
+
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  side_effect=capture_request),
+            patch("decafclaw.embeddings.delete_entries"),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            await tool_vault_rename(ctx, "creative/A", "notes/B")
+        assert "creative/A.md" in captured["message"]
+        assert "notes/B.md" in captured["message"]
 
 
 class TestVaultJournalAppend:
@@ -479,3 +793,205 @@ class TestVaultBacklinks:
             "Classic: [[Tempest (arcade game)|Tempest arcade game]].")
         result = await tool_vault_backlinks(ctx, "Tempest (arcade game)")
         assert "Arcade Games" in result
+
+
+class TestCheckUserWriteAllowed:
+    """Unit tests for `_check_user_write_allowed` — the three-tier gate.
+
+    Phase 1 plumbing only: this verifies the helper's classification.
+    Phases 2-4 wire the helper into the actual write/delete/rename tools.
+    """
+
+    def test_agent_dir_allows(self, ctx, agent_pages):
+        """Paths inside agent/ skip every other check."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        path = agent_pages / "Note.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_agent_journal_allows(self, ctx, agent_journal):
+        """Paths inside agent/journal/ are also under agent/, so ALLOW."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        path = agent_journal / "2026" / "2026-05-07.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_allowlist_allows(self, ctx, vault_dir):
+        """Paths under a configured allowlist entry skip confirmation."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        path = vault_dir / "creative" / "story.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_allowlist_normalizes_entry(self, ctx, vault_dir):
+        """An entry without a trailing slash still matches its subtree."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        ctx.config.vault.user_writable_paths = ["creative"]  # no trailing slash
+        path = vault_dir / "creative" / "story.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_allowlist_partial_prefix_does_not_match(self, ctx, vault_dir):
+        """`creative/` should NOT match `creativewriting/...` — trailing-slash anchors."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        path = vault_dir / "creativewriting" / "story.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.NEEDS_CONFIRMATION
+
+    def test_allowlist_skips_invalid_entries(self, ctx, vault_dir):
+        """Bad allowlist entries are skipped (logged) without breaking the gate."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        ctx.config.vault.user_writable_paths = ["..", "creative/"]
+        path = vault_dir / "creative" / "story.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_grants_allow(self, ctx, vault_dir):
+        """A folder grant on this conv_id allows writes under it."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        ctx.conv_id = "conv-X"
+        add_grant(ctx.config, "conv-X", "creative/")
+        path = vault_dir / "creative" / "foo" / "bar.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_grants_scoped_to_conversation(self, ctx, vault_dir):
+        """A grant for one conv_id does NOT carry over to another."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        add_grant(ctx.config, "other-conv", "creative/")
+        ctx.conv_id = "conv-X"
+        path = vault_dir / "creative" / "foo.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.NEEDS_CONFIRMATION
+
+    def test_outside_yields_needs_confirmation(self, ctx, vault_dir):
+        """Outside agent/, no allowlist, no grant — confirmation required."""
+        ctx.request_confirmation = _dummy_request_confirmation
+        path = vault_dir / "random" / "page.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.NEEDS_CONFIRMATION
+
+    def test_no_request_conf_yields_non_interactive_error(self, ctx, vault_dir):
+        """When no UI is available, the gate signals non-interactive error."""
+        ctx.request_confirmation = None
+        path = vault_dir / "random" / "page.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.NON_INTERACTIVE_ERROR
+
+    def test_agent_dir_allows_even_when_non_interactive(self, ctx, agent_pages):
+        """Agent-dir writes never require confirmation, even from heartbeat ctx."""
+        ctx.request_confirmation = None
+        path = agent_pages / "Note.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+    def test_allowlist_allows_even_when_non_interactive(self, ctx, vault_dir):
+        """Allowlist short-circuit beats the non-interactive check."""
+        ctx.request_confirmation = None
+        ctx.config.vault.user_writable_paths = ["creative/"]
+        path = vault_dir / "creative" / "story.md"
+        assert _check_user_write_allowed(ctx, path) == GateOutcome.ALLOW
+
+
+class TestVaultGrantFolder:
+    """Phase 5: vault_grant_folder requests per-conversation folder trust."""
+
+    @pytest.mark.asyncio
+    async def test_approves_and_persists(self, ctx, vault_dir):
+        ctx.conv_id = "conv-X"
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch(
+            "decafclaw.skills.vault.tools.request_confirmation",
+            AsyncMock(return_value={"approved": True}),
+        ):
+            result = await tool_vault_grant_folder(ctx, "creative", "batch rename")
+        assert "trusted" in result.text
+        from decafclaw.skills.vault._grants import read_grants
+        assert "creative/" in read_grants(ctx.config, "conv-X")
+
+    @pytest.mark.asyncio
+    async def test_denied_returns_error_no_persist(self, ctx, vault_dir):
+        ctx.conv_id = "conv-X"
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch(
+            "decafclaw.skills.vault.tools.request_confirmation",
+            AsyncMock(return_value={"approved": False}),
+        ):
+            result = await tool_vault_grant_folder(ctx, "creative", "...")
+        assert "denied by user" in result.text
+        from decafclaw.skills.vault._grants import read_grants
+        assert read_grants(ctx.config, "conv-X") == set()
+
+    @pytest.mark.asyncio
+    async def test_rejects_dotdot(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        result = await tool_vault_grant_folder(ctx, "../etc", "escape")
+        assert "invalid folder" in result.text
+
+    @pytest.mark.asyncio
+    async def test_strips_leading_slash(self, ctx, vault_dir):
+        """Leading `/` is stripped (consistent with vault.user_writable_paths).
+
+        `/creative` normalizes to `creative/` and is accepted; the grant key
+        in the sidecar omits the leading slash.
+        """
+        ctx.conv_id = "conv-X"
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch(
+            "decafclaw.skills.vault.tools.request_confirmation",
+            AsyncMock(return_value={"approved": True}),
+        ):
+            result = await tool_vault_grant_folder(ctx, "/creative", "batch rename")
+        assert "trusted" in result.text
+        from decafclaw.skills.vault._grants import read_grants
+        grants = read_grants(ctx.config, "conv-X")
+        assert "creative/" in grants
+        assert "/creative/" not in grants
+        assert "/creative" not in grants
+
+    @pytest.mark.asyncio
+    async def test_rejects_inside_agent(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        result = await tool_vault_grant_folder(ctx, "agent/pages", "...")
+        assert "no grant needed" in result.text
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_conv_id(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        # Empty string and None should both be rejected — the impl uses
+        # `if not ctx.conv_id:` which catches both, but the contract is explicit.
+        for missing in ("", None):
+            ctx.conv_id = missing
+            result = await tool_vault_grant_folder(ctx, "creative", "...")
+            assert "conversation context" in result.text, (
+                f"conv_id={missing!r} was not rejected"
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_interactive(self, ctx, vault_dir):
+        ctx.request_confirmation = None
+        result = await tool_vault_grant_folder(ctx, "creative", "...")
+        assert "interactive confirmation" in result.text
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_folder(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        result = await tool_vault_grant_folder(ctx, "", "...")
+        assert "folder is required" in result.text
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_reason(self, ctx, vault_dir):
+        ctx.request_confirmation = _dummy_request_confirmation
+        result = await tool_vault_grant_folder(ctx, "creative", "")
+        assert "reason is required" in result.text
+
+    @pytest.mark.asyncio
+    async def test_grant_then_write_skips_confirmation(self, ctx, vault_dir):
+        """Integration: grant a folder, then write — no second confirmation."""
+        ctx.conv_id = "conv-X"
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch(
+            "decafclaw.skills.vault.tools.request_confirmation",
+            AsyncMock(return_value={"approved": True}),
+        ):
+            await tool_vault_grant_folder(ctx, "creative", "batch")
+        # Now write — should NOT call request_confirmation again
+        sentinel = AsyncMock(side_effect=AssertionError("should not have been called"))
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation", sentinel),
+            patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock),
+        ):
+            result = await tool_vault_write(ctx, "creative/foo", "content body")
+        assert sentinel.call_count == 0
+        assert "saved" in str(result)


### PR DESCRIPTION
## Summary

- Replace the hard-refuse on `vault_write`/`vault_delete`/`vault_rename` outside the agent folder with a three-tier gate: static config allowlist → per-conversation folder grants → user confirmation.
- Add a `vault_grant_folder(folder, reason)` tool so the agent can request batch trust upfront instead of confirming page-by-page.
- Aligns runtime behavior with the policy already documented in `SKILL.md` ("only write outside `agent/` when the user explicitly asks") — previously the runtime refused regardless of user intent.

## Design Decisions

- **Three-tier gate, in order: agent dir → static allowlist → per-conversation grants → user confirmation.** Cheapest checks first, most permissive paths first.
- **Allowlist + per-conversation grant** instead of pure per-call confirmation, because batch ops on user folders (rename a dozen pages, etc.) would otherwise demand a click per page. Static `vault.user_writable_paths` covers stable trust; per-conversation grants cover ad-hoc batches without permanent config edits.
- **Email-tool pattern, not `EndTurnConfirm`.** `await request_confirmation(...)` blocks the tool until the user responds, so the LLM sees the actual write outcome as the tool result. `EndTurnConfirm` is for review-gate flows where "I asked for review" is itself a useful tool result — wrong fit here.
- **Per-conversation grants persist as a sidecar at `{workspace}/conversations/{conv_id}.vault_grants.json`** (matches `notes`/`canvas`/`decisions` convention). Grants survive page reload and server restart; reset between conversations.
- **Shared `_run_gate_or_confirm` helper** collapses the per-tool gate flow to a single call across `vault_write`/`delete`/`rename`/`grant_folder`. Was extracted in Phase 4 polish after three near-identical 8-line blocks emerged.
- **Non-interactive contexts (heartbeat / scheduled / child-agent)** short-circuit with a clean error instead of blocking on a missing UI. The gate returns `GateOutcome.NON_INTERACTIVE_ERROR` when `ctx.request_confirmation is None`.
- **Allowlist matches by prefix on vault-relative paths, no globs.** Simple model; matches "trust this folder" mental model. Globs were rejected as a rabbit hole.
- **Grant tool rejects folders inside `agent/`** ("no grant needed") and folders that escape the vault (`..`, absolute paths). Path safety mirrors `_safe_write_path`.

## Changes

- **Config:** new `VaultConfig.user_writable_paths: list[str]`. Allowlist entries are validated once at config-load time so misconfigured entries surface in logs without spamming per-call.
- **`src/decafclaw/skills/vault/_grants.py`** (new): sidecar I/O — `read_grants`, `add_grant`, `is_path_in_grants`, `normalize_folder`. Atomic tmp-then-rename writes; fail-open on corrupt sidecars; filters invalid entries on read so `""` can't act as a wildcard prefix.
- **`src/decafclaw/skills/vault/tools.py`:** `GateOutcome` enum, `_check_user_write_allowed`, `_is_in_user_writable_paths`, `_run_gate_or_confirm`, three `_format_vault_*_preview` helpers, `tool_vault_grant_folder`. Three existing tools wired to the gate; descriptions updated to teach the LLM the new affordance.
- **SKILL.md:** "Boundaries" section rewritten to reflect that user-page writes are now writable on user request and to teach the agent to call `vault_grant_folder` before batch ops.
- **`docs/vault.md`:** new "Writing to user pages" section + tool table updates for `vault_delete`, `vault_rename`, and the new `vault_grant_folder`.
- **`docs/config.md`:** new `vault.user_writable_paths` entry.
- **Tests:** `tests/test_vault_grants.py` (new, 32 tests covering normalization, sidecar I/O, atomic write, malformed-entry filtering); `tests/test_vault_tools.py` extended with `TestCheckUserWriteAllowed`, `TestVaultWriteUserFolders`, `TestVaultDeleteUserFolders`, `TestVaultRenameUserFolders`, `TestVaultGrantFolder` (~50 new tests including a grant→write integration test that proves no second confirmation prompt).

## Test Plan

- [x] `make lint` passes
- [x] `make test` passes (2385 passing)
- [x] `make check` passes (ruff, pyright, tsc, message-types drift)
- [ ] Live `make dev` smoke: write a user page (e.g. `creative/test.md`) → confirmation appears with path/size/preview; approve → write succeeds; deny → error and no file.
- [ ] Live `make dev` smoke: with `vault.user_writable_paths: ["test/"]` in `data/{agent_id}/config.json`, write `test/foo.md` → no confirmation prompted.
- [ ] Live `make dev` smoke: ask agent to rename multiple pages in a user folder → agent calls `vault_grant_folder` first, single confirmation, then renames execute silently.
- [ ] Reload-resilience: after a grant, reload the page; the grant survives (sidecar at `{workspace}/conversations/{conv_id}.vault_grants.json`).
- [ ] Cross-conversation isolation: open a new conversation, write to a previously-granted folder → confirmation prompts again.

## References

- Spec: `docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/spec.md`
- Plan: `docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/plan.md`
- Notes: `docs/dev-sessions/2026-05-07-0809-vault-write-user-pages/notes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)