### PR TITLE
fix(conv-manager): per-conv asyncio.Lock for dispatch + confirmation race

### DIFF
--- a/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/notes.md
+++ b/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/notes.md
@@ -1,0 +1,70 @@
+# Session notes — ConversationManager asyncio.Lock (#440)
+
+## Outcome
+
+Issue #440 closed. Per-conversation `asyncio.Lock` added to `ConversationState`. All mutation sites named in the spec brought under the lock. `make check` + `make test` green (2421 tests). Background-wake integration tests (#241) all pass.
+
+## Spec/test divergence: USER race window
+
+The spec described a race window in `enqueue_turn` (between `:279` and `:650`) where two concurrent USER enqueues could both bypass the busy check. On investigation that window is **structurally unreachable** in current code: there is no yield between the busy check at line :285 and the synchronous `state.busy = True` write at line :650 inside `_start_turn`. asyncio is cooperative — between awaits, a coroutine runs to completion — so the first task to resume from `await self.emit(...)` runs through the busy check and into `_start_turn`'s body, setting `busy=True` before yielding again. Subsequent tasks see `busy=True` and queue.
+
+**Implication:** the spec's `test #6` (concurrent USER enqueue) PASSES on unmodified code. I considered fabricating a yield (e.g. via `asyncio.sleep(0)` injection) but rejected it — the spec is explicit that the test should exercise the public surface so it would catch a real bug.
+
+Kept the test as a **structural guard** rather than a failing-baseline regression: it documents the invariant ("two simultaneous USER enqueues for the same conv must serialize") and would catch a regression *only when paired with the lock* — if someone later adds an await between busy-check and `busy=True`, the test fails without the lock and passes with it. Without the lock, the invariant is implicit in the control flow and silently regressable.
+
+**Test #7** (concurrent confirmation responses) IS a real failing baseline — both responders race past the `pending_confirmation` check in `respond_to_confirmation` and dispatch handler twice via `recover_confirmation`. `recover_confirmation` only nulls `state.pending_confirmation` AFTER awaiting `dispatch`, so the second caller observes the still-set field. The lock + a `confirmation_response` claim in `respond_to_confirmation` close this window. Test reliably fails on baseline (`handler_calls == 2`) and passes after the fix.
+
+## Design choices made during execution
+
+1. **Refactored `respond_to_confirmation`** to claim the response slot under the lock before doing I/O (archive write, emit). The lock-claim ordering matters: without it, two responders both pass the pending check, both call `append_message`, both call emit, both call recover. With it, only the first writes `confirmation_response`; the second observes it set and returns.
+
+2. **Extracted `_dispatch_recovery`** as a private helper that runs the handler without re-acquiring the lock (the caller in `respond_to_confirmation` has already popped `pending_confirmation` atomically). `recover_confirmation` kept as a thin public wrapper that pops the pending request under the lock then delegates. Both call sites converge on the same "pop atomically, then dispatch" pattern.
+
+3. **`_drain_pending` re-acquires the lock** around its pop-and-dispatch sequence. This means a concurrent `enqueue_turn` and a finally-block drain compete on equal footing — whoever grabs the lock first dispatches. If they happen in the wrong order (queued message dispatches *after* a freshly-arrived enqueue), the freshly-arrived one becomes the in-flight turn and the queued one is drained by the next finally-block cycle. Behaviorally indistinguishable from the original.
+
+4. **`asyncio.Lock` is NOT reentrant** — pyright doesn't catch this, so I traced every lock-using path to ensure no nested acquisitions. `_start_turn` is called from inside the lock (by `enqueue_turn` or `_drain_pending`) but doesn't acquire it itself. `_dispatch_recovery` runs handler code outside the lock (handlers may do arbitrary I/O). Finally-block reset under its own `async with` after the agent task body completes (lock has long since been released).
+
+5. **`emit` calls left under the lock in `enqueue_turn` and `_start_turn`'s synchronous setup but moved OUT of `respond_to_confirmation`'s lock block.** Reason: in `enqueue_turn` the `user_message` emit IS part of the dispatch decision; holding the lock across it serializes user-perceived event ordering correctly. In `respond_to_confirmation` the emit is *after* the decision is made, so it can run lock-free without affecting correctness.
+
+## Verification log
+
+- Phase 1+2 commit: test 2 fails (`handler_calls == 2`), test 1 passes on baseline.
+- Phase 3 commit: both tests pass; `make test` 2421 passed; `make check` clean (0 errors).
+- Background-wake integration tests: 5 passed.
+
+## Open notes for future sessions
+
+- **The USER enqueue race is real once a yield is introduced.** If any future PR adds an `await` between `enqueue_turn`'s busy check and `_start_turn`'s `state.busy = True`, the guard test will catch it. The lock makes this safe rather than relying on the implicit "no yield between these two lines" invariant.
+- Considered tightening `request_confirmation`'s persist-to-archive call to happen under the lock for consistency with `respond_to_confirmation`. Rejected: archive append is sync I/O, doesn't need lock protection, and the request's `confirmation_id` is unique so duplicate archive writes (if they ever happened) wouldn't corrupt state. Kept the archive write outside the lock to minimize hold time.
+- No CLAUDE.md update needed — the "Use `asyncio.Lock` for concurrency guards" convention is already documented. This PR brings the code into compliance.
+
+## Follow-up: Copilot review (round 3)
+
+Copilot ran three review passes against this PR. Rounds 1 and 2 were addressed in the initial squashed commit. Round 3 surfaced four more issues against the squashed code; the prior session also addressed those in the same squashed commit before this follow-up landed:
+
+1. **`cancel_pending_confirmation` archive failure (line 568)** — Cleared in-memory state before the archive write, so a filesystem error would lose the pending request without persisting a denial. Fix evolved across rounds: now archives UNDER the lock so a `request_confirmation` waiter timing out concurrently can't consume an uncommitted denial. State clear only after archive succeeds; on failure the pending state stays intact for retry. Tests: `test_cancel_pending_confirmation_rolls_back_on_archive_failure`, `test_cancel_pending_confirmation_after_response_claimed_is_noop`.
+2. **`recover_confirmation` dispatch failure (line 1329)** — Cleared `state.pending_confirmation` before running the recovery handler, so a handler exception would leave the request orphaned. Fix: try/except around `_dispatch_recovery`; on failure restore `state.pending_confirmation` (under the lock, only if nothing else has taken the slot) and re-raise. Test: `test_recover_confirmation_restores_on_dispatch_failure`.
+3. **Recovered-confirmation overwrite race in `respond_to_confirmation` (line 510)** — For the no-running-loop path, archive write + emit ran outside the lock while `state.pending_confirmation` was still set. A concurrent `request_confirmation` could overwrite it in that window, and the second lock block would then dispatch recovery with the wrong request. Fix: capture `claimed_request = state.pending_confirmation` inside the initial lock block, dispatch using the captured value, and re-check `confirmation_response is response` before clearing state (so a racing cancel that clears our claim short-circuits recovery cleanly). Test added this session: `test_recovered_confirmation_dispatch_uses_captured_request` — subscriber-driven simulation of the race; fails on the buggy re-read pattern (handler called with the racer's `ACTIVATE_SKILL` request instead of `RUN_SHELL_COMMAND`), passes after the capture is restored.
+4. **Finally-block comment / code mismatch (line 1019)** — Old comment claimed the lock prevented concurrent enqueues from observing `busy=False` before `_drain_pending` ran, but the lock is released before `_drain_pending` is called. Fix: rewrite the comment to accurately describe what the lock covers (atomic visibility of the `busy=False` / `agent_task=None` / `cancel_event=None` transition to other lock holders) and acknowledge that a concurrent enqueue CAN see `busy=False` before drain runs — the drain handles that case by re-acquiring the lock around its own pop-and-dispatch.
+
+All four are comment + code changes co-located with the rest of the lock work; no separate commits since the previous session squashed them in before pushing. This session added the missing regression test for #3 and verified the rest of Copilot's items are covered by the existing tests. `make check` clean, `make test` 2427 passed.
+
+## Follow-up: Copilot review (round 4)
+
+After the round-3 fixes were squashed into the PR head commit, Copilot ran a fourth review pass and posted five more inline comments (IDs `3236249305`, `3236249372`, `3236249406`, `3236249437`, `3236249466`). All five describe race / durability concerns that the round-3 code **already addresses**. Concrete walk-through of the current code, line by line:
+
+1. **`respond_to_confirmation` pre-archive claim (comment 3236249437, line 490).** Copilot's claim: `state.confirmation_response` is set before `append_message` succeeds. In the current code (lines 438-490), the entire claim sequence is inside one `async with state.lock:` block. `append_message` is called at lines 475-477; `state.confirmation_response = response` is at line 489, AFTER archive succeeds. The lock is released at line 491 (block dedent), so no other coroutine can observe the intermediate state. The `try/except` at 475-483 re-raises on archive failure without touching `state.confirmation_response`, which is still `None` at that point — no rollback needed because no claim was made.
+
+2. **`cancel_pending_confirmation` pre-archive claim (comment 3236249466).** Same shape as #1 in `cancel_pending_confirmation` (lines 573-612). `append_message` at 597-605, then `state.confirmation_response = response` at 608, under one lock block. Archive-failure path raises with state still untouched.
+
+3. **Timeout path clears in-memory before archive (comment 3236249372).** In `request_confirmation`'s post-wait block (lines 815-844), `append_message` happens at 829-833 BEFORE the pending-state clear at 841-843, all inside `async with state.lock:`. On archive failure, the `raise` at 839 exits the lock block with pending state still intact.
+
+4. **`_drain_pending` race with newly-arrived `enqueue_turn` (comment 3236249305).** `_drain_pending` (lines 1182-1196) re-acquires `state.lock` AND re-checks `state.busy` after acquiring it. If a concurrent enqueue won the dispatch race, drain logs a debug message and returns without dispatching.
+
+5. **Stale `:650` line-number reference (comment 3236249406).** The test docstring (`test_concurrent_user_enqueue_serializes_via_lock`) no longer contains a numeric line reference — line 1221 reads "before its `state.busy = True` assignment". Copilot's suggested fix is exactly what the current code already does.
+
+Existing regression tests covering each concern: `test_respond_to_confirmation_rolls_back_claim_on_archive_failure`, `test_cancel_pending_confirmation_rolls_back_on_archive_failure`, `test_request_confirmation_timeout_archive_failure_preserves_state`, `test_drain_pending_defers_when_concurrent_enqueue_won_dispatch`, plus `test_concurrent_confirmation_responses_dont_double_dispatch` and `test_request_confirmation_timeout_loses_race_to_late_responder`. All pass.
+
+**Decision: no code changes.** Per the project norm "NEVER be agreeable just to be nice — I need your honest technical judgment." Shipping a "fix" for non-existent bugs would add complexity without closing a real window. Replied to each comment on the PR citing current line numbers + tests. `make check` clean, `make test` 2429 passed.
+
+If Copilot's round-4 misreads are diff-rendering artifacts (e.g. it conflated `state.confirmation_response` writes at different lines as the same operation), future reviews may keep producing the same false positives. One option to consider: extract the "archive-then-claim" sequence into a named helper (`_claim_response_atomically(state, response)`) so each call site is a single line rather than a multi-statement block — would make the ordering visually unambiguous even to a confused reader. Deferred since the current comments document the invariant explicitly.

--- a/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/plan.md
+++ b/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/plan.md
@@ -1,0 +1,444 @@
+# ConversationManager asyncio.Lock Migration — Implementation Plan
+
+**Goal:** Replace bare boolean/scalar concurrency guards in `ConversationManager` with a per-`ConversationState` `asyncio.Lock`, closing the read/yield/write race window in `enqueue_turn` and the confirmation lifecycle, and aligning the module with the project's stated convention.
+
+**Approach:** Add a single `asyncio.Lock` to `ConversationState`. Wrap dispatch decisions (`busy` read → `_start_turn` call or `pending_messages.append`) and confirmation-event mutations in `async with state.lock:`. The lock guards the *decision*, not the agent task lifetime — `_start_turn` flips `busy = True` under the lock, then releases before the task runs. TDD: failing regression tests added first per the project's "Bug fix = test first" rule.
+
+**Tech stack:** Python 3.13, asyncio, pytest / pytest-asyncio.
+
+---
+
+## Phase 1: Regression test for `enqueue_turn` USER dispatch race
+
+Add a failing test demonstrating that two simultaneous `enqueue_turn(USER)` calls on the same `conv_id` can both run `_start_turn` (instead of one running, one queueing) because of the yield point at `await self.emit(...)` between the `state.busy` read and the `state.busy = True` write inside `_start_turn`.
+
+**Files:**
+- Modify: `tests/test_conversation_manager.py` — append new test `test_concurrent_user_enqueue_serializes_via_lock`
+
+**Key changes:**
+- Test exercises the public `enqueue_turn(kind=USER)` surface — not internal locks/state directly — so it would fail if someone deleted the lock.
+- Uses an `asyncio.Event` inside a stubbed `run_agent_turn` so the first turn parks deterministically (no wall-clock sleeps).
+- Subscribes to the manager to *force a real subscriber*, ensuring `self.emit(...)` at line :279 actually yields (no subscribers ⇒ early-return ⇒ no yield ⇒ no race).
+- Asserts: exactly one call into `run_agent_turn`, and the other request lands in `state.pending_messages`.
+
+```python
+@pytest.mark.asyncio
+async def test_concurrent_user_enqueue_serializes_via_lock(
+    manager, config, monkeypatch
+):
+    """Two simultaneous enqueue_turn(USER) calls for the same conv must
+    serialize: exactly one runs, the other queues. Regression for
+    issue #440 — the read-yield-write window in enqueue_turn used to
+    let both calls bypass the busy check.
+
+    Forcing a subscriber on the conv ensures `self.emit(...)` actually
+    yields at the race window; without a subscriber it returns
+    synchronously and the race can't be reproduced.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        started.set()
+        await release.wait()
+        from decafclaw.media import ToolResult
+        return ToolResult(text="ok")
+
+    monkeypatch.setattr("decafclaw.agent.run_agent_turn", fake_run_agent_turn)
+
+    # Subscriber forces `emit` to actually await (real yield point at :279).
+    async def _noop(_event):
+        pass
+    manager.subscribe("c1", _noop)
+
+    # Fire both enqueues concurrently. Without the lock both observe
+    # busy=False and both call _start_turn.
+    f1, f2 = await asyncio.gather(
+        manager.enqueue_turn("c1", kind=TurnKind.USER, prompt="one"),
+        manager.enqueue_turn("c1", kind=TurnKind.USER, prompt="two"),
+    )
+
+    # Let the started turn finish.
+    await started.wait()
+    state = manager.get_state("c1")
+    assert state is not None
+
+    # Exactly one turn started; the other is queued.
+    assert call_count == 1, (
+        f"expected exactly one turn started, got {call_count}"
+    )
+    assert len(state.pending_messages) == 1, (
+        f"expected one pending message, got {len(state.pending_messages)}"
+    )
+
+    # Drain so the test cleans up.
+    release.set()
+    await asyncio.wait_for(f1, timeout=2.0)
+    await asyncio.wait_for(f2, timeout=2.0)
+```
+
+**Verification — automated:**
+- [x] Test runs — note: PASSES on unmodified code (race window structurally unreachable today). Repositioned as a guard test, see notes.md.
+- [x] `make lint` passes (test file syntactically clean).
+
+**Verification — manual:**
+- [x] Confirmed the existing control flow has no yield between busy-check and `state.busy = True` in `_start_turn` — the lock prevents future regressions if such a yield is introduced. Documented in test docstring.
+
+---
+
+## Phase 2: Regression test for `confirmation_event` race
+
+Add a failing test demonstrating that two near-simultaneous `respond_to_confirmation` calls (same conv, same confirmation_id) can both observe `state.confirmation_event` as set / not-yet-cleared and call `event.set()` twice (or interleave with `request_confirmation`'s null-out at lines :617/:623). With a lock around the confirmation-event mutations, the second call sees `pending_confirmation is None` and short-circuits.
+
+**Files:**
+- Modify: `tests/test_conversation_manager.py` — append `test_concurrent_confirmation_responses_dont_double_dispatch`
+
+**Key changes:**
+- Two `respond_to_confirmation` calls fired via `asyncio.gather`.
+- Track invocations of the confirmation handler — assert exactly one fires (the other returns early on `state.pending_confirmation is None`).
+- Use a `ConfirmationAction` with a registered handler in a fresh `ConfirmationRegistry` (mirrors `test_respond_to_recovered_confirmation`).
+
+```python
+@pytest.mark.asyncio
+async def test_concurrent_confirmation_responses_dont_double_dispatch(
+    manager, monkeypatch
+):
+    """Two simultaneous respond_to_confirmation calls for the same
+    confirmation_id must not both succeed. Regression for #440 — the
+    state.pending_confirmation / state.confirmation_event mutations
+    used to be unlocked, so two responses could race past the
+    pending_confirmation check before either nulled it out.
+    """
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-conf-race"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    # Pre-populate pending state on a recovered conv (no running loop)
+    # so respond_to_confirmation goes through recover_confirmation.
+    append_message(manager.config, conv_id, request.to_archive_message())
+    await manager.startup_scan()
+
+    handler_calls = 0
+
+    async def handler(ctx, req, resp):
+        nonlocal handler_calls
+        handler_calls += 1
+        # Yield once so both responders are in flight before either finishes.
+        await asyncio.sleep(0)
+        return {"ok": True}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.RUN_SHELL_COMMAND, handler
+    )
+
+    await asyncio.gather(
+        manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True),
+        manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True),
+    )
+
+    assert handler_calls == 1, (
+        f"expected exactly one handler dispatch, got {handler_calls}"
+    )
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is None
+```
+
+**Verification — automated:**
+- [x] Test runs and FAILS on unmodified `conversation_manager.py` (`handler_calls == 2`, race reproduced — `recover_confirmation` only nulls `pending_confirmation` after awaiting `dispatch`, so the second responder races past the check).
+- [x] `make lint` passes.
+
+**Verification — manual:**
+- [x] Confirmed failure is the race (handler_calls == 2 on baseline). Documented in test docstring.
+
+---
+
+## Phase 3: Add `lock` field + wrap dispatch and confirmation mutations
+
+Add `lock: asyncio.Lock = field(default_factory=asyncio.Lock)` to `ConversationState`. Wrap the mutation sites identified in the spec under `async with state.lock:`. The lock is held only during the *decision* (read state → schedule task or queue), then released so the agent task can run without holding it.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py` — add field, wrap call sites
+
+**Mutation sites brought under the lock:**
+
+1. **`enqueue_turn` — dispatch decision** (currently `:273`–`:329`)
+   - Hold lock from after the WAKE rate-limiter through `state.busy` check + `pending_messages.append` or `_start_turn` invocation.
+   - WAKE rate limiter (`:258`–`:270`) does its own `state.wake_times` mutation — also goes under the lock (per spec point 4: "circuit breaker reads under the same lock"; wake rate limiter is structurally identical).
+   - USER `user_message` event emission (`:279`) stays under the lock — the lock protects the *invariant* (one dispatch per turn), and the emit is part of that decision. Holding it across emit is fine: subscribers don't block on the lock and the lock is per-conv, so other convs aren't affected.
+
+2. **`_start_turn` — `state.busy = True` and `state.cancel_event` setup (`:650`–`:651`)**
+   - These are now invoked from inside the lock (held by the caller). No code change needed in `_start_turn` for this site beyond a docstring note that the caller must hold `state.lock`.
+   - **Crucial:** `asyncio.create_task(run())` at `:849` does NOT await the task — it returns immediately, so the lock is released before the agent loop actually executes.
+
+3. **`run()` finally-block — `state.busy = False` reset (`:834`)**
+   - The `busy = False` write at line :834 plus `agent_task = None` / `cancel_event = None` plus the `await self._drain_pending(state)` call at line :847 all need to be under the lock so a concurrent `enqueue_turn` can't see `busy=False` while `_drain_pending` is mid-flight.
+   - But `_drain_pending` itself calls back into `_start_turn`, which now requires the lock. To avoid re-entrancy deadlock, restructure as follows: hold the lock to reset `busy/agent_task/cancel_event` *and* to call `_drain_pending` — `_drain_pending`'s inner `_start_turn` invocation already runs inside the same lock acquisition, which is fine because we never re-acquire the lock from `_start_turn`'s body.
+   - **Alternative (simpler):** drain pending OUTSIDE the lock — release after the state reset, then call `_drain_pending`. `_drain_pending` reacquires the lock itself only for the `busy = True` re-flip inside its `_start_turn` call. This is what the implementation does.
+
+4. **`request_confirmation` (`:573`–`:625`)**
+   - Hold the lock around setting `pending_confirmation` / `confirmation_event` / `confirmation_response` (lines :580–:582).
+   - Release before `await asyncio.wait_for(state.confirmation_event.wait(), ...)` — must release or the responder can never acquire it to set the event.
+   - Re-acquire to null out `pending_confirmation` / `confirmation_event` / `confirmation_response` on both the timeout path (lines :616–:617) and the success path (lines :622–:624).
+
+5. **`respond_to_confirmation` (`:357`–`:417`)**
+   - Hold the lock around the `state.pending_confirmation` / id-match check (`:377`–`:384`) and the `state.confirmation_response = response` / `state.confirmation_event.set()` writes (`:409`–`:411`).
+   - Release before `await self.recover_confirmation(...)` (which calls handler code and shouldn't run under the lock — handlers may do arbitrary I/O).
+
+6. **`cancel_pending_confirmation` (`:419`–`:443`)**
+   - Wrap the read-and-null-out (`:431`–`:442`) under the lock.
+
+7. **`_circuit_breaker_tripped` + `_circuit_breaker_record` (`:212`–`:232`)**
+   - Per spec point 3: these run from inside the `enqueue_turn` lock acquisition and the `run()` finally block (which also holds the lock). Their bodies don't need to acquire the lock themselves — they're called *from inside* the lock. Add a docstring note: "Caller must hold `state.lock`."
+
+8. **`cancel_turn` (`:445`–`:454`)**
+   - Reads `state.cancel_event` / `state.agent_task`. Wrap under the lock for consistency, even though setting `cancel_event` and cancelling a task are themselves atomic — the *read* needs to be paired with the action to avoid TOCTOU on `state.cancel_event` being nulled by the finally block at `:836`.
+
+**Key changes:**
+
+```python
+# ConversationState additions
+@dataclass
+class ConversationState:
+    ...
+    # Per-conversation lock guarding the dispatch decision and
+    # confirmation-event lifecycle (issue #440). Held briefly during:
+    # - enqueue_turn's busy-check → start-or-queue sequence
+    # - request_confirmation / respond_to_confirmation /
+    #   cancel_pending_confirmation state mutations
+    # - the agent task's finally-block busy=False reset
+    # NOT held across the agent task itself, nor across handler
+    # invocations in recover_confirmation.
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+```
+
+`enqueue_turn` skeleton (after the early return for wake-rate-limit drop):
+```python
+async with state.lock:
+    if kind is TurnKind.WAKE:
+        # ... wake rate limiter (state.wake_times mutations)
+    if kind is TurnKind.USER:
+        if self._circuit_breaker_tripped(state):
+            ...
+            future.set_result(None)
+            return future
+        await self.emit(conv_id, {...})  # still inside lock — safe
+    if state.busy:
+        # ... cancel + append to pending_messages
+        return future
+    await self._start_turn(state, ...)
+    return future
+```
+
+`_start_turn` finally-block restructure:
+```python
+finally:
+    self.event_bus.unsubscribe(bus_sub_id)
+    if forward_tasks:
+        await asyncio.gather(*forward_tasks, return_exceptions=True)
+    if kind in STATE_PERSIST_KINDS:
+        self._save_conversation_state(state, ctx)
+    if kind is TurnKind.USER:
+        self._circuit_breaker_record(state)  # caller-holds-lock convention
+    async with state.lock:
+        state.busy = False
+        state.agent_task = None
+        state.cancel_event = None
+    await self.emit(conv_id, {"type": "turn_complete"})
+    if future is not None and not future.done():
+        future.set_result(result_text)
+    await self._drain_pending(state)  # acquires lock internally via _start_turn
+```
+
+`_drain_pending`: invokes `_start_turn` which expects the caller to hold the lock — so `_drain_pending` itself acquires the lock around the dispatch:
+```python
+async def _drain_pending(self, state):
+    if not state.pending_messages:
+        return
+    async with state.lock:
+        # ... existing pop / coalesce / call _start_turn logic
+```
+
+`request_confirmation`:
+```python
+async with state.lock:
+    state.pending_confirmation = request
+    state.confirmation_event = asyncio.Event()
+    state.confirmation_response = None
+await self.emit(conv_id, {...})
+try:
+    await asyncio.wait_for(state.confirmation_event.wait(), timeout=...)
+except asyncio.TimeoutError:
+    response = ConfirmationResponse(...)
+    append_message(...)
+    await self.emit(conv_id, {...})
+    async with state.lock:
+        state.pending_confirmation = None
+        state.confirmation_event = None
+    return response
+
+response = state.confirmation_response
+assert response is not None
+async with state.lock:
+    state.pending_confirmation = None
+    state.confirmation_event = None
+    state.confirmation_response = None
+return response
+```
+
+`respond_to_confirmation`: the lock must atomically claim the response slot — otherwise two responders racing for the recovered-conv path both observe `pending_confirmation` set and both dispatch `recover_confirmation`. Claim semantics: the first responder under the lock pops the request out (sets `confirmation_response`, captures `pending_confirmation`, nulls `state.pending_confirmation`); the second responder finds nothing pending and returns.
+
+```python
+async with state.lock:
+    if not state.pending_confirmation:
+        log.warning("No pending confirmation for conv %s", conv_id)
+        return
+    if state.pending_confirmation.confirmation_id != confirmation_id:
+        log.warning("Confirmation ID mismatch ...")
+        return
+    response = ConfirmationResponse(
+        confirmation_id=confirmation_id,
+        approved=approved,
+        always=always,
+        add_pattern=add_pattern,
+        data=data or {},
+    )
+    state.confirmation_response = response
+    waiter_event = state.confirmation_event  # may be None for recovered convs
+
+# Archive + emit + (wake-running-loop or dispatch-recovery) happen
+# OUTSIDE the lock. The lock has already claimed the response slot,
+# so a concurrent responder will see `pending_confirmation` is gone
+# and return.
+from .archive import append_message
+append_message(self.config, conv_id, response.to_archive_message())
+emit_payload: dict[str, Any] = {
+    "type": "confirmation_response",
+    "confirmation_id": confirmation_id,
+    "approved": approved,
+}
+if response.data:
+    emit_payload["data"] = response.data
+await self.emit(conv_id, emit_payload)
+
+if waiter_event is not None:
+    # Running loop: wake it. request_confirmation will null out
+    # pending_confirmation when it observes the event.
+    waiter_event.set()
+else:
+    # No running loop — dispatch recovery. Atomically null out
+    # pending_confirmation BEFORE recovery so a concurrent responder
+    # entering respond_to_confirmation between this point and the end
+    # of recovery doesn't re-dispatch.
+    async with state.lock:
+        request_for_recovery = state.pending_confirmation
+        state.pending_confirmation = None
+    if request_for_recovery is None:
+        return  # someone else already handled it
+    log.info("No running loop for conv %s, dispatching recovery", conv_id)
+    result = await self._dispatch_recovery(conv_id, request_for_recovery, response)
+    log.info("Recovery result for conv %s: %s", conv_id[:8], result)
+```
+
+Where `_dispatch_recovery` is a small refactor of the existing `recover_confirmation`'s body that takes the request explicitly (since we already nulled `state.pending_confirmation`). To minimize blast radius, keep the public `recover_confirmation` as-is for external callers (none in-tree besides this one site, but cheap insurance) — extract the dispatch body into a private helper.
+
+```python
+async def _dispatch_recovery(
+    self,
+    conv_id: str,
+    request: ConfirmationRequest,
+    response: ConfirmationResponse,
+) -> dict:
+    """Run a confirmation handler for a recovered (no-running-loop) conv.
+
+    Caller is responsible for clearing state.pending_confirmation under
+    state.lock before calling — see respond_to_confirmation.
+    """
+    if not self.confirmation_registry._handlers:
+        log.warning(
+            "No confirmation handlers registered — cannot recover "
+            "confirmation for conv %s (action: %s)",
+            conv_id[:8], request.action_type.value,
+        )
+        return {"error": "No confirmation handlers registered"}
+    recovery_ctx = _RecoveryContext(config=self.config, conv_id=conv_id)
+    return await self.confirmation_registry.dispatch(
+        recovery_ctx, request, response,
+    )
+```
+
+`recover_confirmation` (the existing public method) becomes a thin wrapper that does the read-under-lock then delegates:
+
+```python
+async def recover_confirmation(self, conv_id, response):
+    state = self._conversations.get(conv_id)
+    if not state:
+        return {"error": "No pending confirmation"}
+    async with state.lock:
+        request = state.pending_confirmation
+        if not request:
+            return {"error": "No pending confirmation"}
+        state.pending_confirmation = None
+    return await self._dispatch_recovery(conv_id, request, response)
+```
+
+This preserves the existing single-call recovery semantics while making the claim atomic.
+
+Also: `request_confirmation`'s null-out paths (`:617` / `:623`) need to handle the case where `respond_to_confirmation` has already nulled `state.pending_confirmation` — null-assigning None to a None field is a no-op, so this works without further change. But we should also stop overwriting `state.confirmation_response = None` at `:624` after we've consumed it — the response is locally bound; let's just null state.confirmation_response under the lock to keep the field tidy. Fine as-is in the original code.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make check` passes (pyright + lint + check-message-types + tsc)
+- [x] `make test` passes — full suite (2421 tests), including:
+  - the two new Phase 1 / Phase 2 tests now PASS
+  - existing test `test_message_queued_when_busy` still passes
+  - existing test `test_drain_pending_resolves_all_queued_futures` still passes
+  - existing test `test_drain_pending_fanout_handles_head_exception` still passes
+  - existing test `test_request_confirmation_*` family still passes
+  - existing test `test_respond_to_recovered_confirmation` still passes
+
+**Verification — manual:**
+- [x] Grepped `state.busy / state.confirmation_event / state.pending_confirmation / state.confirmation_response / state.cancel_event / state.agent_task / state.paused_until / state.turn_times / state.wake_times` — every write/paired-read under the lock except startup_scan (pre-transport, no concurrency risk; documented).
+- [x] `_start_turn` does NOT hold the lock across `asyncio.create_task(run())`. Lock is held by the caller (`enqueue_turn` or `_drain_pending`) only across `_start_turn`'s synchronous setup; `asyncio.create_task` returns immediately so the lock releases before `run()` executes.
+- [x] `#241` background-wake integration tests (`tests/test_background_wake_integration.py`) — all 5 pass.
+
+---
+
+## Phase 4: Docs + key-files note
+
+Update CLAUDE.md only if conventions changed; otherwise this is a no-op for docs (the lock is an implementation detail, not a user-visible convention shift). No `docs/` page is the source of truth for `conversation_manager.py` internals; the relevant convention bullet ("Use `asyncio.Lock` for concurrency guards. Not boolean flags — locks auto-release on exception.") in CLAUDE.md is already in place — this PR brings the code into compliance, no doc update needed.
+
+**Files:**
+- Possibly modify: `docs/conversations.md` if it makes any claim about per-conv busy flags. Otherwise no doc changes.
+
+**Verification — automated:**
+- [x] `make check-message-types` passes (no wire-protocol changes) — verified as part of `make check`.
+
+**Verification — manual:**
+- [x] Grepped `docs/` for "busy flag" / "busy boolean" / "boolean flag" — no stale references requiring updates. CLAUDE.md "Per-conversation busy flag" remark at line 137 is still accurate at the language level (the lock guards the busy flag, the busy flag itself remains the serialization signal).
+
+---
+
+## Out of scope (do NOT touch)
+
+- Global manager-wide lock (spec rejects)
+- `TurnKind` semantics / heartbeat / scheduled / child-agent paths beyond using the lock for the same state reads
+- `_start_turn` internals beyond the mutations that touch guarded state
+- `_drain_pending` beyond putting the `busy = False` write under the lock (already covered by the finally-block restructure)
+- Confirmation persistence model (the lock only protects in-memory `confirmation_event`)
+- WebSocket / transport surface
+
+## Risks / things to watch
+
+- **Deadlock from re-entrant lock acquisition.** `asyncio.Lock` is NOT reentrant. If any code path inside a lock-held region tries to acquire the same lock, it deadlocks. Mitigation: every lock acquisition is a flat `async with state.lock:` block, no nested acquisitions. The `_drain_pending → _start_turn` path is fine because `_start_turn` itself does not acquire the lock — the caller is expected to hold it (or for the test/direct-call case, `_drain_pending` acquires it on behalf of `_start_turn`).
+- **Holding lock across `self.emit(...)`.** `emit` awaits subscribers serially. If a subscriber blocks indefinitely, the lock is held indefinitely. This is per-conv only, so cross-conv throughput is fine, but it does mean a slow subscriber on conv X blocks new turns on conv X. Acceptable per existing semantics (emit was always awaited).
+- **Test flakiness if yield window isn't actually exercised.** Mitigate by using `asyncio.Event` for synchronization and forcing a subscriber so `emit` actually yields. No wall-clock sleeps.

--- a/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/spec.md
+++ b/docs/dev-sessions/2026-05-13-0939-conv-manager-lock/spec.md
@@ -1,0 +1,77 @@
+# ConversationManager asyncio.Lock Migration Spec
+
+**Goal:** Replace the bare boolean/scalar concurrency flags in `ConversationManager` with an `asyncio.Lock` per `ConversationState`, closing a narrow but real race window for same-conversation `USER`-kind turns and aligning the module with the project's concurrency-guard convention.
+
+**Source:** [Issue #440](https://github.com/lmorchard/decafclaw/issues/440)
+
+## Current state
+
+`src/decafclaw/conversation_manager.py` guards per-conversation state (`busy`, `paused_until`, `confirmation_event`) with bare booleans / scalars. CLAUDE.md explicitly says: *"Use `asyncio.Lock` for concurrency guards. Not boolean flags — locks auto-release on exception."*
+
+The race window in `enqueue_turn` (`conversation_manager.py:273`):
+
+```python
+# :273 USER-kind only:
+if kind is TurnKind.USER:
+    if self._circuit_breaker_tripped(state):   # reads state.paused_until
+        ...
+    await self.emit(conv_id, {"type": "user_message", ...})   # :279 YIELD POINT
+
+# :285
+if state.busy:
+    ...append to pending_messages and return
+...
+await self._start_turn(...)   # :315 — sets state.busy=True at _start_turn:650 (after more awaits)
+```
+
+Between the `await self.emit(...)` at `:279` and the `state.busy = True` at `_start_turn:650`, another `enqueue_turn(USER)` for the same `conv_id` can land, see `busy=False`, and start a second concurrent agent task. Same shape applies for `paused_until` (read at `:216`, written at `:221`) and `confirmation_event` swap/null/signal at `:410`/`:581`/`:617`/`:623`.
+
+Failure mode is invisible in production today because Mattermost websocket events are processed serially and per-user web sockets are serial too — but rapid double-send from a single tab, two tabs on the same conv, or a `USER` turn racing a `WAKE`/scheduled turn at the same `conv_id` would all trigger it, and "two concurrent agent loops on the same conv" is brutal to debug from logs.
+
+## Desired end state
+
+1. `ConversationState` gains an `asyncio.Lock` field (suggested name: `lock`).
+2. `enqueue_turn`'s busy-check → enqueue-or-start sequence is wrapped in `async with state.lock:` — covers reading `state.busy` and the dispatch into `_start_turn` / `pending_messages.append`.
+3. `_circuit_breaker_tripped` / `_circuit_breaker_record` read-then-write of `paused_until` runs under the same lock.
+4. `confirmation_event` mutations (`request_confirmation` create at `:581`, signal at `:410`, null-out at `:617`/`:623`) run under the same lock.
+5. `_start_turn` does NOT hold the lock across the agent task lifetime — it sets `state.busy = True`, schedules the task, and releases. The agent task clears `busy` from `_drain_pending` (`:894`); that mutation runs inside the lock too.
+6. New regression test: dispatch two simultaneous `enqueue_turn(USER)` calls for the same `conv_id`; assert exactly one runs and the other lands in `pending_messages`.
+7. New regression test: `request_confirmation` racing a duplicate `respond_to_confirmation` doesn't drop or double-deliver.
+
+## Design decisions
+
+- **Decision:** One lock per `ConversationState`, not per-attribute locks.
+  - **Why:** The flags are interdependent — `busy`, `paused_until`, and `confirmation_event` participate in the same dispatch decision. Splitting locks would introduce ordering hazards. One lock per conv is also the project's stated convention.
+  - **Rejected:** A single global manager-wide lock — kills cross-conversation throughput for no benefit.
+
+- **Decision:** Lock is acquired during the dispatch decision but released before the agent task runs.
+  - **Why:** Holding the lock across the agent loop would serialize *all* updates to that conv (including `_drain_pending`) for the duration of a turn. The lock protects the *decision*, not the *execution*.
+  - **Rejected:** Holding lock through the agent task — would deadlock anything `_drain_pending` waits on.
+
+- **Decision:** Bug fix → write a failing test first, per project convention.
+  - **Why:** The race is narrow; the regression test is what proves we actually closed the window. Without a test we can't tell the new code from a no-op.
+
+## Patterns to follow
+
+- Test concurrency primitives use `asyncio.gather` with deliberate yields (`await asyncio.sleep(0)`) to interleave coroutines deterministically — see existing patterns in `tests/` for prior art.
+- Don't `asyncio.sleep(X)` to wait for work in tests; wait on actual signals (`event.wait()`, `await task`, patched clocks) per CLAUDE.md "Test speed discipline."
+
+## What we're NOT doing
+
+- **NOT introducing a global manager lock** — per-conv only.
+- **NOT changing `TurnKind` semantics or the heartbeat/scheduled/child-agent paths** beyond making them use the lock for the same state reads.
+- **NOT refactoring `_start_turn` internals** — only the mutations that touch the guarded state.
+- **NOT touching `_drain_pending` beyond putting the `busy = False` write under the lock.**
+- **NOT changing the confirmation persistence model** — the lock only protects in-memory `confirmation_event`.
+- **NOT modifying the websocket/transport surface.**
+
+## Validation
+
+- `make check` (lint + typecheck) green.
+- `make test` green.
+- New regression tests added per "Desired end state" #6 and #7, watched fail then pass (TDD).
+- `#241` background-wake integration test still passes.
+
+## Open questions
+
+- None blocking — issue body fully specifies which mutation sites need locking. Naming (`lock` vs `state_lock`) is plan-phase detail.

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -147,6 +147,44 @@ class ConversationState:
     agent_task: asyncio.Task | None = None
     cancel_event: asyncio.Event | None = None
 
+    # Per-conversation lock guarding the dispatch decision and the
+    # confirmation lifecycle (issue #440). Held during:
+    #   - enqueue_turn's busy-check → start-or-queue sequence
+    #     (including the user_message emit, the _start_turn dispatch
+    #     up to asyncio.create_task(run()), and any awaits inside
+    #     _start_turn's pre-task setup such as context_setup and the
+    #     turn_start emit)
+    #   - the agent task's finally-block busy=False reset
+    #   - _drain_pending's pop-and-dispatch (same scope as
+    #     enqueue_turn's dispatch path); re-checks state.busy and
+    #     defers if a concurrent enqueue won
+    #   - request_confirmation's pending/event/response triple setup
+    #     and post-wait teardown (released across event.wait() so the
+    #     responder can acquire it); the post-wait timeout-archive
+    #     write also runs inside the lock for durability
+    #   - respond_to_confirmation's pending-check + archive write +
+    #     response-slot claim — archive happens UNDER the lock so the
+    #     durable record exists before any waiter/claimer can observe
+    #     the claim
+    #   - cancel_pending_confirmation's archive write + claim + state
+    #     clear (all under the lock for the same durability reason)
+    #   - cancel_turn's paired read of cancel_event/agent_task
+    #   - recover_confirmation's atomic pop of pending_confirmation
+    # NOT held during:
+    #   - the agent task body itself (asyncio.create_task returns
+    #     immediately so the caller's lock-acquire is released before
+    #     run() executes)
+    #   - confirmation handler invocations in _dispatch_recovery /
+    #     recover_confirmation (handlers may do arbitrary I/O)
+    #   - subscriber emit awaits AFTER the claim/clear in
+    #     respond_to_confirmation, request_confirmation's timeout
+    #     emit, and cancel_pending_confirmation's emit — the durable
+    #     state is already in place by then, so emit failures log
+    #     but don't roll back
+    #   - request_confirmation's event.wait() — released to let the
+    #     responder acquire the lock and claim the slot
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
     # Confirmation state
     pending_confirmation: ConfirmationRequest | None = None
     confirmation_event: asyncio.Event | None = None
@@ -210,7 +248,12 @@ class ConversationManager:
         return self._conversations[conv_id]
 
     def _circuit_breaker_tripped(self, state: ConversationState) -> bool:
-        """Check if the circuit breaker has tripped for a conversation."""
+        """Check if the circuit breaker has tripped for a conversation.
+
+        Caller must hold ``state.lock`` — read-then-write of
+        ``state.paused_until`` and ``state.turn_times`` must be
+        atomic with the surrounding dispatch decision (issue #440).
+        """
 
         now = time.monotonic()
         if now < state.paused_until:
@@ -227,7 +270,10 @@ class ConversationManager:
         return False
 
     def _circuit_breaker_record(self, state: ConversationState) -> None:
-        """Record an agent turn completion for circuit breaker tracking."""
+        """Record an agent turn completion for circuit breaker tracking.
+
+        Caller must hold ``state.lock``.
+        """
 
         state.turn_times.append(time.monotonic())
 
@@ -254,79 +300,89 @@ class ConversationManager:
         state = self._get_or_create(conv_id)
         future: asyncio.Future = asyncio.get_running_loop().create_future()
 
-        # WAKE-kind: rate limiter — drop excess wakes within the window.
-        if kind is TurnKind.WAKE:
-            now = time.monotonic()
-            cutoff = now - self._wake_window_sec
-            state.wake_times = [t for t in state.wake_times if t > cutoff]
-            if len(state.wake_times) >= self._wake_max_per_window:
-                log.warning(
-                    "Wake rate limit exceeded for conv %s "
-                    "(%d wakes in last %ds) — dropping wake",
-                    conv_id[:8], len(state.wake_times), self._wake_window_sec,
-                )
-                future.set_result(None)
+        # Dispatch decision runs under state.lock so the busy-check /
+        # circuit-breaker / wake-limiter reads are atomic with the
+        # decision to queue vs. start a turn. The lock is held across
+        # the user_message emit and the synchronous body of
+        # _start_turn (which sets busy=True before scheduling the
+        # agent task), but the agent task itself runs without the
+        # lock. See issue #440.
+        async with state.lock:
+            # WAKE-kind: rate limiter — drop excess wakes within the window.
+            if kind is TurnKind.WAKE:
+                now = time.monotonic()
+                cutoff = now - self._wake_window_sec
+                state.wake_times = [t for t in state.wake_times if t > cutoff]
+                if len(state.wake_times) >= self._wake_max_per_window:
+                    log.warning(
+                        "Wake rate limit exceeded for conv %s "
+                        "(%d wakes in last %ds) — dropping wake",
+                        conv_id[:8], len(state.wake_times),
+                        self._wake_window_sec,
+                    )
+                    future.set_result(None)
+                    return future
+                state.wake_times.append(now)
+
+            # USER-kind only: circuit breaker check + user_message event emission.
+            if kind is TurnKind.USER:
+                if self._circuit_breaker_tripped(state):
+                    log.warning("Dropping message for paused conversation %s",
+                                conv_id[:8])
+                    future.set_result(None)
+                    return future
+                await self.emit(conv_id, {
+                    "type": "user_message",
+                    "text": archive_text or prompt,
+                    "user_id": user_id,
+                })
+
+            if state.busy:
+                # Cancel-on-new-message: cancel the current turn if configured
+                # (USER kind only, same as previous send_message behavior)
+                if (kind is TurnKind.USER
+                        and self.config.agent.turn_on_new_message == "cancel"
+                        and state.cancel_event
+                        and not state.cancel_event.is_set()):
+                    log.info("Conv %s busy, cancelling for new message",
+                             conv_id[:8])
+                    state.cancel_event.set()
+                    if state.agent_task and not state.agent_task.done():
+                        state.agent_task.cancel()
+
+                state.pending_messages.append({
+                    "kind": kind,
+                    "text": prompt,
+                    "user_id": user_id,
+                    "context_setup": context_setup,
+                    "archive_text": archive_text,
+                    "attachments": attachments,
+                    "command_ctx": command_ctx,
+                    "wiki_page": wiki_page,
+                    "task_mode": task_mode,
+                    "history": history,
+                    "metadata": metadata,
+                    "future": future,
+                })
+                log.info("Conv %s busy, queued message (%d pending)",
+                         conv_id[:8], len(state.pending_messages))
                 return future
-            state.wake_times.append(now)
 
-        # USER-kind only: circuit breaker check + user_message event emission.
-        if kind is TurnKind.USER:
-            if self._circuit_breaker_tripped(state):
-                log.warning("Dropping message for paused conversation %s",
-                            conv_id[:8])
-                future.set_result(None)
-                return future
-            await self.emit(conv_id, {
-                "type": "user_message",
-                "text": archive_text or prompt,
-                "user_id": user_id,
-            })
-
-        if state.busy:
-            # Cancel-on-new-message: cancel the current turn if configured
-            # (USER kind only, same as previous send_message behavior)
-            if (kind is TurnKind.USER
-                    and self.config.agent.turn_on_new_message == "cancel"
-                    and state.cancel_event
-                    and not state.cancel_event.is_set()):
-                log.info("Conv %s busy, cancelling for new message", conv_id[:8])
-                state.cancel_event.set()
-                if state.agent_task and not state.agent_task.done():
-                    state.agent_task.cancel()
-
-            state.pending_messages.append({
-                "kind": kind,
-                "text": prompt,
-                "user_id": user_id,
-                "context_setup": context_setup,
-                "archive_text": archive_text,
-                "attachments": attachments,
-                "command_ctx": command_ctx,
-                "wiki_page": wiki_page,
-                "task_mode": task_mode,
-                "history": history,
-                "metadata": metadata,
-                "future": future,
-            })
-            log.info("Conv %s busy, queued message (%d pending)",
-                     conv_id[:8], len(state.pending_messages))
-            return future
-
-        await self._start_turn(
-            state,
-            prompt,
-            kind=kind,
-            user_id=user_id,
-            context_setup=context_setup,
-            archive_text=archive_text,
-            attachments=attachments,
-            command_ctx=command_ctx,
-            wiki_page=wiki_page,
-            task_mode=task_mode,
-            history=history,
-            metadata=metadata,
-            future=future,
-        )
+            await self._start_turn(
+                state,
+                prompt,
+                kind=kind,
+                user_id=user_id,
+                context_setup=context_setup,
+                archive_text=archive_text,
+                attachments=attachments,
+                command_ctx=command_ctx,
+                wiki_page=wiki_page,
+                task_mode=task_mode,
+                history=history,
+                metadata=metadata,
+                future=future,
+            )
         return future
 
     async def send_message(
@@ -372,49 +428,134 @@ class ConversationManager:
 
         ``data`` carries free-form response payload (widget selections,
         etc.).
+
+        Concurrency: the pending-confirmation match, archive write,
+        response-slot claim, pending-state clear, and waiter capture
+        all happen under ``state.lock`` so the durable record exists
+        before any waiter or concurrent claimer can observe the
+        claim (issue #440 + Copilot review on #484). Emit and the
+        downstream wake / recovery dispatch run OUTSIDE the lock:
+        emit awaits subscribers (arbitrary I/O) and the recovery
+        handler may also do arbitrary I/O.
         """
         state = self._conversations.get(conv_id)
-        if not state or not state.pending_confirmation:
+        if not state:
             log.warning("No pending confirmation for conv %s", conv_id)
             return
-        if state.pending_confirmation.confirmation_id != confirmation_id:
-            log.warning("Confirmation ID mismatch for conv %s: expected %s, got %s",
-                        conv_id, state.pending_confirmation.confirmation_id,
-                        confirmation_id)
-            return
 
-        response = ConfirmationResponse(
-            confirmation_id=confirmation_id,
-            approved=approved,
-            always=always,
-            add_pattern=add_pattern,
-            data=data or {},
-        )
+        async with state.lock:
+            if not state.pending_confirmation:
+                log.warning("No pending confirmation for conv %s", conv_id)
+                return
+            if state.pending_confirmation.confirmation_id != confirmation_id:
+                log.warning(
+                    "Confirmation ID mismatch for conv %s: expected %s, got %s",
+                    conv_id, state.pending_confirmation.confirmation_id,
+                    confirmation_id)
+                return
+            # A previously-responded confirmation that hasn't been cleared
+            # yet (e.g. running-loop case where request_confirmation hasn't
+            # observed the event) — skip rather than double-dispatch.
+            if state.confirmation_response is not None:
+                log.warning(
+                    "Confirmation %s already has a response, ignoring "
+                    "duplicate respond_to_confirmation for conv %s",
+                    confirmation_id, conv_id)
+                return
 
-        # Persist to archive
-        from .archive import append_message
-        append_message(self.config, conv_id, response.to_archive_message())
+            response = ConfirmationResponse(
+                confirmation_id=confirmation_id,
+                approved=approved,
+                always=always,
+                add_pattern=add_pattern,
+                data=data or {},
+            )
+            # Archive the response under the lock so the durable record
+            # is in place BEFORE the waiter or any concurrent claimer
+            # can observe the claim. Without this, a `request_confirmation`
+            # waiter timing out while we're between claim and archive
+            # could consume our (uncommitted) response and clear the
+            # slot — and if the archive then failed, rollback couldn't
+            # restore (Copilot review on #484). `append_message` is
+            # sync filesystem I/O, so holding the per-conv lock across
+            # it just briefly blocks other lock acquirers on this conv.
+            from .archive import append_message
+            try:
+                append_message(self.config, conv_id,
+                               response.to_archive_message())
+            except Exception:
+                log.exception(
+                    "respond_to_confirmation archive write failed for "
+                    "conv %s; pending state untouched, caller may retry",
+                    conv_id[:8])
+                raise
+            # Capture the pending request AND atomically clear all
+            # pending state under the lock. Clearing here (rather
+            # than after the I/O) means a concurrent
+            # `request_confirmation` for a NEW request can land in
+            # the gap and write its own pending state without
+            # overwriting ours; our recovery dispatch uses
+            # `claimed_request` (a local variable), not state.
+            # The waiter_event is captured for the running-loop wake
+            # path before it's cleared. (Copilot review on #484.)
+            claimed_request = state.pending_confirmation
+            waiter_event = state.confirmation_event
+            state.confirmation_response = response
+            state.pending_confirmation = None
+            state.confirmation_event = None
 
-        # Emit to subscribers
-        emit_payload: dict[str, Any] = {
-            "type": "confirmation_response",
-            "confirmation_id": confirmation_id,
-            "approved": approved,
-        }
-        if response.data:
-            emit_payload["data"] = response.data
-        await self.emit(conv_id, emit_payload)
+        # Emit to subscribers outside the lock (subscriber awaits may
+        # do arbitrary I/O). If emit fails, the response is already
+        # durable in the archive and the waiter has observed our
+        # claim — subscribers may be out of sync but no persistent
+        # inconsistency results, so we log and continue.
+        try:
+            emit_payload: dict[str, Any] = {
+                "type": "confirmation_response",
+                "confirmation_id": confirmation_id,
+                "approved": approved,
+            }
+            if response.data:
+                emit_payload["data"] = response.data
+            await self.emit(conv_id, emit_payload)
+        except Exception:
+            log.exception(
+                "respond_to_confirmation emit failed for conv %s "
+                "(archive write already succeeded); continuing",
+                conv_id[:8])
 
-        # Wake the waiting agent loop or dispatch recovery
-        state.confirmation_response = response
-        if state.confirmation_event:
-            state.confirmation_event.set()
+        if waiter_event is not None:
+            # Running loop: wake it. request_confirmation will read
+            # state.confirmation_response under the lock (we already
+            # cleared pending_confirmation / confirmation_event
+            # above; request_confirmation's success path tolerates
+            # those being None) and then clear confirmation_response.
+            waiter_event.set()
         else:
-            # No running loop — dispatch recovery
+            # No running loop — dispatch recovery using the request
+            # captured under the lock above. The slot is already
+            # cleared (pending_confirmation = None, confirmation_event
+            # = None); confirmation_response is still set to mark the
+            # claim. On handler failure, restore pending state so the
+            # next retry / startup recovery can proceed.
+            async with state.lock:
+                state.confirmation_response = None
             log.info("No running loop for conv %s, dispatching recovery",
                      conv_id)
-            result = await self.recover_confirmation(conv_id, response)
-            log.info("Recovery result for conv %s: %s", conv_id[:8], result)
+            try:
+                result = await self._dispatch_recovery(
+                    conv_id, claimed_request, response)
+                log.info("Recovery result for conv %s: %s", conv_id[:8], result)
+            except Exception:
+                log.exception(
+                    "Recovery dispatch failed for conv %s; restoring "
+                    "pending state so retry can proceed",
+                    conv_id[:8])
+                async with state.lock:
+                    # Restore only if nothing else has taken the slot.
+                    if state.pending_confirmation is None:
+                        state.pending_confirmation = claimed_request
+                raise
 
     async def cancel_pending_confirmation(self, conv_id: str) -> bool:
         """Drop a pending confirmation without triggering recovery.
@@ -426,31 +567,90 @@ class ConversationManager:
         future submission attempt is a no-op rather than reviving the
         cancelled turn. Returns True if a pending confirmation was
         cleared, False otherwise.
+
+        State mutations run under ``state.lock`` so a concurrent
+        ``respond_to_confirmation`` can't see the request as still
+        pending after we've started clearing it (issue #440). If a
+        responder has already claimed the slot
+        (``state.confirmation_response is not None``), cancellation is
+        a no-op: the responder's answer wins and we must NOT persist a
+        denial that contradicts an already-emitted approval
+        (Copilot review on #484).
         """
         state = self._conversations.get(conv_id)
-        if not state or not state.pending_confirmation:
+        if not state:
             return False
-        request = state.pending_confirmation
-        response = ConfirmationResponse(
-            confirmation_id=request.confirmation_id,
-            approved=False,
-        )
-        from .archive import append_message
-        append_message(self.config, conv_id, response.to_archive_message())
-        state.pending_confirmation = None
-        state.confirmation_event = None
-        state.confirmation_response = None
+        async with state.lock:
+            if not state.pending_confirmation:
+                return False
+            if state.confirmation_response is not None:
+                # A responder already claimed the slot — let their
+                # response stand. Cancellation arrived too late.
+                log.info("cancel_pending_confirmation arrived after "
+                         "responder claimed slot for conv %s; "
+                         "deferring to responder",
+                         conv_id[:8])
+                return False
+            request = state.pending_confirmation
+            response = ConfirmationResponse(
+                confirmation_id=request.confirmation_id,
+                approved=False,
+            )
+            # Capture the waiter's event (if any) BEFORE clearing
+            # state.confirmation_event — we must signal it after the
+            # archive succeeds so a live request_confirmation with
+            # timeout=None doesn't hang forever. (Copilot review on
+            # #484.)
+            waiter_event = state.confirmation_event
+            # Archive UNDER the lock so the durable record is in place
+            # before the waiter (if any) can observe the claim. If a
+            # `request_confirmation` waiter is timing out and we
+            # claimed before archive, the waiter could consume our
+            # unpersisted denial and a subsequent archive failure
+            # would leave no durable record (Copilot review on #484).
+            # append_message is sync filesystem I/O.
+            from .archive import append_message
+            try:
+                append_message(self.config, conv_id,
+                               response.to_archive_message())
+            except Exception:
+                log.exception(
+                    "cancel_pending_confirmation archive write failed "
+                    "for conv %s; pending state untouched",
+                    conv_id[:8])
+                raise
+            # Archive succeeded — claim the slot for the live waiter
+            # (so request_confirmation's post-wait block observes our
+            # denial) and clear pending state atomically.
+            state.confirmation_response = response
+            state.pending_confirmation = None
+            state.confirmation_event = None
+        # Signal the live waiter outside the lock so its post-wait
+        # block can acquire the lock and consume our denial.
+        # request_confirmation will null out confirmation_response
+        # itself under the lock.
+        if waiter_event is not None:
+            waiter_event.set()
         return True
 
     async def cancel_turn(self, conv_id: str) -> None:
-        """Cancel an in-progress agent turn."""
+        """Cancel an in-progress agent turn.
+
+        Reads ``state.cancel_event`` / ``state.agent_task`` under
+        ``state.lock`` so the finally-block's null-out of those fields
+        (which also runs under the lock) can't race the cancellation
+        request (issue #440).
+        """
         state = self._conversations.get(conv_id)
         if not state:
             return
-        if state.cancel_event:
-            state.cancel_event.set()
-        if state.agent_task and not state.agent_task.done():
-            state.agent_task.cancel()
+        async with state.lock:
+            cancel_event = state.cancel_event
+            agent_task = state.agent_task
+        if cancel_event:
+            cancel_event.set()
+        if agent_task and not agent_task.done():
+            agent_task.cancel()
             log.info("Cancelled agent turn for conv %s", conv_id[:8])
 
     async def shutdown(self, timeout: float = 15) -> None:
@@ -569,19 +769,32 @@ class ConversationManager:
 
         Persists the request to the archive, emits to subscribers, and
         waits for a response (or timeout).
+
+        Concurrency: the waiting-state setup and the post-response /
+        post-timeout cleanup run under ``state.lock`` so the
+        pending_confirmation / confirmation_event / confirmation_response
+        triple is mutated atomically and racing
+        ``respond_to_confirmation`` / ``cancel_pending_confirmation``
+        callers observe a consistent view (issue #440). The lock is
+        released across the ``confirmation_event.wait()`` await so the
+        responder can acquire it to set the event.
         """
         state = self._get_or_create(conv_id)
 
-        # Persist to archive
+        # Persist to archive (outside the lock — sync I/O).
         from .archive import append_message
         append_message(self.config, conv_id, request.to_archive_message())
 
-        # Set up waiting state
-        state.pending_confirmation = request
-        state.confirmation_event = asyncio.Event()
-        state.confirmation_response = None
+        # Set up waiting state under the lock so concurrent responders
+        # see all three fields consistently.
+        async with state.lock:
+            state.pending_confirmation = request
+            state.confirmation_event = asyncio.Event()
+            state.confirmation_response = None
+            event = state.confirmation_event
 
         # Emit to subscribers so transports can show the confirmation UI
+        # (outside the lock — emit awaits subscribers).
         await self.emit(conv_id, {
             "type": "confirmation_request",
             "confirmation_id": request.confirmation_id,
@@ -593,35 +806,86 @@ class ConversationManager:
             "tool_call_id": request.tool_call_id,
         })
 
-        # Wait for response or timeout
+        # Wait for response or timeout (lock not held — responder
+        # needs to acquire it to claim the slot and set the event).
         try:
-            await asyncio.wait_for(
-                state.confirmation_event.wait(),
-                timeout=request.timeout,
-            )
+            await asyncio.wait_for(event.wait(), timeout=request.timeout)
+            timed_out = False
         except asyncio.TimeoutError:
-            log.info("Confirmation timed out for conv %s: %s",
-                     conv_id[:8], request.message)
-            # Create a timeout denial
-            response = ConfirmationResponse(
-                confirmation_id=request.confirmation_id,
-                approved=False,
-            )
-            append_message(self.config, conv_id, response.to_archive_message())
+            timed_out = True
+
+        # Claim the response slot under the lock atomically with the
+        # state read, so a late responder racing the timeout decision
+        # can't slip in between the read and the archive write / emit
+        # / null-out. Three possible states inside the lock:
+        # 1. responder already claimed `confirmation_response` — honor
+        #    it (cooperative path on signaled event, or responder won
+        #    a tight race against the timeout)
+        # 2. timed out with no responder — synthesize a timeout denial
+        #    and persist it
+        # 3. signaled but no response — cancel_pending_confirmation
+        #    raced and cleared the slot; treat as denial without
+        #    archiving (cancel already wrote its own denial)
+        # (Copilot review on #484.)
+        # Hold the lock across the timeout archive write to keep the
+        # in-memory state and the archive in sync — if the write
+        # fails, we leave pending state intact so the caller (or a
+        # later retry / startup recovery) can try again. Other paths
+        # (claimed / cancel-raced) don't archive here so the read-
+        # and-clear stays cheap (Copilot review on #484).
+        needs_timeout_emit = False
+        async with state.lock:
+            claimed = state.confirmation_response
+            if claimed is not None:
+                response = claimed
+                state.pending_confirmation = None
+                state.confirmation_event = None
+                state.confirmation_response = None
+            elif timed_out:
+                log.info("Confirmation timed out for conv %s: %s",
+                         conv_id[:8], request.message)
+                response = ConfirmationResponse(
+                    confirmation_id=request.confirmation_id,
+                    approved=False,
+                )
+                try:
+                    append_message(
+                        self.config, conv_id,
+                        response.to_archive_message(),
+                    )
+                except Exception:
+                    log.exception(
+                        "Timeout archive write failed for conv %s; "
+                        "leaving pending state intact for retry",
+                        conv_id[:8])
+                    raise
+                # Archive succeeded — now safe to clear pending state.
+                state.pending_confirmation = None
+                state.confirmation_event = None
+                state.confirmation_response = None
+                needs_timeout_emit = True
+            else:
+                # Signaled but no response — `cancel_pending_confirmation`
+                # cleared the slot. Return a denial; cancel has already
+                # written its own denial to the archive.
+                response = ConfirmationResponse(
+                    confirmation_id=request.confirmation_id,
+                    approved=False,
+                )
+                state.pending_confirmation = None
+                state.confirmation_event = None
+                state.confirmation_response = None
+                log.info("Confirmation for conv %s was cancelled out "
+                         "from under the waiter; returning denial",
+                         conv_id[:8])
+
+        if needs_timeout_emit:
             await self.emit(conv_id, {
                 "type": "confirmation_response",
                 "confirmation_id": request.confirmation_id,
                 "approved": False,
             })
-            state.pending_confirmation = None
-            state.confirmation_event = None
-            return response
 
-        response = state.confirmation_response
-        assert response is not None, "confirmation_event set but no response"
-        state.pending_confirmation = None
-        state.confirmation_event = None
-        state.confirmation_response = None
         return response
 
     # -- Internal methods ------------------------------------------------------
@@ -643,7 +907,16 @@ class ConversationManager:
         metadata: dict | None = None,
         future: asyncio.Future | None = None,
     ) -> None:
-        """Start an agent turn as an asyncio task."""
+        """Start an agent turn as an asyncio task.
+
+        Caller must hold ``state.lock``. The lock is held across this
+        method's synchronous setup (so ``state.busy = True`` is set
+        before concurrent enqueues observe it) but is released before
+        the agent task itself runs — ``asyncio.create_task(run())``
+        schedules ``run()`` and returns immediately. The finally
+        block inside ``run()`` re-acquires the lock to reset
+        ``busy`` / ``agent_task`` / ``cancel_event`` (issue #440).
+        """
         from .context import Context
 
         conv_id = state.conv_id
@@ -827,13 +1100,23 @@ class ConversationManager:
                 # Persist per-conversation state for kinds that own user convs.
                 if kind in STATE_PERSIST_KINDS:
                     self._save_conversation_state(state, ctx)
-                # Circuit breaker tracking is USER-only (task turns are
-                # externally rate-limited by the scheduler / heartbeat timer).
-                if kind is TurnKind.USER:
-                    self._circuit_breaker_record(state)
-                state.busy = False
-                state.agent_task = None
-                state.cancel_event = None
+                # Reset busy/task/cancel atomically under the lock so
+                # the busy=False write and the cancel_event/agent_task
+                # null-outs become visible to other lock holders as a
+                # single transition. After the lock releases, a
+                # concurrent enqueue_turn CAN acquire the lock and
+                # observe busy=False before _drain_pending has run —
+                # see the "Drain queued messages" comment below for
+                # how the drain handles that case (issue #440).
+                async with state.lock:
+                    # Circuit breaker tracking is USER-only (task turns are
+                    # externally rate-limited by the scheduler / heartbeat
+                    # timer).
+                    if kind is TurnKind.USER:
+                        self._circuit_breaker_record(state)
+                    state.busy = False
+                    state.agent_task = None
+                    state.cancel_event = None
 
                 await self.emit(conv_id, {"type": "turn_complete"})
 
@@ -843,7 +1126,11 @@ class ConversationManager:
                                    if response_text_holder else None)
                     future.set_result(result_text)
 
-                # Drain queued messages
+                # Drain queued messages. _drain_pending re-acquires the
+                # lock around its pop-and-dispatch sequence, so a
+                # concurrent enqueue_turn that landed between the
+                # finally-block lock release and here will compete on
+                # equal footing: whoever grabs the lock first dispatches.
                 await self._drain_pending(state)
 
         state.agent_task = asyncio.create_task(run())
@@ -898,89 +1185,123 @@ class ConversationManager:
         single turn. Any other kind pops a single entry and fires it on its own.
         The recursive _start_turn→_drain_pending path handles the rest of the
         queue once each batch completes.
+
+        Acquires ``state.lock`` around the pop-and-dispatch sequence so
+        a concurrent ``enqueue_turn`` can't observe ``busy=False`` while
+        we are mid-dispatch and start a competing turn (issue #440).
+        Whoever grabs the lock first wins; the loser sees ``busy=True``
+        set by the winner's ``_start_turn`` and queues.
+
+        Re-checks ``state.busy`` under the lock and defers if another
+        turn already won the dispatch race after the finally-block's
+        ``busy=False`` reset (Copilot review on #484). The deferred
+        turn will be picked up by the new in-flight turn's own
+        finally-block drain.
         """
         if not state.pending_messages:
             return
 
-        first = state.pending_messages[0]
+        async with state.lock:
+            if not state.pending_messages:
+                # Another path drained the queue while we were waiting
+                # on the lock.
+                return
+            if state.busy:
+                # A concurrent enqueue won the dispatch race after our
+                # finally-block reset busy=False and before we got here.
+                # Defer: the winner's finally-block will drain whatever
+                # is still queued when its turn completes.
+                log.debug(
+                    "_drain_pending: conv %s already busy with a "
+                    "concurrent turn, deferring drain",
+                    state.conv_id[:8])
+                return
 
-        if first["kind"] is TurnKind.USER:
-            # Pop all contiguous USER entries from the front.
-            run: list[dict] = []
-            while state.pending_messages and state.pending_messages[0]["kind"] is TurnKind.USER:
-                run.append(state.pending_messages.pop(0))
+            first = state.pending_messages[0]
 
-            texts = [q["text"] for q in run]
-            combined = "\n".join(texts)
-            last = run[-1]
+            if first["kind"] is TurnKind.USER:
+                # Pop all contiguous USER entries from the front.
+                run: list[dict] = []
+                while (state.pending_messages
+                       and state.pending_messages[0]["kind"] is TurnKind.USER):
+                    run.append(state.pending_messages.pop(0))
 
-            all_attachments: list[dict] = []
-            for q in run:
-                if q.get("attachments"):
-                    all_attachments.extend(q["attachments"])
+                texts = [q["text"] for q in run]
+                combined = "\n".join(texts)
+                last = run[-1]
 
-            log.info("Draining %d queued USER message(s) for conv %s",
-                     len(run), state.conv_id[:8])
+                all_attachments: list[dict] = []
+                for q in run:
+                    if q.get("attachments"):
+                        all_attachments.extend(q["attachments"])
 
-            # Fan-out: when the head future resolves, resolve all tail futures
-            # with the same result so every waiting caller gets notified.
-            head_fut = last.get("future")
-            tail_futs = [q.get("future") for q in run[:-1]]
-            tail_futs = [f for f in tail_futs if f is not None]
-            if head_fut is not None and tail_futs:
-                def _fanout(fut: asyncio.Future, _tails: list = tail_futs) -> None:
-                    # Determine the value to propagate to tail futures.
-                    # Propagate None on cancellation or exception (tails never
-                    # observe the error — they were coalesced into the head turn
-                    # and the head's error path already returned "[error: ...]"
-                    # text via set_result).  Propagate the result on normal
-                    # completion.  Calling fut.result() on an exception future
-                    # would raise and leave tails unresolved, so guard explicitly.
-                    result = None
-                    if fut.done() and not fut.cancelled():
-                        exc = fut.exception()
-                        if exc is None:
-                            result = fut.result()
-                    for f in _tails:
+                log.info("Draining %d queued USER message(s) for conv %s",
+                         len(run), state.conv_id[:8])
+
+                # Fan-out: when the head future resolves, resolve all tail
+                # futures with the same result so every waiting caller gets
+                # notified.
+                head_fut = last.get("future")
+                tail_futs = [q.get("future") for q in run[:-1]]
+                tail_futs = [f for f in tail_futs if f is not None]
+                if head_fut is not None and tail_futs:
+                    def _fanout(fut: asyncio.Future,
+                                _tails: list = tail_futs) -> None:
+                        # Determine the value to propagate to tail futures.
+                        # Propagate None on cancellation or exception (tails
+                        # never observe the error — they were coalesced into
+                        # the head turn and the head's error path already
+                        # returned "[error: ...]" text via set_result).
+                        # Propagate the result on normal completion. Calling
+                        # fut.result() on an exception future would raise and
+                        # leave tails unresolved, so guard explicitly.
+                        result = None
+                        if fut.done() and not fut.cancelled():
+                            exc = fut.exception()
+                            if exc is None:
+                                result = fut.result()
+                        for f in _tails:
+                            if not f.done():
+                                f.set_result(result)
+                    head_fut.add_done_callback(_fanout)
+                elif tail_futs:
+                    # No head future (edge case) — resolve tails to None so
+                    # callers don't hang.
+                    for f in tail_futs:
                         if not f.done():
-                            f.set_result(result)
-                head_fut.add_done_callback(_fanout)
-            elif tail_futs:
-                # No head future (edge case) — resolve tails to None so callers don't hang.
-                for f in tail_futs:
-                    if not f.done():
-                        f.set_result(None)
+                            f.set_result(None)
 
-            await self._start_turn(
-                state, combined,
-                kind=TurnKind.USER,
-                user_id=last.get("user_id", ""),
-                context_setup=last.get("context_setup"),
-                archive_text=last.get("archive_text", ""),
-                attachments=all_attachments or None,
-                command_ctx=last.get("command_ctx"),
-                wiki_page=last.get("wiki_page"),
-                future=head_fut,
-            )
-        else:
-            # Non-USER kinds fire one at a time, preserving all their own kwargs.
-            q = state.pending_messages.pop(0)
-            log.info("Draining queued %s turn for conv %s",
-                     q["kind"].value, state.conv_id[:8])
-            await self._start_turn(
-                state, q["text"],
-                kind=q["kind"],
-                user_id=q.get("user_id", ""),
-                context_setup=q.get("context_setup"),
-                archive_text=q.get("archive_text", ""),
-                attachments=q.get("attachments"),
-                command_ctx=q.get("command_ctx"),
-                wiki_page=q.get("wiki_page"),
-                task_mode=q.get("task_mode"),
-                history=q.get("history"),
-                metadata=q.get("metadata"),
-                future=q.get("future"),
-            )
+                await self._start_turn(
+                    state, combined,
+                    kind=TurnKind.USER,
+                    user_id=last.get("user_id", ""),
+                    context_setup=last.get("context_setup"),
+                    archive_text=last.get("archive_text", ""),
+                    attachments=all_attachments or None,
+                    command_ctx=last.get("command_ctx"),
+                    wiki_page=last.get("wiki_page"),
+                    future=head_fut,
+                )
+            else:
+                # Non-USER kinds fire one at a time, preserving all their own
+                # kwargs.
+                q = state.pending_messages.pop(0)
+                log.info("Draining queued %s turn for conv %s",
+                         q["kind"].value, state.conv_id[:8])
+                await self._start_turn(
+                    state, q["text"],
+                    kind=q["kind"],
+                    user_id=q.get("user_id", ""),
+                    context_setup=q.get("context_setup"),
+                    archive_text=q.get("archive_text", ""),
+                    attachments=q.get("attachments"),
+                    command_ctx=q.get("command_ctx"),
+                    wiki_page=q.get("wiki_page"),
+                    task_mode=q.get("task_mode"),
+                    history=q.get("history"),
+                    metadata=q.get("metadata"),
+                    future=q.get("future"),
+                )
 
     # -- Startup recovery ------------------------------------------------------
 
@@ -1093,34 +1414,65 @@ class ConversationManager:
                                    response: ConfirmationResponse) -> dict:
         """Handle a confirmation response for a conversation with no running loop.
 
-        Dispatches to the appropriate confirmation handler based on the
-        action type. Returns the handler result dict.
+        Atomically pops ``state.pending_confirmation`` under
+        ``state.lock`` so a concurrent caller can't double-dispatch
+        the same recovery (issue #440), then delegates to
+        ``_dispatch_recovery``. If dispatch raises, restore the
+        pending state so a future retry / startup-recovery can pick
+        up where we left off (Copilot review on #484). Public entry
+        point retained for external callers;
+        ``respond_to_confirmation`` bypasses this wrapper because it
+        has already claimed the slot.
         """
         state = self._conversations.get(conv_id)
-        if not state or not state.pending_confirmation:
+        if not state:
             return {"error": "No pending confirmation"}
+        async with state.lock:
+            request = state.pending_confirmation
+            if not request:
+                return {"error": "No pending confirmation"}
+            state.pending_confirmation = None
+            state.confirmation_response = None
+        try:
+            return await self._dispatch_recovery(conv_id, request, response)
+        except Exception:
+            log.exception(
+                "recover_confirmation dispatch failed for conv %s; "
+                "restoring pending state so retry can proceed",
+                conv_id[:8])
+            async with state.lock:
+                if state.pending_confirmation is None:
+                    state.pending_confirmation = request
+            raise
 
-        request = state.pending_confirmation
+    async def _dispatch_recovery(
+        self,
+        conv_id: str,
+        request: ConfirmationRequest,
+        response: ConfirmationResponse,
+    ) -> dict:
+        """Run a confirmation handler for a recovered (no-running-loop) conv.
 
+        Caller is responsible for clearing ``state.pending_confirmation``
+        under ``state.lock`` before invoking — both call sites
+        (``respond_to_confirmation`` and ``recover_confirmation``) do
+        this so a concurrent responder can't re-enter the same slot.
+        """
         if not self.confirmation_registry._handlers:
             log.warning(
                 "No confirmation handlers registered — cannot recover "
                 "confirmation for conv %s (action: %s)",
                 conv_id[:8], request.action_type.value,
             )
-            state.pending_confirmation = None
             return {"error": "No confirmation handlers registered"}
 
         # The handler needs config + conv_id to write back to the archive
         # (no running loop means no real ctx). Provide a minimal recovery
         # context that handlers can duck-type against.
         recovery_ctx = _RecoveryContext(config=self.config, conv_id=conv_id)
-        result = await self.confirmation_registry.dispatch(
+        return await self.confirmation_registry.dispatch(
             recovery_ctx, request, response,
         )
-
-        state.pending_confirmation = None
-        return result
 
 
 @dataclass

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1195,3 +1195,725 @@ def test_save_truthy_only_preserves_sticky_semantics(manager, config):
     manager._save_conversation_state(state, ctx)
 
     assert state.persisted.skip_vault_retrieval is True
+
+
+# -- Concurrency: per-conv lock (issue #440) ----------------------------------
+
+@pytest.mark.asyncio
+async def test_concurrent_user_enqueue_serializes_via_lock(
+    manager, config, monkeypatch
+):
+    """Two simultaneous enqueue_turn(USER) calls for the same conv must
+    serialize: exactly one runs, the other queues. Guard test for
+    issue #440.
+
+    Status: this test PASSES on both pre- and post-lock code because
+    asyncio is cooperative and the current `enqueue_turn` / `_start_turn`
+    structure has no yield between the busy check (`if state.busy:`)
+    and the `state.busy = True` write inside `_start_turn`. The first
+    task to resume from `await self.emit(...)` synchronously runs
+    through the busy check and into `_start_turn`'s body, setting
+    busy=True before yielding again — so subsequent tasks see busy=True
+    and queue.
+
+    The test is kept as a **structural guard** of the invariant: if
+    someone adds an await between those two points (or in `_start_turn`
+    before its `state.busy = True` assignment) the race opens, and
+    this test would catch it *only when paired with the lock*. The
+    lock makes the invariant explicit; without the lock, the
+    invariant is implicit in the current control flow and silently
+    regressable.
+
+    See `test_concurrent_confirmation_responses_dont_double_dispatch`
+    below for the companion test that DOES reproduce a live race
+    against unlocked code (the confirmation recovery dispatch path).
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        started.set()
+        await release.wait()
+        from decafclaw.media import ToolResult
+        return ToolResult(text="ok")
+
+    monkeypatch.setattr("decafclaw.agent.run_agent_turn", fake_run_agent_turn)
+
+    # Subscriber forces `emit` to actually await (real yield point at the
+    # user_message emission inside enqueue_turn).
+    async def _noop(_event):
+        pass
+    manager.subscribe("c1", _noop)
+
+    # Fire both enqueues concurrently. If a future change adds a
+    # yield between the busy check and `state.busy = True` inside
+    # `_start_turn`, both calls could observe `busy=False` and both
+    # would call `_start_turn` without the lock. With the lock in
+    # place, the second call blocks on the lock and observes
+    # `busy=True` set by the first.
+    f1, f2 = await asyncio.gather(
+        manager.enqueue_turn("c1", kind=TurnKind.USER, prompt="one"),
+        manager.enqueue_turn("c1", kind=TurnKind.USER, prompt="two"),
+    )
+
+    # Let the started turn run to the point of awaiting `release`.
+    await started.wait()
+
+    state = manager.get_state("c1")
+    assert state is not None
+
+    # Exactly one turn started; the other is queued.
+    assert call_count == 1, (
+        f"expected exactly one turn started, got {call_count}"
+    )
+    assert len(state.pending_messages) == 1, (
+        f"expected one pending message, got {len(state.pending_messages)}"
+    )
+
+    # Drain: release the parked turn so the queued one also runs.
+    release.set()
+    await asyncio.wait_for(f1, timeout=2.0)
+    await asyncio.wait_for(f2, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_confirmation_responses_dont_double_dispatch(
+    manager, monkeypatch
+):
+    """Two simultaneous respond_to_confirmation calls for the same
+    confirmation_id must not both dispatch recovery. Regression for
+    issue #440 — the state.pending_confirmation / state.confirmation_event
+    mutations used to be unlocked, so two responses could both observe
+    ``pending_confirmation`` set, both pass the id check, and both
+    dispatch the registered handler.
+    """
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-conf-race"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    # Pre-populate pending state on a recovered conv (no running loop)
+    # so respond_to_confirmation goes through the recovery path.
+    append_message(manager.config, conv_id, request.to_archive_message())
+    await manager.startup_scan()
+
+    handler_calls = 0
+
+    class FakeHandler:
+        async def on_approve(self, ctx, req, resp):
+            nonlocal handler_calls
+            handler_calls += 1
+            # Yield so the second responder can race past
+            # pending_confirmation check before this one clears it.
+            await asyncio.sleep(0)
+            return {"ok": True}
+
+        async def on_deny(self, ctx, req, resp):
+            return {}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.RUN_SHELL_COMMAND, FakeHandler()
+    )
+
+    await asyncio.gather(
+        manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True),
+        manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True),
+    )
+
+    assert handler_calls == 1, (
+        f"expected exactly one handler dispatch, got {handler_calls}"
+    )
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_confirmation_after_response_claimed_is_noop(
+    manager,
+):
+    """If `respond_to_confirmation` has already claimed
+    `state.confirmation_response`, a racing
+    `cancel_pending_confirmation` must NOT clear it — otherwise
+    `request_confirmation`'s success path would observe the slot
+    nulled out and persist a denial that contradicts the already-
+    archived approval. (Copilot review on PR #484.)
+    """
+    conv_id = "conv-cancel-race"
+    state = manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id,
+        approved=True,
+    )
+    # Simulate `respond_to_confirmation` having claimed the slot.
+    state.pending_confirmation = request
+    state.confirmation_event = asyncio.Event()
+    state.confirmation_response = response
+
+    cleared = await manager.cancel_pending_confirmation(conv_id)
+    assert cleared is False, (
+        "cancel_pending_confirmation should defer to the claimed "
+        "response and return False"
+    )
+    # Slot must still be claimed for request_confirmation to find.
+    assert state.confirmation_response is response
+    assert state.pending_confirmation is request
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_timeout_loses_race_to_late_responder(
+    manager, monkeypatch
+):
+    """A responder that wins the race against `request_confirmation`'s
+    timeout — claiming `state.confirmation_response` between
+    `wait_for` raising TimeoutError and the timeout-path archive
+    write — must have its response honored. The timeout path must
+    NOT archive a denial that contradicts the responder's answer.
+    (Copilot review on PR #484.)
+
+    We deterministically force the race by patching `asyncio.wait_for`
+    to raise TimeoutError only AFTER the responder has run and
+    claimed the slot. This exercises the exact post-wait code path
+    the fix protects, rather than relying on wall-clock timing.
+    """
+    from decafclaw import conversation_manager as cm
+
+    conv_id = "conv-timeout-race"
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+        timeout=10.0,  # large; we control timeout via the patched wait_for
+    )
+
+    responder_ran = asyncio.Event()
+
+    async def respond_when_signaled():
+        # Wait until request_confirmation is in `wait_for` (set up by
+        # the patched wait_for below), then claim the slot.
+        await responder_ran.wait()
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True)
+
+    async def fake_wait_for(fut, timeout):
+        # Close the underlying coroutine without awaiting it — we're
+        # simulating a timeout, so the wait never completes. Closing
+        # avoids the "coroutine never awaited" RuntimeWarning.
+        if asyncio.iscoroutine(fut):
+            fut.close()
+        # Release the responder, then yield enough times so it
+        # acquires the lock and claims state.confirmation_response.
+        # Finally raise TimeoutError — putting request_confirmation's
+        # post-wait block on the timeout path with the slot already
+        # claimed.
+        responder_ran.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(cm.asyncio, "wait_for", fake_wait_for)
+
+    responder_task = asyncio.create_task(respond_when_signaled())
+    response = await manager.request_confirmation(conv_id, request)
+    await responder_task
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.confirmation_response is None
+    assert state.pending_confirmation is None
+
+    # The responder claimed the slot first, so request_confirmation's
+    # timeout path honored their approval rather than synthesizing a
+    # denial.
+    assert response.approved is True, (
+        "responder claimed slot under the lock before the timeout path "
+        "ran; request_confirmation must honor that response, not "
+        f"synthesize a denial. Got: {response}"
+    )
+
+    # Archive must have exactly one confirmation_response row (the
+    # responder's approval) — never both a timeout denial and an
+    # approval.
+    from decafclaw.archive import restore_history
+    history = restore_history(manager.config, conv_id) or []
+    responses = [
+        m for m in history if m.get("role") == "confirmation_response"
+    ]
+    assert len(responses) == 1, (
+        f"expected exactly one confirmation_response in archive, "
+        f"got {len(responses)}: {responses}"
+    )
+    assert responses[0]["approved"] is True
+
+
+@pytest.mark.asyncio
+async def test_respond_to_confirmation_rolls_back_claim_on_archive_failure(
+    manager, monkeypatch
+):
+    """If `append_message` raises while `respond_to_confirmation`
+    is dispatching, the response-slot claim must NEVER be written
+    so a retry isn't treated as a duplicate and a running waiter
+    doesn't hang until timeout. Archive write now happens UNDER the
+    lock BEFORE the claim is set; on failure the raise propagates
+    with pending state untouched. Emit happens after the lock and
+    is best-effort — emit failures are logged but the durable
+    record + claim are already in place, so this test does NOT
+    cover the emit-failure path (which is intentionally non-
+    rollback). (Copilot review on PR #484.)
+    """
+    conv_id = "conv-rollback-test"
+    state = manager._get_or_create(conv_id)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    # Set up pending state as if request_confirmation had run.
+    state.pending_confirmation = request
+    state.confirmation_event = asyncio.Event()
+    state.confirmation_response = None
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("archive write failed")
+
+    # respond_to_confirmation does a function-level `from .archive
+    # import append_message`, so patch the source module.
+    monkeypatch.setattr("decafclaw.archive.append_message", boom)
+
+    with pytest.raises(RuntimeError, match="archive write failed"):
+        await manager.respond_to_confirmation(
+            conv_id, request.confirmation_id, approved=True)
+
+    # Claim must be rolled back so retry works.
+    assert state.confirmation_response is None, (
+        "respond_to_confirmation must roll back its claim on I/O "
+        "failure; otherwise a retry would be silently dropped as a "
+        "duplicate."
+    )
+    # Pending request must still be there for the retry.
+    assert state.pending_confirmation is request
+    # Event must NOT be set — running waiter is still waiting and
+    # the retry will signal it.
+    assert state.confirmation_event is not None
+    assert not state.confirmation_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_confirmation_rolls_back_on_archive_failure(
+    manager, monkeypatch
+):
+    """If `append_message` fails during
+    `cancel_pending_confirmation`, the in-memory pending state must
+    not be cleared — otherwise the manager would be left with no
+    pending confirmation and no archive denial, leaving the user
+    unable to retry and startup recovery seeing the request as
+    still unresolved. (Copilot review on PR #484.)
+    """
+    conv_id = "conv-cancel-rollback"
+    state = manager._get_or_create(conv_id)
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    state.pending_confirmation = request
+    state.confirmation_event = asyncio.Event()
+    state.confirmation_response = None
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("archive write failed")
+    monkeypatch.setattr("decafclaw.archive.append_message", boom)
+
+    with pytest.raises(RuntimeError, match="archive write failed"):
+        await manager.cancel_pending_confirmation(conv_id)
+
+    # In-memory state must be preserved so retry can persist a denial.
+    assert state.pending_confirmation is request
+    assert state.confirmation_response is None
+    assert state.confirmation_event is not None
+
+
+@pytest.mark.asyncio
+async def test_recover_confirmation_restores_on_dispatch_failure(manager):
+    """If `_dispatch_recovery` raises (e.g. the registered handler
+    fails), `recover_confirmation` must restore
+    `state.pending_confirmation` so a future retry / startup
+    recovery can pick up where dispatch left off. Otherwise the
+    request would be silently lost from memory while remaining
+    unresolved in the archive. (Copilot review on PR #484.)
+    """
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-recover-rollback"
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    append_message(manager.config, conv_id, request.to_archive_message())
+    await manager.startup_scan()
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is not None
+
+    class BoomHandler:
+        async def on_approve(self, ctx, req, resp):
+            raise RuntimeError("handler exploded")
+
+        async def on_deny(self, ctx, req, resp):
+            return {}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.RUN_SHELL_COMMAND, BoomHandler()
+    )
+
+    response = ConfirmationResponse(
+        confirmation_id=request.confirmation_id, approved=True,
+    )
+    with pytest.raises(RuntimeError, match="handler exploded"):
+        await manager.recover_confirmation(conv_id, response)
+
+    # Pending confirmation must be restored so the next retry can
+    # try dispatch again.
+    assert state.pending_confirmation is not None
+    assert (state.pending_confirmation.confirmation_id
+            == request.confirmation_id)
+
+
+@pytest.mark.asyncio
+async def test_drain_pending_defers_when_concurrent_enqueue_won_dispatch(
+    manager,
+):
+    """If a concurrent ``enqueue_turn`` wins the dispatch race after
+    the finally-block sets ``busy=False`` but before ``_drain_pending``
+    runs, the drain must defer rather than dispatch over the new
+    turn — otherwise ``_start_turn`` would overwrite
+    ``state.agent_task`` / ``state.cancel_event`` and run two turns
+    for the same conv concurrently. (Copilot review on PR #484.)
+    """
+    state = manager._get_or_create("conv-drain-defer")
+    # Simulate the post-finally-block state where busy was just
+    # cleared, but a concurrent enqueue has since taken the slot
+    # (busy=True, agent_task set) and there's still pending work
+    # left over from the original turn.
+    state.busy = True
+    fake_task = asyncio.create_task(asyncio.sleep(0))
+    state.agent_task = fake_task
+    state.pending_messages.append({
+        "kind": TurnKind.USER,
+        "text": "queued",
+        "user_id": "u",
+        "context_setup": None,
+        "archive_text": "",
+        "attachments": None,
+        "command_ctx": None,
+        "wiki_page": None,
+        "task_mode": None,
+        "history": None,
+        "metadata": None,
+        "future": None,
+    })
+
+    # Drain must defer (no dispatch) when busy is already set.
+    await manager._drain_pending(state)
+
+    # The queued message must still be there for the new in-flight
+    # turn's finally-block drain to pick up.
+    assert len(state.pending_messages) == 1
+    # The agent_task must not have been overwritten.
+    assert state.agent_task is fake_task
+
+    # Clean up.
+    await fake_task
+
+
+@pytest.mark.asyncio
+async def test_request_confirmation_timeout_archive_failure_preserves_state(
+    manager, monkeypatch
+):
+    """If the timeout-path archive write fails inside
+    `request_confirmation`, the in-memory pending state must NOT be
+    cleared — otherwise the request would be lost in memory while
+    remaining unresolved in the archive, leaving no way to recover.
+    (Copilot review on PR #484.)
+    """
+    from decafclaw import conversation_manager as cm
+
+    conv_id = "conv-timeout-archive-fail"
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+        timeout=10.0,
+    )
+
+    # Force timeout via patched wait_for.
+    async def fake_wait_for(fut, timeout):
+        if asyncio.iscoroutine(fut):
+            fut.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(cm.asyncio, "wait_for", fake_wait_for)
+
+    # Force the timeout-path archive write to fail. The initial
+    # request archive write succeeds; only the timeout response
+    # write fails.
+    from decafclaw import archive as archive_mod
+    real_archive_append = archive_mod.append_message
+
+    def boom_on_response(config, conv, msg):
+        if msg.get("role") == "confirmation_response":
+            raise RuntimeError("timeout archive failed")
+        return real_archive_append(config, conv, msg)
+
+    monkeypatch.setattr("decafclaw.archive.append_message", boom_on_response)
+
+    with pytest.raises(RuntimeError, match="timeout archive failed"):
+        await manager.request_confirmation(conv_id, request)
+
+    # Pending state must be preserved so retry/recovery can proceed.
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is not None
+    assert state.pending_confirmation.confirmation_id == request.confirmation_id
+
+
+@pytest.mark.asyncio
+async def test_recovered_confirmation_dispatch_uses_captured_request(
+    manager, monkeypatch
+):
+    """In the recovered-confirmation path, ``respond_to_confirmation``
+    captures ``state.pending_confirmation`` under the lock so the
+    recovery dispatch uses the ORIGINAL recovered request — not
+    whatever happens to be in ``state.pending_confirmation`` when the
+    second lock block re-acquires the lock.
+
+    A concurrent ``request_confirmation`` (a fresh turn starting up
+    during our archive/emit I/O window) can overwrite
+    ``state.pending_confirmation`` with a different request. Without
+    the in-lock capture, the recovery dispatch would pop and dispatch
+    the new request with our old response, calling the wrong handler.
+    The capture pins recovery to the request we resolved.
+    (Copilot review on PR #484.)
+    """
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-recovered-capture"
+    original_request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    append_message(manager.config, conv_id,
+                   original_request.to_archive_message())
+    await manager.startup_scan()
+    state = manager.get_state(conv_id)
+    assert state is not None
+
+    dispatched_requests: list[ConfirmationRequest] = []
+
+    class CapturingHandler:
+        async def on_approve(self, ctx, req, resp):
+            dispatched_requests.append(req)
+            return {"ok": True}
+
+        async def on_deny(self, ctx, req, resp):
+            return {}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.RUN_SHELL_COMMAND, CapturingHandler()
+    )
+    # Also register a sentinel handler under a DIFFERENT action so
+    # that if the racer's request is dispatched instead we'd see it.
+    class SentinelHandler:
+        async def on_approve(self, ctx, req, resp):
+            dispatched_requests.append(req)
+            return {"oops": True}
+
+        async def on_deny(self, ctx, req, resp):
+            return {}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.ACTIVATE_SKILL, SentinelHandler()
+    )
+
+    # Force the race: subscribe a callback that mutates
+    # state.pending_confirmation when our confirmation_response emits.
+    # This simulates a concurrent request_confirmation racing in during
+    # respond_to_confirmation's I/O window — specifically the case where
+    # only pending_confirmation is overwritten (e.g., a partially-
+    # complete request_confirmation that landed under the lock just
+    # after our claim). The post-emit lock block must use the captured
+    # request, not re-read state.pending_confirmation.
+    racer_request = ConfirmationRequest(
+        action_type=ConfirmationAction.ACTIVATE_SKILL,
+        action_data={"skill_name": "x"},
+        message="racer",
+    )
+
+    def overwrite_on_response_emit(event):
+        if event.get("type") != "confirmation_response":
+            return
+        # Simulate the racer landing inside the I/O window. Mimic the
+        # exact mutation request_confirmation would do but preserve our
+        # confirmation_response claim — the bug being tested is the
+        # capture-vs-re-read, not the response-clear identity check.
+        state.pending_confirmation = racer_request
+
+    manager.subscribe(conv_id, overwrite_on_response_emit)
+
+    await manager.respond_to_confirmation(
+        conv_id, original_request.confirmation_id, approved=True)
+
+    # The handler must have been called for the ORIGINAL request, not
+    # for the racer. Exactly one dispatch, with original action_type.
+    assert len(dispatched_requests) == 1, (
+        f"expected exactly one handler dispatch, got "
+        f"{len(dispatched_requests)}"
+    )
+    assert (dispatched_requests[0].action_type
+            == ConfirmationAction.RUN_SHELL_COMMAND), (
+        f"recovery dispatched the wrong request — should have used the "
+        f"captured original, not re-read state.pending_confirmation. "
+        f"Got: {dispatched_requests[0].action_type}"
+    )
+    assert (dispatched_requests[0].confirmation_id
+            == original_request.confirmation_id)
+
+
+@pytest.mark.asyncio
+async def test_recovery_dispatch_proceeds_when_new_request_lands_mid_flight(
+    manager, monkeypatch
+):
+    """A real concurrent `request_confirmation` (not just an isolated
+    overwrite of ``state.pending_confirmation``) can land between the
+    initial claim block and the recovery dispatch. The dispatch must
+    still proceed using the captured original request — the new
+    request belongs to a different turn and is handled by its own
+    `request_confirmation` invocation. (Copilot review on PR #484.)
+    """
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-real-concurrent-request"
+    original_request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+    )
+    append_message(manager.config, conv_id,
+                   original_request.to_archive_message())
+    await manager.startup_scan()
+    state = manager.get_state(conv_id)
+    assert state is not None
+
+    dispatched: list[ConfirmationRequest] = []
+
+    class CapturingHandler:
+        async def on_approve(self, ctx, req, resp):
+            dispatched.append(req)
+            return {"ok": True}
+
+        async def on_deny(self, ctx, req, resp):
+            return {}
+
+    manager.confirmation_registry.register(
+        ConfirmationAction.RUN_SHELL_COMMAND, CapturingHandler()
+    )
+
+    # Mid-flight, a NEW request_confirmation kicks off — writes its
+    # own pending_confirmation + confirmation_event + response=None.
+    new_request = ConfirmationRequest(
+        action_type=ConfirmationAction.ACTIVATE_SKILL,
+        action_data={"skill_name": "x"},
+        message="new",
+    )
+
+    def land_new_request(event):
+        if event.get("type") != "confirmation_response":
+            return
+        # Simulate a fresh request_confirmation landing — writes the
+        # full triple, mirroring request_confirmation's claim block.
+        state.pending_confirmation = new_request
+        state.confirmation_event = asyncio.Event()
+        state.confirmation_response = None
+
+    manager.subscribe(conv_id, land_new_request)
+
+    await manager.respond_to_confirmation(
+        conv_id, original_request.confirmation_id, approved=True)
+
+    # Recovery MUST have dispatched the original request, not given
+    # up on it just because state.confirmation_response was overwritten
+    # by the new request_confirmation.
+    assert len(dispatched) == 1, (
+        f"recovery should have dispatched the original request "
+        f"even with a new request_confirmation in flight; got "
+        f"{len(dispatched)} dispatches"
+    )
+    assert (dispatched[0].confirmation_id
+            == original_request.confirmation_id)
+    # The new request should still be pending — recovery didn't
+    # touch it.
+    assert state.pending_confirmation is new_request
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_confirmation_wakes_live_waiter(manager):
+    """If a `request_confirmation` waiter is parked on
+    `event.wait()` when `cancel_pending_confirmation` is called,
+    the waiter must be signaled so its post-wait block can consume
+    the denial and unblock. Without this, a confirmation with
+    `timeout=None` would hang forever even after cancellation.
+    (Copilot review on PR #484.)
+    """
+    conv_id = "conv-cancel-wake"
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="Allow?",
+        timeout=10.0,  # long timeout — proves we don't depend on it
+    )
+
+    waiter_started = asyncio.Event()
+
+    async def cancel_after_waiter_parks():
+        # Wait until the waiter is actually parked on event.wait().
+        await waiter_started.wait()
+        # One extra yield to make sure the waiter is at the await.
+        await asyncio.sleep(0)
+        cleared = await manager.cancel_pending_confirmation(conv_id)
+        assert cleared is True
+
+    # Spy on emit so we can detect the waiter has entered the wait.
+    async def watch_for_request(event):
+        if event.get("type") == "confirmation_request":
+            waiter_started.set()
+    manager.subscribe(conv_id, watch_for_request)
+
+    asyncio.create_task(cancel_after_waiter_parks())
+    response = await asyncio.wait_for(
+        manager.request_confirmation(conv_id, request),
+        timeout=5.0,  # if the waiter hangs, wait_for catches it
+    )
+
+    # Waiter unblocked with the cancellation denial.
+    assert response.approved is False
+    assert response.confirmation_id == request.confirmation_id


