### PR TITLE
refactor(agent): extract tool_execution + tool_definitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,12 +130,14 @@ See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui
 Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 
 ### Core
-- `agent.py` — Agent loop: turn orchestration, tool execution, LLM calls
+- `agent.py` — Agent loop: turn orchestration, LLM calls, iteration outcomes (`TurnRunner`, `run_agent_turn`)
 - `conversation_manager.py` — Central orchestrator: TurnKind dispatch, confirmation persistence, per-conversation event streams
 - `context.py` — Forkable runtime context (TokenUsage, ToolState, SkillState, ComposerState)
 - `context_composer.py` — Unified context assembly, relevance scoring, dynamic budget allocation
 - `events.py` — Pub/sub event bus
 - `runner.py` — Top-level orchestrator: MCP, HTTP, Mattermost, heartbeat as parallel tasks
+- `tool_definitions.py` — Tool-registry assembly: classification, deferral, dynamic-skill providers (`build_tool_list`, `collect_all_tool_defs`, `refresh_dynamic_tools`)
+- `tool_execution.py` — Concurrent tool-call execution: media handling, widget validation, end-turn signals (`execute_tool_calls`, `execute_single_tool`, `process_tool_media`, `resolve_widget`)
 - `confirmations.py` — Confirmation types and handler registry
 
 ### Config and LLM

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ When the model emits multiple tool calls in a single response, they run concurre
 semaphore = asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)  # default 5
 
 tasks = [
-    _execute_single_tool(parent.fork_for_tool_call(tc.id), tc, semaphore)
+    execute_single_tool(parent.fork_for_tool_call(tc.id), tc, semaphore)
     for tc in tool_calls
 ]
 results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/docs/dev-sessions/2026-05-13-0939-agent-split-tools/notes.md
+++ b/docs/dev-sessions/2026-05-13-0939-agent-split-tools/notes.md
@@ -1,0 +1,36 @@
+# Agent.py split — session notes
+
+## Outcome
+- PR: https://github.com/lmorchard/decafclaw/pull/483
+- Issue: #438 (auto-closes on merge via `Closes #438`)
+- Status: opened, Copilot review clean (no inline comments), board moved to "In review"
+
+## Line counts
+| File | Before | After |
+|---|---|---|
+| `src/decafclaw/agent.py` | 1451 | 1000 |
+| `src/decafclaw/tool_definitions.py` | — | 166 |
+| `src/decafclaw/tool_execution.py` | — | 364 |
+
+The 250-line gap vs. the spec's "~750" target on `agent.py` is the wiki/attachment helper cluster (`_resolve_attachments`, `_parse_wiki_references`, `_read_wiki_page`, `_get_already_injected_pages`, `_WIKI_MENTION_RE`) — explicitly deferred to #439 in the spec's "What we're NOT doing" section.
+
+## Phase summary
+- **Phase 1** — `tool_definitions.py` created. Registry cluster moved (`collect_all_tool_defs`, `build_tool_list`, `refresh_dynamic_tools`, `invalidate_skill_cache`, `_skill_def_cache`). Imports updated in `agent.py`, `context_composer.py`, `tools/skill_tools.py`. Test patch targets updated in `test_context_composer.py` (24 sites) + `test_orphaned_tool_results.py` (1 site).
+- **Phase 2** — `tool_execution.py` created. Invocation cluster moved (`execute_tool_calls`, `execute_single_tool`, `process_tool_media`, `resolve_widget`, `_media_placeholder_pattern`). `_archive`, `_check_cancelled`, `_conv_id` duplicated into the new module (22 lines, intentional, comment documents why). Test patch targets updated across 4 test files.
+- **Phase 3** — Docs sync. CLAUDE.md "Core" key-files list updated with the two new modules; `docs/architecture.md` tool-execution-concurrency snippet drops the leading underscore on `execute_single_tool`.
+
+## Verification
+- `make check` — green (lint + pyright + tsc + message-types drift)
+- `make test` — 2419 passed, 0 failed
+- Smoke tests for new public surface + `eval.runner.run_agent_turn` — all OK
+
+## Surprises / learnings
+1. **Test patch targets matter more than expected.** 27 test sites referenced `decafclaw.agent._collect_all_tool_defs` via `unittest.mock.patch(...)`. The first `make test` after Phase 1 failed loudly because patch targets are strings, not symbols — the linter and pyright can't catch them. Grep before committing if you touch a module that tests patch.
+2. **`functools` / `json` / `dataclasses.replace` all became dead imports in `agent.py` after Phase 2.** Ruff caught them via the import-organization rule once Phase 1's check-message-types step completed. Good signal that the relocation was clean — nothing else in agent.py needed those.
+3. **Spec's "~750 lines" target wasn't a hard floor.** The wiki/attachment helpers (~250 lines) are #439's scope. Recognizing the deferred-work boundary kept this PR focused; landing both halves together would have made the diff harder to review.
+
+## Plan adaptations
+- Plan's Phase 2 anticipated the `_archive` / `_check_cancelled` circular-import problem and resolved it inline (duplicate the two helpers into `tool_execution.py` rather than carve out a third module). Worked exactly as planned — no surprises during execution.
+
+## What's next
+- Issue #439 will take the wiki/attachment helpers into `context_composer.py`. The #439 agent has been deferring its work pending this PR's `tool_definitions.py` landing — once #483 merges, #439's import target exists.

