### PR TITLE
fix(skills): substitute $SKILL_DIR in activate_skill body

### DIFF
--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -180,10 +180,12 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
     """
     name = skill_info.name
     # Substitute $SKILL_DIR in the body so the LLM sees usable paths.
-    # The command and schedule paths do the same via commands.substitute_body;
+    # The command and schedule paths do the same via commands.substitute_body
+    # (commands.py:417 / schedules.py:235), both using .resolve() so the LLM
+    # always gets an absolute path regardless of how data_home was configured.
     # activate_skill needs to match so skills loaded via extra_skill_paths
     # (where the location isn't a conventional guess) work consistently.
-    body = skill_info.body.replace("$SKILL_DIR", str(skill_info.location))
+    body = skill_info.body.replace("$SKILL_DIR", str(skill_info.location.resolve()))
     result_parts = [body]
 
     if skill_info.has_native_tools:

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -179,7 +179,12 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
     skill body text on success.
     """
     name = skill_info.name
-    result_parts = [skill_info.body]
+    # Substitute $SKILL_DIR in the body so the LLM sees usable paths.
+    # The command and schedule paths do the same via commands.substitute_body;
+    # activate_skill needs to match so skills loaded via extra_skill_paths
+    # (where the location isn't a conventional guess) work consistently.
+    body = skill_info.body.replace("$SKILL_DIR", str(skill_info.location))
+    result_parts = [body]
 
     if skill_info.has_native_tools:
         try:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -658,6 +658,33 @@ async def test_auto_approve_blocked_by_explicit_deny(ctx, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_activate_substitutes_skill_dir_in_body(ctx, tmp_path):
+    """`activate_skill` substitutes `$SKILL_DIR` in the body with the
+    skill's actual location.
+
+    Without this, a skill body containing `$SKILL_DIR/fetch.sh` is
+    shown verbatim to the LLM, which then has to guess where the
+    skill lives. That guess fails for skills loaded via
+    `extra_skill_paths` (e.g. shared optional skills in `contrib/`)
+    because their location isn't conventional. The substitution
+    matches the behavior of the command and schedule paths
+    (`substitute_body` in `commands.py`).
+    """
+    skill = _make_skill_info(
+        tmp_path,
+        name="dir-test",
+        body="Run: $SKILL_DIR/fetch.sh",
+    )
+    ctx.config.discovered_skills = [skill]
+    _save_permission(ctx.config, skill.name, "always")
+
+    result = await tool_activate_skill(ctx, name=skill.name)
+    text = _text(result)
+    assert "$SKILL_DIR" not in text
+    assert f"Run: {skill.location}/fetch.sh" in text
+
+
+@pytest.mark.asyncio
 async def test_discover_bundled_tabstack(config, monkeypatch):
     """Bundled tabstack skill is discovered when TABSTACK_API_KEY is set."""
     monkeypatch.setenv("TABSTACK_API_KEY", "test-key")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -681,7 +681,9 @@ async def test_activate_substitutes_skill_dir_in_body(ctx, tmp_path):
     result = await tool_activate_skill(ctx, name=skill.name)
     text = _text(result)
     assert "$SKILL_DIR" not in text
-    assert f"Run: {skill.location}/fetch.sh" in text
+    # The substitution uses .resolve() to match the command/schedule paths
+    # so the body always carries an absolute path regardless of data_home.
+    assert f"Run: {skill.location.resolve()}/fetch.sh" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When the agent calls `activate_skill("linkding-ingest")` (or any shell-based skill), `activate_skill_internal` hands the raw `SKILL.md` body to the LLM with literal `$SKILL_DIR/fetch.sh` still in it. The substitution that the command path (`commands.substitute_body`) and schedule path do is missing from the activate path.

The LLM then has to guess where the skill lives. For skills loaded via `extra_skill_paths` (e.g. `$DECAFCLAW_REPO/contrib/skills/linkding-ingest/`) the guess fails — the LLM defaults to a conventional location like `./skills/<name>/fetch.sh` which doesn't exist on disk, and the shell call silently misses.

Repro that exposed it (post-#446):
- User: "We may have missed some linkding bookmarks from last week — can we pick those up?"
- Agent: `activate_skill("linkding-ingest")` → gets body with literal `$SKILL_DIR`
- Agent: `shell ./skills/linkding-ingest/fetch.sh` → no such file
- Agent gives up.

## Fix

One-line replace at the top of `activate_skill_internal`:

```python
body = skill_info.body.replace("$SKILL_DIR", str(skill_info.location))
result_parts = [body]
```

Doesn't import `commands.substitute_body` because that helper also handles `$ARGUMENTS`/`$0`/`$1`, which are command-invocation concerns (the activate path has no arguments to substitute).

## Test plan

- [x] `make check` passes
- [x] `make test` passes (2419 → 2419, +1 new test)
- [x] New test `test_activate_substitutes_skill_dir_in_body` verifies the substitution and fails without the fix
- [ ] On the production deployment: ask the agent in natural language to run linkding ingest, confirm it now finds and runs `fetch.sh` via the substituted path

🤖 Generated with [Claude Code](https://claude.com/claude-code)