### PR DESCRIPTION
## Summary
- Replaces bare boolean/scalar concurrency guards in `ConversationManager` with a per-`ConversationState` `asyncio.Lock`, aligning the module with the CLAUDE.md convention ("Use `asyncio.Lock` for concurrency guards. Not boolean flags — locks auto-release on exception").
- Closes a live race in `respond_to_confirmation` where two concurrent responses for the same confirmation id on a recovered conversation could both dispatch the registered handler.
- Makes the implicit "one dispatch per turn" invariant in `enqueue_turn` explicit so future awaits at the dispatch decision can't silently open a USER-enqueue race.

## Design Decisions

- **One lock per `ConversationState`, not per-attribute.** The flags are interdependent — `busy`, `paused_until`, `confirmation_event`, `pending_confirmation`, and `confirmation_response` participate in the same dispatch / confirmation lifecycle. Splitting locks would introduce ordering hazards. A single global manager-wide lock would kill cross-conversation throughput for no benefit.
- **Lock scope is the dispatch DECISION, never the agent task lifetime.** `_start_turn` runs synchronously up to `asyncio.create_task(run())` under the caller's lock, then returns — the agent task itself runs without the lock. The agent's finally-block re-acquires the lock to reset `busy` / `agent_task` / `cancel_event`. This avoids serializing all per-conv operations for the duration of a turn (which would deadlock anything `_drain_pending` waits on).
- **Test #6 (USER enqueue race) reframed as a guard.** The race window the spec described is structurally unreachable in current code — asyncio is cooperative and there's no yield between the busy check and `state.busy = True`. The lock makes the invariant explicit so future code that introduces a yield at that point can't silently open the window. Test #7 (confirmation race) IS a real failing baseline — see `notes.md` for the full rationale.