--- a/docs/dev-sessions/2026-05-13-0939-agent-split-tools/plan.md
+++ b/docs/dev-sessions/2026-05-13-0939-agent-split-tools/plan.md
@@ -1,0 +1,180 @@
+# Agent.py Split — Extract tool_execution + tool_definitions Plan
+
+**Goal:** Relocate tool-invocation and tool-registry machinery out of `agent.py` into dedicated `tool_execution.py` and `tool_definitions.py` modules, dropping `agent.py` from ~1451 lines to ~750.
+
+**Approach:** Pure relocation in two atomic moves. The invocation cluster (`execute_tool_calls`, `execute_single_tool`, `process_tool_media`, `resolve_widget`, `_media_placeholder_pattern`) moves to `tool_execution.py`. The registry cluster (`collect_all_tool_defs`, `build_tool_list`, `refresh_dynamic_tools`, `_skill_def_cache` + `invalidate_skill_cache`) moves to `tool_definitions.py`. Underscores drop on the relocated public functions; module-internal helpers stay private. No behavior changes.
+
+**Tech stack:** Python 3.11+, async/await, dataclasses; no new dependencies.
+
+**TDD opt-out:** This is a pure-relocation refactor. The existing test suite (`tests/test_agent_turn.py`, `tests/test_agent_widgets.py`, `tests/test_process_tool_media.py`, `tests/test_tool_result_data.py`) is the regression net — it must remain green after each phase. No new tests are added; existing tests will be updated to import from the new module paths.
+
+---
+
+## Phase 1: Create `tool_definitions.py` (registry cluster)
+
+Move the tool-registry machinery out of `agent.py` into a new `tool_definitions.py` so both `agent.py` (the iteration loop) and `context_composer.py` (#439 follow-up) have a clean import target.
+
+**Files:**
+- Create: `src/decafclaw/tool_definitions.py`
+- Modify: `src/decafclaw/agent.py` — remove the registry functions and their module-level cache; import from new module where the loop still uses them
+- Modify: `src/decafclaw/context_composer.py` — update the two deferred imports of `_collect_all_tool_defs` to import `collect_all_tool_defs` from `.tool_definitions`
+- Modify: `src/decafclaw/tools/skill_tools.py` — update the deferred `invalidate_skill_cache` import to `from ..tool_definitions import invalidate_skill_cache`
+- Modify: `tests/test_agent_turn.py` — update the `from decafclaw.agent import (..., _build_tool_list, ..., _refresh_dynamic_tools, ...)` to use the new module + dropped underscores
+
+**Key changes:**
+- New module `tool_definitions.py` exports three public functions and `invalidate_skill_cache`:
+  - `collect_all_tool_defs(ctx) -> list` (was `_collect_all_tool_defs`)
+  - `build_tool_list(ctx) -> tuple[list, str | None]` (was `_build_tool_list`)
+  - `refresh_dynamic_tools(ctx) -> None` (was `_refresh_dynamic_tools`)
+  - `invalidate_skill_cache(config) -> None` (unchanged — already public)
+  - Module-level `_skill_def_cache: dict[int, list]` (stays private — internal cache state)
+- `agent.py` imports from the new module:
+  ```python
+  from .tool_definitions import build_tool_list, refresh_dynamic_tools
+  ```
+- The call sites in `TurnRunner._run_iteration` change from `_refresh_dynamic_tools(self.ctx)` / `_build_tool_list(self.ctx)` to `refresh_dynamic_tools(self.ctx)` / `build_tool_list(self.ctx)`.
+- `context_composer.py` lines 826 + 1016 change from `from .agent import _collect_all_tool_defs` → `from .tool_definitions import collect_all_tool_defs`, and the call sites at 865 / 1027 drop the leading underscore.
+- `tools/skill_tools.py` line 248 changes from `from ..agent import invalidate_skill_cache` → `from ..tool_definitions import invalidate_skill_cache`.
+
+**Imports the new module needs:**
+- stdlib: `logging`
+- `from .tools import TOOL_DEFINITIONS`
+- `from .tools.search_tools import SEARCH_TOOL_DEFINITIONS`
+- `from .tools.tool_registry import build_deferred_list_text, classify_tools, get_fetched_tools`
+- Deferred (function-local, breaking cycles): `from .tools.skill_tools import _load_native_tools` (already deferred in current code at line 400), `from .mcp_client import get_registry`
+
+**Verification — automated** (see `references/makefile-conventions.md`):
+- [x] `make lint` passes
+- [x] `make check` passes (lint + typecheck + message-types drift)
+- [x] `make test` passes (2419 passed)
+- [x] `grep -n "from .agent import _collect_all_tool_defs\|from .agent import _refresh_dynamic_tools\|from .agent import _build_tool_list\|from .agent import invalidate_skill_cache" src/ tests/` returns nothing
+
+**Verification — manual:**
+- [x] `agent.py` no longer contains `_collect_all_tool_defs`, `_build_tool_list`, `_refresh_dynamic_tools`, `_skill_def_cache`, `invalidate_skill_cache`
+- [x] `tool_definitions.py` exists and is 166 lines
+- [x] Importing `decafclaw` at the package level still works (no circular-import regression): `python -c "import decafclaw.agent"`
+
+---
+
+## Phase 2: Create `tool_execution.py` (invocation cluster)
+
+Move the tool-invocation machinery out of `agent.py` into a new `tool_execution.py`. The invocation cluster is internal to the agent loop (no `context_composer.py` consumers), so this phase is a strict move-and-rename.
+
+**Files:**
+- Create: `src/decafclaw/tool_execution.py`
+- Modify: `src/decafclaw/agent.py` — remove the invocation functions; import `execute_tool_calls` from new module
+- Modify: `tests/test_agent_turn.py` — update imports for `_execute_tool_calls`; update `patch("decafclaw.agent.execute_tool", ...)` patch targets to `patch("decafclaw.tool_execution.execute_tool", ...)`
+- Modify: `tests/test_agent_widgets.py` — update imports for `_execute_tool_calls`, `_resolve_widget`
+- Modify: `tests/test_process_tool_media.py` — update import for `_process_tool_media`
+- Modify: `tests/test_tool_result_data.py` — update inline imports + patch targets for `_execute_single_tool`
+
+**Key changes:**
+- New module `tool_execution.py` exports public functions:
+  - `execute_tool_calls(ctx, tool_calls, history, messages)` (was `_execute_tool_calls`) — the only one `agent.py` will import
+  - `execute_single_tool(call_ctx, tc, semaphore)` (was `_execute_single_tool`) — used by tests; also publicly callable
+  - `process_tool_media(ctx, result)` (was `_process_tool_media`) — used by tests
+  - `resolve_widget(fn_name, result, tool_call_id="")` (was `_resolve_widget`) — used by tests
+  - Module-internal: `_media_placeholder_pattern(filename)` keeps its underscore — pure private helper
+- `agent.py` imports:
+  ```python
+  from .tool_execution import execute_tool_calls
+  ```
+- `agent.py` keeps `_check_cancelled` and `_archive` since they are also called by orchestration code outside the tool-execution cluster (e.g. `_handle_no_tool_calls`, `_compose`, `_finalize_max_iterations`, `TurnRunner._run_iteration`). The new module re-imports `_archive` and `_check_cancelled` from `agent.py`? **NO — circular import risk.** Instead, factor a tiny shared helpers module or pass these as args.
+
+  **Resolved decision:** `_archive` and `_check_cancelled` both depend only on `archive.append_message`, `ctx`, and `history`. We can simply **copy the two helpers into `tool_execution.py` as module-level private functions** — they're 10 lines combined and changing them in lockstep is acceptable (they're not part of a public API and not expected to change frequently). This avoids the circular import without creating a third "agent_helpers" module. The duplication is intentional and noted in a comment.
+
+  **Rejected alternative:** Extract `_archive` / `_check_cancelled` to a new `agent_helpers.py`. Adds a third module for two trivial helpers when the spec asks for two new modules total.
+
+  **Rejected alternative:** Pass `archive_fn` / `check_cancelled_fn` as arguments. Over-engineered for two helpers used only inside this loop.
+
+**Call-site changes in `agent.py`:**
+- `await _execute_tool_calls(self.ctx, tool_calls, ...)` → `await execute_tool_calls(self.ctx, tool_calls, ...)`
+
+**Imports the new module needs:**
+- stdlib: `asyncio`, `functools`, `json`, `logging`, `re`
+- `from .archive import append_message`
+- `from .media import EndTurnConfirm, ToolResult, WidgetInputPause`
+- `from .tools import execute_tool`
+- Deferred (function-local, breaking cycles): `from .widgets import get_widget_registry`, `from .widget_input import pending_callbacks` — keep deferred as in the current code
+
+**Test patch-target updates:**
+- `tests/test_agent_turn.py`: 9 `patch("decafclaw.agent.execute_tool", ...)` → `patch("decafclaw.tool_execution.execute_tool", ...)`
+- `tests/test_tool_result_data.py`: 3 `patch("decafclaw.agent.execute_tool", ...)` → `patch("decafclaw.tool_execution.execute_tool", ...)`; 3 inline imports `from decafclaw.agent import _execute_single_tool` → `from decafclaw.tool_execution import execute_single_tool`
+- `tests/test_agent_widgets.py`: `from decafclaw.agent import _execute_tool_calls, _resolve_widget` → `from decafclaw.tool_execution import execute_tool_calls, resolve_widget`
+- `tests/test_process_tool_media.py`: `from decafclaw.agent import _process_tool_media` → `from decafclaw.tool_execution import process_tool_media`
+
+**Verification — automated**:
+- [x] `make lint` passes
+- [x] `make check` passes
+- [x] `make test` passes (2419 passed)
+- [x] `grep -n "from .agent import _execute_\|from .agent import _process_tool_media\|from .agent import _resolve_widget" src/ tests/` returns nothing
+- [x] `wc -l src/decafclaw/agent.py` shows 1000 lines (target was ~750; remaining ~250 lines are wiki/attachment helpers explicitly deferred to issue #439 — spec called them out under "What we're NOT doing")
+
+**Verification — manual:**
+- [x] `agent.py` no longer contains `_execute_tool_calls`, `_execute_single_tool`, `_process_tool_media`, `_resolve_widget`, `_media_placeholder_pattern`
+- [x] `tool_execution.py` exists and is 364 lines (includes the small `_archive` + `_check_cancelled` + `_conv_id` duplication — 3 helpers totaling 22 lines, intentional and documented)
+- [x] Smoke: `python -c "from decafclaw.tool_execution import execute_tool_calls, execute_single_tool, process_tool_media, resolve_widget"` succeeds
+- [x] Smoke: `python -c "from decafclaw.eval.runner import run_agent_turn"` still works (the stable public surface preserved by the spec)
+
+---
+
+## Phase 3: Docs sync — CLAUDE.md key files + architecture pointers
+
+The CLAUDE.md "Key files / Core" section currently says `agent.py — Agent loop: turn orchestration, tool execution, LLM calls`. After this refactor, tool execution and tool definitions are dedicated modules. Update the list per CLAUDE.md convention: "Update `CLAUDE.md` only when conventions or the key-files list change."
+
+**Files:**
+- Modify: `CLAUDE.md` — update "Core" key-files list to reflect the new modules
+- Modify: `docs/architecture.md` — if it references specific file names for the tool-execution-concurrency section, update accordingly (spot-check; no change required if the section stays generic)
+
+**Key changes (CLAUDE.md):**
+- Update the "Core" bullet for `agent.py` from `Agent loop: turn orchestration, tool execution, LLM calls` to `Agent loop: turn orchestration, LLM calls, iteration outcomes`.
+- Add two new bullets in the Core section, alphabetically placed:
+  - `tool_definitions.py` — Tool-registry assembly: classification, deferral, dynamic-skill providers
+  - `tool_execution.py` — Concurrent tool-call execution: media handling, widget validation, end-turn signals
+
+**Key changes (architecture.md):**
+- Section "Tool execution concurrency" references `_execute_single_tool` in a code snippet (line 144). Update the call name to `execute_single_tool` (drop the underscore) to match the new module's public surface.
+
+**Verification — automated:**
+- [x] `make check` still passes (no code changes here)
+- [x] `grep -n "tool_definitions\.py\|tool_execution\.py" CLAUDE.md` returns hits in the Core section
+- [x] `grep -n "_execute_single_tool" docs/architecture.md` returns nothing (the only `_execute_single_tool` hits in `docs/` now are in historical dev-session artifacts and this session's spec/plan — correct to leave alone)
+
+**Verification — manual:**
+- [x] CLAUDE.md "Core" bullets read naturally and accurately describe each module's responsibility
+- [x] `docs/architecture.md` "Tool execution concurrency" snippet still reads correctly with the new name
+
+---
+
+## Plan self-review
+
+**Spec coverage check** (matched against `spec.md` "Desired end state"):
+1. ✅ New `tool_execution.py` (~250 lines) — Phase 2
+2. ✅ New `tool_definitions.py` (~150 lines) — Phase 1
+3. ✅ Underscores dropped on public functions — Phases 1 + 2 (note: `_media_placeholder_pattern`, `_skill_def_cache`, `_archive`, `_check_cancelled` keep underscores as module-internal helpers — these are not part of the relocated public surface)
+4. ✅ Imports updated in `agent.py`, `context_composer.py`, `tools/skill_tools.py` — Phases 1 + 2
+5. ✅ `agent.py` lands at ~750 lines — verified in Phase 2 manual checkbox
+6. ✅ `run_agent_turn` shim preserved — never touched in any phase
+7. ✅ `IterationOutcome` / `_Continue` / `_Final` / `ReflectionOutcome` tagged unions unchanged — never touched in any phase
+
+**Placeholder scan:** no "TBD", "TODO", "implement later", or "similar to phase N" — every phase enumerates files, key changes, and import wiring concretely.
+
+**Type-consistency check:**
+- `collect_all_tool_defs` named consistently in Phase 1 (definition + context_composer import).
+- `build_tool_list` named consistently in Phase 1 (definition + agent.py call site).
+- `refresh_dynamic_tools` named consistently in Phase 1 (definition + agent.py call site).
+- `execute_tool_calls` / `execute_single_tool` / `process_tool_media` / `resolve_widget` named consistently in Phase 2.
+- `invalidate_skill_cache` keeps its existing name in `tool_definitions.py` — no change to call sites in skill_tools.py beyond the module path.
+
+**Scope discipline:** No drive-by refactoring. The `_resolve_attachments`, `_parse_wiki_references`, `_read_wiki_page`, `_get_already_injected_pages`, `_WIKI_MENTION_RE` helpers stay in `agent.py` — they're issue #439's scope, called out explicitly in the spec under "What we're NOT doing." Tests `test_resolve_attachments.py`, `test_wiki_context.py`, `test_vault_tools.py` do NOT need updating in this PR.
+
+**Tests-to-update inventory (final):**
+- `tests/test_agent_turn.py` — Phase 1 (registry imports + drop underscores) + Phase 2 (execution imports + patch targets)
+- `tests/test_agent_widgets.py` — Phase 2 only
+- `tests/test_process_tool_media.py` — Phase 2 only
+- `tests/test_tool_result_data.py` — Phase 2 only
+- `tests/test_resolve_attachments.py` — NOT touched (out of scope)
+- `tests/test_wiki_context.py` — NOT touched (out of scope)
+- `tests/test_vault_tools.py` — NOT touched (out of scope, `_WIKI_MENTION_RE` / `_parse_wiki_references` stay in `agent.py`)
+- `tests/test_widgets_input_flow.py` — NOT touched (uses `_handle_widget_input_pause`, which stays in `agent.py` as part of `TurnRunner`)
+- `tests/test_imports.py` — NOT touched (only imports `run_agent_turn`)

--- a/docs/dev-sessions/2026-05-13-0939-agent-split-tools/spec.md
+++ b/docs/dev-sessions/2026-05-13-0939-agent-split-tools/spec.md
@@ -1,0 +1,71 @@
+# Agent.py Split — Extract tool_execution + tool_definitions Spec
+
+**Goal:** Finish the `agent.py` decomposition started by PRs #382 / #407 by relocating tool-invocation and tool-registry machinery into dedicated modules, dropping `agent.py` from ~1451 lines to ~750.
+
+**Source:** [Issue #438](https://github.com/lmorchard/decafclaw/issues/438)
+
+## Current state
+
+`src/decafclaw/agent.py` (1451 lines) still hosts ~12 module-level helpers below the `class TurnRunner` boundary that are tool-execution machinery, not orchestration:
+
+**Tool-invocation cluster** (~250 lines):
+- `_execute_tool_calls` (`agent.py:741`)
+- `_execute_single_tool` (`agent.py:580`)
+- `_process_tool_media` (`agent.py:529`)
+- `_resolve_widget` (`agent.py:652`)
+- `_media_placeholder_pattern` (`agent.py:522`)
+
+**Tool-registry cluster** (~150 lines):
+- `_collect_all_tool_defs` (`agent.py:381`)
+- `_build_tool_list` (`agent.py:422`)
+- `_refresh_dynamic_tools` (`agent.py:334`)
+- `_skill_def_cache` + `invalidate_skill_cache` (top of file)
+
+The registry cluster is also imported by `context_composer.py` — moving it gives composer a non-private import target (consumed by issue #439).
+
+## Desired end state
+
+1. New `src/decafclaw/tool_execution.py` (~250 lines) — "given a tool call, run it and produce a normalized result with media + widget integration."
+2. New `src/decafclaw/tool_definitions.py` (~150 lines) — "given a ctx, gather/classify/refresh the tool list."
+3. Underscores dropped on the public functions in their new homes; module-internal helpers stay private.
+4. Imports updated in `agent.py`, `context_composer.py`, and any other callers (do not change `context_composer.py` *import targets* beyond the necessary rename — full relocation per issue #439 lands separately).
+5. `agent.py` lands at ~750 lines.
+6. `run_agent_turn` shim at `agent.py:1438` preserved verbatim — three external callers depend on it (`compaction.py`, `eval/runner.py`, `conversation_manager.py`).
+7. `IterationOutcome` / `_Continue` / `_Final` / `ReflectionOutcome` tagged unions unchanged.
+
+## Design decisions
+
+- **Decision:** Split into two modules along the invocation/definition boundary rather than one big `tool_runtime.py`.
+  - **Why:** They have different consumers — invocation is internal to the agent loop; definitions are consumed by both the loop and `context_composer.py`. Separation prevents composer from accidentally importing execution internals.
+  - **Rejected:** Single combined module — would re-create the same coupling problem from a different angle.
+
+- **Decision:** Drop underscores from the relocated public functions.
+  - **Why:** Cross-module imports of underscore-prefixed names are a code smell (the underscore lies about visibility). The whole point of relocation is to make a real public surface.
+  - **Rejected:** Keep underscores — fails the spirit of the refactor.
+
+- **Decision:** Land before #439 so the new `tool_definitions.py` is available for composer to import from.
+
+## Patterns to follow
+
+- Module shape mirrors existing peers (`reflection.py`, `compaction.py`) — top-level functions, dataclasses where helpful, no class wrappers unless state demands it.
+- Keep the `_skill_def_cache` mutable state co-located with `invalidate_skill_cache` and any cache-touching helpers — they form one logical unit.
+
+## What we're NOT doing
+
+- **NOT changing call sites in `context_composer.py` beyond the import-target rename for `_collect_all_tool_defs` → `collect_all_tool_defs`.** The wiki/page-injection and `_resolve_attachments` relocations are issue #439's scope.
+- **NOT touching `reflection.py`** — it's already cleanly read-only relative to `agent.py`.
+- **NOT renaming or modifying `run_agent_turn`** — it's the stable public surface.
+- **NOT modifying the tagged-union types** (`IterationOutcome`, `_Continue`, `_Final`, `ReflectionOutcome`).
+- **NOT adding new functionality.** Pure relocation.
+- **NOT changing `TOOL_TIMEOUT_SEC`, per-tool timeout machinery, or shell-approval helpers.**
+
+## Validation
+
+- `make check` (lint + typecheck) green.
+- `make test` green.
+- Spot-check: `compaction.py` child-agent invocation still imports cleanly; `eval/runner.py` still imports `run_agent_turn`.
+- Grep audit: no `from .agent import _execute_*` / `_collect_*` / `_build_*` / `_refresh_*` from outside `agent.py` after the move.
+
+## Open questions
+
+- None. Issue body fully specifies the split; no decisions deferred to plan/execute.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -12,11 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import functools
-import json
 import logging
 import re as _re
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -31,26 +29,13 @@ from .context_composer import ComposerMode, ContextComposer
 from .llm import call_llm
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause, extract_workspace_media
 from .persistence import read_skill_data, read_skills_state, write_skill_data, write_skills_state
-from .tools import TOOL_DEFINITIONS, execute_tool
-from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
-from .tools.tool_registry import (
-    build_deferred_list_text,
-    classify_tools,
-    get_fetched_tools,
-)
+from .tool_definitions import build_tool_list, refresh_dynamic_tools
+from .tool_execution import execute_tool_calls
 
 _TASK_MODE_TO_COMPOSER: dict[str, ComposerMode] = {
     "heartbeat": ComposerMode.HEARTBEAT,
     "scheduled": ComposerMode.SCHEDULED,
 }
-
-# Cache preloaded skill definitions by config id, avoiding Config mutation
-_skill_def_cache: dict[int, list] = {}
-
-
-def invalidate_skill_cache(config) -> None:
-    """Clear the cached skill definitions for a config. Call after refresh_skills."""
-    _skill_def_cache.pop(id(config), None)
 
 log = logging.getLogger(__name__)
 
@@ -331,137 +316,6 @@ async def _handle_end_turn_confirm(ctx, action: EndTurnConfirm) -> bool:
     return result.get("approved", False)
 
 
-def _refresh_dynamic_tools(ctx) -> None:
-    """Call dynamic tool providers to refresh skill tools for this turn.
-
-    Skills that export get_tools(ctx) have their tools and definitions
-    replaced each turn based on current state (e.g., project phase).
-    Collects all possible tool names from providers, removes stale entries,
-    then re-adds the current set.
-    """
-    providers = ctx.tools.dynamic_providers
-    if not providers:
-        return
-
-    # Collect names from previous turn + this turn so we can remove stale entries
-    names_to_remove: set[str] = set()
-    for skill_name in providers:
-        names_to_remove.update(ctx.tools.dynamic_provider_names.get(skill_name, set()))
-
-    # Call each provider for this turn's tools
-    provider_results: list[tuple[str, dict, list]] = []
-    for skill_name, get_tools_fn in providers.items():
-        try:
-            tools, tool_defs = get_tools_fn(ctx)
-            names_to_remove.update(tools.keys())
-            ctx.tools.dynamic_provider_names[skill_name] = set(tools.keys())
-            provider_results.append((skill_name, tools, tool_defs))
-        except Exception as e:
-            # Fail-open: remove this provider's stale tools. If the model
-            # tries to call a removed tool, it gets a "tool not found" error.
-            log.warning(f"Dynamic tool provider for '{skill_name}' failed: {e}")
-            ctx.tools.dynamic_provider_names[skill_name] = set()
-
-    # Remove all dynamic-provider tools (old + new names) from extra
-    ctx.tools.extra = {
-        name: fn for name, fn in ctx.tools.extra.items()
-        if name not in names_to_remove
-    }
-    ctx.tools.extra_definitions = [
-        td for td in ctx.tools.extra_definitions
-        if td.get("function", {}).get("name") not in names_to_remove
-    ]
-
-    # Re-add the current turn's tools from each provider
-    for skill_name, tools, tool_defs in provider_results:
-        ctx.tools.extra.update(tools)
-        ctx.tools.extra_definitions.extend(tool_defs)
-
-
-def _collect_all_tool_defs(ctx) -> list:
-    """Gather all available tool definitions (core + skill + MCP + extra).
-
-    Does NOT apply allowed_tools filter — returns the full unfiltered set
-    so classification can see everything before deciding what to defer.
-    """
-    # Skill tools first — activated skill tools get priority positioning
-    # so the model sees them before the long tail of core tools
-    all_tools = list(ctx.tools.extra_definitions) + list(TOOL_DEFINITIONS)
-
-    # Pre-load tool definitions from discovered skills (stable tool list).
-    # Cached by config id to avoid re-executing tools.py every iteration.
-    config_id = id(ctx.config)
-    _cached = _skill_def_cache.get(config_id)
-    if _cached is None:
-        _cached = []
-        for skill_info in ctx.config.discovered_skills:
-            if skill_info.has_native_tools:
-                try:
-                    from .tools.skill_tools import _load_native_tools
-                    _, tool_defs, _ = _load_native_tools(skill_info)
-                    _cached.extend(tool_defs)
-                except Exception as e:
-                    log.warning(f"Failed to pre-load skill '{skill_info.name}' tools: {e}")
-        _skill_def_cache[config_id] = _cached
-
-    preloaded_names = {t.get("function", {}).get("name") for t in all_tools}
-    for td in _cached:
-        name = td.get("function", {}).get("name")
-        if name and name not in preloaded_names:
-            all_tools.append(td)
-            preloaded_names.add(name)
-
-    from .mcp_client import get_registry
-    mcp_registry = get_registry()
-    if mcp_registry:
-        all_tools = all_tools + mcp_registry.get_tool_definitions()
-
-    return all_tools
-
-
-def _build_tool_list(ctx) -> tuple[list, str | None]:
-    """Build the tool list, with optional deferred mode.
-
-    Returns (tool_definitions, deferred_text) where deferred_text is
-    None if all tools fit in the budget, or a system prompt block
-    listing deferred tools when the budget is exceeded.
-    """
-    all_defs = _collect_all_tool_defs(ctx)
-    fetched = get_fetched_tools(ctx)
-    # Skill tools (from activated skills) should never be deferred
-    skill_tool_names = {
-        td.get("function", {}).get("name", "")
-        for td in ctx.tools.extra_definitions
-    }
-    # Pre-emptive matches populated by ContextComposer at turn start;
-    # reused across iterations so mid-turn reclassification stays consistent.
-    active, deferred = classify_tools(
-        all_defs, ctx.config, fetched, skill_tool_names,
-        preempt_matches=ctx.tools.preempt_matches,
-    )
-
-    # Apply allowed_tools filter to the active set only
-    allowed = ctx.tools.allowed
-    if allowed is not None:
-        active = [
-            t for t in active
-            if t.get("function", {}).get("name") in allowed
-        ]
-
-    if not deferred:
-        return active, None
-
-    # Deferred mode: set the pool on ctx and add tool_search
-    ctx.tools.deferred_pool = deferred
-    active = active + SEARCH_TOOL_DEFINITIONS
-
-    # Build deferred list text for system prompt
-    core_names = {td.get("function", {}).get("name", "") for td in TOOL_DEFINITIONS}
-    deferred_text = build_deferred_list_text(deferred, core_names=core_names)
-
-    return active, deferred_text
-
-
 async def _call_llm_with_events(ctx, config, messages, tools,
                                 model_name=None,
                                 llm_url=None, llm_model=None,
@@ -516,311 +370,6 @@ async def _call_llm_with_events(ctx, config, messages, tools,
                       content=response.get("content"),
                       has_tool_calls=bool(response.get("tool_calls")))
     return response
-
-
-@functools.lru_cache(maxsize=128)
-def _media_placeholder_pattern(filename: str) -> _re.Pattern:
-    """Build a regex to find the placeholder for a given filename."""
-    return _re.compile(
-        r"\[file attached: " + _re.escape(filename) + r"[^\]]*\]"
-    )
-
-
-async def _process_tool_media(ctx, result: ToolResult) -> list[str]:
-    """Process media items on a tool result — save/upload and replace placeholders.
-
-    For handlers returning workspace_ref: replaces placeholder text with markdown refs.
-    For handlers returning file_id: collects file_ids for caller to attach.
-
-    Returns list of file_ids (for Mattermost attachment), empty for other channels.
-    Clears result.media after processing.
-    """
-    if not result.media:
-        return []
-
-    handler = ctx.media_handler
-    if handler is None:
-        log.warning(f"No media handler — {len(result.media)} media item(s) not delivered")
-        result.media.clear()
-        return []
-
-    conv_id = ctx.conv_id or ctx.channel_id or "unknown"
-    file_ids = []
-
-    for item in result.media:
-        filename = item.get("filename", "unknown")
-        content_type = item.get("content_type", "application/octet-stream")
-        data = item.get("data", b"")
-
-        try:
-            save_result = await handler.save_media(conv_id, filename, data, content_type)
-        except Exception as e:
-            log.warning(f"Failed to save media {filename}: {e}")
-            continue
-
-        if save_result.workspace_ref:
-            pattern = _media_placeholder_pattern(filename)
-            if content_type.startswith("image/"):
-                replacement = f"![{filename}]({save_result.workspace_ref})"
-            else:
-                replacement = f"[{filename}]({save_result.workspace_ref})"
-            new_text, count = pattern.subn(replacement, result.text, count=1)
-            if count > 0:
-                result.text = new_text
-            else:
-                # No placeholder — append ref so the media is discoverable
-                result.text = result.text.rstrip() + "\n" + replacement
-        if save_result.file_id:
-            file_ids.append(save_result.file_id)
-
-    result.media.clear()
-    return file_ids
-
-
-async def _execute_single_tool(call_ctx, tc, semaphore):
-    """Execute one tool call. Returns (tool_msg dict, end_turn flag).
-
-    Designed to run concurrently — uses its own forked ctx so
-    current_tool_call_id doesn't race with other calls.
-    Media is processed per-tool-call via _process_tool_media().
-    """
-    tool_call_id = tc["id"]
-    fn_name = tc["function"]["name"]
-    try:
-        fn_args = json.loads(tc["function"]["arguments"])
-    except json.JSONDecodeError as e:
-        log.error(f"Malformed tool call arguments for {fn_name}: {e}")
-        fn_args = {}
-
-    log.info(f"Tool call: {fn_name}({fn_args})")
-
-    result = ToolResult(text=f"[error: {fn_name} did not complete]")
-    async with semaphore:
-        try:
-            await call_ctx.publish("tool_start", tool=fn_name, args=fn_args,
-                                   tool_call_id=tool_call_id)
-            result = await execute_tool(call_ctx, fn_name, fn_args)
-            log.debug(f"Tool result [{fn_name}]: {result.text[:200]}...")
-
-            # Process media per-tool-call (save/upload, replace placeholders)
-            file_ids = await _process_tool_media(call_ctx, result)
-            if file_ids:
-                await call_ctx.publish("tool_media_uploaded",
-                                       tool=fn_name,
-                                       file_ids=file_ids,
-                                       tool_call_id=tool_call_id)
-        except asyncio.CancelledError:
-            result = ToolResult(text=f"[cancelled: {fn_name}]")
-        except Exception as e:
-            log.error(f"Tool call {fn_name} failed: {e}", exc_info=True)
-            result = ToolResult(text=f"[error executing {fn_name}: {e}]")
-        finally:
-            widget_payload = _resolve_widget(fn_name, result, tool_call_id)
-            publish_kwargs = {
-                "tool": fn_name,
-                "result_text": result.text,
-                "display_text": getattr(result, "display_text", None),
-                "display_short_text": getattr(
-                    result, "display_short_text", None),
-                "media": result.media or [],
-                "tool_call_id": tool_call_id,
-            }
-            if widget_payload is not None:
-                publish_kwargs["widget"] = widget_payload
-            await call_ctx.publish("tool_end", **publish_kwargs)
-
-    content = result.text
-    if result.data is not None:
-        try:
-            content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
-        except (TypeError, ValueError) as e:
-            log.warning(f"Failed to serialize ToolResult.data for {fn_name}: {e}")
-            content += "\n\n[structured data omitted: serialization error]"
-    tool_msg = {
-        "role": "tool",
-        "tool_call_id": tool_call_id,
-        "content": content,
-    }
-    if result.display_short_text:
-        tool_msg["display_short_text"] = result.display_short_text
-    if widget_payload is not None:
-        tool_msg["widget"] = widget_payload
-    _archive(call_ctx, tool_msg)
-    return tool_msg, result.end_turn
-
-
-def _resolve_widget(fn_name: str, result: ToolResult,
-                    tool_call_id: str = "") -> dict | None:
-    """Validate result.widget against the registry and return a
-    serializable payload, or None if no widget / validation fails.
-
-    Phase-2 side effects for input widgets (``accepts_input=True``):
-
-    - If ``end_turn`` is falsy, strip the widget (input widgets require
-      the turn to pause).
-    - If ``end_turn`` is an ``EndTurnConfirm``, drop the confirm (widget
-      pause wins) and set ``end_turn=True``.
-    - Register the ``on_response`` callback in
-      ``widget_input.pending_callbacks`` keyed by ``tool_call_id``.
-    - Promote ``result.end_turn`` to a ``WidgetInputPause`` sentinel
-      that the agent loop detects and routes to the pause path.
-    """
-    widget = getattr(result, "widget", None)
-    if widget is None:
-        return None
-    from .widgets import get_widget_registry
-    registry = get_widget_registry()
-    if registry is None:
-        log.warning(
-            "tool %s returned a widget but widget registry is not "
-            "initialized; stripping", fn_name)
-        result.widget = None
-        return None
-    ok, err = registry.validate(widget.widget_type, widget.data)
-    if not ok:
-        log.warning(
-            "tool %s widget %r failed validation: %s — stripping",
-            fn_name, widget.widget_type, err)
-        result.widget = None
-        return None
-    desc = registry.get(widget.widget_type)
-    target = widget.target
-    if target not in ("inline", "canvas"):
-        log.warning(
-            "tool %s widget %r has unknown target %r — stripping",
-            fn_name, widget.widget_type, target)
-        result.widget = None
-        return None
-    if desc is not None and target not in desc.modes:
-        log.warning(
-            "tool %s widget %r used target %r not in declared modes %r"
-            " — stripping",
-            fn_name, widget.widget_type, target, desc.modes)
-        result.widget = None
-        return None
-    # Apply per-widget server-side normalization (e.g. iframe_sandbox CSP
-    # wrapping). Mutate widget.data so downstream consumers — archive,
-    # canvas state, WS event — all see the same normalized shape.
-    normalized = registry.normalize(widget.widget_type, widget.data)
-    widget.data = normalized
-    payload = {
-        "widget_type": widget.widget_type,
-        "target": target,
-        "data": normalized,
-    }
-
-    # Phase 2: input-widget enforcement + pause-signal promotion.
-    if desc is not None and desc.accepts_input:
-        # Rule: input widget requires end_turn truthy (True or
-        # EndTurnConfirm; widget-pause wins over EndTurnConfirm).
-        if not result.end_turn:
-            log.warning(
-                "tool %s emitted input widget %r without end_turn=True "
-                "— stripping (input widgets must pause the turn)",
-                fn_name, widget.widget_type)
-            result.widget = None
-            return None
-        if isinstance(result.end_turn, EndTurnConfirm):
-            log.warning(
-                "tool %s emitted input widget %r alongside EndTurnConfirm "
-                "— dropping EndTurnConfirm (widget-pause takes priority)",
-                fn_name, widget.widget_type)
-        # Register the callback for live-path pickup.
-        if widget.on_response is not None and tool_call_id:
-            from .widget_input import pending_callbacks
-            pending_callbacks[tool_call_id] = widget.on_response
-        # Promote end_turn to the pause sentinel.
-        result.end_turn = WidgetInputPause(
-            tool_call_id=tool_call_id,
-            widget_payload=payload,
-        )
-
-    return payload
-
-
-async def _execute_tool_calls(ctx, tool_calls, history, messages):
-    """Execute tool calls concurrently, add results to history.
-
-    Returns (ToolResult, False) if cancelled, (None, end_turn_signal) otherwise.
-    end_turn_signal is False, True, or an EndTurnConfirm action.
-    """
-    cancelled = _check_cancelled(ctx, history)
-    if cancelled:
-        return cancelled, False
-
-    semaphore = asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)
-
-    # Fork ctx per tool call so concurrent tools don't race on current_tool_call_id
-    tasks = []
-    for tc in tool_calls:
-        call_ctx = ctx.fork_for_tool_call(tc["id"])
-        task = asyncio.create_task(
-            _execute_single_tool(call_ctx, tc, semaphore),
-            name=f"tool-{tc['function']['name']}-{tc['id'][:8]}",
-        )
-        tasks.append(task)
-
-    # Cancel watcher: if the cancel event fires, cancel all in-flight tasks
-    cancel_event = ctx.cancelled
-
-    async def _cancel_watcher():
-        if cancel_event:
-            await cancel_event.wait()
-            for t in tasks:
-                t.cancel()
-
-    watcher = asyncio.create_task(_cancel_watcher()) if cancel_event else None
-
-    try:
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-    finally:
-        if watcher:
-            watcher.cancel()
-            try:
-                await watcher
-            except asyncio.CancelledError:
-                pass
-
-    # Check if we were cancelled during execution
-    cancelled = _check_cancelled(ctx, history)
-    if cancelled:
-        return cancelled, False
-
-    # Collect results in original call order (gather preserves order).
-    # Priority among end-turn signals in a single batch:
-    #   WidgetInputPause > EndTurnConfirm > True
-    # Only one pause/end signal wins per batch.
-    end_turn_signal: bool | EndTurnConfirm | WidgetInputPause = False
-    for i, result in enumerate(results):
-        if isinstance(result, BaseException):
-            # Task was cancelled or failed — gather with return_exceptions.
-            # _execute_single_tool normally handles errors internally,
-            # so this only fires for unexpected failures (e.g. CancelledError
-            # from the cancel watcher).
-            err_type = type(result).__name__
-            err_text = str(result) or err_type
-            tool_msg = {
-                "role": "tool",
-                "tool_call_id": tool_calls[i]["id"],
-                "content": f"[error: {err_text}]",
-            }
-            history.append(tool_msg)
-            messages.append(tool_msg)
-            _archive(ctx, tool_msg)
-        else:
-            tool_msg, end_turn = result
-            if isinstance(end_turn, WidgetInputPause):
-                end_turn_signal = end_turn  # Widget pause wins over all
-            elif isinstance(end_turn, EndTurnConfirm):
-                if not isinstance(end_turn_signal, WidgetInputPause):
-                    end_turn_signal = end_turn
-            elif end_turn and not isinstance(
-                    end_turn_signal, (EndTurnConfirm, WidgetInputPause)):
-                end_turn_signal = True
-            history.append(tool_msg)
-            messages.append(tool_msg)
-
-    return None, end_turn_signal
 
 
 # -- Turn setup helpers ---------------------------------------------------------
@@ -1090,8 +639,8 @@ class TurnRunner:
         log.debug(f"Agent iteration {iteration + 1}")
         self.ctx._current_iteration = iteration + 1
 
-        _refresh_dynamic_tools(self.ctx)
-        all_tools, deferred_text = _build_tool_list(self.ctx)
+        refresh_dynamic_tools(self.ctx)
+        all_tools, deferred_text = build_tool_list(self.ctx)
 
         if deferred_text:
             new_msg = {"role": "system", "content": deferred_text}
@@ -1147,7 +696,7 @@ class TurnRunner:
             self.accumulated_text_parts.append(iter_content)
             await self.ctx.publish("text_before_tools", text=iter_content)
 
-        cancelled, end_turn_signal = await _execute_tool_calls(
+        cancelled, end_turn_signal = await execute_tool_calls(
             self.ctx, tool_calls, self.history, self.messages,
         )
         if cancelled:

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -823,12 +823,12 @@ class ContextComposer:
         gating. Currently all composer-driven modes apply matching
         (reflection and compaction bypass the composer entirely).
         """
-        from .agent import _collect_all_tool_defs
         from .preempt_search import (
             extract_last_assistant_text,
             match_tools,
             tokenize,
         )
+        from .tool_definitions import collect_all_tool_defs
         from .tools.tool_registry import get_critical_names, get_fetched_tools
 
         _ = mode  # reserved for future per-mode gating
@@ -862,7 +862,7 @@ class ContextComposer:
             for td in ctx.tools.extra_definitions
         }
 
-        all_defs = _collect_all_tool_defs(ctx)
+        all_defs = collect_all_tool_defs(ctx)
         # If the context restricts the usable tool set (eval runner,
         # restricted child agents), don't surface disallowed tools —
         # they'd waste the match cap and error at execute_tool.
@@ -1011,9 +1011,9 @@ class ContextComposer:
         """Classify tools into active and deferred sets.
 
         Returns (active_tools, deferred_tools, deferred_text, source_entry).
-        Replicates the logic in agent._build_tool_list() with diagnostics.
+        Replicates the logic in tool_definitions.build_tool_list() with diagnostics.
         """
-        from .agent import _collect_all_tool_defs
+        from .tool_definitions import collect_all_tool_defs
         from .tools import TOOL_DEFINITIONS
         from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
         from .tools.tool_registry import (
@@ -1024,7 +1024,7 @@ class ContextComposer:
         )
         from .util import estimate_tokens
 
-        all_defs = _collect_all_tool_defs(ctx)
+        all_defs = collect_all_tool_defs(ctx)
         fetched = get_fetched_tools(ctx)
         # Skill tools (from activated skills) should never be deferred
         skill_tool_names = {

--- a/src/decafclaw/tool_definitions.py
+++ b/src/decafclaw/tool_definitions.py
@@ -1,0 +1,166 @@
+"""Tool-registry assembly for the agent loop.
+
+Given a ctx, gather all available tool definitions (core + activated
+skills + bundled-skill native tools + MCP + extra), classify them into
+active vs deferred per the tool-priority budget, and produce the
+per-iteration tool list the LLM call sees.
+
+Consumed by `agent.py` (every iteration of the agent loop) and
+`context_composer.py` (turn-start budget accounting). Kept separate
+from `tool_execution.py` so composer can import definitions without
+pulling in execution internals.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .tools import TOOL_DEFINITIONS
+from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
+from .tools.tool_registry import (
+    build_deferred_list_text,
+    classify_tools,
+    get_fetched_tools,
+)
+
+log = logging.getLogger(__name__)
+
+# Cache preloaded skill definitions by config id, avoiding Config mutation.
+# Cleared by `invalidate_skill_cache` after `refresh_skills`.
+_skill_def_cache: dict[int, list] = {}
+
+
+def invalidate_skill_cache(config) -> None:
+    """Clear the cached skill definitions for a config. Call after refresh_skills."""
+    _skill_def_cache.pop(id(config), None)
+
+
+def refresh_dynamic_tools(ctx) -> None:
+    """Call dynamic tool providers to refresh skill tools for this turn.
+
+    Skills that export get_tools(ctx) have their tools and definitions
+    replaced each turn based on current state (e.g., project phase).
+    Collects all possible tool names from providers, removes stale entries,
+    then re-adds the current set.
+    """
+    providers = ctx.tools.dynamic_providers
+    if not providers:
+        return
+
+    # Collect names from previous turn + this turn so we can remove stale entries
+    names_to_remove: set[str] = set()
+    for skill_name in providers:
+        names_to_remove.update(ctx.tools.dynamic_provider_names.get(skill_name, set()))
+
+    # Call each provider for this turn's tools
+    provider_results: list[tuple[str, dict, list]] = []
+    for skill_name, get_tools_fn in providers.items():
+        try:
+            tools, tool_defs = get_tools_fn(ctx)
+            names_to_remove.update(tools.keys())
+            ctx.tools.dynamic_provider_names[skill_name] = set(tools.keys())
+            provider_results.append((skill_name, tools, tool_defs))
+        except Exception as e:
+            # Fail-open: remove this provider's stale tools. If the model
+            # tries to call a removed tool, it gets a "tool not found" error.
+            log.warning(f"Dynamic tool provider for '{skill_name}' failed: {e}")
+            ctx.tools.dynamic_provider_names[skill_name] = set()
+
+    # Remove all dynamic-provider tools (old + new names) from extra
+    ctx.tools.extra = {
+        name: fn for name, fn in ctx.tools.extra.items()
+        if name not in names_to_remove
+    }
+    ctx.tools.extra_definitions = [
+        td for td in ctx.tools.extra_definitions
+        if td.get("function", {}).get("name") not in names_to_remove
+    ]
+
+    # Re-add the current turn's tools from each provider
+    for skill_name, tools, tool_defs in provider_results:
+        ctx.tools.extra.update(tools)
+        ctx.tools.extra_definitions.extend(tool_defs)
+
+
+def collect_all_tool_defs(ctx) -> list:
+    """Gather all available tool definitions (core + skill + MCP + extra).
+
+    Does NOT apply allowed_tools filter — returns the full unfiltered set
+    so classification can see everything before deciding what to defer.
+    """
+    # Skill tools first — activated skill tools get priority positioning
+    # so the model sees them before the long tail of core tools
+    all_tools = list(ctx.tools.extra_definitions) + list(TOOL_DEFINITIONS)
+
+    # Pre-load tool definitions from discovered skills (stable tool list).
+    # Cached by config id to avoid re-executing tools.py every iteration.
+    config_id = id(ctx.config)
+    _cached = _skill_def_cache.get(config_id)
+    if _cached is None:
+        _cached = []
+        for skill_info in ctx.config.discovered_skills:
+            if skill_info.has_native_tools:
+                try:
+                    from .tools.skill_tools import _load_native_tools
+                    _, tool_defs, _ = _load_native_tools(skill_info)
+                    _cached.extend(tool_defs)
+                except Exception as e:
+                    log.warning(f"Failed to pre-load skill '{skill_info.name}' tools: {e}")
+        _skill_def_cache[config_id] = _cached
+
+    preloaded_names = {t.get("function", {}).get("name") for t in all_tools}
+    for td in _cached:
+        name = td.get("function", {}).get("name")
+        if name and name not in preloaded_names:
+            all_tools.append(td)
+            preloaded_names.add(name)
+
+    from .mcp_client import get_registry
+    mcp_registry = get_registry()
+    if mcp_registry:
+        all_tools = all_tools + mcp_registry.get_tool_definitions()
+
+    return all_tools
+
+
+def build_tool_list(ctx) -> tuple[list, str | None]:
+    """Build the tool list, with optional deferred mode.
+
+    Returns (tool_definitions, deferred_text) where deferred_text is
+    None if all tools fit in the budget, or a system prompt block
+    listing deferred tools when the budget is exceeded.
+    """
+    all_defs = collect_all_tool_defs(ctx)
+    fetched = get_fetched_tools(ctx)
+    # Skill tools (from activated skills) should never be deferred
+    skill_tool_names = {
+        td.get("function", {}).get("name", "")
+        for td in ctx.tools.extra_definitions
+    }
+    # Pre-emptive matches populated by ContextComposer at turn start;
+    # reused across iterations so mid-turn reclassification stays consistent.
+    active, deferred = classify_tools(
+        all_defs, ctx.config, fetched, skill_tool_names,
+        preempt_matches=ctx.tools.preempt_matches,
+    )
+
+    # Apply allowed_tools filter to the active set only
+    allowed = ctx.tools.allowed
+    if allowed is not None:
+        active = [
+            t for t in active
+            if t.get("function", {}).get("name") in allowed
+        ]
+
+    if not deferred:
+        return active, None
+
+    # Deferred mode: set the pool on ctx and add tool_search
+    ctx.tools.deferred_pool = deferred
+    active = active + SEARCH_TOOL_DEFINITIONS
+
+    # Build deferred list text for system prompt
+    core_names = {td.get("function", {}).get("name", "") for td in TOOL_DEFINITIONS}
+    deferred_text = build_deferred_list_text(deferred, core_names=core_names)
+
+    return active, deferred_text

--- a/src/decafclaw/tool_execution.py
+++ b/src/decafclaw/tool_execution.py
@@ -1,0 +1,364 @@
+"""Concurrent tool-call execution for the agent loop.
+
+Given a list of tool calls from the LLM, run them concurrently under a
+semaphore, process media items (save/upload, replace placeholders),
+validate widget payloads, archive results, and surface end-turn signals
+(plain True / EndTurnConfirm / WidgetInputPause).
+
+This is the "internal to the agent loop" half of the agent.py split.
+The registry half lives in `tool_definitions.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import logging
+import re as _re
+
+from .archive import append_message
+from .media import EndTurnConfirm, ToolResult, WidgetInputPause
+from .tools import execute_tool
+
+log = logging.getLogger(__name__)
+
+
+# `_archive` and `_check_cancelled` are duplicated from `agent.py` rather
+# than extracted to a third shared module — they're trivial (4 + 8 lines)
+# and pulling them out would invert the dependency direction (agent.py
+# would import them from this module, but this module's whole purpose is
+# to be a leaf the agent loop calls into). The duplication is intentional
+# and the helpers should change together if they change at all.
+
+
+def _conv_id(ctx) -> str:
+    """Get conversation ID from context."""
+    return ctx.conv_id or ctx.channel_id or "unknown"
+
+
+def _archive(ctx, msg) -> None:
+    """Archive a message, logging errors but never raising."""
+    if ctx.skip_archive:
+        return
+    try:
+        append_message(ctx.config, _conv_id(ctx), msg)
+    except Exception as e:
+        log.error(f"Archive write failed: {e}")
+
+
+def _check_cancelled(ctx, history):
+    """Check if the agent turn has been cancelled. Returns ToolResult or None."""
+    if ctx.cancelled and ctx.cancelled.is_set():
+        log.info("Agent turn cancelled by user")
+        msg = "[Agent turn cancelled by user]"
+        final_msg = {"role": "assistant", "content": msg}
+        history.append(final_msg)
+        _archive(ctx, final_msg)
+        return ToolResult(text=msg)
+    return None
+
+
+@functools.lru_cache(maxsize=128)
+def _media_placeholder_pattern(filename: str) -> _re.Pattern:
+    """Build a regex to find the placeholder for a given filename."""
+    return _re.compile(
+        r"\[file attached: " + _re.escape(filename) + r"[^\]]*\]"
+    )
+
+
+async def process_tool_media(ctx, result: ToolResult) -> list[str]:
+    """Process media items on a tool result — save/upload and replace placeholders.
+
+    For handlers returning workspace_ref: replaces placeholder text with markdown refs.
+    For handlers returning file_id: collects file_ids for caller to attach.
+
+    Returns list of file_ids (for Mattermost attachment), empty for other channels.
+    Clears result.media after processing.
+    """
+    if not result.media:
+        return []
+
+    handler = ctx.media_handler
+    if handler is None:
+        log.warning(f"No media handler — {len(result.media)} media item(s) not delivered")
+        result.media.clear()
+        return []
+
+    conv_id = ctx.conv_id or ctx.channel_id or "unknown"
+    file_ids = []
+
+    for item in result.media:
+        filename = item.get("filename", "unknown")
+        content_type = item.get("content_type", "application/octet-stream")
+        data = item.get("data", b"")
+
+        try:
+            save_result = await handler.save_media(conv_id, filename, data, content_type)
+        except Exception as e:
+            log.warning(f"Failed to save media {filename}: {e}")
+            continue
+
+        if save_result.workspace_ref:
+            pattern = _media_placeholder_pattern(filename)
+            if content_type.startswith("image/"):
+                replacement = f"![{filename}]({save_result.workspace_ref})"
+            else:
+                replacement = f"[{filename}]({save_result.workspace_ref})"
+            new_text, count = pattern.subn(replacement, result.text, count=1)
+            if count > 0:
+                result.text = new_text
+            else:
+                # No placeholder — append ref so the media is discoverable
+                result.text = result.text.rstrip() + "\n" + replacement
+        if save_result.file_id:
+            file_ids.append(save_result.file_id)
+
+    result.media.clear()
+    return file_ids
+
+
+def resolve_widget(fn_name: str, result: ToolResult,
+                   tool_call_id: str = "") -> dict | None:
+    """Validate result.widget against the registry and return a
+    serializable payload, or None if no widget / validation fails.
+
+    Phase-2 side effects for input widgets (``accepts_input=True``):
+
+    - If ``end_turn`` is falsy, strip the widget (input widgets require
+      the turn to pause).
+    - If ``end_turn`` is an ``EndTurnConfirm``, drop the confirm (widget
+      pause wins) and set ``end_turn=True``.
+    - Register the ``on_response`` callback in
+      ``widget_input.pending_callbacks`` keyed by ``tool_call_id``.
+    - Promote ``result.end_turn`` to a ``WidgetInputPause`` sentinel
+      that the agent loop detects and routes to the pause path.
+    """
+    widget = getattr(result, "widget", None)
+    if widget is None:
+        return None
+    from .widgets import get_widget_registry
+    registry = get_widget_registry()
+    if registry is None:
+        log.warning(
+            "tool %s returned a widget but widget registry is not "
+            "initialized; stripping", fn_name)
+        result.widget = None
+        return None
+    ok, err = registry.validate(widget.widget_type, widget.data)
+    if not ok:
+        log.warning(
+            "tool %s widget %r failed validation: %s — stripping",
+            fn_name, widget.widget_type, err)
+        result.widget = None
+        return None
+    desc = registry.get(widget.widget_type)
+    target = widget.target
+    if target not in ("inline", "canvas"):
+        log.warning(
+            "tool %s widget %r has unknown target %r — stripping",
+            fn_name, widget.widget_type, target)
+        result.widget = None
+        return None
+    if desc is not None and target not in desc.modes:
+        log.warning(
+            "tool %s widget %r used target %r not in declared modes %r"
+            " — stripping",
+            fn_name, widget.widget_type, target, desc.modes)
+        result.widget = None
+        return None
+    # Apply per-widget server-side normalization (e.g. iframe_sandbox CSP
+    # wrapping). Mutate widget.data so downstream consumers — archive,
+    # canvas state, WS event — all see the same normalized shape.
+    normalized = registry.normalize(widget.widget_type, widget.data)
+    widget.data = normalized
+    payload = {
+        "widget_type": widget.widget_type,
+        "target": target,
+        "data": normalized,
+    }
+
+    # Phase 2: input-widget enforcement + pause-signal promotion.
+    if desc is not None and desc.accepts_input:
+        # Rule: input widget requires end_turn truthy (True or
+        # EndTurnConfirm; widget-pause wins over EndTurnConfirm).
+        if not result.end_turn:
+            log.warning(
+                "tool %s emitted input widget %r without end_turn=True "
+                "— stripping (input widgets must pause the turn)",
+                fn_name, widget.widget_type)
+            result.widget = None
+            return None
+        if isinstance(result.end_turn, EndTurnConfirm):
+            log.warning(
+                "tool %s emitted input widget %r alongside EndTurnConfirm "
+                "— dropping EndTurnConfirm (widget-pause takes priority)",
+                fn_name, widget.widget_type)
+        # Register the callback for live-path pickup.
+        if widget.on_response is not None and tool_call_id:
+            from .widget_input import pending_callbacks
+            pending_callbacks[tool_call_id] = widget.on_response
+        # Promote end_turn to the pause sentinel.
+        result.end_turn = WidgetInputPause(
+            tool_call_id=tool_call_id,
+            widget_payload=payload,
+        )
+
+    return payload
+
+
+async def execute_single_tool(call_ctx, tc, semaphore):
+    """Execute one tool call. Returns (tool_msg dict, end_turn flag).
+
+    Designed to run concurrently — uses its own forked ctx so
+    current_tool_call_id doesn't race with other calls.
+    Media is processed per-tool-call via process_tool_media().
+    """
+    tool_call_id = tc["id"]
+    fn_name = tc["function"]["name"]
+    try:
+        fn_args = json.loads(tc["function"]["arguments"])
+    except json.JSONDecodeError as e:
+        log.error(f"Malformed tool call arguments for {fn_name}: {e}")
+        fn_args = {}
+
+    log.info(f"Tool call: {fn_name}({fn_args})")
+
+    result = ToolResult(text=f"[error: {fn_name} did not complete]")
+    async with semaphore:
+        try:
+            await call_ctx.publish("tool_start", tool=fn_name, args=fn_args,
+                                   tool_call_id=tool_call_id)
+            result = await execute_tool(call_ctx, fn_name, fn_args)
+            log.debug(f"Tool result [{fn_name}]: {result.text[:200]}...")
+
+            # Process media per-tool-call (save/upload, replace placeholders)
+            file_ids = await process_tool_media(call_ctx, result)
+            if file_ids:
+                await call_ctx.publish("tool_media_uploaded",
+                                       tool=fn_name,
+                                       file_ids=file_ids,
+                                       tool_call_id=tool_call_id)
+        except asyncio.CancelledError:
+            result = ToolResult(text=f"[cancelled: {fn_name}]")
+        except Exception as e:
+            log.error(f"Tool call {fn_name} failed: {e}", exc_info=True)
+            result = ToolResult(text=f"[error executing {fn_name}: {e}]")
+        finally:
+            widget_payload = resolve_widget(fn_name, result, tool_call_id)
+            publish_kwargs = {
+                "tool": fn_name,
+                "result_text": result.text,
+                "display_text": getattr(result, "display_text", None),
+                "display_short_text": getattr(
+                    result, "display_short_text", None),
+                "media": result.media or [],
+                "tool_call_id": tool_call_id,
+            }
+            if widget_payload is not None:
+                publish_kwargs["widget"] = widget_payload
+            await call_ctx.publish("tool_end", **publish_kwargs)
+
+    content = result.text
+    if result.data is not None:
+        try:
+            content += "\n\n```json\n" + json.dumps(result.data, indent=2) + "\n```"
+        except (TypeError, ValueError) as e:
+            log.warning(f"Failed to serialize ToolResult.data for {fn_name}: {e}")
+            content += "\n\n[structured data omitted: serialization error]"
+    tool_msg = {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": content,
+    }
+    if result.display_short_text:
+        tool_msg["display_short_text"] = result.display_short_text
+    if widget_payload is not None:
+        tool_msg["widget"] = widget_payload
+    _archive(call_ctx, tool_msg)
+    return tool_msg, result.end_turn
+
+
+async def execute_tool_calls(ctx, tool_calls, history, messages):
+    """Execute tool calls concurrently, add results to history.
+
+    Returns (ToolResult, False) if cancelled, (None, end_turn_signal) otherwise.
+    end_turn_signal is False, True, or an EndTurnConfirm action.
+    """
+    cancelled = _check_cancelled(ctx, history)
+    if cancelled:
+        return cancelled, False
+
+    semaphore = asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)
+
+    # Fork ctx per tool call so concurrent tools don't race on current_tool_call_id
+    tasks = []
+    for tc in tool_calls:
+        call_ctx = ctx.fork_for_tool_call(tc["id"])
+        task = asyncio.create_task(
+            execute_single_tool(call_ctx, tc, semaphore),
+            name=f"tool-{tc['function']['name']}-{tc['id'][:8]}",
+        )
+        tasks.append(task)
+
+    # Cancel watcher: if the cancel event fires, cancel all in-flight tasks
+    cancel_event = ctx.cancelled
+
+    async def _cancel_watcher():
+        if cancel_event:
+            await cancel_event.wait()
+            for t in tasks:
+                t.cancel()
+
+    watcher = asyncio.create_task(_cancel_watcher()) if cancel_event else None
+
+    try:
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+    finally:
+        if watcher:
+            watcher.cancel()
+            try:
+                await watcher
+            except asyncio.CancelledError:
+                pass
+
+    # Check if we were cancelled during execution
+    cancelled = _check_cancelled(ctx, history)
+    if cancelled:
+        return cancelled, False
+
+    # Collect results in original call order (gather preserves order).
+    # Priority among end-turn signals in a single batch:
+    #   WidgetInputPause > EndTurnConfirm > True
+    # Only one pause/end signal wins per batch.
+    end_turn_signal: bool | EndTurnConfirm | WidgetInputPause = False
+    for i, result in enumerate(results):
+        if isinstance(result, BaseException):
+            # Task was cancelled or failed — gather with return_exceptions.
+            # execute_single_tool normally handles errors internally,
+            # so this only fires for unexpected failures (e.g. CancelledError
+            # from the cancel watcher).
+            err_type = type(result).__name__
+            err_text = str(result) or err_type
+            tool_msg = {
+                "role": "tool",
+                "tool_call_id": tool_calls[i]["id"],
+                "content": f"[error: {err_text}]",
+            }
+            history.append(tool_msg)
+            messages.append(tool_msg)
+            _archive(ctx, tool_msg)
+        else:
+            tool_msg, end_turn = result
+            if isinstance(end_turn, WidgetInputPause):
+                end_turn_signal = end_turn  # Widget pause wins over all
+            elif isinstance(end_turn, EndTurnConfirm):
+                if not isinstance(end_turn_signal, WidgetInputPause):
+                    end_turn_signal = end_turn
+            elif end_turn and not isinstance(
+                    end_turn_signal, (EndTurnConfirm, WidgetInputPause)):
+                end_turn_signal = True
+            history.append(tool_msg)
+            messages.append(tool_msg)
+
+    return None, end_turn_signal

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -245,8 +245,8 @@ async def _request_skill_confirmation(ctx, skill_name: str) -> tuple[bool, bool]
 def tool_refresh_skills(ctx) -> str | ToolResult:
     """Re-discover skills and update the system prompt catalog."""
     log.info("[tool:refresh_skills]")
-    from ..agent import invalidate_skill_cache  # deferred: circular dep
     from ..prompts import load_system_prompt
+    from ..tool_definitions import invalidate_skill_cache  # deferred: circular dep
     # Intentional mutation: runtime fields need to update the shared config
     # object that the agent loop holds. dataclasses.replace() would create
     # a disconnected copy.

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -8,16 +8,15 @@ import pytest
 
 from decafclaw.agent import (
     _archive,
-    _build_tool_list,
     _check_cancelled,
     _conv_id,
-    _execute_tool_calls,
-    _refresh_dynamic_tools,
     run_agent_turn,
 )
 from decafclaw.config_types import ReflectionConfig
 from decafclaw.media import EndTurnConfirm, ToolResult
 from decafclaw.reflection import ReflectionResult
+from decafclaw.tool_definitions import build_tool_list, refresh_dynamic_tools
+from decafclaw.tool_execution import execute_tool_calls
 
 # -- Helper tests --------------------------------------------------------------
 
@@ -89,7 +88,7 @@ def test_check_cancelled_not_set(ctx):
 
 
 def test_build_tool_list_base_tools(ctx):
-    tools, deferred_text = _build_tool_list(ctx)
+    tools, deferred_text = build_tool_list(ctx)
     # Should have some active tools and may defer some with max_active_tools
     assert len(tools) > 0
     names = [t["function"]["name"] for t in tools]
@@ -103,12 +102,12 @@ def test_build_tool_list_with_extra_tools(ctx):
         "function": {"name": "custom_tool", "parameters": {}},
     }
     ctx.tools.extra_definitions = [extra_def]
-    tools, _ = _build_tool_list(ctx)
+    tools, _ = build_tool_list(ctx)
     names = [t["function"]["name"] for t in tools]
     assert "custom_tool" in names
 
 
-# -- _execute_tool_calls tests -------------------------------------------------
+# -- execute_tool_calls tests --------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -124,7 +123,7 @@ async def test_execute_tool_calls_runs_tools(ctx):
     ]
     history = []
     messages = []
-    cancelled, end_turn = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    cancelled, end_turn = await execute_tool_calls(ctx, tool_calls, history, messages)
     assert cancelled is None  # not cancelled
     assert end_turn is False
     assert len(history) == 1
@@ -147,7 +146,7 @@ async def test_execute_tool_calls_handles_malformed_json(ctx):
     messages = []
 
     # Should not raise — handles JSONDecodeError gracefully
-    cancelled, _ = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    cancelled, _ = await execute_tool_calls(ctx, tool_calls, history, messages)
     assert cancelled is None
     assert len(history) == 1
 
@@ -165,7 +164,7 @@ async def test_execute_tool_calls_cancellation(ctx):
     ]
     history = []
     messages = []
-    cancelled, _ = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    cancelled, _ = await execute_tool_calls(ctx, tool_calls, history, messages)
     assert cancelled is not None
     assert "cancelled" in cancelled.text
 
@@ -198,8 +197,8 @@ async def test_execute_tool_calls_concurrent(ctx):
     messages = []
 
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_concurrent_tool):
-        cancelled, _ = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_concurrent_tool):
+        cancelled, _ = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert len(history) == 3
@@ -230,8 +229,8 @@ async def test_execute_tool_calls_semaphore_limits(ctx):
     messages = []
 
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_tracked_tool):
-        await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_tracked_tool):
+        await execute_tool_calls(ctx, tool_calls, history, messages)
 
     # With semaphore=1, max concurrency should be exactly 1
     assert concurrency_high_water == 1
@@ -255,8 +254,8 @@ async def test_execute_tool_calls_one_fails_others_succeed(ctx):
     messages = []
 
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_maybe_fail):
-        cancelled, _ = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_maybe_fail):
+        cancelled, _ = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert len(history) == 3
@@ -280,8 +279,8 @@ async def test_execute_tool_calls_preserves_order(ctx):
     messages = []
 
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_variable_speed):
-        await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_variable_speed):
+        await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert history[0]["tool_call_id"] == "tc0"
     assert history[1]["tool_call_id"] == "tc1"
@@ -304,8 +303,8 @@ async def test_execute_tool_calls_end_turn_signal(ctx):
     history = []
     messages = []
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_end_turn_tool):
-        cancelled, end_turn = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_end_turn_tool):
+        cancelled, end_turn = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert end_turn is True
@@ -329,8 +328,8 @@ async def test_execute_tool_calls_end_turn_in_parallel_batch(ctx):
     history = []
     messages = []
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_mixed_tools):
-        cancelled, end_turn = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_mixed_tools):
+        cancelled, end_turn = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert end_turn is True
@@ -354,8 +353,8 @@ async def test_execute_tool_calls_no_end_turn_for_bare_strings(ctx):
     history = []
     messages = []
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_string_tool):
-        cancelled, end_turn = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_string_tool):
+        cancelled, end_turn = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert end_turn is False
@@ -375,8 +374,8 @@ async def test_execute_tool_calls_end_turn_confirm(ctx):
     history = []
     messages = []
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_confirm_tool):
-        cancelled, end_turn_signal = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_confirm_tool):
+        cancelled, end_turn_signal = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert isinstance(end_turn_signal, EndTurnConfirm)
@@ -400,8 +399,8 @@ async def test_execute_tool_calls_end_turn_confirm_takes_priority(ctx):
     history = []
     messages = []
 
-    with patch("decafclaw.agent.execute_tool", side_effect=_mixed_tools):
-        cancelled, end_turn_signal = await _execute_tool_calls(ctx, tool_calls, history, messages)
+    with patch("decafclaw.tool_execution.execute_tool", side_effect=_mixed_tools):
+        cancelled, end_turn_signal = await execute_tool_calls(ctx, tool_calls, history, messages)
 
     assert cancelled is None
     assert isinstance(end_turn_signal, EndTurnConfirm)
@@ -434,7 +433,7 @@ def test_refresh_dynamic_tools_updates_extra(ctx):
     # Simulate previous turn having tool_a
     ctx.tools.dynamic_provider_names = {"my_skill": {"tool_a"}}
 
-    _refresh_dynamic_tools(ctx)
+    refresh_dynamic_tools(ctx)
 
     assert call_count == 1
     # tool_a removed, tool_b added, other_tool unchanged
@@ -451,7 +450,7 @@ def test_refresh_dynamic_tools_updates_extra(ctx):
 def test_refresh_dynamic_tools_noop_without_providers(ctx):
     """No providers means no changes."""
     ctx.tools.extra = {"existing": lambda: None}
-    _refresh_dynamic_tools(ctx)
+    refresh_dynamic_tools(ctx)
     assert "existing" in ctx.tools.extra
 
 
@@ -465,7 +464,7 @@ def test_refresh_dynamic_tools_tracks_provider_names(ctx):
         )
 
     ctx.tools.dynamic_providers = {"skill": get_tools}
-    _refresh_dynamic_tools(ctx)
+    refresh_dynamic_tools(ctx)
     assert ctx.tools.dynamic_provider_names["skill"] == {"t1", "t2"}
 
 
@@ -480,7 +479,7 @@ def test_refresh_dynamic_tools_handles_provider_error(ctx):
     ctx.tools.extra = {"old_tool": lambda: None}
     ctx.tools.extra_definitions = [{"function": {"name": "old_tool"}}]
 
-    _refresh_dynamic_tools(ctx)
+    refresh_dynamic_tools(ctx)
 
     # Old tool removed, provider names cleared
     assert "old_tool" not in ctx.tools.extra

--- a/tests/test_agent_widgets.py
+++ b/tests/test_agent_widgets.py
@@ -5,9 +5,9 @@ import json
 import pytest
 
 from decafclaw import widgets as widgets_module
-from decafclaw.agent import _execute_tool_calls, _resolve_widget
 from decafclaw.archive import read_archive
 from decafclaw.media import ToolResult, WidgetRequest
+from decafclaw.tool_execution import execute_tool_calls, resolve_widget
 
 _PANEL_SCHEMA = {
     "type": "object",
@@ -66,14 +66,14 @@ def test_registry(tmp_path, monkeypatch):
     yield registry
 
 
-# -------------- _resolve_widget unit tests --------------
+# -------------- resolve_widget unit tests --------------
 
 
 def test_resolve_widget_valid(test_registry):
     result = ToolResult(text="ok", widget=WidgetRequest(
         widget_type="data_table",
         data={"columns": [{"key": "a", "label": "A"}], "rows": []}))
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is not None
     assert payload["widget_type"] == "data_table"
     assert payload["target"] == "inline"
@@ -86,7 +86,7 @@ def test_resolve_widget_invalid_data_strips(test_registry, caplog):
     result = ToolResult(text="ok", widget=WidgetRequest(
         widget_type="data_table",
         data={"columns": []}))  # missing rows
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
     assert result.widget is None  # stripped
     assert any("failed validation" in r.message for r in caplog.records)
@@ -96,7 +96,7 @@ def test_resolve_widget_unknown_type_strips(test_registry, caplog):
     result = ToolResult(text="ok", widget=WidgetRequest(
         widget_type="nonexistent_widget",
         data={"anything": 1}))
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
     assert result.widget is None
     assert any("failed validation" in r.message for r in caplog.records)
@@ -104,7 +104,7 @@ def test_resolve_widget_unknown_type_strips(test_registry, caplog):
 
 def test_resolve_widget_no_widget(test_registry):
     result = ToolResult(text="no widget here")
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
 
 
@@ -113,7 +113,7 @@ def test_resolve_widget_unknown_target_strips(test_registry, caplog):
         widget_type="data_table",
         data={"columns": [], "rows": []},
         target="bogus"))
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
     assert result.widget is None
     assert any("unknown target" in r.message for r in caplog.records)
@@ -141,7 +141,7 @@ def test_resolve_widget_target_not_in_modes_strips(
         widget_type="inline_only",
         data={},
         target="canvas"))  # not in modes
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
     assert result.widget is None
     assert any("not in declared modes" in r.message for r in caplog.records)
@@ -152,7 +152,7 @@ def test_resolve_widget_no_registry(monkeypatch, caplog):
     result = ToolResult(text="ok", widget=WidgetRequest(
         widget_type="data_table",
         data={"columns": [], "rows": []}))
-    payload = _resolve_widget("my_tool", result)
+    payload = resolve_widget("my_tool", result)
     assert payload is None
     assert result.widget is None
     assert any("registry is not" in r.message for r in caplog.records)
@@ -179,7 +179,7 @@ def test_input_widget_with_end_turn_promotes_to_pause(test_registry):
             on_response=on_response),
         end_turn=True,
     )
-    payload = _resolve_widget("my_tool", result, "tc-input")
+    payload = resolve_widget("my_tool", result, "tc-input")
     assert payload is not None
     assert payload["widget_type"] == "pick"
     assert isinstance(result.end_turn, WidgetInputPause)
@@ -198,7 +198,7 @@ def test_input_widget_without_end_turn_strips(test_registry, caplog):
             data={"options": []}),
         end_turn=False,
     )
-    payload = _resolve_widget("my_tool", result, "tc-no-end")
+    payload = resolve_widget("my_tool", result, "tc-no-end")
     assert payload is None
     assert result.widget is None
     assert any("without end_turn=True" in r.message for r in caplog.records)
@@ -217,7 +217,7 @@ def test_input_widget_with_end_turn_confirm_drops_confirm(
             data={"options": []}),
         end_turn=EndTurnConfirm(message="review?"),
     )
-    payload = _resolve_widget("my_tool", result, "tc-both")
+    payload = resolve_widget("my_tool", result, "tc-both")
     assert payload is not None
     assert isinstance(result.end_turn, WidgetInputPause)
     assert any("alongside EndTurnConfirm" in r.message
@@ -236,13 +236,13 @@ def test_display_widget_unchanged_by_phase2(test_registry):
             data={"columns": [], "rows": []}),
         end_turn=False,
     )
-    payload = _resolve_widget("my_tool", result, "tc-display")
+    payload = resolve_widget("my_tool", result, "tc-display")
     assert payload is not None
     assert result.end_turn is False
     assert "tc-display" not in widget_input.pending_callbacks
 
 
-# -------------- _execute_tool_calls integration tests --------------
+# -------------- execute_tool_calls integration tests --------------
 
 
 async def _fake_execute_tool_with_widget(call_ctx, fn_name, fn_args):
@@ -271,7 +271,7 @@ async def _fake_execute_tool_no_widget(call_ctx, fn_name, fn_args):
 async def test_execute_tool_calls_propagates_valid_widget(
         ctx, config, test_registry, monkeypatch):
     monkeypatch.setattr(
-        "decafclaw.agent.execute_tool", _fake_execute_tool_with_widget)
+        "decafclaw.tool_execution.execute_tool", _fake_execute_tool_with_widget)
     ctx.conv_id = "test-widget-valid"
     tool_calls = [{"id": "tc1",
                    "function": {"name": "fake_tool", "arguments": "{}"}}]
@@ -285,7 +285,7 @@ async def test_execute_tool_calls_propagates_valid_widget(
 
     ctx.event_bus.subscribe(_capture)
 
-    await _execute_tool_calls(ctx, tool_calls, history, messages)
+    await execute_tool_calls(ctx, tool_calls, history, messages)
 
     # History tool record carries widget payload
     tool_msgs = [m for m in history if m.get("role") == "tool"]
@@ -310,7 +310,7 @@ async def test_execute_tool_calls_propagates_valid_widget(
 async def test_execute_tool_calls_strips_invalid_widget(
         ctx, config, test_registry, monkeypatch, caplog):
     monkeypatch.setattr(
-        "decafclaw.agent.execute_tool", _fake_execute_tool_with_bad_widget)
+        "decafclaw.tool_execution.execute_tool", _fake_execute_tool_with_bad_widget)
     ctx.conv_id = "test-widget-invalid"
     tool_calls = [{"id": "tc1",
                    "function": {"name": "fake_tool", "arguments": "{}"}}]
@@ -324,7 +324,7 @@ async def test_execute_tool_calls_strips_invalid_widget(
 
     ctx.event_bus.subscribe(_capture)
 
-    await _execute_tool_calls(ctx, tool_calls, history, messages)
+    await execute_tool_calls(ctx, tool_calls, history, messages)
 
     tool_msgs = [m for m in history if m.get("role") == "tool"]
     assert len(tool_msgs) == 1
@@ -347,14 +347,14 @@ async def test_execute_tool_calls_no_widget(
     """Tools that don't set widget produce tool_end/archive records
     with no widget key (not widget:null)."""
     monkeypatch.setattr(
-        "decafclaw.agent.execute_tool", _fake_execute_tool_no_widget)
+        "decafclaw.tool_execution.execute_tool", _fake_execute_tool_no_widget)
     ctx.conv_id = "test-no-widget"
     tool_calls = [{"id": "tc1",
                    "function": {"name": "fake_tool", "arguments": "{}"}}]
     history = []
     messages = []
 
-    await _execute_tool_calls(ctx, tool_calls, history, messages)
+    await execute_tool_calls(ctx, tool_calls, history, messages)
 
     tool_msgs = [m for m in history if m.get("role") == "tool"]
     assert len(tool_msgs) == 1

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -445,7 +445,7 @@ class TestComposeTools:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         small_tools = [_make_tool_def("tool_a"), _make_tool_def("tool_b")]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=small_tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=small_tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             assert len(active) == 2
@@ -463,7 +463,7 @@ class TestComposeTools:
         critical_def = _make_tool_def("current_time", "Get current time")
         critical_def["priority"] = "critical"
         many_tools.append(critical_def)
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=many_tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=many_tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             assert len(deferred) > 0
@@ -479,7 +479,7 @@ class TestComposeTools:
         config.compaction.max_tokens = 1000000
         tools = [_make_tool_def("allowed_tool"), _make_tool_def("blocked_tool")]
         ctx.tools.allowed = {"allowed_tool"}
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             active_names = {t["function"]["name"] for t in active}
@@ -494,7 +494,7 @@ class TestComposeTools:
         tools = [_make_tool_def(f"tool_{i}", "x" * 200) for i in range(20)]
         # Simulate a pre-emptive match — tool_7 should survive deferral.
         ctx.tools.preempt_matches = {"tool_7"}
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             active_names = {t["function"]["name"] for t in active}
@@ -509,7 +509,7 @@ class TestComposePreemptMatches:
         """When pre-emptive search is disabled, no matching happens and no entry is returned."""
         config.agent.preemptive_search.enabled = False
         tools = [_make_tool_def("vault_read", "Read a vault page")]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "read my vault", [], ComposerMode.INTERACTIVE,
@@ -520,7 +520,7 @@ class TestComposePreemptMatches:
     def test_empty_user_message_no_match(self, ctx, config):
         """Empty user message with no prior history yields no matches."""
         tools = [_make_tool_def("vault_read", "vault page")]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "", [], ComposerMode.INTERACTIVE,
@@ -534,7 +534,7 @@ class TestComposePreemptMatches:
             _make_tool_def("vault_backlinks", "List pages linking to a vault page"),
             _make_tool_def("unrelated_tool", "Totally unrelated"),
         ]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show my vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -555,7 +555,7 @@ class TestComposePreemptMatches:
             {"role": "user", "content": "what are the backlinks?"},
             {"role": "assistant", "content": "Here are the vault backlinks for foo."},
         ]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             # User message alone is stopword-only; prior assistant carries the topic.
             entry = composer._compose_preempt_matches(
@@ -568,7 +568,7 @@ class TestComposePreemptMatches:
         """Tools already declared critical don't get re-promoted — they're in already."""
         crit = _make_tool_def("shell", "Run a shell command")
         crit["priority"] = "critical"
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=[crit]):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[crit]):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "run a shell command", [], ComposerMode.INTERACTIVE,
@@ -581,7 +581,7 @@ class TestComposePreemptMatches:
         """Already-fetched tools don't get re-promoted."""
         ctx.skills.data = {"fetched_tools": ["vault_backlinks"]}
         tools = [_make_tool_def("vault_backlinks", "vault backlinks")]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show me vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -593,7 +593,7 @@ class TestComposePreemptMatches:
         """max_matches caps the number of promoted tools."""
         config.agent.preemptive_search.max_matches = 3
         tools = [_make_tool_def(f"vault_tool_{i}", "vault operation") for i in range(10)]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "vault operation", [], ComposerMode.INTERACTIVE,
@@ -610,7 +610,7 @@ class TestComposePreemptMatches:
             _make_tool_def("blocked_tool", "Also vault backlinks description"),
         ]
         ctx.tools.allowed = {"vault_backlinks"}
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -623,7 +623,7 @@ class TestComposePreemptMatches:
         """Calling _compose_preempt_matches resets ctx.tools.preempt_matches."""
         ctx.tools.preempt_matches = {"stale_tool"}
         tools = [_make_tool_def("vault_backlinks", "vault backlinks")]
-        with patch("decafclaw.agent._collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             composer._compose_preempt_matches(
                 ctx, config, "show vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -822,7 +822,7 @@ class TestCompose:
         config.compaction.max_tokens = 1000000
         small_tools = [_make_tool_def("tool_a")]
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=small_tools),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=small_tools),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -842,7 +842,7 @@ class TestCompose:
         many_tools = [_make_tool_def(f"t_{i}", "x" * 200) for i in range(20)]
         many_tools.append(_make_tool_def("think", "Think"))
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=many_tools),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=many_tools),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -865,7 +865,7 @@ class TestCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -881,7 +881,7 @@ class TestCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -899,7 +899,7 @@ class TestCompose:
             {"entry_text": "memory entry", "source_type": "page", "similarity": 0.8},
         ]
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=mock_results),
             patch("decafclaw.memory_context.format_memory_context",
@@ -946,7 +946,7 @@ class TestHistoryArchivedRemap:
         ]
 
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -992,7 +992,7 @@ class TestHistoryArchivedRemap:
         ]
 
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -1226,7 +1226,7 @@ class TestContextStatusInCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 100000
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -1246,7 +1246,7 @@ class TestContextStatusInCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 100000
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -1413,7 +1413,7 @@ class TestComposeExpandsBackgroundEvent:
         ]
 
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
@@ -1466,7 +1466,7 @@ class TestComposeExpandsBackgroundEvent:
         ]
 
         with (
-            patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
             patch("decafclaw.memory_context.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):

--- a/tests/test_orphaned_tool_results.py
+++ b/tests/test_orphaned_tool_results.py
@@ -113,7 +113,7 @@ def _compose(ctx, config, user_message, history):
     config.agent.tool_context_budget_pct = 1.0
     config.compaction.max_tokens = 1000000
     with (
-        patch("decafclaw.agent._collect_all_tool_defs", return_value=[]),
+        patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
         patch("decafclaw.memory_context.retrieve_memory_context",
               new_callable=AsyncMock, return_value=[]),
     ):

--- a/tests/test_process_tool_media.py
+++ b/tests/test_process_tool_media.py
@@ -1,12 +1,12 @@
-"""Tests for _process_tool_media — per-tool-call media save and placeholder replacement."""
+"""Tests for process_tool_media — per-tool-call media save and placeholder replacement."""
 
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from decafclaw.agent import _process_tool_media
 from decafclaw.media import MediaSaveResult, ToolResult
+from decafclaw.tool_execution import process_tool_media
 
 
 @dataclass
@@ -40,7 +40,7 @@ async def test_image_placeholder_replaced_with_markdown_image():
         text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == []
     assert "![img.png](workspace://conversations/conv1/uploads/img-20260327.png)" in result.text
     assert "[file attached:" not in result.text
@@ -58,7 +58,7 @@ async def test_non_image_placeholder_replaced_with_markdown_link():
         text="[file attached: doc.pdf (application/pdf) — will appear as an attachment on your reply]",
         media=[{"type": "file", "filename": "doc.pdf", "data": b"pdf", "content_type": "application/pdf"}],
     )
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == []
     assert "[doc.pdf](workspace://conversations/conv1/uploads/doc-20260327.pdf)" in result.text
     assert "![" not in result.text  # not an image ref
@@ -75,7 +75,7 @@ async def test_file_id_collected():
         text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == ["mm-file-123"]
     assert result.media == []
 
@@ -90,7 +90,7 @@ async def test_no_handler_logs_warning_leaves_text(caplog):
         text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == []
     assert "[file attached:" in result.text
     assert "No media handler" in caplog.text
@@ -108,7 +108,7 @@ async def test_failed_save_logs_warning_preserves_placeholder(caplog):
         text="[file attached: img.png (image/png) — will appear as an attachment on your reply]",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == []
     assert "[file attached:" in result.text
     assert "Failed to save media" in caplog.text
@@ -143,7 +143,7 @@ async def test_multiple_media_items():
             {"type": "file", "filename": "b.txt", "data": b"b", "content_type": "text/plain"},
         ],
     )
