### PR TITLE
fix(kindle): use /kindle command name; rewrite SKILL.md body to be imperative

### DIFF
--- a/contrib/skills/kindle/SKILL.md
+++ b/contrib/skills/kindle/SKILL.md
@@ -11,28 +11,26 @@ required-skills: [kindle]
 
 # Kindle sync
 
-You sync highlights & notes from `read.amazon.com/notebook` into per-book vault pages under `agent/pages/kindle/`.
-
-## When to run
-
-This skill runs in two contexts:
-
-1. **Scheduled (daily 5am UTC)** — full library sync. Call `kindle_sync_all`. The tool itself short-circuits to `kindle skill disabled; skipping` if `skills.kindle.enabled` is False (the default for fresh installs). It also fails fast if the cookies file is missing.
-
-2. **User-invocable (`!kindle-sync` / `/kindle-sync`)** — on-demand. The `enabled` gate does NOT apply here; the user explicitly asked. Still requires cookies.
-
-## Argument parsing
+You are syncing my Kindle highlights & notes from `read.amazon.com/notebook` into per-book vault pages under `agent/pages/kindle/`. Do it now — don't ask for confirmation.
 
 Argument: `$ARGUMENTS`
 
-- **Empty** (`!kindle-sync`) — call `kindle_sync_all`. Summarize the result.
-- **Non-empty** (`!kindle-sync <arg>`) — single-book mode:
-  1. Call `kindle_list_books` to get the library.
-  2. If `<arg>` looks like an ASIN (10 alphanumeric chars, all-caps), look it up directly.
-  3. Otherwise, treat `<arg>` as a title substring. Lowercase-substring match against each book's title. If exactly one matches, use its ASIN. If multiple match, return a numbered list and ask the user to re-invoke with the ASIN. If zero match, return `No book matching '<arg>' in your Kindle library`.
-  4. Call `kindle_sync_book(asin=...)` and summarize.
+## How to run
 
-## Notes
+**Empty argument** — call `kindle_sync_all` and summarize the result. This is the path taken by both the daily 5am UTC scheduled run and bare `!kindle` / `/kindle` invocations.
 
-- The per-book page is fully agent-owned. **Do not** manually edit `agent/pages/kindle/*.md` — your edits will be overwritten on the next sync. Use a separate hand-curated page for cross-links and synthesis (e.g., `agent/pages/<book>-notes.md` that wiki-links to the agent page).
-- If a fetch fails with a 401/403, your cookies have probably expired. Re-export `cookies.txt` from a logged-in browser session and place it at the configured path.
+**Non-empty argument** — single-book mode:
+
+1. Call `kindle_list_books` to fetch the library.
+2. If `<arg>` looks like an ASIN (10 alphanumeric characters, all-caps, typically starting with `B0`), call `kindle_sync_book(asin=<arg>)` directly.
+3. Otherwise treat `<arg>` as a title substring. Lowercase-substring match against each book's title.
+   - **Exactly one match:** call `kindle_sync_book(asin=<that book's asin>)`.
+   - **Multiple matches:** list them as `<asin> · <title>` and tell me to re-invoke with a specific ASIN. Do NOT pick one yourself.
+   - **Zero matches:** respond with `No book matching '<arg>' in your Kindle library`.
+4. Summarize the result of the sync.
+
+## Notes about behavior
+
+- The `kindle_sync_all` tool short-circuits with `kindle skill disabled; skipping` when the scheduled run hits it with `skills.kindle.enabled = False`. That gate doesn't apply to user-invoked runs — you should sync regardless.
+- If a fetch fails with a 401/403 or returns 0 books unexpectedly, the cookies have probably expired or the deployed host's IP isn't authenticated. Surface a message telling me to re-export `cookies.txt` from a logged-in browser session and place it at the configured path.
+- Per-book pages at `agent/pages/kindle/*.md` are fully agent-owned. **Do not** manually edit them — they're overwritten on every sync. Cross-links and prose summaries belong on a separate hand-curated page (e.g., `agent/pages/<book>-notes.md` that wiki-links to the agent page).

--- a/docs/kindle.md
+++ b/docs/kindle.md
@@ -26,11 +26,13 @@ See `contrib/skills/README.md` for detailed installation options (reference vs. 
 
 ## Operating modes
 
-**On-demand:** `!kindle-sync` (Mattermost) / `/kindle-sync` (web UI) syncs all books in your Kindle library that have highlights. Pass a book title or ASIN to sync a single book:
+**On-demand:** `!kindle` (Mattermost) / `/kindle` (web UI) syncs all books in your Kindle library that have highlights. Pass a book title or ASIN to sync a single book:
 
-- `/kindle-sync` — sync all books
-- `/kindle-sync "The Pragmatic Programmer"` — sync by title
-- `/kindle-sync B0XXXXXXXX` — sync by ASIN
+- `/kindle` — sync all books
+- `/kindle "The Pragmatic Programmer"` — sync by title (substring match)
+- `/kindle B0XXXXXXXX` — sync by ASIN
+
+(The skill's `name:` field is `kindle`, which is what the command parser matches. The skill's *purpose* is sync — that's what the body instructs the LLM to do when invoked.)
 
 **Scheduled:** daily at 5am UTC via `schedule: "0 5 * * *"` in SKILL.md. Gated by `skills.kindle.enabled` (default `false`) so fresh installs don't fire failing scrapes.
 


### PR DESCRIPTION
## Summary

Two real bugs surfaced when running the merged kindle skill on the deployed agent.

### Bug 1 — Unknown command `/kindle-sync`

The command parser matches the skill's `name:` field exactly ([`find_command` in `src/decafclaw/skills/__init__.py:335`](https://github.com/lmorchard/decafclaw/blob/main/src/decafclaw/skills/__init__.py#L335)). SKILL.md has `name: kindle`, so the actual command is `/kindle` — not `/kindle-sync`. The body text and `docs/kindle.md` referred to `/kindle-sync` throughout, which surfaced as `Unknown command: kindle-sync` in the chat UI.

### Bug 2 — `/kindle` activated but didn't act

The previous SKILL.md body was descriptive ("This skill runs in two contexts...") rather than imperative. The LLM read it as documentation and responded conversationally ("I have read and understood the information... Is there anything specific you would like me to do?") instead of running the sync.

## Fix

- **SKILL.md body** now opens with `You are syncing my Kindle highlights & notes... Do it now — don't ask for confirmation.` Mirrors the imperative voice in `src/decafclaw/skills/newsletter/SKILL.md`.
- **All `/kindle-sync` and `!kindle-sync` references** replaced with `/kindle` / `!kindle` in both SKILL.md and `docs/kindle.md`.
- **Added a docs note** clarifying that the skill's `name:` is what the command parser matches — the skill's *purpose* is sync, not its command name. Future skill authors should not confuse the two.

No code or test changes. Frontmatter unchanged. `make check` clean. `make test` — 2478 passed.

## Test Plan

- [x] `make check` — clean (ruff + pyright + tsc)
- [x] `make test` — 2478 passed
- [ ] **Live smoke on the deployed agent:** after merging, `/kindle` should activate the skill and immediately call `kindle_sync_all`. `/kindle <asin>` and `/kindle <title-substring>` should sync the matched book.

## Out of scope (follow-up)

Separately, the deployed agent's cookies are being rejected by Amazon (request redirects to `amazon.com/ap/signin`). Same cookies that worked from a laptop's IP earlier today fail from the deployed host's IP — the cross-host cookie-reuse problem the spec called out. Re-exporting cookies from a session that originates near the deployed host's egress, or pivoting to the Playwright fallback the skill already scaffolded for, is the next step. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)