### PR TITLE
feat(ingest): forward user args through fetch.sh for backfill

### DIFF
--- a/contrib/skills/linkding-ingest/SKILL.md
+++ b/contrib/skills/linkding-ingest/SKILL.md
@@ -5,7 +5,7 @@ schedule: "45 */4 * * *"
 effort: default
 required-skills:
   - tabstack
-allowed-tools: shell($SKILL_DIR/fetch.sh*), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, tabstack_extract_markdown, current_time, delegate_tasks
+allowed-tools: shell($SKILL_DIR/fetch.sh), shell($SKILL_DIR/fetch.sh *), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, tabstack_extract_markdown, current_time, delegate_tasks
 user-invocable: true
 ---
 

--- a/contrib/skills/linkding-ingest/SKILL.md
+++ b/contrib/skills/linkding-ingest/SKILL.md
@@ -5,7 +5,7 @@ schedule: "45 */4 * * *"
 effort: default
 required-skills:
   - tabstack
-allowed-tools: shell($SKILL_DIR/fetch.sh), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, tabstack_extract_markdown, current_time, delegate_tasks
+allowed-tools: shell($SKILL_DIR/fetch.sh*), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, tabstack_extract_markdown, current_time, delegate_tasks
 user-invocable: true
 ---
 
@@ -34,9 +34,22 @@ Run the fetch script:
 $SKILL_DIR/fetch.sh
 ```
 
-This outputs ALL recent bookmarks as markdown. Read the entire output to get the full list. Drop obviously low-signal bookmarks (duplicates, ephemeral content) before delegating — don't waste a child on them.
+With no args, the script auto-fetches everything since the last successful run (or the past 1 day on first run) and updates a workspace-side timestamp file when it succeeds. This is what scheduled cycles use.
 
-If the output is empty (no bookmarks since the last run), start your final summary with `HEARTBEAT_OK` and stop.
+**Backfill mode.** When invoked with arguments, the script forwards them directly to the underlying `linkding-to-markdown fetch` binary and skips the timestamp update — so a backfill doesn't clobber the scheduled-cycle state. Use this when the user asks for older bookmarks or a specific date range:
+
+```
+$SKILL_DIR/fetch.sh --days 30                       # last 30 days
+$SKILL_DIR/fetch.sh --since 2026-04-01              # since a date
+$SKILL_DIR/fetch.sh --since 2026-04-01 --until 2026-04-30
+$SKILL_DIR/fetch.sh --query golang --days 365       # filtered fetch
+```
+
+Available flags (forwarded to the binary): `--days N`, `--since YYYY-MM-DD`, `--until YYYY-MM-DD`, `--query <text>`. See `$SKILL_DIR/bin/<platform>/linkding-to-markdown fetch --help` for the full list.
+
+This outputs ALL matching bookmarks as markdown. Read the entire output to get the full list. Drop obviously low-signal bookmarks (duplicates, ephemeral content) before delegating — don't waste a child on them.
+
+If the output is empty (no matching bookmarks), start your final summary with `HEARTBEAT_OK` and stop.
 
 ## Step 2: Delegate analysis with `delegate_tasks`
 

--- a/contrib/skills/linkding-ingest/fetch.sh
+++ b/contrib/skills/linkding-ingest/fetch.sh
@@ -19,8 +19,26 @@ fi
 : "${LINKDING_URL:?LINKDING_URL env var is required}"
 : "${LINKDING_TOKEN:?LINKDING_TOKEN env var is required}"
 
-# Last-run tracking
-# State lives in workspace, not the skill directory
+# Backfill mode: any args from the caller are forwarded directly to the
+# binary, bypassing the last-run-based incremental fetch. Last-run
+# tracking is also skipped so a backfill doesn't clobber the timestamp
+# the scheduled cycle relies on.
+#
+# Examples:
+#   fetch.sh                              # auto: since last run (or 1 day)
+#   fetch.sh --days 30                    # last 30 days, ad-hoc
+#   fetch.sh --since 2026-04-01           # since a specific date
+#   fetch.sh --since 2026-04-01 --until 2026-04-30
+#   fetch.sh --query golang               # filtered fetch
+if [ "$#" -gt 0 ]; then
+    exec "$BIN" fetch \
+        --url "${LINKDING_URL}" \
+        --token "${LINKDING_TOKEN}" \
+        "$@"
+fi
+
+# No args → auto-fetch since the last successful run.
+# State lives in workspace, not the skill directory.
 WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/../../workspace" 2>/dev/null && pwd || echo "${SCRIPT_DIR}")"
 LAST_RUN_DIR="${WORKSPACE_DIR}/skill-state/linkding-ingest"
 mkdir -p "$LAST_RUN_DIR"

--- a/contrib/skills/mastodon-ingest/SKILL.md
+++ b/contrib/skills/mastodon-ingest/SKILL.md
@@ -3,7 +3,7 @@ name: mastodon-ingest
 description: Fetch recent Mastodon posts and record interesting content to the vault
 schedule: "30 */4 * * *"
 effort: default
-allowed-tools: shell($SKILL_DIR/fetch.sh), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, current_time
+allowed-tools: shell($SKILL_DIR/fetch.sh*), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, current_time
 user-invocable: true
 ---
 
@@ -32,13 +32,24 @@ Run the fetch script using the shell tool. The script is bundled with this skill
 $SKILL_DIR/fetch.sh
 ```
 
-**What this does:**
+**What this does (no-args mode):**
 - Detects the current platform and runs the correct `mastodon-to-markdown` binary
 - Reads Mastodon credentials from env vars