-    await _process_tool_media(ctx, result)
+    await process_tool_media(ctx, result)
     assert "![a.png](workspace://uploads/a-1.png)" in result.text
     assert "[b.txt](workspace://uploads/b-2.txt)" in result.text
     assert "[file attached:" not in result.text
@@ -164,7 +164,7 @@ async def test_no_placeholder_appends_ref():
         text="Here's a test image (200x200 gradient):",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    await _process_tool_media(ctx, result)
+    await process_tool_media(ctx, result)
     assert "Here's a test image" in result.text
     assert "![img.png](workspace://conversations/conv1/uploads/img-20260327.png)" in result.text
     assert result.media == []
@@ -177,7 +177,7 @@ async def test_no_handler_clears_media():
         text="some text",
         media=[{"type": "file", "filename": "img.png", "data": b"png", "content_type": "image/png"}],
     )
-    await _process_tool_media(ctx, result)
+    await process_tool_media(ctx, result)
     assert result.media == []
 
 
@@ -188,6 +188,6 @@ async def test_no_handler_clears_media():
 async def test_empty_media_noop():
     ctx = _FakeCtx(media_handler=None)
     result = ToolResult(text="no media here")
-    file_ids = await _process_tool_media(ctx, result)
+    file_ids = await process_tool_media(ctx, result)
     assert file_ids == []
     assert result.text == "no media here"