## Changes

`src/decafclaw/conversation_manager.py`:
- New `ConversationState.lock: asyncio.Lock` field
- `enqueue_turn`: busy-check / circuit-breaker / wake-limiter / `_start_turn` dispatch all under one lock acquisition
- `_start_turn` finally-block: `busy=False` reset + circuit-breaker record + `agent_task`/`cancel_event` null-out under the lock
- `_drain_pending`: pop-and-dispatch under the lock (mirrors `enqueue_turn`)
- `request_confirmation`: pending/event/response triple mutated atomically; lock released across `event.wait()` so the responder can acquire it; both timeout and success paths null state under the lock
- `respond_to_confirmation`: pending-check + response-slot claim under the lock; archive write / emit / wake or recover dispatch outside the lock; second concurrent responder sees `confirmation_response` set and bails with a warning
- `recover_confirmation`: thin wrapper that atomically pops `pending_confirmation` under the lock then delegates to new `_dispatch_recovery` helper (handlers run lock-free)
- `cancel_pending_confirmation`: state clear under the lock
- `cancel_turn`: paired read of `cancel_event` / `agent_task` under the lock
- `_circuit_breaker_*` and `_start_turn` docstrings document the caller-holds-lock convention

`tests/test_conversation_manager.py`:
- `test_concurrent_confirmation_responses_dont_double_dispatch` — regression test for the confirmation race; fails on baseline with `handler_calls == 2`, passes after the fix.
- `test_concurrent_user_enqueue_serializes_via_lock` — guard test for the USER-enqueue invariant.

## Test Plan
- [x] `make test` — 2421 tests pass
- [x] `make check` — lint + pyright + tsc + message-types drift check green
- [x] `tests/test_background_wake_integration.py` (#241) — 5 tests pass
- [x] Baseline reproduction: `test_concurrent_confirmation_responses_dont_double_dispatch` fails on pre-fix code (`handler_calls == 2`); passes after the fix.
- [ ] Manual: chat with bot in web UI / Mattermost to confirm no behavior change in single-conversation flow.

## References
- Spec: `docs/dev-sessions/2026-05-13-0939-conv-manager-lock/spec.md`
- Plan: `docs/dev-sessions/2026-05-13-0939-conv-manager-lock/plan.md`
- Notes (including USER-race reframe rationale): `docs/dev-sessions/2026-05-13-0939-conv-manager-lock/notes.md`
- Closes #440