### PR TITLE
feat(tui): network-client TUI spike (closes #464)

### DIFF
--- a/docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md
+++ b/docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md
@@ -1,0 +1,177 @@
+# TUI Spike — Session Notes
+
+Branch: `worktree-tui-spike` (worktree at `.claude/worktrees/tui-spike/`).
+Spec: [spec.md](spec.md). Plan: [plan.md](plan.md).
+
+## What got built
+
+Ten tasks delivered as planned: TS scaffold (T1), hand-typed wire message types
+(T2), pure dispatcher reducer with vitest TDD (T3), WS transport with cookie auth
+and reconnect backoff (T4), entry point with argv/env parsing and TTY gate (T5),
+App with transcript + composer + activity lane (T6-T7), inline confirm prompt +
+Ctrl+C cancel/exit (T8), conversation picker on launch when `--conv` is absent
+(T9), and this retro (T10). The final file layout matches the plan (six source
+files + one test file). No bot-side changes were needed.
+
+## Plan / reality deltas
+
+A handful of things in the plan turned out to be wrong or underspecified:
+
+- **T1: typecheck on empty src passes silently.** `tsc --noEmit` with no `.ts`/`.tsx`
+  files exits 0 with no output, so the "verify typecheck" step was a no-op. Not a
+  bug — just an anti-climactic first smoke test.
+
+- **T2: `vault_changed` missing `kind` field.** The plan's `types.ts` snippet
+  defined `SrvVaultChanged` with only `path: string`. The actual
+  `message_types.json` has a second field `kind: string`. Fixed in T2; documented
+  with a `NOTE` comment inline. Also: `CliSetEffort.effort` in the plan was wrong
+  — the actual manifest field is `model: string` (same as `set_model`). `set_effort`
+  is a deprecated alias. Corrected in T2 and documented with a comment.
+
+- **T4: WSClient lifecycle edge cases.** Two gaps flagged in code review: (a)
+  calling `connect()` while a socket is still open could cause double-emit of
+  `__reconnected` during the overlap window; (b) `close()` did not reset `hadOpen`,
+  so a re-`connect()` after an intentional close would spuriously emit
+  `__reconnected`. Fixed in a follow-up commit (`fix(tui): tighten WSClient
+  lifecycle`) — both are one-liners that close the windows cleanly.
+
+- **T6: JSX text `>` must be expressed as `{"bot> "}`** when used as a literal in
+  JSX — the bare `>` character is ambiguous to the parser. Fixed in App.tsx.
+
+- **T6: Ink's `render()` defaults to `exitOnCtrlC: true`**, which preempts the
+  `useInput` handler in App.tsx. The plan did not flag this. The fix is to pass
+  `{ exitOnCtrlC: false }` to `render()` in `entry.tsx`, then let App own shutdown
+  (which it needs to do anyway to call `client.close()` and set `wantClosed`
+  before exiting). Fixed in a follow-up commit before T8 was started.
+
+- **T8: Ctrl+C swallowed during confirm prompt.** The plan's `useInput`
+  implementation checked `state.confirm` before the Ctrl+C check, so a user with
+  a pending confirmation had no way to exit. Fixed by moving the Ctrl+C handler
+  to the top of the `useInput` callback (so it always fires) and adding a `return`
+  after each branch.
+
+- **T9: REST shape is not a bare array.** The plan assumed `GET /api/conversations`
+  returns `ConvSummary[]`. The actual endpoint returns
+  `{ folder, folders, conversations }`. `conversationPicker.tsx` was updated to
+  extract `data.conversations` rather than treating the response as an array.
+
+- **T9: Stale closure on `conv_id` breaks reconnect-resume.** The WS subscription
+  `useEffect` runs once on mount (empty dep array) and captures `state.conv_id`
+  as null at that point. On `__reconnected`, the handler was reading the stale null
+  and never re-sending `select_conv`. Fixed with a `useRef` (`activeConvIdRef`)
+  that is kept current by a separate `useEffect([pickedConv])`. This is the React
+  stale-closure footgun for long-lived subscriptions.
+
+## Acceptance criteria walkthrough — completed
+
+Live-smoked against `make dev` on port 18880. All eight criteria passed:
+
+- [x] Connect with `--token <t>` and `--conv <id>` — works (picker also works).
+- [x] Send a user message, see streamed assistant response, see `message_complete` finalize it.
+- [x] Trigger a confirm-gated tool (shell command), approve inline, see tool output continue.
+- [x] Trigger a confirm-gated tool, deny inline, see the agent recover.
+- [x] `Ctrl+C` mid-turn cancels via `cancel_turn`; transcript reflects the cancel (now preserves the streamed draft, see deltas below).
+- [x] Kill `make dev`, restart, see TUI reconnect and resume the same conversation — `[reconnected]` line appears and conversation context is intact.
+- [x] `cd tui && npm test` — 12/12 (added one test for cancel-preserves-draft).
+- [x] `cd tui && npm run typecheck` — clean.
+
+Working launch command (single line, semicolons keep vars in shell):
+
+```bash
+TOKEN=$(jq -r 'keys[0]' /Users/lorchard/devel/decafclaw/data/decafclaw/web_tokens.json); \
+CONV=$(curl -s -X POST -H "Cookie: decafclaw_session=$TOKEN" \
+  -H "Content-Type: application/json" -d '{"title":"tui smoke"}' \
+  http://localhost:18880/api/conversations | jq -r .conv_id); \
+echo "Created: $CONV"; \
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/tui-spike/tui && \
+  DECAFCLAW_TOKEN=$TOKEN DECAFCLAW_HOST=http://localhost:18880 \
+  npm run dev -- --conv "$CONV"
+```
+
+Notes:
+
+- Conversation IDs are *server-assigned* via `POST /api/conversations`; we can't just pass a random fresh ID. The picker's `newConvId()` local-random generator is also broken because of this — needs a Phase 2 fix to POST first.
+- Default `make dev` port is 18880 in this environment, not the plan's 8088.
+
+## Smoke-driven wire deltas (manifest reconciliation)
+
+Live testing surfaced four wire-shape errors in `src/decafclaw/web/message_types.json`. The manifest had drifted from the actual implementation; the TUI was the first hand-typed consumer to catch them. Fixed in both the manifest *and* the TUI:
+
+- **`user_message`**: manifest declared `{conv_id, message: object}`, server actually emits `{conv_id, text: string}` (websocket.py:505).
+- **`message_complete`**: manifest declared `{conv_id, message: object}`, server actually emits `{conv_id, text: string, ...}` (conversation_manager.py:1062).
+- **`confirm_request`**: manifest declared `{request_id, kind, payload}`, server actually emits flat fields `{confirmation_id, action_type, tool, command, suggested_pattern, message, approve_label, deny_label, tool_call_id, action_data}` (websocket.py:600).
+- **`confirm_response`**: manifest declared `{request_id, decision, extras}`, server actually reads `{confirmation_id, approved: bool, always: bool, add_pattern: bool}` (websocket.py:_handle_confirm_response).
+
+Plus one routing error:
+
+- **WS path**: plan/spec said `/api/ws`. Actual mount is `/ws/chat` (http_server.py:1834).
+
+Codegen blast radius from the manifest fix: only `docs/websocket-messages.md` regenerated. `message_types.py` and `message-types.js` enumerate names only (which were already correct), so they're unchanged. Existing Python and JS consumers were unaffected.
+
+## Smoke-driven UX improvement
+
+- **Cancel preserves the streamed draft.** Server emits `message_complete` with `text: "[cancelled]"` on cancel (conversation_manager.py:1080). The first version of the dispatcher replaced the streamed `bot>` output with `[cancelled]`, throwing away the partial response. Fixed: when `text === "[cancelled]"` and there's a streamed draft, emit two transcript lines — the partial reply preserved as assistant text, then a yellow `[cancelled]` system marker. New test added (`message_complete with [cancelled] preserves streamed draft`).
+
+## Server-side curiosity (not a TUI issue)
+
+After a cancel-then-reconnect cycle, sending "hello" triggered the agent to first re-fulfill the cancelled essay request (writing a fresh full essay on a new topic), then respond to "hello." Inspecting the conversation history, the cancel persists `[cancelled]` as the assistant message — so the LLM sees `user(write essay) → assistant([cancelled]) → user(hello)` and apparently treats the original request as still open.
+
+This is server-side / archive behavior, not a TUI bug. Worth a separate issue: cancelled turns probably want a stronger marker that signals "the user is done with this, don't continue."
+
+## Retro candidates (Phase 2 follow-ups)
+
+Items flagged during code reviews but explicitly deferred. See the spec's
+"Phase 2 candidates" table for the big-ticket items (markdown rendering,
+multi-line composer, persistent input history, tab completion, theme, model
+picker, widgets, canvas, vault sidebars). Smaller items that surfaced during
+reviews:
+
+- **WSClient:** `setTimeout` reference in `scheduleReconnect` is untracked — can't
+  be cancelled if `close()` is called in the same tick before the timer fires.
+- **WSClient:** error logs lack URL and attempt-count context (hard to debug
+  reconnect loops without them).
+- **WSClient:** no jitter in backoff. Irrelevant for a single-client terminal tool;
+  matters at scale.
+- **Dispatcher:** `conv_history` handler has no test. Intentional per plan (history
+  load is hard to unit-test without fixtures); note it for Phase 2 coverage.
+- **App.tsx:** `setInterval` send-on-mount hack (100 ms before `select_conv`) would
+  benefit from a proper send-buffer in WSClient rather than polling.
+- **App.tsx:** `cancelArmed` timeout is untracked (process lifetime is short enough
+  that it doesn't matter in practice).
+- **App.tsx:** `JSON.stringify(payload)` confirm display is ugly for complex
+  payloads — a compact pretty-printer would help.
+- **App.tsx:** `[disconnected]` system line (on `__closed`) could complement the
+  existing `[reconnected]` for clearer connection state during the drop window.
+- **Picker:** no Ctrl+C / Escape / `q` to abort during the fetch loading state.
+- **Picker:** `updated_at` field is declared in `ConvSummary` but never displayed
+  (the plan included it for possible sorting/display; dropped from scope).
+- **Entry:** TTY check fires before `--help` parsing — `--help` on a non-TTY exits
+  with "requires a TTY stdin" rather than showing usage. Minor but non-standard.
+- **Entry:** argv parsing has no missing-value detection — `--token` at end of
+  argv silently gets `undefined` as the token value.
+- **types.ts:** `decision: string` on `CliConfirmResponse` could be
+  `"approve" | "deny" | "always"` literal union for tighter wire safety.
+
+## Capability gap (Issue #487)
+
+The spec's cross-cutting concern about transport capabilities is tracked at
+https://github.com/lmorchard/decafclaw/issues/487 — not blocking the spike but
+relevant for Phase 2 widget/canvas work. The TUI is the first new transport that
+can't render the full web UI surface, making the implicit capability assumption
+visible.
+
+## Whether the spike "validated"
+
+Pending Les's manual smoke walkthrough. The implementation passes typecheck +
+unit tests + spec-compliance reviews + code-quality reviews. Every acceptance
+criterion that doesn't require a live environment is satisfied. The only
+validation gap is live behavior against `make dev`.
+
+## Recommended Phase 2 first step
+
+Per the spec's Phase 2 sequence: **markdown rendering of assistant text**. The
+plain-text transcript gets old quickly and users expect at minimum code-block
+rendering. Hermes's Ink markdown renderer (`@inkjs/ui` or a small custom
+component) is the reference. After that: **multi-line composer + persistent input
+history** — the single-line `ink-text-input` composer is the next most visible
+friction point.

--- a/docs/dev-sessions/2026-05-13-1039-tui-spike/plan.md
+++ b/docs/dev-sessions/2026-05-13-1039-tui-spike/plan.md
@@ -1,0 +1,1576 @@
+# TUI Network Client Spike — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a minimal Ink (React-for-terminal) TUI that connects to the running decafclaw bot over its existing WebSocket gateway and drives a single conversation: chat with streaming, tool activity lane, inline confirmation prompts, Ctrl+C cancel/exit. Validate Option A (hand-typed minimal Ink) from `spec.md`.
+
+**Architecture:** Node CLI binary `decafclaw-tui` in a new `tui/` sibling directory. Connects to `/ws/chat` on the running daemon with `Cookie: decafclaw_session=<token>` (same auth as the browser). Single WS connection, per-conversation subscription via `select_conv`. No bot-side changes. Wire types hand-typed but codegen-shaped so we can graduate to generated types from `src/decafclaw/web/message_types.json` later without consumer churn.
+
+**Tech Stack:** Node 20+, TypeScript, Ink 5, `ink-text-input`, React 18, `ws` (for cookie-header WS upgrade), `tsx` (run TS directly, no build step), Vitest (dispatcher unit test only).
+
+**Spec:** [`spec.md`](spec.md). Read it first if you haven't.
+
+**File layout (final state):**
+```
+tui/
+  .gitignore
+  package.json
+  tsconfig.json
+  README.md
+  src/
+    entry.tsx                # TTY gate, argv/env parsing, render <App/>
+    App.tsx                  # Ink tree: transcript + activity + composer + confirm prompt
+    wsClient.ts              # WS connect, send, on, reconnect w/ backoff
+    types.ts                 # hand-typed WS message discriminated union
+    dispatcher.ts            # pure reducer: (state, msg) -> state
+    dispatcher.test.ts       # vitest unit tests for dispatcher
+    conversationPicker.tsx   # initial list/create picker
+```
+
+Six source files + one test (a one-file expansion past the spec's "5 files" budget — justified by pulling the dispatcher out of `App.tsx` for testability without bringing Ink rendering into the test). All other files are scaffolding.
+
+**Reference paths in main repo:**
+- Wire contract: `src/decafclaw/web/message_types.json`
+- WS handler implementation: `src/decafclaw/web/websocket.py`
+- Auth + token store: `src/decafclaw/web/auth.py`, `data/{agent_id}/web_tokens.json`
+- Comparison transport (Python stdin/stdout): `src/decafclaw/interactive_terminal.py`
+
+---
+
+### Task 1: Project scaffold
+
+**Files:**
+- Create: `tui/.gitignore`
+- Create: `tui/package.json`
+- Create: `tui/tsconfig.json`
+- Create: `tui/README.md`
+- Create: `tui/src/.gitkeep` (delete after Task 2 adds first source file)
+
+- [ ] **Step 1: Create `tui/.gitignore`**
+
+```
+node_modules/
+dist/
+*.log
+.DS_Store
+```
+
+- [ ] **Step 2: Create `tui/package.json`**
+
+```json
+{
+  "name": "decafclaw-tui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "decafclaw-tui": "./src/entry.tsx"
+  },
+  "scripts": {
+    "dev": "tsx src/entry.tsx",
+    "start": "tsx src/entry.tsx",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ink": "^5.0.1",
+    "ink-text-input": "^6.0.0",
+    "react": "^18.3.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "@types/react": "^18.3.11",
+    "@types/ws": "^8.5.12",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.2"
+  }
+}
+```
+
+- [ ] **Step 3: Create `tui/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 4: Create `tui/README.md`**
+
+```markdown
+# decafclaw-tui
+
+Minimal Ink TUI that connects to a running decafclaw bot over its WebSocket gateway.
+Spec: `docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md`.
+
+## Running
+
+```bash
+cd tui
+npm install
+DECAFCLAW_TOKEN=<token> npm run dev
+# or
+npm run dev -- --token <token> --conv <conv_id>
+```
+
+Requires the bot to be running locally (e.g. `make dev` in the repo root).
+
+## Configuration
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--token <t>` | `DECAFCLAW_TOKEN` | (required) |
+| `--host <url>` | `DECAFCLAW_HOST` | `http://localhost:8088` |
+| `--conv <id>` | — | (picker shown if absent) |
+
+Get a token from `data/{agent_id}/web_tokens.json` in the main clone.
+
+## Scripts
+
+- `npm run dev` — run the TUI
+- `npm test` — run dispatcher unit tests
+- `npm run typecheck` — type-check without emitting
+
+## Status
+
+Spike. See `docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md` for scope and deferred items.
+```
+
+- [ ] **Step 5: Create `tui/src/.gitkeep` placeholder**
+
+```
+```
+
+(empty file)
+
+- [ ] **Step 6: Install dependencies**
+
+```bash
+cd tui && npm install
+```
+
+Expected: `node_modules/` populated, lockfile written. No errors.
+
+- [ ] **Step 7: Verify typecheck passes on empty source tree**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: no output, exit 0. (No `.ts` / `.tsx` files yet; tsc has nothing to complain about.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tui/.gitignore tui/package.json tui/package-lock.json tui/tsconfig.json tui/README.md tui/src/.gitkeep
+git commit -m "feat(tui): TypeScript project scaffold for Ink TUI spike"
+```
+
+---
+
+### Task 2: Wire types
+
+**Files:**
+- Create: `tui/src/types.ts`
+- Delete: `tui/src/.gitkeep`
+
+The TS types mirror `src/decafclaw/web/message_types.json` verbatim. Field names match, envelope key is `"type"`. Two unions: `ServerMessage` (received) and `ClientMessage` (sent). When we promote to codegen, this file gets replaced by `types.generated.ts` with the same exported names.
+
+- [ ] **Step 1: Create `tui/src/types.ts`**
+
+```typescript
+/**
+ * WebSocket message types for the decafclaw bot.
+ *
+ * Mirrors src/decafclaw/web/message_types.json. Hand-typed for the spike.
+ * Codegen-shaped: when we promote, replace with generated file using the
+ * same exported names. See spec for the A->B promotion path.
+ */
+
+// ---- Server -> client ----
+
+export interface SrvBackgroundEvent { type: "background_event"; conv_id: string; event: Record<string, unknown>; }
+export interface SrvCanvasUpdate { type: "canvas_update"; conv_id: string; state: Record<string, unknown>; }
+export interface SrvChunk { type: "chunk"; conv_id: string; text: string; }
+export interface SrvCommandAck { type: "command_ack"; conv_id: string; command: string; }
+export interface SrvCompactionDone { type: "compaction_done"; conv_id: string; }
+export interface SrvConfirmRequest { type: "confirm_request"; conv_id: string; request_id: string; kind: string; payload: Record<string, unknown>; }
+export interface SrvConfirmationResponse { type: "confirmation_response"; conv_id: string; request_id: string; decision: string; }
+export interface SrvConvHistory { type: "conv_history"; conv_id: string; messages: Array<Record<string, unknown>>; before: string | null; }
+export interface SrvConvSelected { type: "conv_selected"; conv_id: string; model: string | null; }
+export interface SrvError { type: "error"; message: string; conv_id: string | null; }
+export interface SrvMessageComplete { type: "message_complete"; conv_id: string; message: Record<string, unknown>; }
+export interface SrvModelChanged { type: "model_changed"; conv_id: string; model: string; }
+export interface SrvModelsAvailable { type: "models_available"; models: string[]; }
+export interface SrvNotificationCreated { type: "notification_created"; notification: Record<string, unknown>; }
+export interface SrvNotificationRead { type: "notification_read"; id: string; }
+export interface SrvReflectionResult { type: "reflection_result"; conv_id: string; result: Record<string, unknown>; }
+export interface SrvToolEnd { type: "tool_end"; conv_id: string; tool_call_id: string; name: string; ok: boolean; result: string | Record<string, unknown>; }
+export interface SrvToolStart { type: "tool_start"; conv_id: string; tool_call_id: string; name: string; input: Record<string, unknown>; }
+export interface SrvToolStatus { type: "tool_status"; conv_id: string; tool_call_id: string; status: string; }
+export interface SrvTurnComplete { type: "turn_complete"; conv_id: string; }
+export interface SrvTurnStart { type: "turn_start"; conv_id: string; }
+export interface SrvUserMessage { type: "user_message"; conv_id: string; message: Record<string, unknown>; }
+export interface SrvVaultChanged { type: "vault_changed"; path: string; }
+
+export type ServerMessage =
+  | SrvBackgroundEvent
+  | SrvCanvasUpdate
+  | SrvChunk
+  | SrvCommandAck
+  | SrvCompactionDone
+  | SrvConfirmRequest
+  | SrvConfirmationResponse
+  | SrvConvHistory
+  | SrvConvSelected
+  | SrvError
+  | SrvMessageComplete
+  | SrvModelChanged
+  | SrvModelsAvailable
+  | SrvNotificationCreated
+  | SrvNotificationRead
+  | SrvReflectionResult
+  | SrvToolEnd
+  | SrvToolStart
+  | SrvToolStatus
+  | SrvTurnComplete
+  | SrvTurnStart
+  | SrvUserMessage
+  | SrvVaultChanged;
+
+// ---- Client -> server ----
+
+export interface CliCancelTurn { type: "cancel_turn"; conv_id: string; }
+export interface CliConfirmResponse { type: "confirm_response"; conv_id: string; request_id: string; decision: string; extras: Record<string, unknown>; }
+export interface CliLoadHistory { type: "load_history"; conv_id: string; limit: number; before: string | null; }
+export interface CliSelectConv { type: "select_conv"; conv_id: string; }
+export interface CliSend { type: "send"; conv_id: string; text: string; attachments: Array<Record<string, unknown>>; }
+export interface CliSetEffort { type: "set_effort"; conv_id: string; effort: string; }
+export interface CliSetModel { type: "set_model"; conv_id: string; model: string; }
+export interface CliWidgetResponse { type: "widget_response"; conv_id: string; request_id: string; value: Record<string, unknown>; }
+
+export type ClientMessage =
+  | CliCancelTurn
+  | CliConfirmResponse
+  | CliLoadHistory
+  | CliSelectConv
+  | CliSend
+  | CliSetEffort
+  | CliSetModel
+  | CliWidgetResponse;
+```
+
+- [ ] **Step 2: Delete the placeholder**
+
+```bash
+rm tui/src/.gitkeep
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tui/src/types.ts
+git rm tui/src/.gitkeep
+git commit -m "feat(tui): hand-typed wire message types mirroring message_types.json"
+```
+
+---
+
+### Task 3: Pure dispatcher with TDD
+
+**Files:**
+- Create: `tui/src/dispatcher.ts`
+- Create: `tui/src/dispatcher.test.ts`
+
+The dispatcher is the only test-worthy unit in the spike. It's a pure reducer `(state, msg) -> state`. Extract it from `App.tsx` so we can test without rendering Ink.
+
+**State shape (kept inline in dispatcher.ts):**
+
+```typescript
+type TranscriptItem =
+  | { kind: "user"; text: string }
+  | { kind: "assistant"; text: string }
+  | { kind: "system"; text: string }; // [reconnected], [compaction complete], errors
+
+type Activity = { tool_call_id: string; name: string; status: string } | null;
+
+type Confirm = { request_id: string; kind: string; payload: Record<string, unknown> } | null;
+
+interface State {
+  conv_id: string | null;
+  transcript: TranscriptItem[];
+  draft: string; // in-flight assistant message
+  activity: Activity;
+  confirm: Confirm;
+  turnInFlight: boolean;
+  model: string | null;
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tui/src/dispatcher.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { initialState, dispatch } from "./dispatcher.js";
+import type { ServerMessage } from "./types.js";
+
+const CONV = "conv-abc";
+
+describe("dispatcher", () => {
+  it("chunk appends to draft", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "chunk", conv_id: CONV, text: "hello " });
+    const s2 = dispatch(s1, { type: "chunk", conv_id: CONV, text: "world" });
+    expect(s2.draft).toBe("hello world");
+  });
+
+  it("message_complete finalizes draft into transcript", () => {
+    const s0 = { ...initialState, conv_id: CONV, draft: "answer" };
+    const s1 = dispatch(s0, {
+      type: "message_complete",
+      conv_id: CONV,
+      message: { text: "answer" },
+    });
+    expect(s1.draft).toBe("");
+    expect(s1.transcript).toEqual([{ kind: "assistant", text: "answer" }]);
+  });
+
+  it("turn_start / turn_complete toggle turnInFlight", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "turn_start", conv_id: CONV });
+    expect(s1.turnInFlight).toBe(true);
+    const s2 = dispatch(s1, { type: "turn_complete", conv_id: CONV });
+    expect(s2.turnInFlight).toBe(false);
+  });
+
+  it("tool_start sets activity; tool_status updates it; tool_end clears it", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "tool_start",
+      conv_id: CONV,
+      tool_call_id: "tc1",
+      name: "run_shell_command",
+      input: {},
+    });
+    expect(s1.activity).toEqual({
+      tool_call_id: "tc1",
+      name: "run_shell_command",
+      status: "",
+    });
+    const s2 = dispatch(s1, {
+      type: "tool_status",
+      conv_id: CONV,
+      tool_call_id: "tc1",
+      status: "running",
+    });
+    expect(s2.activity?.status).toBe("running");
+    const s3 = dispatch(s2, {
+      type: "tool_end",
+      conv_id: CONV,
+      tool_call_id: "tc1",
+      name: "run_shell_command",
+      ok: true,
+      result: "done",
+    });
+    expect(s3.activity).toBeNull();
+  });
+
+  it("confirm_request sets confirm; we clear it on response intent", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "confirm_request",
+      conv_id: CONV,
+      request_id: "req1",
+      kind: "run_shell_command",
+      payload: { command: "ls" },
+    });
+    expect(s1.confirm).toEqual({
+      request_id: "req1",
+      kind: "run_shell_command",
+      payload: { command: "ls" },
+    });
+  });
+
+  it("user_message echo appends to transcript", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "user_message",
+      conv_id: CONV,
+      message: { text: "hi" },
+    });
+    expect(s1.transcript).toEqual([{ kind: "user", text: "hi" }]);
+  });
+
+  it("conv_selected stores model", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "conv_selected",
+      conv_id: CONV,
+      model: "claude-opus-4-7",
+    });
+    expect(s1.conv_id).toBe(CONV);
+    expect(s1.model).toBe("claude-opus-4-7");
+  });
+
+  it("compaction_done appends system line", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "compaction_done", conv_id: CONV });
+    expect(s1.transcript.at(-1)).toEqual({
+      kind: "system",
+      text: "[compaction complete]",
+    });
+  });
+
+  it("model_changed appends system line + updates model", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "model_changed",
+      conv_id: CONV,
+      model: "claude-haiku-4-5",
+    });
+    expect(s1.model).toBe("claude-haiku-4-5");
+    expect(s1.transcript.at(-1)?.text).toContain("claude-haiku-4-5");
+  });
+
+  it("error appends system line", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "error",
+      message: "boom",
+      conv_id: null,
+    });
+    expect(s1.transcript.at(-1)).toEqual({
+      kind: "system",
+      text: "[error: boom]",
+    });
+  });
+
+  it("unknown type returns state unchanged (forward-compat)", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const unknown = { type: "future_message", conv_id: CONV } as unknown as ServerMessage;
+    const s1 = dispatch(s0, unknown);
+    expect(s1).toBe(s0); // referential equality — no copy
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd tui && npm test
+```
+
+Expected: errors importing `./dispatcher.js` (file doesn't exist). All tests fail.
+
+- [ ] **Step 3: Implement `tui/src/dispatcher.ts`**
+
+```typescript
+/**
+ * Pure reducer mapping (state, ServerMessage) -> new state.
+ *
+ * Exhaustive switch with TS `never` guard on default — adding a new
+ * ServerMessage variant in types.ts will surface here as a compile error
+ * rather than silent drift. See spec.md "Promotion path" section.
+ */
+
+import type { ServerMessage } from "./types.js";
+
+export type TranscriptItem =
+  | { kind: "user"; text: string }
+  | { kind: "assistant"; text: string }
+  | { kind: "system"; text: string };
+
+export type Activity = {
+  tool_call_id: string;
+  name: string;
+  status: string;
+} | null;
+
+export type Confirm = {
+  request_id: string;
+  kind: string;
+  payload: Record<string, unknown>;
+} | null;
+
+export interface State {
+  conv_id: string | null;
+  transcript: TranscriptItem[];
+  draft: string;
+  activity: Activity;
+  confirm: Confirm;
+  turnInFlight: boolean;
+  model: string | null;
+}
+
+export const initialState: State = {
+  conv_id: null,
+  transcript: [],
+  draft: "",
+  activity: null,
+  confirm: null,
+  turnInFlight: false,
+  model: null,
+};
+
+function appendTranscript(s: State, item: TranscriptItem): State {
+  return { ...s, transcript: [...s.transcript, item] };
+}
+
+function extractText(msg: Record<string, unknown>): string {
+  const t = msg["text"];
+  return typeof t === "string" ? t : "";
+}
+
+export function dispatch(s: State, m: ServerMessage): State {
+  switch (m.type) {
+    case "chunk":
+      return { ...s, draft: s.draft + m.text };
+
+    case "message_complete": {
+      const text = extractText(m.message) || s.draft;
+      const next = appendTranscript(s, { kind: "assistant", text });
+      return { ...next, draft: "" };
+    }
+
+    case "user_message":
+      return appendTranscript(s, { kind: "user", text: extractText(m.message) });
+
+    case "turn_start":
+      return { ...s, turnInFlight: true };
+
+    case "turn_complete":
+      return { ...s, turnInFlight: false };
+
+    case "tool_start":
+      return {
+        ...s,
+        activity: { tool_call_id: m.tool_call_id, name: m.name, status: "" },
+      };
+
+    case "tool_status":
+      if (s.activity && s.activity.tool_call_id === m.tool_call_id) {
+        return { ...s, activity: { ...s.activity, status: m.status } };
+      }
+      return s;
+
+    case "tool_end":
+      if (s.activity && s.activity.tool_call_id === m.tool_call_id) {
+        return { ...s, activity: null };
+      }
+      return s;
+
+    case "confirm_request":
+      return {
+        ...s,
+        confirm: {
+          request_id: m.request_id,
+          kind: m.kind,
+          payload: m.payload,
+        },
+      };
+
+    case "confirmation_response":
+      // Server replay of a prior decision (e.g., loading history). Currently no-op for live UI.
+      return s;
+
+    case "conv_selected":
+      return { ...s, conv_id: m.conv_id, model: m.model };
+
+    case "conv_history": {
+      const items: TranscriptItem[] = [];
+      for (const raw of m.messages) {
+        const role = (raw as { role?: string }).role;
+        const text = extractText(raw as Record<string, unknown>);
+        if (role === "user") items.push({ kind: "user", text });
+        else if (role === "assistant") items.push({ kind: "assistant", text });
+        // skip tool/system roles in the spike
+      }
+      return { ...s, transcript: [...items, ...s.transcript] };
+    }
+
+    case "compaction_done":
+      return appendTranscript(s, { kind: "system", text: "[compaction complete]" });
+
+    case "model_changed":
+      return appendTranscript(
+        { ...s, model: m.model },
+        { kind: "system", text: `[model: ${m.model}]` }
+      );
+
+    case "error":
+      return appendTranscript(s, { kind: "system", text: `[error: ${m.message}]` });
+
+    // Spike-deferred. Acknowledged in types.ts but not surfaced in UI.
+    case "background_event":
+    case "canvas_update":
+    case "command_ack":
+    case "models_available":
+    case "notification_created":
+    case "notification_read":
+    case "reflection_result":
+    case "vault_changed":
+      return s;
+
+    default: {
+      // Forward-compat: surface unknown types as unchanged.
+      // TS exhaustiveness check — if a new variant is added to ServerMessage
+      // and not handled above, this will fail to compile.
+      const _exhaustive: never = m;
+      void _exhaustive;
+      return s;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd tui && npm test
+```
+
+Expected: all 11 tests pass.
+
+- [ ] **Step 5: Verify typecheck passes**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tui/src/dispatcher.ts tui/src/dispatcher.test.ts
+git commit -m "feat(tui): pure dispatcher reducer + vitest unit tests"
+```
+
+---
+
+### Task 4: WS transport
+
+**Files:**
+- Create: `tui/src/wsClient.ts`
+
+`wsClient.ts` owns the socket. Dumb pipe: `connect()`, `send(msg)`, `on(handler)`, `close()`. Reconnect with exponential backoff. Surfaces a synthetic `__reconnected` event so the dispatcher / App can mark `[reconnected]` and re-issue `select_conv`.
+
+The `ws` npm package supports cookie headers on upgrade; Node's global `WebSocket` does not. We use `ws`.
+
+- [ ] **Step 1: Implement `tui/src/wsClient.ts`**
+
+```typescript
+/**
+ * WebSocket transport for the TUI.
+ *
+ * Dumb pipe: opens a connection with the same cookie auth the browser uses,
+ * parses incoming JSON, surfaces parsed ServerMessage envelopes (or a synthetic
+ * `__reconnected` marker after a reconnect). Caller decides what to do.
+ *
+ * Reconnect with exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+ * Auth-failure exits are surfaced by leaving the WS closed and emitting a
+ * synthetic `__auth_failed` marker. The App treats this as fatal.
+ */
+
+import WebSocket from "ws";
+import type { ClientMessage, ServerMessage } from "./types.js";
+
+export type WSEvent =
+  | ServerMessage
+  | { type: "__reconnected" }
+  | { type: "__auth_failed"; reason: string }
+  | { type: "__closed"; code: number; reason: string };
+
+export interface WSClientOptions {
+  host: string; // e.g. "http://localhost:8088" or "https://example.com"
+  token: string;
+}
+
+export class WSClient {
+  private opts: WSClientOptions;
+  private ws: WebSocket | null = null;
+  private handlers: Array<(e: WSEvent) => void> = [];
+  private reconnectAttempt = 0;
+  private wantClosed = false;
+  private hadOpen = false;
+
+  constructor(opts: WSClientOptions) {
+    this.opts = opts;
+  }
+
+  on(handler: (e: WSEvent) => void): void {
+    this.handlers.push(handler);
+  }
+
+  send(msg: ClientMessage): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+    // else: silently drop; reconnect path will re-establish state via re-select_conv
+  }
+
+  close(): void {
+    this.wantClosed = true;
+    this.ws?.close();
+  }
+
+  connect(): void {
+    const wsUrl = this.opts.host.replace(/^http/, "ws") + "/api/ws";
+    const ws = new WebSocket(wsUrl, {
+      headers: {
+        Cookie: `decafclaw_session=${this.opts.token}`,
+      },
+    });
+    this.ws = ws;
+
+    ws.on("open", () => {
+      const wasReconnect = this.hadOpen;
+      this.hadOpen = true;
+      this.reconnectAttempt = 0;
+      if (wasReconnect) {
+        this.emit({ type: "__reconnected" });
+      }
+    });
+
+    ws.on("message", (data: WebSocket.RawData) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data.toString());
+      } catch {
+        // eslint-disable-next-line no-console
+        console.error("[tui] malformed WS message:", data.toString());
+        return;
+      }
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "type" in parsed &&
+        typeof (parsed as { type: unknown }).type === "string"
+      ) {
+        this.emit(parsed as ServerMessage);
+      }
+    });
+
+    ws.on("unexpected-response", (_req, res) => {
+      // 401/403 etc. — auth failure on upgrade.
+      const reason = `HTTP ${res.statusCode} ${res.statusMessage ?? ""}`.trim();
+      this.wantClosed = true;
+      this.emit({ type: "__auth_failed", reason });
+    });
+
+    ws.on("close", (code: number, reasonBuf: Buffer) => {
+      const reason = reasonBuf.toString();
+      this.emit({ type: "__closed", code, reason });
+      this.ws = null;
+      if (this.wantClosed) return;
+      this.scheduleReconnect();
+    });
+
+    ws.on("error", (err: Error) => {
+      // eslint-disable-next-line no-console
+      console.error("[tui] ws error:", err.message);
+      // close handler will fire after this; reconnect is scheduled there.
+    });
+  }
+
+  private scheduleReconnect(): void {
+    const delays = [1000, 2000, 4000, 8000, 16000, 30000];
+    const idx = Math.min(this.reconnectAttempt, delays.length - 1);
+    const delay = delays[idx]!;
+    this.reconnectAttempt += 1;
+    setTimeout(() => {
+      if (!this.wantClosed) this.connect();
+    }, delay);
+  }
+
+  private emit(e: WSEvent): void {
+    for (const h of this.handlers) h(e);
+  }
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Verify dispatcher tests still pass**
+
+```bash
+cd tui && npm test
+```
+
+Expected: 11 tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tui/src/wsClient.ts
+git commit -m "feat(tui): WS transport with cookie auth + reconnect backoff"
+```
+
+---
+
+### Task 5: Entry + argv
+
+**Files:**
+- Create: `tui/src/entry.tsx`
+
+Entry point: TTY gate, argv/env parsing, construct `WSClient`, render `<App/>`. Exits early on missing token or non-TTY stdin.
+
+- [ ] **Step 1: Implement `tui/src/entry.tsx`**
+
+```typescript
+#!/usr/bin/env -S npx tsx
+/**
+ * Entry point: parse argv + env, construct WSClient, render App.
+ *
+ * Required: token (--token / DECAFCLAW_TOKEN).
+ * Optional: --host (default http://localhost:8088), --conv <id>.
+ */
+
+import React from "react";
+import { render } from "ink";
+import { WSClient } from "./wsClient.js";
+import { App } from "./App.js";
+
+interface Args {
+  token: string;
+  host: string;
+  conv: string | null;
+}
+
+function parseArgs(argv: string[]): Args | { error: string } {
+  const args: Partial<Args> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--token") args.token = argv[++i];
+    else if (a === "--host") args.host = argv[++i];
+    else if (a === "--conv") args.conv = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      return {
+        error:
+          "Usage: decafclaw-tui [--token <t>] [--host <url>] [--conv <id>]\n" +
+          "Env: DECAFCLAW_TOKEN, DECAFCLAW_HOST",
+      };
+    }
+  }
+  const token = args.token ?? process.env.DECAFCLAW_TOKEN;
+  const host = args.host ?? process.env.DECAFCLAW_HOST ?? "http://localhost:8088";
+  if (!token) {
+    return { error: "Missing token. Use --token <t> or DECAFCLAW_TOKEN." };
+  }
+  return { token, host, conv: args.conv ?? null };
+}
+
+function main(): void {
+  if (!process.stdin.isTTY) {
+    // eslint-disable-next-line no-console
+    console.error("decafclaw-tui requires a TTY stdin.");
+    process.exit(1);
+  }
+
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    // eslint-disable-next-line no-console
+    console.error(parsed.error);
+    process.exit(1);
+  }
+
+  const client = new WSClient({ host: parsed.host, token: parsed.token });
+  client.connect();
+
+  render(<App client={client} initialConvId={parsed.conv} host={parsed.host} token={parsed.token} />);
+}
+
+main();
+```
+
+- [ ] **Step 2: Create a minimal `App.tsx` stub so entry typechecks**
+
+`tui/src/App.tsx`:
+
+```typescript
+import React from "react";
+import { Text } from "ink";
+import type { WSClient } from "./wsClient.js";
+
+export interface AppProps {
+  client: WSClient;
+  initialConvId: string | null;
+  host: string;
+  token: string;
+}
+
+export function App(_props: AppProps): React.JSX.Element {
+  return <Text>decafclaw-tui (placeholder)</Text>;
+}
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Smoke-check the `--help` path (no WS required)**
+
+```bash
+cd tui && node --import tsx src/entry.tsx --help
+```
+
+Expected: usage text printed, exit 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tui/src/entry.tsx tui/src/App.tsx
+git commit -m "feat(tui): entry point with argv/env parsing + TTY gate"
+```
+
+---
+
+### Task 6: App — transcript + composer (basic chat)
+
+**Files:**
+- Modify: `tui/src/App.tsx`
+
+Wire the dispatcher into App state. Render transcript + composer. Send `select_conv` on mount (if `initialConvId` is set) and dispatch incoming WS events. Composer submit → `send` message.
+
+This task validates the chat round-trip without confirm prompts or activity lane.
+
+- [ ] **Step 1: Replace `tui/src/App.tsx` with the basic chat view**
+
+```typescript
+import React, { useEffect, useReducer, useState } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import TextInput from "ink-text-input";
+import type { WSClient, WSEvent } from "./wsClient.js";
+import { dispatch, initialState, type State } from "./dispatcher.js";
+import type { ServerMessage } from "./types.js";
+
+export interface AppProps {
+  client: WSClient;
+  initialConvId: string | null;
+  host: string;
+  token: string;
+}
+
+type Action =
+  | { kind: "wire"; msg: ServerMessage }
+  | { kind: "reconnected" }
+  | { kind: "auth_failed"; reason: string }
+  | { kind: "closed"; code: number; reason: string };
+
+function reducer(s: State, a: Action): State {
+  switch (a.kind) {
+    case "wire":
+      return dispatch(s, a.msg);
+    case "reconnected":
+      return {
+        ...s,
+        transcript: [...s.transcript, { kind: "system", text: "[reconnected]" }],
+      };
+    case "auth_failed":
+      return {
+        ...s,
+        transcript: [
+          ...s.transcript,
+          { kind: "system", text: `[auth failed: ${a.reason}]` },
+        ],
+      };
+    case "closed":
+      return s;
+  }
+}
+
+export function App({ client, initialConvId }: AppProps): React.JSX.Element {
+  const [state, dispatchUi] = useReducer(reducer, initialState);
+  const [draft, setDraft] = useState("");
+  const { exit } = useApp();
+
+  useEffect(() => {
+    client.on((e: WSEvent) => {
+      if (e.type === "__reconnected") {
+        dispatchUi({ kind: "reconnected" });
+        if (state.conv_id) client.send({ type: "select_conv", conv_id: state.conv_id });
+      } else if (e.type === "__auth_failed") {
+        dispatchUi({ kind: "auth_failed", reason: e.reason });
+      } else if (e.type === "__closed") {
+        dispatchUi({ kind: "closed", code: e.code, reason: e.reason });
+      } else {
+        dispatchUi({ kind: "wire", msg: e });
+      }
+    });
+
+    if (initialConvId) {
+      // tiny delay to let the socket open; the WSClient drops sends when not open
+      // and a real reconnect-aware send would buffer — out of scope for spike.
+      const t = setInterval(() => {
+        client.send({ type: "select_conv", conv_id: initialConvId });
+        clearInterval(t);
+      }, 100);
+      return () => clearInterval(t);
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useInput((_input, key) => {
+    if (key.ctrl && _input === "c") {
+      client.close();
+      exit();
+    }
+  });
+
+  function onSubmit(text: string): void {
+    if (!state.conv_id) return;
+    if (!text.trim()) return;
+    client.send({
+      type: "send",
+      conv_id: state.conv_id,
+      text,
+      attachments: [],
+    });
+    setDraft("");
+  }
+
+  return (
+    <Box flexDirection="column">
+      {state.transcript.map((item, i) => (
+        <Text key={i} color={item.kind === "system" ? "yellow" : undefined}>
+          {item.kind === "user" ? "you> " : item.kind === "assistant" ? "bot> " : ""}
+          {item.text}
+        </Text>
+      ))}
+      {state.draft && <Text color="cyan">bot> {state.draft}</Text>}
+      <Box>
+        <Text>{state.conv_id ? "> " : "(connecting...) "}</Text>
+        <TextInput value={draft} onChange={setDraft} onSubmit={onSubmit} />
+      </Box>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+```bash
+cd tui && npm run typecheck
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Verify dispatcher tests still pass**
+
+```bash
+cd tui && npm test
+```
+
+Expected: 11 tests pass.
+
+- [ ] **Step 4: Manual smoke test**
+
+Prerequisite: `make dev` running on `http://localhost:8088`. Token from `data/{agent_id}/web_tokens.json`.
+
+```bash
+cd tui && DECAFCLAW_TOKEN=<token> npm run dev -- --conv smoke-tui-spike
+```
+
+Expected:
+1. TUI launches, shows `> ` prompt.
+2. Type "hello" and Enter.
+3. See `bot> ...` stream in.
+4. After completion the streamed line stays.
+5. Ctrl+C exits cleanly.
+
+If `--conv smoke-tui-spike` is a fresh ID, the bot creates a new conversation lazily on the first `send`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tui/src/App.tsx
+git commit -m "feat(tui): wire dispatcher into App; basic chat round-trip working"
+```
+
+---
+
+### Task 7: Activity lane
+
+**Files:**
+- Modify: `tui/src/App.tsx`
+
+Add a single-line activity indicator showing the current tool's name + status. Renders above the composer when `state.activity` is non-null.
+
+- [ ] **Step 1: Update `App.tsx`'s render to include the activity lane**
+
+Replace the JSX `return` in `App` with:
+
+```typescript
+  return (
+    <Box flexDirection="column">
+      {state.transcript.map((item, i) => (
+        <Text key={i} color={item.kind === "system" ? "yellow" : undefined}>
+          {item.kind === "user" ? "you> " : item.kind === "assistant" ? "bot> " : ""}
+          {item.text}
+        </Text>
+      ))}
+      {state.draft && <Text color="cyan">bot> {state.draft}</Text>}
+      {state.activity && (
+        <Text color="gray">
+          [{state.activity.name}] {state.activity.status || "running..."}
+        </Text>
+      )}
+      <Box>
+        <Text>{state.conv_id ? "> " : "(connecting...) "}</Text>
+        <TextInput value={draft} onChange={setDraft} onSubmit={onSubmit} />
+      </Box>
+    </Box>
+  );
+```
+
+- [ ] **Step 2: Verify typecheck + tests**
+
+```bash
+cd tui && npm run typecheck && npm test
+```
+
+Expected: clean + 11 pass.
+
+- [ ] **Step 3: Manual smoke test**
+
+Same setup as Task 6. In the TUI, send a message that triggers a tool — e.g., ask the agent to read a file via the existing `read_file` tool (no confirmation required) or run a vault read.
+
+Expected:
+1. While the tool runs, a gray `[tool_name] running...` line appears between the streaming `bot>` line and the composer.
+2. When `tool_end` arrives, the gray line disappears.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tui/src/App.tsx
+git commit -m "feat(tui): activity lane shows in-flight tool name + status"
+```
+
+---
+
+### Task 8: Confirm prompt + Ctrl+C cancel
+
+**Files:**
+- Modify: `tui/src/App.tsx`
+
+When `state.confirm` is non-null, suspend the composer and show an inline prompt. Accept `y` / `n` / `a` keys and send `confirm_response` with `decision` of `approve` / `deny` / `always`. Then clear `state.confirm`.
+
+Also: Ctrl+C while `turnInFlight` sends `cancel_turn` instead of exiting. Ctrl+C twice in a row (or while idle) exits.
+
+- [ ] **Step 1: Add a confirm-cleared local Action variant**
+
+Update the `Action` type and `reducer` in `App.tsx`:
+
+```typescript
+type Action =
+  | { kind: "wire"; msg: ServerMessage }
+  | { kind: "reconnected" }
+  | { kind: "auth_failed"; reason: string }
+  | { kind: "closed"; code: number; reason: string }
+  | { kind: "clear_confirm" };
+
+function reducer(s: State, a: Action): State {
+  switch (a.kind) {
+    case "wire":
+      return dispatch(s, a.msg);
+    case "reconnected":
+      return {
+        ...s,
+        transcript: [...s.transcript, { kind: "system", text: "[reconnected]" }],
+      };
+    case "auth_failed":
+      return {
+        ...s,
+        transcript: [
+          ...s.transcript,
+          { kind: "system", text: `[auth failed: ${a.reason}]` },
+        ],
+      };
+    case "closed":
+      return s;
+    case "clear_confirm":
+      return { ...s, confirm: null };
+  }
+}
+```
+
+- [ ] **Step 2: Update `useInput` to handle confirm + Ctrl+C semantics**
+
+Replace the `useInput` block:
+
+```typescript
+  const [cancelArmed, setCancelArmed] = useState(false);
+
+  useInput((input, key) => {
+    // Confirm prompt active: y/n/a keys send decision.
+    if (state.confirm) {
+      const decision =
+        input === "y" || input === "Y" ? "approve" :
+        input === "n" || input === "N" ? "deny" :
+        input === "a" || input === "A" ? "always" :
+        null;
+      if (decision && state.conv_id) {
+        client.send({
+          type: "confirm_response",
+          conv_id: state.conv_id,
+          request_id: state.confirm.request_id,
+          decision,
+          extras: {},
+        });
+        dispatchUi({ kind: "clear_confirm" });
+      }
+      return;
+    }
+
+    // Ctrl+C: cancel turn if busy (first press), or exit (idle or second press).
+    if (key.ctrl && input === "c") {
+      if (state.turnInFlight && !cancelArmed && state.conv_id) {
+        client.send({ type: "cancel_turn", conv_id: state.conv_id });
+        setCancelArmed(true);
+        // arm for 2s; after that Ctrl+C cancels again instead of exiting
+        setTimeout(() => setCancelArmed(false), 2000);
+      } else {
+        client.close();
+        exit();
+      }
+    }
+  });
+```
+
+- [ ] **Step 3: Render the confirm prompt above the composer**
+
+Update the JSX return to include the prompt:
+
+```typescript
+  return (
+    <Box flexDirection="column">
+      {state.transcript.map((item, i) => (
+        <Text key={i} color={item.kind === "system" ? "yellow" : undefined}>
+          {item.kind === "user" ? "you> " : item.kind === "assistant" ? "bot> " : ""}
+          {item.text}
+        </Text>
+      ))}
+      {state.draft && <Text color="cyan">bot> {state.draft}</Text>}
+      {state.activity && (
+        <Text color="gray">
+          [{state.activity.name}] {state.activity.status || "running..."}
+        </Text>
+      )}
+      {state.confirm && (
+        <Box flexDirection="column">
+          <Text color="magenta">
+            confirm ({state.confirm.kind}): {JSON.stringify(state.confirm.payload)}
+          </Text>
+          <Text color="magenta">[y]es / [n]o / [a]lways</Text>
+        </Box>
+      )}
+      <Box>
+        <Text>{state.conv_id ? "> " : "(connecting...) "}</Text>
+        {!state.confirm && (
+          <TextInput value={draft} onChange={setDraft} onSubmit={onSubmit} />
+        )}
+      </Box>
+    </Box>
+  );
+```
+
+- [ ] **Step 4: Verify typecheck + tests**
+
+```bash
+cd tui && npm run typecheck && npm test
+```
+
+Expected: clean + 11 pass.
+
+- [ ] **Step 5: Manual smoke test (approve)**
+
+In the TUI, send a message that triggers a confirmation. For example: "run the shell command `ls /tmp`".
+
+Expected:
+1. After a moment, magenta confirmation block appears with the command + `[y]es / [n]o / [a]lways`.
+2. Press `y`. Confirmation disappears, composer reactivates, tool runs, output streams back.
+
+- [ ] **Step 6: Manual smoke test (deny)**
+
+Same setup, press `n` instead.
+
+Expected: agent acknowledges denial and recovers (probably explains it won't run the command).
+
+- [ ] **Step 7: Manual smoke test (cancel mid-turn)**
+
+Send a message that produces a long response. Hit Ctrl+C while the response streams.
+
+Expected: stream halts shortly after (server processes `cancel_turn` and emits `turn_complete`). Composer reactivates. A second Ctrl+C within 2s exits.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tui/src/App.tsx
+git commit -m "feat(tui): inline confirm prompt + Ctrl+C cancel/exit"
+```
+
+---
+
+### Task 9: Conversation picker
+
+**Files:**
+- Create: `tui/src/conversationPicker.tsx`
+- Modify: `tui/src/App.tsx`
+
+When `--conv` is absent, show a picker on launch: list recent conversations from `GET /api/conversations` with cookie auth, plus a "New conversation" option that generates a fresh `conv_id`.
+
+- [ ] **Step 1: Verify the REST endpoint shape**
+
+```bash
+TOKEN=<token>; curl -s -H "Cookie: decafclaw_session=$TOKEN" http://localhost:8088/api/conversations | head -c 500
+```
+
+Expected: JSON array of `{conv_id, ...}` records. If the shape is something else, adjust the picker's mapping accordingly. If `/api/conversations` doesn't exist, check `web/conversations.py` for the actual route and update.
+
+- [ ] **Step 2: Implement `tui/src/conversationPicker.tsx`**
+
+```typescript
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+interface ConvSummary {
+  conv_id: string;
+  title?: string;
+  updated_at?: string;
+}
+
+interface Props {
+  host: string;
+  token: string;
+  onPick: (convId: string) => void;
+}
+
+function newConvId(): string {
+  // Random short ID; the bot creates the conversation lazily on first send.
+  return "tui-" + Math.random().toString(36).slice(2, 10);
+}
+
+export function ConversationPicker({ host, token, onPick }: Props): React.JSX.Element {
+  const [convs, setConvs] = useState<ConvSummary[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [cursor, setCursor] = useState(0);
+
+  useEffect(() => {
+    fetch(host + "/api/conversations", {
+      headers: { Cookie: `decafclaw_session=${token}` },
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return (await r.json()) as ConvSummary[] | { conversations: ConvSummary[] };
+      })
+      .then((data) => {
+        const arr = Array.isArray(data) ? data : data.conversations;
+        setConvs(arr.slice(0, 20));
+      })
+      .catch((e: Error) => setErr(e.message));
+  }, [host, token]);
+
+  useInput((input, key) => {
+    if (!convs) return;
+    const max = convs.length; // +1 for "new conversation" at index `max`
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+    else if (key.downArrow) setCursor((c) => Math.min(max, c + 1));
+    else if (key.return) {
+      if (cursor === max) onPick(newConvId());
+      else onPick(convs[cursor]!.conv_id);
+    } else if (input === "n" || input === "N") {
+      onPick(newConvId());
+    }
+  });
+
+  if (err) return <Text color="red">Failed to list conversations: {err}</Text>;
+  if (!convs) return <Text>Loading conversations…</Text>;
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Pick a conversation (Up/Down + Enter, or `n` for new):</Text>
+      {convs.map((c, i) => (
+        <Text key={c.conv_id} color={i === cursor ? "cyan" : undefined}>
+          {i === cursor ? "> " : "  "}
+          {c.title || c.conv_id}
+        </Text>
+      ))}
+      <Text color={cursor === convs.length ? "cyan" : "gray"}>
+        {cursor === convs.length ? "> " : "  "}[new conversation]
+      </Text>
+    </Box>
+  );
+}
+```
+
+- [ ] **Step 3: Wire the picker into `App.tsx`**
+
+Modify the top of the `App` body:
+
+```typescript
+  const [pickedConv, setPickedConv] = useState<string | null>(initialConvId);
+
+  useEffect(() => {
+    if (pickedConv) {
+      const t = setInterval(() => {
+        client.send({ type: "select_conv", conv_id: pickedConv });
+        clearInterval(t);
+      }, 100);
+      return () => clearInterval(t);
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickedConv]);
+```
+
+Remove the old `initialConvId`-only `useEffect` (the one from Task 6). And at the top of the JSX `return`:
+
+```typescript
+  if (!pickedConv) {
+    return (
+      <ConversationPicker
+        host={host}
+        token={token}
+        onPick={(id) => setPickedConv(id)}
+      />
+    );
+  }
+```
+
+Add the import:
+
+```typescript
+import { ConversationPicker } from "./conversationPicker.js";
+```
+
+(`host` and `token` are already in `AppProps`.)
+
+- [ ] **Step 4: Verify typecheck + tests**
+
+```bash
+cd tui && npm run typecheck && npm test
+```
+
+Expected: clean + 11 pass.
+
+- [ ] **Step 5: Manual smoke test**
+
+```bash
+cd tui && DECAFCLAW_TOKEN=<token> npm run dev
+```
+
+(No `--conv` flag.)
+
+Expected:
+1. Picker appears listing recent conversations.
+2. Arrow keys move the cursor.
+3. Enter on a conversation switches to chat view with history loaded.
+4. Enter on `[new conversation]` (or `n` key) starts a fresh conversation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tui/src/App.tsx tui/src/conversationPicker.tsx
+git commit -m "feat(tui): conversation picker on launch when --conv absent"
+```
+
+---
+
+### Task 10: Acceptance criteria walkthrough + README polish
+
+**Files:**
+- Modify: `tui/README.md`
+
+Final task: walk the acceptance criteria from the spec, fixing anything that surfaces. Then polish the README with what's actually working.
+
+- [ ] **Step 1: Walk the acceptance criteria (spec.md "Acceptance criteria")**
+
+For each box, run the smoke + check it off. Note any deviations in `notes.md`.
+
+```bash
+ls docs/dev-sessions/2026-05-13-1039-tui-spike/
+# create notes.md if not present
+```
+
+Spec acceptance criteria:
+- [ ] Connect with `--token <t>` and either pick a conversation or pass `--conv <id>`.
+- [ ] Send a user message, see streamed assistant response, see `message_complete` finalize it.
+- [ ] Trigger a confirm-gated tool (shell command), approve inline, see tool output continue.
+- [ ] Trigger a confirm-gated tool, deny inline, see the agent recover.
+- [ ] `Ctrl+C` mid-turn cancels via `cancel_turn`; transcript reflects the cancel.
+- [ ] Kill `make dev`, restart, see TUI reconnect and resume the same conversation.
+- [ ] Run `cd tui && npm test` — dispatcher unit test passes.
+- [ ] Run `cd tui && npm run typecheck` — clean.
+
+(The spec's earlier `npm run lint` line is dropped — no lint configured for the spike.)
+
+- [ ] **Step 2: Update `tui/README.md` with anything you learned**
+
+Examples: actual REST endpoint shape, token-finding command, any quirks. Add a "Known limitations" section listing what the spike doesn't do (cross-reference the spec's Phase 2 candidates table).
+
+- [ ] **Step 3: Capture session retro in `notes.md`**
+
+Per CLAUDE.md dev-session convention, write a brief retro:
+- What worked / what surprised.
+- Wire-protocol corrections needed beyond the spec patch.
+- Whether the design held up under implementation.
+- Recommended Phase 2 first-step (markdown rendering? something else?).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tui/README.md docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md
+git commit -m "docs(tui): acceptance criteria walkthrough + session retro"
+```
+
+---
+
+## After completion
+
+Plan complete when all task checkboxes are checked. Next steps the user may want:
+
+1. **Promote A → B** (codegen from `message_types.json`) if the spike is keeping. Write `tui/scripts/gen-types.ts`, extend `make gen-message-types` to also emit `tui/src/types.generated.ts`.
+2. **Phase 2 work** — see the spec's "Phase 2 candidates" table. Natural first step: markdown rendering of assistant text.
+3. **Engage with #487** if widget / canvas work surfaces — that's the cross-cutting capability concern.
+4. **Open PR** for the spike if keeping. The branch is `worktree-tui-spike` (harness-prefixed). Rename to `tui-spike` via `git branch -m tui-spike` first if preferred.

--- a/docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md
+++ b/docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md
@@ -1,0 +1,210 @@
+# TUI Network Client — Spike
+
+**Status:** Implemented + live-smoke validated 2026-05-13. See [notes.md](notes.md) for retro. PR: [#489](https://github.com/lmorchard/decafclaw/pull/489).
+**Issue:** [#464](https://github.com/lmorchard/decafclaw/issues/464) (reframed from original "Ink TUI over JSON-RPC stdio")
+**Type:** Prototype / spike. Throwaway-friendly until promoted.
+
+## Context
+
+Issue 464 was originally filed during a hermes-agent inspiration scan: hermes's TUI is an Ink (React-for-terminal, TypeScript) frontend that spawns its own Python backend over JSON-RPC stdio. We deprioritized it because `interactive_terminal.py` is sufficient for current use and the hermes model would duplicate session/tool/model state and conflict with the "one bot instance per token" Mattermost rule.
+
+The reframing: build the Ink TUI as a **thin network client to the running decafclaw bot** over the existing WebSocket gateway — the same surface the web UI already drives. This sidesteps both problems:
+
+- No competing bot instance — the TUI is a viewer/driver, not its own agent.
+- No duplicate state — sessions, tools, model calls, confirmations, compaction all stay on the running daemon.
+- No new transport — reuses `src/decafclaw/web/websocket.py` and the wire contracts in `src/decafclaw/web/message_types.json`.
+
+Hermes remains a reference for terminal-UX patterns (composer behavior, prompt flows, markdown rendering) but **not** a template for the architecture. This is decafclaw-native: WebSocket + cookie auth + per-conversation event subscription, not stdio + JSON-RPC + spawned backend.
+
+## Goals
+
+A working spike that lets a developer:
+
+1. Run `decafclaw-tui --token <t>` against `make dev` on localhost.
+2. Pick or specify a conversation.
+3. Send messages and watch streaming assistant responses.
+4. See tool activity (`tool_call_start` / `tool_start` / `tool_status`) in an activity lane.
+5. Approve or deny inline confirmation requests (shell commands, end-turn gates).
+6. Hit `Ctrl+C` to cancel an in-flight turn or exit cleanly.
+
+The bar for "spike validated": the TUI is good enough to drive a normal coding-assistance turn end-to-end without falling back to the web UI.
+
+## Non-goals (Phase 2 candidates)
+
+These are **explicitly deferred from the spike**, not rejected. If the spike validates the idea, several of these are likely first follow-ups — captured here so we don't re-derive them.
+
+| Deferred item | Notes |
+|---|---|
+| Markdown rendering of assistant text | Hermes has a small Markdown-to-Ink renderer. Likely first Phase 2 add — plain text gets old fast. |
+| Multi-line composer / queued input | Hermes-style queue while agent is busy, `\` + Enter newline, Shift+Enter, `$EDITOR` integration. |
+| Input history (persistent) | `~/.decafclaw/tui_history` or similar. |
+| Tab completion | Slash commands, `@[[Page]]` mentions, file paths. |
+| Theme/skin support | Match decafclaw's web UI theme tokens if we promote. |
+| Canvas panel mirror | Render a `canvas_update` view in a side pane. |
+| Files / vault sidebars | Browse and open via REST + WS. |
+| Notification inbox | Bell push over WS already exists; surface it in a status line. |
+| Widget inputs | `widget_input` flow — needed for skills that emit widgets. |
+| Scrollback past current session | Currently relies on terminal scrollback; would need internal pager. |
+| Mouse support | Stock Ink supports it; we're just not wiring it. |
+| OSC52 clipboard copy | Convenient for grabbing assistant output. |
+| Conversation folders / move/rename | REST endpoints exist; not part of the chat surface. |
+| Model picker UI | `set_model` wire message exists; spike just uses whatever's active. |
+| Reflection / context inspector views | Diagnostic surfaces in the web UI; not core to chat. |
+| Windows support | Mac/Linux only for the spike. |
+
+If the spike succeeds, the natural Phase 2 sequence is roughly: **markdown rendering → multi-line composer + history → tab completion → theme → model picker**, with widgets/canvas/files/vault later if there's appetite.
+
+### Cross-cutting concern: transport / client capabilities
+
+The TUI spike surfaces a latent gap that's broader than this work: **decafclaw's agent loop has no explicit way to reason about what the active transport can render or accept.** Today, transport-capability knowledge lives implicitly inside each adapter (`mattermost.py`, `interactive_terminal.py`, `web/websocket.py`) and tools/skills mostly assume the most capable surface (web UI: HTML widgets, canvas, Milkdown, attachments). The TUI is the first new transport that *can't* render that full surface, so the implicit assumption becomes visible.
+
+Real differences across transports already in the codebase:
+
+| Transport | HTML widgets | Canvas | Inline buttons | Markdown | Attachments | Notes |
+|---|---|---|---|---|---|---|
+| Web UI (`web/`) | ✓ | ✓ | ✓ (HTML) | ✓ Milkdown | ✓ | most capable |
+| Mattermost (`mattermost.py`) | — | — | ✓ (with ID quirks — no underscores; needs reachable callback host) | ✓ (MM-flavored) | ✓ inline | already has its own constraints |
+| Interactive terminal (`interactive_terminal.py`) | — | — | — | plain text | — | plain stdin/stdout |
+| TUI (proposed) | — (Phase 2 fallback?) | — (Phase 2 view?) | — (inline prompt only) | rendered subset (Phase 2) | — | new |
+| Future (email / SMS / Discord / Slack / voice) | varies | varies | varies | varies | varies | each will need its own answer |
+
+A general "client capabilities" feature would let the agent loop and tools inspect the active transport's surface — same way `ctx.task_mode` exposes turn-kind today — and pick output forms accordingly. Naively adding widget/canvas rendering to the TUI without that story will either break silently (HTML widget emitted to a terminal) or force a protocol break later. The same logic applies if we ever want a widget tool to gracefully degrade for Mattermost mobile.
+
+Plausible directions (not chosen here — flagged for separate design):
+
+- **Client capability handshake on connect / per-turn.** Transport adapter publishes a `ClientCapabilities` dataclass into `ctx` (`html_widgets: bool`, `canvas: bool`, `inline_buttons: bool`, `max_message_chars: int`, …). Skills/tools branch on it.
+- **Per-feature fallback in the definition.** Each widget / canvas update / attachment kind declares fallbacks for less-capable surfaces. Host renders the highest fallback the transport supports.
+- **Capability gate at emit time.** Skill author opts into "widget" only when supported; otherwise emits plain text. Simplest, pushes the burden onto each tool author.
+
+Markdown rendering, theme/skin, and font/color preferences are *not* in this bucket — they're pure client-side rendering concerns. The bot doesn't need to know.
+
+This may deserve its own initiative/issue independent of the TUI work; the TUI is a forcing function, not the only consumer.
+
+Tracked separately as [#487](https://github.com/lmorchard/decafclaw/issues/487). The TUI spike does not block on it — widgets and canvas are deferred Phase 2 items anyway.
+
+## Architecture
+
+```
+┌────────────────────┐   WebSocket (cookie auth)   ┌─────────────────────────┐
+│  decafclaw-tui     │  ──────────────────────►   │  decafclaw bot (running) │
+│  (Node + Ink)      │  ◄──────────────────────    │  src/decafclaw/web/      │
+│                    │                              │  websocket.py            │
+│  - WS client       │                              │  - existing handler      │
+│  - dispatcher      │                              │  - existing auth         │
+│  - Ink UI          │                              │  - ConversationManager   │
+└────────────────────┘                              └─────────────────────────┘
+                                                              │
+                                                              ▼
+                                                         Mattermost / heartbeat /
+                                                         schedules / web UI users
+                                                         (all unaffected)
+```
+
+- Network boundary: `ws://<host>:<port>/ws/chat` with `Cookie: decafclaw_session=<token>` on upgrade.
+- Conversation selection: REST `GET /api/conversations` for the picker; WS `select_conv` to subscribe.
+- No bot-side changes. The TUI is a pure client.
+
+## Components
+
+```
+tui/
+  package.json          # ink, ink-text-input, react, ws, tsx, typescript
+  tsconfig.json
+  README.md
+  src/
+    entry.tsx           # TTY gate, argv/env parsing, auth resolution, render <App/>
+    App.tsx             # Ink tree: transcript + activity + composer + confirm prompt
+    wsClient.ts         # connect, send, onMessage, reconnect w/ backoff, close
+    types.ts            # hand-typed WS message discriminated union (codegen-shaped)
+    conversationPicker.tsx  # initial list/create picker when --conv is absent
+```
+
+Five files. The spike's structural budget is "everything lives in one of these five." When a file needs to split, it's a signal to revisit Option B (layered structure, codegen).
+
+### File responsibilities
+
+- **`entry.tsx`** — TTY check, argv parsing (`--token` / `--conv` / `--host`), env fallback (`DECAFCLAW_TOKEN`, `DECAFCLAW_HOST`), construct `WSClient`, render `<App/>`. Exits early on missing token or non-TTY stdin.
+- **`wsClient.ts`** — Owns the socket. Exposes `connect()`, `send(msg)`, `on(handler)`, `close()`. Reconnect with exponential backoff (1s, 2s, 4s, … cap 30s). Surfaces `reconnected` events to the dispatcher so the UI can mark `[reconnected]` and re-issue `select_conv`.
+- **`types.ts`** — One TS type per wire message, keyed on `type` field. Exports `WSMessage` discriminated union. Field names match `src/decafclaw/web/message_types.json` verbatim. Includes both directions; client→server types are used by `wsClient.send()` callers, server→client by the dispatcher.
+- **`App.tsx`** — React `useState` for: transcript array, in-flight assistant draft text, activity-lane state (current tool name/status), confirm-prompt state (request_id + payload), connection state. Single `dispatch(msg: WSMessage)` reducer-style function with an exhaustive `switch` (TS `never` guard on default). Composer is a stock `ink-text-input`. Confirm prompt suspends the composer and accepts `y` / `n` / `a` (always).
+- **`conversationPicker.tsx`** — Hits `/api/conversations` via `fetch` (Node 18+ has it), shows up to N recent conversations, lets user pick or trigger "new conversation" (server creates lazily on first `user_message` to a fresh `conv_id`, so picker just generates one).
+
+## Data flow
+
+1. `entry.tsx` resolves token → constructs `WSClient({host, token})` → renders `<App/>`.
+2. `WSClient` opens `/ws/chat` with `Cookie: decafclaw_session=<token>` header. On open, emits `ready` to dispatcher.
+3. If `--conv <id>` provided: dispatcher sends `select_conv` immediately. Otherwise: render `<ConversationPicker/>`, fetch list via REST, on selection send `select_conv`.
+4. Server responds with `conv_selected` (+ initial state) and `conv_history` (recent messages). Dispatcher populates transcript.
+5. **Message handling** (server → client):
+   - `turn_start` → set in-flight UI state (composer hint, optional spinner).
+   - `chunk` → append to in-flight assistant draft.
+   - `message_complete` → finalize draft into transcript, clear draft.
+   - `tool_start` / `tool_status` → update activity-lane state.
+   - `tool_end` → clear activity lane; if `ok: false` show terminal state.
+   - `turn_complete` → clear in-flight UI state.
+   - `user_message` (echo) → append user message to transcript (for parity / multi-tab sync).
+   - `confirm_request` → set confirm-prompt state, suspend composer.
+   - `compaction_done` → show `[compaction complete]` line; optionally reload history.
+   - `model_changed` → show `[model: …]` line.
+   - `error` → push error line.
+   - Unknown `type` → log to stderr, ignore. (Forward-compat.)
+6. **Message handling** (client → server):
+   - Composer submit → `{type: "send", conv_id, text, attachments: []}`.
+   - Confirm `y` → `{type: "confirm_response", conv_id, request_id, decision: "approve", extras: {}}`. `n` → `"deny"`. `a` → `"always"`.
+   - `Ctrl+C` while turn is in flight → `{type: "cancel_turn", conv_id}`. While idle → close WS cleanly, exit.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| Missing token (no flag, no env) | Print error, exit 1. |
+| WS upgrade rejected (401/403) | Print "auth failed" + URL, exit 1. |
+| WS dropped mid-session | Reconnect with backoff. On success: re-`select_conv`, request fresh `conv_history`, mark `[reconnected]` in transcript. |
+| Malformed JSON line | Log to stderr (above the Ink frame), ignore. |
+| Unknown wire `type` | Log to stderr, ignore. Don't crash on protocol additions. |
+| Non-TTY stdin | Exit early with a message — same gate hermes uses. |
+| `Ctrl+C` while WS busy | Send `cancel_turn`. Press again to exit. |
+
+No retry loops with hidden state, no silent fallbacks. If something keeps failing, the user sees it on stderr above the UI.
+
+## Testing
+
+- **Vitest unit test** for the dispatcher: feed sample WS messages → assert state transitions. Pure-function reducer is the only thing worth testing in a spike.
+- **Manual smoke**:
+  - Run `make dev` (already running per Les's workflow) and `cd tui && npm run dev` in another shell.
+  - Send a message → see streaming chunks → see `message_complete`.
+  - Trigger `run_shell_command` via the agent → see `confirm_request` → approve → see tool output.
+  - Force a compaction → see `compaction_done` line.
+  - Drop the WS (kill `make dev`, restart) → see reconnect + `[reconnected]` marker.
+- **No Ink rendering tests, no end-to-end tests.** Promoting the spike includes adding those.
+
+## Promotion path (A → B, no rework)
+
+The spike is Option A (hand-typed minimal Ink). The successor is Option B (codegen from `message_types.json`, optionally split into layered directories). The discipline that makes A→B free:
+
+1. **`types.ts` is shaped exactly like codegen output would be.** One type alias per message, field names matching `message_types.json` verbatim, `WSMessage` discriminated union exported. When we promote: write `tui/scripts/gen-types.ts`, extend `make gen-message-types` to also emit `tui/src/types.generated.ts`, `git mv` the hand-written file out. Zero consumer churn.
+2. **Dispatcher switch is exhaustive against `WSMessage["type"]`.** TS `never` guard on default. A new wire type added in `message_types.json` becomes a compile error in the TUI rather than silent drift.
+3. **No reaching into message internals from `wsClient.ts`.** It's a dumb pipe — `send(msg)` and `on(handler)`. State decisions live in `App.tsx`. This means splitting `App.tsx` later doesn't require restructuring the transport.
+
+If the spike grows past five files organically, that's the trigger to split — not premature.
+
+## Acceptance criteria
+
+The spike is "validated" when all of the following work against a locally running `make dev`:
+
+- [ ] Connect with `--token <t>` and either pick a conversation or pass `--conv <id>`.
+- [ ] Send a user message, see streamed assistant response, see `message_complete` finalize it.
+- [ ] Trigger a confirm-gated tool (shell command), approve inline, see tool output continue.
+- [ ] Trigger a confirm-gated tool, deny inline, see the agent recover.
+- [ ] `Ctrl+C` mid-turn cancels via `cancel_turn`; transcript reflects the cancel.
+- [ ] Kill `make dev`, restart, see TUI reconnect and resume the same conversation.
+- [ ] Run `cd tui && npm test` — dispatcher unit test passes.
+- [ ] Run `cd tui && npm run typecheck` — clean. (Lint is not part of the spike's quality bar; add in Phase 2 if we promote.)
+
+## Open questions
+
+None at spec time. Items that may surface during implementation:
+
+- Whether `/api/conversations` returns a shape the picker can use directly, or we need a different REST endpoint for the listing. (`tool_end` is confirmed present in `message_types.json` — original open question resolved during plan drafting.)
+
+Implementation-time verification, not a blocker.

--- a/docs/websocket-messages.md
+++ b/docs/websocket-messages.md
@@ -60,9 +60,16 @@ Server is asking the user to approve or deny a pending action (tool call, end-of
 **Fields:**
 
 - `conv_id` — string
-- `request_id` — string
-- `kind` — string
-- `payload` — object
+- `confirmation_id` — string
+- `action_type` — string
+- `tool` — string
+- `command` — string
+- `suggested_pattern` — string
+- `message` — string
+- `approve_label` — string
+- `deny_label` — string
+- `tool_call_id` — string
+- `action_data` — object
 
 ### `confirmation_response`
 
@@ -109,7 +116,7 @@ Final form of an assistant message after streaming completed (or when replayed f
 **Fields:**
 
 - `conv_id` — string
-- `message` — object
+- `text` — string
 
 ### `model_changed`
 
@@ -160,10 +167,11 @@ Final result of a tool call. Replaces the in-flight tool_status with terminal st
 **Fields:**
 
 - `conv_id` — string
+- `tool` — string
 - `tool_call_id` — string
-- `name` — string
-- `ok` — boolean
-- `result` — string | object
+- `result_text` — string
+- `display_short_text` — string?
+- `widget` — object?
 
 ### `tool_start`
 
@@ -172,9 +180,8 @@ Tool call has begun execution.
 **Fields:**
 
 - `conv_id` — string
+- `tool` — string
 - `tool_call_id` — string
-- `name` — string
-- `input` — object
 
 ### `tool_status`
 
@@ -183,8 +190,9 @@ Mid-flight progress update from a running tool.
 **Fields:**
 
 - `conv_id` — string
+- `tool` — string
 - `tool_call_id` — string
-- `status` — string
+- `message` — string
 
 ### `turn_complete`
 
@@ -209,7 +217,7 @@ Echo of a user-authored message to all subscribers of the conversation (used for
 **Fields:**
 
 - `conv_id` — string
-- `message` — object
+- `text` — string
 
 ### `vault_changed`
 
@@ -237,9 +245,10 @@ User's decision on a pending confirm_request.
 **Fields:**
 
 - `conv_id` — string
-- `request_id` — string
-- `decision` — string
-- `extras` — object
+- `confirmation_id` — string
+- `approved` — boolean
+- `always` — boolean
+- `add_pattern` — boolean
 
 ### `load_history`
 
@@ -294,5 +303,5 @@ Submission of an interactive widget input.
 **Fields:**
 
 - `conv_id` — string
-- `request_id` — string
-- `value` — object
+- `confirmation_id` — string
+- `data` — object

--- a/src/decafclaw/web/message_types.json
+++ b/src/decafclaw/web/message_types.json
@@ -30,7 +30,7 @@
     "confirm_request": {
       "direction": "server_to_client",
       "description": "Server is asking the user to approve or deny a pending action (tool call, end-of-turn gate, widget input).",
-      "fields": {"conv_id": "string", "request_id": "string", "kind": "string", "payload": "object"}
+      "fields": {"conv_id": "string", "confirmation_id": "string", "action_type": "string", "tool": "string", "command": "string", "suggested_pattern": "string", "message": "string", "approve_label": "string", "deny_label": "string", "tool_call_id": "string", "action_data": "object"}
     },
     "confirmation_response": {
       "direction": "server_to_client",
@@ -55,7 +55,7 @@
     "message_complete": {
       "direction": "server_to_client",
       "description": "Final form of an assistant message after streaming completed (or when replayed from history).",
-      "fields": {"conv_id": "string", "message": "object"}
+      "fields": {"conv_id": "string", "text": "string"}
     },
     "model_changed": {
       "direction": "server_to_client",
@@ -85,17 +85,17 @@
     "tool_end": {
       "direction": "server_to_client",
       "description": "Final result of a tool call. Replaces the in-flight tool_status with terminal state.",
-      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "ok": "boolean", "result": "string | object"}
+      "fields": {"conv_id": "string", "tool": "string", "tool_call_id": "string", "result_text": "string", "display_short_text": "string?", "widget": "object?"}
     },
     "tool_start": {
       "direction": "server_to_client",
       "description": "Tool call has begun execution.",
-      "fields": {"conv_id": "string", "tool_call_id": "string", "name": "string", "input": "object"}
+      "fields": {"conv_id": "string", "tool": "string", "tool_call_id": "string"}
     },
     "tool_status": {
       "direction": "server_to_client",
       "description": "Mid-flight progress update from a running tool.",
-      "fields": {"conv_id": "string", "tool_call_id": "string", "status": "string"}
+      "fields": {"conv_id": "string", "tool": "string", "tool_call_id": "string", "message": "string"}
     },
     "turn_complete": {
       "direction": "server_to_client",
@@ -110,7 +110,7 @@
     "user_message": {
       "direction": "server_to_client",
       "description": "Echo of a user-authored message to all subscribers of the conversation (used for multi-tab sync).",
-      "fields": {"conv_id": "string", "message": "object"}
+      "fields": {"conv_id": "string", "text": "string"}
     },
     "vault_changed": {
       "direction": "server_to_client",
@@ -126,7 +126,7 @@
     "confirm_response": {
       "direction": "client_to_server",
       "description": "User's decision on a pending confirm_request.",
-      "fields": {"conv_id": "string", "request_id": "string", "decision": "string", "extras": "object"}
+      "fields": {"conv_id": "string", "confirmation_id": "string", "approved": "boolean", "always": "boolean", "add_pattern": "boolean"}
     },
     "load_history": {
       "direction": "client_to_server",
@@ -156,7 +156,7 @@
     "widget_response": {
       "direction": "client_to_server",
       "description": "Submission of an interactive widget input.",
-      "fields": {"conv_id": "string", "request_id": "string", "value": "object"}
+      "fields": {"conv_id": "string", "confirmation_id": "string", "data": "object"}
     }
   }
 }

--- a/tui/.gitignore
+++ b/tui/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+.env
+.env.*
+coverage/

--- a/tui/README.md
+++ b/tui/README.md
@@ -1,0 +1,83 @@
+# decafclaw-tui
+
+Minimal Ink (React-for-terminal) TUI that connects to a running decafclaw bot over
+its existing WebSocket gateway — the same surface the web UI drives. No competing
+bot process; the TUI is a thin viewer/driver.
+
+Design rationale and Phase 2 candidates: [`docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md`](../docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md).
+
+## Running
+
+```bash
+cd tui
+npm install
+DECAFCLAW_TOKEN=<token> npm run dev
+# or
+npm run dev -- --token <token> --conv <conv_id>
+```
+
+Requires the bot running locally (`make dev` in the repo root, default port 8088).
+
+## Configuration
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--token <t>` | `DECAFCLAW_TOKEN` | (required) |
+| `--host <url>` | `DECAFCLAW_HOST` | `http://localhost:8088` |
+| `--conv <id>` | — | (picker shown if absent) |
+
+Tokens look like `dfc_<random>`. Find them as keys in
+`data/<agent_id>/web_tokens.json` in the main clone. `<agent_id>` is the
+subdirectory name under `data/` for the agent you want to connect to.
+
+## Creating a conversation
+
+Conversation IDs are server-assigned, not client-generated. Two ways to start
+one:
+
+- **From the picker** — launch without `--conv` and choose `[new conversation]`.
+  The picker POSTs `/api/conversations`, then opens the new conv.
+- **By REST first** — `curl -X POST -H "Cookie: decafclaw_session=$TOKEN"`
+  `-H "Content-Type: application/json" -d '{"title":"..."}'`
+  `http://localhost:18880/api/conversations`, then pass the returned `conv_id`
+  via `--conv`.
+
+`--conv <id>` with a non-existent ID will surface a `Conversation not found`
+error from the server.
+
+## Scripts
+
+```
+npm run dev       run the TUI
+npm test          dispatcher unit tests (vitest)
+npm run typecheck type-check without emitting
+```
+
+## Key bindings
+
+- **Enter** — send message / confirm picker selection
+- **y / n / a** — approve / deny / always when a confirmation prompt is shown
+- **Ctrl+C** — cancel in-flight turn (first press while agent is busy); exit cleanly
+  (when idle, or second press within 2 s of cancel)
+- **Up / Down** — move cursor in conversation picker
+
+## Known limitations
+
+This is a spike validating the "thin network client over the existing WebSocket
+gateway" architecture. The following are explicitly deferred to Phase 2:
+
+- **No markdown rendering** — assistant text is plain. Code blocks, tables, and
+  emphasis are not rendered. Likely the first Phase 2 add.
+- **Single-line composer** — no multi-line input, no `$EDITOR` integration, no
+  input history.
+- **No tab completion** — slash commands, `@[[Page]]` mentions, and file paths.
+- **Activity lane tracks one tool at a time** — concurrent tools show only the
+  last one started.
+- **No widget support** — `widget_input` flows from skills are silently ignored.
+- **No canvas panel** — `canvas_update` events are acknowledged but not rendered.
+- **Confirmation payload display is raw JSON** — pretty-printing is deferred.
+- **Mac/Linux only** — not tested on Windows.
+
+For the full Phase 2 candidates table (markdown rendering, multi-line composer,
+history, tab completion, theme, model picker, widgets, canvas, files, vault, etc.)
+see the spec linked above.

--- a/tui/package-lock.json
+++ b/tui/package-lock.json
@@ -1,0 +1,2642 @@
+{
+  "name": "decafclaw-tui",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "decafclaw-tui",
+      "version": "0.0.0",
+      "dependencies": {
+        "ink": "^5.0.1",
+        "ink-text-input": "^6.0.0",
+        "react": "^18.3.1",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "decafclaw-tui": "src/entry.tsx"
+      },
+      "devDependencies": {
+        "@types/node": "^22.7.5",
+        "@types/react": "^18.3.11",
+        "@types/ws": "^8.5.12",
+        "tsx": "^4.19.1",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-text-input": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+      "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5",
+        "react": ">=18"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "decafclaw-tui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "decafclaw-tui": "./src/entry.tsx"
+  },
+  "scripts": {
+    "dev": "tsx src/entry.tsx",
+    "start": "tsx src/entry.tsx",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "ink": "^5.0.1",
+    "ink-text-input": "^6.0.0",
+    "react": "^18.3.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "@types/react": "^18.3.11",
+    "@types/ws": "^8.5.12",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.2"
+  }
+}

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -1,0 +1,207 @@
+import React, { useEffect, useReducer, useRef, useState } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import TextInput from "ink-text-input";
+import type { WSClient, WSEvent } from "./wsClient.js";
+import { dispatch, initialState, type State } from "./dispatcher.js";
+import type { ServerMessage } from "./types.js";
+import { ConversationPicker } from "./conversationPicker.js";
+
+export interface AppProps {
+  client: WSClient;
+  initialConvId: string | null;
+  host: string;
+  token: string;
+}
+
+type Action =
+  | { kind: "wire"; msg: ServerMessage }
+  | { kind: "reconnected" }
+  | { kind: "auth_failed"; reason: string }
+  | { kind: "closed"; code: number; reason: string }
+  | { kind: "clear_confirm" };
+
+function reducer(s: State, a: Action): State {
+  switch (a.kind) {
+    case "wire":
+      return dispatch(s, a.msg);
+    case "reconnected":
+      return {
+        ...s,
+        transcript: [...s.transcript, { kind: "system", text: "[reconnected]" }],
+      };
+    case "auth_failed":
+      return {
+        ...s,
+        transcript: [
+          ...s.transcript,
+          { kind: "system", text: `[auth failed: ${a.reason}]` },
+        ],
+      };
+    case "closed":
+      return s;
+    case "clear_confirm":
+      return { ...s, confirm: null };
+  }
+}
+
+export function App({
+  client,
+  initialConvId,
+  host,
+  token,
+}: AppProps): React.JSX.Element {
+  const [state, dispatchUi] = useReducer(reducer, initialState);
+  const [draft, setDraft] = useState("");
+  const { exit } = useApp();
+  const [pickedConv, setPickedConv] = useState<string | null>(initialConvId);
+
+  // Live pointer to the currently-active conversation. The WS subscription
+  // effect runs once on mount with stale-closed state, so it reads through
+  // this ref to know which conv to re-select after a reconnect.
+  const activeConvIdRef = useRef<string | null>(initialConvId);
+  useEffect(() => {
+    activeConvIdRef.current = pickedConv;
+  }, [pickedConv]);
+
+  // Subscribe to WS events once on mount. The empty dep array is deliberate —
+  // re-subscribing on every state change would accumulate handlers (wsClient.on
+  // is append-only). State references inside the handler are stale-closed; use
+  // activeConvIdRef.current for the currently-picked conversation id.
+  useEffect(() => {
+    client.on((e: WSEvent) => {
+      if (e.type === "__reconnected") {
+        dispatchUi({ kind: "reconnected" });
+        const liveConvId = activeConvIdRef.current;
+        if (liveConvId) client.send({ type: "select_conv", conv_id: liveConvId });
+      } else if (e.type === "__auth_failed") {
+        dispatchUi({ kind: "auth_failed", reason: e.reason });
+      } else if (e.type === "__closed") {
+        dispatchUi({ kind: "closed", code: e.code, reason: e.reason });
+      } else {
+        dispatchUi({ kind: "wire", msg: e });
+      }
+    });
+  }, []);
+
+  // Select the active conversation whenever the user picks one. WSClient
+  // silently drops sends before the socket is OPEN, and we don't have a
+  // buffered-send yet — so poll until conv_selected echoes back. We can detect
+  // that by watching state.conv_id (the dispatcher sets it on conv_selected).
+  useEffect(() => {
+    if (!pickedConv) return undefined;
+    let cancelled = false;
+    const t = setInterval(() => {
+      if (cancelled) return;
+      if (state.conv_id === pickedConv) {
+        clearInterval(t);
+        return;
+      }
+      client.send({ type: "select_conv", conv_id: pickedConv });
+    }, 250);
+    // Fire one attempt immediately so the common fast-open case doesn't wait.
+    client.send({ type: "select_conv", conv_id: pickedConv });
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pickedConv, state.conv_id]);
+
+  const [cancelArmed, setCancelArmed] = useState(false);
+
+  useInput((input, key) => {
+    // Universal escape: Ctrl+C always works, even mid-confirm.
+    // Mirrors what users expect from CLI prompts everywhere.
+    if (key.ctrl && input === "c") {
+      // If a turn is in flight (and we haven't already armed), send cancel_turn
+      // and arm for 2s — a second Ctrl+C within that window forces exit.
+      if (state.turnInFlight && !cancelArmed && state.conv_id) {
+        client.send({ type: "cancel_turn", conv_id: state.conv_id });
+        setCancelArmed(true);
+        setTimeout(() => setCancelArmed(false), 2000);
+        return;
+      }
+      // Otherwise: close cleanly and exit. This also fires from inside a
+      // confirm prompt — server will time out the confirm on its end.
+      client.close();
+      exit();
+      return;
+    }
+
+    // Confirm prompt active: y/n/a keys send decision.
+    if (state.confirm) {
+      // Map UI keys to the server's flat-flag confirm shape (websocket.py).
+      // y → approved once, n → deny, a → approved + always.
+      const decision =
+        input === "y" || input === "Y" ? { approved: true, always: false } :
+        input === "n" || input === "N" ? { approved: false, always: false } :
+        input === "a" || input === "A" ? { approved: true, always: true } :
+        null;
+      if (decision && state.conv_id) {
+        client.send({
+          type: "confirm_response",
+          conv_id: state.conv_id,
+          confirmation_id: state.confirm.confirmation_id,
+          approved: decision.approved,
+          always: decision.always,
+          add_pattern: false,
+        });
+        dispatchUi({ kind: "clear_confirm" });
+      }
+      return;
+    }
+  });
+
+  function onSubmit(text: string): void {
+    if (!state.conv_id) return;
+    if (!text.trim()) return;
+    client.send({
+      type: "send",
+      conv_id: state.conv_id,
+      text,
+      attachments: [],
+    });
+    setDraft("");
+  }
+
+  if (!pickedConv) {
+    return (
+      <ConversationPicker
+        host={host}
+        token={token}
+        onPick={(id) => setPickedConv(id)}
+      />
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      {state.transcript.map((item, i) => (
+        <Text key={i} color={item.kind === "system" ? "yellow" : undefined}>
+          {item.kind === "user" ? "you> " : item.kind === "assistant" ? "bot> " : ""}
+          {item.text}
+        </Text>
+      ))}
+      {state.draft && <Text color="cyan">{"bot> "}{state.draft}</Text>}
+      {state.activity && (
+        <Text color="gray">
+          [{state.activity.name}] {state.activity.status || "running..."}
+        </Text>
+      )}
+      {state.confirm && (
+        <Box flexDirection="column">
+          <Text color="magenta">
+            confirm ({state.confirm.action_type}): {state.confirm.command || state.confirm.message}
+          </Text>
+          <Text color="magenta">[y]es / [n]o / [a]lways</Text>
+        </Box>
+      )}
+      <Box>
+        <Text>{state.conv_id ? "> " : "(connecting...) "}</Text>
+        {!state.confirm && (
+          <TextInput value={draft} onChange={setDraft} onSubmit={onSubmit} />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/tui/src/conversationPicker.tsx
+++ b/tui/src/conversationPicker.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+interface ConvSummary {
+  conv_id: string;
+  title?: string;
+  updated_at?: string;
+}
+
+// Actual API shape: GET /api/conversations returns {folder, folders, conversations}
+// (not a bare array). The plan assumed a bare array; we adapt here.
+interface ConversationsResponse {
+  folder: string;
+  folders: unknown[];
+  conversations: ConvSummary[];
+}
+
+interface CreatedConv {
+  conv_id: string;
+}
+
+interface Props {
+  host: string;
+  token: string;
+  onPick: (convId: string) => void;
+}
+
+export function ConversationPicker({
+  host,
+  token,
+  onPick,
+}: Props): React.JSX.Element {
+  const [convs, setConvs] = useState<ConvSummary[] | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    fetch(host + "/api/conversations", {
+      headers: { Cookie: `decafclaw_session=${token}` },
+    })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const data = (await r.json()) as ConversationsResponse;
+        setConvs(data.conversations.slice(0, 20));
+      })
+      .catch((e: Error) => setErr(e.message));
+  }, [host, token]);
+
+  async function createConversation(): Promise<void> {
+    setCreating(true);
+    try {
+      const r = await fetch(host + "/api/conversations", {
+        method: "POST",
+        headers: {
+          Cookie: `decafclaw_session=${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title: "tui" }),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      const created = (await r.json()) as CreatedConv;
+      onPick(created.conv_id);
+    } catch (e) {
+      setErr((e as Error).message);
+      setCreating(false);
+    }
+  }
+
+  useInput((input, key) => {
+    if (!convs || creating) return;
+    const max = convs.length; // index `max` = "new conversation" option
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1));
+    else if (key.downArrow) setCursor((c) => Math.min(max, c + 1));
+    else if (key.return) {
+      if (cursor === max) void createConversation();
+      else onPick(convs[cursor]!.conv_id);
+    } else if (input === "n" || input === "N") {
+      void createConversation();
+    }
+  });
+
+  if (err) return <Text color="red">Failed to list conversations: {err}</Text>;
+  if (!convs) return <Text>Loading conversations…</Text>;
+  if (creating) return <Text>Creating new conversation…</Text>;
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Pick a conversation (Up/Down + Enter, or `n` for new):</Text>
+      {convs.map((c, i) => (
+        <Text key={c.conv_id} color={i === cursor ? "cyan" : undefined}>
+          {i === cursor ? "> " : "  "}
+          {c.title || c.conv_id}
+        </Text>
+      ))}
+      <Text color={cursor === convs.length ? "cyan" : "gray"}>
+        {cursor === convs.length ? "> " : "  "}[new conversation]
+      </Text>
+    </Box>
+  );
+}

--- a/tui/src/dispatcher.test.ts
+++ b/tui/src/dispatcher.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { initialState, dispatch } from "./dispatcher.js";
+import type { ServerMessage } from "./types.js";
+
+const CONV = "conv-abc";
+
+describe("dispatcher", () => {
+  it("chunk appends to draft", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "chunk", conv_id: CONV, text: "hello " });
+    const s2 = dispatch(s1, { type: "chunk", conv_id: CONV, text: "world" });
+    expect(s2.draft).toBe("hello world");
+  });
+
+  it("message_complete finalizes draft into transcript", () => {
+    const s0 = { ...initialState, conv_id: CONV, draft: "answer" };
+    const s1 = dispatch(s0, {
+      type: "message_complete",
+      conv_id: CONV,
+      text: "answer",
+    });
+    expect(s1.draft).toBe("");
+    expect(s1.transcript).toEqual([{ kind: "assistant", text: "answer" }]);
+  });
+
+  it("message_complete with [cancelled] preserves streamed draft", () => {
+    const s0 = { ...initialState, conv_id: CONV, draft: "partial reply..." };
+    const s1 = dispatch(s0, {
+      type: "message_complete",
+      conv_id: CONV,
+      text: "[cancelled]",
+    });
+    expect(s1.draft).toBe("");
+    expect(s1.transcript).toEqual([
+      { kind: "assistant", text: "partial reply..." },
+      { kind: "system", text: "[cancelled]" },
+    ]);
+  });
+
+  it("turn_start / turn_complete toggle turnInFlight", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "turn_start", conv_id: CONV });
+    expect(s1.turnInFlight).toBe(true);
+    const s2 = dispatch(s1, { type: "turn_complete", conv_id: CONV });
+    expect(s2.turnInFlight).toBe(false);
+  });
+
+  it("tool_start sets activity; tool_status updates it; tool_end clears it", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "tool_start",
+      conv_id: CONV,
+      tool: "run_shell_command",
+      tool_call_id: "tc1",
+    });
+    expect(s1.activity).toEqual({
+      tool_call_id: "tc1",
+      name: "run_shell_command",
+      status: "",
+    });
+    const s2 = dispatch(s1, {
+      type: "tool_status",
+      conv_id: CONV,
+      tool: "run_shell_command",
+      tool_call_id: "tc1",
+      message: "running",
+    });
+    expect(s2.activity?.status).toBe("running");
+    const s3 = dispatch(s2, {
+      type: "tool_end",
+      conv_id: CONV,
+      tool: "run_shell_command",
+      tool_call_id: "tc1",
+      result_text: "done",
+    });
+    expect(s3.activity).toBeNull();
+  });
+
+  it("confirm_request sets confirm", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "confirm_request",
+      conv_id: CONV,
+      confirmation_id: "req1",
+      action_type: "run_shell_command",
+      tool: "shell",
+      command: "ls",
+      suggested_pattern: "",
+      message: "Run ls",
+      approve_label: "",
+      deny_label: "",
+      tool_call_id: "",
+      action_data: {},
+    });
+    expect(s1.confirm).toEqual({
+      confirmation_id: "req1",
+      action_type: "run_shell_command",
+      command: "ls",
+      message: "Run ls",
+      suggested_pattern: "",
+    });
+  });
+
+  it("user_message echo appends to transcript", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "user_message",
+      conv_id: CONV,
+      text: "hi",
+    });
+    expect(s1.transcript).toEqual([{ kind: "user", text: "hi" }]);
+  });
+
+  it("conv_selected stores model", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "conv_selected",
+      conv_id: CONV,
+      model: "claude-opus-4-7",
+    });
+    expect(s1.conv_id).toBe(CONV);
+    expect(s1.model).toBe("claude-opus-4-7");
+  });
+
+  it("compaction_done appends system line", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, { type: "compaction_done", conv_id: CONV });
+    expect(s1.transcript.at(-1)).toEqual({
+      kind: "system",
+      text: "[compaction complete]",
+    });
+  });
+
+  it("model_changed appends system line + updates model", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const s1 = dispatch(s0, {
+      type: "model_changed",
+      conv_id: CONV,
+      model: "claude-haiku-4-5",
+    });
+    expect(s1.model).toBe("claude-haiku-4-5");
+    expect(s1.transcript.at(-1)?.text).toContain("claude-haiku-4-5");
+  });
+
+  it("error appends system line", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "error",
+      message: "boom",
+      conv_id: null,
+    });
+    expect(s1.transcript.at(-1)).toEqual({
+      kind: "system",
+      text: "[error: boom]",
+    });
+  });
+
+  it("unknown type returns state unchanged (forward-compat)", () => {
+    const s0 = { ...initialState, conv_id: CONV };
+    const unknown = { type: "future_message", conv_id: CONV } as unknown as ServerMessage;
+    const s1 = dispatch(s0, unknown);
+    expect(s1).toBe(s0); // referential equality — no copy
+  });
+});

--- a/tui/src/dispatcher.ts
+++ b/tui/src/dispatcher.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure reducer mapping (state, ServerMessage) -> new state.
+ *
+ * Exhaustive switch with TS `never` guard on default — adding a new
+ * ServerMessage variant in types.ts will surface here as a compile error
+ * rather than silent drift. See spec.md "Promotion path" section.
+ */
+
+import type { ServerMessage } from "./types.js";
+
+export type TranscriptItem =
+  | { kind: "user"; text: string }
+  | { kind: "assistant"; text: string }
+  | { kind: "system"; text: string };
+
+// Spike simplification: tracks one active tool at a time. Phase 2 with
+// concurrent tools would need this to become `Activity[]` or a Map.
+export type Activity = {
+  tool_call_id: string;
+  name: string;
+  status: string;
+} | null;
+
+export type Confirm = {
+  confirmation_id: string;
+  action_type: string;
+  command: string;
+  message: string;
+  suggested_pattern: string;
+} | null;
+
+export interface State {
+  conv_id: string | null;
+  transcript: TranscriptItem[];
+  draft: string;
+  activity: Activity;
+  confirm: Confirm;
+  turnInFlight: boolean;
+  model: string | null;
+}
+
+export const initialState: State = {
+  conv_id: null,
+  transcript: [],
+  draft: "",
+  activity: null,
+  confirm: null,
+  turnInFlight: false,
+  model: null,
+};
+
+function assertNever(_x: never): void {
+  // Exhaustiveness check — TS errors here if a new ServerMessage variant
+  // is added without a matching case in `dispatch`.
+}
+
+function appendTranscript(s: State, item: TranscriptItem): State {
+  return { ...s, transcript: [...s.transcript, item] };
+}
+
+function extractText(msg: Record<string, unknown> | null | undefined): string {
+  if (!msg) return "";
+  const t = msg["text"];
+  return typeof t === "string" ? t : "";
+}
+
+export function dispatch(s: State, m: ServerMessage): State {
+  switch (m.type) {
+    case "chunk":
+      return { ...s, draft: s.draft + m.text };
+
+    case "message_complete": {
+      // Cancel preserves the streamed draft: the server replaces text with
+      // "[cancelled]" but the partial assistant response is still useful to
+      // keep in the transcript. Emit two lines: the partial reply + a system
+      // marker.
+      if (m.text === "[cancelled]" && s.draft) {
+        const withDraft = appendTranscript(s, { kind: "assistant", text: s.draft });
+        const withMarker = appendTranscript(withDraft, { kind: "system", text: "[cancelled]" });
+        return { ...withMarker, draft: "" };
+      }
+      const text = m.text || s.draft;
+      const next = appendTranscript(s, { kind: "assistant", text });
+      return { ...next, draft: "" };
+    }
+
+    case "user_message":
+      return appendTranscript(s, { kind: "user", text: m.text });
+
+    case "turn_start":
+      return { ...s, turnInFlight: true };
+
+    case "turn_complete":
+      return { ...s, turnInFlight: false };
+
+    case "tool_start":
+      return {
+        ...s,
+        activity: { tool_call_id: m.tool_call_id, name: m.tool, status: "" },
+      };
+
+    case "tool_status":
+      if (s.activity && s.activity.tool_call_id === m.tool_call_id) {
+        return { ...s, activity: { ...s.activity, status: m.message } };
+      }
+      return s;
+
+    case "tool_end":
+      if (s.activity && s.activity.tool_call_id === m.tool_call_id) {
+        return { ...s, activity: null };
+      }
+      return s;
+
+    case "confirm_request":
+      return {
+        ...s,
+        confirm: {
+          confirmation_id: m.confirmation_id,
+          action_type: m.action_type,
+          command: m.command,
+          message: m.message,
+          suggested_pattern: m.suggested_pattern,
+        },
+      };
+
+    case "confirmation_response":
+      // Server replay of a prior decision (e.g., loading history). Currently no-op for live UI.
+      return s;
+
+    case "conv_selected":
+      return { ...s, conv_id: m.conv_id, model: m.model };
+
+    case "conv_history": {
+      const items: TranscriptItem[] = [];
+      for (const raw of m.messages) {
+        const role = (raw as { role?: string }).role;
+        const text = extractText(raw as Record<string, unknown>);
+        if (role === "user") items.push({ kind: "user", text });
+        else if (role === "assistant") items.push({ kind: "assistant", text });
+        // skip tool/system roles in the spike
+      }
+      // Preserves draft/activity/confirm/turnInFlight from prior state — history
+      // is expected to arrive on connect, before any turn is in flight.
+      return { ...s, transcript: [...items, ...s.transcript] };
+    }
+
+    case "compaction_done":
+      return appendTranscript(s, { kind: "system", text: "[compaction complete]" });
+
+    case "model_changed":
+      return appendTranscript(
+        { ...s, model: m.model },
+        { kind: "system", text: `[model: ${m.model}]` }
+      );
+
+    case "error":
+      return appendTranscript(s, { kind: "system", text: `[error: ${m.message}]` });
+
+    // Spike-deferred. Acknowledged in types.ts but not surfaced in UI.
+    case "background_event":
+    case "canvas_update":
+    case "command_ack":
+    case "models_available":
+    case "notification_created":
+    case "notification_read":
+    case "reflection_result":
+    case "vault_changed":
+      return s;
+
+    default: {
+      // Forward-compat: surface unknown types as unchanged. The assertNever
+      // call below is a compile-time exhaustiveness check; at runtime we
+      // silently no-op so new wire types from the server don't crash the TUI.
+      assertNever(m);
+      return s;
+    }
+  }
+}

--- a/tui/src/entry.tsx
+++ b/tui/src/entry.tsx
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Entry point: parse argv + env, construct WSClient, render App.
+ *
+ * Required: token (--token / DECAFCLAW_TOKEN).
+ * Optional: --host (default http://localhost:8088), --conv <id>.
+ */
+
+import React from "react";
+import { render } from "ink";
+import { WSClient } from "./wsClient.js";
+import { App } from "./App.js";
+
+interface Args {
+  token: string;
+  host: string;
+  conv: string | null;
+}
+
+function parseArgs(argv: string[]): Args | { error: string } {
+  const args: Partial<Args> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--token") args.token = argv[++i];
+    else if (a === "--host") args.host = argv[++i];
+    else if (a === "--conv") args.conv = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      return {
+        error:
+          "Usage: decafclaw-tui [--token <t>] [--host <url>] [--conv <id>]\n" +
+          "Env: DECAFCLAW_TOKEN, DECAFCLAW_HOST",
+      };
+    }
+  }
+  const token = args.token ?? process.env.DECAFCLAW_TOKEN;
+  const host = args.host ?? process.env.DECAFCLAW_HOST ?? "http://localhost:8088";
+  if (!token) {
+    return { error: "Missing token. Use --token <t> or DECAFCLAW_TOKEN." };
+  }
+  return { token, host, conv: args.conv ?? null };
+}
+
+function main(): void {
+  if (!process.stdin.isTTY) {
+    console.error("decafclaw-tui requires a TTY stdin.");
+    process.exit(1);
+  }
+
+  const parsed = parseArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    process.exit(1);
+  }
+
+  const client = new WSClient({ host: parsed.host, token: parsed.token });
+  client.connect();
+
+  render(
+    <App client={client} initialConvId={parsed.conv} host={parsed.host} token={parsed.token} />,
+    { exitOnCtrlC: false }
+  );
+}
+
+main();

--- a/tui/src/types.ts
+++ b/tui/src/types.ts
@@ -1,0 +1,111 @@
+/**
+ * WebSocket message types for the decafclaw bot.
+ *
+ * Mirrors src/decafclaw/web/message_types.json. Hand-typed for the spike.
+ * Codegen-shaped: when we promote, replace with generated file using the
+ * same exported names. See spec for the A->B promotion path.
+ */
+
+// ---- Server -> client ----
+
+export interface SrvBackgroundEvent { type: "background_event"; conv_id: string; event: Record<string, unknown>; }
+export interface SrvCanvasUpdate { type: "canvas_update"; conv_id: string; state: Record<string, unknown>; }
+export interface SrvChunk { type: "chunk"; conv_id: string; text: string; }
+export interface SrvCommandAck { type: "command_ack"; conv_id: string; command: string; }
+export interface SrvCompactionDone { type: "compaction_done"; conv_id: string; }
+// NOTE: manifest declares {request_id, kind, payload} but server (websocket.py:600)
+// actually emits these flat fields (confirmation_id, action_type, command, ...).
+export interface SrvConfirmRequest {
+  type: "confirm_request";
+  conv_id: string;
+  confirmation_id: string;
+  action_type: string;
+  tool: string;
+  command: string;
+  suggested_pattern: string;
+  message: string;
+  approve_label: string;
+  deny_label: string;
+  tool_call_id: string;
+  action_data: Record<string, unknown>;
+}
+export interface SrvConfirmationResponse { type: "confirmation_response"; conv_id: string; request_id: string; decision: string; }
+export interface SrvConvHistory { type: "conv_history"; conv_id: string; messages: Array<Record<string, unknown>>; before: string | null; }
+export interface SrvConvSelected { type: "conv_selected"; conv_id: string; model: string | null; }
+export interface SrvError { type: "error"; message: string; conv_id: string | null; }
+// NOTE: manifest declares {message: object} but server (conversation_manager.py)
+// actually emits {text: string, ...}. Matching the wire reality, not the manifest.
+export interface SrvMessageComplete { type: "message_complete"; conv_id: string; text: string; }
+export interface SrvModelChanged { type: "model_changed"; conv_id: string; model: string; }
+export interface SrvModelsAvailable { type: "models_available"; models: string[]; }
+export interface SrvNotificationCreated { type: "notification_created"; notification: Record<string, unknown>; }
+export interface SrvNotificationRead { type: "notification_read"; id: string; }
+export interface SrvReflectionResult { type: "reflection_result"; conv_id: string; result: Record<string, unknown>; }
+export interface SrvToolEnd { type: "tool_end"; conv_id: string; tool: string; tool_call_id: string; result_text: string; display_short_text?: string; widget?: Record<string, unknown>; }
+export interface SrvToolStart { type: "tool_start"; conv_id: string; tool: string; tool_call_id: string; }
+export interface SrvToolStatus { type: "tool_status"; conv_id: string; tool: string; tool_call_id: string; message: string; }
+export interface SrvTurnComplete { type: "turn_complete"; conv_id: string; }
+export interface SrvTurnStart { type: "turn_start"; conv_id: string; }
+// NOTE: manifest declares {message: object} but server (websocket.py:505) actually
+// emits {text: string}. Matching the wire reality, not the manifest.
+export interface SrvUserMessage { type: "user_message"; conv_id: string; text: string; }
+// NOTE: manifest has two fields: path + kind. Plan omitted kind — corrected here.
+export interface SrvVaultChanged { type: "vault_changed"; path: string; kind: string; }
+
+export type ServerMessage =
+  | SrvBackgroundEvent
+  | SrvCanvasUpdate
+  | SrvChunk
+  | SrvCommandAck
+  | SrvCompactionDone
+  | SrvConfirmRequest
+  | SrvConfirmationResponse
+  | SrvConvHistory
+  | SrvConvSelected
+  | SrvError
+  | SrvMessageComplete
+  | SrvModelChanged
+  | SrvModelsAvailable
+  | SrvNotificationCreated
+  | SrvNotificationRead
+  | SrvReflectionResult
+  | SrvToolEnd
+  | SrvToolStart
+  | SrvToolStatus
+  | SrvTurnComplete
+  | SrvTurnStart
+  | SrvUserMessage
+  | SrvVaultChanged;
+
+// ---- Client -> server ----
+
+export interface CliCancelTurn { type: "cancel_turn"; conv_id: string; }
+// NOTE: manifest declares {request_id, decision, extras} but server
+// (websocket.py:_handle_confirm_response) actually reads
+// {confirmation_id, approved, always, add_pattern}.
+export interface CliConfirmResponse {
+  type: "confirm_response";
+  conv_id: string;
+  confirmation_id: string;
+  approved: boolean;
+  always: boolean;
+  add_pattern: boolean;
+}
+export interface CliLoadHistory { type: "load_history"; conv_id: string; limit: number; before: string | null; }
+export interface CliSelectConv { type: "select_conv"; conv_id: string; }
+export interface CliSend { type: "send"; conv_id: string; text: string; attachments: Array<Record<string, unknown>>; }
+// NOTE: `set_effort` is a deprecated alias for `set_model` (older web clients).
+// The manifest field is `model: string` — intentionally matches set_model's field.
+export interface CliSetEffort { type: "set_effort"; conv_id: string; model: string; }
+export interface CliSetModel { type: "set_model"; conv_id: string; model: string; }
+export interface CliWidgetResponse { type: "widget_response"; conv_id: string; confirmation_id: string; data: Record<string, unknown>; }
+
+export type ClientMessage =
+  | CliCancelTurn
+  | CliConfirmResponse
+  | CliLoadHistory
+  | CliSelectConv
+  | CliSend
+  | CliSetEffort
+  | CliSetModel
+  | CliWidgetResponse;

--- a/tui/src/wsClient.ts
+++ b/tui/src/wsClient.ts
@@ -1,0 +1,134 @@
+/**
+ * WebSocket transport for the TUI.
+ *
+ * Dumb pipe: opens a connection with the same cookie auth the browser uses,
+ * parses incoming JSON, surfaces parsed ServerMessage envelopes (or a synthetic
+ * `__reconnected` marker after a reconnect). Caller decides what to do.
+ *
+ * Reconnect with exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s.
+ * Auth-failure exits are surfaced by leaving the WS closed and emitting a
+ * synthetic `__auth_failed` marker. The App treats this as fatal.
+ *
+ * Lifecycle: a WSClient is intended for one-shot use. After `close()`, create
+ * a new instance to reconnect intentionally — don't reuse.
+ */
+
+import WebSocket from "ws";
+import type { ClientMessage, ServerMessage } from "./types.js";
+
+export type WSEvent =
+  | ServerMessage
+  | { type: "__reconnected" }
+  | { type: "__auth_failed"; reason: string }
+  | { type: "__closed"; code: number; reason: string };
+
+export interface WSClientOptions {
+  host: string; // e.g. "http://localhost:8088" or "https://example.com"
+  token: string;
+}
+
+export class WSClient {
+  private opts: WSClientOptions;
+  private ws: WebSocket | null = null;
+  private handlers: Array<(e: WSEvent) => void> = [];
+  private reconnectAttempt = 0;
+  private wantClosed = false;
+  private hadOpen = false;
+
+  constructor(opts: WSClientOptions) {
+    this.opts = opts;
+  }
+
+  on(handler: (e: WSEvent) => void): void {
+    this.handlers.push(handler);
+  }
+
+  send(msg: ClientMessage): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+    // else: silently drop; reconnect path will re-establish state via re-select_conv
+  }
+
+  close(): void {
+    this.wantClosed = true;
+    this.ws?.close();
+    this.hadOpen = false;
+  }
+
+  connect(): void {
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+    const wsUrl = this.opts.host.replace(/^http/, "ws") + "/ws/chat";
+    const ws = new WebSocket(wsUrl, {
+      headers: {
+        Cookie: `decafclaw_session=${this.opts.token}`,
+      },
+    });
+    this.ws = ws;
+
+    ws.on("open", () => {
+      const wasReconnect = this.hadOpen;
+      this.hadOpen = true;
+      this.reconnectAttempt = 0;
+      if (wasReconnect) {
+        this.emit({ type: "__reconnected" });
+      }
+    });
+
+    ws.on("message", (data: WebSocket.RawData) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data.toString());
+      } catch {
+        console.error("[tui] malformed WS message:", data.toString());
+        return;
+      }
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "type" in parsed &&
+        typeof (parsed as { type: unknown }).type === "string"
+      ) {
+        this.emit(parsed as ServerMessage);
+      }
+    });
+
+    ws.on("unexpected-response", (_req, res) => {
+      // 401/403 etc. — auth failure on upgrade.
+      const reason = `HTTP ${res.statusCode} ${res.statusMessage ?? ""}`.trim();
+      this.wantClosed = true;
+      this.emit({ type: "__auth_failed", reason });
+    });
+
+    ws.on("close", (code: number, reasonBuf: Buffer) => {
+      const reason = reasonBuf.toString();
+      this.emit({ type: "__closed", code, reason });
+      this.ws = null;
+      if (this.wantClosed) return;
+      this.scheduleReconnect();
+    });
+
+    ws.on("error", (err: Error) => {
+      console.error("[tui] ws error:", err.message);
+      // close handler will fire after this; reconnect is scheduled there.
+    });
+  }
+
+  private scheduleReconnect(): void {
+    const delays = [1000, 2000, 4000, 8000, 16000, 30000];
+    const idx = Math.min(this.reconnectAttempt, delays.length - 1);
+    const delay = delays[idx]!;
+    this.reconnectAttempt += 1;
+    setTimeout(() => {
+      if (!this.wantClosed) this.connect();
+    }, delay);
+  }
+
+  private emit(e: WSEvent): void {
+    for (const h of this.handlers) h(e);
+  }
+}

--- a/tui/tsconfig.json
+++ b/tui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
> Supersedes #488 (auto-closed by branch rename `worktree-tui-spike` → `tui-spike`).

## Summary

- Minimal Ink (React-for-terminal) TUI in `tui/` that connects to the running decafclaw bot via its existing WebSocket gateway — not a separate bot instance, not a stdio-bridged backend.
- Sidesteps #464's original "spawn Python backend via JSON-RPC stdio" model. Reuses the web UI's transport, cookie auth, and per-conversation event subscription. No bot-side architecture changes.
- Validated end-to-end against `make dev`: chat round-trip with streaming, confirm-gated tools (approve + deny), Ctrl+C mid-turn cancel (preserves streamed draft), reconnect-and-resume.

## What's in `tui/`

Six source files + one test, ~520 lines of TS total:

- `entry.tsx` — argv/env parsing, TTY gate, render
- `App.tsx` — Ink tree: transcript + composer + activity lane + confirm prompt + Ctrl+C semantics
- `wsClient.ts` — WS transport with cookie auth + exponential backoff reconnect
- `dispatcher.ts` — pure state reducer with exhaustive `switch` + `assertNever` guard (12 vitest unit tests)
- `types.ts` — hand-typed wire-message discriminated union, codegen-shaped so it can be replaced by generated types from `message_types.json` later without consumer churn
- `conversationPicker.tsx` — REST-driven picker on launch when `--conv` is absent

## Side effects

- **Manifest reconciliation** (`src/decafclaw/web/message_types.json`). The TUI was the first hand-typed consumer of the manifest's `fields` and surfaced four wire-shape drifts (`user_message`, `message_complete`, `confirm_request`, `confirm_response`) — manifest had drifted from `websocket.py` / `conversation_manager.py`. Codegen blast radius: only `docs/websocket-messages.md` regenerated; the `.py` and `.js` enum bindings only use names which were correct.
- **Issue #487 filed** for the broader transport / client capabilities concern (widgets/canvas/HTML-rendering assumptions across web UI / Mattermost / interactive_terminal / TUI). The TUI is a forcing function, not the only consumer.

## Spec / plan / notes

Full design at [`docs/dev-sessions/2026-05-13-1039-tui-spike/`](docs/dev-sessions/2026-05-13-1039-tui-spike/):

- [`spec.md`](docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md) — Option A (hand-typed minimal Ink) + the Phase 2 candidates table + cross-cutting capabilities section
- [`plan.md`](docs/dev-sessions/2026-05-13-1039-tui-spike/plan.md) — 10-task subagent-driven execution plan
- [`notes.md`](docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md) — retro: plan/reality deltas, wire-shape findings, cancel UX improvement, server-side curiosity about `[cancelled]` archive interaction (separate retro candidate)

## Phase 2 candidates (not in this PR)

Captured explicitly in [`spec.md`](docs/dev-sessions/2026-05-13-1039-tui-spike/spec.md). Recommended sequence if we keep building: markdown rendering → multi-line composer + history → tab completion → theme → model picker. Widgets / canvas / files / vault later, gated on resolving #487's capability negotiation question.

## Test plan

- [x] `cd tui && npm test` — 12/12
- [x] `cd tui && npm run typecheck` — clean
- [x] `make check` — clean (manifest changes propagate correctly)
- [x] `make test` — 2431/2431
- [x] Live smoke against `make dev` — all 8 spec acceptance criteria walked
- [ ] Optional: reviewer can re-run the live smoke from the launch command in [`notes.md`](docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md#acceptance-criteria-walkthrough--completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)