### PR TITLE
feat(skills): contrib kindle skill — periodic Kindle highlights ingest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ See [docs/skills.md](docs/skills.md).
 - **Skills must use absolute imports** (`from decafclaw.skills.X.Y import ...`). The loader uses `importlib.spec_from_file_location` without package context, so relative imports fail at runtime.
 - **Skill config via `SkillConfig` dataclass in `tools.py`.** Resolved at activation by `load_sub_config` (env + `config.skills[name]` + defaults). `init(config, skill_config)` receives both.
 - **User-invokable commands** (`user-invocable: true`) trigger via `!name` (Mattermost) / `/name` (web UI). Supports `$ARGUMENTS`/`$0`/`$1`, `context: fork`, `allowed-tools`.
-- **`schedule:` frontmatter** turns a skill into a scheduled task. Bundled and admin-level only — workspace skills can't self-schedule.
+- **`schedule:` frontmatter** turns a skill into a scheduled task. Bundled, admin-level, and `extra_skill_paths`-loaded skills can self-schedule — workspace skills cannot.
 - **Permissions at `data/{agent_id}/skill_permissions.json`** — outside the workspace, so the agent can't grant itself permission.
 - **Dynamic per-turn tools:** export `get_tools(ctx) -> (dict, list)` to vary tools by state.
 
@@ -164,7 +164,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `preempt_search.py` — Keyword-match for pre-emptive tool promotion
 
 ### Skills (bundled)
-`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded.
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
 
 ### Other
 - `prompts/` — System prompt assembly

--- a/Makefile
+++ b/Makefile
@@ -60,20 +60,25 @@ lint-fix:
 fmt:
 	uv run ruff format src/ tests/
 
-# Run tests (pytest, excludes integration tests by default — see pyproject.toml addopts)
+# Run tests (pytest, excludes integration tests by default — see pyproject.toml addopts).
+# Includes contrib/skills/ so contrib-skill tests don't bit-rot.
 test:
-	uv run pytest tests/
+	uv run pytest tests/ contrib/skills/
 
 # Run integration tests only (requires provider credentials).
 # Override the default `-m "not integration"` from addopts, and disable
 # xdist so parallel workers don't hammer the real APIs concurrently.
 test-integration:
-	uv run pytest tests/ -v -m integration -n 0
+	uv run pytest tests/ contrib/skills/ -v -m integration -n 0
 
 # Run all tests including integration. Matches parallel + default policy,
 # but opts back in to integration by OR-ing the markers.
 test-all:
-	uv run pytest tests/ -m "integration or not integration"
+	uv run pytest tests/ contrib/skills/ -m "integration or not integration"
+
+# Run contrib-skill tests in isolation (subset of `make test`).
+test-contrib:
+	uv run pytest contrib/skills/ -v
 
 # Rebuild production embedding index
 reindex:

--- a/contrib/skills/README.md
+++ b/contrib/skills/README.md
@@ -54,6 +54,20 @@ A skill at `data/{agent_id}/skills/<name>/` shadows any same-named entry in `ext
 
 ## Available Skills
 
