### PR TITLE
feat(prompts): XML delimiters for reflection/sweep/compaction (#357)

### DIFF
--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -41,6 +41,30 @@ See #304 for the change history and #357 for the follow-up that
 applies the same convention to the reflection / memory-sweep /
 compaction prompts.
 
+#### Auxiliary prompt surfaces
+
+The reflection judge, pre-compaction memory sweep, and compaction
+summarizer follow the same delimiter convention for their dynamic
+inputs (#357). The shared helper is `wrap_xml(tag, body)` exported
+from `src/decafclaw/prompts/__init__.py` — same empty-body gating as
+the main system prompt assembly. Static instruction bodies are not
+wrapped: the imperative-voice prose + message role (system for
+sweep/compaction, user for reflection) carry the framing already.
+
+| Surface | Tags | Where |
+|---------|------|-------|
+| Reflection judge (user message) | `<retrieved_context>`, `<prior_turn_tools>`, `<user_request>`, `<tool_results>`, `<assistant_response>` | `src/decafclaw/prompts/REFLECTION.md` (placeholders wrapped in the template) |
+| Memory sweep (user message) | `<messages_to_compact>` | `_build_sweep_user_input` in `compaction.py` |
+| Compaction full mode (user message) | `<decision_slice>` (optional), `<messages_to_compact>` | `_build_compaction_user_input` in `compaction.py` |
+| Compaction incremental mode (user message) | `<decision_slice>` (optional), `<previous_summary>`, `<new_messages>` | `_build_compaction_user_input` in `compaction.py` |
+
+The `<decision_slice>` block is pre-wrapped by `format_slice` in
+`compaction_decisions.py` (#302). `DECISIONS_PROMPT_ADDENDUM`
+references this tag name directly so the LLM's instructions and the
+input it sees stay aligned. The chunked-compaction fallback for
+oversized inputs does not wrap chunks in `<messages_to_compact>` —
+the slice guidance still lives in the system prompt via the addendum.
+
 ### Context window layout
 
 ```

--- a/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/plan.md
+++ b/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/plan.md
@@ -1,0 +1,413 @@
+# Prompt Delimiters Implementation Plan
+
+**Goal:** Wrap dynamic inputs of the reflection, memory sweep, and compaction LLM surfaces in snake_case XML tags, matching #304's pattern.
+
+**Approach:** Promote the existing `_wrap` helper to public `wrap_xml`, then apply it (or template-literal XML for the reflection markdown file) at each call site. Extract small input-builder helpers so the assembled prompts are unit-testable without mocking `call_llm`. Update the decisions addendum so its instructions reference the new `<decision_slice>` tag.
+
+**Tech stack:** Python stdlib only (no new deps); pytest for tests.
+
+---
+
+## Phase 1: Promote `_wrap` → public `wrap_xml`
+
+Refactor the existing helper in `src/decafclaw/prompts/__init__.py` to be a public, importable utility. No behavior change. Establishes the shared building block Phase 2 and Phase 3 rely on.
+
+**Files:**
+- Modify: `src/decafclaw/prompts/__init__.py` — rename `_wrap` → `wrap_xml`; update 3 internal callers (lines 68, 76, 84). Keep the docstring (drop the "Callers rely on…" sentence's leading underscore reference).
+- Modify: `tests/test_prompts.py` — add a small `TestWrapXml` class with the three contract cases below; do not delete existing tests (they exercise `wrap_xml` indirectly through `load_system_prompt`).
+
+**Key changes:**
+
+```python
+# src/decafclaw/prompts/__init__.py
+def wrap_xml(tag: str, body: str) -> str:
+    """Wrap body in <tag>\n…\n</tag>; return "" if body is empty.
+
+    Callers rely on the empty-case returning "" so they can skip the
+    section entirely — no dangling `<tag></tag>` wrappers.
+    """
+    if not body:
+        return ""
+    return f"<{tag}>\n{body}\n</{tag}>"
+```
+
+Three internal call sites in `load_system_prompt` (current lines 68, 76, 84) become `wrap_xml(...)`. The literal `f'<skill name="{safe_name}">\n{skill.body}\n</skill>'` at line 107 and the manual outer `<loaded_skills>` wrapper at lines 110-112 stay as-is — those use an attribute (`name="…"`) which the helper does not support, so inlining is appropriate. Out of scope to refactor further.
+
+**Test additions** (`tests/test_prompts.py`, new class):
+
+```python
+from decafclaw.prompts import wrap_xml
+
+
+class TestWrapXml:
+    def test_wraps_body_in_tag(self):
+        assert wrap_xml("foo", "bar") == "<foo>\nbar\n</foo>"
+
+    def test_empty_body_returns_empty_string(self):
+        assert wrap_xml("foo", "") == ""
+
+    def test_preserves_internal_newlines(self):
+        assert wrap_xml("foo", "line1\nline2") == "<foo>\nline1\nline2\n</foo>"
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (full suite — refactor must not break #304's existing tag tests)
+- [x] `make check` passes
+- [x] `uv run pytest tests/test_prompts.py -v` — confirm `TestWrapXml` passes and existing system-prompt tests still pass
+
+**Verification — manual:**
+- [x] `grep -n "_wrap\b" src/` returns no remaining references (rename is complete; vendor JS bundle matches are unrelated)
+- [x] `grep -n "wrap_xml" src/decafclaw/prompts/__init__.py` shows 4 occurrences (1 def + 3 callers)
+
+---
+
+## Phase 2: Compaction — extract input builder + wrap dynamic data
+
+Wrap the compaction user-message dynamic data in `<messages_to_compact>` (full) / `<previous_summary>` + `<new_messages>` (incremental). Extract the assembly to a helper so it's directly testable. Update `DECISIONS_PROMPT_ADDENDUM` so its instructions reference the new tag name. Update one existing test that asserts on now-removed string literals.
+
+**Files:**
+- Modify: `src/decafclaw/compaction.py`
+  - Update `DECISIONS_PROMPT_ADDENDUM` (lines 106-133): change `"Current state slice"` (line 126) → `` `<decision_slice>` `` (backticks for inline-code emphasis in the prompt).
+  - Add: `_build_compaction_user_input(mode, old_slice_block: str) -> str` near the other helpers (after `_with_decisions_addendum` at line 151).
+  - Modify `compact_history` (lines 532-573): replace inline assembly with `_build_compaction_user_input`. The `slice_prefix_input` literal-string prefix (lines 537-542) becomes a bare `format_slice(old_slice)` block; the prose prefix is dropped.
+- Modify: `tests/test_compaction.py`
+  - Update `test_incremental_compaction_includes_existing_summary` (around line 239-241): replace `assert "Existing summary:" in user_content` and `assert "New conversation turns to incorporate:" in user_content` with `assert "<previous_summary>" in user_content` and `assert "<new_messages>" in user_content`. Keep `"Summary of turns 0-4." in user_content` (the summary text is preserved inside the new tag).
+  - Add: new `TestBuildCompactionUserInput` class exercising the helper directly for both modes and the slice-gated branches.
+  - Add: standalone `test_decisions_addendum_references_decision_slice_tag` function.
+
+**Key changes:**
+
+```python
+# src/decafclaw/compaction.py — new import near top
+from .prompts import wrap_xml
+
+
+# After _with_decisions_addendum (current line ~151):
+def _build_compaction_user_input(mode, old_slice_block: str = "") -> str:
+    """Assemble the user-message text fed to the compaction LLM.
+
+    Sections, in order, joined by "\n\n":
+      - <decision_slice>...</decision_slice>          (optional; pre-wrapped via format_slice)
+      - Incremental mode:
+          <previous_summary>{prev_summary}</previous_summary>
+          <new_messages>{newly_old_flat}</new_messages>
+      - Full mode:
+          <messages_to_compact>{flattened}</messages_to_compact>
+
+    ``old_slice_block`` is either the output of ``format_slice(slice_)``
+    (a full XML block, possibly with a trailing newline) or "" when no
+    slice is active.
+    """
+    sections: list[str] = []
+    slice_section = old_slice_block.strip()
+    if slice_section:
+        sections.append(slice_section)
+
+    if mode.incremental:
+        newly_old_flat = flatten_messages(
+            [msg for turn in mode.newly_old_turns for msg in turn]
+        )
+        sections.append(wrap_xml("previous_summary", mode.prev_summary))
+        sections.append(wrap_xml("new_messages", newly_old_flat))
+    else:
+        flattened = flatten_messages(mode.old_messages)
+        sections.append(wrap_xml("messages_to_compact", flattened))
+
+    return "\n\n".join(s for s in sections if s)
+```
+
+Then replace the inline assembly in `compact_history`:
+
+```python
+# Replace lines 537-542 (slice_prefix_input construction) with:
+old_slice_block = (
+    format_slice(old_slice)
+    if old_slice and not old_slice.is_empty()
+    else ""
+)
+
+# Replace lines 548-573 (incremental + full branches) with:
+if mode.incremental:
+    combined_input = _build_compaction_user_input(mode, old_slice_block)
+    estimated = estimate_tokens(combined_input)
+    log.info(f"Incremental summarization: ~{estimated} est. tokens")
+    summary = await _single_summarize(
+        ctx, config, combined_input,
+        _with_decisions_addendum(INCREMENTAL_COMPACTION_PROMPT, config))
+else:
+    prompt = _with_decisions_addendum(_load_compaction_prompt(config), config)
+    flattened_input = _build_compaction_user_input(mode, old_slice_block)
+    estimated = estimate_tokens(flattened_input)
+    if estimated > budget:
+        log.info(f"Flattened text ({estimated} est. tokens) exceeds "
+                 f"budget ({budget}), using chunked compaction")
+        # Note: chunked path flattens per-chunk and does not wrap in
+        # <messages_to_compact> — it's a rare fallback for oversized
+        # inputs. The <decision_slice> guidance still lives in the
+        # system prompt via the addendum.
+        summary = await _chunked_summarize(
+            ctx, config, mode.old_turns, prompt, budget)
+    else:
+        summary = await _single_summarize(ctx, config, flattened_input, prompt)
+```
+
+```python
+# src/decafclaw/compaction.py — DECISIONS_PROMPT_ADDENDUM update at line ~126
+# Old:
+#   If a "Current state slice" is provided in the input, **reuse existing
+# New:
+#   If a `<decision_slice>` block is provided in the input, **reuse existing
+```
+
+**Test additions** (`tests/test_compaction.py`):
+
+```python
+from decafclaw.compaction import (
+    DECISIONS_PROMPT_ADDENDUM,
+    _build_compaction_user_input,
+)
+
+
+class TestBuildCompactionUserInput:
+    def _mock_mode(self, incremental: bool, **kwargs):
+        from types import SimpleNamespace
+        return SimpleNamespace(incremental=incremental, **kwargs)
+
+    def test_full_mode_wraps_in_messages_to_compact(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<messages_to_compact>" in out
+        assert "</messages_to_compact>" in out
+        assert "User: hi" in out
+        assert "Assistant: hello" in out
+
+    def test_incremental_mode_wraps_previous_summary_and_new_messages(self):
+        mode = self._mock_mode(
+            incremental=True,
+            prev_summary="prior summary text",
+            newly_old_turns=[
+                [{"role": "user", "content": "next message"}],
+            ],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<previous_summary>\nprior summary text\n</previous_summary>" in out
+        assert "<new_messages>" in out
+        assert "User: next message" in out
+
+    def test_decision_slice_block_prepended_when_provided(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[{"role": "user", "content": "hi"}],
+        )
+        slice_block = "<decision_slice>\nDecisions:\n- foo\n</decision_slice>"
+        out = _build_compaction_user_input(mode, old_slice_block=slice_block)
+        assert out.startswith("<decision_slice>")
+        assert "<messages_to_compact>" in out
+        assert "</decision_slice>\n\n<messages_to_compact>" in out
+
+    def test_empty_slice_block_omits_section(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[{"role": "user", "content": "hi"}],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<decision_slice>" not in out
+        assert out.startswith("<messages_to_compact>")
+
+
+def test_decisions_addendum_references_decision_slice_tag():
+    """The addendum must instruct the LLM about the actual tag name it sees."""
+    assert "<decision_slice>" in DECISIONS_PROMPT_ADDENDUM
+    assert "Current state slice" not in DECISIONS_PROMPT_ADDENDUM
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (entire suite — confirms updated `test_incremental_compaction_includes_existing_summary` passes against new tag names)
+- [x] `make check` passes
+- [x] `uv run pytest tests/test_compaction.py -v` — confirm new `TestBuildCompactionUserInput` + addendum test + updated incremental test all pass
+
+**Verification — manual:**
+- [x] `grep -n "Existing summary:\|New conversation turns to incorporate\|Current state slice" src/decafclaw/compaction.py` returns no matches
+- [x] Read the chunked-compaction comment to confirm the no-slice-on-chunked behavior is documented
+
+---
+
+## Phase 3: Memory sweep — wrap flattened conversation in `<messages_to_compact>`
+
+Wrap the sweep child-agent's user message body in `<messages_to_compact>`. Drop the `"Conversation history to review:\n\n"` prefix. Extract a tiny helper for testability.
+
+**Files:**
+- Modify: `src/decafclaw/compaction.py`
+  - Add: `_build_sweep_user_input(flattened: str) -> str` near `_run_memory_sweep` (around line 30). One-line body using `wrap_xml`.
+  - Modify `_run_memory_sweep` (line 51): replace `task_prompt = f"Conversation history to review:\n\n{flattened}"` with `task_prompt = _build_sweep_user_input(flattened)`.
+- Modify: `tests/test_compaction.py`
+  - Add: `TestBuildSweepUserInput` class with two tests (tag presence, legacy prefix gone).
+
+**Key changes:**
+
+```python
+# src/decafclaw/compaction.py — near _load_sweep_prompt (~line 30):
+def _build_sweep_user_input(flattened: str) -> str:
+    """Wrap flattened messages in <messages_to_compact> for the memory sweep child agent."""
+    return wrap_xml("messages_to_compact", flattened)
+```
+
+Then in `_run_memory_sweep`:
+
+```python
+# Replace line 51:
+task_prompt = _build_sweep_user_input(flattened)
+```
+
+Note: `wrap_xml` returns `""` for an empty body, but the sweep is only invoked when `mode.old_messages` is non-empty (guard at `compact_history:521-523`), so empty-flatten is not a real edge case. No defensive code needed.
+
+**Test additions** (`tests/test_compaction.py`):
+
+```python
+from decafclaw.compaction import _build_sweep_user_input
+
+
+class TestBuildSweepUserInput:
+    def test_wraps_flattened_in_messages_to_compact(self):
+        out = _build_sweep_user_input("User: hi\nAssistant: hello")
+        assert out == "<messages_to_compact>\nUser: hi\nAssistant: hello\n</messages_to_compact>"
+
+    def test_no_legacy_prefix_present(self):
+        out = _build_sweep_user_input("any text")
+        assert "Conversation history to review:" not in out
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+- [x] `uv run pytest tests/test_compaction.py::TestBuildSweepUserInput -v` — confirm new tests pass
+
+**Verification — manual:**
+- [x] `grep -n "Conversation history to review" src/` returns no matches
+
+---
+
+## Phase 4: Reflection — wrap template placeholders in `REFLECTION.md`; drop prose prefix in `evaluate_response`
+
+Edit `REFLECTION.md` so each `.format()` placeholder lives inside its own XML tag. Remove the Python-side "Retrieved context (automatically injected…)" prefix (the tag name now carries that meaning). Add a test that fills the template with sample values and asserts the tags appear in the expected order.
+
+**Files:**
+- Modify: `src/decafclaw/prompts/REFLECTION.md` — replace lines 33-43 (the `---` divider + placeholder block) with the tagged structure below.
+- Modify: `src/decafclaw/reflection.py` — in `evaluate_response` (lines 274-280), simplify `context_block` to just `retrieved_context` (no prefix line).
+- Modify: `tests/test_reflection.py` — add a `TestReflectionPromptStructure` class that loads `_BUNDLED_PROMPT`, fills it with sample values, and asserts every tag appears.
+
+**Key changes:**
+
+`src/decafclaw/prompts/REFLECTION.md`, replace lines 33-43 with:
+
+```markdown
+---
+
+<retrieved_context>
+{retrieved_context}
+</retrieved_context>
+
+<prior_turn_tools>
+{prior_turn_tools}
+</prior_turn_tools>
+
+<user_request>
+{user_message}
+</user_request>
+
+<tool_results>
+{tool_results_summary}
+</tool_results>
+
+<assistant_response>
+{agent_response}
+</assistant_response>
+```
+
+`src/decafclaw/reflection.py`, replace lines 274-280:
+
+```python
+context_block = retrieved_context  # tag in REFLECTION.md conveys "auto-injected" semantic
+```
+
+The full `.format()` call (lines 281-287) is otherwise unchanged.
+
+**Test additions** (`tests/test_reflection.py`):
+
+```python
+from decafclaw.reflection import _BUNDLED_PROMPT
+
+
+class TestReflectionPromptStructure:
+    """Assert the bundled REFLECTION.md wraps each dynamic input in its tag."""
+
+    def _filled(self) -> str:
+        return _BUNDLED_PROMPT.read_text().format(
+            user_message="what is 2+2?",
+            agent_response="4",
+            tool_results_summary="(no tools used)",
+            prior_turn_tools="(none)",
+            retrieved_context="page X is relevant",
+        )
+
+    def test_all_expected_tags_present(self):
+        out = self._filled()
+        for tag in (
+            "<user_request>", "</user_request>",
+            "<assistant_response>", "</assistant_response>",
+            "<tool_results>", "</tool_results>",
+            "<prior_turn_tools>", "</prior_turn_tools>",
+            "<retrieved_context>", "</retrieved_context>",
+        ):
+            assert tag in out, f"missing {tag}"
+
+    def test_placeholder_values_inside_tags(self):
+        out = self._filled()
+        assert out.index("<user_request>") < out.index("what is 2+2?") < out.index("</user_request>")
+        assert out.index("<assistant_response>") < out.index("4") < out.index("</assistant_response>")
+        assert out.index("<retrieved_context>") < out.index("page X is relevant") < out.index("</retrieved_context>")
+
+    def test_legacy_prefix_removed(self):
+        text = _BUNDLED_PROMPT.read_text()
+        assert "Retrieved context (automatically injected" not in text
+        assert "User: {user_message}" not in text
+        assert "Assistant response: {agent_response}" not in text
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+- [x] `uv run pytest tests/test_reflection.py -v` — confirm new structure tests pass alongside existing reflection tests
+
+**Verification — manual:**
+- [x] Read `src/decafclaw/prompts/REFLECTION.md` end-to-end — confirm static instruction body is unchanged, all five tags appear, no stray legacy headers (`User:`, `Assistant response:`)
+- [x] `grep -n "Retrieved context (automatically" src/` returns no matches
+
+---
+
+## Phase 5: Update docs
+
+Update `docs/context-composer.md` with a brief note that the delimiter convention now applies to reflection / memory sweep / compaction dynamic inputs.
+
+**Files:**
+- Modify: `docs/context-composer.md` — add a short subsection (or extend the existing #304 section) listing the additional tags and noting `wrap_xml` is the shared helper.
+
+**Key changes:** documentation only; no code changes. TDD opt-out: docs phase.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (no test changes — sanity check that docs edits don't break anything)
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] Read the updated `docs/context-composer.md` section — confirms the new tags are listed (`<user_request>`, `<assistant_response>`, `<tool_results>`, `<prior_turn_tools>`, `<retrieved_context>`, `<messages_to_compact>`, `<previous_summary>`, `<new_messages>`) and the `wrap_xml` rename is mentioned.

--- a/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/research.md
+++ b/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/research.md
@@ -1,0 +1,272 @@
+# Prompt Delimiter Systems Research
+
+## 1. REFLECTION.md Call Site
+
+**Load point:** `src/decafclaw/reflection.py:24` — bundled default and `src/decafclaw/reflection.py:43-49` (override path check)
+
+**Function:** `load_reflection_prompt(config) -> str` (lines 36-49)
+- Priority: `data/{agent_id}/REFLECTION.md` (override) → bundled `src/decafclaw/prompts/REFLECTION.md`
+- Returns raw markdown stripped of leading/trailing whitespace
+
+**Template usage:** `src/decafclaw/reflection.py:260-287` in `evaluate_response()`
+- Line 281: template is used with `.format()` to inject placeholders:
+  - `{user_message}` — current user input
+  - `{agent_response}` — the agent's text response
+  - `{tool_results_summary}` — built via `build_tool_summary()` (lines 156-165) or "(no tools used)" stub
+  - `{prior_turn_tools}` — built via `build_prior_turn_summary()` (lines 168-205)
+  - `{retrieved_context}` — formatted vault retrieval block (line 274-280), wrapped as "Retrieved context (automatically injected...)\n" when present, empty string when missing
+
+**Dynamic data concatenation (exact order in prompt):**
+```python
+prompt = prompt_template.format(
+    user_message=user_message,                    # direct param
+    tool_results_summary=tool_summary or "(no tools used)",  # fallback stub if empty
+    agent_response=agent_response,                # direct param
+    retrieved_context=context_block,              # see above
+    prior_turn_tools=prior_turn_summary,          # built separately
+)
+```
+
+**LLM call:** Line 289 — single-turn invocation with no system prompt:
+```python
+messages = [{"role": "user", "content": prompt}]
+```
+The filled template becomes the entire user message. No wrapping, no XML delimiters in the current system.
+
+**Separators:** Template placeholders are inline, no explicit join/separator — the template markdown itself controls flow (lines 35-43 in REFLECTION.md show headers and blank lines).
+
+---
+
+## 2. MEMORY_SWEEP.md Call Site
+
+**Load point:** `src/decafclaw/compaction.py:21` — bundled path; `src/decafclaw/compaction.py:24-29` loads with override support
+
+**Function:** `_load_sweep_prompt(config) -> str` (lines 24-29)
+- Override: `config.agent_path / "MEMORY_SWEEP.md"` (check line 26)
+- Default: `Path(__file__).parent / "prompts" / "MEMORY_SWEEP.md"`
+- Returns raw text via `.read_text()`
+
+**Integration:** `_run_memory_sweep(ctx, old_messages: list[dict]) -> None` (lines 32-82)
+- Called asynchronously in background during compaction (line 523 in `compact_history()`)
+- Line 49: `sweep_prompt = _load_sweep_prompt(config)`
+- Line 50-51: conversation messages are flattened to text via `flatten_messages()` (lines 208-233)
+- Line 51: task prompt built as:
+  ```python
+  task_prompt = f"Conversation history to review:\n\n{flattened}"
+  ```
+  — simple `\n\n` join between header and flattened text
+
+**LLM call:** Line 78
+```python
+result = await run_agent_turn(child_ctx, task_prompt, [])
+```
+- `task_prompt` becomes the user message in a child agent turn
+- `system_prompt=sweep_prompt` (line 59) is set on a forked context
+- No parent system prompt; sweep_prompt is the complete system message
+- Vault tools only (lines 73-76), no standard tools
+
+**Separators:** `\n\n` between "Conversation history to review:" header and flattened message list. Flattening itself uses `\n` (line 233).
+
+---
+
+## 3. Compaction Prompt Construction
+
+**Location:** `src/decafclaw/compaction.py` — inline string definitions and assembly
+
+**Default prompt (no decisions):** Lines 83-92
+```python
+DEFAULT_COMPACTION_PROMPT = """\
+Summarize the following conversation, preserving:
+- Key facts and decisions made
+- User preferences and corrections
+- Important tool results and findings
+- Approaches that were tried but didn't work, and why — this prevents re-exploration
+- The current topic and any open questions
+
+Be concise but don't lose critical details. Err on the side of including information
+that would prevent duplicate work or repeated mistakes. Format as a brief narrative."""
+```
+Inline plain-text string, no XML wrapping at definition.
+
+**Incremental variant:** Lines 94-100
+```python
+INCREMENTAL_COMPACTION_PROMPT = """\
+You have an existing conversation summary and new turns that need to be incorporated.
+Update the summary to include the new information while preserving all important details
+from the original summary. ...
+```
+
+**Decisions addendum (when enabled):** Lines 106-133
+```python
+DECISIONS_PROMPT_ADDENDUM = """\
+
+After your prose summary, append a JSON block in this exact shape:
+
+```json
+{
+  "decisions": ["..."],
+  "open_questions": ["..."],
+  "artifacts": ["..."]
+}
+```
+[instructions for reusing existing entries verbatim, adding new, dropping obsolete]
+...
+```
+
+**Assembly pipeline:**
+
+1. Line 138-143: `_load_compaction_prompt(config)` — loads custom override from `config.agent_path / "COMPACTION.md"` or returns `DEFAULT_COMPACTION_PROMPT`
+
+2. Line 146-151: `_with_decisions_addendum(prompt: str, config)` — appends addendum if `config.compaction.decisions_enabled` is true (direct string concatenation with no separator — the addendum starts with `\n\n`)
+
+3. **Full compaction flow** (lines 561-573):
+   ```python
+   prompt = _with_decisions_addendum(_load_compaction_prompt(config), config)
+   flattened = (slice_prefix_input + flatten_messages(mode.old_messages)
+                if slice_prefix_input
+                else flatten_messages(mode.old_messages))
+   ```
+   - `slice_prefix_input` (lines 537-542) is `"Current state slice (preserve verbatim...)\n{format_slice(old_slice)}\n\n"` when non-empty, empty string otherwise
+   - `flatten_messages()` produces text with `\n` joins (line 233)
+   - Order: prompt + optional slice prefix + flattened messages
+
+4. **Incremental flow** (lines 548-560):
+   ```python
+   newly_old_flat = flatten_messages([msg for turn in mode.newly_old_turns for msg in turn])
+   combined_input = (
+       f"{slice_prefix_input}"
+       f"Existing summary:\n{mode.prev_summary}\n\n"
+       f"New conversation turns to incorporate:\n{newly_old_flat}"
+   )
+   summary = await _single_summarize(ctx, config, combined_input, 
+       _with_decisions_addendum(INCREMENTAL_COMPACTION_PROMPT, config))
+   ```
+   Order: slice_prefix + "Existing summary:\n" + summary_text + "\n\n" + "New conversation turns to incorporate:\n" + flat_text
+
+5. **LLM call:** Lines 238-254 in `_single_summarize()`
+   ```python
+   summary_messages = [
+       {"role": "system", "content": prompt},
+       {"role": "user", "content": flattened_text},
+   ]
+   ```
+   — Two-message structure: system (the prompt template) + user (the input text)
+
+**Exact separators:**
+- Addendum: starts with `\n\n`, prepended to prompt string
+- Slice prefix: `"Current state slice...\n{slice}\n\n"` (line 540-541)
+- Section headers in combined_input: literal strings like `"Existing summary:\n"`, `"New conversation turns to incorporate:\n"`
+- Message flatten: `\n` joins (line 233)
+- Messages flattened: "User: ...", "Assistant: ...", "Tool result: ..." prefixes, joined by newline (line 233)
+
+---
+
+## 4. System Prompt XML Delimiter Pattern (#304)
+
+**Assembly location:** `src/decafclaw/prompts/__init__.py` — function `load_system_prompt(config)` (lines 36-115)
+
+**Wrapping function:** `_wrap(tag: str, body: str) -> str` (lines 25-33)
+```python
+def _wrap(tag: str, body: str) -> str:
+    """Wrap body in <tag>\n…\n</tag>; return "" if body is empty."""
+    if not body:
+        return ""
+    return f"<{tag}>\n{body}\n</{tag}>"
+```
+Pattern: `<tag>\n{body}\n</tag>` with literal newlines, empty string for empty body (gating applies).
+
+**Exact tags and order** (from `_PROMPT_FILES` and subsequent appends, lines 19-115):
+
+| Order | Tag | Source | Condition |
+|-------|-----|--------|-----------|
+| 1 | `<soul>` | `SOUL.md` (bundled or override) | Always (paired line 20) |
+| 2 | `<agent_role>` | `AGENT.md` (bundled or override) | Always (paired line 21) |
+| 3 | `<user_context>` | `USER.md` (workspace only) | Only when file exists + non-empty (lines 73-78) |
+| 4 | `<skill_catalog>` | `build_catalog_text(skills)` output | Only when non-empty (lines 82-86) |
+| 5 | `<loaded_skills>` | Always-loaded bundled skill bodies | Only when at least one present (lines 110-113) |
+| - | `<deferred_tools>` | Separate system message (not system prompt) | See `tool_registry.build_deferred_list_text()` |
+
+**Assembly mechanics** (lines 54-115):
+1. Iterate `_PROMPT_FILES` pairs (SOUL→soul, AGENT→agent_role); load, wrap, append (lines 56-70)
+2. Check USER.md, wrap if present and non-empty (lines 73-78)
+3. Call `discover_skills()`, build catalog, wrap if non-empty (lines 82-86)
+4. Collect always-loaded skill bodies, wrap each as `<skill name="{safe_name}">\n{body}\n</skill>` inside `<loaded_skills>` wrapper (lines 92-113)
+5. Join all sections with `\n\n` (line 115)
+
+**Skill name escaping:** Line 106 — `html.escape(skill.name, quote=True)` for XML attribute safety (defends against quotes, `<`, `>`, `&` in skill names).
+
+**Empty section gating:** `_wrap()` returns `""` for empty body, so dangling empty wrappers never appear (lines 25-33).
+
+**Inner content:** Plain markdown preserved as-is within tags; no escaping or rewriting (lines 79-89 of test_prompts.py confirm this).
+
+**Deferred tools variant:** Built separately in `build_deferred_list_text()` (tool_registry.py, referenced by docs/context-composer.md:34). Sent as a second system message if deferred pool exists (context_composer.py:443-445):
+```python
+if deferred_text:
+    messages.append({"role": "system", "content": deferred_text})
+```
+
+---
+
+## 5. Tests for Prompt Assembly
+
+**System prompt tests:** `tests/test_prompts.py` (all lines 1-200)
+
+- **TestDefaultLoad** (lines 13-36): Validates bundled load with expected tags in order (soul → agent_role → skill_catalog → loaded_skills). Confirms tags are closed properly.
+- **TestUserContext** (lines 42-72): USER.md wrapping, positioning between agent_role and skill_catalog, empty-file gating.
+- **TestInnerContent** (lines 78-99): Content inside tags preserved intact, markdown not transformed.
+- **TestSkillSections** (lines 105-165): Catalog/loaded_skills gating on discovery results, per-skill `<skill name="…">` blocks, XML attribute escaping for skill names containing special characters, trust-boundary checks (non-bundled skills excluded from bodies).
+
+**Reflection tests:** `tests/test_reflection.py` (lines 1-120 shown, extends further)
+
+- **TestBuildToolSummary** (lines 24-48): Tool call/result extraction and formatting. No prompt-assembly tests.
+- **TestBuildToolSummary.test_with_tools()** (lines 32-47): Verifies tool names and arguments appear in summary.
+- **TestBuildToolSummary.test_includes_widget_response_user_messages()** (lines 49-71): Widget synthetic messages included.
+- Widget response turn-boundary handling verified (lines 73-102).
+- Tool result truncation tested (lines 104-118).
+
+No direct tests of reflection prompt assembly or template substitution (template filling happens in `evaluate_response()`, not tested in isolation).
+
+**Compaction tests:** `tests/test_compaction.py` (lines 1-190+ shown)
+
+- **TestSplitIntoTurns** (lines 20-66): Turn splitting logic for partitioning archive into old/protected/recent.
+- **TestFlattenMessages** (lines 69-100): Message flattening to text (tool call names, tool results truncation, role prefixes).
+- **TestEstimateTokens** (lines 104-108): Token estimation utility.
+- **TestCompactHistory** (lines 111-214+): Full compaction workflow. Mock LLM responses, verify summary message structure, incremental vs full modes, decision slice handling.
+
+No direct tests of compaction prompt assembly or template substitution. Tests mock `call_llm()` to avoid dependency on actual LLM.
+
+**No existing tests snapshot or assert against assembled prompt text** (neither system prompt, reflection, memory sweep, nor compaction). All tests validate behavior (tags present, structure, gating logic) but not the exact wording or formatting of assembled prompts.
+
+**Fixture:** All tests use a shared `config` fixture (conftest.py) with bundled skills and minimal workspace.
+
+---
+
+## Summary of Conventions
+
+### System Prompt (#304)
+- **Delimiter pattern:** `<tag>\n{body}\n</tag>`
+- **Separator:** `\n\n` between sections
+- **Gating:** Empty sections emit nothing (prevent dangling tags)
+- **Attribute escaping:** `html.escape(value, quote=True)` for XML attributes
+
+### Reflection Prompt
+- **Template:** Markdown with placeholders `{user_message}`, `{agent_response}`, `{tool_results_summary}`, `{retrieved_context}`, `{prior_turn_tools}`
+- **Placeholder injection:** `.format()` substitution
+- **LLM context:** Single user message, no system prompt
+- **Separators:** Template controls via markdown headers/blanks (no programmatic join)
+
+### Memory Sweep Prompt
+- **Template:** Plain markdown, loaded as-is
+- **LLM context:** System prompt, separate user message with `\n\n` join ("Conversation history to review:\n\n" + flattened)
+- **Child turn:** Isolated agent loop with vault tools only
+- **Separator:** `\n\n` before message list
+
+### Compaction Prompt
+- **Template variants:** Default + Incremental + optional Decisions addendum
+- **Assembly:** `_with_decisions_addendum()` prepends addendum (starts with `\n\n`)
+- **Input structure (full):** `slice_prefix + flattened_messages` or just `flattened_messages`
+- **Input structure (incremental):** `slice_prefix + "Existing summary:\n" + summary + "\n\n" + "New conversation turns to incorporate:\n" + newly_old_flat`
+- **LLM context:** Two-message (system prompt + user text)
+- **Separators:** Explicit header strings ("Existing summary:\n", etc.) + `\n\n` between major sections + `\n` within flattened messages
+- **Decision slice format:** Rendered inline before prose via `format_slice()` (compaction_decisions.py, not detailed here)
+

--- a/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/spec.md
+++ b/docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/spec.md
@@ -1,0 +1,146 @@
+# Prompt Delimiters: Reflection / Memory Sweep / Compaction Spec
+
+**Goal:** Apply explicit XML delimiters to the dynamic inputs of the three remaining LLM prompt surfaces (reflection judge, pre-compaction memory sweep, compaction summarizer) so each segment's role is structurally clear to the model. Mirrors the convention #304 established for the main system prompt.
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/357
+
+## Current state
+
+Three prompt surfaces today concatenate dynamic content with minimal or no delimiters:
+
+- **Reflection judge** (`src/decafclaw/reflection.py:281`): `REFLECTION.md` is loaded as a markdown template (`src/decafclaw/prompts/REFLECTION.md`), filled via `.format()` with five placeholders (`{retrieved_context}`, `{prior_turn_tools}`, `{user_message}`, `{tool_results_summary}`, `{agent_response}`), and sent as a single `user` message — no system prompt, no XML wrappers. The template uses ad-hoc headers like `User: {user_message}` and `Assistant response: {agent_response}` as inline labels.
+
+- **Memory sweep** (`src/decafclaw/compaction.py:32-78`): `MEMORY_SWEEP.md` becomes the system prompt of a child agent; the user message is built as `f"Conversation history to review:\n\n{flattened}"` where `flattened` comes from `flatten_messages()` (`compaction.py:208-233`). No XML wrapping anywhere.
+
+- **Compaction** (`compaction.py:548-573`): Two inline prompt strings (`DEFAULT_COMPACTION_PROMPT`, `INCREMENTAL_COMPACTION_PROMPT`) plus optional `DECISIONS_PROMPT_ADDENDUM` form the system message. User message is assembled in Python with literal section headers (`Existing summary:\n`, `New conversation turns to incorporate:\n`) and an optional `Current state slice (preserve verbatim if still applicable):\n` prefix containing a `<decision_slice>` block (already XML-wrapped via `format_slice()` in `compaction_decisions.py:264`). Otherwise plain text.
+
+The #304 system-prompt pattern (`src/decafclaw/prompts/__init__.py:25-33`) uses `_wrap(tag, body)` to produce `<tag>\n{body}\n</tag>` with empty-body gating (returns `""`), sections joined by `\n\n`. Tags so far: `<soul>`, `<agent_role>`, `<user_context>`, `<skill_catalog>`, `<loaded_skills>`, plus nested `<skill name="…">` and `<deferred_tools>`. Snake_case, lean.
+
+Existing tests in `tests/test_prompts.py`, `tests/test_reflection.py`, `tests/test_compaction.py` assert structural facts (tags present, order, gating) but don't snapshot full prompt text. They mock `call_llm` to avoid live LLM dependencies.
+
+## Desired end state
+
+Each of the three call sites produces an LLM input where every dynamic chunk lives inside a snake_case XML tag whose name conveys its semantic role.
+
+**Reflection** (`REFLECTION.md` template; single user message):
+- Static instruction text remains role-less plain markdown (imperative voice is unambiguous on its own — no `<task>` wrapper needed).
+- Placeholders are wrapped inside the template itself:
+  ```
+  <retrieved_context>
+  {retrieved_context}
+  </retrieved_context>
+
+  <prior_turn_tools>
+  {prior_turn_tools}
+  </prior_turn_tools>
+
+  <user_request>
+  {user_message}
+  </user_request>
+
+  <tool_results>
+  {tool_results_summary}
+  </tool_results>
+
+  <assistant_response>
+  {agent_response}
+  </assistant_response>
+  ```
+- Python (`reflection.py:281`) keeps using `.format()` with the same placeholder names; the wrapping moves into the markdown. Empty-string placeholders produce empty tags — acceptable here (every section is semantically relevant and the model can read "empty" as "none"). Existing prefix line "Retrieved context (automatically injected before the user's message):" is dropped — the tag name conveys it.
+
+**Memory sweep** (`MEMORY_SWEEP.md` system prompt; user message in `_run_memory_sweep`):
+- System prompt unchanged (the prompt is itself the instruction block — owns the system slot).
+- User message becomes:
+  ```
+  <messages_to_compact>
+  {flattened}
+  </messages_to_compact>
+  ```
+- Drop the `f"Conversation history to review:\n\n"` prefix — the tag name carries the same meaning.
+
+**Compaction** (system prompt + user message; two modes):
+- System prompts (`DEFAULT_COMPACTION_PROMPT`, `INCREMENTAL_COMPACTION_PROMPT`, `DECISIONS_PROMPT_ADDENDUM`) stay inline strings. No wrapping of the static body (system slot conveys role).
+- `DECISIONS_PROMPT_ADDENDUM` text update: replace the literal string `"Current state slice"` with `<decision_slice>` (the actual tag name the model sees). One-line wording change inside the addendum.
+- **Full mode** user message:
+  ```
+  <decision_slice>
+  ...
+  </decision_slice>
+
+  <messages_to_compact>
+  {flatten_messages(old_messages)}
+  </messages_to_compact>
+  ```
+  When `slice_prefix_input` is empty, the `<decision_slice>` block is omitted.
+- **Incremental mode** user message:
+  ```
+  <decision_slice>
+  ...
+  </decision_slice>
+
+  <previous_summary>
+  {mode.prev_summary}
+  </previous_summary>
+
+  <new_messages>
+  {newly_old_flat}
+  </new_messages>
+  ```
+- The "Current state slice (preserve verbatim if still applicable):" prefix line is dropped — `<decision_slice>` is self-describing, and the addendum already instructs the model to reuse entries verbatim.
+- Sections joined by `\n\n`.
+
+**Shared helper:** `src/decafclaw/prompts/__init__.py` `_wrap` renamed to `wrap_xml` (public). Internal callers in `prompts/__init__.py` updated. Imported by `compaction.py`. `reflection.py` does not need it (wrapping lives in the template).
+
+**Tests:** new structural assertions for each of the three sites — tag presence, snake_case match, expected order, slice-gated behavior in compaction. Following `test_prompts.py` style: build minimal inputs, call the assembly function, assert substring presence and ordering. No full-text snapshots.
+
+## Design decisions
+
+- **Decision:** Tag dynamic data only; do not wrap static instruction bodies in `<task>` or `<instructions>`.
+  - **Why:** The static text is already imperative-voice prose; the model role (system message for sweep/compaction, user message for reflection) provides framing. Adding an outer wrapper buys little, and the issue scope is "wrap dynamic inputs."
+  - **Rejected:** Wrapping the reflection static body in `<task>` for symmetry. Not load-bearing — the data tags do the structural work.
+
+- **Decision:** Tag names — `<user_request>`, `<assistant_response>`, `<tool_results>` (plural), `<prior_turn_tools>`, `<retrieved_context>`, `<messages_to_compact>`, `<previous_summary>`, `<new_messages>`, `<decision_slice>` (existing, unchanged).
+  - **Why:** Snake_case + descriptive, matching #304 (`<soul>`, `<agent_role>`, `<user_context>`, `<skill_catalog>`). `<tool_results>` plural reflects that it's a summary across multiple tool calls. `<messages_to_compact>` carries semantic intent (these are slated for summarization) and is the issue text's literal suggestion.
+  - **Rejected:** `<conversation_history>` (less specific about why it's here), singular `<tool_result>` (inaccurate when summary covers multiple calls).
+
+- **Decision:** Promote `_wrap` → public `wrap_xml` in `src/decafclaw/prompts/__init__.py`.
+  - **Why:** Empty-body gating logic is non-trivial enough to share. Single source of truth for the wrap convention. Cross-module use (`compaction.py`) is the third call site (after #304's internal use), so the helper has earned extraction (per the three-callsite rule).
+  - **Rejected:** Inlining `f"<{tag}>\n{body}\n</{tag}>"` at each new site — duplicates the empty-gating concern. Moving to `util.py` — `prompts/__init__.py` is already the home of `_PROMPT_FILES` and `load_system_prompt`; adding the helper there keeps prompt-assembly utilities colocated.
+
+- **Decision:** Reflection wrapping lives inside `REFLECTION.md`, not in `reflection.py`.
+  - **Why:** `REFLECTION.md` already owns the template structure via `.format()` placeholders. Putting tags in the markdown keeps the template self-contained and lets operators view the full prompt shape by reading one file. The only Python-side change is dropping the "Retrieved context (automatically injected…)" string-prefix logic in `evaluate_response()`.
+  - **Rejected:** Wrapping in `evaluate_response()` (Python) — would split the template definition across two files.
+
+- **Decision:** Update `DECISIONS_PROMPT_ADDENDUM` to reference `<decision_slice>` instead of `"Current state slice"`.
+  - **Why:** The addendum instructs the LLM to look for a particular section by name. When we replace the literal heading with a tag, the addendum must point at the new name or instructions and rendered input drift apart.
+  - **Rejected:** Keeping the legacy heading wording — would create a documentation/reality mismatch (model is told to look for X, sees Y).
+
+- **Decision:** Drop the leading prose lines (`"Conversation history to review:\n\n"`, `"Current state slice (preserve verbatim if still applicable):\n"`, `"Existing summary:\n"`, `"New conversation turns to incorporate:\n"`) when adding the matching XML wrapper.
+  - **Why:** The tag name conveys the same semantic, with less token bloat and no risk of the literal heading drifting from the tag name. The "preserve verbatim" instruction relocates to the decisions addendum where it already lives.
+  - **Rejected:** Keeping headings *and* tags — token cost without payoff; two synonyms confuse rather than clarify.
+
+- **Decision:** Empty-body sections in compaction (e.g., no decision slice) emit no tag at all (via `wrap_xml`'s empty gating). Reflection's `.format()` style intentionally always emits the tag — empty tags acceptable there because the placeholder names enumerate a fixed, always-relevant set.
+  - **Why:** `wrap_xml` already implements gating for compaction. For reflection, the template uses positional `.format()`; making sections conditional would require Python-side assembly and re-tooling that's out of scope. Empty tag = "no data this time."
+  - **Rejected:** Wrapping reflection sections in Python so empty ones can be omitted — too much refactoring for the stated benefit.
+
+## Patterns to follow
+
+- **Wrap helper signature and contract:** mirror `_wrap` at `src/decafclaw/prompts/__init__.py:25-33` (empty body → empty string return; produces `<tag>\n{body}\n</tag>`). Rename to `wrap_xml` and remove underscore prefix.
+- **Section join:** `"\n\n".join(sections)` per `prompts/__init__.py:115`.
+- **Test style:** assertion-based structural tests (tags present, order correct) per `tests/test_prompts.py:13-99`. Don't snapshot full text — too brittle.
+- **Skill-name attribute escaping** (`prompts/__init__.py:106`, `html.escape(value, quote=True)`) — not applicable here since no user-provided strings flow into tag names or attributes. All tags are static literals.
+- **Test fixtures**: existing `tests/conftest.py` `config` fixture for any test that needs a Config instance.
+
+## What we're NOT doing
+
+- **Not extracting `DEFAULT_COMPACTION_PROMPT` / `INCREMENTAL_COMPACTION_PROMPT` / `DECISIONS_PROMPT_ADDENDUM` to markdown files** for parity with `REFLECTION.md` / `MEMORY_SWEEP.md`. Override path exists (`data/{agent_id}/COMPACTION.md`); a bundled markdown sibling is a reasonable future change but scope-creep for this issue.
+- **Not changing `flatten_messages()` output format** to wrap each message in `<message role="user">…</message>` style. The flattened block gets a single outer tag; internal `User: / Assistant: / Tool result: ` prefixes are unchanged. Per-message wrapping is a bigger change with separate trade-offs.
+- **Not adding an `<instructions>` or `<task>` outer wrapper** around the static prompt bodies. (See design decision above.)
+- **Not modifying the `<decision_slice>` tag itself** or `format_slice()` / `compaction_decisions.py`. Already shaped correctly. (One exception: the trailing `\n` that `format_slice` adds is consumed naturally by `\n\n` section joining — no change needed there.)
+- **Not running an end-to-end eval pass** against real reflection/sweep/compaction outputs to measure delta. The issue references #303's eval harness as a dependency; we'll rely on existing unit-test coverage + manual smoke for this change.
+- **Not touching workspace overrides** at `data/{agent_id}/REFLECTION.md` / `MEMORY_SWEEP.md` / `COMPACTION.md`. Operators with overrides keep their current files unless they choose to adopt the new pattern. No migration helper.
+- **Not adjusting tag-naming or wrap conventions in `<deferred_tools>` or any already-wrapped section.** Out of scope.
+
+## Open questions
+
+None — design decisions resolved during brainstorm.

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -14,6 +14,7 @@ from .compaction_decisions import (
     strip_json_block,
 )
 from .llm import call_llm
+from .prompts import wrap_xml
 from .util import estimate_tokens
 
 log = logging.getLogger(__name__)
@@ -27,6 +28,11 @@ def _load_sweep_prompt(config) -> str:
     if override.exists():
         return override.read_text()
     return _BUNDLED_SWEEP_PROMPT_PATH.read_text()
+
+
+def _build_sweep_user_input(flattened: str) -> str:
+    """Wrap flattened messages in <messages_to_compact> for the memory sweep child agent."""
+    return wrap_xml("messages_to_compact", flattened)
 
 
 async def _run_memory_sweep(ctx, old_messages: list[dict]) -> None:
@@ -48,7 +54,7 @@ async def _run_memory_sweep(ctx, old_messages: list[dict]) -> None:
     try:
         sweep_prompt = _load_sweep_prompt(config)
         flattened = flatten_messages(old_messages)
-        task_prompt = f"Conversation history to review:\n\n{flattened}"
+        task_prompt = _build_sweep_user_input(flattened)
 
         # Build an isolated child context with vault tools only
         from dataclasses import replace
@@ -123,7 +129,7 @@ Each list contains short strings (≤ 200 chars):
 - artifacts: concrete things produced (files written, vault pages
   created, PRs opened, scripts shipped).
 
-If a "Current state slice" is provided in the input, **reuse existing
+If a `<decision_slice>` block is provided in the input, **reuse existing
 entries verbatim** when they still apply — do NOT paraphrase. Add new
 entries for new info. Drop entries that have been obsoleted (e.g. a
 decision was reversed, a question was resolved). The list you emit IS
@@ -149,6 +155,39 @@ def _with_decisions_addendum(prompt: str, config) -> str:
     if config.compaction.decisions_enabled:
         return prompt + DECISIONS_PROMPT_ADDENDUM
     return prompt
+
+
+def _build_compaction_user_input(mode, old_slice_block: str = "") -> str:
+    """Assemble the user-message text fed to the compaction LLM.
+
+    Sections, joined by ``\\n\\n``:
+      - ``<decision_slice>``…``</decision_slice>`` (optional; pre-wrapped
+        by :func:`compaction_decisions.format_slice`)
+      - Incremental mode:
+        ``<previous_summary>``…``</previous_summary>``,
+        ``<new_messages>``…``</new_messages>``
+      - Full mode:
+        ``<messages_to_compact>``…``</messages_to_compact>``
+
+    ``old_slice_block`` is the output of ``format_slice(slice_)`` when a
+    non-empty slice exists, or ``""`` to omit the section.
+    """
+    sections: list[str] = []
+    slice_section = old_slice_block.strip()
+    if slice_section:
+        sections.append(slice_section)
+
+    if mode.incremental:
+        newly_old_flat = flatten_messages(
+            [msg for turn in mode.newly_old_turns for msg in turn]
+        )
+        sections.append(wrap_xml("previous_summary", mode.prev_summary))
+        sections.append(wrap_xml("new_messages", newly_old_flat))
+    else:
+        flattened = flatten_messages(mode.old_messages)
+        sections.append(wrap_xml("messages_to_compact", flattened))
+
+    return "\n\n".join(s for s in sections if s)
 
 
 def _extract_previous_summary(config, conv_id: str) -> tuple[str | None, str | None]:
@@ -534,25 +573,18 @@ async def compact_history(ctx, history: list) -> bool:
     # captured. After summarization, the LLM's emitted slice replaces
     # this in the merge step.
     old_slice = load_slice(config, conv_id) if config.compaction.decisions_enabled else None
-    slice_prefix_input = ""
-    if old_slice and not old_slice.is_empty():
-        slice_prefix_input = (
-            f"Current state slice (preserve verbatim if still applicable):\n"
-            f"{format_slice(old_slice)}\n"
-        )
+    old_slice_block = (
+        format_slice(old_slice)
+        if old_slice and not old_slice.is_empty()
+        else ""
+    )
 
     try:
         await ctx.publish("compaction_start")
 
         # Summarize
         if mode.incremental:
-            newly_old_flat = flatten_messages(
-                [msg for turn in mode.newly_old_turns for msg in turn])
-            combined_input = (
-                f"{slice_prefix_input}"
-                f"Existing summary:\n{mode.prev_summary}\n\n"
-                f"New conversation turns to incorporate:\n{newly_old_flat}"
-            )
+            combined_input = _build_compaction_user_input(mode, old_slice_block)
             estimated = estimate_tokens(combined_input)
             log.info(f"Incremental summarization: ~{estimated} est. tokens")
             summary = await _single_summarize(
@@ -560,17 +592,20 @@ async def compact_history(ctx, history: list) -> bool:
                 _with_decisions_addendum(INCREMENTAL_COMPACTION_PROMPT, config))
         else:
             prompt = _with_decisions_addendum(_load_compaction_prompt(config), config)
-            flattened = (slice_prefix_input + flatten_messages(mode.old_messages)
-                         if slice_prefix_input
-                         else flatten_messages(mode.old_messages))
-            estimated = estimate_tokens(flattened)
+            flattened_input = _build_compaction_user_input(mode, old_slice_block)
+            estimated = estimate_tokens(flattened_input)
             if estimated > budget:
                 log.info(f"Flattened text ({estimated} est. tokens) exceeds "
                          f"budget ({budget}), using chunked compaction")
+                # Chunked path flattens per-chunk inside _chunked_summarize
+                # and does not wrap in <messages_to_compact> — a rare
+                # fallback for oversized inputs. The <decision_slice>
+                # guidance still lives in the system prompt via the
+                # addendum.
                 summary = await _chunked_summarize(
                     ctx, config, mode.old_turns, prompt, budget)
             else:
-                summary = await _single_summarize(ctx, config, flattened, prompt)
+                summary = await _single_summarize(ctx, config, flattened_input, prompt)
 
         if not summary:
             log.warning("Compaction LLM returned empty summary, skipping")

--- a/src/decafclaw/prompts/REFLECTION.md
+++ b/src/decafclaw/prompts/REFLECTION.md
@@ -32,12 +32,22 @@ the response meaningfully misses what the user asked for.
 
 ---
 
+<retrieved_context>
 {retrieved_context}
+</retrieved_context>
 
+<prior_turn_tools>
 {prior_turn_tools}
+</prior_turn_tools>
 
-User: {user_message}
+<user_request>
+{user_message}
+</user_request>
 
+<tool_results>
 {tool_results_summary}
+</tool_results>
 
-Assistant response: {agent_response}
+<assistant_response>
+{agent_response}
+</assistant_response>

--- a/src/decafclaw/prompts/__init__.py
+++ b/src/decafclaw/prompts/__init__.py
@@ -22,7 +22,7 @@ _PROMPT_FILES: list[tuple[str, str]] = [
 ]
 
 
-def _wrap(tag: str, body: str) -> str:
+def wrap_xml(tag: str, body: str) -> str:
     """Wrap body in <tag>\n…\n</tag>; return "" if body is empty.
 
     Callers rely on the empty-case returning "" so they can skip the
@@ -65,7 +65,7 @@ def load_system_prompt(config):
                 text = bundled_file.read_text().strip()
             else:
                 continue
-        wrapped = _wrap(tag, text)
+        wrapped = wrap_xml(tag, text)
         if wrapped:
             sections.append(wrapped)
 
@@ -73,7 +73,7 @@ def load_system_prompt(config):
     user_file = agent_dir / "USER.md"
     if user_file.exists():
         text = user_file.read_text().strip()
-        wrapped = _wrap("user_context", text)
+        wrapped = wrap_xml("user_context", text)
         if wrapped:
             sections.append(wrapped)
             log.info("Loaded USER.md from workspace")
@@ -81,7 +81,7 @@ def load_system_prompt(config):
     # Discover skills and append catalog
     skills = discover_skills(config)
     catalog = build_catalog_text(skills)
-    wrapped = _wrap("skill_catalog", catalog)
+    wrapped = wrap_xml("skill_catalog", catalog)
     if wrapped:
         sections.append(wrapped)
 

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -271,18 +271,14 @@ async def evaluate_response(
     """
     try:
         prompt_template = load_reflection_prompt(config)
-        if retrieved_context:
-            context_block = (
-                "Retrieved context (automatically injected before the user's message):\n"
-                + retrieved_context
-            )
-        else:
-            context_block = ""
+        # The <retrieved_context> tag in REFLECTION.md conveys the
+        # "auto-injected before the user's message" semantic that the
+        # legacy prose prefix used to carry.
         prompt = prompt_template.format(
             user_message=user_message,
             tool_results_summary=tool_summary or "(no tools used)",
             agent_response=agent_response,
-            retrieved_context=context_block,
+            retrieved_context=retrieved_context,
             prior_turn_tools=prior_turn_summary,
         )
 

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -1,12 +1,16 @@
 """Tests for conversation compaction."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from decafclaw.archive import append_message, write_compacted_history
 from decafclaw.compaction import (
+    DECISIONS_PROMPT_ADDENDUM,
     SUMMARY_PREFIX,
+    _build_compaction_user_input,
+    _build_sweep_user_input,
     _extract_previous_summary,
     _run_memory_sweep,
     _split_into_turns,
@@ -236,9 +240,11 @@ class TestCompactHistory:
         call_args = mock_llm.call_args
         messages = call_args[0][1]  # second positional arg
         user_content = messages[1]["content"]
-        assert "Existing summary:" in user_content
+        assert "<previous_summary>" in user_content
+        assert "</previous_summary>" in user_content
         assert "Summary of turns 0-4." in user_content
-        assert "New conversation turns to incorporate:" in user_content
+        assert "<new_messages>" in user_content
+        assert "</new_messages>" in user_content
 
     @pytest.mark.asyncio
     async def test_incremental_skips_when_no_new_turns(self, ctx, config):
@@ -677,3 +683,73 @@ class TestDecisionSliceIntegration:
         summary = history[0]["content"]
         assert "```json" in summary
         assert "<decision_slice>" not in summary
+
+
+class TestBuildCompactionUserInput:
+    """Pure-function checks for the user-message assembly helper."""
+
+    def _mock_mode(self, incremental: bool, **kwargs):
+        return SimpleNamespace(incremental=incremental, **kwargs)
+
+    def test_full_mode_wraps_in_messages_to_compact(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<messages_to_compact>" in out
+        assert "</messages_to_compact>" in out
+        assert "User: hi" in out
+        assert "Assistant: hello" in out
+
+    def test_incremental_mode_wraps_previous_summary_and_new_messages(self):
+        mode = self._mock_mode(
+            incremental=True,
+            prev_summary="prior summary text",
+            newly_old_turns=[
+                [{"role": "user", "content": "next message"}],
+            ],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<previous_summary>\nprior summary text\n</previous_summary>" in out
+        assert "<new_messages>" in out
+        assert "User: next message" in out
+
+    def test_decision_slice_block_prepended_when_provided(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[{"role": "user", "content": "hi"}],
+        )
+        slice_block = "<decision_slice>\nDecisions:\n- foo\n</decision_slice>"
+        out = _build_compaction_user_input(mode, old_slice_block=slice_block)
+        assert out.startswith("<decision_slice>")
+        assert "<messages_to_compact>" in out
+        assert "</decision_slice>\n\n<messages_to_compact>" in out
+
+    def test_empty_slice_block_omits_section(self):
+        mode = self._mock_mode(
+            incremental=False,
+            old_messages=[{"role": "user", "content": "hi"}],
+        )
+        out = _build_compaction_user_input(mode, old_slice_block="")
+        assert "<decision_slice>" not in out
+        assert out.startswith("<messages_to_compact>")
+
+
+def test_decisions_addendum_references_decision_slice_tag():
+    """The addendum must instruct the LLM about the actual tag name it sees."""
+    assert "<decision_slice>" in DECISIONS_PROMPT_ADDENDUM
+    assert "Current state slice" not in DECISIONS_PROMPT_ADDENDUM
+
+
+class TestBuildSweepUserInput:
+    def test_wraps_flattened_in_messages_to_compact(self):
+        out = _build_sweep_user_input("User: hi\nAssistant: hello")
+        assert out == "<messages_to_compact>\nUser: hi\nAssistant: hello\n</messages_to_compact>"
+
+    def test_no_legacy_prefix_present(self):
+        out = _build_sweep_user_input("any text")
+        assert "Conversation history to review:" not in out

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,8 +4,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from decafclaw.prompts import load_system_prompt
+from decafclaw.prompts import load_system_prompt, wrap_xml
 from decafclaw.skills import _BUNDLED_SKILLS_DIR, SkillInfo
+
+
+class TestWrapXml:
+    def test_wraps_body_in_tag(self):
+        assert wrap_xml("foo", "bar") == "<foo>\nbar\n</foo>"
+
+    def test_empty_body_returns_empty_string(self):
+        assert wrap_xml("foo", "") == ""
+
+    def test_preserves_internal_newlines(self):
+        assert wrap_xml("foo", "line1\nline2") == "<foo>\nline1\nline2\n</foo>"
 
 # -- Default bundled load ------------------------------------------------------
 

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -8,6 +8,7 @@ import pytest
 from decafclaw.config import Config
 from decafclaw.config_types import AgentConfig, LlmConfig, ReflectionConfig
 from decafclaw.reflection import (
+    _BUNDLED_PROMPT,
     ReflectionResult,
     _parse_verdict,
     _summarize_tool_result,
@@ -531,3 +532,39 @@ class TestEvaluateResponse:
             await evaluate_response(config, "hello", "Hi!", "")
         prompt = mock_call.call_args[0][1][0]["content"]
         assert "Tools used in prior turns:" not in prompt
+
+
+class TestReflectionPromptStructure:
+    """Assert the bundled REFLECTION.md wraps each dynamic input in its tag."""
+
+    def _filled(self) -> str:
+        return _BUNDLED_PROMPT.read_text().format(
+            user_message="what is 2+2?",
+            agent_response="4",
+            tool_results_summary="(no tools used)",
+            prior_turn_tools="(none)",
+            retrieved_context="page X is relevant",
+        )
+
+    def test_all_expected_tags_present(self):
+        out = self._filled()
+        for tag in (
+            "<user_request>", "</user_request>",
+            "<assistant_response>", "</assistant_response>",
+            "<tool_results>", "</tool_results>",
+            "<prior_turn_tools>", "</prior_turn_tools>",
+            "<retrieved_context>", "</retrieved_context>",
+        ):
+            assert tag in out, f"missing {tag}"
+
+    def test_placeholder_values_inside_tags(self):
+        out = self._filled()
+        assert out.index("<user_request>") < out.index("what is 2+2?") < out.index("</user_request>")
+        assert out.index("<assistant_response>") < out.index("4") < out.index("</assistant_response>")
+        assert out.index("<retrieved_context>") < out.index("page X is relevant") < out.index("</retrieved_context>")
+
+    def test_legacy_prefix_removed(self):
+        text = _BUNDLED_PROMPT.read_text()
+        assert "Retrieved context (automatically injected" not in text
+        assert "User: {user_message}" not in text
+        assert "Assistant response: {agent_response}" not in text


### PR DESCRIPTION
## Summary

- Apply the #304 system-prompt delimiter convention to the three remaining LLM prompt surfaces (reflection judge, pre-compaction memory sweep, compaction summarizer) so each dynamic chunk lives inside a snake_case XML tag whose name conveys its role.
- Improves the model's ability to distinguish instruction from data on prompts that previously concatenated dynamic content with minimal or no delimiters.

## Design decisions

- **Tag dynamic data only — don't wrap static instruction bodies.** Imperative-voice prose + message role (system for sweep/compaction, user for reflection) carry the framing already. Adding `<task>` or `<instructions>` outer wrappers buys little and wasn't load-bearing for the issue.
- **Tag set:** `<user_request>`, `<assistant_response>`, `<tool_results>` (plural — it's a summary across multiple calls), `<prior_turn_tools>`, `<retrieved_context>` (reflection); `<messages_to_compact>` (sweep + compaction full); `<previous_summary>`, `<new_messages>` (compaction incremental); `<decision_slice>` (existing from #302, unchanged).
- **Reflection wrapping lives in `REFLECTION.md`** (not `reflection.py`). The template already owns the structure via `.format()` placeholders; putting the tags in the markdown keeps the prompt self-contained.
- **Promote `_wrap` → public `wrap_xml`** in `prompts/__init__.py`. Empty-body gating is non-trivial enough to share; cross-module use (`compaction.py`) is the third call site so the helper has earned extraction.
- **Drop legacy prose prefixes** (`"Conversation history to review:"`, `"Current state slice…"`, `"Existing summary:"`, `"New conversation turns to incorporate:"`, `"Retrieved context (automatically injected…)"`). The tag names carry the same semantic, with less token bloat and no risk of literal heading wording drifting from tag name.
- **Update `DECISIONS_PROMPT_ADDENDUM`** to reference `<decision_slice>` rather than `"Current state slice"`. Otherwise the addendum tells the LLM to look for a section name that no longer appears in the input.
- **Chunked compaction (rare oversize fallback) deliberately does not wrap chunks** in `<messages_to_compact>`. Documented inline. Slice guidance remains in the system prompt via the addendum.

## Changes

- `src/decafclaw/prompts/__init__.py` — rename `_wrap` → `wrap_xml` (public); three internal callers updated.
- `src/decafclaw/prompts/REFLECTION.md` — each placeholder wrapped in its own tag; legacy `User:` / `Assistant response:` ad-hoc labels dropped.
- `src/decafclaw/reflection.py` — drop the legacy "Retrieved context (automatically injected…)" Python-side prose prefix.
- `src/decafclaw/compaction.py` — new `_build_compaction_user_input` and `_build_sweep_user_input` helpers; `compact_history` uses the new compaction helper; `_run_memory_sweep` uses the new sweep helper; `DECISIONS_PROMPT_ADDENDUM` references `<decision_slice>`.
- `tests/test_prompts.py` — `TestWrapXml` (3 cases).
- `tests/test_compaction.py` — `TestBuildCompactionUserInput` (4 cases), `TestBuildSweepUserInput` (2 cases), standalone `test_decisions_addendum_references_decision_slice_tag`; updated `test_incremental_compaction_includes_existing_summary` to assert on the new tag names.
- `tests/test_reflection.py` — `TestReflectionPromptStructure` (3 cases).
- `docs/context-composer.md` — new "Auxiliary prompt surfaces" subsection summarizing the tag set and chunked-compaction caveat.

## Test Plan

- [x] `make check` clean
- [x] `make test` — 2507 passed (baseline 2494 + 13 new structural tests)
- [ ] Manual smoke once merged: reflection / compaction / memory sweep all run in normal agent loop without errors. (Existing unit-test coverage + mocked LLM tests cover the assembly logic; live smoke validates no regression in real LLM behavior.)

## What we're NOT doing

- Not extracting `DEFAULT_COMPACTION_PROMPT` / `INCREMENTAL_COMPACTION_PROMPT` / `DECISIONS_PROMPT_ADDENDUM` to markdown files for parity with `REFLECTION.md` / `MEMORY_SWEEP.md` — out of scope; override path at `data/{agent_id}/COMPACTION.md` already works.
- Not changing `flatten_messages()` output to wrap per-message in `<message role="…">`. The flattened block gets a single outer tag; internal `User: / Assistant: / Tool result:` prefixes are unchanged.
- Not touching workspace overrides at `data/{agent_id}/REFLECTION.md` / `MEMORY_SWEEP.md` / `COMPACTION.md`. Operators with overrides keep their files unless they choose to adopt the new pattern.

## References

- Spec: `docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/spec.md`
- Plan: `docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/plan.md`
- Research: `docs/dev-sessions/2026-05-14-1037-prompt-delimiters-357/research.md`
- Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)