### PR TITLE
docs: recommend $VAR over ../../ for extra_skill_paths

### DIFF
--- a/contrib/skills/README.md
+++ b/contrib/skills/README.md
@@ -10,18 +10,28 @@ Two installation styles, depending on whether you want updates to flow with `git
 
 Add the skill's directory to your agent's `extra_skill_paths` so the loader picks it up in place. `git pull` then keeps `SKILL.md` up to date automatically; downloaded binaries persist (they're already gitignored).
 
-In `data/{agent_id}/config.json`:
+**Why `$VAR` over relative paths.** Relative entries in `extra_skill_paths` are anchored to `data/{agent_id}/`, not to the repo or the CWD. That only reaches the repo's `contrib/skills/` when `data_home` happens to live inside the repo (the default `./data` dev layout). Production deployments usually keep `data_home` somewhere stable like `~/.decafclaw/`, which is nowhere near the repo — relative paths will silently miss. A `$VAR` decouples the two.
+
+Add to `.env`:
+
+```bash
+DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
+```
+
+Then in `data/{agent_id}/config.json`:
 
 ```json
 {
   "extra_skill_paths": [
-    "../../contrib/skills/linkding-ingest",
-    "../../contrib/skills/mastodon-ingest"
+    "$DECAFCLAW_REPO/contrib/skills/linkding-ingest",
+    "$DECAFCLAW_REPO/contrib/skills/mastodon-ingest"
   ]
 }
 ```
 
-Each entry points at a single skill directory (one with `SKILL.md` at its root). **Relative paths are anchored to `data/{agent_id}/`**, so `../../contrib/skills/<name>` reaches the repo's `contrib/skills/` directory when `data_home` is at its default `./data` location. Absolute paths and `~` / `$VAR` expansion also work — e.g. set `DECAFCLAW_REPO=/path/to/repo` in `.env` and use `$DECAFCLAW_REPO/contrib/skills/<name>` to decouple from the `data_home` layout.
+Each entry points at a single skill directory (one with `SKILL.md` at its root). The loader runs `os.path.expandvars` + `~` expansion on every entry before scanning, so plain absolute paths and `~/...` also work. Use whichever fits your deployment.
+
+(If `data_home` is the default `./data` location inside the repo, a relative `../../contrib/skills/<name>` will also work — but the `$VAR` form is portable across deployment layouts.)
 
 Then download the required binaries (run from the repo root):
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -230,7 +230,7 @@ Skills are discovered from three locations, in priority order (highest first):
 | 1 | `data/{agent_id}/workspace/skills/` | Agent-writable. ClawHub installs land here. |
 | 2 | `data/{agent_id}/skills/` | Admin-managed. |
 | 3 | `src/decafclaw/skills/` | Bundled with the package. |
-| 4 | Paths listed in `extra_skill_paths` config | Externally-managed. Each entry can be a directory of skills (e.g., `~/.claude/skills`) or a direct skill directory (e.g., `../../contrib/skills/linkding-ingest`). Lowest priority — cannot shadow bundled skills. |
+| 4 | Paths listed in `extra_skill_paths` config | Externally-managed. Each entry can be a directory of skills (e.g., `~/.claude/skills`) or a direct skill directory (e.g., `$DECAFCLAW_REPO/contrib/skills/linkding-ingest`). Lowest priority — cannot shadow bundled skills. |
 
 Higher-priority skills override lower-priority ones with the same name. External skills (tier 4) cannot shadow bundled skills, but workspace and admin skills can shadow them.
 
@@ -243,19 +243,26 @@ Each entry in `extra_skill_paths` is interpreted polymorphically:
 
 The two forms can be mixed within the same `extra_skill_paths` list. Detection is per-entry — the loader checks for `SKILL.md` at the entry path first; if absent, it falls back to scanning subdirectories.
 
-Example mixing both forms (relative paths anchor to `data/{agent_id}/`, so `../../contrib/skills/<name>` reaches the repo's `contrib/skills/` directory when `data_home` is at its default `./data` location):
+**Path resolution.** Each entry is run through `os.path.expandvars` + `~` expansion, then anchored to `config.agent_path` (i.e. `data/{agent_id}/`) if still relative. The agent-path anchor only reaches the repo's `contrib/skills/` when `data_home` happens to live inside the repo (the default `./data` dev layout). Production deployments typically keep `data_home` somewhere stable like `~/.decafclaw/`, where relative paths can't see the repo — prefer absolute paths or a `$VAR` for those.
+
+Example pointing at shared skills via a repo-locating env var (recommended for any deployment where `data_home` is outside the repo):
+
+```bash
+# .env
+DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
+```
 
 ```json
 {
   "extra_skill_paths": [
-    "../../contrib/skills/linkding-ingest",
-    "../../contrib/skills/mastodon-ingest",
+    "$DECAFCLAW_REPO/contrib/skills/linkding-ingest",
+    "$DECAFCLAW_REPO/contrib/skills/mastodon-ingest",
     "~/.claude/skills"
   ]
 }
 ```
 
-For deployments where `data_home` lives outside the repo, use absolute paths or `$VAR` expansion (e.g. set `DECAFCLAW_REPO=/path/to/repo` in `.env` and reference `$DECAFCLAW_REPO/contrib/skills/<name>`).
+For an in-repo `data_home` (default dev layout), a relative `../../contrib/skills/<name>` also works.
 
 Per-deployment customization still works via the priority order: a same-named skill under `data/{agent_id}/skills/<name>/` shadows any entry in `extra_skill_paths`. So you can start by referencing a shared skill and switch to a local copy later if you need to fork it.
 


### PR DESCRIPTION
## Summary

Follow-up to #446. The original docs led with `"../../contrib/skills/<name>"` as the primary example for opting into shared optional skills via `extra_skill_paths`. That form only works when `data_home` lives inside the repo (the default `./data` dev layout). On a production deployment with `DATA_HOME=~/.decafclaw/` (or any out-of-repo location), `../../` silently misses the repo and the skills don't load.

Flips the recommended example to a `$VAR`-expanded path:

```bash
# .env
DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
```

```json
{
  "extra_skill_paths": [
    "$DECAFCLAW_REPO/contrib/skills/linkding-ingest",
    "$DECAFCLAW_REPO/contrib/skills/mastodon-ingest"
  ]
}
```

`_resolve_extra_skill_paths` already runs `os.path.expandvars` on every entry, so this works without any code change. The `../../` form gets demoted to a "if your `data_home` happens to be in-repo" parenthetical.

Files touched: `contrib/skills/README.md`, `docs/skills.md` (discovery-table row + the new subsection).

## Test plan

- [ ] On the production deployment (`DATA_HOME=~/.decafclaw/`), set `DECAFCLAW_REPO` in `.env`, switch the config entries to `$DECAFCLAW_REPO/contrib/skills/<name>`, restart the agent, and confirm both `linkding-ingest` and `mastodon-ingest` appear in the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)