### PR TITLE
fix(cancel): persist cancel marker to archive (#491)

### DIFF
--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -116,6 +116,8 @@ the slice guidance still lives in the system prompt via the addendum.
 
 `compose()` treats the input `history` list as read-only during all token-budget and diagnostics calculation. Fresh-this-turn injections (`vault_references`, `conversation_notes`, `vault_retrieval`, and the current user message) are each tracked via their own `SourceEntry` (`wiki_entry`, `notes_entry`, `memory_entry`, `user_msg_entry`). The `history` source entry counts everything archived from prior turns, including messages whose role is in `ROLE_REMAP` (auto-injected role messages archived from earlier turns) — they're sent to the LLM after remap, so they count.
 
+`ROLE_REMAP` also covers `cancel_marker` (remapped to `user`), an archive-only role written when a user cancels a turn. See [Cancelled turns](conversations.md#cancelled-turns) for the producer-side details — the remap is what guarantees the marker reaches the LLM at the right position regardless of provider (Vertex collapses `system`-role messages into `systemInstruction`).
+
 After all token accounting and message-list assembly, `compose()` appends this turn's injections to `history` so the caller (agent loop) sees the post-turn state on subsequent turns. The single mutation point at the end of `compose()` replaces a previous shape that mixed input and scratchpad uses of `history`.
 
 This contract closes a class of underreporting bugs (#393) where a role-based filter excluded archived auto-injected messages even though the LLM still sees them after remap.

--- a/docs/conversations.md
+++ b/docs/conversations.md
@@ -22,6 +22,21 @@ Each line is a JSON object with `role`, `content`, optional `tool_calls`/`tool_c
 
 When DecafClaw restarts, it reads the archive for any conversation that receives a new message. The full history is replayed into memory, so the agent picks up where it left off.
 
+### Cancelled turns
+
+When a user cancels an in-progress agent turn (Ctrl+C in the TUI, the cancel button in the web UI), `ConversationManager` persists:
+
+1. Any partial assistant text that was streamed before the cancel (as an `assistant` row). Omitted if no content streamed.
+2. A `cancel_marker` row carrying `CANCEL_MARKER_TEXT`: `"[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"`.
+
+The write happens on **whichever cancel path fires first** — either the `CancelledError` handler when `task.cancel()` propagates an exception, or the normal-completion path when the agent loop observes the cancel cleanly (via `_check_cancelled` at iteration start, or the streaming short-circuit in `_handle_no_tool_calls`). The agent reports the clean-observation via `ConversationManager.note_cancel_observed_by_agent`. A write-once latch (`ConversationState.cancel_marker_written`) makes both entries safe when both fire.
+
+The normal-path write is gated on the agent's explicit `cancel_observed_by_agent` flag rather than the raw `cancel_event` state — so a cancel signal that arrives *after* the agent has already returned a real response doesn't spuriously mark a delivered response as cancelled.
+
+`cancel_marker` is an archive-only role; the [context composer](context-composer.md) remaps it to `user` before sending history to the LLM (matching the `vault_retrieval` / `conversation_notes` pattern, see `ROLE_REMAP`). The marker sits between the cancelled-user-turn and the next user turn at the right position across all providers — Gemini/Vertex collapses `system`-role messages into the top-level `systemInstruction` field, which would lose the positional meaning.
+
+If the agent loop happened to archive a complete assistant message before the cancel propagated, the helper skips its partial write (tracked via `ConversationState.partial_assistant_archived`) so the archive doesn't carry a duplicate body.
+
 ## Compaction
 
 When the conversation grows too large (exceeding the token budget), the agent automatically compacts older messages into a summary.

--- a/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/notes.md
+++ b/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/notes.md
@@ -1,0 +1,34 @@
+# Notes — fix #491
+
+## Session summary
+
+**Goal:** stop the agent from re-fulfilling a cancelled request when the user sends a fresh message after cancel.
+
+**Shape of the fix:**
+- New archive role `cancel_marker`, added to `context_composer.ROLE_REMAP` → `user`.
+- `_write_cancel_archive()` helper in `conversation_manager.py` writes optional `assistant: <partial>` + always `cancel_marker: [...]`.
+- Partial text accumulated server-side via the existing `on_stream_chunk` callback into `ConversationState.partial_assistant_text`.
+- Cross-path latch (`ConversationState.cancel_marker_written`) ensures the marker is written exactly once whether the cancel propagated via `CancelledError` or was observed cleanly by `_check_cancelled` / streaming-cancel returning empty.
+- `_archive()` in `agent.py` sets `partial_assistant_archived` via `ctx.manager.note_partial_assistant_archived()` after archiving an assistant body, so the helper skips its partial-write to avoid duplicates.
+
+## Surprises during the work
+
+**Issue body's archive claim was wrong.** Issue said the archive contained `assistant: [cancelled]`. The actual code never writes that string to the archive — it's only a WebSocket payload. The fact that nothing (or only an empty assistant) lands in the archive is the actual mechanism by which the LLM treats the prior request as still-open.
+
+**Vertex/Gemini collapses `system`-role messages.** `vertex._build_request_body` lifts all `role: system` messages into a single top-level `systemInstruction` field. A mid-conversation system message would lose positional meaning. That's why the marker uses a new role remapped to `user` rather than `system`.
+
+**Iteration-boundary race surfaced in self-review.** The first pass at Phase 3 only wired the marker write into the `CancelledError` handler. But `_check_cancelled` at iteration start returns `_Final` cleanly, and the streaming provider's SSE-loop cancel observation also returns cleanly. Both paths go through the manager's normal-completion branch, NOT the `CancelledError` handler. Required adding a check on the normal path (gated by `state.cancel_event.is_set()`) and a write-once latch.
+
+## What we're NOT doing (deferred follow-ups)
+
+- **LLM-error path's missing archive write.** `conversation_manager.py:1160-1167` catches generic exceptions and emits `type: "error"` but doesn't archive anything. Same class of bug shape — open user request + missing/weak assistant → next turn re-fulfills. File a follow-up issue.
+- **Max-iterations exhaustion + circuit breaker** paths likely have the same missing-archive shape. Same follow-up.
+- **Removing the dead `preempt_search.py:133` filter** for `"[cancelled]"` — it's defensive code for a string that was never actually archived. Harmless; leave for a future cleanup pass.
+- **UI affordance for the new `cancel_marker` role.** Default UI fallback (rendering unknown roles) is the assumption — needs live-smoke confirmation in TUI + web UI after merge.
+
+## Live-smoke checklist after merge
+
+1. Web UI: start a long streaming response, cancel mid-stream, send "hello" — agent should NOT regenerate the cancelled essay.
+2. TUI: same test once #489 lands.
+3. Verify the cancel_marker row renders sensibly in both UIs (or is invisible — both acceptable).
+4. Verify after page reload, archive replay still shows the partial + marker pattern (no LLM retry on resume).

--- a/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/plan.md
+++ b/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/plan.md
@@ -1,0 +1,362 @@
+# fix #491 — cancelled-turn archive marker — Implementation Plan
+
+**Goal:** When a user cancels a streaming agent turn, write a strong cancel signal to the conversation archive so the next turn's LLM doesn't re-fulfill the cancelled request.
+
+**Approach:** Introduce a new archive-only `cancel_marker` role (remapped to `user` for the LLM via the existing `ROLE_REMAP` pattern). On every cancel path (iteration-start check, streaming-cancel, `CancelledError` propagation), write any partial assistant content followed by the canonical cancel marker. Partial content accumulated server-side via the existing `on_stream_chunk` callback.
+
+**Tech stack:** Python (`src/decafclaw/`), pytest, existing archive/composer infrastructure.
+
+---
+
+## Phase 1: New `cancel_marker` archive role + composer remap
+
+Register a new role that the archive accepts and that the composer remaps to `"user"` before LLM dispatch — no behavior change yet, just the plumbing.
+
+**Files:**
+- Modify: `src/decafclaw/context_composer.py` — add `"cancel_marker": "user"` to `ROLE_REMAP` (line 24-28).
+- Modify: `tests/test_context_composer.py` — add a test asserting a `cancel_marker` message in history is sent to the LLM as a `user` message at the correct position.
+
+**Key changes:**
+
+```python
+# src/decafclaw/context_composer.py — extend existing ROLE_REMAP
+ROLE_REMAP: dict[str, str] = {
+    "vault_retrieval": "user",
+    "vault_references": "user",
+    "conversation_notes": "user",
+    "cancel_marker": "user",
+}
+```
+
+```python
+# tests/test_context_composer.py — new test
+async def test_cancel_marker_remapped_to_user_in_messages(composer):
+    """cancel_marker rows in history reach the LLM as user-role messages
+    at the position they occupied in history."""
+    history = [
+        {"role": "user", "content": "write me an essay"},
+        {"role": "assistant", "content": "Once upon a"},
+        {"role": "cancel_marker", "content": "[User cancelled this turn. ...]"},
+    ]
+    composed = await composer.compose(
+        ctx=..., history=history, user_message="hello",
+    )
+    # The composed messages list should contain the cancel marker as a
+    # user-role message between the partial assistant and the new "hello".
+    roles = [m["role"] for m in composed.messages]
+    contents = [m.get("content", "") for m in composed.messages]
+    # Find the cancel-marker remap
+    assert any(
+        r == "user" and "cancelled this turn" in c
+        for r, c in zip(roles, contents)
+    )
+```
+
+**Verification — automated:**
+- [ ] `make test` passes (existing tests unchanged + new test green)
+- [ ] `make lint` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_context_composer.py -k cancel_marker -v` passes
+
+**Verification — manual:**
+- [ ] Read the new ROLE_REMAP entry — `cancel_marker → user` reads correctly next to the existing entries.
+
+---
+
+## Phase 2: Cancel-write helper + partial-text accumulation
+
+Centralize the cancel-archive write into a single helper, and add server-side accumulation of streamed text so the helper has access to whatever was partially delivered.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py`
+  - Add `partial_assistant_text: str = ""` field to `ConversationState` (after line 148).
+  - Reset `state.partial_assistant_text = ""` inside `_start_turn` after the busy-flag set (so each turn starts clean).
+  - In the `on_stream_chunk` callback (line 992-1004), append `data` to `state.partial_assistant_text` in the `chunk_type == "text"` branch.
+  - Add a module-level helper `_write_cancel_archive(config, conv_id: str, partial: str) -> None` that writes the two archive entries (partial assistant if non-empty, then the cancel marker).
+- Modify: `tests/test_conversation_manager.py` — add unit tests for `_write_cancel_archive` covering empty / non-empty partial.
+
+**Key changes:**
+
+```python
+# src/decafclaw/conversation_manager.py — module-level
+CANCEL_MARKER_TEXT = (
+    "[User cancelled this turn. Do not retry the cancelled request "
+    "unless they explicitly ask for it again.]"
+)
+
+
+def _write_cancel_archive(config, conv_id: str, partial: str) -> None:
+    """Append the canonical cancel marker (and any partial assistant
+    content) to the conversation archive. Idempotent at the call-site
+    level: callers should invoke at most once per cancelled turn."""
+    from .archive import append_message
+    if partial:
+        append_message(config, conv_id, {
+            "role": "assistant",
+            "content": partial,
+        })
+    append_message(config, conv_id, {
+        "role": "cancel_marker",
+        "content": CANCEL_MARKER_TEXT,
+    })
+```
+
+```python
+# src/decafclaw/conversation_manager.py — ConversationState
+@dataclass
+class ConversationState:
+    ...
+    cancel_event: asyncio.Event | None = None
+    partial_assistant_text: str = ""   # accumulated streamed text for the
+                                       # current turn; reset at turn start.
+```
+
+```python
+# src/decafclaw/conversation_manager.py — inside _start_turn,
+# alongside the existing on_stream_chunk setup (around line 992)
+state.partial_assistant_text = ""
+
+async def on_stream_chunk(chunk_type, data):
+    if chunk_type == "text":
+        if isinstance(data, str):
+            state.partial_assistant_text += data
+        await self.emit(conv_id, {
+            "type": "chunk", "text": data,
+        })
+    elif chunk_type == "done":
+        ...
+```
+
+```python
+# tests/test_conversation_manager.py — unit tests
+def test_write_cancel_archive_with_partial(tmp_path, config):
+    conv_id = "conv-1"
+    _write_cancel_archive(config, conv_id, "partial response so far")
+    messages = read_archive(config, conv_id)
+    assert len(messages) == 2
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["content"] == "partial response so far"
+    assert messages[1]["role"] == "cancel_marker"
+    assert "do not retry" in messages[1]["content"].lower()
+
+
+def test_write_cancel_archive_without_partial(tmp_path, config):
+    conv_id = "conv-2"
+    _write_cancel_archive(config, conv_id, "")
+    messages = read_archive(config, conv_id)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "cancel_marker"
+```
+
+**Verification — automated:**
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_conversation_manager.py -k cancel_archive -v` passes
+
+**Verification — manual:**
+- [ ] Reset of `partial_assistant_text` happens before any chunk could arrive (in `_start_turn`, not in the agent task body).
+
+---
+
+## Phase 3: Wire the helper into all three cancel paths
+
+Replace ad-hoc writes (or missing writes) on the three cancel paths with calls to `_write_cancel_archive`. Add an integration test that reproduces the bug shape.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py` — in the `except asyncio.CancelledError` block (line 1076-1085), call `_write_cancel_archive(self.config, conv_id, state.partial_assistant_text)` before the WebSocket emit.
+- Modify: `src/decafclaw/agent.py`
+  - Update `_check_cancelled` (line 106-115) so it no longer writes its own bracketed marker — instead, leave a marker that signals "cancelled" without polluting the archive (returns ToolResult only). The actual archive write happens in `conversation_manager.run()` once the iteration loop unwinds via `_Final`. To preserve the existing test invariant (`history.append(final_msg)` makes the loop's `accumulated_text_parts` include the cancel notice), keep the in-history append for the loop's reflection-skip path, but stop archiving it from `_check_cancelled`. NOTE: this changes test_check_cancelled_returns_result_when_cancelled which inspects `history[0]["role"] == "assistant"` — update the assertion shape (history append remains; archive write removed).
+  - Streaming-cancel path: in `_handle_no_tool_calls` (line 668+), when `ctx.cancelled.is_set()` and `content == ""`, **skip** the empty-archive write (the empty-retry path already exists; cancellation just propagates to `_Final` and the manager-level handler writes the canonical marker).
+- Modify: `tests/test_agent_turn.py` — update `test_check_cancelled_returns_result_when_cancelled` to reflect that archive write moved (assert `history` still has the in-memory marker; assert nothing extra in archive). Existing `test_run_agent_turn_cancellation` should continue to pass.
+- Add: `tests/test_conversation_manager.py::test_cancel_during_turn_archives_marker_and_partial` — integration test exercising the full cancel-then-fresh-turn flow:
+  1. Mock LLM with a streaming response that accumulates partial text.
+  2. Start a turn via `enqueue_turn`.
+  3. After partial text streamed, call `manager.cancel_turn(conv_id)`.
+  4. Await turn settlement.
+  5. Read archive — assert it contains user → assistant(partial) → cancel_marker.
+  6. Read composed messages for a follow-up turn — assert no synthesized retry of the original request; cancel marker is between user messages as remapped `user`.
+
+**Key changes:**
+
+```python
+# src/decafclaw/conversation_manager.py — inside run() coroutine
+except asyncio.CancelledError:
+    log.info("Agent turn cancelled for conv %s", conv_id[:8])
+    response_text_holder.append("[cancelled]")
+    # Persist cancel to archive — partial text + canonical marker.
+    try:
+        _write_cancel_archive(
+            self.config, conv_id, state.partial_assistant_text,
+        )
+    except Exception as exc:
+        log.warning(
+            "Failed to write cancel marker for %s: %s", conv_id, exc,
+        )
+    await self.emit(conv_id, {
+        "type": "message_complete",
+        "role": "assistant",
+        "text": "[cancelled]",
+        "final": True,
+        "suppress_user_message": False,
+    })
+```
+
+```python
+# src/decafclaw/agent.py — _check_cancelled
+def _check_cancelled(ctx, history):
+    """Check if the agent turn has been cancelled.
+
+    Appends an in-memory marker to history so the iteration loop's
+    accumulated-text logic sees the cancel notice; does NOT write to
+    the archive. The canonical cancel-archive write happens in
+    ConversationManager.run()'s CancelledError handler once the loop
+    unwinds.
+    """
+    if ctx.cancelled and ctx.cancelled.is_set():
+        log.info("Agent turn cancelled by user")
+        msg = "[Agent turn cancelled by user]"
+        final_msg = {"role": "assistant", "content": msg}
+        history.append(final_msg)
+        # No _archive(ctx, final_msg) call — manager handles archive on cancel.
+        return ToolResult(text=msg)
+    return None
+```
+
+```python
+# src/decafclaw/agent.py — _handle_no_tool_calls,
+# at the start of the function before the empty-retry block
+async def _handle_no_tool_calls(self, response: dict) -> IterationOutcome:
+    content = response.get("content") or ""
+    # If cancellation fired during the LLM call and we got an empty
+    # response back, don't archive an empty assistant message — let
+    # the cancel propagate to the manager which writes the canonical
+    # marker (with any partial text accumulated server-side).
+    if (not content and self.ctx.cancelled
+            and self.ctx.cancelled.is_set()):
+        return _Final(result=ToolResult(text=""))
+    if not content:
+        if self.empty_retries < 1:
+            ...
+```
+
+```python
+# tests/test_conversation_manager.py — new integration test (sketch)
+@pytest.mark.asyncio
+async def test_cancel_during_turn_archives_marker_and_partial(
+    manager, mock_llm_streaming,
+):
+    """Cancelling mid-stream writes partial text + cancel_marker to archive;
+    a follow-up turn's composed messages contain the cancel marker as a
+    user-role message between the two user turns."""
+    conv_id = "conv-cancel-test"
+    mock_llm_streaming.stream_text("Once upon a time, in ")
+    mock_llm_streaming.set_cancel_after_chunks(2)
+
+    await manager.enqueue_turn(
+        conv_id=conv_id, text="write me a 600-word essay", kind=TurnKind.USER,
+    )
+    # Cancellation logic fires inside the mock; await settlement.
+    state = manager._conversations[conv_id]
+    await asyncio.wait_for(state.agent_task, timeout=5)
+
+    messages = read_archive(manager.config, conv_id)
+    roles = [m["role"] for m in messages]
+    assert "user" in roles  # original prompt
+    assert "cancel_marker" in roles
+    # Partial assistant only if any text streamed
+    partial_idx = roles.index("cancel_marker") - 1
+    if messages[partial_idx]["role"] == "assistant":
+        assert messages[partial_idx]["content"]  # non-empty
+    # Cancel marker text matches the canonical constant
+    assert CANCEL_MARKER_TEXT in messages[
+        roles.index("cancel_marker")]["content"]
+```
+
+**Verification — automated:**
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_agent_turn.py -k cancel -v` passes
+- [ ] `pytest tests/test_conversation_manager.py -k cancel -v` passes (new integration test + existing cancel tests)
+
+**Verification — manual:**
+- [ ] Read the diff for `_check_cancelled` — the in-history `final_msg` append stays so the iteration loop's downstream code (reflection skip, accumulated_text) keeps working; only the archive write is removed.
+- [ ] Confirm there's no other archive call inside the agent loop that would double-write on cancel (search for `_archive` in `_handle_no_tool_calls` and the surrounding methods).
+
+---
+
+## Phase 4: Docs update
+
+Document the new role in the context-composer doc and add a short note to the conversations doc.
+
+**Files:**
+- Modify: `docs/context-composer.md` — extend the existing `ROLE_REMAP` mention (around line 117) with a brief note that `cancel_marker` is included and what it means.
+- Modify: `docs/conversations.md` — add a short subsection describing what happens on cancel (archive shape: optional partial + cancel marker).
+
+**Key changes:**
+
+```markdown
+<!-- docs/context-composer.md — extend existing paragraph or add a brief subsection -->
+
+### `cancel_marker`
+
+Archived when a user cancels an in-progress agent turn. Persists any
+streamed partial assistant content (as an `assistant` row) followed by a
+canonical marker telling the next LLM call not to retry the cancelled
+request. Remapped to `user` before LLM dispatch so it lands between the
+cancelled-user-turn and the next-user-turn at the correct position
+across all providers (avoids Gemini's collapse of `system`-role messages
+into the top-level `systemInstruction`).
+```
+
+```markdown
+<!-- docs/conversations.md — new short subsection near the archive/structure section -->
+
+### Cancelled turns
+
+When a user cancels mid-turn (Ctrl+C in the TUI, cancel button in the
+web UI), the archive records:
+
+1. Any partial assistant text that was streamed before cancel (as an
+   `assistant` row; omitted if no content streamed).
+2. A `cancel_marker` row with the canonical "do not retry" text.
+
+The `cancel_marker` is remapped to `user` for the LLM (see
+[context-composer.md](context-composer.md#cancel_marker)), so the next
+turn's composed message list contains a clear signal that the prior
+request was cancelled and shouldn't be re-fulfilled.
+```
+
+**Verification — automated:**
+- [ ] `make check` passes (no markdown linting in this repo, but check for broken refs)
+
+**Verification — manual:**
+- [ ] Read the new doc sections in-place; references to other docs resolve.
+
+---
+
+## Risks and mitigations
+
+- **Existing cancel tests will need updating** (`test_check_cancelled_returns_result_when_cancelled` asserts a history shape that we're keeping; archive-side assertion change is the new shape). Phase 3 handles this.
+- **The streaming provider may return a non-empty partial that we don't want to lose.** Confirmed: `_handle_no_tool_calls` writes non-empty `content` to archive via `_archive` (agent.py:691). We only short-circuit on `not content AND cancelled` so non-empty partials get archived through the normal flow — but then we'd double-archive when the manager's helper *also* writes partial.
+  - **Mitigation:** the manager's helper reads from `state.partial_assistant_text` for the partial. If the agent loop already archived a non-empty `assistant` message before cancel propagated, the helper would write a duplicate. To avoid this, the helper should be passed a flag (or check) for "did the agent loop already archive an assistant message this turn?". Simplest: track a `assistant_archived_this_turn: bool` on ConversationState, set when the agent loop writes an assistant message; helper skips its partial-write if true.
+  - **Alternative simpler mitigation:** the partial that lands in `state.partial_assistant_text` accumulated via `on_stream_chunk` IS the same content the agent loop would archive if it got far enough. If the agent loop did archive it (non-empty content path), we don't need the helper to write it again — just the marker. We can pin this by adding to the agent loop's archive path: set `state.partial_assistant_archived = True` after archiving. Helper checks that flag.
+
+  Pinning during plan since this is load-bearing: **add `partial_assistant_archived: bool = False` to ConversationState**. Reset at turn start. Set to `True` immediately after the agent loop archives a non-empty assistant message in `_handle_no_tool_calls` (around line 691) and in the tool-call branches that archive an assistant message (lines 586, 625, 662). Helper checks this flag: if `True`, write only the cancel marker; if `False`, write partial+marker.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- Acceptance criterion 1 (cancel marker on archive across all paths) → Phase 3.
+- Acceptance criterion 2 (partial assistant content preserved) → Phase 2 + 3.
+- Acceptance criterion 3 (LLM sees cancel marker as user message at right position) → Phase 1 + integration test in Phase 3.
+- Acceptance criterion 4 (new test reproduces bug shape) → Phase 3 integration test.
+- Acceptance criterion 5 (existing tests still pass) → Phase 3 test updates.
+- Acceptance criterion 6 (`make check` and `make test` clean) → automated verification on every phase.
+
+**Placeholder scan:** none — every code snippet is concrete; the dual-archive-write risk is pinned with a specific state field (`partial_assistant_archived`).
+
+**Type consistency:** `_write_cancel_archive(config, conv_id, partial)` signature used consistently. `CANCEL_MARKER_TEXT` referenced as a module-level constant in both source and tests.

--- a/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/research.md
+++ b/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/research.md
@@ -1,0 +1,79 @@
+# Research — fix #491
+
+Codebase findings for the cancelled-turn-replay bug.
+
+## Cancel paths (three, not one)
+
+The issue body says the archive contains `assistant: [cancelled]`. **That string is never written to the archive.** It exists only as a WebSocket payload and as a `response_text_holder` sentinel used to resolve the caller's future.
+
+Three actual cancel paths exist:
+
+1. **`_check_cancelled` at iteration start** — `src/decafclaw/agent.py:106-115`. Writes `{"role": "assistant", "content": "[Agent turn cancelled by user]"}` to history + archive. Only fires if cancel is observed at the *start* of an iteration.
+
+2. **Cancel during streaming (provider-level)** — `src/decafclaw/llm/providers/openai_compat.py:191-196` (and `vertex.py:177-181`). `_consume_sse_events` polls `cancel_event` between SSE chunks and breaks. Whatever partial content was streamed sits in `state` and gets returned as a normal response. Agent then processes it via `_handle_no_tool_calls` (`agent.py:668-709`), which archives `{"role": "assistant", "content": <partial>}` if content is non-empty, or skips after empty-retry.
+
+3. **`asyncio.CancelledError` propagation** — `src/decafclaw/conversation_manager.py:1076-1085`. When `cancel_turn()` calls `agent_task.cancel()` (line 653), the exception propagates through the agent loop and is caught in `run()`. The handler **only emits a WebSocket event** (`type: "message_complete"`, `text: "[cancelled]"`); **no archive write**. This is the path the issue references.
+
+## What the archive actually looks like after cancel
+
+Depends on timing:
+- Cancel hits between iterations → marker from path 1 archived: `assistant: "[Agent turn cancelled by user]"`
+- Cancel hits mid-stream, provider returns cleanly → partial content archived as `assistant: "<partial>"`, possibly empty
+- `task.cancel()` propagates before archive write completes → **nothing archived for the assistant turn**
+
+None of these is the literal `assistant: "[cancelled]"` the issue describes (the user inferred that from the WS payload they saw in the UI).
+
+## Cancel signal flow
+
+`conversation_manager.py:636-654` `cancel_turn(conv_id)`:
+1. Reads `state.cancel_event` + `state.agent_task` under `state.lock`.
+2. `cancel_event.set()` — observed by `_check_cancelled` (start-of-iteration) and provider SSE loops.
+3. `agent_task.cancel()` — raises `CancelledError` at the next await point in `run()`.
+
+## Archive schema
+
+`src/decafclaw/archive.py:13`: `LLM_ROLES = {"system", "user", "assistant", "tool"}`.
+
+Other archive-only roles (filtered before LLM):
+- `confirmation_request`, `confirmation_response` — skipped entirely (`context_composer.py`).
+- `reflection` — skipped.
+- `vault_retrieval`, `vault_references`, `conversation_notes` — remapped to `user` for LLM (`context_composer.py:24-28` `ROLE_REMAP`).
+- `background_event` — expanded into synthetic tool_call + tool_result pair (`context_composer.py:408-412`).
+
+No precedent for an "interrupted" or `cancelled` role/marker field. Messages have no `metadata`/`props` field on the message level (only timestamp).
+
+## History → LLM transformation
+
+`src/decafclaw/context_composer.py:404-424` `compose()`:
+- Combines `[*history, *wiki_msgs, *notes_msgs, *memory_msgs, user_msg]`.
+- Filters: `LLM_ROLES` kept; `ROLE_REMAP` keys remapped to `"user"`; everything else dropped.
+- Tool result reordering ensures each tool result follows its matching assistant tool_call.
+
+No existing "rewrite this message" or "inject cancel context" code path that conditions on the last assistant message being a cancel marker.
+
+## `[cancelled]` literal references
+
+- `conversation_manager.py:1078` — `response_text_holder.append("[cancelled]")` (future resolution).
+- `conversation_manager.py:1082` — WS `message_complete` payload `text: "[cancelled]"`.
+- `preempt_search.py:133` — defensive filter (`stripped == "[cancelled]"`); defensive because that exact string isn't actually archived anywhere.
+
+## Tests pinning cancel behavior
+
+- `tests/test_agent_turn.py:59-90` — `_check_cancelled` unit tests.
+- `tests/test_agent_turn.py:155` — `test_execute_tool_calls_cancellation` (tool path).
+- `tests/test_agent_turn.py:555` — `test_run_agent_turn_cancellation` — cancels *before* LLM; asserts `"cancelled" in result.text`.
+- `tests/test_conversation_manager.py:355` — `test_cancel_turn_sets_event` — verifies signals fire; doesn't inspect archive.
+
+**No test exercises a cancelled turn followed by a fresh user message** — the bug-shape isn't covered.
+
+## TUI cancel-preserve
+
+Commit `567cc8e` on `tui-spike` preserves partial content **client-side display only** when the user cancels — does not affect the archive. Web UI may behave differently (need to check).
+
+## Class-of-bug analogues
+
+The same shape (open user request + weak/missing assistant turn + new user message → re-fulfill) could appear when:
+- LLM call errors mid-turn and the error handler at `conversation_manager.py:1086-1093` emits `type: "error"` (also no archive write).
+- A turn aborts due to circuit breaker, max_iterations exhaustion, etc.
+
+Out of scope for this fix; flagged for follow-up.

--- a/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/spec.md
+++ b/docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/spec.md
@@ -1,0 +1,111 @@
+# Spec — fix #491: cancelled turns cause replay on resume
+
+## Source
+
+GitHub issue [#491](https://github.com/lmorchard/decafclaw/issues/491).
+
+## Goal
+
+After a user cancels a streaming agent turn, the next user message must NOT cause the agent to re-fulfill the cancelled request. The conversation archive must carry an unambiguous signal — both for the next LLM turn *and* for the human reading the archive — that says "this turn was cancelled; don't retry it."
+
+## Current state
+
+Three cancel paths, none of which writes a strong cancel signal to the archive:
+
+| Path | Where | Archive write |
+|---|---|---|
+| `_check_cancelled` at iteration start | `agent.py:106-115` | `assistant: "[Agent turn cancelled by user]"` — only fires if cancel observed *between* iterations |
+| Provider-level cancel during streaming | `openai_compat.py:191-196`, `vertex.py:177-181` | Partial content via normal `_handle_no_tool_calls` flow, may be empty |
+| `asyncio.CancelledError` propagates to `run()` | `conversation_manager.py:1076-1085` | **Nothing.** Only a WebSocket `message_complete` event with `text: "[cancelled]"` is emitted |
+
+The most common cancel path (path 3) leaves the archive looking like:
+
+```
+user:      write me a 600-word essay about anything at all
+user:      hello
+```
+
+The LLM sees an open user request with no assistant response in between and treats it as still-pending, re-fulfilling it before responding to "hello." (The issue body's claim that `assistant: [cancelled]` is in the archive is inaccurate — that string only ever exists on the WebSocket wire, never on disk.)
+
+## Desired end state
+
+After any cancel, the archive contains:
+
+```
+user:           write me a 600-word essay about anything at all
+assistant:      <partial streamed content, or empty if none>
+cancel_marker:  [User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]
+user:           hello
+```
+
+- The `assistant` partial message is omitted only if no content was streamed before cancel (no point archiving an empty message).
+- The `cancel_marker` row is always written, on every cancel path.
+- The cancel marker is a **new archive-only role** (`cancel_marker`) added to `context_composer.py:ROLE_REMAP` so it survives the LLM transform by being remapped to `user` (consistent with how `vault_retrieval` / `conversation_notes` work today). This preserves the "between user turns" position across all providers.
+- The Web UI / TUI display the cancel marker as a distinct, muted line (small styling change — out of scope for THIS PR if the existing display handles it gracefully via the default fallback, see "What we're NOT doing").
+
+## Design decisions
+
+### Why a new role, not `system`
+
+Vertex/Gemini's `_build_request_body` (`vertex.py:445-447, 500-501`) collapses ALL `system`-role messages into a single top-level `systemInstruction`, losing the mid-conversation position. A new `cancel_marker` role remapped to `user` (via the existing `ROLE_REMAP` pattern in `context_composer.py:24-28`) keeps the marker at the correct point in the conversation across all providers.
+
+### Why preserve partial content
+
+The TUI already preserves partial content client-side (commit `567cc8e`). Persisting it to the archive matches user expectation: cancelling shouldn't silently delete what was already streamed. The partial assistant message tells the LLM "I did start answering" — combined with the cancel marker, the LLM understands the user interrupted intentionally rather than the response being lost.
+
+### Single canonical cancel write
+
+All three cancel paths funnel through a single helper that writes:
+1. Optional `assistant: <partial>` (only if partial content non-empty).
+2. Always `cancel_marker: [...]`.
+
+Path 1 (`_check_cancelled`) and path 3 (`run()` CancelledError handler) call the helper directly. Path 2 (streaming cancel returning empty/partial through the normal flow) needs a guard so the regular `_handle_no_tool_calls` doesn't archive an empty assistant message on cancel — instead, the cancel helper handles it.
+
+### Cancel marker text
+
+```
+[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]
+```
+
+Clear instruction; doesn't presume what the cancelled content was. Falls in line with the bracketed-marker idiom already used in the codebase (`"[Agent turn cancelled by user]"`, `"[User approved: ...]"`).
+
+### Partial content source
+
+Decision deferred to plan phase (see Open questions). Default: if partial content isn't trivially reachable from the `run()` CancelledError handler, accumulate streamed chunks at the `ConversationManager` level — a small new state field on `ConversationState` cleared at turn start and appended to in the same place where `message_complete` deltas already pass through the manager's event bus.
+
+## Patterns to follow
+
+- `ROLE_REMAP` pattern — `src/decafclaw/context_composer.py:24-28`, `src/decafclaw/archive.py:13`.
+- Archive write helper — `src/decafclaw/agent.py:50-55` `_archive(ctx, msg)`.
+- Cancel detection — existing `cancel_event` + `agent_task.cancel()` plumbing in `cancel_turn()`.
+- Test pattern — existing cancel tests in `tests/test_agent_turn.py:59-90` and `tests/test_conversation_manager.py:355` show the fixture shape.
+
+## What we're NOT doing
+
+- **Adding a `cancel_marker` UI affordance.** If the existing message renderer falls through to "display unknown role as muted text," that's good enough for this PR. Visual polish (icon, distinct styling) gets a follow-up if needed after live-smoke.
+- **Updating the WebSocket payload schema.** The `message_complete` event with `text: "[cancelled]"` keeps its current shape so existing UI clients don't break. The archive-side marker is internal to the agent ↔ LLM contract.
+- **Fixing the equivalent shape for other turn-aborting paths** — LLM error in `conversation_manager.py:1086-1093`, max_iterations exhaustion, circuit breaker. Same class of bug (open user request + weak/missing assistant turn) but out of scope. Flag in `notes.md` for follow-up issue.
+- **Compaction / decision-slice interaction.** Cancel markers should pass through compaction prose summaries naturally; not adding special handling unless tests show otherwise.
+- **Reworking `_check_cancelled` semantics.** It already does the right thing for its narrow case (between iterations). The fix folds it into the same canonical helper rather than replacing it.
+- **Preempt search defensive `"[cancelled]"` filter** at `preempt_search.py:133` — dead code now (and arguably always was). Leave it; harmless. Removing it is a separate cleanup.
+
+## Acceptance criteria
+
+1. After a cancel — by any of the three paths — the archive JSONL contains a `{"role": "cancel_marker", "content": "[User cancelled this turn. ...]"}` row.
+2. If partial assistant content was streamed before cancel, the archive contains it as `{"role": "assistant", "content": "<partial>"}` immediately before the cancel marker.
+3. The LLM-facing messages list (from `ContextComposer.compose()`) sees the cancel marker as a `user`-role message at the correct position.
+4. A new test reproduces the bug shape: archive a cancelled turn, then queue a fresh user turn, and assert the LLM message stream does NOT contain a synthesized retry of the cancelled request. (Easiest pin: assert the composed messages list has the cancel marker between the two user messages, in the right shape.)
+5. Existing cancel tests still pass (`test_check_cancelled_returns_result_when_cancelled`, `test_cancel_turn_sets_event`, `test_run_agent_turn_cancellation`).
+6. `make check` and `make test` clean.
+
+## Open questions
+
+- **Where exactly does partial assistant content get accumulated server-side that's reachable from the `run()` CancelledError handler?**
+  - *Default if no clean source exists:* add `partial_assistant_text: str = ""` to `ConversationState`, reset at turn start, append in the existing `on_stream_chunk` callback (or in the event-bus forwarder for `chunk`/`text_before_tools` events), read by the cancel helper.
+  - The plan phase should answer this conclusively before writing code; if the default is needed, it's a 5-line addition.
+
+## Risks
+
+- **Vertex provider** discovery surfaced one provider-specific transform; OpenAI-compat should pass-through cleanly since `cancel_marker → user` happens before the provider sees the message. Still: smoke against both providers (Gemini + OpenAI) post-merge.
+- **Partial content accumulation** is the load-bearing detail. If the partial isn't reachable at cancel time, the implementation degrades to "marker only" — still better than current.
+- **No live integration test runs the full WebSocket → ConversationManager → archive cycle.** The PR's coverage is unit/integration at the manager level; Les should live-smoke in TUI + web UI after merge.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -51,10 +51,26 @@ def _archive(ctx, msg) -> None:
     """Archive a message, logging errors but never raising."""
     if ctx.skip_archive:
         return
+    wrote = False
     try:
         append_message(ctx.config, _conv_id(ctx), msg)
+        wrote = True
     except Exception as e:
         log.error(f"Archive write failed: {e}")
+    # Mark the conversation so a subsequent CancelledError handler
+    # doesn't double-archive the partial body (issue #491). Only fires
+    # for assistant messages with actual body content that actually
+    # landed in the archive — tool_call-only assistant rows don't count
+    # as "delivered text" for cancel bookkeeping, and we don't want a
+    # failed write to make the manager think the partial is durable.
+    if (wrote
+            and msg.get("role") == "assistant"
+            and msg.get("content")
+            and ctx.manager is not None):
+        try:
+            ctx.manager.note_partial_assistant_archived(_conv_id(ctx))
+        except Exception as exc:
+            log.debug("note_partial_assistant_archived failed: %s", exc)
 
 
 
@@ -104,15 +120,37 @@ async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
 
 
 def _check_cancelled(ctx, history):
-    """Check if the agent turn has been cancelled. Returns ToolResult or None."""
+    """Check if the agent turn has been cancelled. Returns ToolResult or None.
+
+    Appends an in-memory marker to history so the iteration loop's
+    accumulated-text / reflection logic sees the cancel notice, but does
+    NOT write to the archive. The canonical cancel-archive write happens
+    in ConversationManager.run() once the loop unwinds. Notifies the
+    manager that the agent observed the cancellation so the normal-
+    completion path persists the marker even when this helper returns
+    cleanly via _Final (issue #491).
+    """
     if ctx.cancelled and ctx.cancelled.is_set():
         log.info("Agent turn cancelled by user")
         msg = "[Agent turn cancelled by user]"
         final_msg = {"role": "assistant", "content": msg}
         history.append(final_msg)
-        _archive(ctx, final_msg)
+        _note_cancel_observed(ctx)
         return ToolResult(text=msg)
     return None
+
+
+def _note_cancel_observed(ctx) -> None:
+    """Tell the manager the agent observed the cancel signal cleanly,
+    so the normal-completion path persists the marker. No-op when no
+    manager is attached (e.g. unit tests calling the helper directly).
+    """
+    if ctx.manager is None:
+        return
+    try:
+        ctx.manager.note_cancel_observed_by_agent(_conv_id(ctx))
+    except Exception as exc:
+        log.debug("note_cancel_observed_by_agent failed: %s", exc)
 
 
 @dataclass(frozen=True)
@@ -670,6 +708,14 @@ class TurnRunner:
         reflection, archive of last_reflection, and compaction trigger.
         Returns _Continue (retry) or _Final(result) (deliver response)."""
         content = response.get("content") or ""
+        # If cancellation fired mid-stream and the provider returned an
+        # empty body, don't archive an empty assistant message — the
+        # cancel propagates to the manager which writes the canonical
+        # marker (plus any partial accumulated server-side). Issue #491.
+        if (not content and self.ctx.cancelled
+                and self.ctx.cancelled.is_set()):
+            _note_cancel_observed(self.ctx)
+            return _Final(result=ToolResult(text=""))
         if not content:
             if self.empty_retries < 1:
                 self.empty_retries += 1

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -25,6 +25,7 @@ ROLE_REMAP: dict[str, str] = {
     "vault_retrieval": "user",
     "vault_references": "user",
     "conversation_notes": "user",
+    "cancel_marker": "user",
 }
 
 

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Any, Callable
 from uuid import uuid4
 
+from .archive import append_message
 from .confirmations import (
     ConfirmationRegistry,
     ConfirmationRequest,
@@ -22,6 +23,39 @@ from .confirmations import (
 from .heartbeat import is_background_wake_ok
 
 log = logging.getLogger(__name__)
+
+
+# Canonical archive text written when a user cancels an in-progress agent
+# turn (issue #491). Strong enough wording that the LLM treats the prior
+# request as closed instead of re-fulfilling it on the next turn. The
+# message is archived under the cancel_marker role and remapped to "user"
+# for the LLM via context_composer.ROLE_REMAP.
+CANCEL_MARKER_TEXT = (
+    "[User cancelled this turn. Do not retry the cancelled request "
+    "unless they explicitly ask for it again.]"
+)
+
+
+def _write_cancel_archive(
+    config, conv_id: str, partial: str,
+    *, partial_already_archived: bool = False,
+) -> None:
+    """Append optional partial assistant content followed by the
+    canonical cancel marker to the conversation archive. Chronological
+    order matters: the LLM-side conversation reads
+    `user → assistant(partial) → cancel_marker(→user) → user`, so the
+    partial must precede the marker. Step-level dedup against retry
+    failures is handled in `_write_cancel_marker_once`.
+    """
+    if partial and not partial_already_archived:
+        append_message(config, conv_id, {
+            "role": "assistant",
+            "content": partial,
+        })
+    append_message(config, conv_id, {
+        "role": "cancel_marker",
+        "content": CANCEL_MARKER_TEXT,
+    })
 
 
 class TurnKind(Enum):
@@ -146,6 +180,27 @@ class ConversationState:
     pending_messages: list = field(default_factory=list)
     agent_task: asyncio.Task | None = None
     cancel_event: asyncio.Event | None = None
+
+    # Streamed assistant text accumulated for the current turn so the
+    # cancel handler can persist whatever was delivered before cancel
+    # (issue #491). Reset at turn start; appended to in on_stream_chunk
+    # (list of chunks — joined lazily to avoid O(n²) concatenation).
+    # `partial_assistant_archived` indicates whether the agent loop
+    # already wrote the assistant content to the archive — if so, the
+    # cancel handler only appends the marker, avoiding a duplicate body.
+    # `cancel_observed_by_agent` is set by the agent when it observes
+    # cancellation cleanly (iteration-start check or streaming short-
+    # circuit). The manager's normal-completion path uses this rather
+    # than raw `cancel_event.is_set()` to avoid persisting a cancel
+    # marker when cancel arrives *after* the turn fully completed.
+    # `cancel_marker_written` is a write-once latch: both the clean
+    # cancel-observed path and the CancelledError handler funnel through
+    # the same marker write; the latch prevents a double-write when
+    # both fire.
+    partial_assistant_chunks: list[str] = field(default_factory=list)
+    partial_assistant_archived: bool = False
+    cancel_observed_by_agent: bool = False
+    cancel_marker_written: bool = False
 
     # Per-conversation lock guarding the dispatch decision and the
     # confirmation lifecycle (issue #440). Held during:
@@ -633,6 +688,70 @@ class ConversationManager:
             waiter_event.set()
         return True
 
+    def note_partial_assistant_archived(self, conv_id: str) -> None:
+        """Mark that the agent loop has archived an assistant message for
+        the current turn. The cancel handler reads this flag to avoid
+        double-writing the partial content (issue #491).
+        """
+        state = self._conversations.get(conv_id)
+        if state is not None:
+            state.partial_assistant_archived = True
+
+    def note_cancel_observed_by_agent(self, conv_id: str) -> None:
+        """Mark that the agent loop observed the cancel signal cleanly
+        (iteration-start check or streaming short-circuit). The manager's
+        normal-completion path uses this flag rather than raw
+        `cancel_event.is_set()` so a cancel arriving *after* the turn
+        already completed normally doesn't spuriously persist a cancel
+        marker (issue #491).
+        """
+        state = self._conversations.get(conv_id)
+        if state is not None:
+            state.cancel_observed_by_agent = True
+
+    def _write_cancel_marker_once(
+        self, conv_id: str, state: ConversationState,
+    ) -> None:
+        """Persist the canonical cancel marker (and any streamed partial)
+        for this turn, exactly once across both the iteration-start
+        cancel path and the CancelledError handler (issue #491).
+
+        Each archive append updates `state` immediately on success so
+        that if marker-write fails mid-flight, a later retry doesn't
+        double-write the partial body.
+        """
+        if state.cancel_marker_written:
+            return
+        partial = "".join(state.partial_assistant_chunks)
+        # Step 1: persist any streamed partial that the agent loop
+        # didn't already archive itself.
+        if partial and not state.partial_assistant_archived:
+            try:
+                append_message(self.config, conv_id, {
+                    "role": "assistant",
+                    "content": partial,
+                })
+                state.partial_assistant_archived = True
+            except Exception as exc:
+                log.warning(
+                    "Failed to archive cancel partial for %s: %s",
+                    conv_id, exc,
+                )
+        # Step 2: persist the canonical marker. This is the load-bearing
+        # signal; if it fails we leave the latch unset so a later cancel
+        # call can retry the marker (the partial-archived flag protects
+        # against duplicating the partial).
+        try:
+            append_message(self.config, conv_id, {
+                "role": "cancel_marker",
+                "content": CANCEL_MARKER_TEXT,
+            })
+            state.cancel_marker_written = True
+        except Exception as exc:
+            log.warning(
+                "Failed to write cancel marker for %s: %s", conv_id, exc,
+            )
+
     async def cancel_turn(self, conv_id: str) -> None:
         """Cancel an in-progress agent turn.
 
@@ -983,6 +1102,13 @@ class ConversationManager:
             else:
                 context_setup(ctx)
 
+        # Reset cancel/partial accounting so this turn starts clean and
+        # a subsequent cancel only persists what we actually streamed.
+        state.partial_assistant_chunks = []
+        state.partial_assistant_archived = False
+        state.cancel_observed_by_agent = False
+        state.cancel_marker_written = False
+
         # Set up streaming callback that emits to subscribers.
         # WAKE turns don't stream: the agent may emit BACKGROUND_WAKE_OK to
         # suppress the final message, and streaming would have already
@@ -991,6 +1117,8 @@ class ConversationManager:
         if kind is not TurnKind.WAKE and resolve_streaming(self.config, ctx.active_model):
             async def on_stream_chunk(chunk_type, data):
                 if chunk_type == "text":
+                    if isinstance(data, str):
+                        state.partial_assistant_chunks.append(data)
                     await self.emit(conv_id, {
                         "type": "chunk", "text": data,
                     })
@@ -1056,6 +1184,19 @@ class ConversationManager:
                 response_text = result.text if hasattr(result, "text") else str(result)
                 response_text_holder.append(response_text)
                 response_media = result.media if hasattr(result, "media") else []
+                # If cancel was observed cleanly inside the agent loop
+                # (e.g. the iteration-start check returned _Final, or
+                # the streaming provider broke out of its SSE loop
+                # without raising), we still need to persist the cancel
+                # marker. Gated on the agent's explicit cancel-observed
+                # flag — NOT raw cancel_event.is_set() — so a cancel
+                # signal arriving after the turn already completed
+                # normally doesn't spuriously mark the response as
+                # cancelled. The latch in _write_cancel_marker_once
+                # makes this safe even if the CancelledError handler
+                # also fires below. Issue #491.
+                if state.cancel_observed_by_agent:
+                    self._write_cancel_marker_once(conv_id, state)
                 suppress = (kind is TurnKind.WAKE
                             and is_background_wake_ok(response_text))
                 await self.emit(conv_id, {
@@ -1076,6 +1217,9 @@ class ConversationManager:
             except asyncio.CancelledError:
                 log.info("Agent turn cancelled for conv %s", conv_id[:8])
                 response_text_holder.append("[cancelled]")
+                # Persist a strong cancel signal so the next turn's LLM
+                # doesn't re-fulfill the cancelled request (issue #491).
+                self._write_cancel_marker_once(conv_id, state)
                 await self.emit(conv_id, {
                     "type": "message_complete",
                     "role": "assistant",

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -69,7 +69,10 @@ def test_check_cancelled_returns_none_when_no_event(ctx):
 
 
 @pytest.mark.asyncio
-async def test_check_cancelled_returns_result_when_cancelled(ctx):
+async def test_check_cancelled_returns_result_when_cancelled(ctx, config):
+    """_check_cancelled appends an in-memory marker to history but no
+    longer writes to the archive — the canonical cancel write happens
+    in the manager's CancelledError handler (issue #491)."""
     ctx.cancelled = asyncio.Event()
     ctx.cancelled.set()
     history = []
@@ -78,6 +81,10 @@ async def test_check_cancelled_returns_result_when_cancelled(ctx):
     assert "cancelled" in result.text
     assert len(history) == 1
     assert history[0]["role"] == "assistant"
+    # No archive write for the in-memory cancel marker.
+    from decafclaw.archive import read_archive
+    archived = read_archive(config, ctx.conv_id or ctx.channel_id)
+    assert archived == []
 
 
 def test_check_cancelled_not_set(ctx):

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -1032,6 +1032,53 @@ class TestHistoryArchivedRemap:
         )
 
 
+class TestCancelMarker:
+    """The cancel_marker role is archived when a user cancels a turn;
+    composer must remap it to user-role so the LLM sees the marker
+    between the cancelled-user-turn and the next user message at the
+    correct position (issue #491)."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_marker_remapped_to_user(self, ctx, config):
+        config.system_prompt = "System."
+        config.agent.tool_context_budget_pct = 1.0
+        config.compaction.max_tokens = 1000000
+        history = [
+            {"role": "user", "content": "write me a 600-word essay"},
+            {"role": "assistant", "content": "Once upon a"},
+            {
+                "role": "cancel_marker",
+                "content": "[User cancelled this turn. Do not retry.]",
+            },
+        ]
+        with (
+            patch("decafclaw.tool_definitions.collect_all_tool_defs",
+                  return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composer = ContextComposer()
+            result = await composer.compose(
+                ctx, "hello", history, mode=ComposerMode.INTERACTIVE,
+            )
+
+        # cancel_marker should appear as a user-role message in the
+        # composed messages list, with its content preserved.
+        cancel_msgs = [
+            m for m in result.messages
+            if m.get("role") == "user"
+            and "cancelled this turn" in m.get("content", "")
+        ]
+        assert len(cancel_msgs) == 1, (
+            f"expected exactly one user-role cancel marker in "
+            f"composed.messages; got {len(cancel_msgs)}"
+        )
+        # No cancel_marker role should leak through to the LLM.
+        assert not any(
+            m.get("role") == "cancel_marker" for m in result.messages
+        )
+
+
 # -- Relevance scoring ---------------------------------------------------------
 
 

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from decafclaw.archive import read_archive
 from decafclaw.confirmations import (
     ConfirmationAction,
     ConfirmationRegistry,
@@ -14,10 +15,12 @@ from decafclaw.confirmations import (
 from decafclaw.conversation_manager import (
     _CTX_DRIVEN_FIELDS,
     _PERSISTED_BINDINGS,
+    CANCEL_MARKER_TEXT,
     ConversationManager,
     ConversationState,
     PersistedTurnState,
     TurnKind,
+    _write_cancel_archive,
 )
 from decafclaw.events import EventBus
 
@@ -366,6 +369,273 @@ async def test_cancel_turn_sets_event(manager):
     # Give the task a moment to be cancelled
     await asyncio.sleep(0.05)
     assert state.agent_task.cancelled()
+
+
+# -- Cancel archive helper (issue #491) ----------------------------------------
+
+
+def test_write_cancel_archive_with_partial(config):
+    """When partial text is present, _write_cancel_archive emits two
+    archive rows: the partial assistant message, then the cancel marker."""
+    conv_id = "conv-cancel-1"
+    _write_cancel_archive(config, conv_id, "Once upon a time, in ")
+
+    messages = read_archive(config, conv_id)
+    assert len(messages) == 2
+    assert messages[0]["role"] == "assistant"
+    assert messages[0]["content"] == "Once upon a time, in "
+    assert messages[1]["role"] == "cancel_marker"
+    assert messages[1]["content"] == CANCEL_MARKER_TEXT
+
+
+def test_write_cancel_archive_without_partial(config):
+    """Empty partial → only the cancel marker is archived."""
+    conv_id = "conv-cancel-2"
+    _write_cancel_archive(config, conv_id, "")
+
+    messages = read_archive(config, conv_id)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "cancel_marker"
+    assert messages[0]["content"] == CANCEL_MARKER_TEXT
+
+
+def test_write_cancel_archive_skips_partial_when_already_archived(config):
+    """If the partial was already archived by the agent loop, the helper
+    must not double-write it — only the cancel marker is appended."""
+    conv_id = "conv-cancel-3"
+    _write_cancel_archive(
+        config, conv_id, "partial text", partial_already_archived=True,
+    )
+
+    messages = read_archive(config, conv_id)
+    assert len(messages) == 1
+    assert messages[0]["role"] == "cancel_marker"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_turn_archives_marker_and_partial(
+    manager, config, monkeypatch,
+):
+    """End-to-end: a turn that streams partial text and then raises
+    CancelledError should leave the archive with the streamed partial
+    (as an assistant row) followed by the cancel_marker row (issue #491).
+    The real run_agent_turn archives the user prompt as part of context
+    composition; this fake replaces that with a manual write."""
+    from decafclaw.archive import append_message
+    conv_id = "c1-cancel-integration"
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        # Emulate the real agent's user-archive step.
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "user", "content": user_message,
+        })
+        # Simulate streaming a few text chunks before cancellation.
+        assert ctx.on_stream_chunk is not None
+        await ctx.on_stream_chunk("text", "Once upon a time, ")
+        await ctx.on_stream_chunk("text", "in a faraway kingdom...")
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        "decafclaw.agent.run_agent_turn", fake_run_agent_turn,
+    )
+
+    future = await manager.enqueue_turn(
+        conv_id=conv_id,
+        kind=TurnKind.USER,
+        prompt="write me a 600-word essay",
+        user_id="u",
+    )
+    await asyncio.wait_for(future, timeout=2.0)
+
+    messages = read_archive(config, conv_id)
+    roles = [m["role"] for m in messages]
+    # user, assistant (partial), cancel_marker — in that order.
+    assert roles == ["user", "assistant", "cancel_marker"]
+    assert messages[0]["content"] == "write me a 600-word essay"
+    assert messages[1]["content"] == "Once upon a time, in a faraway kingdom..."
+    assert messages[2]["content"] == CANCEL_MARKER_TEXT
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_partial_archives_marker_only(
+    manager, config, monkeypatch,
+):
+    """When no text streamed before cancel, the archive holds only the
+    marker for the cancelled turn (no empty assistant row)."""
+    from decafclaw.archive import append_message
+    conv_id = "c1-cancel-no-partial"
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "user", "content": user_message,
+        })
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        "decafclaw.agent.run_agent_turn", fake_run_agent_turn,
+    )
+
+    future = await manager.enqueue_turn(
+        conv_id=conv_id,
+        kind=TurnKind.USER,
+        prompt="hi",
+        user_id="u",
+    )
+    await asyncio.wait_for(future, timeout=2.0)
+
+    messages = read_archive(config, conv_id)
+    roles = [m["role"] for m in messages]
+    assert roles == ["user", "cancel_marker"]
+    assert messages[1]["content"] == CANCEL_MARKER_TEXT
+
+
+@pytest.mark.asyncio
+async def test_cancel_observed_cleanly_still_writes_marker(
+    manager, config, monkeypatch,
+):
+    """When the agent loop observes the cancel signal at iteration start
+    and returns a ToolResult cleanly (no CancelledError), the manager's
+    normal-path emit must still persist the cancel marker (issue #491).
+    This guards against the iteration-boundary race where task.cancel()
+    hasn't fired yet but cancel_event has been set."""
+    from decafclaw.archive import append_message
+    from decafclaw.media import ToolResult
+    conv_id = "c1-cancel-clean-return"
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "user", "content": user_message,
+        })
+        # Set cancel_event AND mark the manager that the agent observed
+        # it — emulates _check_cancelled firing at iteration start and
+        # returning ToolResult via _Final.
+        ctx.cancelled.set()
+        ctx.manager.note_cancel_observed_by_agent(ctx.conv_id)
+        return ToolResult(text="[Agent turn cancelled by user]")
+
+    monkeypatch.setattr(
+        "decafclaw.agent.run_agent_turn", fake_run_agent_turn,
+    )
+
+    future = await manager.enqueue_turn(
+        conv_id=conv_id,
+        kind=TurnKind.USER,
+        prompt="hi",
+        user_id="u",
+    )
+    await asyncio.wait_for(future, timeout=2.0)
+
+    messages = read_archive(config, conv_id)
+    roles = [m["role"] for m in messages]
+    assert "cancel_marker" in roles, (
+        f"expected cancel marker in archive after clean cancel return; "
+        f"got roles={roles}"
+    )
+    cancel_idx = roles.index("cancel_marker")
+    assert messages[cancel_idx]["content"] == CANCEL_MARKER_TEXT
+
+
+@pytest.mark.asyncio
+async def test_late_cancel_after_completion_no_marker(
+    manager, config, monkeypatch,
+):
+    """When cancel_event is set AFTER the agent loop already returned
+    a real response (a late cancel that didn't actually interrupt
+    anything), the archive must NOT carry a cancel marker — the
+    response was real and delivered. Distinguishes via the explicit
+    cancel_observed_by_agent flag rather than raw cancel_event state.
+    Issue #491 Copilot review."""
+    from decafclaw.archive import append_message
+    from decafclaw.media import ToolResult
+    conv_id = "c1-cancel-too-late"
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "user", "content": user_message,
+        })
+        # The agent completes a real response. Cancel fires AFTER the
+        # agent returned (e.g., the user clicked cancel just after the
+        # final chunk landed). The agent never observed it.
+        ctx.cancelled.set()
+        return ToolResult(text="here is the real answer")
+
+    monkeypatch.setattr(
+        "decafclaw.agent.run_agent_turn", fake_run_agent_turn,
+    )
+
+    future = await manager.enqueue_turn(
+        conv_id=conv_id,
+        kind=TurnKind.USER,
+        prompt="hi",
+        user_id="u",
+    )
+    await asyncio.wait_for(future, timeout=2.0)
+
+    messages = read_archive(config, conv_id)
+    roles = [m["role"] for m in messages]
+    assert "cancel_marker" not in roles, (
+        f"late cancel after real completion must not write a marker; "
+        f"got roles={roles}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_skips_partial_when_already_archived(
+    manager, config, monkeypatch,
+):
+    """When the agent loop already archived the assistant content before
+    cancel propagated, the marker is appended but no duplicate partial
+    row is written."""
+    from decafclaw.archive import append_message
+    conv_id = "c1-cancel-dedupe"
+
+    async def fake_run_agent_turn(ctx, user_message, history, **kwargs):
+        # Simulate streaming + the agent loop archiving the partial.
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "user", "content": user_message,
+        })
+        assert ctx.on_stream_chunk is not None
+        await ctx.on_stream_chunk("text", "Hello ")
+        await ctx.on_stream_chunk("text", "world")
+        # The real agent does this via _archive() in agent.py — emulate.
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "assistant", "content": "Hello world",
+        })
+        ctx.manager.note_partial_assistant_archived(ctx.conv_id)
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(
+        "decafclaw.agent.run_agent_turn", fake_run_agent_turn,
+    )
+
+    future = await manager.enqueue_turn(
+        conv_id=conv_id,
+        kind=TurnKind.USER,
+        prompt="say hi",
+        user_id="u",
+    )
+    await asyncio.wait_for(future, timeout=2.0)
+
+    messages = read_archive(config, conv_id)
+    # user, assistant (from agent), cancel_marker — no duplicate assistant
+    assert [m["role"] for m in messages] == [
+        "user", "assistant", "cancel_marker",
+    ]
+    assert messages[1]["content"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_partial_assistant_chunks_resets_each_turn(manager):
+    """ConversationState.partial_assistant_chunks starts empty and
+    tracks streamed text for the current turn only."""
+    state = manager._get_or_create("conv-stream-1")
+    assert state.partial_assistant_chunks == []
+    state.partial_assistant_chunks.append("leftover from prior turn")
+    # _start_turn resets this before any chunk could arrive. We assert
+    # the field exists and is mutable; the reset behavior is exercised
+    # by the integration tests above.
+    state.partial_assistant_chunks = []
+    assert state.partial_assistant_chunks == []
 
 
 # -- Send message with mocked agent turn ---------------------------------------


### PR DESCRIPTION
## Summary
- Cancelling a streaming agent turn left the conversation archive in a state the LLM read as "user request still open" — the next user message would cause the agent to re-fulfill the cancelled request before responding.
- This PR writes a strong, role-remapped cancel marker to the archive on every cancel path, optionally preceded by any partial assistant text that was streamed before the cancel.

## Design decisions
- **New archive role `cancel_marker`**, added to `context_composer.ROLE_REMAP` → `user`. We can't use `system` mid-conversation: Vertex/Gemini's request builder collapses all `role: system` messages into the top-level `systemInstruction`, losing the "between two user turns" position.
- **Preserve partial streamed content** as an `assistant` row before the marker, when present. The TUI already preserves partial content client-side (commit `567cc8e` on `tui-spike`); persisting it server-side matches that intent and gives the LLM a "I did start answering, then was interrupted" signal.
- **Write-once latch** (`ConversationState.cancel_marker_written`) funnels both the `CancelledError` handler and the manager's normal-completion path through the same archive write. Required because `_check_cancelled` at iteration start returns `_Final` cleanly without raising — `task.cancel()` may not have fired by the time the agent returns.

## Changes
- `src/decafclaw/context_composer.py` — register `cancel_marker` in `ROLE_REMAP`.
- `src/decafclaw/conversation_manager.py` — `CANCEL_MARKER_TEXT` constant, `_write_cancel_archive` helper, `_write_cancel_marker_once` latched method, `note_partial_assistant_archived` API, three new `ConversationState` fields, partial-text accumulation in `on_stream_chunk`, marker write on both completion paths.
- `src/decafclaw/agent.py` — `_archive` notifies the manager when an assistant body lands; `_check_cancelled` keeps the in-history append but no longer archives; `_handle_no_tool_calls` short-circuits on cancel+empty.
- Tests: unit tests for the helper, three end-to-end cancel-shape tests, one composer remap test, one race-coverage test for the iteration-start path. Existing `test_check_cancelled_returns_result_when_cancelled` updated for the new archive-write contract.
- Docs: new "Cancelled turns" subsection in `docs/conversations.md`, cross-link from `docs/context-composer.md`.

## Test plan
- [x] `make test` — 2516 passed (+9 vs baseline)
- [x] `make check` — clean (lint + pyright + tsc + message-types drift)
- [ ] **Live smoke (post-merge):** start a long streaming response in the web UI, cancel mid-stream, send "hello" — agent should NOT regenerate the cancelled essay.
- [ ] **Live smoke (post-merge):** repeat in TUI once #489 lands.
- [ ] **Live smoke (post-merge):** verify the cancel_marker row renders sensibly (or invisibly — both acceptable) in both UIs.
- [ ] **Live smoke (post-merge):** reload page after a cancel, confirm archive replay still shows partial + marker and no LLM retry.

## References
- Spec: `docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/spec.md`
- Plan: `docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/plan.md`
- Notes: `docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/notes.md` (includes deferred follow-ups: same bug shape exists for the generic-exception handler at `conversation_manager.py:1160-1167` and likely for max-iterations exhaustion — both out of scope for this PR)

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)