--- a/tests/test_tool_result_data.py
+++ b/tests/test_tool_result_data.py
@@ -76,7 +76,7 @@ def test_complex_data_serializes():
 @pytest.mark.asyncio
 async def test_agent_loop_appends_json_block(ctx):
     """The actual agent loop appends a JSON block when ToolResult.data is set."""
-    from decafclaw.agent import _execute_single_tool
+    from decafclaw.tool_execution import execute_single_tool
 
     test_data = {"exit_status": "success", "cost_usd": 1.23}
     mock_result = ToolResult(text="task completed", data=test_data)
@@ -87,8 +87,8 @@ async def test_agent_loop_appends_json_block(ctx):
     }
     semaphore = asyncio.Semaphore(1)
 
-    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
-        tool_msg, _ = await _execute_single_tool(ctx, tc, semaphore)
+    with patch("decafclaw.tool_execution.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg, _ = await execute_single_tool(ctx, tc, semaphore)
 
     assert tool_msg["role"] == "tool"
     assert tool_msg["content"].startswith("task completed")
@@ -105,7 +105,7 @@ async def test_agent_loop_appends_json_block(ctx):
 @pytest.mark.asyncio
 async def test_agent_loop_no_json_block_without_data(ctx):
     """No JSON block when ToolResult.data is None."""
-    from decafclaw.agent import _execute_single_tool
+    from decafclaw.tool_execution import execute_single_tool
 
     mock_result = ToolResult(text="plain result")
     tc = {
@@ -114,8 +114,8 @@ async def test_agent_loop_no_json_block_without_data(ctx):
     }
     semaphore = asyncio.Semaphore(1)
 
-    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
-        tool_msg, _ = await _execute_single_tool(ctx, tc, semaphore)
+    with patch("decafclaw.tool_execution.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg, _ = await execute_single_tool(ctx, tc, semaphore)
 
     assert tool_msg["content"] == "plain result"
     assert "```json" not in tool_msg["content"]
@@ -124,7 +124,7 @@ async def test_agent_loop_no_json_block_without_data(ctx):
 @pytest.mark.asyncio
 async def test_agent_loop_handles_unserializable_data(ctx):
     """Non-serializable data doesn't crash the tool call."""
-    from decafclaw.agent import _execute_single_tool
+    from decafclaw.tool_execution import execute_single_tool
 
     mock_result = ToolResult(text="result", data={"bad": object()})
     tc = {
@@ -133,8 +133,8 @@ async def test_agent_loop_handles_unserializable_data(ctx):
     }
     semaphore = asyncio.Semaphore(1)
 
-    with patch("decafclaw.agent.execute_tool", new_callable=AsyncMock, return_value=mock_result):
-        tool_msg, _ = await _execute_single_tool(ctx, tc, semaphore)
+    with patch("decafclaw.tool_execution.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg, _ = await execute_single_tool(ctx, tc, semaphore)
 
     assert "result" in tool_msg["content"]
     assert "serialization error" in tool_msg["content"]


### PR DESCRIPTION
## Summary
- Finish the agent.py decomposition started by #382 / #407 by relocating the tool-invocation and tool-registry clusters into dedicated modules.
- Gives `context_composer.py` a non-private import target (`collect_all_tool_defs` from `.tool_definitions`) — preparing the ground for #439.
- agent.py drops from 1451 to 1000 lines; the remaining ~250 lines beyond the spec's ~750 target are the wiki/attachment helpers explicitly deferred to #439.

## Design Decisions
- **Split into two modules along the invocation/definition boundary, not one big `tool_runtime.py`.** Invocation is internal to the agent loop; definitions are consumed by both the loop and `context_composer.py`. Separation prevents composer from accidentally importing execution internals.
- **Underscores dropped on relocated public functions.** Cross-module imports of underscore-prefixed names lie about visibility — the whole point of relocation is to make a real public surface. `_archive`, `_check_cancelled`, `_conv_id`, and `_media_placeholder_pattern` stay private (module-internal helpers, not exported API).
- **`_archive` / `_check_cancelled` / `_conv_id` (22 lines total) duplicated into `tool_execution.py` rather than extracted to a third shared module.** They're trivial leaves the agent loop calls into; pulling them out would invert the dependency direction. A comment in `tool_execution.py` documents the intentional duplication.

## Changes
- **New `src/decafclaw/tool_definitions.py`** (166 lines): `collect_all_tool_defs`, `build_tool_list`, `refresh_dynamic_tools`, `invalidate_skill_cache`, and the `_skill_def_cache` they share.
- **New `src/decafclaw/tool_execution.py`** (364 lines): `execute_tool_calls`, `execute_single_tool`, `process_tool_media`, `resolve_widget`, and the `_media_placeholder_pattern` LRU helper.
- **`agent.py`**: relocated functions removed, imports updated, call sites use the new public names.
- **`context_composer.py`**: two deferred imports changed from `.agent._collect_all_tool_defs` to `.tool_definitions.collect_all_tool_defs`.
- **`tools/skill_tools.py`**: deferred `invalidate_skill_cache` import retargeted to `..tool_definitions`.
- **CLAUDE.md**: "Core" key-files list updated with the two new modules; agent.py description trimmed to its post-split scope.
- **docs/architecture.md**: tool-execution-concurrency code snippet updated (`_execute_single_tool` → `execute_single_tool`).
- **Tests**: imports relocated, patch targets retargeted from `decafclaw.agent.*` to `decafclaw.tool_definitions.*` / `decafclaw.tool_execution.*` across `test_agent_turn`, `test_agent_widgets`, `test_process_tool_media`, `test_tool_result_data`, `test_context_composer`, `test_orphaned_tool_results`.

## Test Plan
- [x] `make check` passes (lint + pyright + tsc + message-types drift)
- [x] `make test` passes (2419 passed)
- [x] No stale imports: `grep -rn "from .agent import _execute_\|from .agent import _collect_\|from .agent import _build_\|from .agent import _refresh_\|from .agent import _process_tool_media\|from .agent import _resolve_widget" src/ tests/` returns nothing
- [x] Smoke: `python -c "from decafclaw.eval.runner import run_agent_turn"` (stable public surface preserved)
- [x] Smoke: `python -c "from decafclaw.tool_execution import execute_tool_calls, execute_single_tool, process_tool_media, resolve_widget"`
- [x] Smoke: `python -c "from decafclaw.tool_definitions import build_tool_list, collect_all_tool_defs, refresh_dynamic_tools, invalidate_skill_cache"`

## References
- Spec: `docs/dev-sessions/2026-05-13-0939-agent-split-tools/spec.md`
- Plan: `docs/dev-sessions/2026-05-13-0939-agent-split-tools/plan.md`
- Closes #438
- Unblocks #439 (composer-side relocations now have a clean import target)