-- Automatically fetches posts since the last successful run (stored in `$SKILL_DIR/last-run-time.txt`)
-- On first run (no `.last_run` file), defaults to the last 24 hours
-- Updates `.last_run` on success so the next run only fetches new posts
+- Automatically fetches posts since the last successful run (timestamp stored under `workspace/skill-state/mastodon-ingest/last-run-time.txt`)
+- On first run (no timestamp file), defaults to the last 24 hours
+- Applies `--exclude-boosts` and `--exclude-replies` by default
+- Updates the timestamp on success so the next run only fetches new posts
 - Outputs the posts as formatted markdown to stdout
+
+**Backfill mode.** When invoked with arguments, the script forwards them directly to the underlying `mastodon-to-markdown fetch` binary and skips the timestamp update — so a backfill doesn't clobber the scheduled-cycle state. The `--exclude-boosts` / `--exclude-replies` defaults are also dropped; pass them explicitly if you want them. Use this when the user asks for older posts or a specific date range:
+
+```
+$SKILL_DIR/fetch.sh --since 7d                      # last 7 days, ad-hoc
+$SKILL_DIR/fetch.sh --start 2026-04-01 --end 2026-04-30
+$SKILL_DIR/fetch.sh --since 7d --exclude-boosts --exclude-replies
+```
+
+Available flags (forwarded to the binary): `--since <duration>` (e.g. `24h`, `7d`), `--start YYYY-MM-DD`, `--end YYYY-MM-DD`, `--exclude-boosts`, `--exclude-replies`, `--exclude-favorites`, `--public-only`, `--visibility <list>`, `--sort-order asc|desc`. See `$SKILL_DIR/bin/<platform>/mastodon-to-markdown fetch --help` for the full list.
 
 If the script fails (missing env vars, binary not found), report the error and stop.
 

--- a/contrib/skills/mastodon-ingest/fetch.sh
+++ b/contrib/skills/mastodon-ingest/fetch.sh
@@ -19,8 +19,27 @@ fi
 : "${MASTODON_SERVER:?MASTODON_SERVER env var is required}"
 : "${MASTODON_ACCESS_TOKEN:?MASTODON_ACCESS_TOKEN env var is required}"
 
-# Last-run tracking
-# State lives in workspace, not the skill directory
+# Backfill mode: any args from the caller are forwarded directly to the
+# binary, bypassing the last-run-based incremental fetch. Last-run
+# tracking is also skipped so a backfill doesn't clobber the timestamp
+# the scheduled cycle relies on. `--exclude-boosts` / `--exclude-replies`
+# defaults are NOT applied in this mode — pass them explicitly if you
+# want them.
+#
+# Examples:
+#   fetch.sh                              # auto: since last run (or 24h)
+#   fetch.sh --since 7d                   # last week, ad-hoc
+#   fetch.sh --start 2026-04-01 --end 2026-04-30
+#   fetch.sh --since 7d --exclude-boosts --exclude-replies
+if [ "$#" -gt 0 ]; then
+    exec "$BIN" fetch \
+        --server "${MASTODON_SERVER}" \
+        --token "${MASTODON_ACCESS_TOKEN}" \
+        "$@"
+fi
+
+# No args → auto-fetch since the last successful run.
+# State lives in workspace, not the skill directory.
 WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/../../workspace" 2>/dev/null && pwd || echo "${SCRIPT_DIR}")"
 LAST_RUN_DIR="${WORKSPACE_DIR}/skill-state/mastodon-ingest"
 mkdir -p "$LAST_RUN_DIR"


### PR DESCRIPTION
## Summary

Both `linkding-ingest` and `mastodon-ingest` expose a `fetch.sh` that auto-fetches since the last successful run, updating a workspace-side timestamp on success. That works for scheduled cycles but gave the agent no clean way to handle "fetch further back" user requests — the only workaround was mutating `last-run-time.txt`, which would also clobber the next scheduled cycle.

Adds a **backfill mode**: when `fetch.sh` is called with any arguments, it forwards them directly to the underlying binary via `exec ... "$@"` and skips both the auto-detect and the timestamp update.

Examples the agent can now use:

```bash
# linkding
$SKILL_DIR/fetch.sh --days 30
$SKILL_DIR/fetch.sh --since 2026-04-01 --until 2026-04-30
$SKILL_DIR/fetch.sh --query golang --days 365

# mastodon
$SKILL_DIR/fetch.sh --since 7d
$SKILL_DIR/fetch.sh --start 2026-04-01 --end 2026-04-30
```

Both binaries already accept these flags — verified via their `--help` output. No changes to the binaries.

## Security check

`allowed-tools` updated from `shell($SKILL_DIR/fetch.sh)` (literal match) to `shell($SKILL_DIR/fetch.sh*)` (glob with suffix). The shell tool rejects shell metacharacters (`;`, `&&`, `|`, etc.) before pattern matching (see `shell_tools.py:110-112`), so chaining and injection are still blocked even with the wildcard.

## SKILL.md changes

Both SKILL.md files now document the no-args (scheduled) mode separately from the backfill mode, list the forwarded flag set, and point at `--help` for the full reference.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Verified both binaries accept the documented flags (`fetch --help` inspected for linkding-to-markdown and mastodon-to-markdown)
- [ ] Manual on the deployed agent: ask in natural language "fetch linkding bookmarks from the last 30 days" — confirm the agent runs `fetch.sh --days 30` (or `--since YYYY-MM-DD`), gets results, and that the next scheduled cycle's incremental window isn't affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)