+### kindle
+
+Syncs highlights and notes from your Kindle library (`read.amazon.com/notebook`) into per-book vault pages under `agent/pages/kindle/`. Each book gets one page with frontmatter tracking the ASIN, title, author, and highlight count. Deleted highlights are moved to an `## Archived` section with a date stamp.
+
+**Requires:** A Netscape-format `cookies.txt` file exported from a logged-in Amazon session. Place at `data/{agent_id}/secrets/kindle.cookies.txt` (or configure `skills.kindle.cookies_path`). No binary downloads needed.
+
+**Smoke test:** `uv run python contrib/skills/kindle/smoke.py`
+
+**Tests:** `make test-contrib` (or `uv run pytest contrib/skills/kindle/ -v`)
+
+**Schedule:** Daily at 5am UTC (`0 5 * * *`). Gated by `skills.kindle.enabled` (default `false`); on-demand via `/kindle-sync` always works.
+
+See [docs/kindle.md](../../docs/kindle.md) for full setup and configuration details.
+
 ### linkding-ingest
 
 Fetches bookmarks from a [Linkding](https://github.com/sissbruecker/linkding) instance, reads the bookmarked content via Tabstack, and records insights to the wiki knowledge base. Delegates each bookmark to a child agent for parallel processing.

--- a/contrib/skills/kindle/SKILL.md
+++ b/contrib/skills/kindle/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: kindle
+description: Sync highlights & notes from your Kindle library (read.amazon.com/notebook) into per-book vault pages.
+schedule: "0 5 * * *"
+user-invocable: true
+context: inline
+argument-hint: "[asin-or-title]"
+allowed-tools: kindle_list_books, kindle_fetch_highlights, kindle_sync_book, kindle_sync_all, vault_read, vault_list, vault_write, vault_journal_append, current_time
+required-skills: [kindle]
+---
+
+# Kindle sync
+
+You sync highlights & notes from `read.amazon.com/notebook` into per-book vault pages under `agent/pages/kindle/`.
+
+## When to run
+
+This skill runs in two contexts:
+
+1. **Scheduled (daily 5am UTC)** — full library sync. Call `kindle_sync_all`. The tool itself short-circuits to `kindle skill disabled; skipping` if `skills.kindle.enabled` is False (the default for fresh installs). It also fails fast if the cookies file is missing.
+
+2. **User-invocable (`!kindle-sync` / `/kindle-sync`)** — on-demand. The `enabled` gate does NOT apply here; the user explicitly asked. Still requires cookies.
+
+## Argument parsing
+
+Argument: `$ARGUMENTS`
+
+- **Empty** (`!kindle-sync`) — call `kindle_sync_all`. Summarize the result.
+- **Non-empty** (`!kindle-sync <arg>`) — single-book mode:
+  1. Call `kindle_list_books` to get the library.
+  2. If `<arg>` looks like an ASIN (10 alphanumeric chars, all-caps), look it up directly.
+  3. Otherwise, treat `<arg>` as a title substring. Lowercase-substring match against each book's title. If exactly one matches, use its ASIN. If multiple match, return a numbered list and ask the user to re-invoke with the ASIN. If zero match, return `No book matching '<arg>' in your Kindle library`.
+  4. Call `kindle_sync_book(asin=...)` and summarize.
+
+## Notes
+
+- The per-book page is fully agent-owned. **Do not** manually edit `agent/pages/kindle/*.md` — your edits will be overwritten on the next sync. Use a separate hand-curated page for cross-links and synthesis (e.g., `agent/pages/<book>-notes.md` that wiki-links to the agent page).
+- If a fetch fails with a 401/403, your cookies have probably expired. Re-export `cookies.txt` from a logged-in browser session and place it at the configured path.

--- a/contrib/skills/kindle/conftest.py
+++ b/contrib/skills/kindle/conftest.py
@@ -1,0 +1,38 @@
+"""Shared test fixtures for the contrib kindle skill tests."""
+
+import pytest
+
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig, ReflectionConfig
+from decafclaw.context import Context
+from decafclaw.events import EventBus
+
+
+@pytest.fixture
+def tmp_data(tmp_path):
+    """Provides a temporary data directory."""
+    return tmp_path
+
+
+@pytest.fixture
+def config(tmp_data):
+    """Provides a Config pointing at temporary directories."""
+    return Config(
+        agent=AgentConfig(
+            data_home=str(tmp_data),
+            id="test-agent",
+            user_id="testuser",
+        ),
+        reflection=ReflectionConfig(enabled=False),
+    )
+
+
+@pytest.fixture
+def ctx(config):
+    """Provides a Context with config and event bus."""
+    bus = EventBus()
+    context = Context(config=config, event_bus=bus)
+    context.conv_id = "test-conv"
+    context.channel_id = "test-channel"
+    context.user_id = "testuser"
+    return context

--- a/contrib/skills/kindle/fixtures/cookies.txt
+++ b/contrib/skills/kindle/fixtures/cookies.txt
@@ -1,0 +1,3 @@
+# Netscape HTTP Cookie File — synthetic, for testing only
+.amazon.com	TRUE	/	TRUE	9999999999	at-main	dummy-value-1
+.amazon.com	TRUE	/	TRUE	9999999999	sess-at-main	dummy-value-2

--- a/contrib/skills/kindle/fixtures/notebook_page.html
+++ b/contrib/skills/kindle/fixtures/notebook_page.html
@@ -1,0 +1,257 @@
+<!-- Redacted from a real read.amazon.com/notebook capture; titles/authors/highlight-text/notes scrubbed for privacy.
+     ASINs and annotation IDs are retained (they are random-looking identifiers, not PII).
+     Cover image URLs point to local save paths from the original download and are not PII.
+     Contains 4 books and 6 highlights (4 yellow, 1 blue, 1 yellow-with-note) for parser testing. -->
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>Kindle Notebook - Test Fixture</title></head>
+<body>
+
+<!-- Book library section -->
+<div id="books-filter" class="a-row a-spacing-base a-spacing-top-base kp-notebook-books-filter">
+  <p class="a-spacing-none a-text-center a-size-mini a-color-base a-text-bold a-text-caps">Annotated books from your library</p>
+  <div class="a-row kp-notebook-header">
+    <span class="a-size-small a-color-base">(Most recently accessed shown first)</span>
+  </div>
+</div>
+
+<div id="library-section" class="a-section kp-notebook-library-header-separator">
+  <div class="a-scroller kp-notebook-scroller-addon a-scroller-vertical">
+    <div id="kp-notebook-library" class="a-row">
+
+      <!-- Book 1 (currently selected) -->
+      <div id="B078VWDNKT" class="a-row kp-notebook-library-each-book a-color-base-background">
+        <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin="{&quot;asin&quot;:&quot;B078VWDNKT&quot;}">
+          <a class="a-link-normal a-text-normal" href="javascript:void(0);">
+            <div class="a-row">
+              <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium">
+                <img alt="" src="amazon-kindle-notebook_files/71QT-dIEr8L._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border">
+              </div>
+            </div>
+            <h2 class="a-size-base a-color-base a-text-center kp-notebook-searchable a-text-bold">Sample Book One</h2>
+            <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary kp-notebook-searchable">By: Author One</p>
+          </a>
+        </span>
+        <input type="hidden" name="" value="Wednesday, May 13, 2026" id="kp-notebook-annotated-date-B078VWDNKT">
+      </div>
+
+      <!-- Book 2 -->
+      <div id="B09G14BQMM" class="a-row kp-notebook-library-each-book">
+        <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin="{&quot;asin&quot;:&quot;B09G14BQMM&quot;}">
+          <a class="a-link-normal a-text-normal" href="javascript:void(0);">
+            <div class="a-row">
+              <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium">
+                <img alt="" src="amazon-kindle-notebook_files/81H6am-hATL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border">
+              </div>
+            </div>
+            <h2 class="a-size-base a-color-base a-text-center kp-notebook-searchable a-text-bold">Sample Book Two</h2>
+            <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary kp-notebook-searchable">By: Author Two</p>
+          </a>
+        </span>
+        <input type="hidden" name="" value="Tuesday, May 12, 2026" id="kp-notebook-annotated-date-B09G14BQMM">
+      </div>
+
+      <!-- Book 3 -->
+      <div id="B07WYSGHC7" class="a-row kp-notebook-library-each-book">
+        <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin="{&quot;asin&quot;:&quot;B07WYSGHC7&quot;}">
+          <a class="a-link-normal a-text-normal" href="javascript:void(0);">
+            <div class="a-row">
+              <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium">
+                <img alt="" src="amazon-kindle-notebook_files/81wVk-n7G7S._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border">
+              </div>
+            </div>
+            <h2 class="a-size-base a-color-base a-text-center kp-notebook-searchable a-text-bold">Sample Book Three</h2>
+            <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary kp-notebook-searchable">By: Author Two</p>
+          </a>
+        </span>
+        <input type="hidden" name="" value="Monday, May 11, 2026" id="kp-notebook-annotated-date-B07WYSGHC7">
+      </div>
+
+      <!-- Book 4 -->
+      <div id="B07J6HWLPR" class="a-row kp-notebook-library-each-book">
+        <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin="{&quot;asin&quot;:&quot;B07J6HWLPR&quot;}">
+          <a class="a-link-normal a-text-normal" href="javascript:void(0);">
+            <div class="a-row">
+              <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium">
+                <img alt="" src="amazon-kindle-notebook_files/71GHKo78YBL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border">
+              </div>
+            </div>
+            <h2 class="a-size-base a-color-base a-text-center kp-notebook-searchable a-text-bold">Sample Book Four</h2>
+            <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary kp-notebook-searchable">By: Author Two</p>
+          </a>
+        </span>
+        <input type="hidden" name="" value="Sunday, May 10, 2026" id="kp-notebook-annotated-date-B07J6HWLPR">
+      </div>
+
+    </div><!-- #kp-notebook-library -->
+  </div>
+</div><!-- #library-section -->
+
+<!-- Annotations section for currently-selected book (B078VWDNKT) -->
+<input id="kp-notebook-asin" value="B078VWDNKT" type="hidden">
+
+<div id="kp-notebook-annotations-header">
+  <span id="kp-notebook-annotation-count">6&nbsp;Highlights | 1&nbsp;Notes</span>
+</div>
+
+<div id="kp-notebook-annotations" class="a-row">
+
+  <!-- Annotation 1: yellow, no note -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDoyNDg0NzpISUdITElHSFQ6YTMxYmVkYjYzLTIxY2EtNDVlYy05ZTI4LTIyM2U4ZmUwN2E0ZA">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="166"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Yellow highlight | Location:&#160;166</span>
+          <span class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;166</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDoyNDg0NzpISUdITElHSFQ6YTMxYmVkYjYzLTIxY2EtNDVlYy05ZTI4LTIyM2U4ZmUwN2E0ZA">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 1. This is a longer passage to test that highlight text extraction works correctly for multi-sentence highlights.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable" id="note-">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Annotation 2: yellow, no note -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDoyODA5NDpISUdITElHSFQ6YTFl">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="188"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Yellow highlight | Location:&#160;188</span>
+          <span class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;188</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDoyODA5NDpISUdITElHSFQ6YTFl">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 2. A shorter passage here.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable" id="note-">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Annotation 3: yellow, no note -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozMTYyNjpISUdITElHSFQ6YWEz">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="211"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Yellow highlight | Location:&#160;211</span>
+          <span class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;211</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozMTYyNjpISUdITElHSFQ6YWEz">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 3. Yet another passage to exercise the parser.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable" id="note-">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Annotation 4: yellow, no note -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozMzc1NTpISUdITElHSFQ6YWI5">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="226"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Yellow highlight | Location:&#160;226</span>
+          <span class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;226</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozMzc1NTpISUdITElHSFQ6YWI5">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 4.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable" id="note-">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Annotation 5: blue highlight, no note (synthetic — exercises non-yellow color path) -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozNTIzOTpISUdITElHSFQ6Ymx1ZQ">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="247"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Blue highlight | Location:&#160;247</span>
+          <span class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;247</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-blue" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozNTIzOTpISUdITElHSFQ6Ymx1ZQ">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 5. This highlight is blue to test color extraction.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable" id="note-">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Annotation 6: yellow highlight WITH a note (synthetic — exercises note extraction) -->
+  <div class="a-row a-spacing-base" id="QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozNzQxMjpISUdITElHSFQ6bm90ZQ">
+    <div class="a-column a-span10 kp-notebook-row-separator">
+      <div class="a-row">
+        <input id="kp-annotation-location" name="" type="hidden" value="312"/>
+        <div class="a-column a-span8">
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationHighlightHeader">Yellow highlight | Location:&#160;312</span>
+          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata" id="annotationNoteHeader">Note | Location:&#160;312</span>
+        </div>
+      </div>
+      <div class="a-row a-spacing-top-medium">
+        <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
+          <div class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow" id="highlight-QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozNzQxMjpISUdITElHSFQ6bm90ZQ">
+            <span class="a-size-base-plus a-color-base" id="highlight">Sample highlight text 6. This one has a user note attached to it.</span>
+            <div></div>
+          </div>
+          <div class="a-row a-spacing-top-base kp-notebook-note kp-notebook-selectable" id="note-with-content">
+            <span class="a-size-small a-color-secondary" id="note-label">Note:<span class="a-letter-space"></span></span>
+            <span class="a-size-base-plus a-color-base" id="note">Sample note 1.</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Empty annotations pane placeholder (matches real page structure) -->
+  <div id="empty-annotations-pane" class="a-row aok-hidden">
+    <p>No annotations yet.</p>
+  </div>
+
+</div><!-- #kp-notebook-annotations -->
+
+</body>
+</html>

--- a/contrib/skills/kindle/smoke.py
+++ b/contrib/skills/kindle/smoke.py
@@ -1,0 +1,203 @@
+"""Live smoke test for the kindle contrib skill.
+
+Run from inside the worktree:
+    uv run python contrib/skills/kindle/smoke.py [step]
+
+Steps (run progressively; default `all` runs each in order, stopping on first failure):
+    cookies           — Verify cookies file exists + parses; show count.
+    list              — Run kindle_list_books against real Amazon; show count + first 3 entries.
+    fetch <asin>      — Run kindle_fetch_highlights for one ASIN; show count + first 2 entries.
+    sync <asin>       — Run kindle_sync_book end-to-end; write a real vault page.
+    sync-all          — Run kindle_sync_all (WARNING: takes ~N×60s for N books).
+    enabled-gate      — Test scheduled gate short-circuits when enabled=False.
+    all               — cookies → list → (no sync; manual review).
+
+Exits non-zero on first failure. Does not touch Mattermost / web UI; talks directly
+to the tool functions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+from decafclaw.config import load_config
+
+# Load tools.py from the colocated path via importlib (same as production loader).
+_THIS_DIR = Path(__file__).parent
+_tools_spec = importlib.util.spec_from_file_location(
+    "decafclaw_contrib_kindle_tools_smoke", _THIS_DIR / "tools.py"
+)
+assert _tools_spec is not None and _tools_spec.loader is not None
+_tools = importlib.util.module_from_spec(_tools_spec)
+sys.modules["decafclaw_contrib_kindle_tools_smoke"] = _tools
+_tools_spec.loader.exec_module(_tools)
+
+SkillConfig = _tools.SkillConfig
+init = _tools.init
+kindle_list_books = _tools.kindle_list_books
+kindle_fetch_highlights = _tools.kindle_fetch_highlights
+kindle_sync_book = _tools.kindle_sync_book
+kindle_sync_all = _tools.kindle_sync_all
+_resolve_cookies_path = _tools._resolve_cookies_path
+_load_cookie_jar = _tools._load_cookie_jar
+_cookie_file_age_days = _tools._cookie_file_age_days
+
+
+def _print(label: str, value: object) -> None:
+    print(f"  {label}: {value}")
+
+
+async def step_cookies(config, skill_config: SkillConfig) -> None:
+    print("\n=== step: cookies ===")
+    path = _resolve_cookies_path(config, skill_config)
+    _print("path", path)
+    if not path.is_file():
+        print(f"  FAIL: cookies file not found at {path}")
+        sys.exit(1)
+    jar = _load_cookie_jar(path)
+    _print("cookie count", len(jar))
+    _print("age (days)", round(_cookie_file_age_days(path), 1))
+    names = sorted({c.name for c in jar})
+    _print("names", ", ".join(names[:10]) + (f" ... +{len(names) - 10} more" if len(names) > 10 else ""))
+    expected = {"at-main", "sess-at-main"}
+    missing = expected - set(names)
+    if missing:
+        print(f"  WARN: expected cookies missing: {missing}")
+    else:
+        print("  OK: at-main + sess-at-main present")
+
+
+async def step_list(ctx) -> list:
+    print("\n=== step: list ===")
+    result = await kindle_list_books(ctx)
+    print(f"  text: {result.text}")
+    if result.text.startswith("[error:"):
+        print("  FAIL: kindle_list_books returned error")
+        sys.exit(1)
+    books = (result.data or {}).get("books", []) if result.data else []
+    _print("count", len(books))
+    for i, b in enumerate(books[:3]):
+        _print(f"  [{i}]", f"{b.get('asin')} — {b.get('title')[:60]} ({b.get('author')[:30]})")
+    return books
+
+
+async def step_fetch(ctx, asin: str) -> None:
+    print(f"\n=== step: fetch {asin} ===")
+    result = await kindle_fetch_highlights(ctx, asin)
+    print(f"  text: {result.text}")
+    if result.text.startswith("[error:"):
+        print("  FAIL: kindle_fetch_highlights returned error")
+        sys.exit(1)
+    highlights = (result.data or {}).get("highlights", []) if result.data else []
+    _print("count", len(highlights))
+    for i, h in enumerate(highlights[:2]):
+        text_preview = h.get("text", "")[:80]
+        _print(f"  [{i}]", f"{h.get('location')} · {h.get('color')} · {text_preview}...")
+
+
+async def step_sync(ctx, asin: str) -> None:
+    print(f"\n=== step: sync {asin} ===")
+    result = await kindle_sync_book(ctx, asin=asin)
+    print(f"  text: {result.text}")
+    if result.text.startswith("[error:"):
+        print("  FAIL: kindle_sync_book returned error")
+        sys.exit(1)
+    print(f"  data: {result.data}")
+
+
+async def step_sync_all(ctx) -> None:
+    print("\n=== step: sync-all ===")
+    print("  WARNING: this rate-limits at 60s/book by default. Tune via skills.kindle.sync_min_interval_seconds.")
+    result = await kindle_sync_all(ctx)
+    print(f"  text: {result.text}")
+    if result.text.startswith("[error:"):
+        print("  FAIL: kindle_sync_all returned error")
+        sys.exit(1)
+    print(f"  data: {result.data}")
+
+
+async def step_enabled_gate(config) -> None:
+    print("\n=== step: enabled-gate ===")
+    # Re-init with enabled=False and simulate scheduled mode
+    disabled_config = SkillConfig(enabled=False)
+    init(config, disabled_config)
+
+    # Build a minimal stand-in ctx with task_mode="scheduled".
+    class FakeCtx:
+        config = None
+        task_mode = "scheduled"
+    fake = FakeCtx()
+    fake.config = config
+
+    result = await kindle_sync_all(fake)
+    _print("text", result.text)
+    if "disabled" not in result.text.lower():
+        print("  FAIL: scheduled+disabled run did NOT short-circuit")
+        sys.exit(1)
+    print("  OK: scheduled+disabled short-circuited")
+
+
+class _SmokeCtx:
+    """Minimal ctx for direct tool invocation outside the agent loop."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.task_mode = "interactive"
+        # vault_write needs an event_bus to publish on; stub it.
+        self.event_bus = _NullEventBus()
+        self.channel_name = ""
+        self.channel_id = ""
+        self.thread_id = ""
+
+
+class _NullEventBus:
+    async def publish(self, *args, **kwargs):
+        pass
+
+
+async def main() -> None:
+    args = sys.argv[1:]
+    step = args[0] if args else "all"
+
+    config = load_config()
+    skill_config = SkillConfig()
+    init(config, skill_config)
+    ctx = _SmokeCtx(config)
+
+    if step in ("cookies", "all"):
+        await step_cookies(config, skill_config)
+
+    books: list = []
+    if step in ("list", "all"):
+        books = await step_list(ctx)
+
+    if step == "fetch":
+        if len(args) < 2:
+            print("usage: smoke.py fetch <asin>")
+            sys.exit(2)
+        await step_fetch(ctx, args[1])
+
+    if step == "sync":
+        if len(args) < 2:
+            print("usage: smoke.py sync <asin>")
+            sys.exit(2)
+        await step_sync(ctx, args[1])
+
+    if step == "sync-all":
+        await step_sync_all(ctx)
+
+    if step == "enabled-gate":
+        await step_enabled_gate(config)
+
+    if step == "all":
+        print("\n=== smoke OK ===")
+        print("Next: pick an ASIN from the list above and run:")
+        print("  uv run python contrib/skills/kindle/smoke.py fetch <ASIN>")
+        print("  uv run python contrib/skills/kindle/smoke.py sync <ASIN>")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/contrib/skills/kindle/test_tools.py
+++ b/contrib/skills/kindle/test_tools.py
@@ -1,0 +1,1644 @@
+"""Tests for the contrib kindle skill (loaded via importlib)."""
+
+from __future__ import annotations
+
+import http.cookiejar
+import importlib.util
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load tools.py via importlib — mirroring the production skill loader.
+# ---------------------------------------------------------------------------
+
+_THIS_DIR = Path(__file__).parent
+_tools_spec = importlib.util.spec_from_file_location(
+    "decafclaw_contrib_kindle_tools", _THIS_DIR / "tools.py"
+)
+assert _tools_spec is not None and _tools_spec.loader is not None
+kindle_tools = importlib.util.module_from_spec(_tools_spec)
+# Register under a stable name so monkeypatch.setattr(kindle_tools, ...) and
+# dataclass round-trips work correctly.
+sys.modules["decafclaw_contrib_kindle_tools"] = kindle_tools
+_tools_spec.loader.exec_module(kindle_tools)
+
+# Re-export the names that test functions use, as if this were a regular import.
+SkillConfig = kindle_tools.SkillConfig
+init = kindle_tools.init
+BookSummary = kindle_tools.BookSummary
+HighlightEntry = kindle_tools.HighlightEntry
+_resolve_cookies_path = kindle_tools._resolve_cookies_path
+_load_cookie_jar = kindle_tools._load_cookie_jar
+_cookie_file_age_days = kindle_tools._cookie_file_age_days
+_make_session = kindle_tools._make_session
+_parse_books_list = kindle_tools._parse_books_list
+_parse_highlights = kindle_tools._parse_highlights
+_slug = kindle_tools._slug
+_book_page_path = kindle_tools._book_page_path
+_upsert_book_page = kindle_tools._upsert_book_page
+book_to_dict = kindle_tools.book_to_dict
+highlight_to_dict = kindle_tools.highlight_to_dict
+
+# ---------------------------------------------------------------------------
+# Blocker 1: skill-loader pipeline registers the skill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kindle_skill_registers_via_loader(ctx):
+    """kindle skill must be discoverable and activatable via the skill-loader
+    pipeline after it's added to extra_skill_paths. This guards against
+    missing SKILL.md, tools.py, or missing exports.
+    """
+    from decafclaw.skills import discover_skills
+    from decafclaw.tools.skill_tools import activate_skill_internal
+
+    # Point extra_skill_paths at the contrib skill directory so the loader finds it.
+    ctx.config.extra_skill_paths = [str(_THIS_DIR)]
+
+    skills = discover_skills(ctx.config)
+    kindle_info = next((s for s in skills if s.name == "kindle"), None)
+    assert kindle_info is not None, "kindle skill not found via extra_skill_paths"
+
+    # Has tools.py, so has_native_tools should be True
+    assert kindle_info.has_native_tools, "kindle skill should have tools.py"
+
+    # Activation should complete without errors
+    await activate_skill_internal(ctx, kindle_info)
+
+
+def test_skill_config_defaults():
+    """All SkillConfig fields should have correct defaults."""
+    cfg = SkillConfig()
+    assert cfg.enabled is False
+    assert cfg.cookies_path == ""
+    assert cfg.amazon_domain == "amazon.com"
+    assert cfg.vault_subfolder == "agent/pages/kindle"
+    assert cfg.sync_min_interval_seconds == 60
+    assert cfg.archive_deleted is True
+    assert (
+        cfg.user_agent
+        == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    )
+    assert cfg.cookies_warn_after_days == 300
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Cookie loading + curl_cffi session helper
+# ---------------------------------------------------------------------------
+
+
+def test_load_cookie_jar_reads_netscape_format():
+    """_load_cookie_jar should read a Netscape-format cookies.txt file."""
+    fixture_path = _THIS_DIR / "fixtures" / "cookies.txt"
+    jar = _load_cookie_jar(fixture_path)
+
+    # Verify that cookies were loaded
+    assert len(jar) == 2, f"Expected 2 cookies, got {len(jar)}"
+
+    # Verify specific cookies
+    cookies = {c.name: c.value for c in jar}
+    assert "at-main" in cookies
+    assert cookies["at-main"] == "dummy-value-1"
+    assert "sess-at-main" in cookies
+    assert cookies["sess-at-main"] == "dummy-value-2"
+
+
+def test_load_cookie_jar_missing_file_raises():
+    """_load_cookie_jar should raise FileNotFoundError for missing file."""
+    missing_path = Path("/tmp/nonexistent-cookies-12345.txt")
+    with pytest.raises(FileNotFoundError, match="not found"):
+        _load_cookie_jar(missing_path)
+
+
+def test_resolve_cookies_path_default(ctx):
+    """_resolve_cookies_path should default to agent_path/secrets/kindle.cookies.txt."""
+    skill_config = SkillConfig(cookies_path="")
+    result = _resolve_cookies_path(ctx.config, skill_config)
+
+    expected = ctx.config.agent_path / "secrets" / "kindle.cookies.txt"
+    assert result == expected
+
+
+def test_resolve_cookies_path_relative_override(ctx):
+    """_resolve_cookies_path should resolve relative paths relative to agent_path."""
+    skill_config = SkillConfig(cookies_path="my/custom/cookies.txt")
+    result = _resolve_cookies_path(ctx.config, skill_config)
+
+    expected = ctx.config.agent_path / "my" / "custom" / "cookies.txt"
+    assert result == expected
+
+
+def test_resolve_cookies_path_absolute_override(tmp_path):
+    """_resolve_cookies_path should use absolute paths unchanged."""
+    from dataclasses import dataclass
+
+    # Create a minimal config mock with agent_path
+    @dataclass
+    class MockConfig:
+        agent_path: Path
+
+    config = MockConfig(agent_path=tmp_path / "agent")
+    skill_config = SkillConfig(cookies_path=str(tmp_path / "absolute" / "cookies.txt"))
+
+    result = _resolve_cookies_path(config, skill_config)
+
+    # For absolute paths, should use them as-is
+    expected = Path(str(tmp_path / "absolute" / "cookies.txt"))
+    assert result == expected
+
+
+def test_make_session_uses_chrome_impersonation():
+    """_make_session should construct an AsyncSession with chrome131 impersonation."""
+    jar = http.cookiejar.MozillaCookieJar()
+    user_agent = "Test User Agent"
+
+    session = _make_session(jar, user_agent)
+
+    # Verify session was created
+    assert session is not None
+    assert hasattr(session, "headers")
+    assert session.headers["User-Agent"] == user_agent
+
+    # Verify impersonate attribute is set
+    assert hasattr(session, "impersonate")
+    assert session.impersonate == "chrome131"
+
+
+def test_cookie_file_age_days(tmp_path):
+    """_cookie_file_age_days should return the age of a cookie file in days."""
+    # Create a test file
+    test_file = tmp_path / "test_cookies.txt"
+    test_file.write_text("# test")
+
+    # Modify its mtime to be 2 days old (172800 seconds)
+    now = time.time()
+    old_time = now - (2 * 86400)  # 2 days ago
+    os.utime(test_file, (old_time, old_time))
+
+    age_days = _cookie_file_age_days(test_file)
+
+    # Should be approximately 2 days old (allow 0.1 day tolerance for test execution time)
+    assert 1.9 < age_days < 2.1, f"Expected age ~2 days, got {age_days}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: HTML parsers — books list
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_PATH = _THIS_DIR / "fixtures" / "notebook_page.html"
+
+
+def test_parse_books_list_basic():
+    """_parse_books_list should return 4 books from the test fixture."""
+    html = _FIXTURE_PATH.read_text()
+    books = _parse_books_list(html)
+
+    assert len(books) >= 4, f"Expected at least 4 books, got {len(books)}"
+
+    # All entries must be BookSummary instances with non-empty ASINs.
+    for book in books:
+        assert isinstance(book, BookSummary)
+        assert book.asin, f"Book has empty ASIN: {book!r}"
+
+    # Assert a specific known (asin, title) pair from the fixture.
+    asins = {b.asin: b for b in books}
+    assert "B078VWDNKT" in asins, "Expected ASIN B078VWDNKT not found"
+    assert asins["B078VWDNKT"].title == "Sample Book One"
+    assert asins["B078VWDNKT"].author == "Author One"
+    assert asins["B078VWDNKT"].cover_url != ""
+
+    # Second book
+    assert "B09G14BQMM" in asins
+    assert asins["B09G14BQMM"].title == "Sample Book Two"
+
+
+def test_parse_books_list_empty():
+    """_parse_books_list should return [] for HTML with no book entries."""
+    books = _parse_books_list("<html><body></body></html>")
+    assert books == []
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: HTML parsers — highlights
+# ---------------------------------------------------------------------------
+
+
+def test_parse_highlights_basic():
+    """_parse_highlights should return 6 highlights from the test fixture."""
+    html = _FIXTURE_PATH.read_text()
+    entries = _parse_highlights(html)
+
+    assert len(entries) > 0, "Expected at least one highlight entry"
+
+    # All entries must be HighlightEntry with non-empty annotation_id.
+    for entry in entries:
+        assert isinstance(entry, HighlightEntry)
+        assert entry.annotation_id, f"Entry has empty annotation_id: {entry!r}"
+
+    # At least one entry must have a non-empty color.
+    colors = {e.color for e in entries}
+    assert colors - {""}, f"No entries with a non-empty color; colors={colors}"
+
+    # At least one entry must have non-empty text.
+    assert any(e.text for e in entries), "No entries with non-empty text"
+
+    # Fixture has one blue highlight — verify color extraction works.
+    blue_entries = [e for e in entries if e.color == "blue"]
+    assert len(blue_entries) == 1, f"Expected 1 blue highlight, got {len(blue_entries)}"
+    assert "Sample highlight text 5" in blue_entries[0].text
+
+
+def test_parse_highlights_empty():
+    """_parse_highlights should return [] for HTML with no annotations container."""
+    entries = _parse_highlights("<html><body></body></html>")
+    assert entries == []
+
+
+def test_parse_highlights_no_note():
+    """Highlights without a user note should have note == ''."""
+    html = _FIXTURE_PATH.read_text()
+    entries = _parse_highlights(html)
+
+    # The first annotation in the fixture has no note (aok-hidden empty span).
+    first_id_prefix = "QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDoyNDg0"
+    no_note = next(
+        (e for e in entries if e.annotation_id.startswith(first_id_prefix)), None
+    )
+    assert no_note is not None, "Could not find first annotation in parsed entries"
+    assert no_note.note == "", f"Expected empty note, got {no_note.note!r}"
+
+    # The sixth annotation has a note — verify it was extracted.
+    note_id_prefix = "QTNONVpPTk1aR044NUo6QjA3OFZXRE5LVDozNzQx"
+    with_note = next(
+        (e for e in entries if e.annotation_id.startswith(note_id_prefix)), None
+    )
+    assert with_note is not None, "Could not find annotated highlight in parsed entries"
+    assert with_note.note == "Sample note 1."
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Page upsert logic
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc)
+_TODAY = "2026-05-13"
+
+
+def _make_book(
+    asin: str = "B001TEST",
+    title: str = "Test Book",
+    author: str = "Test Author",
+    cover_url: str = "https://example.com/cover.jpg",
+):
+    return BookSummary(asin=asin, title=title, author=author, cover_url=cover_url)
+
+
+def _make_highlight(
+    annotation_id: str,
+    location: str = "100",
+    color: str = "yellow",
+    text: str = "Sample text",
+    note: str = "",
+):
+    return HighlightEntry(
+        annotation_id=annotation_id,
+        location=location,
+        color=color,
+        text=text,
+        note=note,
+    )
+
+
+def test_upsert_new_page():
+    """Empty existing_md + 2 fresh highlights → frontmatter + 2 Highlights, no Archived."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", location="10", text="First highlight")
+    h2 = _make_highlight("ANN002", location="20", text="Second highlight")
+    book = _make_book()
+
+    result = _upsert_book_page("", [h1, h2], book, _NOW)
+
+    metadata, body = parse_frontmatter(result)
+
+    # Frontmatter present with required fields
+    assert metadata["asin"] == "B001TEST"
+    assert metadata["title"] == "Test Book"
+    assert metadata["author"] == "Test Author"
+    assert metadata["highlight_count"] == 2
+
+    # Highlights section present
+    assert "## Highlights" in body
+    assert "ANN001" in body
+    assert "ANN002" in body
+    assert "First highlight" in body
+    assert "Second highlight" in body
+
+    # No Archived section
+    assert "## Archived" not in body
+
+
+def test_upsert_updates_existing_highlight():
+    """Existing page H1 with old text; fresh H1 with new text (same ID) → new text only."""
+    # Build an existing page with H1 having old text
+    existing_h1 = _make_highlight("ANN001", location="10", text="Old highlight text")
+    existing_page = _upsert_book_page("", [existing_h1], _make_book(), _NOW)
+
+    # Fresh: same ID but updated text
+    fresh_h1 = _make_highlight("ANN001", location="10", text="New highlight text")
+    result = _upsert_book_page(existing_page, [fresh_h1], _make_book(), _NOW)
+
+    assert "New highlight text" in result
+    assert "Old highlight text" not in result
+
+
+def test_upsert_inserts_new_highlight():
+    """Existing has H1; fresh has H1+H2. Both present, in fresh order."""
+    h1 = _make_highlight("ANN001", location="10", text="First highlight")
+    existing_page = _upsert_book_page("", [h1], _make_book(), _NOW)
+
+    h2 = _make_highlight("ANN002", location="20", text="Second highlight")
+    result = _upsert_book_page(existing_page, [h1, h2], _make_book(), _NOW)
+
+    # Both highlights present
+    assert "First highlight" in result
+    assert "Second highlight" in result
+
+    # Order: H1 before H2 in the Highlights section
+    h1_pos = result.find("ANN001")
+    h2_pos = result.find("ANN002")
+    assert h1_pos < h2_pos, "H1 should appear before H2"
+
+
+def test_upsert_archives_deleted():
+    """Existing H1+H2; fresh has only H1. H1 in Highlights; H2 in Archived with today's date + strikethrough."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", location="10", text="Kept highlight")
+    h2 = _make_highlight("ANN002", location="20", text="Deleted highlight")
+    existing_page = _upsert_book_page("", [h1, h2], _make_book(), _NOW)
+
+    # Only h1 in fresh
+    result = _upsert_book_page(existing_page, [h1], _make_book(), _NOW, archive_deleted=True)
+    metadata, body = parse_frontmatter(result)
+
+    # H1 in active Highlights (before Archived section)
+    archived_pos = body.find("## Archived")
+    highlights_pos = body.find("## Highlights")
+    assert highlights_pos >= 0, "Highlights section missing"
+    assert archived_pos >= 0, "Archived section missing"
+
+    highlights_section = body[highlights_pos:archived_pos]
+    assert "ANN001" in highlights_section
+    assert "ANN002" not in highlights_section
+
+    # H2 in Archived with today's date and strikethrough
+    archived_section = body[archived_pos:]
+    assert "ANN002" in archived_section
+    assert f"archived {_TODAY}" in archived_section
+    assert "~~" in archived_section  # strikethrough
+
+    # Frontmatter archived_count
+    assert metadata["archived_count"] == 1
+
+
+def test_upsert_preserves_existing_archived_date():
+    """Previously-archived H3 (archived 2026-01-01); fresh has H1. H3 date preserved."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    old_archived_date = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Create a page with H1+H3, then archive H3 on 2026-01-01
+    h1 = _make_highlight("ANN001", location="10", text="Kept highlight")
+    h3 = _make_highlight("ANN003", location="30", text="Old archived")
+    page_v1 = _upsert_book_page("", [h1, h3], _make_book(), _NOW)
+    # Archive H3 by syncing with only H1 on the old date
+    page_v2 = _upsert_book_page(page_v1, [h1], _make_book(), old_archived_date, archive_deleted=True)
+
+    # Verify H3 was archived on 2026-01-01
+    _, body_v2 = parse_frontmatter(page_v2)
+    assert "archived 2026-01-01" in body_v2
+
+    # Now re-sync with H1 on today — H3 should still show 2026-01-01
+    result = _upsert_book_page(page_v2, [h1], _make_book(), _NOW, archive_deleted=True)
+    metadata, body = parse_frontmatter(result)
+
+    archived_section = body[body.find("## Archived"):]
+    assert "archived 2026-01-01" in archived_section
+    assert f"archived {_TODAY}" not in archived_section  # should NOT re-archive with today's date
+
+    # archived_count should include the preserved archived item
+    assert metadata["archived_count"] >= 1
+
+
+def test_upsert_archive_disabled_drops_deleted():
+    """archive_deleted=False: existing H1+H2, fresh H1. No Archived section; archived_count=0."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", location="10", text="Kept highlight")
+    h2 = _make_highlight("ANN002", location="20", text="Dropped highlight")
+    existing_page = _upsert_book_page("", [h1, h2], _make_book(), _NOW)
+
+    result = _upsert_book_page(existing_page, [h1], _make_book(), _NOW, archive_deleted=False)
+    metadata, body = parse_frontmatter(result)
+
+    assert "## Archived" not in body
+    assert metadata["archived_count"] == 0
+
+
+def test_upsert_frontmatter_fields():
+    """All required frontmatter fields present with correct values."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", text="Some text")
+    book = _make_book(
+        asin="B123",
+        title="My Book",
+        author="Jane Doe",
+        cover_url="https://example.com/cover.jpg",
+    )
+    result = _upsert_book_page("", [h1], book, _NOW)
+    metadata, _ = parse_frontmatter(result)
+
+    assert metadata["asin"] == "B123"
+    assert metadata["title"] == "My Book"
+    assert metadata["author"] == "Jane Doe"
+    assert metadata["cover_url"] == "https://example.com/cover.jpg"
+    assert "ingested" in metadata["tags"]
+    assert "kindle" in metadata["tags"]
+    assert metadata["highlight_count"] == 1
+    assert "last_synced" in metadata
+    assert metadata["last_synced"] == "2026-05-13T12:00:00+00:00"
+
+
+def test_slug_safe_for_filenames():
+    """_slug produces filesystem-safe strings."""
+    # Spaces become hyphens
+    assert _slug("Hello World") == "hello-world"
+
+    # Punctuation stripped/replaced
+    assert _slug("It's a Test!") == "it-s-a-test"
+
+    # Already lowercase, no change
+    assert _slug("simple") == "simple"
+
+    # Length cap: >60 chars truncated
+    long_title = "a" * 80
+    result = _slug(long_title)
+    assert len(result) <= 60
+
+    # Empty-ish → "untitled"
+    assert _slug("") == "untitled"
+    assert _slug("!!!") == "untitled"
+
+
+def test_upsert_empty_metadata_summary():
+    """Empty title AND empty author should produce sensible default summary (no double-space-by)."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", text="Sample text")
+    book = _make_book(
+        asin="B001EMPTY",
+        title="",  # Empty title
+        author="",  # Empty author
+        cover_url="",
+    )
+    result = _upsert_book_page("", [h1], book, _NOW)
+    metadata, _ = parse_frontmatter(result)
+
+    # Summary should be "Kindle highlights" with no trailing garbage like " by"
+    summary = metadata["summary"]
+    assert summary == "Kindle highlights", f"Expected 'Kindle highlights', got {summary!r}"
+    # Ensure no double-space or trailing "by"
+    assert "  " not in summary, f"Summary has double-space: {summary!r}"
+    assert not summary.endswith("by"), f"Summary should not end with 'by': {summary!r}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: HTTP fetch tools
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_session(html: str):
+    """Return a mock AsyncSession-like context manager that yields a session whose
+    .get() returns a response with .text=<html> and a no-op .raise_for_status()."""
+    response = MagicMock()
+    response.text = html
+    response.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.get = AsyncMock(return_value=response)
+    # async-context-manager protocol
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_kindle_list_books_happy_path(ctx, tmp_path, monkeypatch):
+    """kindle_list_books with mocked session returns books data from fixture HTML."""
+    fixture_html = _FIXTURE_PATH.read_text()
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    # Copy the fixture cookies file so it exists
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        lambda jar, ua: _make_mock_session(fixture_html),
+    )
+
+    result = await kindle_tools.kindle_list_books(ctx)
+
+    assert result.data is not None
+    assert "books" in result.data
+    assert len(result.data["books"]) >= 4, f"Expected at least 4 books, got {result.data['books']}"
+    assert "Found" in result.text
+    assert "book" in result.text
+
+    # Verify structure of each book dict
+    for book in result.data["books"]:
+        assert "asin" in book
+        assert "title" in book
+        assert "author" in book
+        assert "cover_url" in book
+
+
+@pytest.mark.asyncio
+async def test_kindle_list_books_missing_cookies(ctx, tmp_path, monkeypatch):
+    """kindle_list_books returns an error if the cookies file doesn't exist."""
+    missing_cookies = tmp_path / "nonexistent" / "cookies.txt"
+    skill_config = SkillConfig(cookies_path=str(missing_cookies))
+    init(ctx.config, skill_config)
+
+    result = await kindle_tools.kindle_list_books(ctx)
+
+    assert result.text.startswith("[error: Kindle cookies file not found")
+
+
+@pytest.mark.asyncio
+async def test_kindle_list_books_warns_old_cookies(ctx, tmp_path, monkeypatch):
+    """kindle_list_books warns when the cookies file is older than cookies_warn_after_days."""
+    fixture_html = _FIXTURE_PATH.read_text()
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    # Touch mtime to ~400 days ago
+    epoch = time.time() - (400 * 86400)
+    os.utime(cookies_file, (epoch, epoch))
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file), cookies_warn_after_days=300)
+    init(ctx.config, skill_config)
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        lambda jar, ua: _make_mock_session(fixture_html),
+    )
+
+    result = await kindle_tools.kindle_list_books(ctx)
+
+    assert "Warning" in result.text
+    assert result.data is not None
+    assert result.data["cookies_age_days"] >= 400
+
+
+@pytest.mark.asyncio
+async def test_kindle_fetch_highlights_happy_path(ctx, tmp_path, monkeypatch):
+    """kindle_fetch_highlights with mocked session returns highlight data from fixture HTML."""
+    fixture_html = _FIXTURE_PATH.read_text()
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        lambda jar, ua: _make_mock_session(fixture_html),
+    )
+
+    result = await kindle_tools.kindle_fetch_highlights(ctx, asin="B078VWDNKT")
+
+    assert result.data is not None
+    assert "highlights" in result.data
+    assert result.data["asin"] == "B078VWDNKT"
+    assert len(result.data["highlights"]) > 0
+
+    # Verify structure of each highlight dict
+    for hl in result.data["highlights"]:
+        assert "annotation_id" in hl
+        assert "location" in hl
+        assert "color" in hl
+        assert "text" in hl
+        assert "note" in hl
+
+    assert "Found" in result.text
+
+
+@pytest.mark.asyncio
+async def test_kindle_fetch_highlights_http_error(ctx, tmp_path, monkeypatch):
+    """kindle_fetch_highlights returns an error when the HTTP request fails."""
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    # Mock session whose .get() raises an exception
+    failing_session = MagicMock()
+    failing_session.get = AsyncMock(side_effect=RuntimeError("connection refused"))
+    failing_cm = MagicMock()
+    failing_cm.__aenter__ = AsyncMock(return_value=failing_session)
+    failing_cm.__aexit__ = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        lambda jar, ua: failing_cm,
+    )
+
+    result = await kindle_tools.kindle_fetch_highlights(ctx, asin="B078VWDNKT")
+
+    assert result.text.startswith("[error: failed to fetch highlights for B078VWDNKT")
+
+
+@pytest.mark.asyncio
+async def test_kindle_tools_register_via_skill_loader(ctx):
+    """After activation, ctx.tools.extra should contain both kindle tool functions."""
+    from decafclaw.skills import discover_skills
+    from decafclaw.tools.skill_tools import activate_skill_internal
+
+    ctx.config.extra_skill_paths = [str(_THIS_DIR)]
+
+    skills = discover_skills(ctx.config)
+    kindle_info = next((s for s in skills if s.name == "kindle"), None)
+    assert kindle_info is not None
+
+    await activate_skill_internal(ctx, kindle_info)
+
+    assert "kindle_list_books" in ctx.tools.extra, (
+        f"kindle_list_books not in ctx.tools.extra; keys={list(ctx.tools.extra.keys())}"
+    )
+    assert "kindle_fetch_highlights" in ctx.tools.extra, (
+        f"kindle_fetch_highlights not in ctx.tools.extra; keys={list(ctx.tools.extra.keys())}"
+    )
+
+    # Also check that TOOL_DEFINITIONS are registered
+    def_names = {d["function"]["name"] for d in ctx.tools.extra_definitions}
+    assert "kindle_list_books" in def_names
+    assert "kindle_fetch_highlights" in def_names
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: kindle_sync_book — single-book end-to-end
+# ---------------------------------------------------------------------------
+
+# Helpers reused across Phase 6 tests
+
+
+def _make_sync_mock_session(list_html: str, highlights_html: str = ""):
+    """Mock session for kindle_sync_book: first .get() returns list HTML,
+    second returns highlights HTML (falls back to list_html if not provided)."""
+    if not highlights_html:
+        highlights_html = list_html
+    list_response = MagicMock()
+    list_response.text = list_html
+    list_response.raise_for_status = MagicMock()
+    hl_response = MagicMock()
+    hl_response.text = highlights_html
+    hl_response.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.get = AsyncMock(side_effect=[list_response, hl_response])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _make_single_book_html(asin: str, title: str, author: str) -> str:
+    """Minimal HTML with one book entry and one highlight for integration tests."""
+    return f"""<html><body>
+<div class="kp-notebook-library-each-book" id="{asin}">
+  <h2 class="kp-notebook-searchable">{title}</h2>
+  <p class="kp-notebook-searchable">By: {author}</p>
+  <img class="kp-notebook-cover-image-border" src="https://example.com/cover.jpg" />
+</div>
+<div id="kp-notebook-annotations">
+  <div id="ANN_H1_001">
+    <span id="annotationHighlightHeader">Header</span>
+    <input id="kp-annotation-location" value="100" />
+    <div class="kp-notebook-highlight-yellow"></div>
+    <span id="highlight">First highlight text</span>
+    <span id="note"></span>
+  </div>
+  <div id="ANN_H2_002">
+    <span id="annotationHighlightHeader">Header</span>
+    <input id="kp-annotation-location" value="200" />
+    <div class="kp-notebook-highlight-blue"></div>
+    <span id="highlight">Second highlight text</span>
+    <span id="note">A note here</span>
+  </div>
+</div>
+</body></html>"""
+
+
+def _make_single_highlight_html(asin: str, title: str, author: str) -> str:
+    """HTML with only the first highlight (H2 removed — simulates Amazon deletion)."""
+    return f"""<html><body>
+<div class="kp-notebook-library-each-book" id="{asin}">
+  <h2 class="kp-notebook-searchable">{title}</h2>
+  <p class="kp-notebook-searchable">By: {author}</p>
+  <img class="kp-notebook-cover-image-border" src="https://example.com/cover.jpg" />
+</div>
+<div id="kp-notebook-annotations">
+  <div id="ANN_H1_001">
+    <span id="annotationHighlightHeader">Header</span>
+    <input id="kp-annotation-location" value="100" />
+    <div class="kp-notebook-highlight-yellow"></div>
+    <span id="highlight">First highlight text</span>
+    <span id="note"></span>
+  </div>
+</div>
+</body></html>"""
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_first_run(ctx, tmp_path, monkeypatch):
+    """Fresh vault, no existing page. Vault page created with correct frontmatter+body.
+
+    Summary says '2 new, 0 re-checked, 0 archived'.
+    """
+    from decafclaw.frontmatter import parse_frontmatter
+
+    asin = "B001SYNCTEST"
+    title = "Sync Test Book"
+    author = "Test Author"
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    html = _make_single_book_html(asin, title, author)
+
+    def _mock_session_factory(jar, ua):
+        return _make_sync_mock_session(html, html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory)
+
+    result = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    assert "2 new" in result.text, f"Expected '2 new' in: {result.text}"
+    assert "0 archived" in result.text, f"Expected '0 archived' in: {result.text}"
+    assert result.data is not None
+    assert result.data["asin"] == asin
+    assert result.data["new_count"] == 2
+    assert result.data["archived_count"] == 0
+
+    # Verify the vault page was actually created
+    book = BookSummary(asin=asin, title=title, author=author)
+    page_path_str = _book_page_path(skill_config, book)
+    vault_file = ctx.config.vault_root / page_path_str
+    assert vault_file.exists(), f"Expected vault page at {vault_file}"
+
+    content = vault_file.read_text()
+    metadata, body = parse_frontmatter(content)
+    assert metadata["asin"] == asin
+    assert metadata["title"] == title
+    assert metadata["author"] == author
+    assert metadata["highlight_count"] == 2
+    assert "## Highlights" in body
+    assert "ANN_H1_001" in body
+    assert "ANN_H2_002" in body
+    assert "## Archived" not in body
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_idempotent(ctx, tmp_path, monkeypatch):
+    """Sync twice without Amazon changes; page content identical except last_synced."""
+    from decafclaw.frontmatter import parse_frontmatter
+
+    asin = "B001IDEMTEST"
+    title = "Idempotent Book"
+    author = "Author Idem"
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    html = _make_single_book_html(asin, title, author)
+
+    call_count = 0
+
+    def _mock_session_factory(jar, ua):
+        nonlocal call_count
+        call_count += 1
+        return _make_sync_mock_session(html, html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory)
+
+    result1 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result1.text.startswith("[error:")
+
+    result2 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result2.text.startswith("[error:")
+
+    # Read the page after both syncs and compare content
+    book = BookSummary(asin=asin, title=title, author=author)
+    page_path_str = _book_page_path(skill_config, book)
+    vault_file = ctx.config.vault_root / page_path_str
+    assert vault_file.exists()
+
+    content_after_both = vault_file.read_text()
+    metadata, body = parse_frontmatter(content_after_both)
+
+    # Highlights section should be the same after both syncs
+    assert "ANN_H1_001" in body
+    assert "ANN_H2_002" in body
+    assert "## Archived" not in body
+
+    # Second sync: 0 new highlights
+    assert result2.data["new_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_archives_deleted(ctx, tmp_path, monkeypatch):
+    """Sync with H1+H2; then sync with only H1. H2 moves to Archived.
+
+    Summary says '0 new, 1 re-checked, 1 archived'.
+    """
+    from decafclaw.frontmatter import parse_frontmatter
+
+    asin = "B001ARCHTEST"
+    title = "Archive Test Book"
+    author = "Author Archive"
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file), archive_deleted=True)
+    init(ctx.config, skill_config)
+
+    full_html = _make_single_book_html(asin, title, author)
+    partial_html = _make_single_highlight_html(asin, title, author)
+
+    # First session: list + highlights both return full_html (H1+H2)
+    def _mock_session_factory_1(jar, ua):
+        return _make_sync_mock_session(full_html, full_html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory_1)
+
+    result1 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result1.text.startswith("[error:")
+    assert result1.data["new_count"] == 2
+
+    # Second round: list returns full_html (book still exists), highlights returns partial_html (only H1).
+    # kindle_sync_book calls _make_session twice — once for list, once for highlights.
+    # Use a stateful factory so the Nth _make_session invocation returns the right HTML.
+    _second_calls = []
+
+    def _mock_session_factory_2(jar, ua):
+        call_idx = len(_second_calls)
+        _second_calls.append(call_idx)
+        html_for_this_call = full_html if call_idx == 0 else partial_html
+        response = MagicMock()
+        response.text = html_for_this_call
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory_2)
+
+    result2 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result2.text.startswith("[error:"), f"Unexpected error: {result2.text}"
+
+    assert result2.data["archived_count"] == 1, f"Expected 1 archived, got {result2.data}"
+    assert "1 archived" in result2.text, f"Expected '1 archived' in: {result2.text}"
+
+    # Verify vault page: H1 in Highlights, H2 in Archived with strikethrough
+    book = BookSummary(asin=asin, title=title, author=author)
+    page_path_str = _book_page_path(skill_config, book)
+    vault_file = ctx.config.vault_root / page_path_str
+    content = vault_file.read_text()
+    metadata, body = parse_frontmatter(content)
+
+    archived_pos = body.find("## Archived")
+    highlights_pos = body.find("## Highlights")
+    assert highlights_pos >= 0
+    assert archived_pos >= 0
+
+    highlights_section = body[highlights_pos:archived_pos]
+    assert "ANN_H1_001" in highlights_section
+    assert "ANN_H2_002" not in highlights_section
+
+    archived_section = body[archived_pos:]
+    assert "ANN_H2_002" in archived_section
+    assert "~~" in archived_section  # strikethrough
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_no_double_archive_count(ctx, tmp_path, monkeypatch):
+    """archived_count must not re-count previously-archived entries on 3rd+ sync.
+
+    Regression: existing_ids regex used to scan the WHOLE existing page,
+    so previously-archived entries leaked back into 'archived this run' on every
+    subsequent sync.
+
+    Scenario:
+    - Run 1: H1 + H2 fresh. archived_count == 0.
+    - Run 2: only H1 fresh; H2 moves to ## Archived. archived_count == 1.
+    - Run 3: only H1 fresh again; H2 should STILL be in ## Archived
+             BUT the return summary's archived_count must be 0 (no new deletions).
+    """
+    asin = "B001ARCHIVE_REGRESS"
+    title = "Archive Regression Book"
+    author = "Regression Author"
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file), archive_deleted=True)
+    init(ctx.config, skill_config)
+
+    full_html = _make_single_book_html(asin, title, author)
+    partial_html = _make_single_highlight_html(asin, title, author)
+
+    # Run 1: H1 + H2
+    def _mock_session_factory_1(jar, ua):
+        return _make_sync_mock_session(full_html, full_html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory_1)
+    result1 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result1.text.startswith("[error:")
+    assert result1.data["archived_count"] == 0
+
+    # Run 2: only H1
+    _second_calls = []
+
+    def _mock_session_factory_2(jar, ua):
+        call_idx = len(_second_calls)
+        _second_calls.append(call_idx)
+        html_for_this_call = full_html if call_idx == 0 else partial_html
+        response = MagicMock()
+        response.text = html_for_this_call
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory_2)
+    result2 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result2.text.startswith("[error:")
+    assert result2.data["archived_count"] == 1, f"Run 2: expected 1 archived, got {result2.data}"
+
+    # Run 3: only H1 again — no new deletions, so archived_count must be 0
+    _third_calls = []
+
+    def _mock_session_factory_3(jar, ua):
+        call_idx = len(_third_calls)
+        _third_calls.append(call_idx)
+        html_for_this_call = full_html if call_idx == 0 else partial_html
+        response = MagicMock()
+        response.text = html_for_this_call
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory_3)
+    result3 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result3.text.startswith("[error:")
+    assert (
+        result3.data["archived_count"] == 0
+    ), f"Run 3: expected 0 archived (no new deletions), but got {result3.data['archived_count']}"
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_unknown_asin(ctx, tmp_path, monkeypatch):
+    """Books list doesn't contain the requested ASIN; returns an error."""
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file))
+    init(ctx.config, skill_config)
+
+    # HTML has a different ASIN, not B999UNKNOWN
+    html = _make_single_book_html("B001OTHER", "Other Book", "Other Author")
+
+    def _mock_session_factory(jar, ua):
+        return _make_sync_mock_session(html, html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_session_factory)
+
+    result = await kindle_tools.kindle_sync_book(ctx, asin="B999UNKNOWN")
+
+    assert result.text.startswith("[error: ASIN"), f"Expected ASIN error, got: {result.text}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 regression: _upsert_book_page archived-section order is deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_archived_section_order_is_deterministic():
+    """Two calls with identical inputs must produce byte-identical output.
+
+    This guards against set hash-randomized iteration order for ``newly_archived``
+    that was present before the sorted() fix.  We use two highlights so that the
+    set has at least two elements and order can actually differ across runs.
+    """
+    from decafclaw.frontmatter import parse_frontmatter
+
+    h1 = _make_highlight("ANN001", location="10", text="Keep this")
+    h2 = _make_highlight("ANN002", location="20", text="Delete me alpha")
+    h3 = _make_highlight("ANN003", location="30", text="Delete me beta")
+    book = _make_book()
+
+    # Build a page with all three highlights
+    existing_page = _upsert_book_page("", [h1, h2, h3], book, _NOW)
+
+    # Sync with only h1 → h2 and h3 become newly_archived (a 2-element set)
+    result_a = _upsert_book_page(existing_page, [h1], book, _NOW, archive_deleted=True)
+    result_b = _upsert_book_page(existing_page, [h1], book, _NOW, archive_deleted=True)
+
+    assert result_a == result_b, (
+        "Two identical _upsert_book_page calls produced different output — "
+        "archived section ordering is non-deterministic."
+    )
+
+    # Also verify the archived section contains both IDs in sorted order
+    _, body = parse_frontmatter(result_a)
+    archived_pos = body.find("## Archived")
+    assert archived_pos >= 0
+    archived_section = body[archived_pos:]
+    pos_ann002 = archived_section.find("ANN002")
+    pos_ann003 = archived_section.find("ANN003")
+    assert pos_ann002 >= 0 and pos_ann003 >= 0
+    assert pos_ann002 < pos_ann003, "Archived entries must appear in sorted(annotation_id) order"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 regression: archived_count in tool result is 0 when archive_deleted=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_book_archive_disabled_tool_result_archived_count_zero(
+    ctx, tmp_path, monkeypatch
+):
+    """With archive_deleted=False, the tool-result archived_count must be 0.
+
+    Even if Amazon deleted a highlight (it would appear in existing_ids - fresh_ids),
+    the tool should report archived_count=0 rather than the raw deletion count.
+    """
+    asin = "B001ARCHDISABLED"
+    title = "Archive Disabled Book"
+    author = "Test Author"
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(cookies_path=str(cookies_file), archive_deleted=False)
+    init(ctx.config, skill_config)
+
+    full_html = _make_single_book_html(asin, title, author)
+    partial_html = _make_single_highlight_html(asin, title, author)
+
+    # First sync: H1 + H2
+    def _mock_full(jar, ua):
+        return _make_sync_mock_session(full_html, full_html)
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_full)
+    result1 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result1.text.startswith("[error:")
+
+    # Second sync: only H1 (H2 deleted on Amazon). archive_deleted=False means it's silently dropped.
+    _calls: list[int] = []
+
+    def _mock_partial(jar, ua):
+        idx = len(_calls)
+        _calls.append(idx)
+        # With book= param, kindle_sync_book no longer calls list; just highlights
+        response = MagicMock()
+        response.text = partial_html
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _mock_partial)
+    result2 = await kindle_tools.kindle_sync_book(ctx, asin=asin)
+    assert not result2.text.startswith("[error:")
+
+    # Key assertion: archived_count must be 0 (not 1) when archive_deleted=False
+    assert result2.data["archived_count"] == 0, (
+        f"Expected archived_count=0 with archive_deleted=False, got {result2.data['archived_count']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 regression: kindle_sync_all makes N+1 _make_session calls, not 2N+1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_session_count_n_plus_1(ctx, tmp_path, monkeypatch):
+    """kindle_sync_all should make exactly N+1 _make_session calls for N books.
+
+    Before Fix 3, kindle_sync_book always called kindle_list_books internally,
+    making 2N+1 total calls (1 initial list + 2 per book).  After the fix,
+    kindle_sync_all passes the already-known BookSummary to kindle_sync_book,
+    so each book needs only 1 highlights fetch → N+1 total.
+    """
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    books_info = [
+        ("B001CNT1", "Count Book One", "Author A"),
+        ("B001CNT2", "Count Book Two", "Author B"),
+        ("B001CNT3", "Count Book Three", "Author C"),
+    ]
+    skill_config = SkillConfig(
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=0,
+    )
+    init(ctx.config, skill_config)
+
+    list_html = _make_multi_book_list_html(books_info)
+
+    session_call_count = 0
+
+    def _counting_factory(jar, ua):
+        nonlocal session_call_count
+        session_call_count += 1
+        response = MagicMock()
+        response.text = list_html
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(kindle_tools, "_make_session", _counting_factory)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    n_books = len(books_info)
+    expected_calls = n_books + 1  # 1 initial list + N highlights fetches
+    assert session_call_count == expected_calls, (
+        f"Expected {expected_calls} _make_session calls for {n_books} books, "
+        f"got {session_call_count}. kindle_sync_all is making redundant list fetches."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: kindle_sync_all — multi-book orchestrator + journal
+# ---------------------------------------------------------------------------
+
+# HTML helpers for multi-book sync tests
+
+def _make_multi_book_list_html(books: list[tuple[str, str, str]]) -> str:
+    """Build a books-list HTML with multiple book entries.
+
+    books: list of (asin, title, author)
+    """
+    entries = []
+    for asin, title, author in books:
+        entries.append(f"""
+<div class="kp-notebook-library-each-book" id="{asin}">
+  <h2 class="kp-notebook-searchable">{title}</h2>
+  <p class="kp-notebook-searchable">By: {author}</p>
+  <img class="kp-notebook-cover-image-border" src="https://example.com/{asin}.jpg" />
+</div>""")
+    highlights = """
+<div id="kp-notebook-annotations">
+  <div id="ANN_MULTI_001">
+    <span id="annotationHighlightHeader">Header</span>
+    <input id="kp-annotation-location" value="100" />
+    <div class="kp-notebook-highlight-yellow"></div>
+    <span id="highlight">Highlight text</span>
+    <span id="note"></span>
+  </div>
+</div>"""
+    return f"<html><body>{''.join(entries)}{highlights}</body></html>"
+
+
+def _make_session_sequence(responses: list[str]):
+    """Return a factory that hands out sessions one at a time, each returning
+    the corresponding HTML string from ``responses``.
+
+    Each session is a fresh async context manager that returns a mock session
+    whose ``.get()`` returns the given HTML.
+    """
+    iterator = iter(responses)
+
+    def factory(jar, ua):
+        html = next(iterator)
+        response = MagicMock()
+        response.text = html
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_happy_path(ctx, tmp_path, monkeypatch):
+    """3 books each with 1 highlight. All succeed.
+
+    Asserts: books_synced=3, new_total=3, journal file contains expected content.
+    """
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    books_info = [
+        ("B001SYNC1", "Book One", "Author A"),
+        ("B001SYNC2", "Book Two", "Author B"),
+        ("B001SYNC3", "Book Three", "Author C"),
+    ]
+    skill_config = SkillConfig(
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=0,
+    )
+    init(ctx.config, skill_config)
+
+    # Build response sequence (N+1 after Fix 3 — no per-book list fetch):
+    # Call 0: kindle_sync_all -> kindle_list_books (all 3 books)
+    # Call 1: kindle_sync_book(B001SYNC1) -> kindle_fetch_highlights
+    # Call 2: kindle_sync_book(B001SYNC2) -> kindle_fetch_highlights
+    # Call 3: kindle_sync_book(B001SYNC3) -> kindle_fetch_highlights
+    list_html = _make_multi_book_list_html(books_info)
+    responses = [list_html] * 4  # 1 initial + 1 highlights per book × 3 books
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        _make_session_sequence(responses),
+    )
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    assert result.data is not None
+    assert result.data["books_synced"] == 3, f"Expected 3, got {result.data}"
+    assert result.data["books_total"] == 3
+    assert result.data["new_total"] == 3, f"Expected new_total=3, got {result.data}"
+    assert result.data["archived_total"] == 0
+    assert result.data["failures"] == []
+
+    # Check journal was written
+    from datetime import date
+
+    today = date.today()
+    journal_path = (
+        ctx.config.vault_root
+        / "agent"
+        / "journal"
+        / str(today.year)
+        / f"{today}.md"
+    )
+    assert journal_path.exists(), f"Expected journal at {journal_path}"
+    journal_content = journal_path.read_text()
+    assert "Kindle sync run" in journal_content
+    assert "Books processed: 3 / 3" in journal_content
+    assert "New highlights: 3" in journal_content
+    assert "Failures: 0" in journal_content
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_partial_failure(ctx, tmp_path, monkeypatch):
+    """Middle book's highlights fetch raises; first and third succeed.
+
+    Asserts: 2 books succeed, 1 in failures list, journal entry mentions failure.
+    """
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    books_info = [
+        ("B001PFAIL1", "Book One", "Author A"),
+        ("B001PFAIL2", "Book Two Fail", "Author B"),
+        ("B001PFAIL3", "Book Three", "Author C"),
+    ]
+    skill_config = SkillConfig(
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=0,
+    )
+    init(ctx.config, skill_config)
+
+    list_html = _make_multi_book_list_html(books_info)
+
+    # Build a failing response for book 2's highlights fetch.
+    # After Fix 3, kindle_sync_all passes the BookSummary to kindle_sync_book,
+    # so there's no per-book list fetch.  Response sequence is now N+1:
+    # 0: sync_all -> list_books (all 3)
+    # 1: sync_book(B001PFAIL1) -> highlights OK
+    # 2: sync_book(B001PFAIL2) -> highlights raises (simulated failure)
+    # 3: sync_book(B001PFAIL3) -> highlights OK
+
+    call_idx = 0
+
+    def _failing_factory(jar, ua):
+        nonlocal call_idx
+        idx = call_idx
+        call_idx += 1
+
+        if idx == 2:
+            # Book 2 highlights: raise to simulate network failure
+            session = MagicMock()
+            session.get = AsyncMock(side_effect=RuntimeError("simulated fetch error"))
+            cm = MagicMock()
+            cm.__aenter__ = AsyncMock(return_value=session)
+            cm.__aexit__ = AsyncMock(return_value=None)
+            return cm
+
+        response = MagicMock()
+        response.text = list_html
+        response.raise_for_status = MagicMock()
+        session = MagicMock()
+        session.get = AsyncMock(return_value=response)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=None)
+        return cm
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        _failing_factory,
+    )
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    assert result.data is not None
+    assert result.data["books_synced"] == 2, f"Expected 2, got {result.data}"
+    assert len(result.data["failures"]) == 1, f"Expected 1 failure, got {result.data}"
+    # The failure should be for the middle book
+    failed_asin = result.data["failures"][0][0]
+    assert failed_asin == "B001PFAIL2", f"Expected B001PFAIL2 in failures, got {failed_asin}"
+
+    # Journal should mention the failure
+    from datetime import date
+
+    today = date.today()
+    journal_path = (
+        ctx.config.vault_root
+        / "agent"
+        / "journal"
+        / str(today.year)
+        / f"{today}.md"
+    )
+    assert journal_path.exists(), f"Expected journal at {journal_path}"
+    journal_content = journal_path.read_text()
+    assert "Failures: 1" in journal_content
+    assert "B001PFAIL2" in journal_content
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_rate_limit(ctx, tmp_path, monkeypatch):
+    """With 3 books and sync_min_interval_seconds=10, sleep is called exactly twice with arg 10."""
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    books_info = [
+        ("B001RL1", "Rate Limit Book 1", "Author A"),
+        ("B001RL2", "Rate Limit Book 2", "Author B"),
+        ("B001RL3", "Rate Limit Book 3", "Author C"),
+    ]
+    skill_config = SkillConfig(
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=10,
+    )
+    init(ctx.config, skill_config)
+
+    list_html = _make_multi_book_list_html(books_info)
+    responses = [list_html] * 4  # N+1 after Fix 3: 1 initial list + 1 highlights per book
+
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        _make_session_sequence(responses),
+    )
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+
+    # 3 books → sleep called exactly twice (before book 2 and book 3, not before book 1)
+    assert sleep_mock.call_count == 2, (
+        f"Expected sleep called 2 times, got {sleep_mock.call_count} calls: {sleep_mock.call_args_list}"
+    )
+    for call in sleep_mock.call_args_list:
+        args, kwargs = call
+        sleep_arg = args[0] if args else kwargs.get("delay", kwargs.get("seconds"))
+        assert sleep_arg == 10, f"Expected sleep(10), got sleep({sleep_arg})"
+
+
+# ---------------------------------------------------------------------------
+# Phase 8 fix: enabled-gate in kindle_sync_all (short-circuit for scheduled runs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_scheduled_gate_disabled(ctx, tmp_path):
+    """When ctx.task_mode == 'scheduled' AND enabled=False, kindle_sync_all returns
+    a no-op without doing any fetches. The gate short-circuits before any network call.
+    """
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(
+        enabled=False,  # Disabled
+        cookies_path=str(cookies_file),
+    )
+    init(ctx.config, skill_config)
+
+    # Set task_mode to 'scheduled' on the ctx
+    ctx.task_mode = "scheduled"
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    # Should return a no-op message with 'disabled' and 'skipping'
+    assert "disabled" in result.text.lower(), f"Expected 'disabled' in: {result.text}"
+    assert "skipping" in result.text.lower(), f"Expected 'skipping' in: {result.text}"
+    assert not result.text.startswith("[error:"), f"Should not be an error: {result.text}"
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_scheduled_gate_enabled_proceeds(ctx, tmp_path, monkeypatch):
+    """When ctx.task_mode == 'scheduled' AND enabled=True, kindle_sync_all proceeds
+    and attempts the fetch (mocked here).
+    """
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(
+        enabled=True,  # Enabled
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=0,
+    )
+    init(ctx.config, skill_config)
+
+    ctx.task_mode = "scheduled"
+
+    # Mock the session to return empty book list (no network call)
+    empty_list_html = '<div class="kp-notebook-library-each-book"></div>'
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        _make_session_sequence([empty_list_html]),
+    )
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    # Should proceed (gate did NOT trigger)
+    # With no books, it should report "Synced 0/0"
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    assert "0" in result.text, f"Should show 0 books: {result.text}"
+    assert "disabled" not in result.text.lower(), f"Gate should not trigger: {result.text}"
+
+
+@pytest.mark.asyncio
+async def test_kindle_sync_all_user_invocable_gate_bypassed(ctx, tmp_path, monkeypatch):
+    """When ctx.task_mode != 'scheduled' (e.g., empty or 'interactive'), the gate
+    does NOT trigger even if enabled=False. User-invocable paths bypass the gate.
+    """
+    import asyncio
+
+    cookies_file = tmp_path / "kindle.cookies.txt"
+    fixture_cookies = _THIS_DIR / "fixtures" / "cookies.txt"
+    cookies_file.write_text(fixture_cookies.read_text())
+
+    skill_config = SkillConfig(
+        enabled=False,  # Disabled
+        cookies_path=str(cookies_file),
+        sync_min_interval_seconds=0,
+    )
+    init(ctx.config, skill_config)
+
+    # Default ctx.task_mode is "" (empty string, interactive mode)
+    assert ctx.task_mode != "scheduled", f"Expected non-scheduled mode, got {ctx.task_mode!r}"
+
+    # Mock the session to return empty book list
+    empty_list_html = '<div class="kp-notebook-library-each-book"></div>'
+    monkeypatch.setattr(
+        kindle_tools, "_make_session",
+        _make_session_sequence([empty_list_html]),
+    )
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await kindle_tools.kindle_sync_all(ctx)
+
+    # Gate should NOT trigger because task_mode != "scheduled"
+    # Should proceed as normal
+    assert not result.text.startswith("[error:"), f"Unexpected error: {result.text}"
+    assert "disabled" not in result.text.lower(), f"Gate should not trigger in user-invocable mode: {result.text}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 8: SKILL.md frontmatter + schedule discovery
+# ---------------------------------------------------------------------------
+
+
+def test_skill_md_frontmatter_parses():
+    """SKILL.md frontmatter has all the expected fields wired for scheduled + user-invocable use."""
+    from decafclaw.skills import parse_skill_md
+
+    skill_md_path = _THIS_DIR / "SKILL.md"
+    info = parse_skill_md(skill_md_path)
+    assert info is not None, "Failed to parse SKILL.md"
+    assert info.name == "kindle"
+    assert info.schedule == "0 5 * * *"
+    assert info.user_invocable is True
+    # Allowed-tools should contain all 4 kindle tools + the vault read/write/list/journal ones + current_time
+    for required in (
+        "kindle_list_books", "kindle_fetch_highlights",
+        "kindle_sync_book", "kindle_sync_all",
+        "vault_read", "vault_write", "vault_list", "vault_journal_append", "current_time",
+    ):
+        assert required in info.allowed_tools, f"missing {required} in allowed_tools: {info.allowed_tools}"
+
+
+def test_skill_discovered_as_scheduled(monkeypatch, tmp_path):
+    """discover_schedules picks up the kindle contrib skill via extra_skill_paths.
+
+    Must patch run_schedule_task to a no-op per CLAUDE.md test-speed discipline.
+    """
+    from decafclaw.config import Config
+    from decafclaw.config_types import AgentConfig
+    from decafclaw.schedules import discover_schedules
+
+    monkeypatch.setattr("decafclaw.schedules.run_schedule_task", lambda *a, **kw: None)
+
+    # Point extra_skill_paths at this skill dir so discover_schedules finds it.
+    cfg = Config(
+        agent=AgentConfig(data_home=str(tmp_path), id="test-agent"),
+        extra_skill_paths=[str(_THIS_DIR)],
+    )
+    schedules = discover_schedules(cfg)
+    kindle = next((s for s in schedules if s.name == "kindle"), None)
+    assert kindle is not None, f"kindle not found in schedules: {[s.name for s in schedules]}"
+    assert kindle.schedule == "0 5 * * *"
+    assert kindle.source == "extra"

