### PR TITLE
refactor: relocate composer helpers out of agent.py internals

### DIFF
--- a/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/notes.md
+++ b/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/notes.md
@@ -1,0 +1,29 @@
+# Session Notes — Composer Helper Relocation (#439)
+
+## Scope landed in this PR
+
+- **Sub-task #2** — wiki helpers (`parse_wiki_references`, `read_wiki_page`, `get_already_injected_pages`, `_WIKI_MENTION_RE`) relocated from `agent.py` to `memory_context.py`. Renamed (underscore dropped) for the public functions; the regex constant stays underscore-prefixed (module-private). `_WIKI_MENTION_RE` (matches `@[[Page]]` mentions in user messages) now lives next to the pre-existing `_WIKI_LINK_RE` (matches bare `[[Page]]` links inside vault page bodies) — comment distinguishes the two.
+- **Sub-task #3** — `_resolve_attachments` relocated from `agent.py` to `attachments.py` (where its only collaborator `read_attachment_base64` already lives). Renamed to `resolve_attachments`. Docstring/comment references in `llm/providers/vertex.py` and `tests/test_vertex_translation.py` updated for consistency.
+
+## Sub-task #1 — deferred
+
+`_collect_all_tool_defs` import update is deferred because `src/decafclaw/tool_definitions.py` (created by issue #438) was not present on `origin/main` at plan time. Will file a follow-up issue after PR opens; re-check origin/main right before pushing.
+
+## Decisions
+
+- **Home for wiki helpers: `memory_context.py` (not a new `vault_refs.py`).** `memory_context.py` already contains wiki-link handling (`_WIKI_LINK_RE`, `_expand_graph_links`) and the graph-expansion helper reads vault pages via `resolve_page`. New module would be unjustified proliferation. Cohesion check from the spec passed.
+- **Test fixtures' patch target retargeted to source module.** `tests/test_context_composer.py` patches were redirected from `decafclaw.agent._parse_wiki_references` (etc.) to `decafclaw.memory_context.parse_wiki_references`. Because `context_composer.py` does the import function-locally (inside `_compose_vault_references`), the *source-module* patch is the one that fires when the call site looks up the name.
+- **TDD path:** for both phases I updated test imports first (failing import errors = red), then implemented the move (green). Pure-relocation flavor of TDD — the test bodies didn't change, only the names they bind to.
+- **No backwards-compat shims** — per session brief and CLAUDE.md "No deprecated code for test compatibility."
+
+## Verification
+
+- `make check` passes (ruff + pyright + JS tsc — all clean).
+- `make test` passes — 2419 tests, no failures.
+- Grep audit: only the two deferred `_collect_all_tool_defs` imports remain in `src/` for `from .agent import _`. No `from decafclaw.agent import _` anywhere in `src/`.
+
+## What might surprise a reviewer
+
+- The `resolve_page` import inside `read_wiki_page` is function-local — mirrors the function-local import already in `_expand_graph_links` in the same file. Same lazy-import pattern, same reason (avoid pulling skill plumbing at module import time).
+- Two regex constants now live in `memory_context.py`: `_WIKI_LINK_RE` (bare `[[...]]`) and `_WIKI_MENTION_RE` (`@[[...]]`). They are intentionally distinct; the comment above the new one calls this out.
+- `tests/test_vault_tools.py::TestWikiMentionRegex` still reaches into the module-private `_WIKI_MENTION_RE`. That's an existing pattern (tests are allowed to touch private constants); the regex isn't part of the public API and keeping it module-private prevents accidental external use.

--- a/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/plan.md
+++ b/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/plan.md
@@ -1,0 +1,216 @@
+# Context Composer Helper Relocation — Implementation Plan
+
+**Goal:** Move the wiki/page-injection helpers and `_resolve_attachments` out of `agent.py` to honest homes so `context_composer.py` stops importing underscore-prefixed names from `agent.py`.
+
+**Approach:** Pure relocation + rename (drop the `_` prefix). Wiki helpers land in `memory_context.py` (already owns wiki-link handling: `_WIKI_LINK_RE` + `_expand_graph_links`). Attachment helper lands in `attachments.py` (already owns `read_attachment_base64`). Both `agent.py` and `context_composer.py` import from the new homes. No backwards-compat shims.
+
+**Tech stack:** Python 3 stdlib + existing decafclaw modules.
+
+**Scope note:** Sub-task #1 from the spec (updating the `_collect_all_tool_defs` import target) is **deferred** because `tool_definitions.py` does not yet exist on `origin/main` (issue #438 has not merged). This plan covers sub-tasks #2 (wiki helpers) and #3 (attachments). A follow-up issue will be filed after this PR opens.
+
+---
+
+## Phase 1: Relocate `_resolve_attachments` → `attachments.resolve_attachments`
+
+Move the multimodal-content builder from `agent.py:65–110` into `attachments.py` where its only collaborator (`read_attachment_base64`) already lives. Drop the underscore. Update the two import sites (`agent.py` internal uses, `context_composer.py:269`) and the dedicated test file's import path.
+
+**Files:**
+- Modify: `src/decafclaw/attachments.py` — append a new top-level `resolve_attachments(config, message: dict) -> dict` function (body copied verbatim from `agent.py:_resolve_attachments`, minus the function-level `from .attachments import read_attachment_base64` since the call is now intra-module). The module already imports `base64`, `logging`, etc.; no new module-level imports beyond what is already present.
+- Modify: `src/decafclaw/agent.py` — delete the `_resolve_attachments` function definition (lines 65–110). Update any internal use to `from .attachments import resolve_attachments`. Audit: grep showed only `context_composer.py` and the test file used the name externally; internal agent.py use, if any, will surface during edit — none was found in the read.
+- Modify: `src/decafclaw/context_composer.py` — change `from .agent import _resolve_attachments` (line 269) to `from .attachments import resolve_attachments`. Update the call site (line 425): `[_resolve_attachments(config, m) for m in llm_history]` → `[resolve_attachments(config, m) for m in llm_history]`.
+- Modify: `tests/test_resolve_attachments.py` — change `from decafclaw.agent import _resolve_attachments` (line 5) to `from decafclaw.attachments import resolve_attachments`. Update three call sites (lines 12, 28, 48) to use the new name.
+- Modify: `src/decafclaw/llm/providers/vertex.py` — update the two docstring/comment mentions of `_resolve_attachments` (lines 397, 403) to `resolve_attachments` so the dangling reference doesn't rot.
+- Modify: `tests/test_vertex_translation.py` — update the docstring mention of `_resolve_attachments` at line 463 to `resolve_attachments`.
+
+**Key changes:**
+- `resolve_attachments(config, message: dict) -> dict` — new public function in `attachments.py` (body identical to the old `_resolve_attachments`).
+
+```python
+# src/decafclaw/attachments.py — appended after read_attachment_base64
+
+def resolve_attachments(config, message: dict) -> dict:
+    """Transform a message with attachments into multimodal content for the LLM.
+
+    Messages without attachments pass through unchanged. The archive stores
+    plain text + attachment metadata; this builds the ephemeral content array.
+    """
+    atts = message.get("attachments")
+    if not atts:
+        return message
+
+    content_parts: list[dict] = []
+    text = message.get("content", "")
+    if text:
+        content_parts.append({"type": "text", "text": text})
+
+    for att in atts:
+        b64_data = read_attachment_base64(config, att)
+        if b64_data is None:
+            content_parts.append({
+                "type": "text",
+                "text": f"[attachment missing: {att.get('filename', '?')}]",
+            })
+            continue
+
+        mime = att.get("mime_type", "application/octet-stream")
+        # TODO(#137): MIME type is client-supplied — validate with magic bytes
+        # server-side to prevent non-images from being base64-embedded
+        if mime.startswith("image/"):
+            content_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{b64_data}"},
+            })
+        else:
+            content_parts.append({
+                "type": "text",
+                "text": f"[file: {att.get('filename', '?')} ({mime})]",
+            })
+
+    result = {k: v for k, v in message.items() if k != "attachments"}
+    result["content"] = content_parts
+    return result
+```
+
+**Test-first approach:** The pre-existing `tests/test_resolve_attachments.py` already covers this function (pass-through, image, missing-file, non-image cases). The TDD step is to (a) update the test imports to the *new* path first, (b) confirm tests now fail (import error from a not-yet-created `resolve_attachments`), then (c) implement the move. This is the cleanest available "failing test first" for a pure relocation.
+
+**Verification — automated:**
+- [x] `grep -rn "_resolve_attachments" src/ tests/` returns no matches.
+- [x] `pytest tests/test_resolve_attachments.py -v` passes (3 tests).
+- [x] `pytest tests/test_vertex_translation.py -v` passes.
+- [x] `make lint` passes.
+- [x] `make check` passes.
+
+**Verification — manual:**
+- [x] Skim the diff of `attachments.py` and `agent.py` to confirm the move is byte-for-byte (modulo the dropped function-level `read_attachment_base64` import which is now intra-module).
+
+---
+
+## Phase 2: Relocate wiki helpers → `memory_context.py`
+
+Move three helpers and their private regex from `agent.py:896–952` into `memory_context.py` where wiki-link handling already lives (`_WIKI_LINK_RE`, `_expand_graph_links`). Drop the underscore on each public name. Update the import sites (`context_composer.py:725`) and update existing tests to the new path.
+
+**Files:**
+- Modify: `src/decafclaw/memory_context.py` — add a new section "Wiki references — @[[Page]] mentions" (delimiter comment in the established style). Add three new top-level functions: `parse_wiki_references`, `read_wiki_page`, `get_already_injected_pages`. Add module-level `_WIKI_MENTION_RE = re.compile(r'@\[\[([^\]]+)\]\]')` (separate from the existing `_WIKI_LINK_RE` since `@[[...]]` mentions and bare `[[...]]` wiki-links are distinct concepts — preserve the distinction). `resolve_page` from `.skills.vault.tools` is needed; mirror agent.py's pattern of importing it inside `read_wiki_page` (function-local) since `memory_context._expand_graph_links` already does the same thing — keeps the lazy-import pattern consistent within this module and avoids any new import-cycle risk.
+- Modify: `src/decafclaw/agent.py` — delete the wiki helper section (`# -- Wiki context helpers ---`, `_WIKI_MENTION_RE`, `_parse_wiki_references`, `_read_wiki_page`, `_get_already_injected_pages`, lines 896–952). The `import re as _re` at line 18 is used elsewhere in agent.py — verify with grep and keep it if so; remove only if `_WIKI_MENTION_RE` was its sole consumer.
+- Modify: `src/decafclaw/context_composer.py` — change `from .agent import _get_already_injected_pages, _parse_wiki_references, _read_wiki_page` (line 725) to `from .memory_context import get_already_injected_pages, parse_wiki_references, read_wiki_page`. Update the three call sites at lines 731, 735, 743 to drop the underscores.
+- Modify: `tests/test_wiki_context.py` — update the imports at lines 6–8 from `from decafclaw.agent import _get_already_injected_pages, _parse_wiki_references, _read_wiki_page` to `from decafclaw.memory_context import get_already_injected_pages, parse_wiki_references, read_wiki_page`. Update all in-test references (lines 16, 22, 30, 38, 45, 53, 59, 73, 80, 85, 92, 102, 110) to drop the underscore.
+- Modify: `tests/test_vault_tools.py` — three references at lines 867, 869, 873, 875, 879, 881. Update `from decafclaw.agent import _WIKI_MENTION_RE` → `from decafclaw.memory_context import _WIKI_MENTION_RE` (regex stays underscore-prefixed since it's a private module global — tests reaching into it is acceptable, mirroring how `test_memory_context` already touches `_WIKI_LINK_RE` if any do). Update `_parse_wiki_references` → `parse_wiki_references` and adjust the import path.
+- Modify: `tests/test_context_composer.py` — three patch paths at lines 396, 398, 416. Update `patch("decafclaw.agent._parse_wiki_references", ...)` → `patch("decafclaw.memory_context.parse_wiki_references", ...)` and `patch("decafclaw.agent._read_wiki_page", ...)` → `patch("decafclaw.memory_context.read_wiki_page", ...)`. **Important:** patch the *imported* binding inside `context_composer` if these are used post-import — verify by reading the test context. If `context_composer.py` does `from .memory_context import parse_wiki_references` at function scope (which it does — line 725 is a function-local import), the right patch target is `decafclaw.memory_context.parse_wiki_references` (the module where the name is defined). This matches the existing patch pattern in tests where the helpers were `agent._parse_wiki_references` (defined in agent, imported function-locally by composer).
+
+**Key changes:**
+- `parse_wiki_references(user_message: str, wiki_page: str | None = None) -> list[dict]` — new (relocated, renamed).
+- `read_wiki_page(config, page_name: str) -> str | None` — new (relocated, renamed).
+- `get_already_injected_pages(history: list) -> set[str]` — new (relocated, renamed).
+- `_WIKI_MENTION_RE` — new module-level regex in `memory_context.py`.
+
+```python
+# src/decafclaw/memory_context.py — appended in a new section
+
+# -- Wiki references (@[[Page]] mentions) --------------------------------------
+
+# Matches @[[PageName]] (and @[[PageName|display]]) mentions in user messages.
+# Distinct from _WIKI_LINK_RE above which matches bare [[PageName]] links
+# inside vault page bodies.
+_WIKI_MENTION_RE = re.compile(r'@\[\[([^\]]+)\]\]')
+
+
+def parse_wiki_references(
+    user_message: str, wiki_page: str | None = None,
+) -> list[dict]:
+    """Parse @[[PageName]] mentions and optional open wiki page.
+
+    Returns a list of dicts: {"page": name, "source": "mention"|"open_page"}.
+    Does NOT resolve or read pages — caller filters against already-injected
+    pages first, then resolves only the ones needed.
+    """
+    seen: set[str] = set()
+    results: list[dict] = []
+
+    for match in _WIKI_MENTION_RE.finditer(user_message):
+        raw = match.group(1).strip()
+        page_name = raw.split("|")[0].strip()
+        if page_name and page_name not in seen:
+            seen.add(page_name)
+            results.append({"page": page_name, "source": "mention"})
+
+    if wiki_page and wiki_page not in seen:
+        results.append({"page": wiki_page, "source": "open_page"})
+
+    return results
+
+
+def read_wiki_page(config, page_name: str) -> str | None:
+    """Resolve and read a wiki page. Returns content or None. Fail-open."""
+    from .skills.vault.tools import resolve_page
+
+    resolved = resolve_page(config, page_name)
+    if not resolved:
+        return None
+    try:
+        return resolved.read_text()
+    except (OSError, UnicodeError):
+        log.warning("Failed to read wiki page %s at %s", page_name, resolved,
+                    exc_info=True)
+        return None
+
+
+def get_already_injected_pages(history: list) -> set[str]:
+    """Scan history for vault_references messages and return set of page names."""
+    pages: set[str] = set()
+    for msg in history:
+        if msg.get("role") == "vault_references":
+            page = msg.get("wiki_page")
+            if page:
+                pages.add(page)
+    return pages
+```
+
+**Test-first approach:** Same as Phase 1 — update imports in the existing test files first so they fail (or break collection), confirm failure, then complete the move. `tests/test_wiki_context.py` provides comprehensive coverage of all three functions.
+
+**Verification — automated:**
+- [x] `grep -rn "_parse_wiki_references\|_read_wiki_page\|_get_already_injected_pages\|_WIKI_MENTION_RE" src/ tests/` returns only `_WIKI_MENTION_RE` in `memory_context.py` and test files (tests are allowed to reach module-private regex).
+- [x] `pytest tests/test_wiki_context.py -v` passes.
+- [x] `pytest tests/test_vault_tools.py::TestWikiMentionRegex -v` passes.
+- [x] `pytest tests/test_context_composer.py -v` passes (patch targets correctly redirected).
+- [x] `make lint` passes.
+- [x] `make check` passes.
+
+**Verification — manual:**
+- [x] Confirm `_WIKI_LINK_RE` (existing) and `_WIKI_MENTION_RE` (new) live as two distinct regex constants in `memory_context.py`. A reader should be able to tell from the comment which matches which.
+
+---
+
+## Phase 3: Audit and final verification
+
+Confirm the relocation goal — no non-test module imports an underscore-prefixed name from `agent.py` — and run the full suite.
+
+**Files:** None modified in this phase (verification only).
+
+**Verification — automated:**
+- [x] `grep -rn "from .agent import _" src/` shows only the two deferred `_collect_all_tool_defs` lines (sub-task #1, blocked on #438).
+- [x] `grep -rn "from decafclaw.agent import _" src/` returns nothing.
+- [x] `grep -rn "_resolve_attachments\|_parse_wiki_references\|_read_wiki_page\|_get_already_injected_pages" src/` returns nothing.
+- [x] `make check` passes (full lint + typecheck).
+- [x] `make test` passes (full suite, 2419 tests).
+
+**Verification — manual:**
+- [x] Skim the final diff: changes are confined to relocation + rename + import-site updates. No drive-by edits, no behavior changes.
+
+---
+
+## Plan self-review
+
+**Spec coverage:**
+- Spec sub-task #1 (`_collect_all_tool_defs` import update): **deferred** — `tool_definitions.py` not on `origin/main` at plan time. Follow-up issue to be filed after PR opens.
+- Spec sub-task #2 (wiki helpers): covered by Phase 2 (lands in `memory_context.py`, the cohesion check passed — `_WIKI_LINK_RE` and `_expand_graph_links` already live there).
+- Spec sub-task #3 (`_resolve_attachments`): covered by Phase 1.
+- Spec validation criterion (grep audit): covered by Phase 3.
+
+**Placeholder scan:** no TBDs, no "implement later", no "similar to phase N". Each phase carries its full detail.
+
+**Type consistency:** function signatures match between phases and between plan and existing source. New names are the underscore-stripped originals — no renames beyond the underscore drop.
+
+**Rejected during planning:**
+- Creating a new `vault_refs.py` module — rejected because `memory_context.py` already owns wiki-link handling and the helpers are tightly related to existing functions there. New module would be unjustified proliferation.
+- Keeping `_WIKI_MENTION_RE` as a private constant inside `parse_wiki_references` — rejected because tests already import it directly (`tests/test_vault_tools.py:867`), and there's no harm in keeping it module-level (matches `_WIKI_LINK_RE` next door).
+- Backwards-compat shims re-exporting the old names from `agent.py` — explicitly out of scope per the session brief.

--- a/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/spec.md
+++ b/docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/spec.md
@@ -1,0 +1,65 @@
+# Context Composer Helper Relocation Spec
+
+**Goal:** Stop `context_composer.py` from importing underscore-prefixed helpers out of `agent.py`. Move each helper to a module that legitimately owns it so the public import surface is honest.
+
+**Source:** [Issue #439](https://github.com/lmorchard/decafclaw/issues/439)
+
+## Current state
+
+`src/decafclaw/context_composer.py` reaches into `agent.py` for four underscore-prefixed helpers:
+
+| Line | Import | Lives in |
+|---|---|---|
+| `:269` | `from .agent import _resolve_attachments` | `agent.py:65` |
+| `:725` | `from .agent import _get_already_injected_pages, _parse_wiki_references, _read_wiki_page` | `agent.py:901–953` |
+| `:826`, `:1016` | `from .agent import _collect_all_tool_defs` | `agent.py:381` |
+
+The underscore prefix lies about the surface — these are effectively part of the public API of `agent.py`, but cross-module imports of `_`-names are a coupling smell.
+
+## Desired end state
+
+1. **`_collect_all_tool_defs` → `tool_definitions.collect_all_tool_defs`.** This relocation is performed by issue #438; this session only needs to update the import in `context_composer.py` to `from .tool_definitions import collect_all_tool_defs`.
+2. **Wiki/page-injection helpers** (`_get_already_injected_pages`, `_parse_wiki_references`, `_read_wiki_page`) → new home, either `vault_refs.py` (new module) or folded into `memory_context.py` where related vault retrieval lives. Rename to drop the underscore. Both `agent.py` and `context_composer.py` import from the new home.
+3. **`_resolve_attachments` → `attachments.py`** (where it already imports `read_attachment_base64`). Drop the underscore. Update `tests/test_resolve_attachments.py` to the new import path.
+4. Grep audit confirms no `from .agent import _` in any non-test module.
+
+## Design decisions
+
+- **Decision:** Pick `memory_context.py` vs new `vault_refs.py` based on cohesion. If `memory_context.py` already has wiki-link handling, fold the three helpers there; otherwise create `vault_refs.py`.
+  - **Why:** Avoid module proliferation when an existing module already owns the same concept; create a new module only if the existing candidates aren't a good fit.
+  - **Rejected:** Forcing into `agent.py` (the status quo) — fails the refactor goal.
+
+- **Decision:** Drop underscores on the relocated helpers.
+  - **Why:** Same reason as #438 — cross-module imports of `_`-names are a coupling smell. The move is the moment to fix it.
+
+- **Decision:** Treat `_resolve_attachments` as *not* dead code, despite an earlier exploration agent reporting otherwise. Verification showed it's actively called at `context_composer.py:425` and has dedicated tests.
+
+## Patterns to follow
+
+- New-module shape mirrors existing peers (`memory_context.py`, `attachments.py`) — top-level functions, no class wrappers unless state demands it.
+- If creating `vault_refs.py`: keep helpers private (with `_` prefix) unless imported externally; export only the three relocated helpers + anything they need.
+
+## What we're NOT doing
+
+- **NOT performing the `_collect_all_tool_defs` extraction itself** — that's #438. This session only updates the import target.
+- **NOT modifying `_resolve_attachments` behavior** — pure relocation + rename.
+- **NOT modifying wiki-link parsing logic** — pure relocation + rename.
+- **NOT introducing a new module unless `memory_context.py` is the wrong home.**
+- **NOT touching anything in `agent.py` not directly related to these three helpers.**
+
+## Validation
+
+- `make check` (lint + typecheck) green.
+- `make test` green, including `tests/test_resolve_attachments.py` (with updated import path).
+- Grep audit: `grep -rn "from .agent import _" src/` returns nothing in non-test code.
+- Grep audit: `grep -rn "from decafclaw.agent import _" src/` returns nothing in non-test code.
+
+## Sequencing dependency
+
+This session depends on #438 landing first (or at minimum, `tool_definitions.py` being available). If #438 hasn't merged yet, this branch will need to either:
+1. Wait for #438's PR to merge to main, then rebase onto main, OR
+2. Rebase onto the `refactor/agent-split-tools` branch directly so the agent has access to `tool_definitions.py`.
+
+## Open questions
+
+- None blocking — module-home decision (`memory_context.py` vs new `vault_refs.py`) is made during plan/execute by reading `memory_context.py` cohesion.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -62,54 +62,6 @@ def _conv_id(ctx) -> str:
     return ctx.conv_id or ctx.channel_id or "unknown"
 
 
-def _resolve_attachments(config, message: dict) -> dict:
-    """Transform a message with attachments into multimodal content for the LLM.
-
-    Messages without attachments pass through unchanged. The archive stores
-    plain text + attachment metadata; this builds the ephemeral content array.
-    """
-    atts = message.get("attachments")
-    if not atts:
-        return message
-
-    from .attachments import read_attachment_base64
-
-    content_parts: list[dict] = []
-    text = message.get("content", "")
-    if text:
-        content_parts.append({"type": "text", "text": text})
-
-    for att in atts:
-        b64_data = read_attachment_base64(config, att)
-        if b64_data is None:
-            content_parts.append({
-                "type": "text",
-                "text": f"[attachment missing: {att.get('filename', '?')}]",
-            })
-            continue
-
-        mime = att.get("mime_type", "application/octet-stream")
-        # TODO(#137): MIME type is client-supplied — validate with magic bytes
-        # server-side to prevent non-images from being base64-embedded
-        if mime.startswith("image/"):
-            content_parts.append({
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{b64_data}"},
-            })
-        else:
-            # Non-image: represent as a textual placeholder only
-            # (binary data is not sent to the LLM)
-            content_parts.append({
-                "type": "text",
-                "text": f"[file: {att.get('filename', '?')} ({mime})]",
-            })
-
-    # Return message with multimodal content, stripping attachments key
-    result = {k: v for k, v in message.items() if k != "attachments"}
-    result["content"] = content_parts
-    return result
-
-
 def _archive(ctx, msg) -> None:
     """Archive a message, logging errors but never raising."""
     if ctx.skip_archive:
@@ -891,65 +843,6 @@ async def _setup_turn_state(ctx, config, history) -> dict[str, str]:
         log.info("Agent turn: model=%s (legacy config.llm)", config.llm.model)
 
     return model_override
-
-
-# -- Wiki context helpers ------------------------------------------------------
-
-_WIKI_MENTION_RE = _re.compile(r'@\[\[([^\]]+)\]\]')
-
-
-def _parse_wiki_references(
-    user_message: str, wiki_page: str | None = None,
-) -> list[dict]:
-    """Parse @[[PageName]] mentions and optional open wiki page.
-
-    Returns a list of dicts: {"page": name, "source": "mention"|"open_page"}.
-    Does NOT resolve or read pages — caller filters against already-injected
-    pages first, then resolves only the ones needed.
-    """
-    seen: set[str] = set()
-    results: list[dict] = []
-
-    # Parse @[[...]] mentions from message text
-    for match in _WIKI_MENTION_RE.finditer(user_message):
-        raw = match.group(1).strip()
-        # Handle @[[target|display]] — extract target before pipe
-        page_name = raw.split("|")[0].strip()
-        if page_name and page_name not in seen:
-            seen.add(page_name)
-            results.append({"page": page_name, "source": "mention"})
-
-    # Add open wiki page from web UI (if not already mentioned)
-    if wiki_page and wiki_page not in seen:
-        results.append({"page": wiki_page, "source": "open_page"})
-
-    return results
-
-
-def _read_wiki_page(config, page_name: str) -> str | None:
-    """Resolve and read a wiki page. Returns content or None. Fail-open."""
-    from .skills.vault.tools import resolve_page
-
-    resolved = resolve_page(config, page_name)
-    if not resolved:
-        return None
-    try:
-        return resolved.read_text()
-    except (OSError, UnicodeError):
-        log.warning("Failed to read wiki page %s at %s", page_name, resolved,
-                     exc_info=True)
-        return None
-
-
-def _get_already_injected_pages(history: list) -> set[str]:
-    """Scan history for vault_references messages and return set of page names."""
-    pages: set[str] = set()
-    for msg in history:
-        if msg.get("role") == "vault_references":
-            page = msg.get("wiki_page")
-            if page:
-                pages.add(page)
-    return pages
 
 
 class IterationOutcome:

--- a/src/decafclaw/attachments.py
+++ b/src/decafclaw/attachments.py
@@ -93,3 +93,49 @@ def delete_conversation_uploads(config, conv_id: str) -> None:
     dest_dir = uploads_dir(config, conv_id)
     if dest_dir.exists():
         shutil.rmtree(dest_dir)
+
+
+def resolve_attachments(config, message: dict) -> dict:
+    """Transform a message with attachments into multimodal content for the LLM.
+
+    Messages without attachments pass through unchanged. The archive stores
+    plain text + attachment metadata; this builds the ephemeral content array.
+    """
+    atts = message.get("attachments")
+    if not atts:
+        return message
+
+    content_parts: list[dict] = []
+    text = message.get("content", "")
+    if text:
+        content_parts.append({"type": "text", "text": text})
+
+    for att in atts:
+        b64_data = read_attachment_base64(config, att)
+        if b64_data is None:
+            content_parts.append({
+                "type": "text",
+                "text": f"[attachment missing: {att.get('filename', '?')}]",
+            })
+            continue
+
+        mime = att.get("mime_type", "application/octet-stream")
+        # TODO(#137): MIME type is client-supplied — validate with magic bytes
+        # server-side to prevent non-images from being base64-embedded
+        if mime.startswith("image/"):
+            content_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{b64_data}"},
+            })
+        else:
+            # Non-image: represent as a textual placeholder only
+            # (binary data is not sent to the LLM)
+            content_parts.append({
+                "type": "text",
+                "text": f"[file: {att.get('filename', '?')} ({mime})]",
+            })
+
+    # Return message with multimodal content, stripping attachments key
+    result = {k: v for k, v in message.items() if k != "attachments"}
+    result["content"] = content_parts
+    return result

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -266,8 +266,8 @@ class ContextComposer:
         Does NOT archive — the caller is responsible for persisting messages
         via the messages_to_archive list.
         """
-        from .agent import _resolve_attachments
         from .archive import LLM_ROLES
+        from .attachments import resolve_attachments
         from .util import estimate_tokens
 
         config = ctx.config
@@ -422,7 +422,7 @@ class ContextComposer:
         # Fix: pull tool results out and reattach them right after their
         # matching assistant message; drop any with no match.
         llm_history = _reorder_tool_results(llm_history)
-        llm_history = [_resolve_attachments(config, m) for m in llm_history]
+        llm_history = [resolve_attachments(config, m) for m in llm_history]
 
         # -- History source entry --
         # history_tokens was computed above (budget side); reuse the same value
@@ -722,17 +722,21 @@ class ContextComposer:
         if mode in skip_modes:
             return [], None
 
-        from .agent import _get_already_injected_pages, _parse_wiki_references, _read_wiki_page
+        from .memory_context import (
+            get_already_injected_pages,
+            parse_wiki_references,
+            read_wiki_page,
+        )
 
         vault_dir = config.vault_root
         if not vault_dir.exists():
             return [], None
 
-        wiki_refs = _parse_wiki_references(user_message, ctx.wiki_page)
+        wiki_refs = parse_wiki_references(user_message, ctx.wiki_page)
         if not wiki_refs:
             return [], None
 
-        already_injected = _get_already_injected_pages(history)
+        already_injected = get_already_injected_pages(history)
         messages = []
         skipped = 0
 
@@ -740,7 +744,7 @@ class ContextComposer:
             if ref["page"] in already_injected:
                 skipped += 1
                 continue
-            content = _read_wiki_page(config, ref["page"])
+            content = read_wiki_page(config, ref["page"])
             if content is None:
                 text = f"[Wiki page '{ref['page']}' not found]"
             elif ref["source"] == "open_page":

--- a/src/decafclaw/llm/providers/vertex.py
+++ b/src/decafclaw/llm/providers/vertex.py
@@ -394,13 +394,13 @@ def _content_to_parts(content) -> list[dict]:
     """Convert message content (string or multimodal list) to Vertex parts.
 
     Handles both plain string content and the OpenAI multimodal format
-    produced by _resolve_attachments: [{"type": "text", ...}, {"type": "image_url", ...}].
+    produced by resolve_attachments: [{"type": "text", ...}, {"type": "image_url", ...}].
     """
     if not content:
         return []
     if isinstance(content, str):
         return [{"text": content}]
-    # Multimodal list (from _resolve_attachments)
+    # Multimodal list (from resolve_attachments)
     parts = []
     for item in content:
         item_type = item.get("type", "")

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -299,3 +299,65 @@ def _excerpt_for_headline(text: str, max_chars: int) -> str:
     # Collapse internal whitespace so the headline is one tidy line.
     cleaned = " ".join(text.split())
     return cleaned[:max_chars] if max_chars > 0 else cleaned
+
+
+# -- Wiki references (@[[Page]] mentions) --------------------------------------
+
+# Matches @[[PageName]] (and @[[PageName|display]]) mentions in user messages.
+# Distinct from _WIKI_LINK_RE above which matches bare [[PageName]] links
+# inside vault page bodies.
+_WIKI_MENTION_RE = re.compile(r'@\[\[([^\]]+)\]\]')
+
+
+def parse_wiki_references(
+    user_message: str, wiki_page: str | None = None,
+) -> list[dict]:
+    """Parse @[[PageName]] mentions and optional open wiki page.
+
+    Returns a list of dicts: {"page": name, "source": "mention"|"open_page"}.
+    Does NOT resolve or read pages — caller filters against already-injected
+    pages first, then resolves only the ones needed.
+    """
+    seen: set[str] = set()
+    results: list[dict] = []
+
+    # Parse @[[...]] mentions from message text
+    for match in _WIKI_MENTION_RE.finditer(user_message):
+        raw = match.group(1).strip()
+        # Handle @[[target|display]] — extract target before pipe
+        page_name = raw.split("|")[0].strip()
+        if page_name and page_name not in seen:
+            seen.add(page_name)
+            results.append({"page": page_name, "source": "mention"})
+
+    # Add open wiki page from web UI (if not already mentioned)
+    if wiki_page and wiki_page not in seen:
+        results.append({"page": wiki_page, "source": "open_page"})
+
+    return results
+
+
+def read_wiki_page(config, page_name: str) -> str | None:
+    """Resolve and read a wiki page. Returns content or None. Fail-open."""
+    from .skills.vault.tools import resolve_page
+
+    resolved = resolve_page(config, page_name)
+    if not resolved:
+        return None
+    try:
+        return resolved.read_text()
+    except (OSError, UnicodeError):
+        log.warning("Failed to read wiki page %s at %s", page_name, resolved,
+                    exc_info=True)
+        return None
+
+
+def get_already_injected_pages(history: list) -> set[str]:
+    """Scan history for vault_references messages and return set of page names."""
+    pages: set[str] = set()
+    for msg in history:
+        if msg.get("role") == "vault_references":
+            page = msg.get("wiki_page")
+            if page:
+                pages.add(page)
+    return pages

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -393,9 +393,9 @@ class TestComposeWikiContext:
         vault_dir = tmp_path / "vault"
         vault_dir.mkdir()
         config.vault.vault_path = str(vault_dir)
-        with patch("decafclaw.agent._parse_wiki_references",
+        with patch("decafclaw.memory_context.parse_wiki_references",
                    return_value=[{"page": "TestPage", "source": "mention"}]):
-            with patch("decafclaw.agent._read_wiki_page",
+            with patch("decafclaw.memory_context.read_wiki_page",
                        return_value="Page content here"):
                 composer = ContextComposer()
                 msgs, entry = composer._compose_vault_references(
@@ -413,7 +413,7 @@ class TestComposeWikiContext:
         vault_dir.mkdir()
         config.vault.vault_path = str(vault_dir)
         history = [{"role": "vault_references", "content": "old", "wiki_page": "TestPage"}]
-        with patch("decafclaw.agent._parse_wiki_references",
+        with patch("decafclaw.memory_context.parse_wiki_references",
                    return_value=[{"page": "TestPage", "source": "mention"}]):
             composer = ContextComposer()
             msgs, entry = composer._compose_vault_references(

--- a/tests/test_resolve_attachments.py
+++ b/tests/test_resolve_attachments.py
@@ -1,15 +1,14 @@
-"""Tests for _resolve_attachments in agent.py."""
+"""Tests for resolve_attachments in attachments.py."""
 
 import pytest
 
-from decafclaw.agent import _resolve_attachments
-from decafclaw.attachments import save_attachment
+from decafclaw.attachments import resolve_attachments, save_attachment
 
 
 def test_message_without_attachments_passes_through(config):
     """Messages without attachments are returned unchanged."""
     msg = {"role": "user", "content": "hello"}
-    result = _resolve_attachments(config, msg)
+    result = resolve_attachments(config, msg)
     assert result is msg
 
 
@@ -25,7 +24,7 @@ def test_image_attachment_becomes_multimodal(config):
     att = save_attachment(config, "test-conv", "photo.png", pixel, "image/png")
 
     msg = {"role": "user", "content": "look at this", "attachments": [att]}
-    result = _resolve_attachments(config, msg)
+    result = resolve_attachments(config, msg)
 
     assert "attachments" not in result
     assert isinstance(result["content"], list)
@@ -45,7 +44,7 @@ def test_missing_file_gets_placeholder(config):
         "mime_type": "image/png",
     }
     msg = {"role": "user", "content": "see this", "attachments": [att]}
-    result = _resolve_attachments(config, msg)
+    result = resolve_attachments(config, msg)
 
     assert isinstance(result["content"], list)
     # Text content still present

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -864,21 +864,21 @@ class TestWikiMentionRegex:
     """Verify @[[folder/Page]] mentions work with folder paths."""
 
     def test_folder_path_mention(self):
-        from decafclaw.agent import _WIKI_MENTION_RE
+        from decafclaw.memory_context import _WIKI_MENTION_RE
         text = "Check @[[agent/pages/Foo]] for details"
         matches = _WIKI_MENTION_RE.findall(text)
         assert matches == ["agent/pages/Foo"]
 
     def test_pipe_display_with_folder(self):
-        from decafclaw.agent import _WIKI_MENTION_RE
+        from decafclaw.memory_context import _WIKI_MENTION_RE
         text = "See @[[agent/pages/Foo|my display text]]"
         matches = _WIKI_MENTION_RE.findall(text)
         assert matches == ["agent/pages/Foo|my display text"]
 
     def test_multiple_folder_mentions(self):
-        from decafclaw.agent import _parse_wiki_references
+        from decafclaw.memory_context import parse_wiki_references
         text = "Check @[[projects/Alpha]] and @[[people/Bob]]"
-        results = _parse_wiki_references(text)
+        results = parse_wiki_references(text)
         pages = [r["page"] for r in results]
         assert "projects/Alpha" in pages
         assert "people/Bob" in pages

--- a/tests/test_vertex_translation.py
+++ b/tests/test_vertex_translation.py
@@ -460,7 +460,7 @@ def test_parse_usage_missing():
 
 
 def test_user_message_with_image_attachment():
-    """Multimodal user content (from _resolve_attachments) → Vertex inlineData."""
+    """Multimodal user content (from resolve_attachments) → Vertex inlineData."""
     messages = [{
         "role": "user",
         "content": [

--- a/tests/test_wiki_context.py
+++ b/tests/test_wiki_context.py
@@ -2,24 +2,24 @@
 
 import pytest
 
-from decafclaw.agent import (
-    _get_already_injected_pages,
-    _parse_wiki_references,
-    _read_wiki_page,
+from decafclaw.memory_context import (
+    get_already_injected_pages,
+    parse_wiki_references,
+    read_wiki_page,
 )
 
-# -- _parse_wiki_references ---------------------------------------------------
+# -- parse_wiki_references ----------------------------------------------------
 
 
 def test_parse_no_mentions_no_page():
     """No @[[...]] and no wiki_page → empty list."""
-    result = _parse_wiki_references("hello world")
+    result = parse_wiki_references("hello world")
     assert result == []
 
 
 def test_parse_mention():
     """@[[TestPage]] is parsed."""
-    result = _parse_wiki_references("check @[[TestPage]] please")
+    result = parse_wiki_references("check @[[TestPage]] please")
     assert len(result) == 1
     assert result[0]["page"] == "TestPage"
     assert result[0]["source"] == "mention"
@@ -27,7 +27,7 @@ def test_parse_mention():
 
 def test_parse_open_page():
     """wiki_page param appears as open_page source."""
-    result = _parse_wiki_references("hello", wiki_page="OpenPage")
+    result = parse_wiki_references("hello", wiki_page="OpenPage")
     assert len(result) == 1
     assert result[0]["page"] == "OpenPage"
     assert result[0]["source"] == "open_page"
@@ -35,14 +35,14 @@ def test_parse_open_page():
 
 def test_parse_dedup_mention_and_open_page():
     """If @[[X]] and wiki_page=X, only one entry (mention wins)."""
-    result = _parse_wiki_references("@[[Page]]", wiki_page="Page")
+    result = parse_wiki_references("@[[Page]]", wiki_page="Page")
     assert len(result) == 1
     assert result[0]["source"] == "mention"
 
 
 def test_parse_multiple_mentions():
     """Multiple @[[...]] in one message all parse."""
-    result = _parse_wiki_references("see @[[A]] and @[[B]]")
+    result = parse_wiki_references("see @[[A]] and @[[B]]")
     assert len(result) == 2
     pages = {r["page"] for r in result}
     assert pages == {"A", "B"}
@@ -50,19 +50,19 @@ def test_parse_multiple_mentions():
 
 def test_parse_duplicate_mention():
     """Same page mentioned twice → only one entry."""
-    result = _parse_wiki_references("@[[X]] and @[[X]]")
+    result = parse_wiki_references("@[[X]] and @[[X]]")
     assert len(result) == 1
 
 
 def test_parse_pipe_display_syntax():
     """@[[target|display]] extracts the target before the pipe."""
-    result = _parse_wiki_references("see @[[Tempest (arcade game)|Tempest arcade game]]")
+    result = parse_wiki_references("see @[[Tempest (arcade game)|Tempest arcade game]]")
     assert len(result) == 1
     assert result[0]["page"] == "Tempest (arcade game)"
     assert result[0]["source"] == "mention"
 
 
-# -- _read_wiki_page ----------------------------------------------------------
+# -- read_wiki_page -----------------------------------------------------------
 
 
 def test_read_wiki_page_found(config):
@@ -70,26 +70,26 @@ def test_read_wiki_page_found(config):
     vault_dir = config.vault_root
     vault_dir.mkdir(parents=True, exist_ok=True)
     (vault_dir / "TestPage.md").write_text("# Test\nHello")
-    assert _read_wiki_page(config, "TestPage") == "# Test\nHello"
+    assert read_wiki_page(config, "TestPage") == "# Test\nHello"
 
 
 def test_read_wiki_page_not_found(config):
     """Missing page returns None."""
     vault_dir = config.vault_root
     vault_dir.mkdir(parents=True, exist_ok=True)
-    assert _read_wiki_page(config, "Missing") is None
+    assert read_wiki_page(config, "Missing") is None
 
 
 def test_read_wiki_page_no_vault_dir(config):
     """No vault directory → None (no crash)."""
-    assert _read_wiki_page(config, "Anything") is None
+    assert read_wiki_page(config, "Anything") is None
 
 
-# -- _get_already_injected_pages -----------------------------------------------
+# -- get_already_injected_pages -----------------------------------------------
 
 
 def test_already_injected_empty():
-    assert _get_already_injected_pages([]) == set()
+    assert get_already_injected_pages([]) == set()
 
 
 def test_already_injected_finds_vault_references():
@@ -99,7 +99,7 @@ def test_already_injected_finds_vault_references():
         {"role": "assistant", "content": "ok"},
         {"role": "vault_references", "content": "...", "wiki_page": "Page2"},
     ]
-    assert _get_already_injected_pages(history) == {"Page1", "Page2"}
+    assert get_already_injected_pages(history) == {"Page1", "Page2"}
 
 
 def test_already_injected_ignores_other_roles():
@@ -107,7 +107,7 @@ def test_already_injected_ignores_other_roles():
         {"role": "user", "content": "hi"},
         {"role": "vault_retrieval", "content": "..."},
     ]
-    assert _get_already_injected_pages(history) == set()
+    assert get_already_injected_pages(history) == set()
 
 
 # -- Integration: wiki context via ContextComposer --------------------------------


### PR DESCRIPTION
## Summary
- Stop `context_composer.py` from importing underscore-prefixed helpers out of `agent.py`. Move each helper to a module that legitimately owns it so the public import surface is honest.
- Pure relocation + rename (drop the `_` prefix). No behavior changes.

## Design Decisions
- **Wiki helpers home: `memory_context.py`, not a new module.** `memory_context.py` already owns wiki-link handling (`_WIKI_LINK_RE`, `_expand_graph_links`). Creating a new `vault_refs.py` would be unjustified proliferation. The new `_WIKI_MENTION_RE` (for `@[[Page]]` mentions in user messages) lives next to the pre-existing `_WIKI_LINK_RE` (for bare `[[Page]]` links in vault page bodies); a comment distinguishes the two.
- **`resolve_attachments` home: `attachments.py`.** Its only collaborator, `read_attachment_base64`, already lives there. The relocation lets the function-local `from .attachments import read_attachment_base64` shim go away — now an intra-module call.
- **Drop the underscore on relocated public helpers.** Cross-module imports of `_`-names are a coupling smell. The move is the moment to fix it. The `_WIKI_MENTION_RE` regex stays underscore-prefixed as a module-private constant; existing tests that reach into it (`test_vault_tools.py::TestWikiMentionRegex`) follow the existing pattern of allowing tests to touch private module globals.
- **No backwards-compat shims.** Per CLAUDE.md ("No deprecated code for test compatibility") — the relocation IS the rename.

## Sub-task deferred
The third sub-task from the spec — updating the `_collect_all_tool_defs` import target to `tool_definitions.collect_all_tool_defs` — is **deferred** because `src/decafclaw/tool_definitions.py` (created by #438) is not yet on `main`. A follow-up issue will be filed once this PR is open. The two remaining `from .agent import _collect_all_tool_defs` lines in `context_composer.py` are the only `from .agent import _` imports left in `src/`.

## Changes
- `src/decafclaw/agent.py` — delete relocated definitions (`_resolve_attachments`, `_WIKI_MENTION_RE`, `_parse_wiki_references`, `_read_wiki_page`, `_get_already_injected_pages`). No other changes.
- `src/decafclaw/attachments.py` — add `resolve_attachments`.
- `src/decafclaw/memory_context.py` — add the "Wiki references" section: `_WIKI_MENTION_RE`, `parse_wiki_references`, `read_wiki_page`, `get_already_injected_pages`.
- `src/decafclaw/context_composer.py` — import the renamed helpers from their new homes; update three internal call sites.
- `src/decafclaw/llm/providers/vertex.py` — update docstring/comment references to `resolve_attachments` (no code change).
- Tests: `test_resolve_attachments.py`, `test_wiki_context.py`, `test_vault_tools.py`, `test_context_composer.py`, `test_vertex_translation.py` — updated import paths, function names, and `mock.patch` targets (now patching `decafclaw.memory_context.*` instead of `decafclaw.agent.*`).

## Test Plan
- [x] `make check` (ruff + pyright + JS tsc) — green
- [x] `make test` — 2419 tests, all pass
- [x] Grep audit: `grep -rn "from .agent import _" src/` shows only the two deferred `_collect_all_tool_defs` imports
- [x] Grep audit: `grep -rn "_resolve_attachments\|_parse_wiki_references\|_read_wiki_page\|_get_already_injected_pages" src/` returns nothing
- [ ] Smoke test in live UI / Mattermost after merge — wiki references (`@[[Page]]`) still inject correctly; image attachments still flow through to the LLM as multimodal content

## References
- Spec: `docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/spec.md`
- Plan: `docs/dev-sessions/2026-05-13-0939-composer-helper-relocation/plan.md`
- Refs #439 (does NOT close — sub-task #1 deferred to follow-up; this PR handles sub-tasks #2 and #3)
- Related: #438 (relocates `_collect_all_tool_defs` to `tool_definitions.py`; the import-update follow-up depends on it)