--- a/contrib/skills/kindle/tools.py
+++ b/contrib/skills/kindle/tools.py
@@ -1,0 +1,724 @@
+"""Kindle bundled skill — periodic ingest of Kindle highlights & notes."""
+
+import asyncio
+import http.cookiejar
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from curl_cffi.requests import AsyncSession
+
+from decafclaw.frontmatter import parse_frontmatter, serialize_frontmatter
+from decafclaw.media import ToolResult
+from decafclaw.skills.vault.tools import (
+    tool_vault_journal_append,
+    tool_vault_read,
+    tool_vault_write,
+)
+
+log = logging.getLogger(__name__)
+
+_config = None
+_skill_config: "SkillConfig | None" = None
+
+
+@dataclass
+class SkillConfig:
+    enabled: bool = field(
+        default=False, metadata={"env_alias": "KINDLE_ENABLED"}
+    )
+    cookies_path: str = field(
+        default="", metadata={"env_alias": "KINDLE_COOKIES_PATH"}
+    )
+    amazon_domain: str = field(
+        default="amazon.com", metadata={"env_alias": "KINDLE_AMAZON_DOMAIN"}
+    )
+    vault_subfolder: str = field(
+        default="agent/pages/kindle",
+        metadata={"env_alias": "KINDLE_VAULT_SUBFOLDER"},
+    )
+    sync_min_interval_seconds: int = field(
+        default=60, metadata={"env_alias": "KINDLE_SYNC_MIN_INTERVAL_SECONDS"}
+    )
+    archive_deleted: bool = field(
+        default=True, metadata={"env_alias": "KINDLE_ARCHIVE_DELETED"}
+    )
+    user_agent: str = field(
+        default=(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        ),
+        metadata={"env_alias": "KINDLE_USER_AGENT"},
+    )
+    cookies_warn_after_days: int = field(
+        default=300, metadata={"env_alias": "KINDLE_COOKIES_WARN_AFTER_DAYS"}
+    )
+
+
+def init(config, skill_config: SkillConfig) -> None:
+    """Initialize the kindle skill. Called by the skill loader on activation."""
+    global _config, _skill_config
+    _config = config
+    _skill_config = skill_config
+
+
+# TOOLS and TOOL_DEFINITIONS are populated at the bottom of this module
+# after the tool functions are defined.
+TOOLS: dict = {}
+TOOL_DEFINITIONS: list = []
+
+
+# ---------------------------------------------------------------------------
+# Auth substrate: cookie loading + curl_cffi session helper
+# ---------------------------------------------------------------------------
+
+
+def _resolve_cookies_path(config, skill_config: SkillConfig) -> Path:
+    """Resolve the cookies file path. Defaults to admin secrets directory if unset."""
+    if skill_config.cookies_path:
+        p = Path(skill_config.cookies_path)
+        return p if p.is_absolute() else config.agent_path / p
+    return config.agent_path / "secrets" / "kindle.cookies.txt"
+
+
+def _load_cookie_jar(path: Path) -> http.cookiejar.MozillaCookieJar:
+    """Load a Netscape cookies.txt file. Raises FileNotFoundError if missing."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Kindle cookies file not found: {path}")
+    jar = http.cookiejar.MozillaCookieJar(str(path))
+    jar.load(ignore_discard=True, ignore_expires=True)
+    return jar
+
+
+def _cookie_file_age_days(path: Path) -> float:
+    """Return how many days old the cookies file is, based on mtime."""
+    return (datetime.now().timestamp() - path.stat().st_mtime) / 86400.0
+
+
+def _make_session(
+    cookie_jar: http.cookiejar.MozillaCookieJar, user_agent: str
+) -> AsyncSession:
+    """Construct a curl_cffi AsyncSession with cookies + Chrome impersonation."""
+    return AsyncSession(
+        impersonate="chrome131",
+        headers={
+            "User-Agent": user_agent,
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept": "text/html,application/xhtml+xml,*/*;q=0.8",
+        },
+        cookies=cookie_jar,
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTML parsers: books list + highlights
+# ---------------------------------------------------------------------------
+
+_HIGHLIGHT_COLORS = frozenset({"yellow", "blue", "pink", "orange"})
+
+
+@dataclass
+class BookSummary:
+    asin: str
+    title: str
+    author: str
+    cover_url: str = ""
+    last_annotation_date: str = ""  # ISO-8601 or Amazon's date string; may be empty
+
+
+@dataclass
+class HighlightEntry:
+    annotation_id: str  # stable Amazon annotation ID (base64-encoded string)
+    location: str  # raw value from the location input, e.g. "166"
+    color: str  # "yellow" | "blue" | "pink" | "orange" | ""
+    text: str  # the highlighted passage
+    note: str = ""  # optional user note attached to the highlight
+
+
+def _parse_books_list(html: str) -> list[BookSummary]:
+    """Parse the read.amazon.com/notebook library pane.
+
+    Returns an ordered list of BookSummary objects, one per book entry found.
+    Each book entry in the page has class ``kp-notebook-library-each-book`` and
+    uses its ``id`` attribute as the ASIN.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    books: list[BookSummary] = []
+    for node in soup.select(".kp-notebook-library-each-book"):
+        asin = str(node.get("id") or "").strip()
+        if not asin:
+            continue
+        title_node = node.select_one("h2.kp-notebook-searchable")
+        author_node = node.select_one("p.kp-notebook-searchable")
+        cover_node = node.select_one("img.kp-notebook-cover-image-border")
+        if cover_node is None:
+            cover_node = node.select_one("img")
+        title = title_node.get_text(strip=True) if title_node else ""
+        author = author_node.get_text(strip=True) if author_node else ""
+        # Amazon renders "By: Author Name" — strip the prefix.
+        if author.lower().startswith("by:"):
+            author = author[3:].strip()
+        elif author.lower().startswith("by "):
+            author = author[3:].strip()
+        cover_url = str(cover_node.get("src") or "") if cover_node else ""
+        books.append(
+            BookSummary(asin=asin, title=title, author=author, cover_url=cover_url)
+        )
+    return books
+
+
+def _parse_highlights(html: str) -> list[HighlightEntry]:
+    """Parse a book's highlights pane from read.amazon.com/notebook.
+
+    Returns highlights in document order.  Each annotation row is identified by
+    the presence of an ``#annotationHighlightHeader`` span, which is only present
+    on genuine annotation entries (not wrapper divs or the empty-pane placeholder).
+    """
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[HighlightEntry] = []
+    container = soup.select_one("#kp-notebook-annotations")
+    if container is None:
+        return entries
+
+    for row in container.select("div[id]"):
+        # Only process divs that have the annotation header — this reliably
+        # distinguishes real annotation rows from wrapper/placeholder divs.
+        if row.select_one("#annotationHighlightHeader") is None:
+            continue
+        annotation_id = str(row.get("id") or "").strip()
+        if not annotation_id:
+            continue
+
+        # Location: stored as the value of a hidden <input id="kp-annotation-location">.
+        loc_input = row.select_one("input#kp-annotation-location")
+        location = str(loc_input.get("value") or "") if loc_input else ""
+
+        # Color: look for a descendant div with class kp-notebook-highlight-<color>.
+        color = ""
+        for elem in row.select("[class]"):
+            for cls in elem.get("class") or []:
+                if cls.startswith("kp-notebook-highlight-"):
+                    suffix = cls[len("kp-notebook-highlight-"):]
+                    if suffix in _HIGHLIGHT_COLORS:
+                        color = suffix
+                        break
+            if color:
+                break
+
+        # Highlight text: inside <span id="highlight"> (not the div with id="highlight-...").
+        text_node = row.select_one("span#highlight")
+        text = text_node.get_text(strip=True) if text_node else ""
+
+        # Note text: inside <span id="note">.  Only capture if non-empty — the note
+        # container exists on every row but is aok-hidden and empty when there's no note.
+        note_node = row.select_one("span#note")
+        note = note_node.get_text(strip=True) if note_node else ""
+
+        entries.append(
+            HighlightEntry(
+                annotation_id=annotation_id,
+                location=location,
+                color=color,
+                text=text,
+                note=note,
+            )
+        )
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Page upsert helpers
+# ---------------------------------------------------------------------------
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(title: str, max_len: int = 60) -> str:
+    """Lowercase + ASCII-fold-ish slug for page filenames."""
+    s = title.lower().strip()
+    s = _SLUG_RE.sub("-", s).strip("-")
+    return s[:max_len] or "untitled"
+
+
+def _book_page_path(skill_config: SkillConfig, book: BookSummary) -> str:
+    """Return the vault-relative page path for a book."""
+    subfolder = skill_config.vault_subfolder.rstrip("/")
+    return f"{subfolder}/{book.asin}-{_slug(book.title)}.md"
+
+
+def _format_highlight_section(entry: HighlightEntry, archived_date: str = "") -> str:
+    """Render one highlight (or archived highlight) as markdown. Marker first."""
+    marker = f"<!-- annotation-id: {entry.annotation_id} -->"
+    color = f" · *{entry.color}*" if entry.color else ""
+    if archived_date:
+        header = f"~~**{entry.location}**{color}~~ *(archived {archived_date})*"
+        body = f"> ~~{entry.text}~~"
+    else:
+        header = f"**{entry.location}**{color}"
+        body = f"> {entry.text}"
+    out = [marker, header, "", body]
+    if entry.note:
+        out.append("")
+        out.append(f"*Note:* {entry.note}")
+    return "\n".join(out)
+
+
+def _archive_format_block(highlight_block: str, archived_date: str) -> str:
+    """Convert a current-form rendered highlight block to its archived form."""
+    out = re.sub(
+        r"^\*\*(.+?)\*\*(.*?)$",
+        rf"~~**\1**\2~~ *(archived {archived_date})*",
+        highlight_block,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    out = re.sub(r"^> (.+)$", r"> ~~\1~~", out, count=1, flags=re.MULTILINE)
+    return out
+
+
+def _upsert_book_page(
+    existing_md: str,
+    fresh_highlights: list[HighlightEntry],
+    book: BookSummary,
+    now: datetime,
+    archive_deleted: bool = True,
+) -> str:
+    """Merge fresh highlights into an existing per-book page (or fresh-create).
+
+    Algorithm:
+      1. Parse existing frontmatter + body.
+      2. Detect existing annotation IDs (Highlights vs Archived sections).
+      3. Walk fresh in document order → emit ## Highlights section.
+      4. Newly-deleted (existing-not-in-fresh) → move to ## Archived with today's date.
+      5. Previously-archived → preserve in ## Archived with their original date.
+      6. Update frontmatter (counts, last_synced, etc.).
+    """
+    metadata, body = parse_frontmatter(existing_md or "")
+
+    # Index fresh
+    fresh_ids = {h.annotation_id for h in fresh_highlights}
+
+    # Split body at "## Archived"
+    archive_split = body.find("## Archived")
+    highlight_body = body[:archive_split] if archive_split >= 0 else body
+
+    existing_highlight_ids: set[str] = set()
+    for m in re.finditer(r"<!-- annotation-id: (\S+) -->", highlight_body):
+        existing_highlight_ids.add(m.group(1))
+
+    newly_archived = existing_highlight_ids - fresh_ids
+
+    # Render new Highlights section
+    sections: list[str] = ["## Highlights", ""]
+    for entry in fresh_highlights:
+        sections.append(_format_highlight_section(entry))
+        sections.append("")
+
+    # Extract previously-archived blocks (preserve original date)
+    archived_blocks: dict[str, str] = {}
+    if archive_split >= 0:
+        archived_md = body[archive_split:]
+        parts = re.split(r"(<!-- annotation-id: \S+ -->)", archived_md)
+        for i in range(1, len(parts) - 1, 2):
+            marker_line = parts[i]
+            block = (marker_line + parts[i + 1]).rstrip() + "\n"
+            id_match = re.match(r"<!-- annotation-id: (\S+) -->", marker_line)
+            if id_match:
+                archived_blocks[id_match.group(1)] = block
+
+    today = now.date().isoformat()
+    archived_section: list[str] = []
+    if archive_deleted:
+        # Preserve previously-archived items
+        for aid in sorted(archived_blocks.keys()):
+            archived_section.append(archived_blocks[aid].rstrip("\n"))
+            archived_section.append("")
+        # Newly-archived: extract block from prior Highlights and convert
+        for aid in sorted(newly_archived):
+            block_match = re.search(
+                rf"(<!-- annotation-id: {re.escape(aid)} -->.*?)(?=<!-- annotation-id: |\Z)",
+                highlight_body,
+                flags=re.DOTALL,
+            )
+            if block_match is None:
+                continue
+            original_block = block_match.group(1).rstrip()
+            archived_form = _archive_format_block(original_block, today)
+            archived_section.append(archived_form)
+            archived_section.append("")
+
+    full_sections = sections
+    if archived_section:
+        full_sections.append("## Archived")
+        full_sections.append("")
+        full_sections.extend(archived_section)
+
+    new_body = "\n".join(full_sections).rstrip() + "\n"
+
+    # Update metadata (avoid mutating the parsed input)
+    metadata = dict(metadata)
+    metadata["asin"] = book.asin
+    metadata["title"] = book.title
+    metadata["author"] = book.author
+    if book.cover_url:
+        metadata["cover_url"] = book.cover_url
+    metadata["tags"] = sorted(set((metadata.get("tags") or []) + ["ingested", "kindle"]))
+    metadata["highlight_count"] = len(fresh_highlights)
+    metadata["archived_count"] = (
+        len(archived_blocks) + len(newly_archived) if archive_deleted else 0
+    )
+    metadata["last_synced"] = now.replace(microsecond=0).isoformat()
+    # Embedding-retrieval defaults: only set if absent (user edits preserved).
+    parts = ["Kindle highlights"]
+    if book.title:
+        parts.append(f"from {book.title}")
+    if book.author:
+        parts.append(f"by {book.author}")
+    metadata.setdefault("summary", " ".join(parts))
+    metadata.setdefault("keywords", [])
+    metadata.setdefault("importance", 0.5)
+
+    return serialize_frontmatter(metadata, new_body)
+
+
+# ---------------------------------------------------------------------------
+# URL helpers + low-level network fetchers
+# ---------------------------------------------------------------------------
+
+
+def _notebook_url(domain: str, asin: str | None = None) -> str:
+    """URL for the books list (no asin) or a specific book's highlights (with asin).
+
+    Starting hypothesis:
+      books list: https://read.amazon.{tld}/notebook
+      book page:  https://read.amazon.{tld}/notebook?asin={asin}&contentLimitState=&
+    Verify the exact URL against a real cookie-auth'd browser request before merging.
+    """
+    base = f"https://read.amazon.{domain.removeprefix('amazon.')}/notebook"
+    if asin is None:
+        return base
+    return f"{base}?asin={asin}&contentLimitState=&"
+
+
+async def _fetch_books_list_html(session: AsyncSession, domain: str) -> str:
+    response = await session.get(_notebook_url(domain))
+    response.raise_for_status()
+    return response.text
+
+
+async def _fetch_book_highlights_html(
+    session: AsyncSession, asin: str, domain: str
+) -> str:
+    response = await session.get(_notebook_url(domain, asin))
+    response.raise_for_status()
+    return response.text
+
+
+# ---------------------------------------------------------------------------
+# Tool helper: dataclass → dict serializers
+# ---------------------------------------------------------------------------
+
+
+def book_to_dict(b: BookSummary) -> dict:
+    return {"asin": b.asin, "title": b.title, "author": b.author, "cover_url": b.cover_url}
+
+
+def highlight_to_dict(h: HighlightEntry) -> dict:
+    return {
+        "annotation_id": h.annotation_id,
+        "location": h.location,
+        "color": h.color,
+        "text": h.text,
+        "note": h.note,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool functions
+# ---------------------------------------------------------------------------
+
+
+async def kindle_list_books(ctx) -> ToolResult:
+    """List books with highlights from read.amazon.com/notebook.
+
+    Reads cookies from the configured path; uses curl_cffi with Chrome
+    impersonation. Returns one entry per book (asin, title, author, cover_url).
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+    cookies_path = _resolve_cookies_path(_config, _skill_config)
+    try:
+        jar = _load_cookie_jar(cookies_path)
+    except FileNotFoundError as exc:
+        return ToolResult(text=f"[error: {exc}]")
+
+    age_days = _cookie_file_age_days(cookies_path)
+    warn = age_days > _skill_config.cookies_warn_after_days
+
+    async with _make_session(jar, _skill_config.user_agent) as session:
+        try:
+            html = await _fetch_books_list_html(session, _skill_config.amazon_domain)
+        except Exception as exc:  # noqa: BLE001 — network boundary
+            return ToolResult(text=f"[error: failed to fetch books list: {exc}]")
+
+    books = _parse_books_list(html)
+    summary = f"Found {len(books)} book(s) with highlights."
+    if warn:
+        summary += f" Warning: cookies file is {int(age_days)} days old; consider re-exporting."
+    return ToolResult(
+        text=summary,
+        data={
+            "books": [book_to_dict(b) for b in books],
+            "cookies_age_days": int(age_days),
+        },
+    )
+
+
+async def kindle_fetch_highlights(ctx, asin: str) -> ToolResult:
+    """Fetch all highlights for a single book by ASIN."""
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+    cookies_path = _resolve_cookies_path(_config, _skill_config)
+    try:
+        jar = _load_cookie_jar(cookies_path)
+    except FileNotFoundError as exc:
+        return ToolResult(text=f"[error: {exc}]")
+    async with _make_session(jar, _skill_config.user_agent) as session:
+        try:
+            html = await _fetch_book_highlights_html(
+                session, asin, _skill_config.amazon_domain
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(text=f"[error: failed to fetch highlights for {asin}: {exc}]")
+    entries = _parse_highlights(html)
+    return ToolResult(
+        text=f"Found {len(entries)} highlight(s) for {asin}.",
+        data={"highlights": [highlight_to_dict(h) for h in entries], "asin": asin},
+    )
+
+
+async def kindle_sync_book(ctx, asin: str, *, book: "BookSummary | None" = None) -> ToolResult:
+    """Fetch highlights for a single book and upsert into its vault page.
+
+    Returns a summary of new/edited/archived counts.
+
+    The optional keyword-only ``book`` param accepts an already-fetched BookSummary.
+    When provided, the library-list fetch is skipped (used by kindle_sync_all to
+    avoid 2N+1 network calls).  Do NOT expose this in TOOL_DEFINITIONS — BookSummary
+    is not JSON-serializable for the LLM.
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+
+    if book is None:
+        # Standalone call — look up the book in the library.
+        list_result = await kindle_list_books(ctx)
+        if list_result.text.startswith("[error:"):
+            return list_result
+        list_data = list_result.data or {}
+        books = [BookSummary(**b) for b in list_data.get("books", [])]
+        book = next((b for b in books if b.asin == asin), None)
+        if book is None:
+            return ToolResult(text=f"[error: ASIN {asin!r} not found in Kindle library]")
+
+    matched = book
+
+    # Fetch highlights
+    h_result = await kindle_fetch_highlights(ctx, asin)
+    if h_result.text.startswith("[error:"):
+        return h_result
+    h_data = h_result.data or {}
+    fresh = [HighlightEntry(**h) for h in h_data.get("highlights", [])]
+
+    page = _book_page_path(_skill_config, matched)
+    read_result = await tool_vault_read(ctx, page)
+    existing_md = ""
+    if isinstance(read_result, ToolResult) and not read_result.text.startswith("[error:"):
+        existing_md = read_result.text
+
+    now = datetime.now(timezone.utc)
+    new_md = _upsert_book_page(
+        existing_md, fresh, matched, now,
+        archive_deleted=_skill_config.archive_deleted,
+    )
+
+    # Count diff for the return summary
+    # Restrict existing_ids to Highlights section only (match what _upsert_book_page does)
+    # to avoid re-counting previously-archived entries on subsequent syncs.
+    existing_highlights_body = (
+        existing_md.split("## Archived")[0]
+        if "## Archived" in existing_md
+        else existing_md
+    )
+    existing_ids = set(re.findall(r"<!-- annotation-id: (\S+) -->", existing_highlights_body))
+    fresh_ids = {h.annotation_id for h in fresh}
+    new_count = len(fresh_ids - existing_ids)
+    archived_count = len(existing_ids - fresh_ids) if _skill_config.archive_deleted else 0
+    edited_count = sum(1 for h in fresh if h.annotation_id in existing_ids)
+
+    write_result = await tool_vault_write(ctx, page=page, content=new_md)
+    if isinstance(write_result, ToolResult) and write_result.text.startswith("[error:"):
+        return write_result
+
+    summary = (
+        f"Synced '{matched.title}' ({asin}): "
+        f"{new_count} new, {edited_count} re-checked, {archived_count} archived."
+    )
+    return ToolResult(text=summary, data={
+        "asin": asin,
+        "page": page,
+        "new_count": new_count,
+        "archived_count": archived_count,
+        "highlight_count": len(fresh),
+    })
+
+
+async def kindle_sync_all(ctx) -> ToolResult:
+    """Sync all books in the Kindle library that have highlights. Rate-limited.
+
+    Appends a journal entry summarizing new/edited/archived counts across the run.
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+
+    # Gate: scheduled invocations skip silently when enabled=False.
+    # User-invocable invocations (ctx.task_mode != "scheduled") proceed regardless.
+    if ctx.task_mode == "scheduled" and not _skill_config.enabled:
+        return ToolResult(text="kindle skill disabled; skipping (set skills.kindle.enabled=true to opt in)")
+
+    list_result = await kindle_list_books(ctx)
+    if list_result.text.startswith("[error:"):
+        return list_result
+    list_data = list_result.data or {}
+    books = [BookSummary(**b) for b in list_data.get("books", [])]
+
+    results: list[dict] = []
+    new_total = 0
+    archived_total = 0
+    failures: list[tuple[str, str]] = []
+    for i, book in enumerate(books):
+        if i > 0:
+            await asyncio.sleep(_skill_config.sync_min_interval_seconds)
+        try:
+            # Pass the already-known BookSummary so kindle_sync_book skips the
+            # redundant library-list fetch (reduces 2N+1 requests to N+1).
+            r = await kindle_sync_book(ctx, asin=book.asin, book=book)
+        except Exception as exc:  # noqa: BLE001 — isolation boundary for partial-failure handling
+            log.warning("kindle_sync_book(%s) failed: %s", book.asin, exc)
+            failures.append((book.asin, str(exc)))
+            continue
+        if r.text.startswith("[error:"):
+            failures.append((book.asin, r.text))
+            continue
+        data = r.data or {}
+        results.append(data)
+        new_total += data.get("new_count", 0)
+        archived_total += data.get("archived_count", 0)
+
+    body = (
+        f"**Kindle sync run**\n\n"
+        f"- Books processed: {len(results)} / {len(books)}\n"
+        f"- New highlights: {new_total}\n"
+        f"- Archived (deleted on Amazon): {archived_total}\n"
+        f"- Failures: {len(failures)}\n"
+    )
+    if failures:
+        body += "\n**Failures:**\n"
+        for asin, msg in failures:
+            body += f"- {asin}: {msg}\n"
+    await tool_vault_journal_append(ctx, tags=["ingested", "kindle"], content=body)
+
+    summary = (
+        f"Synced {len(results)}/{len(books)} books: "
+        f"{new_total} new highlights, {archived_total} archived, "
+        f"{len(failures)} failures."
+    )
+    return ToolResult(text=summary, data={
+        "books_synced": len(results),
+        "books_total": len(books),
+        "new_total": new_total,
+        "archived_total": archived_total,
+        "failures": failures,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Tool registry
+# ---------------------------------------------------------------------------
+
+# Replace the placeholder TOOLS / TOOL_DEFINITIONS declared above.
+TOOLS = {
+    "kindle_list_books": kindle_list_books,
+    "kindle_fetch_highlights": kindle_fetch_highlights,
+    "kindle_sync_book": kindle_sync_book,
+    "kindle_sync_all": kindle_sync_all,
+}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_list_books",
+            "description": (
+                "List books with highlights from your Amazon Kindle notebook "
+                "(read.amazon.com/notebook). Requires a valid cookies.txt at the "
+                "configured path. Returns asin, title, author, cover_url per book."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+        "timeout": None,
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_fetch_highlights",
+            "description": (
+                "Fetch all highlights for a single book by ASIN from read.amazon.com/notebook. "
+                "Returns annotation_id, location, color, text, note per highlight."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "asin": {"type": "string", "description": "Amazon ASIN of the book."}
+                },
+                "required": ["asin"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_sync_book",
+            "description": (
+                "Sync highlights for a single Kindle book by ASIN into its vault page "
+                "under agent/pages/kindle/. Upserts new/edited highlights and moves "
+                "any Amazon-side deletions into the page's ## Archived section."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "asin": {"type": "string", "description": "Amazon ASIN of the book to sync."},
+                },
+                "required": ["asin"],
+            },
+        },
+        "timeout": None,
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_sync_all",
+            "description": (
+                "Sync every book with highlights in your Kindle library. "
+                "Rate-limited by sync_min_interval_seconds (default 60s) between books. "
+                "Writes a per-run journal entry tagged [ingested, kindle] summarizing "
+                "new/edited/archived counts and any failures."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+        "timeout": None,
+    },
+]

--- a/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/notes.md
+++ b/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/notes.md
@@ -1,0 +1,145 @@
+# Session notes — kindle-skill-375
+
+Started: 2026-05-13 11:37
+Issue: https://github.com/lmorchard/decafclaw/issues/375
+Branch: kindle-skill-375
+Worktree: .claude/worktrees/kindle-skill-375/
+Baseline tests: 2431 passed (16.31s)
+
+Spec seeded from issue body (no `<!-- dev-session:spec -->` marker, so treating as sketch to refine in brainstorm).
+
+## Brainstorm conclusions (2026-05-13 ~12:00)
+
+Documentarian research → `research.md` (key findings: newsletter is closest prior art; vault has no user-preserved-region convention; #374 unimplemented so we go first on the cookie convention).
+
+Four design decisions resolved via Q&A:
+
+1. **Scope:** All three phases in one PR (on-demand + scheduled + archive).
+2. **HTTP client:** `curl_cffi` primary; Playwright as fallback if Amazon escalates fingerprinting.
+3. **Cookies:** Netscape `cookies.txt` at `data/{agent_id}/secrets/kindle.cookies.txt` (admin path, not workspace). Convention #374 can adopt later.
+4. **Page ownership:** Per-book pages fully agent-owned (mechanical overwrite + archived section in same file). Synthesis is user-owned on a separate page. Sidesteps the missing vault primitive for user-preserved regions.
+5. **Observability:** `vault_journal_append` per run, tagged `[ingested, kindle]`.
+
+Spec passes readiness checklist (no placeholders; open questions all have default answers; "what we're NOT doing" has 11 concrete non-goals; 140 lines).
+
+## Plan (2026-05-13 ~12:20)
+
+Plan at `plan.md` — 9 vertical-slice phases (~980 lines for ~1000-1500 LOC expected, proportional). One commit per phase:
+
+1. **Scaffolding + `curl-cffi` dep** — skill registers with empty TOOLS; baseline test green
+2. **Auth substrate** — cookie loading + curl_cffi session helper; unit-tested in isolation
+3. **HTML parsers** — books-list + highlights parsers via BeautifulSoup, fixture-tested
+4. **Page upsert** — pure-Python `_upsert_book_page` with archive section, fixture-tested
+5. **HTTP fetch tools** — `kindle_list_books` + `kindle_fetch_highlights` (network boundary; Playwright-swap point)
+6. **`kindle_sync_book`** — single-book end-to-end (spec Phase 1)
+7. **`kindle_sync_all` + journal entry** — multi-book + observability (spec Phase 2)
+8. **SKILL.md body + schedule frontmatter** — on-demand `!kindle-sync` + daily cron (spec Phase 3 cron; archive logic done in Phase 4)
+9. **Docs** — `docs/kindle.md`, `docs/index.md`, `CLAUDE.md` bundled-skill list
+
+Self-review fixes applied inline:
+- Removed undefined `_render_book_page` reference (rendering happens inside `_upsert_book_page`).
+- Added `summary` / `keywords` / `importance` frontmatter defaults in Phase 4 (spec example showed them but plan didn't set them).
+- Added `timeout=None` to `kindle_list_books`, `kindle_sync_book`, `kindle_sync_all` TOOL_DEFINITIONS (per spec open-question default).
+- Made Playwright fallback explicit as the swap point at Phase 5's fetch helpers.
+- Removed punt language ("may simplify by ...") in Phase 4 archive parsing — committed to textual round-trip.
+- Consolidated `make lint` + `make typecheck` → `make check` (per Makefile convention).
+
+Plan passes self-review checklist: spec coverage complete, no placeholders, type consistency intact.
+
+## Execute (subagent-driven, 2026-05-13 ~13:00–16:00)
+
+12 commits on branch `kindle-skill-375`:
+
+| Commit | Phase |
+|---|---|
+| `1e44709` | Phase 1: scaffolding + `curl-cffi` (cherry-picked recovery — implementer subagent landed it on `main` initially) |
+| `2d37a09` | Phase 2: auth substrate |
+| `2cd3f3b` | Phase 3: HTML parsers (real fixture from `/Users/lorchard/Downloads/amazon-kindle-notebook.html`) |
+| `3124d17` | Phase 4: page upsert logic |
+| `6e17ecb` | Phase 4 cleanup: drop dead `_parse_existing_archived` + fix empty-metadata summary |
+| `400807e` | Phase 5: HTTP fetch tools |
+| `613b152` | Phase 6: `kindle_sync_book` |
+| `69e5e43` | Phase 7: `kindle_sync_all` + journal |
+| `c042036` | Phase 8: SKILL.md body + schedule |
+| `8f08ed2` | Phase 8 fix: push `enabled` gate into `kindle_sync_all` (was unreachable from SKILL.md) |
+| `4dfe5f0` | Phase 9: docs (`docs/kindle.md` + index + CLAUDE.md skill list) |
+| `a5deea7` | Phase 9 fix: archived_count double-counting + drop unused `title` param |
+
+**Final state:** `make check` clean; `make test` = 2473 passed (started from 2431 baseline, +42 kindle tests).
+
+### Lessons / surprises from execute
+
+- **Subagent CWD doesn't propagate from parent.** Phase 1 implementer initially committed on `main` because it ran `git commit` from the main clone instead of the worktree. Recovery via cherry-pick + reset. **Mitigation:** every subsequent implementer prompt opened with explicit `cd <worktree>` + verify `pwd` + `git rev-parse --abbrev-ref HEAD` instructions. No recurrences.
+- **Real Amazon fixture made Phase 3 much more accurate.** Les provided `~/Downloads/amazon-kindle-notebook.html` (444 KB). Implementer redacted to ~6.5 KB while preserving real ASINs, annotation IDs, and DOM structure. Selector adaptations vs the plan sketch: location lives in a hidden `<input>` not a span; author prefix is "By: " (colon); annotation-row filter via `#annotationHighlightHeader` presence; `span#highlight` (not bare `#highlight`).
+- **Bug caught at branch-level review that wasn't caught per-phase:** `kindle_sync_book`'s `existing_ids` regex scanned the WHOLE page, so on a 3rd+ sync previously-archived entries leaked back into the "archived this run" count. Cross-phase review surfaces things per-phase reviews don't.
+- **Design bug caught by code-quality review at Phase 8:** SKILL.md instructed the LLM to "read the skill config and check `enabled`" but no tool exposed config to the LLM. Fixed by pushing the gate into `kindle_sync_all` itself (mirror of `newsletter_publish`'s `ctx.task_mode` short-circuit).
+
+### Deferred to live-smoke batch
+
+The following manual verifications were deferred from per-phase checks. Run them with real Amazon cookies before opening the PR:
+
+- [ ] Place real `cookies.txt` at `data/{agent_id}/secrets/kindle.cookies.txt`.
+- [ ] `/kindle-sync` in web UI → returns book list + sync summary with correct counts.
+- [ ] `/kindle-sync <real-asin>` → syncs single book; vault page appears at `agent/pages/kindle/<asin>-<slug>.md`.
+- [ ] Frontmatter fields match `docs/kindle.md` schema; `## Highlights` populated.
+- [ ] Re-run `/kindle-sync <same-asin>` → idempotent (`new_count=0`, `archived_count=0`).
+- [ ] Set `skills.kindle.enabled=false`; trigger scheduled run manually → silent skip message.
+- [ ] Set `skills.kindle.enabled=true`; trigger scheduled run → journal entry appears tagged `[ingested, kindle]`.
+- [ ] Verify cookies age warning when file is artificially old (`touch -d "301 days ago"`).
+- [ ] Open one rendered page in Obsidian; confirm strikethrough on archived highlights renders correctly and `<!-- annotation-id -->` markers don't visually break.
+
+### Squash plan for PR
+
+12 commits, but the 3 follow-up fix commits are worth squashing for review clarity:
+- Squash `6e17ecb` into `3124d17` → single Phase 4 commit.
+- Squash `8f08ed2` into `c042036` → single Phase 8 commit.
+- Squash `a5deea7` into `4dfe5f0` → single Phase 9 commit (alternative: leave separate as a final-review fix commit; preference up to Les).
+
+Resulting clean PR history: 9 commits, one per phase.
+
+## PR + smoke (2026-05-13 ~16:00–17:30)
+
+### PR #490
+
+Opened https://github.com/lmorchard/decafclaw/pull/490. Project board: #375 → "In review".
+
+### Copilot review (first pass)
+
+Returned 5 substantive comments after ~3 minutes. All real, all addressed:
+
+1. `newly_archived` set iteration is non-deterministic → sort before iterating.
+2. `archived_count` reported even when `archive_deleted=False` → zero it out.
+3. `kindle_sync_all` makes 2N+1 requests (each `sync_book` re-calls `list_books`) → add keyword-only `book: BookSummary | None` to `sync_book`; `sync_all` passes the known summary. N+1 total.
+4. `docs/kindle.md` "recent activity" claim doesn't match impl (no filter) + `B0XXXXXX` example is 8 chars, not 10.
+5. `docs/kindle.md` shows removed `title` param on `sync_book`.
+
+### Live smoke against real Amazon
+
+All steps passed:
+
+| Step | Result |
+|---|---|
+| Cookies parse | 26 cookies, `at-main` + `sess-at-main` present |
+| `kindle_list_books` | 24 books returned |
+| `kindle_fetch_highlights B078VWDNKT` | 65 highlights (matches Amazon UI) |
+| `kindle_sync_book B078VWDNKT` | 343-line vault page, frontmatter clean |
+| Idempotent re-sync | 0 new / 65 re-checked / 0 archived |
+| Scheduled+disabled gate | Short-circuits, no network |
+
+Critical-path validated: `curl_cffi` Chrome 131 impersonation works; we don't need the Playwright fallback.
+
+### Contrib relocation (post-Copilot-fixes)
+
+Les requested moving the skill to `contrib/skills/kindle/` since it's not core functionality (parallels `linkding-ingest`, `mastodon-ingest`). Full refactor:
+
+- Moved skill + fixtures + smoke + tests into `contrib/skills/kindle/`.
+- Tests use `importlib.util.spec_from_file_location` to load `tools.py` (production skill loader pattern).
+- Extended `decafclaw.schedules.discover_schedules` to scan `extra_skill_paths` — previously only bundled + admin could self-schedule. CLAUDE.md updated.
+- Initially tried Option C (`make test-contrib` only); pivoted to Option B (contrib tests in default `make test`) to avoid bit-rot.
+- New target: `make test-contrib` for focused contrib-only runs.
+
+### Lessons
+
+- **Main advanced mid-session.** `feat(tui) #489` merged while we were refactoring. Caught at squash time when the soft-reset diff showed `tui/` files as deleted. Rebased onto fresh `origin/main` before re-squashing. Reinforces the [[feedback_rebase_before_squash]] memory.
+- **Subagent missed `git add` after `git mv`.** The refactor subagent moved `test_tools.py` via `git mv` (preserves content) then edited it for importlib loading but didn't `git add` before committing. Commit `5b04974` had the file at the new path but with old content. Tests passed locally (pytest reads working tree, not commit) so the gap wasn't visible until I checked `git status`. Fixup commit before squash recovered.
+- **Branch-level code review catches things per-phase reviews miss.** Two real bugs surfaced only at the end-of-branch review pass (archived_count overcount, enabled-gate unreachable from SKILL.md). Worth keeping that step in the workflow.

--- a/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/plan.md
+++ b/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/plan.md
@@ -1,0 +1,973 @@
+# Kindle skill — Implementation Plan
+
+**Goal:** Build the bundled `kindle` skill — on-demand and scheduled ingest of Kindle highlights & notes from `read.amazon.com/notebook` into per-book vault pages, with archived-section handling for deleted highlights.
+
+**Approach:** Mirror the `newsletter` bundled-skill shape (`SkillConfig` + `init` + `TOOL_DEFINITIONS`). Use `curl_cffi` (TLS-impersonating client) for fetches with cookies loaded from `data/{agent_id}/secrets/kindle.cookies.txt`. Per-book pages at `agent/pages/kindle/<asin>-<slug>.md` are fully agent-owned mechanical overwrites with an `## Archived` section for deleted highlights. Each sync run appends a journal entry tagged `[ingested, kindle]`.
+
+**Tech stack:** Python 3.13+, `curl-cffi` (new dep), `http.cookiejar.MozillaCookieJar` (stdlib), `pyyaml` (existing), `croniter` (existing — schedule discovery), Pytest with `pytest-asyncio`.
+
+---
+
+## Phase 1: Skill scaffolding + new dependency [x] DONE — commit `1e44709`
+
+Bundled `kindle` skill that registers via the skill loader with zero tools and a no-op SKILL.md body. Establishes the file layout and proves the loader integration before any logic exists.
+
+**Files:**
+- Modify: `pyproject.toml` — add `"curl-cffi>=0.7.0"` to `dependencies` (alphabetical insertion between `croniter` and `httpx` looks reasonable).
+- Create: `src/decafclaw/skills/kindle/__init__.py` — empty file (marker for skill loader; no Python exports).
+- Create: `src/decafclaw/skills/kindle/SKILL.md` — minimal frontmatter (`name: kindle`, `description: ...`, `user-invocable: true`, `context: inline`, `allowed-tools:` empty list, `required-skills: [kindle]`) plus a placeholder body that says "Phase 1 — no tools yet, do nothing." (We add real frontmatter fields incrementally; this prevents earlier phases from depending on a feature that lands later.)
+- Create: `src/decafclaw/skills/kindle/tools.py` — `SkillConfig` dataclass with all the fields the spec calls for, plus `init(config, skill_config)` (mirror `src/decafclaw/skills/newsletter/tools.py:19-48`). No tool functions yet. `TOOLS = {}` and `TOOL_DEFINITIONS = []` exported for symmetry.
+- Test: `tests/test_kindle_skill.py` — new test file covering Phase 1 only for now. Phases 2-7 extend it.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/kindle/tools.py
+"""Kindle bundled skill — periodic ingest of Kindle highlights & notes."""
+
+import logging
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+_config = None
+_skill_config: "SkillConfig | None" = None
+
+
+@dataclass
+class SkillConfig:
+    enabled: bool = field(
+        default=False, metadata={"env_alias": "KINDLE_ENABLED"}
+    )
+    cookies_path: str = field(
+        default="", metadata={"env_alias": "KINDLE_COOKIES_PATH"}
+    )
+    amazon_domain: str = field(
+        default="amazon.com", metadata={"env_alias": "KINDLE_AMAZON_DOMAIN"}
+    )
+    vault_subfolder: str = field(
+        default="agent/pages/kindle",
+        metadata={"env_alias": "KINDLE_VAULT_SUBFOLDER"},
+    )
+    sync_min_interval_seconds: int = field(
+        default=60, metadata={"env_alias": "KINDLE_SYNC_MIN_INTERVAL_SECONDS"}
+    )
+    archive_deleted: bool = field(
+        default=True, metadata={"env_alias": "KINDLE_ARCHIVE_DELETED"}
+    )
+    user_agent: str = field(
+        default=(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+        ),
+        metadata={"env_alias": "KINDLE_USER_AGENT"},
+    )
+    cookies_warn_after_days: int = field(
+        default=300, metadata={"env_alias": "KINDLE_COOKIES_WARN_AFTER_DAYS"}
+    )
+
+
+def init(config, skill_config: SkillConfig) -> None:
+    """Initialize the kindle skill. Called by the skill loader on activation."""
+    global _config, _skill_config
+    _config = config
+    _skill_config = skill_config
+
+
+TOOLS: dict = {}
+TOOL_DEFINITIONS: list = []
+```
+
+`cookies_path = ""` default means "resolve at activation to `config.agent_path / 'secrets' / 'kindle.cookies.txt'`." The resolution helper goes in Phase 2 where it's first used; the empty default in the dataclass keeps Phase 1 minimal.
+
+The `SKILL.md` body is a few lines; intentionally empty of agent logic until Phase 8.
+
+**Verification — automated:**
+- [x] `make check` passes (lint + typecheck for both Python and JS)
+- [x] `uv sync` after editing `pyproject.toml` resolves `curl-cffi`
+- [x] `uv run python -c "import curl_cffi.requests; print(curl_cffi.requests.AsyncSession)"` prints the class (proves the dependency installs and imports)
+- [x] `make test` passes, including the new test file (2433 tests)
+- [x] `tests/test_kindle_skill.py::test_kindle_skill_registers_via_loader` passes
+- [x] `tests/test_kindle_skill.py::test_skill_config_defaults` passes
+
+**Verification — manual:**
+- [x] `uv run python -c "from decafclaw.skills.kindle.tools import SkillConfig; print(SkillConfig())"` — output captured in session notes; all 8 fields match defaults.
+
+---
+
+## Phase 2: Cookie loading + curl_cffi session helper [x] DONE — commit `2d37a09`
+
+Build the auth substrate: load Netscape `cookies.txt` into a cookie jar; construct a `curl_cffi.requests.AsyncSession` with that jar attached and a Chrome impersonation header. Tested in isolation; no network calls.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add `_resolve_cookies_path(config, skill_config) -> Path`, `_load_cookie_jar(path: Path) -> http.cookiejar.MozillaCookieJar`, `_make_session(cookie_jar, user_agent) -> curl_cffi.requests.AsyncSession`. New imports at top: `http.cookiejar`, `curl_cffi.requests`, `pathlib.Path`, `datetime`.
+- Test: `tests/test_kindle_skill.py` — extend with cookie-loading tests.
+- Test fixture: `tests/fixtures/kindle/cookies.txt` — a synthetic Netscape-format cookie file with two cookies (`at-main` and `sess-at-main`) pointing at `.amazon.com`. Document at the top: "# Netscape HTTP Cookie File — synthetic, for testing only".
+
+**Key changes:**
+
+```python
+import http.cookiejar
+from datetime import datetime
+from pathlib import Path
+
+from curl_cffi.requests import AsyncSession
+
+
+def _resolve_cookies_path(config, skill_config: "SkillConfig") -> Path:
+    """Resolve the cookies file path. Defaults to admin secrets directory if unset."""
+    if skill_config.cookies_path:
+        p = Path(skill_config.cookies_path)
+        return p if p.is_absolute() else config.agent_path / p
+    return config.agent_path / "secrets" / "kindle.cookies.txt"
+
+
+def _load_cookie_jar(path: Path) -> http.cookiejar.MozillaCookieJar:
+    """Load a Netscape cookies.txt file. Raises FileNotFoundError if missing."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Kindle cookies file not found: {path}")
+    jar = http.cookiejar.MozillaCookieJar(str(path))
+    # Both kwargs True — let the load tolerate expired cookies; curl_cffi can
+    # still send them and Amazon decides whether to honor.
+    jar.load(ignore_discard=True, ignore_expires=True)
+    return jar
+
+
+def _cookie_file_age_days(path: Path) -> float:
+    """Return how many days old the cookies file is, based on mtime."""
+    return (datetime.now().timestamp() - path.stat().st_mtime) / 86400.0
+
+
+def _make_session(
+    cookie_jar: http.cookiejar.MozillaCookieJar, user_agent: str
+) -> AsyncSession:
+    """Construct a curl_cffi AsyncSession with cookies + Chrome impersonation."""
+    session = AsyncSession(
+        impersonate="chrome131",
+        headers={
+            "User-Agent": user_agent,
+            "Accept-Language": "en-US,en;q=0.9",
+            "Accept": "text/html,application/xhtml+xml,*/*;q=0.8",
+        },
+        cookies=cookie_jar,
+    )
+    return session
+```
+
+**Verification — automated:**
+- [x] `make check` passes (lint + typecheck)
+- [x] `tests/test_kindle_skill.py::test_load_cookie_jar_reads_netscape_format`
+- [x] `tests/test_kindle_skill.py::test_load_cookie_jar_missing_file_raises`
+- [x] `tests/test_kindle_skill.py::test_resolve_cookies_path_default`
+- [x] `tests/test_kindle_skill.py::test_resolve_cookies_path_relative_override`
+- [x] `tests/test_kindle_skill.py::test_resolve_cookies_path_absolute_override`
+- [x] `tests/test_kindle_skill.py::test_make_session_uses_chrome_impersonation`
+- [x] `make test` passes overall (2440 tests; +7 from Phase 1's 2433).
+
+**Verification — manual (deferred to end-of-branch live-smoke batch):**
+- [ ] Place a real `cookies.txt` (exported from a logged-in Amazon session) at `data/{agent_id}/secrets/kindle.cookies.txt` in the main clone, and from the worktree run `uv run python -c "from decafclaw.config import load_config; from decafclaw.skills.kindle.tools import _resolve_cookies_path, _load_cookie_jar, SkillConfig; cfg = load_config(); p = _resolve_cookies_path(cfg, SkillConfig()); print(p); print(len(_load_cookie_jar(p)))"`. Expect: a positive count of cookies. If 0, the file format is off.
+
+---
+
+## Phase 3: HTML parsers — books list + per-book highlights [x] DONE — commit `2cd3f3b`
+
+Two synchronous parsers that take HTML strings and return structured data. No network. The hardest piece of the skill; this is where DOM-selector fragility lives.
+
+The parsers should reference [`obsidian-kindle-plugin`'s parser](https://github.com/hadynz/obsidian-kindle-plugin/tree/main/src/scraper) at implementation time for canonical selectors. We don't copy their TypeScript code; we mirror their selector strategy in BeautifulSoup-style Python.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add `BookSummary` and `HighlightEntry` dataclasses; add `_parse_books_list(html: str) -> list[BookSummary]` and `_parse_highlights(html: str) -> list[HighlightEntry]`. New stdlib imports: `html.parser` (or use third-party `lxml` / `bs4` if already a dep).
+- Modify: `pyproject.toml` — add `"beautifulsoup4>=4.12.0"` (and `"lxml>=5.0"` as the parser backend) to `dependencies` IF the implementer confirms BS4 isn't already pulled in transitively. Use a stdlib-only `html.parser`-based parser only if BS4 would be the sole dependency-pull justification; BS4 is the standard pick for this kind of scraping and the implementer should add it.
+- Test: `tests/test_kindle_skill.py` — extend.
+- Test fixtures:
+  - Create: `tests/fixtures/kindle/books_list.html` — minimal HTML containing 2 books (`<div class="kp-notebook-library-each-book" id="ASIN1"><h2 class="kp-notebook-searchable">Title 1</h2><p>by Author 1</p>...`). Mirror the actual `read.amazon.com/notebook` library DOM. The implementer should derive selectors from obsidian-kindle-plugin's `scrapeBooks.ts`-equivalent.
+  - Create: `tests/fixtures/kindle/highlights.html` — minimal HTML with 3 highlights for one book, varying colors and one with a user note. Capture from obsidian-kindle-plugin's `scrapeHighlights.ts`-equivalent.
+  - Capture caveat: if the synthetic fixtures don't match real Amazon HTML at implementation time, the implementer should replace them with redacted-from-real captures and update the parsers accordingly. **Both parsers should be re-validated against a real fixture before merge** (see Verification — manual).
+
+**Key changes:**
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass
+class BookSummary:
+    asin: str
+    title: str
+    author: str
+    cover_url: str = ""
+    last_annotation_date: str = ""  # ISO-8601, may be empty if Amazon doesn't surface it
+
+
+@dataclass
+class HighlightEntry:
+    annotation_id: str          # stable Amazon annotation ID
+    location: str               # "Location 412" or "Page 33", string-preserved as Amazon renders it
+    color: str                  # "yellow" | "blue" | "pink" | "orange" | ""
+    text: str                   # the highlighted passage
+    note: str = ""              # optional user note attached to the highlight
+
+
+def _parse_books_list(html: str) -> list[BookSummary]:
+    """Parse the read.amazon.com/notebook library page. Returns ordered list of books."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "lxml")
+    books: list[BookSummary] = []
+    for node in soup.select(".kp-notebook-library-each-book"):
+        asin = node.get("id", "").strip()
+        if not asin:
+            continue
+        title_node = node.select_one("h2.kp-notebook-searchable")
+        author_node = node.select_one("p.kp-notebook-searchable")
+        cover_node = node.select_one("img")
+        title = (title_node.get_text(strip=True) if title_node else "").strip()
+        author = (author_node.get_text(strip=True) if author_node else "").strip()
+        if author.lower().startswith("by "):
+            author = author[3:]
+        cover_url = (cover_node.get("src") if cover_node else "") or ""
+        books.append(BookSummary(asin=asin, title=title, author=author, cover_url=cover_url))
+    return books
+
+
+def _parse_highlights(html: str) -> list[HighlightEntry]:
+    """Parse a single book's highlights page. Returns highlights in document order."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[HighlightEntry] = []
+    for row in soup.select(".kp-notebook-row-separator"):
+        annotation_id = row.get("id", "").strip()
+        if not annotation_id:
+            continue
+        text_node = row.select_one("#highlight")
+        note_node = row.select_one("#note")
+        location_node = row.select_one("#kp-annotation-location")
+        # Color comes from a hidden input or a class — encode the lookup at impl time:
+        color_node = row.select_one("input.kp-notebook-color")
+        color = (color_node.get("value") if color_node else "").lower() if color_node else ""
+
+        entries.append(HighlightEntry(
+            annotation_id=annotation_id,
+            location=(location_node.get_text(strip=True) if location_node else ""),
+            color=color,
+            text=(text_node.get_text(strip=True) if text_node else ""),
+            note=(note_node.get_text(strip=True) if note_node else ""),
+        ))
+    return entries
+```
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `test_parse_books_list_basic` — 4 books from fixture incl. ASIN B078VWDNKT verified.
+- [x] `test_parse_books_list_empty` — empty HTML returns `[]`.
+- [x] `test_parse_highlights_basic` — 6 highlights parsed, colors extracted.
+- [x] `test_parse_highlights_no_note` — note presence/absence distinguished.
+- [x] `test_parse_highlights_empty` — empty HTML returns `[]`.
+- [x] `make test` passes (2445 tests; +5 from Phase 2's 2440).
+
+**Adaptations from sketch:** location is in `<input id="kp-annotation-location" value="N">`; author prefix can be `"By: "`; annotation filter uses `#annotationHighlightHeader` presence; `span#highlight` (not bare `#highlight`).
+
+**Verification — manual:**
+- [ ] Capture a real `read.amazon.com/notebook` page using your cookies (e.g., `curl -b cookies.txt -A '<UA>' 'https://read.amazon.com/notebook' > /tmp/real_books.html`). Run the parser against it via `uv run python -c "from decafclaw.skills.kindle.tools import _parse_books_list; print(len(_parse_books_list(open('/tmp/real_books.html').read())))"`. Verify the count matches Amazon's UI. If not, reconcile selectors and update fixtures.
+- [ ] Same exercise for a single book's highlights page.
+
+---
+
+## Phase 4: Per-book page upsert logic [x] DONE — commits `3124d17` + cleanup `6e17ecb`
+
+Pure-Python function: take an existing page's markdown (or empty), a fresh list of highlights from Amazon, a `BookSummary`, and a `now` timestamp; produce the new page markdown. Encodes the agent-owned upsert + archive model the spec defines.
+
+No I/O. Tested via fixture markdown round-trips.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add helpers `_slug(title) -> str`, `_book_page_path(skill_config, book) -> str`, `_format_highlight_section(entry, archived_date="") -> str`, `_archive_format_block(block, archived_date) -> str`, `_parse_existing_archived(body) -> dict[str, str]`, and the main `_upsert_book_page(existing_md, fresh_highlights, book, now, archive_deleted=True) -> str`. Rendering happens inside `_upsert_book_page` — no separate `_render_book_page`. Imports `re`, `datetime` already present after Phase 2.
+- Test: `tests/test_kindle_skill.py` — extend.
+
+**Key changes:**
+
+```python
+import re
+from datetime import datetime, timezone
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(title: str, max_len: int = 60) -> str:
+    """Lowercase + ASCII-fold-ish slug for page filenames."""
+    s = title.lower().strip()
+    s = _SLUG_RE.sub("-", s).strip("-")
+    return s[:max_len] or "untitled"
+
+
+def _book_page_path(skill_config: "SkillConfig", book: BookSummary) -> str:
+    """Return the vault-relative page path for a book."""
+    subfolder = skill_config.vault_subfolder.rstrip("/")
+    return f"{subfolder}/{book.asin}-{_slug(book.title)}.md"
+
+
+def _format_highlight_section(entry: HighlightEntry, archived_date: str = "") -> str:
+    """Render one highlight (or archived highlight) as markdown. Marker first."""
+    marker = f"<!-- annotation-id: {entry.annotation_id} -->"
+    color = f" · *{entry.color}*" if entry.color else ""
+    if archived_date:
+        # Strikethrough form
+        header = f"~~**{entry.location}**{color}~~ *(archived {archived_date})*"
+        body = f"> ~~{entry.text}~~"
+    else:
+        header = f"**{entry.location}**{color}"
+        body = f"> {entry.text}"
+    out = [marker, header, "", body]
+    if entry.note:
+        out.append("")
+        out.append(f"*Note:* {entry.note}")
+    return "\n".join(out)
+
+
+def _parse_existing_archived(body: str) -> dict[str, str]:
+    """Extract a {annotation_id: archive_date} map from the existing ## Archived section.
+
+    Lets us preserve the original archived-on date instead of stamping today's
+    date over it on every re-sync.
+    """
+    out: dict[str, str] = {}
+    # Find each annotation-id marker that appears anywhere after `## Archived`.
+    marker = body.find("## Archived")
+    if marker < 0:
+        return out
+    archived_body = body[marker:]
+    # Match: <!-- annotation-id: X --> followed (eventually) by (archived YYYY-MM-DD)
+    for m in re.finditer(
+        r"<!-- annotation-id: (\S+) -->.*?\(archived (\d{4}-\d{2}-\d{2})\)",
+        archived_body, flags=re.DOTALL,
+    ):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def _upsert_book_page(
+    existing_md: str,
+    fresh_highlights: list[HighlightEntry],
+    book: BookSummary,
+    now: datetime,
+    archive_deleted: bool = True,
+) -> str:
+    """Merge fresh highlights into an existing per-book page (or fresh-create).
+
+    Algorithm:
+      1. Parse existing frontmatter + body. If empty, treat as new page.
+      2. Build {annotation_id: HighlightEntry} for fresh.
+      3. Extract existing archived annotation-id → archive_date map.
+      4. Walk fresh in document order → emit ## Highlights section.
+      5. Find existing annotation-ids that are NOT in fresh → if archive_deleted,
+         emit in ## Archived with their original archive_date (or today's date if
+         this is their first sync to the archived state).
+      6. Render frontmatter with updated counts + last_synced.
+    """
+    from decafclaw.frontmatter import parse_frontmatter, serialize_frontmatter
+
+    metadata, body = parse_frontmatter(existing_md or "")
+    archived_dates = _parse_existing_archived(body)
+
+    # Index fresh by annotation_id
+    fresh_ids = {h.annotation_id for h in fresh_highlights}
+
+    # Existing IDs from the previous Highlights section (so we know what dropped out).
+    existing_highlight_ids: set[str] = set()
+    # Strip everything after ## Archived for the highlight scan.
+    archive_split = body.find("## Archived")
+    highlight_body = body[:archive_split] if archive_split >= 0 else body
+    for m in re.finditer(r"<!-- annotation-id: (\S+) -->", highlight_body):
+        existing_highlight_ids.add(m.group(1))
+
+    # Highlights to archive on this run (previously current, now missing from fresh).
+    newly_archived = existing_highlight_ids - fresh_ids
+
+    # Build the new Highlights section
+    sections: list[str] = ["## Highlights", ""]
+    for entry in fresh_highlights:
+        sections.append(_format_highlight_section(entry))
+        sections.append("")  # blank line between
+
+    # Build the new Archived section (if any)
+    today = now.date().isoformat()
+    archived_entries: list[HighlightEntry] = []
+    # We need the HighlightEntry data for previously-archived items too, but we
+    # only have the markers in the existing body — we can't recover the text/color
+    # because the page itself is the source of truth. Re-parse the existing
+    # archived section for the full text per ID.
+    archived_blocks: dict[str, str] = {}
+    if archive_split >= 0:
+        archived_md = body[archive_split:]
+        # Split on annotation-id markers and keep them.
+        parts = re.split(r"(<!-- annotation-id: \S+ -->)", archived_md)
+        for i in range(1, len(parts) - 1, 2):
+            marker_line = parts[i]
+            block = (marker_line + parts[i + 1]).rstrip() + "\n"
+            id_match = re.match(r"<!-- annotation-id: (\S+) -->", marker_line)
+            if id_match:
+                archived_blocks[id_match.group(1)] = block
+
+    archived_section: list[str] = []
+    if archive_deleted:
+        # Preserve previously-archived items in original order (sorted by date for determinism)
+        for aid in sorted(archived_blocks.keys()):
+            archived_section.append(archived_blocks[aid].rstrip("\n"))
+            archived_section.append("")
+        # Add newly-archived (from previously-current items). For these we have
+        # the most recent text/color from the prior Highlights section — extract
+        # the rendered block from highlight_body to preserve fidelity.
+        for aid in newly_archived:
+            block_match = re.search(
+                rf"(<!-- annotation-id: {re.escape(aid)} -->.*?)(?=<!-- annotation-id: |\Z)",
+                highlight_body, flags=re.DOTALL,
+            )
+            if block_match is None:
+                continue
+            original_block = block_match.group(1).rstrip()
+            # Convert to archived form: wrap header/body in strikethrough, append date.
+            archived_form = _archive_format_block(original_block, today)
+            archived_section.append(archived_form)
+            archived_section.append("")
+
+    full_sections = sections
+    if archived_section:
+        full_sections.append("## Archived")
+        full_sections.append("")
+        full_sections.extend(archived_section)
+
+    new_body = "\n".join(full_sections).rstrip() + "\n"
+
+    # Update metadata
+    metadata = dict(metadata)  # avoid mutating input
+    metadata["asin"] = book.asin
+    metadata["title"] = book.title
+    metadata["author"] = book.author
+    if book.cover_url:
+        metadata["cover_url"] = book.cover_url
+    metadata["tags"] = sorted(set((metadata.get("tags") or []) + ["ingested", "kindle"]))
+    metadata["highlight_count"] = len(fresh_highlights)
+    metadata["archived_count"] = (
+        len(archived_blocks) + len(newly_archived) if archive_deleted else 0
+    )
+    metadata["last_synced"] = now.replace(microsecond=0).isoformat()
+    # Vault embedding-retrieval fields: set sensible defaults if absent so the
+    # page joins the semantic index meaningfully. User edits are preserved
+    # via setdefault (we never overwrite existing summary/keywords/importance).
+    metadata.setdefault(
+        "summary",
+        f"Kindle highlights from {book.title} by {book.author}".strip(),
+    )
+    metadata.setdefault("keywords", [])
+    metadata.setdefault("importance", 0.5)
+
+    return serialize_frontmatter(metadata, new_body)
+
+
+def _archive_format_block(highlight_block: str, archived_date: str) -> str:
+    """Convert a current-form rendered highlight block to its archived form."""
+    # Replace **Location** with ~~**Location**~~ on the header line; same for body `> text`.
+    # Conservative regex on the first occurrences only.
+    out = re.sub(r"^\*\*(.+?)\*\*(.*?)$", r"~~**\1**\2~~ *(archived %s)*" % archived_date, highlight_block, count=1, flags=re.MULTILINE)
+    out = re.sub(r"^> (.+)$", r"> ~~\1~~", out, count=1, flags=re.MULTILINE)
+    return out
+```
+
+Archived entries round-trip *textually* from the existing page (Amazon won't return them again, so the page is their only home). The regex extraction in `_parse_existing_archived` + the block-extraction loop above is sufficient — do not introduce a parallel JSON sidecar to store archived state.
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `test_upsert_new_page` / `_updates_existing_highlight` / `_inserts_new_highlight` / `_archives_deleted`
+- [x] `test_upsert_preserves_existing_archived_date` / `_archive_disabled_drops_deleted` / `_frontmatter_fields`
+- [x] `test_slug_safe_for_filenames`
+- [x] `test_upsert_empty_metadata_summary` (added in cleanup commit — regression for empty title+author edge case)
+- [x] `make test` passes (2454 tests)
+
+**Cleanup commit notes:** Removed unused `_parse_existing_archived` helper; fixed default-summary edge case for empty book metadata.
+
+**Verification — manual (deferred to end-of-branch live-smoke batch):**
+- [ ] Hand-eyeball one rendered page from a unit test to confirm readability — paste into Obsidian, confirm strikethrough renders correctly and `<!-- annotation-id -->` markers don't visually break anything.
+
+---
+
+## Phase 5: HTTP fetch tools — `kindle_list_books` and `kindle_fetch_highlights` [x] DONE — commit `400807e`
+
+Two low-level async tool functions that combine session-creation + URL fetch + parser. Each returns a `ToolResult` with structured `data` for downstream tools. This is the network boundary — the only place that does I/O against Amazon.
+
+**Playwright fallback hook:** `_fetch_books_list_html` and `_fetch_book_highlights_html` are the only functions that touch the network. If `curl_cffi` stops working (Amazon escalates detection), the fallback is implemented by swapping the bodies of these two helpers to use Playwright + a persistent profile. Everything else (parsing, upsert, vault writes, tool defs) stays unchanged. Keep these two functions thin; don't leak `curl_cffi`-specific types into their signatures.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add `async def _fetch_books_list_html(session, domain) -> str`, `async def _fetch_book_highlights_html(session, asin, domain) -> str`, `async def kindle_list_books(ctx) -> ToolResult`, `async def kindle_fetch_highlights(ctx, asin) -> ToolResult`. Update `TOOLS` and `TOOL_DEFINITIONS`. Import `decafclaw.media.ToolResult`.
+- Test: `tests/test_kindle_skill.py` — extend with mocked-session tests.
+
+**Key changes:**
+
+```python
+from decafclaw.media import ToolResult
+
+
+def _notebook_url(domain: str, asin: str | None = None) -> str:
+    """URL for the books list (no asin) or a specific book's highlights (with asin).
+
+    NOTE: The exact path for a single book's highlights page changes occasionally
+    on read.amazon.com. The implementer must verify by capturing a real
+    cookies-auth'd browser request and matching the URL. Document the captured
+    URL in a comment when implementing. As a starting hypothesis:
+      books list: https://read.amazon.{tld}/notebook
+      book page:  https://read.amazon.{tld}/notebook?library=light-library&asin={asin}&contentLimitState=&
+    """
+    base = f"https://read.amazon.{domain.removeprefix('amazon.')}/notebook"
+    if asin is None:
+        return base
+    return f"{base}?asin={asin}&contentLimitState=&"
+
+
+async def _fetch_books_list_html(session: AsyncSession, domain: str) -> str:
+    response = await session.get(_notebook_url(domain))
+    response.raise_for_status()
+    return response.text
+
+
+async def _fetch_book_highlights_html(
+    session: AsyncSession, asin: str, domain: str
+) -> str:
+    response = await session.get(_notebook_url(domain, asin))
+    response.raise_for_status()
+    return response.text
+
+
+async def kindle_list_books(ctx) -> ToolResult:
+    """List books with highlights from read.amazon.com/notebook.
+
+    Reads cookies from the configured path; uses curl_cffi with Chrome
+    impersonation. Returns one entry per book (asin, title, author, cover_url).
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+    cookies_path = _resolve_cookies_path(_config, _skill_config)
+    try:
+        jar = _load_cookie_jar(cookies_path)
+    except FileNotFoundError as exc:
+        return ToolResult(text=f"[error: {exc}]")
+
+    age_days = _cookie_file_age_days(cookies_path)
+    warn = age_days > _skill_config.cookies_warn_after_days
+
+    async with _make_session(jar, _skill_config.user_agent) as session:
+        try:
+            html = await _fetch_books_list_html(session, _skill_config.amazon_domain)
+        except Exception as exc:  # noqa: BLE001 — network boundary
+            return ToolResult(text=f"[error: failed to fetch books list: {exc}]")
+
+    books = _parse_books_list(html)
+    summary = f"Found {len(books)} book(s) with highlights."
+    if warn:
+        summary += f" Warning: cookies file is {int(age_days)} days old; consider re-exporting."
+    return ToolResult(text=summary, data={
+        "books": [book_to_dict(b) for b in books],
+        "cookies_age_days": int(age_days),
+    })
+
+
+async def kindle_fetch_highlights(ctx, asin: str) -> ToolResult:
+    """Fetch all highlights for a single book by ASIN."""
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+    cookies_path = _resolve_cookies_path(_config, _skill_config)
+    try:
+        jar = _load_cookie_jar(cookies_path)
+    except FileNotFoundError as exc:
+        return ToolResult(text=f"[error: {exc}]")
+    async with _make_session(jar, _skill_config.user_agent) as session:
+        try:
+            html = await _fetch_book_highlights_html(
+                session, asin, _skill_config.amazon_domain
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(text=f"[error: failed to fetch highlights for {asin}: {exc}]")
+    entries = _parse_highlights(html)
+    return ToolResult(
+        text=f"Found {len(entries)} highlight(s) for {asin}.",
+        data={"highlights": [highlight_to_dict(h) for h in entries], "asin": asin},
+    )
+
+
+def book_to_dict(b: BookSummary) -> dict:
+    return {"asin": b.asin, "title": b.title, "author": b.author, "cover_url": b.cover_url}
+
+
+def highlight_to_dict(h: HighlightEntry) -> dict:
+    return {
+        "annotation_id": h.annotation_id,
+        "location": h.location,
+        "color": h.color,
+        "text": h.text,
+        "note": h.note,
+    }
+
+
+# Update TOOLS + TOOL_DEFINITIONS
+TOOLS = {
+    "kindle_list_books": kindle_list_books,
+    "kindle_fetch_highlights": kindle_fetch_highlights,
+}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_list_books",
+            "description": (
+                "List books with highlights from your Amazon Kindle notebook "
+                "(read.amazon.com/notebook). Requires a valid cookies.txt at the "
+                "configured path. Returns asin, title, author, cover_url per book."
+            ),
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "kindle_fetch_highlights",
+            "description": (
+                "Fetch all highlights for a single book by ASIN from read.amazon.com/notebook. "
+                "Returns annotation_id, location, color, text, note per highlight."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "asin": {"type": "string", "description": "Amazon ASIN of the book."}
+                },
+                "required": ["asin"],
+            },
+        },
+    },
+]
+```
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `test_kindle_list_books_happy_path` / `_missing_cookies` / `_warns_old_cookies`
+- [x] `test_kindle_fetch_highlights_happy_path` / `_http_error`
+- [x] `test_kindle_tools_register_via_skill_loader` — both new tools registered
+- [x] `make test` passes (2460 tests; +6 from Phase 4's 2454).
+
+**Verification — manual:**
+- [ ] One end-to-end live test against real Amazon, run from the worktree, **before** moving on:
+  `uv run python -c "import asyncio; from decafclaw.config import load_config; from decafclaw.tools.skill_tools import activate_skill_internal; from decafclaw.context import make_context; from decafclaw.skills.kindle.tools import kindle_list_books, init, SkillConfig; cfg = load_config(); init(cfg, SkillConfig()); print(asyncio.run(kindle_list_books(None)))"` (sketch only — the implementer adapts to whatever bootstrap works). Expect: real book list. If Amazon returns a captcha page / 503 / login redirect, curl_cffi is being blocked → escalate (try a different impersonate target like `chrome120`, or pivot to Playwright per the fallback decision).
+
+---
+
+## Phase 6: `kindle_sync_book` — single-book end-to-end (spec Phase 1) [x] DONE — commit `613b152`
+
+Compose Phase 4 + Phase 5: fetch one book's highlights, read the existing vault page (if any), run upsert, write back via `vault_write`. The first tool a user can call to actually see the skill do something useful.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add `async def kindle_sync_book(ctx, asin: str, title: str = "") -> ToolResult` and update `TOOLS`/`TOOL_DEFINITIONS`. Imports: `decafclaw.skills.vault.tools.tool_vault_read, tool_vault_write` (or call them via the tool registry — see implementation note).
+- Test: `tests/test_kindle_skill.py` — extend.
+
+**Implementation note on calling vault tools:** The cleanest call into the vault is via direct function import — `tool_vault_write(ctx, page=..., content=...)`. This skips the tool-registry dispatch (timeouts, etc.) and treats it as an internal helper. Mirror this pattern; do not invent a new vault-write abstraction.
+
+If `tool_vault_read` returns `[error: ...]` (page doesn't exist yet), treat as empty `existing_md=""` and continue.
+
+**Key changes:**
+
+```python
+async def kindle_sync_book(ctx, asin: str, title: str = "") -> ToolResult:
+    """Fetch highlights for a single book and upsert into its vault page.
+
+    Returns a summary of new/edited/archived counts.
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+
+    # First, get the BookSummary for this ASIN (need title/author/cover for frontmatter).
+    list_result = await kindle_list_books(ctx)
+    if list_result.text.startswith("[error:"):
+        return list_result
+    books = [BookSummary(**b) for b in list_result.data["books"]]
+    matched = next((b for b in books if b.asin == asin), None)
+    if matched is None:
+        return ToolResult(text=f"[error: ASIN {asin!r} not found in Kindle library]")
+
+    # Fetch highlights
+    h_result = await kindle_fetch_highlights(ctx, asin)
+    if h_result.text.startswith("[error:"):
+        return h_result
+    fresh = [HighlightEntry(**h) for h in h_result.data["highlights"]]
+
+    # Read existing page (if any)
+    from decafclaw.skills.vault.tools import tool_vault_read, tool_vault_write
+
+    page = _book_page_path(_skill_config, matched)
+    read_result = await tool_vault_read(ctx, page)
+    existing_md = ""
+    if isinstance(read_result, ToolResult) and not read_result.text.startswith("[error:"):
+        existing_md = read_result.text
+
+    now = datetime.now(timezone.utc)
+    new_md = _upsert_book_page(
+        existing_md, fresh, matched, now,
+        archive_deleted=_skill_config.archive_deleted,
+    )
+
+    # Count diff for the return summary
+    existing_ids = set(re.findall(r"<!-- annotation-id: (\S+) -->", existing_md))
+    fresh_ids = {h.annotation_id for h in fresh}
+    new_count = len(fresh_ids - existing_ids)
+    archived_count = len(existing_ids - fresh_ids)
+    edited_count = sum(1 for h in fresh if h.annotation_id in existing_ids)
+
+    write_result = await tool_vault_write(ctx, page=page, content=new_md)
+    if isinstance(write_result, ToolResult) and write_result.text.startswith("[error:"):
+        return write_result
+
+    summary = (
+        f"Synced '{matched.title}' ({asin}): "
+        f"{new_count} new, {edited_count} re-checked, {archived_count} archived."
+    )
+    return ToolResult(text=summary, data={
+        "asin": asin,
+        "page": page,
+        "new_count": new_count,
+        "archived_count": archived_count,
+        "highlight_count": len(fresh),
+    })
+
+
+# Extend TOOLS and TOOL_DEFINITIONS (append to the dict/list from Phase 5):
+TOOLS["kindle_sync_book"] = kindle_sync_book
+TOOL_DEFINITIONS.append({
+    "type": "function",
+    "function": {
+        "name": "kindle_sync_book",
+        "description": (
+            "Sync highlights for a single Kindle book by ASIN into its vault page "
+            "under agent/pages/kindle/. Upserts new/edited highlights and moves "
+            "any Amazon-side deletions into the page's ## Archived section."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "asin": {"type": "string", "description": "Amazon ASIN of the book to sync."},
+                "title": {
+                    "type": "string",
+                    "description": "Optional title hint, used for logging; not required.",
+                },
+            },
+            "required": ["asin"],
+        },
+    },
+    "timeout": None,
+})
+```
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `test_kindle_sync_book_first_run` / `_idempotent` / `_archives_deleted` / `_unknown_asin`
+- [x] `make test` passes (2464 tests; +4 from Phase 5's 2460).
+
+**Verification — manual:**
+- [ ] One live sync against real Amazon for a small book (low highlight count) from the worktree: invoke `kindle_sync_book` directly via a Python REPL (same bootstrap as Phase 5 manual step). Expect: a real vault page lands at `agent/pages/kindle/<asin>-<slug>.md` with sensible frontmatter and Highlights section.
+
+---
+
+## Phase 7: `kindle_sync_all` + per-run journal entry (spec Phase 2) [x] DONE — commit `69e5e43`
+
+Multi-book sync orchestrator. Rate-limited via `sync_min_interval_seconds` between book fetches. Appends one `vault_journal_append` entry per run with structured summary.
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/tools.py` — add `async def kindle_sync_all(ctx) -> ToolResult`; update `TOOLS`/`TOOL_DEFINITIONS`. Add `"timeout": None` to the `kindle_sync_all` and `kindle_sync_book` entries in `TOOL_DEFINITIONS` (multi-book sync at 60s intervals will exceed the 180s default by design). Import `asyncio`.
+- Test: `tests/test_kindle_skill.py` — extend.
+
+**Key changes:**
+
+```python
+import asyncio
+
+
+async def kindle_sync_all(ctx) -> ToolResult:
+    """Sync all books in the Kindle library that have highlights. Rate-limited.
+
+    Appends a journal entry summarizing new/edited/archived counts across the run.
+    """
+    if _skill_config is None:
+        return ToolResult(text="[error: kindle skill not initialized]")
+
+    list_result = await kindle_list_books(ctx)
+    if list_result.text.startswith("[error:"):
+        return list_result
+    books = [BookSummary(**b) for b in list_result.data["books"]]
+
+    results = []
+    new_total = 0
+    archived_total = 0
+    failures = []
+    for i, book in enumerate(books):
+        if i > 0:
+            await asyncio.sleep(_skill_config.sync_min_interval_seconds)
+        try:
+            r = await kindle_sync_book(ctx, asin=book.asin)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("kindle_sync_book(%s) failed: %s", book.asin, exc)
+            failures.append((book.asin, str(exc)))
+            continue
+        if r.text.startswith("[error:"):
+            failures.append((book.asin, r.text))
+            continue
+        results.append(r.data)
+        new_total += r.data.get("new_count", 0)
+        archived_total += r.data.get("archived_count", 0)
+
+    # Journal entry — every run, even with no changes
+    from decafclaw.skills.vault.tools import tool_vault_journal_append
+
+    body = (
+        f"**Kindle sync run**\n\n"
+        f"- Books processed: {len(results)} / {len(books)}\n"
+        f"- New highlights: {new_total}\n"
+        f"- Archived (deleted on Amazon): {archived_total}\n"
+        f"- Failures: {len(failures)}\n"
+    )
+    if failures:
+        body += "\n**Failures:**\n"
+        for asin, msg in failures:
+            body += f"- {asin}: {msg}\n"
+    await tool_vault_journal_append(ctx, tags=["ingested", "kindle"], content=body)
+
+    summary = (
+        f"Synced {len(results)}/{len(books)} books: "
+        f"{new_total} new highlights, {archived_total} archived, "
+        f"{len(failures)} failures."
+    )
+    return ToolResult(text=summary, data={
+        "books_synced": len(results),
+        "books_total": len(books),
+        "new_total": new_total,
+        "archived_total": archived_total,
+        "failures": failures,
+    })
+
+
+# Extend TOOLS and TOOL_DEFINITIONS:
+TOOLS["kindle_sync_all"] = kindle_sync_all
+TOOL_DEFINITIONS.append({
+    "type": "function",
+    "function": {
+        "name": "kindle_sync_all",
+        "description": (
+            "Sync every book with highlights in your Kindle library. "
+            "Rate-limited by sync_min_interval_seconds (default 60s) between books. "
+            "Writes a per-run journal entry tagged [ingested, kindle] summarizing "
+            "new/edited/archived counts and any failures."
+        ),
+        "parameters": {"type": "object", "properties": {}},
+    },
+    "timeout": None,
+})
+```
+
+**Important test fixture note:** The tests for this phase must patch `asyncio.sleep` to a no-op (`asyncio.sleep = AsyncMock()` or patch the module attribute). Otherwise a 3-book sync test would take 2 minutes. Also patch `vault_journal_append`'s embedding side effect or accept its no-op behavior under a tmp `vault_root` per `CLAUDE.md`'s test-speed discipline.
+
+**Verification — automated:**
+- [ ] `make check` passes (lint + typecheck)
+- [ ] `tests/test_kindle_skill.py::test_kindle_sync_all_happy_path` — 3 books each with 1 highlight; patch `asyncio.sleep` to a no-op; assert `new_total=3`, `books_synced=3`, journal entry written with the expected body.
+- [ ] `tests/test_kindle_skill.py::test_kindle_sync_all_partial_failure` — middle book's fetch_highlights raises; assert that book is in `failures`, other two complete, journal entry mentions failures.
+- [ ] `tests/test_kindle_skill.py::test_kindle_sync_all_rate_limit` — `sync_min_interval_seconds=10`; patch `asyncio.sleep` to record calls; with 3 books, assert `sleep` is called twice with `10`.
+- [ ] `make test` passes overall. `pytest --durations=10` shows no kindle test in the slow tail.
+
+**Verification — manual:**
+- [ ] One live `kindle_sync_all` against real Amazon from the worktree (small library only — if you have >10 books, expect this to take >10 minutes due to the rate limit). Expect: per-book pages all written, one journal entry under `agent/journal/`.
+
+---
+
+## Phase 8: User-invokable command, SKILL.md body, scheduled trigger (spec Phase 3 — already covered by upsert; this wires the cron) [x] DONE — commits `c042036` + gate-fix `8f08ed2`
+
+Flesh out `SKILL.md` so:
+- `!kindle-sync` and `!kindle-sync <asin-or-title>` work as on-demand interactive commands
+- Add `schedule: "0 5 * * *"` frontmatter so the bundled-skill discovery picks it up
+- Add the gate logic in the prompt body: scheduled invocations check `enabled` + cookies-file presence; return silently if not ready
+
+**Files:**
+- Modify: `src/decafclaw/skills/kindle/SKILL.md` — replace placeholder body with the real prompt; add `schedule: "0 5 * * *"`; populate `allowed-tools: kindle_list_books, kindle_fetch_highlights, kindle_sync_book, kindle_sync_all, vault_read, vault_list, vault_write, vault_journal_append, current_time`; add `argument-hint: "[asin-or-title]"`. Update `name: kindle` and add a useful `description:` for the catalog.
+- Test: `tests/test_kindle_skill.py` — add discovery + frontmatter tests.
+
+**Key changes — SKILL.md body sketch:**
+
+```markdown
+---
+name: kindle
+description: Sync highlights & notes from your Kindle library (read.amazon.com/notebook) into per-book vault pages.
+schedule: "0 5 * * *"
+user-invocable: true
+context: inline
+argument-hint: "[asin-or-title]"
+allowed-tools: kindle_list_books, kindle_fetch_highlights, kindle_sync_book, kindle_sync_all, vault_read, vault_list, vault_write, vault_journal_append, current_time
+required-skills: [kindle]
+---
+
+# Kindle sync
+
+You sync highlights & notes from `read.amazon.com/notebook` into per-book vault pages under `agent/pages/kindle/`.
+
+## When to run
+
+This skill runs in two contexts:
+
+1. **Scheduled (daily 5am UTC)** — full library sync. Before doing anything: read the skill config. If `enabled` is False, return immediately with the single-line message `kindle skill disabled; skipping`. Don't do any fetches, don't write any journal entry. Same if the cookies file is missing (a `kindle_list_books` call returns `[error: Kindle cookies file not found ...]`).
+
+2. **User-invokable (`!kindle-sync` / `/kindle-sync`)** — on-demand. The `enabled` gate does NOT apply here; the user explicitly asked. Still requires cookies.
+
+## Argument parsing
+
+Argument: `$ARGUMENTS`
+
+- **Empty** (`!kindle-sync`) — call `kindle_sync_all`. Summarize the result.
+- **Non-empty** (`!kindle-sync <arg>`) — single-book mode:
+  1. Call `kindle_list_books` to get the library.
+  2. If `<arg>` looks like an ASIN (10 alphanumeric chars, all-caps), look it up directly.
+  3. Otherwise, treat `<arg>` as a title substring. Lowercase-substring match against each book's title. If exactly one matches, use its ASIN. If multiple match, return a numbered list and ask the user to re-invoke with the ASIN. If zero match, return `No book matching '<arg>' in your Kindle library`.
+  4. Call `kindle_sync_book(asin=...)` and summarize.
+
+## Notes
+
+- The per-book page is fully agent-owned. **Do not** manually edit `agent/pages/kindle/*.md` — your edits will be overwritten on the next sync. Use a separate hand-curated page for cross-links and synthesis (e.g., `agent/pages/<book>-notes.md` that wiki-links to the agent page).
+- If a fetch fails with a 401/403, your cookies have probably expired. Re-export `cookies.txt` from a logged-in browser session and place it at the configured path.
+```
+
+**Verification — automated:**
+- [ ] `make check` passes (lint + typecheck)
+- [ ] `tests/test_kindle_skill.py::test_skill_md_frontmatter_parses` — load `SKILL.md`, assert `schedule == "0 5 * * *"`, `user-invocable: true`, `allowed-tools` contains all 8 tools.
+- [ ] `tests/test_kindle_skill.py::test_skill_discovered_as_scheduled` — call `discover_schedules` on a test config; assert kindle is in the returned list with `source == "bundled"` and matching schedule. **MUST patch `decafclaw.schedules.run_schedule_task` to a no-op for this test** per `CLAUDE.md` test-speed discipline (otherwise the bundled scheduled skills can fire real tool runs).
+- [ ] `make test` passes overall.
+
+**Verification — manual:**
+- [ ] In the worktree, with cookies in place, run `make run` (interactive REPL mode) — type `!kindle-sync` and confirm the skill activates and runs against real Amazon. (If `make dev` is running in another worktree against the same Mattermost token, do NOT also start it here — single-bot rule per CLAUDE.md.)
+- [ ] With cookies in place, change `enabled=False` in `data/{agent_id}/config.json`'s `skills.kindle` section, then trigger the scheduled body manually via `!kindle-sync` (still works — user-invocable bypasses gate). Then re-trigger via a one-off `croniter`-faked scheduled run, and confirm the body short-circuits with the disabled message.
+
+---
+
+## Phase 9: Documentation + key-files updates [x] DONE — commit `4dfe5f0`
+
+Lock in the docs the spec touches.
+
+**Files:**
+- Create: `docs/kindle.md` — full skill documentation: setup (cookies export workflow, where to put the file, the warning threshold), config keys with defaults, the agent-owned vs synthesis page boundary, what to do when cookies expire, the on-demand vs scheduled distinction. Cross-link from this file to `docs/skills.md` (and reverse).
+- Modify: `docs/index.md` — add a one-line entry for `docs/kindle.md`.
+- Modify: `docs/skills.md` — if it lists bundled skills, add `kindle` to that list with a one-line description. (Read it first to confirm structure.)
+- Modify: `CLAUDE.md` — in the "Skills (bundled)" line, add `kindle` to the comma-separated list: `skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,kindle}/`.
+
+**Key changes:** Documentation only. No code logic.
+
+**Verification — automated:**
+- [ ] `make lint` passes (in case any code drifted)
+- [ ] `make test` passes
+- [ ] `grep -n kindle CLAUDE.md` — kindle appears in the bundled-skills list.
+- [ ] `ls docs/kindle.md` — file exists.
+- [ ] `grep -n kindle docs/index.md` — entry present.
+
+**Verification — manual:**
+- [ ] Read `docs/kindle.md` top-to-bottom. Confirm a new user could follow the setup instructions and land on a working install. Pay attention to the cookies-export step (it's the friction point).
+- [ ] Walk through one fresh-install simulation in your head: clone repo, configure `skills.kindle.enabled=True`, drop cookies file, run `!kindle-sync`. Are there any silent failure modes the docs don't cover? If so, add them.
+- [ ] Confirm the linked spec/plan/notes session docs in this dev session correctly describe the implementation that landed.

--- a/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/research.md
+++ b/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/research.md
@@ -1,0 +1,192 @@
+# Decafclaw Codebase Research — Kindle Skill #375
+
+## Q1. Bundled skill anatomy: Newsletter and Ingest
+
+**Newsletter skill** (`src/decafclaw/skills/newsletter/`):
+
+- **SKILL.md** (lines 1–65): Frontmatter fields used:
+  - `name: newsletter`
+  - `description: ...`
+  - `schedule: "0 7 * * *"` (cron, daily 7am)
+  - `user-invocable: true`
+  - `context: inline`
+  - `allowed-tools: newsletter_list_scheduled_activity, newsletter_list_vault_changes, newsletter_publish, current_time`
+  - `required-skills: [newsletter]`
+
+- **tools.py** (lines 1–250+):
+  - `SkillConfig` dataclass (lines 19–42): `window_hours`, `email_enabled`, `email_recipients`, `email_subject_prefix`, `vault_page_enabled`, `vault_folder`. Env aliases: `NEWSLETTER_*` prefix.
+  - `init(config, skill_config: SkillConfig)` (lines 44–48): signature matches bundled skill loader contract. Stores globals `_config`, `_skill_config`.
+  - Tool functions: `newsletter_list_scheduled_activity(ctx, hours=None, window="")` (async, line 194), `newsletter_list_vault_changes(ctx, hours=None, window="")` (async, presumed similar pattern), `newsletter_publish(...)` (presumed exists).
+  - Exports: `TOOL_DEFINITIONS` dict mapping tool names to functions (likely lines ~250+).
+  - Helper: `_parse_window(spec)` parses "7d", "48h", "2w" to hours; croniter used implicitly for validation.
+
+**Ingest skill** (`src/decafclaw/skills/ingest/`):
+
+- **SKILL.md only** (no tools.py):
+  - Frontmatter:
+    - `name: ingest`
+    - `description: Fetch a URL, workspace file, or attachment...`
+    - `user-invocable: true`
+    - `context: inline`
+    - `required-skills: [tabstack]`
+    - `allowed-tools: tabstack_extract_markdown, web_fetch, workspace_read, list_attachments, get_attachment, vault_search, vault_read, vault_write, vault_list, vault_backlinks, current_time`
+  - No native tools — imported via `required-skills: [tabstack]`. Skill body (lines 12–97) is the full prompt instruction text, no Python tool wrapper.
+
+**Key pattern**: Bundled skills in `src/decafclaw/skills/{name}/` contain SKILL.md (always) + optional tools.py. Skill loader parses SKILL.md frontmatter for metadata, imports tools.py if present, and calls `init(config, skill_config)` to initialize. `SkillConfig` dataclass in tools.py defines per-skill config with env_alias metadata for environment variable lookup. No `get_tools` dynamic provider observed in newsletter/ingest.
+
+---
+
+## Q2. Scheduled skill plumbing: cron → 60s poll loop → `run_schedule_task`
+
+**Discovery** (`schedules.py:99–160`):
+- `discover_schedules(config)` rescans on each poll tick. Searches two sources in precedence order:
+  1. Admin: `config.agent_path / "schedules"` (flat .md files in root)
+  2. Workspace: `config.workspace_path / "schedules"` (flat .md files, agent-writable)
+  3. Bundled and admin skills: iterates `_BUNDLED_SKILLS_DIR` and `config.agent_path / "skills"`, reads SKILL.md for each skill with `schedule:` frontmatter (lines 121–158).
+- Returns list of `ScheduleTask` dataclass (lines 18–36): name, schedule (5-field cron), body, source ("admin"/"workspace"/"bundled"), path, enabled, model, allowed_tools, shell_patterns, required_skills, email_recipients.
+
+**Parsing**:
+- Schedule files: `parse_schedule_file(path)` (lines 38–93) splits frontmatter via `_split_frontmatter`, extracts `schedule:` field, validates with `croniter.is_valid()`.
+- Skill SKILL.md: `parse_skill_md()` in `skills/__init__.py:41–100` extracts `schedule:` field (line 97).
+
+**Poll loop** (`schedules.py:340–416`):
+- `schedule_timer(config, event_bus, manager, interval=60, shutdown_event=None, on_result=None)` (line 340+).
+- `run_polling_loop(interval=60, ...)` at line 403 calls `_tick()` every 60s.
+- Per tick: `discover_schedules()`, check each task via `is_due(config, task)` (line 373, uses croniter), dispatch via `run_schedule_task()` (line 382).
+
+**Task execution** (`run_schedule_task`, lines 216–295):
+- Conv ID: `schedule-{task.name}-{YYYYMMDD-HHMMSS}` (line 224). Conv ID naming allows newsletter to parse scheduled task conversations.
+- Setup via `setup_schedule_ctx(ctx)` closure (lines 247–273):
+  - Applies per-task model override (line 250)
+  - Restricts tools to `task.allowed_tools` if specified (lines 251–253)
+  - Sets shell patterns (lines 254–255)
+  - Overrides email recipients (line 257)
+  - Pre-activates required skills via `activate_skill_internal()` (lines 262–273)
+- Preamble + body substitution (lines 275–279): `build_task_preamble()` + `substitute_body()` from `polling` and `commands`.
+- Dispatches to manager via `enqueue_turn(conv_id, kind=TurnKind.SCHEDULED_TASK, prompt, context_setup=setup_schedule_ctx)` (lines 283–292).
+
+**Bundled skill scheduling integration**: Skills with `schedule:` frontmatter discovered in `discover_schedules()` (line 139 checks `skill.schedule`). Skill body becomes the task prompt (line 150 sets `body=skill.body`). Skill's tools are auto-activated via `required_skills` in the task setup (lines 243, 262–273).
+
+---
+
+## Q3. Vault page write conventions: frontmatter + body serialization
+
+**Frontmatter parsing** (`frontmatter.py:19–55`):
+- `parse_frontmatter(text)` (line 19): regex `_FRONTMATTER_RE` (line 16: `\A---\n(.*?)\n---\n`, re.DOTALL) extracts YAML block, returns `(dict, body_text)`. Falls back to `({}, text)` on parse error.
+- `serialize_frontmatter(metadata, body)` (line 46): YAML dumps metadata, wraps with `---` delimiters, returns full markdown.
+
+**Vault write** (`skills/vault/tools.py:300–325+`):
+- `tool_vault_write(ctx, page: str, content: str)` (async, line 300):
+  - Validates page name via `_safe_write_path()` (line 303).
+  - Checks user write permissions via `_check_user_write_allowed()` (line 310).
+  - Runs confirmation gate if needed (lines 311–318).
+  - Writes file directly (presumed to call path.write_text()).
+- Frontmatter fields used:
+  - Ingest skill expects `tags: [ingested, ...]`, `summary: ...` in SKILL.md step 5 (lines 71–77).
+  - `frontmatter.py:get_frontmatter_field()` (line 58) handles type coercion for `importance` (float [0,1]), `keywords`/`tags` (list[str]), `summary` (str).
+  - `build_composite_text(metadata, body)` (line 88) prepends summary, keywords, tags for embedding indexing.
+
+**Agent-managed sections vs user-preserved regions**: No existing convention documented. Writes are full-page overwrites; no per-section update mechanism detected. SKILL.md describes writing to `agent/pages/` folder to avoid collision with user pages (line 57).
+
+**Vault journal** (`vault/tools.py:563`):
+- `tool_vault_journal_append(ctx, tags: list[str], content: str)` writes daily entries under `vault_agent_journal_dir`.
+
+---
+
+## Q4. SkillConfig resolution and persistence
+
+**Config loading** (`config.py:88–145`):
+- `load_sub_config(dc_class, json_data, env_prefix, env_aliases=None)` (line 88):
+  1. Env var: `{ENV_PREFIX}_{FIELD_NAME}` (line 115)
+  2. Env alias from field metadata `env_alias` or dict (line 120)
+  3. JSON data `json_data[field_name]` (line 126)
+  4. Dataclass default (line 144)
+  - Nested dataclass recursion (lines 130–137): derives nested prefix `{PREFIX}_{FIELD_NAME}`.
+  - Returns instantiated `dc_class(**kwargs)` (line 145).
+
+**Skill config location**:
+- Resolved at skill activation. Root config has `skills: dict[str, dict[str, Any]]` (line 163 in Config dataclass). Per-skill config loaded into `config.skills[skill_name]` dict via `load_sub_config(SkillConfig, config.skills.get(skill_name, {}), env_prefix="")` (presumed in skill loader, exact location not traced).
+- Admin-level config at `data/{agent_id}/config.json` under `skills` key. Env vars with `SKILL_*` prefix or field-specific aliases (e.g., `NEWSLETTER_WINDOW_HOURS`, `TABSTACK_API_KEY`) override JSON.
+
+**Fresh install defaults**: Dataclass field defaults apply when no JSON entry and no env var set. Newsletter defaults: `window_hours=24`, `email_enabled=False`, `vault_page_enabled=True` (lines 21–42).
+
+**`init()` signature**: `init(config, skill_config: SkillConfig)` — receives global Config + resolved SkillConfig. Called once per skill activation, initializes module-level state (`_config`, `_skill_config` in newsletter).
+
+---
+
+## Q5. Notification surfaces for scheduled-skill outcomes
+
+**Notification record** (`notifications.py:29–42`):
+- `NotificationRecord` dataclass: `id`, `timestamp` (ISO-8601 UTC), `category` ("heartbeat", "schedule", "background", ...), `title`, `priority` ("low"/"normal"/"high"), `body`, `link`, `conv_id`.
+- `to_dict()` / `from_dict()` for JSONL serialization.
+
+**Notification emission** (inferred from `vault_page.py:1–95`):
+- Event-driven: publisher calls `ctx.publish("notification_created", record=NotificationRecord(...))` (presumed, based on channel subscription at line 1).
+- No direct tool function observed; agent-side emission likely via custom handler or event API.
+
+**Channels** (`notification_channels/`):
+1. **Vault page** (`vault_page.py`):
+   - Daily rollup under `vault_root / configured_folder / YYYY-MM-DD.md`.
+   - Appends one markdown section per notification (subheading + metadata block + body).
+   - Per-path lock serializes concurrent appends (line 45).
+   - Folder validation (line 64): relative path, no `..`, must stay in vault.
+
+2. **Email** (`email.py`):
+   - Sends email to configured recipients.
+
+3. **Mattermost DM** (`mattermost_dm.py`):
+   - Sends direct message.
+
+**Scheduled-skill outcome surface**:
+- Newsletter calls `newsletter_publish()` → returns ToolResult. No explicit notification emission observed (may be implicit in vault journal append or email send).
+- `run_schedule_task()` captures result text (line 293) and checks `is_heartbeat_ok(result_text)` (line 294) for status classification.
+
+---
+
+## Q6. HTTP client / scraping patterns and YouTube/transcript work
+
+**Current HTTP clients** (outside tests):
+- **`httpx`** (async HTTP): used in:
+  - `mattermost.py:14` — MM API calls
+  - `embeddings.py:10` — embedding model requests
+  - `tools/http_tools.py:9` — web_fetch tool
+  - `tools/heartbeat_tools.py:6` — heartbeat HTTP checks
+  - `tools/core.py:6` — HTTP utilities
+  - `llm/providers/*` — LLM API calls
+- **`tabstack`** (web extraction/automation):
+  - Imported in `skills/tabstack/tools.py:7` from `tabstack` package.
+  - Initialized as AsyncTabstack client in `init(config, skill_config)` (line 24–31).
+  - Tools: `tabstack_extract_markdown()`, `tabstack_extract_json()`, `tabstack_generate()`, `tabstack_automate()`, `tabstack_research()` (lines 43–116).
+  - Used by `ingest` skill (SKILL.md:8, `required-skills: [tabstack]`).
+
+**No existing authenticated HTML fetch pattern**: httpx client used raw; no cookie jar or session persistence observed. Tabstack handles auth/cookies internally (black-box).
+
+**YouTube / transcript / issue #374 work**:
+- Git log shows recent ingest-related commits:
+  - `069fcdf feat(ingest): forward user args through fetch.sh for backfill (#467)`
+  - `c0cd581 feat: ingest skill — one-shot URL/file/attachment ingestion into the vault (#290)`
+  - No YouTube-specific or transcript commits detected.
+- Issue #374 not directly referenced in logs; issue title unknown from available data.
+- No `youtube`, `transcript` Python modules found in codebase (grep returned zero matches in src/decafclaw).
+
+---
+
+## Summary Table
+
+| Q | Component | File:Lines | Key Contract |
+|---|-----------|-----------|--------------|
+| Q1 | Newsletter SKILL.md | `skills/newsletter/SKILL.md:1–65` | Scheduled (cron `0 7 * * *`), user-invocable, 4 allowed tools |
+| Q1 | Newsletter tools | `skills/newsletter/tools.py:19–48` | `SkillConfig` + `init(config, skill_config)` |
+| Q1 | Ingest SKILL.md | `skills/ingest/SKILL.md:1–97` | User-invocable, no native tools, requires tabstack |
+| Q2 | Discovery | `schedules.py:99–160` | `discover_schedules()` rescans admin/workspace/.md + bundled skills SKILL.md |
+| Q2 | Poll loop | `schedules.py:340–416` | `schedule_timer()` calls `_tick()` every 60s, checks `is_due()`, dispatches via `run_schedule_task()` |
+| Q2 | Task exec | `schedules.py:216–295` | Conv ID `schedule-{name}-{timestamp}`, pre-activates skills, applies per-task model/tools |
+| Q3 | Parse FM | `frontmatter.py:19–55` | Regex extract YAML, serialize with `---` delimiters |
+| Q3 | Vault write | `skills/vault/tools.py:300` | Full-page overwrite; expects YAML frontmatter with `tags`, `summary` |
+| Q4 | Config load | `config.py:88–145` | Env → JSON → dataclass default; nested recursion for sub-configs |
+| Q4 | Skill activation | `skills/__init__.py:41–100` | `parse_skill_md()` reads SKILL.md, `init()` called by loader |
+| Q5 | Notifications | `notifications.py:29–42` | `NotificationRecord` JSONL, event-driven subscription |
+| Q5 | Vault channel | `notification_channels/vault_page.py:1–95` | Daily MD pages, per-path lock, folder sandboxing |
+| Q6 | HTTP | `tools/http_tools.py`, `llm/providers/*` | httpx for sync calls; async via asyncio.to_thread |
+| Q6 | Web automation | `skills/tabstack/tools.py:7–116` | AsyncTabstack client, extract/automate/research tools |
+

--- a/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/spec.md
+++ b/docs/dev-sessions/2026-05-13-1137-kindle-skill-375/spec.md
@@ -1,0 +1,140 @@
+# Kindle highlights & notes ingest skill — Spec
+
+**Goal:** Periodically scrape Kindle highlights & notes from `read.amazon.com/notebook` into per-book vault pages, with on-demand and scheduled sync modes, plus archived-section handling for deleted highlights. Replaces the manual Obsidian Kindle Highlights plugin workflow for the agent host.
+
+**Source:** [issue #375](https://github.com/lmorchard/decafclaw/issues/375).
+
+## Current state
+
+- No Kindle ingest exists today. The user manually exports highlights via the [Obsidian Kindle plugin](https://github.com/hadynz/obsidian-kindle-plugin) on a separate host.
+- The closest prior art is the bundled `ingest` skill (`src/decafclaw/skills/ingest/SKILL.md`) — one-shot URL/file ingestion via `tabstack_extract_markdown` + LLM-driven page composition. It does *not* support upsert/dedup or periodic re-sync.
+- Bundled skill anatomy that this skill will mirror: `src/decafclaw/skills/newsletter/tools.py:19-48` (`SkillConfig` dataclass + `init(config, skill_config)` + `TOOL_DEFINITIONS` export) and `src/decafclaw/skills/newsletter/SKILL.md:1-65` (frontmatter with `schedule:` + `user-invocable: true` + `allowed-tools`).
+- Bundled-skill schedule discovery already wired: `src/decafclaw/schedules.py:99-160` rescans bundled skill SKILL.md files for `schedule:` frontmatter every poll tick; `run_schedule_task` (lines 216-295) dispatches with conv ID `schedule-{name}-{timestamp}`.
+- Vault primitives: `frontmatter.py:19-55` (parse/serialize YAML frontmatter); `skills/vault/tools.py:300` (`vault_write` does full-page overwrite); `skills/vault/tools.py:563` (`vault_journal_append` for episodic per-run logging).
+- Existing HTTP clients: `httpx` throughout (`tools/http_tools.py:9`, etc.) but **no existing pattern for cookie-authenticated HTML scraping** — this skill establishes it.
+- Sibling issue #374 (YouTube transcript ingest) is open but unimplemented. It shares the cross-host cookie problem; the cookie-storage convention defined here is intended for #374 to adopt later.
+
+## Desired end state
+
+A bundled `kindle` skill at `src/decafclaw/skills/kindle/` with three operating modes:
+
+1. **On-demand full sync** — `!kindle-sync` (Mattermost) / `/kindle-sync` (web UI) → list books with new activity since last sync → re-fetch each book's highlights → upsert into per-book vault page.
+2. **On-demand single-book sync** — `!kindle-sync <asin-or-title>` → fetch just that book's highlights and upsert. Title fuzzy match falls through to ASIN if ambiguous.
+3. **Scheduled sync** — daily cron (default `0 5 * * *`) runs the full-sync path. Gated by `skill_config.enabled` + presence of cookies file; silently skips otherwise. Logs a `vault_journal_append` entry tagged `[ingested, kindle]` per run.
+
+Per-book vault page at `agent/pages/kindle/<asin>-<title-slug>.md` is **fully agent-owned**, mechanically overwritten on every sync:
+
+```markdown
+---
+asin: B0XXXXXX
+title: "Book Title"
+author: "Author Name"
+cover_url: https://...
+tags: [ingested, kindle]
+summary: "<one-line description for embedding retrieval>"
+keywords: [...]
+importance: 0.5
+highlight_count: 42
+archived_count: 3
+last_synced: 2026-05-13T05:00:00Z
+---
+
+## Highlights
+
+<!-- annotation-id: ABC123 -->
+**Location 412** · *yellow*
+
+> Highlight text here.
+
+*Note:* Optional user note.
+
+<!-- annotation-id: DEF456 -->
+...
+
+## Archived
+
+<!-- annotation-id: GHI789 -->
+~~**Location 102** · *yellow*~~ *(archived 2026-05-12)*
+
+> ~~Deleted highlight text.~~
+```
+
+Upsert model: on each sync, parse the existing page (if any), index existing entries by `annotation-id`, then re-emit. New IDs are inserted in location order; edited highlights overwrite the text in place; missing-from-Amazon IDs move to `## Archived` with a strikethrough + archive date.
+
+Synthesis (cross-linking, wiki-links, prose summaries) is the **user's responsibility on a separate hand-curated page** — the agent never touches the synthesis page. This is the explicit boundary between mechanical ingest and curated knowledge.
+
+## Design decisions
+
+- **Decision:** Ship all three phases (on-demand single + on-demand all + scheduled with archive handling) in this one PR.
+  - **Why:** The work isn't actually three phases of effort — Phase 1 (on-demand single-book) does 90% of the implementation (auth, fetch, parse, upsert), and adding "loop over all books" and "archive missing IDs" is incremental on top of that. Splitting into three PRs would be three rebases for not much review benefit.
+  - **Rejected:** Phase 1 only first. Mirrors `ingest` but leaves the user with no scheduled sync until later — a real loss of value for the size of effort saved.
+
+- **Decision:** Use `curl_cffi` (TLS-impersonating Python HTTP client) as the primary fetch client.
+  - **Why:** Amazon flags vanilla `requests`/`httpx` clients via TLS fingerprinting (mid-2023+). `curl_cffi` impersonates a real Chrome/Firefox TLS handshake. Async-capable, accepts standard cookie jars, lightweight. Same approach as the Node.js `kindle-api` library uses (via external TLS-client proxy).
+  - **Rejected:** Raw `httpx` — known to be blocked. Tabstack — black-box for auth, unclear if per-request cookie injection is supported. Playwright — heavy (~100MB install) for what is a single static HTML page.
+  - **Fallback:** If `curl_cffi` stops working (Amazon escalates detection), pivot to Playwright with persistent profile. Keep the fetch layer thin enough that swapping the client is a localized change — the parser and upsert logic don't care which client supplied the HTML.
+
+- **Decision:** Cookies live at `data/{agent_id}/secrets/kindle.cookies.txt` in Netscape `cookies.txt` format, path configurable via `KINDLE_COOKIES_PATH` env var or `skills.kindle.cookies_path` JSON config.
+  - **Why:** Netscape format is the de-facto standard every browser-cookie-exporter extension produces ("Get cookies.txt LOCALLY", "cookies.txt", etc.). Loads cleanly into `curl_cffi` via `http.cookiejar.MozillaCookieJar`. Admin path (`data/{agent_id}/`) is agent-readable but not agent-writable — appropriate for credentials.
+  - **Rejected:** Workspace path — agent could overwrite the cookies (undesirable for secrets). JSON blob — no de-facto exporter exists. Generic shared `cookies/{domain}.txt` directory — speculative over-engineering before we know what #374 actually needs.
+  - **Coordination with #374:** This skill defines the convention (Netscape format, admin secrets directory). #374 follows the same path scheme later, e.g. `data/{agent_id}/secrets/youtube.cookies.txt`. No shared abstraction is built yet — each skill loads its own cookies file directly. If a second source proves the pattern useful, we extract a helper at that point.
+
+- **Decision:** Per-book pages are fully agent-owned mechanical overwrites. Synthesis lives on a separate user-curated page.
+  - **Why:** The vault has no existing "agent-managed sections vs user-preserved regions" convention. Building one would be a separate sub-project (parse + preserve outside-region content + define the delimiter syntax + handle conflicts), all of which is unrelated to Kindle ingest. The clean boundary — agent owns the highlights page entirely; user owns the synthesis page entirely — sidesteps the whole problem.
+  - **Rejected:** Single page with `<!-- BEGIN agent-managed -->` delimiters (requires new vault primitive); append-only with dedup (loses the ability to detect edited highlights).
+
+- **Decision:** Deleted highlights move to an `## Archived` section in the same per-book page, with strikethrough markdown and the archive date. The `archived_count` field on frontmatter tracks the running total.
+  - **Why:** Preserves history (the user invested in those highlights at one point and may want them back). One file per book stays the unit of organization — no separate "archive store" to maintain. Strikethrough + archive date makes the human-readable diff between current and lost obvious.
+  - **Rejected:** Hard-delete (loses history); separate archive store (more files to manage).
+
+- **Decision:** Per-run observability via `vault_journal_append` — one entry per sync run, tagged `[ingested, kindle]`, with a structured summary line (e.g., `Synced 3 books: 12 new, 2 edited, 1 archived`).
+  - **Why:** Same pattern `newsletter` and `dream` use. Cheap. The journal is already wikilinked, searchable, and indexed for embedding retrieval. Issue #289 (structured ingest log) might supersede this later; if so, both consumers can read the journal entries directly.
+  - **Rejected:** Workspace JSONL ingest log (premature; #289 isn't built yet); return-text-only (not searchable, lost outside the scheduled-task conv archive).
+
+- **Decision:** Scheduled run is gated by `skill_config.enabled` (default `False`) AND presence of the cookies file. Schedule frontmatter is always present in SKILL.md; the gate happens inside the prompt body.
+  - **Why:** Fresh installs shouldn't fire failing Amazon scrapes daily. `enabled=False` default means scheduled runs no-op until the user has set up cookies and flipped the toggle. On-demand `!kindle-sync` still works regardless of `enabled` (gated only by cookies file presence) — useful for one-off backfills.
+  - **Rejected:** Omitting `schedule:` until enabled — would require config-aware skill discovery, which doesn't exist.
+
+- **Decision:** Highlight color is captured as metadata on each highlight entry (Amazon's yellow/blue/pink/orange).
+  - **Why:** Trivial to capture during parsing; lets the user grep/filter later. Free signal.
+
+- **Decision:** Multi-domain support is config-driven from day one via `amazon_domain` (default `amazon.com`), but v1 is single-domain-per-install — no per-book domain detection.
+  - **Why:** Single-account users only ever hit one domain. Building per-book detection without a user with multiple Amazon accounts is over-engineering.
+
+## Patterns to follow
+
+- **Skill structure:** Mirror `src/decafclaw/skills/newsletter/`:
+  - `tools.py`: `SkillConfig` dataclass with `env_alias` metadata on each field (`src/decafclaw/skills/newsletter/tools.py:19-42`); `init(config, skill_config)` signature stores module-level `_config` and `_skill_config` (lines 44-48); `TOOL_DEFINITIONS` dict mapping tool names → callables.
+  - `SKILL.md`: frontmatter with `name`, `description`, `schedule`, `user-invocable: true`, `context: inline`, `allowed-tools`, `required-skills`. Mirror `src/decafclaw/skills/newsletter/SKILL.md:1-65`.
+- **Tool signatures:** All native tools take `ctx` as first param (`src/decafclaw/CLAUDE.md` convention). Async, return `ToolResult` (errors as `ToolResult(text="[error: ...]")`).
+- **Config resolution:** `load_sub_config(SkillConfig, json_data, env_prefix="KINDLE")` per `config.py:88-145`. Env precedence: `KINDLE_FIELD_NAME` → `env_alias` → JSON `skills.kindle.field_name` → dataclass default.
+- **Frontmatter:** Use `frontmatter.parse_frontmatter()` and `frontmatter.serialize_frontmatter()` (`frontmatter.py:19-55`) for read-modify-write. The vault page body string is what `vault_write` accepts.
+- **Vault writes:** Call `tool_vault_write(ctx, page, content)` (`skills/vault/tools.py:300`) directly from within the kindle tools; it handles path validation and write permissions.
+- **Vault journal:** Call `tool_vault_journal_append(ctx, tags=[...], content="...")` (`skills/vault/tools.py:563`) for per-run summaries.
+- **Scheduled-task body:** The SKILL.md body is the LLM prompt the scheduled run sees. Write it so the LLM (a) checks `enabled` via reading skill config / cookies file, (b) calls `kindle_sync_all`, (c) appends a journal entry. Mirror `src/decafclaw/skills/newsletter/SKILL.md` structure.
+- **Test patterns:**
+  - Mock at the HTTP-client boundary (the `curl_cffi` Session). Capture fixture HTML from `read.amazon.com/notebook` (one book list page + one highlights page per fixture) under `tests/fixtures/kindle/`.
+  - Per `CLAUDE.md` testing rules: patch `decafclaw.schedules.run_schedule_task` in any test that touches the scheduler (bundled scheduled skills will otherwise fire real fetches).
+  - Test the upsert logic end-to-end via the parsed-HTML → page-string path; don't network in CI.
+
+## What we're NOT doing
+
+- **Building a generic "agent-managed sections + user-preserved regions" vault primitive.** Filed mentally as a future option if a second skill needs it. Single-page agent ownership is the boundary for now.
+- **Downloading book cover images.** Cover URL goes in frontmatter; the image stays on Amazon's CDN. Defer to a separate issue if image-on-disk ever matters.
+- **Supporting `My Clippings.txt` (USB device) fallback.** Out of scope; device-only and sparse metadata. File as follow-up if needed.
+- **Readwise / Send-to-Kindle / official Amazon API integrations.** Out of scope.
+- **Solving cross-host cookie *transport*.** User is responsible for getting `cookies.txt` to the agent host (scp, sync, manual paste). This skill consumes the file; it does not produce it.
+- **Building #374's YouTube ingest.** Sibling skill, separate session. We only define the cookie-path convention #374 can adopt.
+- **Implementing issue #289's structured ingest log.** We use `vault_journal_append` for now; #289 can read those entries if/when it ships.
+- **Per-book domain detection.** Single Amazon domain per install via `amazon_domain` config.
+- **Automatic 2FA / re-auth.** When cookies expire, user re-exports manually. No retry loops, no captcha solving, no headless-browser login flow.
+- **Synthesis / cross-linking pages.** Highlights pages are mechanical; cross-linking and prose summaries are the user's hand-curated work on separate pages.
+- **A wrapped notification tool for the agent to emit `NotificationRecord`s directly.** The scheduled task surfaces status via `vault_journal_append` + the schedule conv archive; no direct notification emission.
+
+## Open questions
+
+- **Title-fuzzy-match strategy for `!kindle-sync <arg>`.** Default answer: substring match on lowercased title; if ambiguous (>1 match), return a list and ask the user to pass the ASIN instead. Simple; no fuzzy-string library needed for v1.
+- **Rate-limit cadence between book fetches.** Default answer: `sync_min_interval_seconds=60` (one book/minute). Conservative; can tune downward later if Amazon doesn't object.
+- **Handling of un-highlighted books.** Default answer: skip silently. The notebook page only lists books with at least one highlight, so this should be a non-issue in practice.
+- **Cookies-file age warning threshold.** Default answer: warn (via journal entry) when cookies file is older than 300 days. Amazon cookies are ~365-day TTL, so 300 days gives the user time to re-export before failures start.
+- **Tool timeouts.** Default answer: `kindle_sync_all` and `kindle_list_books` opt out of the 180s default timeout (set `timeout=None` or `timeout=600`). Per-book `kindle_sync_book` and `kindle_fetch_highlights` keep the default 180s.

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ These docs are as much for me as they are for agents working on this project. Th
 - [Project Skill](project-skill.md) — Structured workflow: brainstorm → spec → plan → execute for multi-step tasks
 - [Postmortem Skill](postmortem-skill.md) — User-invokable blameless RCA: structured report on what went wrong, archived to the vault
 - [Ingest Skill](ingest-skill.md) — User-invokable one-shot ingestion: fetch a URL/file/attachment, synthesize it into vault pages
+- [Kindle](kindle.md) — Periodic ingest of Kindle highlights and notes into per-book vault pages
 - [File Attachments](file-attachments.md) — Upload files, MCP media, workspace image refs, rich cards
 
 ## Agent Behavior

--- a/docs/kindle.md
+++ b/docs/kindle.md
@@ -1,0 +1,117 @@
+# Kindle
+
+Periodically ingest Kindle highlights and notes from `read.amazon.com/notebook` into per-book vault pages.
+
+This is a **contrib skill** — it lives at `contrib/skills/kindle/` and is not bundled by default. See [Installation](#installation) below to enable it.
+
+## Installation
+
+Add the skill directory to `extra_skill_paths` in your agent config. First, expose the repo path as an env var in `.env`:
+
+```bash
+DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
+```
+
+Then in `data/{agent_id}/config.json`:
+
+```json
+{
+  "extra_skill_paths": [
+    "$DECAFCLAW_REPO/contrib/skills/kindle"
+  ]
+}
+```
+
+See `contrib/skills/README.md` for detailed installation options (reference vs. copy, env var vs. absolute path).
+
+## Operating modes
+
+**On-demand:** `!kindle-sync` (Mattermost) / `/kindle-sync` (web UI) syncs all books in your Kindle library that have highlights. Pass a book title or ASIN to sync a single book:
+
+- `/kindle-sync` — sync all books
+- `/kindle-sync "The Pragmatic Programmer"` — sync by title
+- `/kindle-sync B0XXXXXXXX` — sync by ASIN
+
+**Scheduled:** daily at 5am UTC via `schedule: "0 5 * * *"` in SKILL.md. Gated by `skills.kindle.enabled` (default `false`) so fresh installs don't fire failing scrapes.
+
+## Setup
+
+1. **Export `cookies.txt`** from a logged-in Amazon session. Recommended: the "Get cookies.txt LOCALLY" browser extension (Chrome, Firefox). Make sure your browser is signed in to amazon.com (or your local TLD) at the time of export.
+
+2. **Place the file** at `data/{agent_id}/secrets/kindle.cookies.txt` on the agent host. The path is configurable via `KINDLE_COOKIES_PATH` env var or `skills.kindle.cookies_path` config.
+
+3. **Opt in to scheduled sync** by setting `skills.kindle.enabled = true` in `data/{agent_id}/config.json` (under the `skills` key). On-demand sync works regardless of this flag — you just need cookies present.
+
+Cookies are long-lived (typically ~1 year for Amazon). The skill warns when the cookies file is older than `cookies_warn_after_days` (default 300 days). When you see the warning — or when sync fails with a 401/403 — re-export `cookies.txt` and replace the file.
+
+## Vault layout
+
+The skill writes one page per book at `agent/pages/kindle/<asin>-<title-slug>.md`. The page is **fully agent-owned** — running sync overwrites the page on each run. Do NOT manually edit these pages — your edits will be overwritten on the next sync. For synthesis, cross-links, and prose notes, create a separate hand-curated page (e.g., `agent/pages/<book>-notes.md`) that the skill never touches.
+
+Frontmatter:
+
+```yaml
+asin: B0XXXXXXXX
+title: "Book Title"
+author: "Author Name"
+cover_url: https://...
+tags: [ingested, kindle]
+summary: "Kindle highlights from <Title> by <Author>"
+keywords: []
+importance: 0.5
+highlight_count: 42
+archived_count: 3
+last_synced: 2026-05-13T05:00:00+00:00
+```
+
+Body has two sections:
+
+- **`## Highlights`** — current highlights in document order. Each highlight is preceded by an HTML comment marker (`<!-- annotation-id: ... -->`) used for upsert tracking.
+- **`## Archived`** — highlights that have been deleted on Amazon's side since the last sync. Rendered with strikethrough markdown and an "archived YYYY-MM-DD" stamp.
+
+## Per-run observability
+
+Each `kindle_sync_all` run appends a journal entry tagged `[ingested, kindle]` under `agent/journal/YYYY/YYYY-MM-DD.md` summarizing books processed, new highlights, archived count, and any failures.
+
+## Configuration
+
+All keys live under `skills.kindle` in `data/{agent_id}/config.json`, or as env vars with the `KINDLE_*` prefix:
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Gates the scheduled run. On-demand works regardless. |
+| `cookies_path` | `""` (resolves to `data/{agent_id}/secrets/kindle.cookies.txt`) | Path to the Netscape-format cookies file. Relative paths resolve against `agent_path`. |
+| `amazon_domain` | `"amazon.com"` | Configurable TLD for non-US accounts (`amazon.co.uk`, `amazon.de`, etc.). |
+| `vault_subfolder` | `"agent/pages/kindle"` | Vault-relative folder for per-book pages. |
+| `sync_min_interval_seconds` | `60` | Delay between books in a multi-book sync. |
+| `archive_deleted` | `true` | If false, deleted highlights are dropped instead of moved to the Archived section. |
+| `user_agent` | (Chrome 131 UA) | Override the User-Agent header. Defaults to a realistic recent Chrome string. |
+| `cookies_warn_after_days` | `300` | When cookies file is older than this, the sync summary includes a "consider re-exporting" warning. |
+
+## Tools
+
+The skill provides four native tools:
+
+- **`kindle_list_books(ctx)`** — fetch the books-with-highlights index. Returns ASIN, title, author, and cover_url per book.
+- **`kindle_fetch_highlights(ctx, asin)`** — fetch all highlights for one book. Returns annotation_id, location, color, text, and note per highlight.
+- **`kindle_sync_book(ctx, asin)`** — fetch and upsert a single book's vault page.
+- **`kindle_sync_all(ctx)`** — orchestrate a full library sync with rate-limiting and per-run journal entry.
+
+## Architecture notes
+
+- **HTTP client:** `curl_cffi` with Chrome TLS impersonation. Amazon flags vanilla `requests`/`httpx` via TLS fingerprinting; `curl_cffi` mimics a real Chrome handshake.
+- **Playwright fallback hook:** the two network functions (`_fetch_books_list_html`, `_fetch_book_highlights_html`) are the only places that touch the network. If `curl_cffi` stops working, swap their bodies to use a Playwright headless session — everything else (parsing, upsert, vault writes, tool defs) stays unchanged.
+- **Upsert model:** stable Amazon annotation IDs survive across syncs. Edits in place (same ID, different text); deletions move to `## Archived` with today's date stamp. Previously-archived entries keep their original archive date.
+
+## Troubleshooting
+
+- **`[error: Kindle cookies file not found ...]`** — Export cookies.txt and place at the configured path.
+- **`[error: failed to fetch books list: ...]` after cookies are in place** — Cookies probably expired (401/403). Re-export.
+- **Sync runs but pages don't update** — Check that the `kindle_sync_book` tool isn't being blocked by vault user-write confirmation (agent-owned `agent/pages/kindle/*` should bypass the gate automatically).
+- **The scheduled run silently does nothing** — Confirm `skills.kindle.enabled` is `true` in config.
+
+## Related
+
+- Filed as part of [issue #375](https://github.com/lmorchard/decafclaw/issues/375).
+- Sibling pattern with the (still-open) [YouTube transcript ingest](https://github.com/lmorchard/decafclaw/issues/374) — both consume the `data/{agent_id}/secrets/<source>.cookies.txt` convention introduced here.
+- Inspired by the [Obsidian Kindle Highlights plugin](https://github.com/hadynz/obsidian-kindle-plugin), which proves the differential-sync model against `read.amazon.com/notebook`.

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -83,7 +83,7 @@ context: fork
 
 This makes a skill both a user command (`!dream`) and a scheduled task — no separate schedule file needed.
 
-**Trust boundary:** only bundled skills (`src/decafclaw/skills/`) and admin-level skills (`data/{agent_id}/skills/`) can declare schedules. Workspace skills are ignored.
+**Trust boundary:** bundled skills (`src/decafclaw/skills/`), admin-level skills (`data/{agent_id}/skills/`), and `extra_skill_paths`-loaded skills can declare schedules. Workspace skills are ignored.
 
 File-based schedules take precedence over skill schedules when names collide.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,24 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
+    "beautifulsoup4>=4.12.0",
     "claude-code-sdk>=0.0.25",
+    "croniter>=6.0.0",
+    "curl-cffi>=0.7.0",
+    "google-auth>=2.0.0",
     "httpx>=0.28.1",
+    "aiosmtplib>=3.0.0",
+    "jsonschema>=4.0",
+    "lxml>=5.0",
     "mcp>=1.0.0",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0",
+    "requests>=2.0.0",
+    "sqlite-vec>=0.1.7",
     "starlette>=0.52.1",
     "tabstack>=2.3.0",
     "uvicorn>=0.41.0",
-    "croniter>=6.0.0",
     "websockets>=16.0",
-    "sqlite-vec>=0.1.7",
-    "google-auth>=2.0.0",
-    "requests>=2.0.0",
-    "aiosmtplib>=3.0.0",
-    "jsonschema>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -118,20 +118,30 @@ def discover_schedules(config) -> list[ScheduleTask]:
             if task.name not in tasks_by_name or source == "admin":
                 tasks_by_name[task.name] = task
 
-    # Also discover scheduled skills from disk (bundled + admin only, not workspace).
+    # Also discover scheduled skills from disk (bundled, admin, and extra_skill_paths).
     # Re-reads SKILL.md files each poll so edits (e.g. enabled: false) take
     # effect without restart.
-    from .skills import _BUNDLED_SKILLS_DIR, parse_skill_md
+    from .skills import _BUNDLED_SKILLS_DIR, _iter_skill_dirs, _resolve_extra_skill_paths, parse_skill_md
     bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
     admin_skills_dir = (config.agent_path / "skills").resolve()
+    extra_paths = _resolve_extra_skill_paths(config)
 
-    for source_label, base_dir in [
-        ("bundled", bundled_dir),
+    # Sources: list of (label, scan_base_path). For bundled/admin, _iter_skill_dirs
+    # yields their subdirectories; for extra_skill_paths, each entry is itself a
+    # single skill directory (SKILL.md at its root) — _iter_skill_dirs handles both.
+    #
+    # Precedence (first wins via the `skill.name in tasks_by_name` guard below):
+    # admin > extra > bundled. Admin is explicit per-deployment customization
+    # and always wins. `extra_skill_paths` is opt-in third-party — beats bundled
+    # because the user took explicit action to enable it. Bundled is the default.
+    skill_sources: list[tuple[str, Path]] = [
         ("admin", admin_skills_dir),
-    ]:
-        if not base_dir.is_dir():
-            continue
-        for skill_dir in sorted(base_dir.iterdir()):
+        *[("extra", p) for p in extra_paths],
+        ("bundled", bundled_dir),
+    ]
+
+    for source_label, base_dir in skill_sources:
+        for skill_dir in _iter_skill_dirs(base_dir):
             skill_md = skill_dir / "SKILL.md"
             if not skill_md.exists():
                 continue

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -251,6 +251,73 @@ class TestDiscoverSchedules:
         task = [t for t in tasks if t.name == "paused-job"][0]
         assert task.enabled is False
 
+    def test_skill_precedence_admin_over_extra_over_bundled(self, config, tmp_path, monkeypatch):
+        """Skill-based schedule precedence is admin > extra > bundled.
+
+        Admin is explicit per-deployment customization; extra is opt-in third-party;
+        bundled is the default. Uses `dream` (a real bundled skill) as the collision
+        target — its bundled schedule is `0 3 * * *`. Asserts that admin and extra
+        copies with different schedules correctly shadow it.
+        """
+        monkeypatch.setattr("decafclaw.schedules.run_schedule_task", lambda *a, **kw: None)
+
+        # Admin copy of `dream` with a distinct schedule.
+        admin_dream = config.agent_path / "skills" / "dream"
+        admin_dream.mkdir(parents=True)
+        (admin_dream / "SKILL.md").write_text(
+            "---\nname: dream\ndescription: Admin override\n"
+            "schedule: '15 4 * * *'\n---\nAdmin dream body.\n"
+        )
+
+        # Extra copy with yet another distinct schedule.
+        extra_dream = tmp_path / "dream"
+        extra_dream.mkdir()
+        (extra_dream / "SKILL.md").write_text(
+            "---\nname: dream\ndescription: Extra-paths override\n"
+            "schedule: '30 5 * * *'\n---\nExtra dream body.\n"
+        )
+        config.extra_skill_paths = [str(extra_dream)]
+
+        tasks = discover_schedules(config)
+        dream_tasks = [t for t in tasks if t.name == "dream"]
+        assert len(dream_tasks) == 1
+        # Admin wins over both extra and bundled.
+        assert dream_tasks[0].source == "admin"
+        assert dream_tasks[0].schedule == "15 4 * * *"
+
+        # Now remove the admin copy and re-check — extra should win over bundled.
+        (admin_dream / "SKILL.md").unlink()
+        admin_dream.rmdir()
+
+        tasks = discover_schedules(config)
+        dream_tasks = [t for t in tasks if t.name == "dream"]
+        assert len(dream_tasks) == 1
+        assert dream_tasks[0].source == "extra"
+        assert dream_tasks[0].schedule == "30 5 * * *"
+
+    def test_discovers_extra_skill_path_schedules(self, config, tmp_path, monkeypatch):
+        """Skills in extra_skill_paths with schedule field are discovered with source='extra'.
+
+        Patches run_schedule_task so discovered skills don't fire real agent turns.
+        """
+        monkeypatch.setattr("decafclaw.schedules.run_schedule_task", lambda *a, **kw: None)
+
+        # Create a minimal scheduled skill in an isolated tmp dir.
+        skill_dir = tmp_path / "ext-job"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: ext-job\ndescription: External scheduled job\n"
+            "schedule: '0 7 * * *'\n---\nDo external things.\n"
+        )
+        config.extra_skill_paths = [str(skill_dir)]
+
+        tasks = discover_schedules(config)
+        names = {t.name for t in tasks}
+        assert "ext-job" in names
+        task = next(t for t in tasks if t.name == "ext-job")
+        assert task.source == "extra"
+        assert task.schedule == "0 7 * * *"
+
 
 # -- Last-run tracking --------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -274,16 +287,52 @@ wheels = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "decafclaw"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
+    { name = "beautifulsoup4" },
     { name = "claude-code-sdk" },
     { name = "croniter" },
+    { name = "curl-cffi" },
     { name = "google-auth" },
     { name = "httpx" },
     { name = "jsonschema" },
+    { name = "lxml" },
     { name = "mcp" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -314,11 +363,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosmtplib", specifier = ">=3.0.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "claude-code-sdk", specifier = ">=0.0.25" },
     { name = "croniter", specifier = ">=6.0.0" },
+    { name = "curl-cffi", specifier = ">=0.7.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.0" },
+    { name = "lxml", specifier = ">=5.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -466,6 +518,80 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -488,6 +614,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -814,6 +949,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -920,6 +1068,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a **contrib** `kindle` skill at `contrib/skills/kindle/` that scrapes Kindle highlights & notes from `read.amazon.com/notebook` into per-book vault pages — replacing the manual Obsidian-plugin workflow with one that runs on the agent host.
- Opt-in via `extra_skill_paths` (per `contrib/skills/README.md`). Defaults to disabled.
- Three operating modes: on-demand all-book (`!kindle-sync`), on-demand single-book (`!kindle-sync <asin-or-title>`), and scheduled daily at 5am UTC. The scheduled run is gated by `skills.kindle.enabled` (default `false`) so fresh installs don't fire failing scrapes.

## Design Decisions

- **Contrib, not bundled.** Not core functionality — sits with `linkding-ingest` and `mastodon-ingest` as an optional external-service integration. Users add the path to `extra_skill_paths` to enable. (Originally implemented as bundled and moved during PR review.)
- **`curl_cffi` for TLS fingerprinting** with Chrome 131 impersonation. Amazon flags vanilla `requests`/`httpx` clients via TLS fingerprinting (mid-2023+). The two thin fetch helpers (`_fetch_books_list_html`, `_fetch_book_highlights_html`) are the only network surface — **Playwright fallback** can swap their bodies without touching parsing/upsert/vault if Amazon escalates detection later.
- **Auth via Netscape `cookies.txt`** at `data/{agent_id}/secrets/kindle.cookies.txt` (configurable). Same convention #374 (YouTube transcript ingest) can adopt later — `<source>.cookies.txt` in `secrets/`.
- **Per-book pages are fully agent-owned mechanical overwrites.** No "agent-managed sections + user-preserved regions" primitive built — that's its own subproject. Synthesis/cross-linking is the user's responsibility on a separate hand-curated page.
- **Deleted highlights → `## Archived` section** with strikethrough + archive date. History preserved; one file per book stays the unit of organization.
- **Per-run observability via `vault_journal_append`** tagged `[ingested, kindle]`. Cheap; mirrors how `newsletter` and `dream` log themselves.
- **Scheduler extended** to scan `extra_skill_paths` so contrib skills can self-schedule (previously bundled + admin only). CLAUDE.md updated accordingly. Contrib tests now run on every `make test` so they don't bit-rot.

Full reasoning: `docs/dev-sessions/2026-05-13-1137-kindle-skill-375/spec.md`.

## Changes

**Skill code (`contrib/skills/kindle/`):**
- `SKILL.md` — frontmatter (`name`, `description`, `schedule: 0 5 * * *`, `user-invocable: true`, `argument-hint`, `allowed-tools`, `required-skills`) + body with on-demand argument parsing logic.
- `tools.py` — `SkillConfig` dataclass (8 fields with `KINDLE_*` env aliases), `init`, 4 native tools (`kindle_list_books`, `kindle_fetch_highlights`, `kindle_sync_book`, `kindle_sync_all`), HTML parsers (`_parse_books_list`, `_parse_highlights`), pure-Python page upsert (`_upsert_book_page` with archive-section handling), auth helpers (`_resolve_cookies_path`, `_load_cookie_jar`, `_cookie_file_age_days`, `_make_session`).
- `smoke.py` — live-Amazon smoke script. Progressive steps: cookies → list → fetch → sync → enabled-gate.
- `fixtures/notebook_page.html` — redacted real capture from `read.amazon.com/notebook` (DOM structure preserved, PII scrubbed).
- `fixtures/cookies.txt` — synthetic Netscape format for unit tests.
- `test_tools.py` — 45 tests covering all the above (uses `importlib` to load `tools.py`, mirroring the production skill loader).

**Core changes outside the skill:**
- `src/decafclaw/schedules.py` — `discover_schedules` now also scans `extra_skill_paths` so contrib skills can self-schedule.
- `tests/test_schedules.py` — `test_discovers_extra_skill_path_schedules` regression.
- `Makefile` — `make test` now includes `contrib/skills/` so contrib tests run by default; `make test-contrib` remains for focused runs.
- `pyproject.toml` — adds `curl-cffi>=0.7.0`, `beautifulsoup4>=4.12.0`, `lxml>=5.0`.

**Docs:**
- `docs/kindle.md` — contrib-flavored: setup via extra_skill_paths, config reference, troubleshooting.
- `docs/index.md` — entry.
- `contrib/skills/README.md` — added kindle section.
- `docs/schedules.md` — updated for the extra_skill_paths discovery change.
- `CLAUDE.md` — updated for the new schedule-discovery scope.

**Session artifacts (`docs/dev-sessions/2026-05-13-1137-kindle-skill-375/`):**
- `spec.md`, `plan.md`, `research.md`, `notes.md` — full session record.

## Test Plan

- [x] `make check` — clean (ruff + pyright + tsc)
- [x] `make test` — **2477 passed** (2432 core + 45 contrib)
- [x] `pytest --durations=10` — no kindle test in slow tail (asyncio.sleep properly patched)

**Live smoke validated against real Amazon (already complete):**
- [x] Cookies parse — 26 cookies, `at-main` + `sess-at-main` present
- [x] `kindle_list_books` returns full library (24 books)
- [x] `kindle_fetch_highlights B078VWDNKT` returns 65 highlights (matches Amazon UI count)
- [x] `kindle_sync_book B078VWDNKT` writes vault page (343 lines, all frontmatter fields)
- [x] Idempotent re-sync — 0 new / 65 re-checked / 0 archived
- [x] Scheduled+disabled gate short-circuits cleanly, no network

## References

- Spec: `docs/dev-sessions/2026-05-13-1137-kindle-skill-375/spec.md`
- Plan: `docs/dev-sessions/2026-05-13-1137-kindle-skill-375/plan.md`
- Closes #375
- Related #374 (YouTube transcript ingest — same cookie convention)
- Related #286 (umbrella for source-specific ingest skills)
- Related #289 (vault structured ingest log — would consume this skill's journal output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)