### PR TITLE
fix(conversation_manager): queue concurrent request_confirmation calls per conv (closes #485)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,8 @@ The rule: **one agent turn per conversation at a time, unlimited concurrent conv
 
 When a tool needs user approval (shell commands, skill activation), the ConversationManager persists the confirmation request as a JSONL archive entry with `role: "confirmation_request"`. The agent loop suspends mechanically until it receives a matching `confirmation_response` entry. Pending confirmations survive page reload and server restart — a startup scan recovers them. See `confirmations.py` for the `ConfirmationAction` enum and handler registry.
 
+Concurrent `request_confirmation` calls on the same conversation (common with delegated background tasks producing parallel approval prompts) are serialized through a per-conversation FIFO queue: the user sees them one at a time, each waits for its own response, and `request.timeout` starts only when a queued request becomes active.
+
 ## Transport adapters
 
 Each transport is responsible for:

--- a/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/plan.md
+++ b/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/plan.md
@@ -1,0 +1,321 @@
+# Queue concurrent request_confirmation — Implementation Plan
+
+**Goal:** Replace `request_confirmation`'s unconditional pending-slot overwrite with a per-conversation FIFO queue so simultaneous approval requests (esp. from delegated background tasks) all reach the user serially.
+
+**Approach:** Add a `confirmation_queue: list[_QueuedConfirmation]` on `ConversationState`. When `request_confirmation` lands while `state.pending_confirmation is not None`, enqueue a `_QueuedConfirmation(request, event)` and block on its own event until promoted. A single `_promote_next_confirmation_unlocked` helper, called from every clear-active path (respond, cancel, timeout, cancel-raced), pops the next waiter and signals it. Timeout starts at promote time, not at enqueue. #486 stays separate.
+
+**Tech stack:** Python 3, `asyncio.Lock` / `asyncio.Event`, existing `confirmations.py` types, pytest + pytest-asyncio. No new dependencies.
+
+---
+
+## Phase 1: Queue + concurrent-request regression slice
+
+End-to-end slice: failing regression test → queue scaffolding → enqueue / promote / wire-up at all clear-active call sites → test passes. After this phase, two concurrent `request_confirmation` calls on the same conv resolve to their own responses in submission order.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py`
+  - Add `_QueuedConfirmation` dataclass (module-level, near `ConversationState`).
+  - Add `confirmation_queue: list[_QueuedConfirmation] = field(default_factory=list)` to `ConversationState` (next to the existing confirmation-state triple at L188–191).
+  - Add `_promote_next_confirmation_unlocked(state, conv_id) -> ConfirmationRequest | None`. Caller must hold `state.lock`; returns the promoted request (None if queue empty); side-effect installs the promoted request into the active slot and signals its event.
+  - Add a private helper `_confirmation_request_payload(request) -> dict` so the multiple emit sites share one payload-builder.
+  - Rework `request_confirmation` (L763–889):
+    - Archive (unchanged, pre-lock).
+    - Under lock: if `state.pending_confirmation is None`, install active (old path); else create a `_QueuedConfirmation`, append to `state.confirmation_queue`, capture local handle.
+    - For the queued branch only: `await queued.promoted_event.wait()` (no timeout) outside the lock. Promote helper signals this event when it activates the entry.
+    - Once active (either path), execute the existing post-wait claim block (`asyncio.wait_for(event.wait(), timeout=request.timeout)` plus the three-branch resolution at L837–887). When the active slot is cleared in any of the three branches, call `_promote_next_confirmation_unlocked` under the same lock; capture its return value; emit the new `confirmation_request` outside the lock if one was promoted.
+  - Modify `respond_to_confirmation` (L501–558):
+    - After the existing claim-and-clear at L501–505 (still under lock), call `_promote_next_confirmation_unlocked` and capture the result.
+    - Emit the promoted request's `confirmation_request` event outside the lock (same place as the existing `confirmation_response` emit).
+    - Recovery branch (`waiter_event is None`): identity check stays as-is (out of scope per spec — that's #486).
+  - Modify `cancel_pending_confirmation` (L625–633):
+    - After the existing claim-and-clear at L625–627, call `_promote_next_confirmation_unlocked` and capture the result.
+    - Emit promoted `confirmation_request` outside the lock (after the `waiter_event.set()` at L632–633).
+- Add: `tests/test_conversation_manager.py`
+  - `test_concurrent_request_confirmation_serializes` — two `asyncio.create_task` calls of `request_confirmation` on same `conv_id`. After awaiting an iteration of the event loop, assert task B is not done (it's queued behind A). `respond_to_confirmation` to A; A completes. Then `respond_to_confirmation` to B; B completes. Both responses have correct `confirmation_id` and `approved=True`.
+  - `test_promoted_confirmation_emits_request_event` — install a subscriber capturing emits; submit two concurrent requests; respond to first; assert two `confirmation_request` events fire (one per submission), in correct order.
+
+**Key changes:**
+
+```python
+# src/decafclaw/conversation_manager.py — module level near ConversationState
+
+@dataclass
+class _QueuedConfirmation:
+    """A confirmation request waiting to become active.
+
+    Holds the request and a per-request asyncio.Event the waiter
+    blocks on. The promote helper signals promoted_event when the
+    queued entry is moved to the active slot, releasing the waiter
+    to run the post-wait claim block.
+    """
+    request: ConfirmationRequest
+    promoted_event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+# On ConversationState (next to pending_confirmation / confirmation_event / confirmation_response):
+
+    # FIFO queue of confirmations awaiting their turn. Each entry is
+    # a request that arrived while another was active; the waiter
+    # blocks on the entry's promoted_event until
+    # _promote_next_confirmation_unlocked moves it to the active slot.
+    confirmation_queue: list[_QueuedConfirmation] = field(default_factory=list)
+
+
+# Module-level payload helper:
+def _confirmation_request_payload(request: ConfirmationRequest) -> dict:
+    return {
+        "type": "confirmation_request",
+        "confirmation_id": request.confirmation_id,
+        "action_type": request.action_type.value,
+        "action_data": request.action_data,
+        "message": request.message,
+        "approve_label": request.approve_label,
+        "deny_label": request.deny_label,
+        "tool_call_id": request.tool_call_id,
+    }
+
+
+# ConversationManager — new helper method
+def _promote_next_confirmation_unlocked(
+    self, state: "ConversationState", conv_id: str,
+) -> ConfirmationRequest | None:
+    """Move the next queued confirmation (if any) into the active slot.
+
+    Caller must hold ``state.lock``. The active slot must be clear
+    (pending_confirmation / confirmation_event / confirmation_response
+    all None) when this is called — promote is the *next step* after
+    the active slot is cleared by respond/cancel/timeout/cancel-raced.
+
+    Side effects (all under lock):
+      - state.pending_confirmation = queued.request
+      - state.confirmation_event = asyncio.Event()  (fresh)
+      - state.confirmation_response = None
+      - queued.promoted_event.set()  (wakes the queued waiter)
+
+    Returns the promoted request so the caller can emit the
+    confirmation_request event outside the lock, or None if the queue
+    is empty.
+    """
+    if not state.confirmation_queue:
+        return None
+    queued = state.confirmation_queue.pop(0)
+    state.pending_confirmation = queued.request
+    state.confirmation_event = asyncio.Event()
+    state.confirmation_response = None
+    queued.promoted_event.set()
+    log.info("Promoted queued confirmation for conv %s: %s",
+             conv_id[:8], queued.request.action_type.value)
+    return queued.request
+
+
+# request_confirmation — restructured
+
+async def request_confirmation(self, conv_id, request):
+    state = self._get_or_create(conv_id)
+    # Archive always (spec: archive at enqueue time so crash-recovery
+    # sees every requested confirmation).
+    from .archive import append_message
+    append_message(self.config, conv_id, request.to_archive_message())
+
+    async with state.lock:
+        if state.pending_confirmation is None:
+            state.pending_confirmation = request
+            state.confirmation_event = asyncio.Event()
+            state.confirmation_response = None
+            event = state.confirmation_event
+            queued = None
+        else:
+            queued = _QueuedConfirmation(request=request)
+            state.confirmation_queue.append(queued)
+            event = None
+            log.info("Conv %s has active confirmation; queued new request "
+                     "(%d in queue)", conv_id[:8], len(state.confirmation_queue))
+
+    if queued is None:
+        await self.emit(conv_id, _confirmation_request_payload(request))
+    else:
+        # Wait for promotion. Phase 2 hardens this branch.
+        try:
+            await queued.promoted_event.wait()
+        except asyncio.CancelledError:
+            async with state.lock:
+                if queued in state.confirmation_queue:
+                    state.confirmation_queue.remove(queued)
+            raise
+        async with state.lock:
+            event = state.confirmation_event
+        await self.emit(conv_id, _confirmation_request_payload(request))
+
+    # Post-wait claim block — today's logic, with promote added to each
+    # clear-active branch.
+    try:
+        await asyncio.wait_for(event.wait(), timeout=request.timeout)
+        timed_out = False
+    except asyncio.TimeoutError:
+        timed_out = True
+
+    needs_timeout_emit = False
+    promoted_after: ConfirmationRequest | None = None
+    async with state.lock:
+        claimed = state.confirmation_response
+        if claimed is not None:
+            response = claimed
+            state.pending_confirmation = None
+            state.confirmation_event = None
+            state.confirmation_response = None
+            promoted_after = self._promote_next_confirmation_unlocked(
+                state, conv_id)
+        elif timed_out:
+            log.info("Confirmation timed out for conv %s: %s",
+                     conv_id[:8], request.message)
+            response = ConfirmationResponse(
+                confirmation_id=request.confirmation_id, approved=False,
+            )
+            try:
+                append_message(
+                    self.config, conv_id, response.to_archive_message(),
+                )
+            except Exception:
+                log.exception(
+                    "Timeout archive write failed for conv %s; leaving "
+                    "pending state intact for retry", conv_id[:8])
+                raise
+            state.pending_confirmation = None
+            state.confirmation_event = None
+            state.confirmation_response = None
+            promoted_after = self._promote_next_confirmation_unlocked(
+                state, conv_id)
+            needs_timeout_emit = True
+        else:
+            response = ConfirmationResponse(
+                confirmation_id=request.confirmation_id, approved=False,
+            )
+            state.pending_confirmation = None
+            state.confirmation_event = None
+            state.confirmation_response = None
+            promoted_after = self._promote_next_confirmation_unlocked(
+                state, conv_id)
+            log.info("Confirmation for conv %s was cancelled out from "
+                     "under the waiter; returning denial", conv_id[:8])
+
+    if needs_timeout_emit:
+        await self.emit(conv_id, {
+            "type": "confirmation_response",
+            "confirmation_id": request.confirmation_id,
+            "approved": False,
+        })
+    if promoted_after is not None:
+        await self.emit(conv_id, _confirmation_request_payload(promoted_after))
+
+    return response
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `make test` passes — full suite green (2509 passed; +2 new tests)
+- [x] `pytest tests/test_conversation_manager.py -k "concurrent_request_confirmation or promoted_confirmation_emits" -v` passes
+- [x] `pytest --durations=10 tests/test_conversation_manager.py` — new tests do not appear in top-10 slowest (top is 0.66s; new tests at ~0.0s)
+
+**Verification — manual** (deferred to branch self-review per express mode):
+- [ ] Walk: tool A and tool B in same turn both call `request_confirmation`. A becomes active. B queues. User approves A. B promotes and emits its `confirmation_request`. User approves B. Both responses return correctly.
+- [ ] Walk: A active, B queued, A times out. A's timeout denial archived and emitted. B promotes, gets emitted, runs its own timeout countdown.
+
+---
+
+## Phase 2: Queue-waiter cancellation cleanup
+
+Harden the queued-wait branch so cancellation cleans up correctly whether the waiter was still queued OR had just been promoted before cancel arrived.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py`
+  - Refactor the `except asyncio.CancelledError` block in `request_confirmation`'s queued-wait branch to: re-acquire the lock, check whether `queued` is still in the queue (simple drop) or has been promoted (clear active slot + promote next + emit outside lock).
+- Add: `tests/test_conversation_manager.py`
+  - `test_cancelled_queued_waiter_removed_from_queue` — submit active A + queued B; cancel B's task; respond to A; assert state.confirmation_queue is empty, A resolves normally, B's task raised `CancelledError`.
+  - `test_cancelled_after_promote_drains_to_next` — submit A + B + C; respond to A so B promotes; cancel B's task before B observes the promote; assert C promotes and is then resolvable via `respond_to_confirmation`. Guards the "cancelled-after-promote" edge case.
+
+**Key changes:**
+
+```python
+# request_confirmation — queued-wait branch with hardened cleanup
+
+if queued is not None:
+    try:
+        await queued.promoted_event.wait()
+    except asyncio.CancelledError:
+        promoted_after: ConfirmationRequest | None = None
+        async with state.lock:
+            if queued in state.confirmation_queue:
+                state.confirmation_queue.remove(queued)
+            elif state.pending_confirmation is request:
+                # Promoted but cancelled before consuming. Clear and
+                # promote the next entry so the queue doesn't stall.
+                state.pending_confirmation = None
+                state.confirmation_event = None
+                state.confirmation_response = None
+                promoted_after = self._promote_next_confirmation_unlocked(
+                    state, conv_id)
+        if promoted_after is not None:
+            await self.emit(
+                conv_id, _confirmation_request_payload(promoted_after))
+        raise
+    async with state.lock:
+        event = state.confirmation_event
+    await self.emit(conv_id, _confirmation_request_payload(request))
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `make test` passes (2511 passed)
+- [x] `pytest tests/test_conversation_manager.py -k "cancelled_queued or cancelled_after_promote" -v` passes
+
+**Verification — manual** (deferred to branch self-review per express mode):
+- [ ] Walk: A active, B+C queued. B's task is cancelled. B's `CancelledError` removes B from the queue. C is still queued. A continues normally; on A's resolution, C promotes.
+- [ ] Walk: A resolves, B promotes, B's task is cancelled before consuming the promote signal. Cleanup clears B's active slot and promotes C.
+
+---
+
+## Phase 3: Timeout-from-promote + cancel-pending behavior tests
+
+Lock down the two remaining behaviors from the spec via tests (no new production code — these follow from Phase 1's structure). Structural-invariant guard for the queue's two non-obvious semantics.
+
+**Files:**
+- Add: `tests/test_conversation_manager.py`
+  - `test_queued_confirmation_timeout_starts_at_promote` — submit A with `timeout=10.0` (long); submit B with `timeout=0.05` (short). After ~0.2s of wall time, assert B's task is not done (it's queued; the 0.05s deadline only applies post-promote, not while queued). Respond to A. Then assert B times out 0.05s after promotion (B's task completes with a denial whose `confirmation_id` matches B's). Total wall < ~0.5s. No `asyncio.sleep` longer than ~0.05–0.2s — use `asyncio.wait_for(...task..., timeout=...)` patterns.
+  - `test_cancel_pending_promotes_next_queued` — submit A active + B queued; call `cancel_pending_confirmation(conv_id)`; assert A's task returns a denial response (existing cancel behavior); assert B promotes (state.pending_confirmation is B's request); resolve B via `respond_to_confirmation`; assert B's task gets approval. Capture emits and assert ordering: `confirmation_response (A denial)` then `confirmation_request (B promoted)`.
+  - `test_cancel_pending_with_empty_queue_unchanged` — control: submit only A; cancel; assert behavior identical to today's denial + no promote event emitted; `state.confirmation_queue` stays empty.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (2514 passed)
+- [x] `pytest tests/test_conversation_manager.py -k "queued_confirmation_timeout or cancel_pending_promotes or cancel_pending_with_empty" -v` passes
+- [x] `pytest --durations=25 tests/test_conversation_manager.py` — `test_queued_confirmation_timeout_starts_at_promote` lands at #9 (0.39s) because it intentionally awaits real time to verify the post-promote timeout property. This is by design, not an accidental sleep; the other Phase 3 tests are sub-0.05s. Acceptable.
+
+**Verification — manual** (deferred to branch self-review per express mode):
+- [ ] Re-read `test_queued_confirmation_timeout_starts_at_promote` and confirm the assertion is on *post-promote* elapsed time. The wrong assertion ("B's task finishes within 0.05s of submission") would be a false positive against the queue-deferred timeout semantics.
+
+---
+
+## Phase 4: Docs update + final commit
+
+Update the one user-facing doc that describes the confirmation lifecycle. The internal docstrings on `request_confirmation` and `_promote_next_confirmation_unlocked` already cover implementation; this phase touches public-facing prose only.
+
+**Files:**
+- Modify: `docs/architecture.md` — "Confirmations" section. Append a one-line note: "Concurrent `request_confirmation` calls on the same conversation are queued FIFO; the user sees them one at a time and each gets its own response."
+- Modify: `src/decafclaw/conversation_manager.py` — extend the docstring of `request_confirmation` to mention the queue path and the "timeout starts at promote" semantics. Extend the "Per-conversation lock guarding..." comment on `ConversationState.lock` (L150–186) to add a bullet for "the confirmation queue mutations and promote-the-next-on-clear".
+
+No changes to:
+- `CLAUDE.md` — confirmation conventions are unchanged; queue is internal.
+- `docs/websocket-messages.md` — wire format unchanged (still one `confirmation_request` at a time).
+- `docs/skills.md` — `request_confirmation` import/usage unchanged.
+- `docs/index.md` — no new top-level page.
+
+**Verification — automated:**
+- [x] `make check` passes (Python lint + typecheck + JS check)
+- [x] `make test` passes (2514 passed)
+- [x] `grep -n "confirmation_queue\|_QueuedConfirmation\|_promote_next_confirmation_unlocked" src/decafclaw/conversation_manager.py` shows the new identifiers across the dataclass, the lock-comment, the helper definition, and the four call sites (queued-wait cleanup, post-wait-claimed/timeout/cancel-raced, respond-recovery, cancel-no-waiter)
+
+**Verification — manual** (handled at branch self-review):
+- [ ] `docs/architecture.md` Confirmations section reads cleanly with the new sentence — no contradiction with the existing "agent loop suspends mechanically" description.
+- [ ] Skim full diff one more time against `spec.md`'s "What we're NOT doing" — no out-of-scope changes (no #486 fix, no new wire types, no API changes, no archive-format changes).

--- a/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/research.md
+++ b/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/research.md
@@ -1,0 +1,142 @@
+# Research — #485 request_confirmation overwrite
+
+Documentarian read of the confirmation lifecycle in `src/decafclaw/conversation_manager.py` and surrounding code.
+
+## 1. `request_confirmation` contract
+
+**Signature** (`conversation_manager.py:763`):
+```python
+async def request_confirmation(self, conv_id: str, request: ConfirmationRequest) -> ConfirmationResponse
+```
+
+Flow:
+1. **Archive** (L786) — `append_message` persists request synchronously, **outside** the lock.
+2. **State setup under `state.lock`** (L790–794):
+   - `state.pending_confirmation = request`
+   - `state.confirmation_event = asyncio.Event()` (fresh event)
+   - `state.confirmation_response = None`
+   - Captures `event` locally for the release-and-wait pattern.
+3. **Emit** `confirmation_request` event outside the lock (L798–807).
+4. **Wait** on `event.wait()` with `request.timeout` (L812). Timeout may be `None` (block indefinitely — widget inputs).
+5. **Post-wait claim** under lock (L837–881):
+   - Responder claimed → honor it.
+   - Timeout → synthesize `ConfirmationResponse(approved=False)`, archive, `needs_timeout_emit=True`.
+   - Cancel raced → return denial without archiving (cancel already wrote it).
+6. **Timeout emit** outside lock (L882–887) if needed.
+
+Returns `ConfirmationResponse`.
+
+## 2. `respond_to_confirmation` flow
+
+`conversation_manager.py:413–559`.
+
+Lock-held sequence (L446–505):
+- Pending check (L447–449), ID match (L450–455), duplicate-response guard (L459–464).
+- Build `ConfirmationResponse` (L466–472).
+- Archive under lock (L483–491) — on failure, raise without partial claim.
+- Capture & claim (L501–505): `claimed_request = state.pending_confirmation`, `waiter_event = state.confirmation_event`, set `state.confirmation_response = response`, clear `state.pending_confirmation = None`, clear `state.confirmation_event = None`.
+
+Emit `confirmation_response` outside lock (L512–525).
+
+Recovery dispatch (L527–558):
+- If `waiter_event is not None` → `waiter_event.set()`; waiter post-block re-acquires lock and consumes claim.
+- If `waiter_event is None` → no running loop. Re-acquire lock, clear `state.confirmation_response = None`, call `_dispatch_recovery(conv_id, claimed_request, response)`. On handler failure (L550–558), restore `state.pending_confirmation = claimed_request` for retry.
+
+L527 identity check pattern (described in #486): the check that `state.confirmation_response is not response` in the recovery branch was the path documented in #486; #485 is the upstream design question.
+
+## 3. `cancel_pending_confirmation` flow
+
+`conversation_manager.py:560–634`.
+
+Lock-held checks (L580–627):
+1. State exists (L580–582) — else return False.
+2. Pending exists (L584–585) — else return False.
+3. **Response already claimed (L586–593)** — if `state.confirmation_response is not None`, defer to responder and return False. This is the asymmetry from `request_confirmation`: cancel respects a live claim; request_confirmation does not.
+4. Capture pending (L594), build denial (L595–598), capture `waiter_event` (L604).
+5. Archive under lock (L614–621) — raise on failure with pending state untouched.
+6. Claim & clear (L625–627): set `state.confirmation_response = response`, clear `state.pending_confirmation` and `state.confirmation_event`.
+
+Signal waiter outside lock (L632–633).
+
+## 4. `execute_tool_calls` concurrency
+
+`src/decafclaw/tool_execution.py:282–364`.
+
+- `asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)` at L292 (default 5).
+- Per-tool ctx fork at L297: `call_ctx = ctx.fork_for_tool_call(tc["id"])`.
+- `asyncio.create_task(execute_single_tool(call_ctx, tc, semaphore))` per tool (L298–302).
+- `asyncio.gather(*tasks, return_exceptions=True)` at L316.
+
+Call path for confirmation from a tool:
+- `execute_single_tool` (L210) → `execute_tool` (L232) → tool handler → `request_confirmation(ctx, ...)` (in `tools/confirmation.py:106`) → `ctx.request_confirmation(request)` → `ConversationManager.request_confirmation` (L763).
+
+**Concurrency conclusion:** Two tools running concurrently in the same turn can each invoke `request_confirmation` on the same `conv_id`. The second's state setup (L790–794) will overwrite the first's `pending_confirmation` / `confirmation_event` / `confirmation_response`, orphaning the first waiter on a now-dead event.
+
+## 5. Existing tests
+
+In `tests/test_conversation_manager.py` and `tests/test_confirmation.py`.
+
+**Lifecycle** (`test_conversation_manager.py`):
+- `test_request_confirmation_approved` (L104)
+- `test_request_confirmation_denied` (L132)
+- `test_request_confirmation_timeout` (L155)
+- `test_confirmation_emits_request_event` (L170)
+- `test_confirmation_persisted_to_archive` (L196)
+- `test_request_confirmation_no_timeout` (L296)
+- `test_always_field_in_confirmation_response` (L388)
+
+**Startup recovery** (L414–481):
+- `test_startup_scan_finds_pending_confirmation`
+- `test_startup_scan_ignores_resolved_confirmations`
+- `test_startup_scan_ignores_stale_confirmations`
+
+**Race / durability** (L1283–1799):
+- `test_concurrent_confirmation_responses_dont_double_dispatch` (L1283) — two `respond_to_confirmation` for same id → handler runs once (#440).
+- `test_cancel_pending_confirmation_after_response_claimed_is_noop` (L1340)
+- `test_request_confirmation_timeout_loses_race_to_late_responder` (L1378)
+- `test_respond_to_confirmation_rolls_back_claim_on_archive_failure` (L1465)
+- `test_cancel_pending_confirmation_rolls_back_on_archive_failure` (L1518)
+- `test_recover_confirmation_restores_on_dispatch_failure` (L1553)
+- `test_request_confirmation_timeout_archive_failure_preserves_state` (L1647)
+- `test_recovered_confirmation_dispatch_uses_captured_request` (L1699) — covers a related concurrent-overwrite case at the recovery-branch level.
+- `test_recovery_dispatch_proceeds_when_new_request_lands_mid_flight` (L1802) — related to #486.
+- `test_cancel_pending_confirmation_wakes_live_waiter` (L1878)
+
+**Gap:** no test exercising **two concurrent `request_confirmation` calls** on the same `conv_id` (the #485 reproduction).
+
+`test_confirmation.py` covers archive round-trips only (L15–112).
+
+## 6. Types and state fields
+
+**`ConfirmationRequest`** (`confirmations.py:23–60`):
+- `action_type: ConfirmationAction` (enum: RUN_SHELL_COMMAND, ACTIVATE_SKILL, CONTINUE_TURN, ADVANCE_PROJECT_PHASE, WIDGET_RESPONSE)
+- `action_data: dict`, `message: str`, `approve_label: str`, `deny_label: str`
+- `tool_call_id: str` (empty for non-tool contexts)
+- `timeout: float | None` (default 300.0; None for widgets)
+- `confirmation_id: str` — `uuid4().hex[:12]` (L37). 48 bits of entropy.
+- `timestamp: str`
+
+`to_archive_message()` / `from_archive_message()` at L40 / L50.
+
+**`ConfirmationResponse`** (`confirmations.py:63–97`):
+- `confirmation_id: str` (matches the request)
+- `approved: bool`, `always: bool`, `add_pattern: bool`
+- `data: dict`, `timestamp: str`
+
+`to_archive_message()` (L78) drops falsy optional flags; `from_archive_message()` (L93) tolerant of missing keys.
+
+**`ConversationState` fields** (`conversation_manager.py:188–191`):
+- `pending_confirmation: ConfirmationRequest | None`
+- `confirmation_event: asyncio.Event | None`
+- `confirmation_response: ConfirmationResponse | None`
+
+All three mutated atomically under `state.lock`.
+
+## Summary
+
+| Aspect | Status |
+|---|---|
+| `request_confirmation` overwrite | unconditional — sets `pending_confirmation` / `confirmation_event` / `confirmation_response = None` without checking for an existing live claim (L790–794) |
+| `cancel_pending_confirmation` overwrite | guarded — defers to claimed responses (L586–593) |
+| Concurrent tool path | real: per-tool `asyncio.create_task` under `max_concurrent_tools` semaphore (default 5) |
+| Test coverage of concurrent `request_confirmation` | none |

--- a/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/spec.md
+++ b/docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/spec.md
@@ -1,0 +1,95 @@
+# Queue concurrent request_confirmation calls per conversation
+
+**Goal:** When two or more `request_confirmation` calls happen concurrently on the same conversation, serialize them through a FIFO queue instead of letting the second clobber the first's pending-confirmation slot.
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/485
+
+## Current state
+
+`ConversationManager.request_confirmation` (`src/decafclaw/conversation_manager.py:763`) unconditionally writes the per-conversation pending-confirmation triple under `state.lock`:
+
+```python
+state.pending_confirmation = request
+state.confirmation_event = asyncio.Event()
+state.confirmation_response = None
+```
+
+(Lines 790–794.) The lock from #484 makes that transition atomic, but doesn't stop the **overwrite** itself. Two tools dispatched concurrently by `execute_tool_calls` (`src/decafclaw/tool_execution.py:282–364`) — common in delegated background tasks producing parallel approval prompts — both hit `request_confirmation` on the same `conv_id`. The second's setup orphans the first waiter on a now-dead event; the first request never gets a response.
+
+`cancel_pending_confirmation` (L560–634) already guards against overwriting a claimed response (L586–593). The asymmetry between cancel (defers to live claim) and request_confirmation (clobbers it) is the bug shape.
+
+See `research.md` for the full trace.
+
+## Desired end state
+
+- A second concurrent `request_confirmation` on the same conv enqueues behind any active confirmation and waits its turn. Each request still resolves to its own `ConfirmationResponse` keyed by its own `confirmation_id`.
+- The active slot (`state.pending_confirmation` / `state.confirmation_event` / `state.confirmation_response`) is mutated only by activation/completion of the queue head — never overwritten by a queued request.
+- The UI/transport layer sees exactly one `confirmation_request` event at a time per conv. When the active confirmation resolves (respond / cancel / timeout), the next queued request is promoted and a fresh `confirmation_request` event fires for it.
+- Queued requests are invisible to the UI until they reach the head — no "queued" state surfaced; queue is an implementation detail of `ConversationManager`.
+- Existing `request_confirmation` callers (tool authors, widget input, skill confirmations) don't change. The semantics they observe are: "I get my response when the user gets around to it."
+
+## Design decisions
+
+- **Decision:** Implement a FIFO queue on `ConversationState`; the queue is the list of *not-yet-active* requests waiting for a turn. The currently-active confirmation continues to live in `pending_confirmation` / `confirmation_event` / `confirmation_response` exactly as today.
+  - **Why:** Minimum change to the active-slot semantics. Existing code paths (`respond_to_confirmation`, `cancel_pending_confirmation`, startup recovery, archive serialization) keep working on the active slot. The queue only adds enqueue-on-collision and promote-on-completion behavior.
+  - **Rejected:** Replacing the active triple with a list and always indexing by head — touches more surface, more risk for the same outcome.
+
+- **Decision:** A queued request carries its own `asyncio.Event` and a `response: ConfirmationResponse | None` slot in a small dataclass `_QueuedConfirmation`. The waiter blocks on its own event, not on `state.confirmation_event`.
+  - **Why:** Each request needs its own signaling primitive so promote-the-next-one can wake exactly that waiter. `state.confirmation_event` continues to belong to the active request.
+  - **Rejected:** A single shared event with a "look at the head" check — fragile against spurious wakes and re-entry.
+
+- **Decision:** Archive each request at **enqueue time**, not at promote time. Emit the `confirmation_request` UI event only at **promote time** (i.e. when the request becomes active).
+  - **Why:** Archive faithfulness — the archive captures the agent's actual sequence of tool decisions in the order the tools made them. If we crash, all requested confirmations are durable. The UI event is the user-facing surface; emitting only on promote keeps the "one active confirmation at a time" abstraction clean.
+  - **Rejected:** Archive-at-promote — loses queued requests on crash, agent loop can't tell what was "in flight" on restart.
+
+- **Decision:** Timeout (`request.timeout`) **starts at promote time**, not at enqueue time. Specifically: the waiter first awaits its promote signal (no timeout), then once promoted, runs the existing post-wait claim block with `request.timeout`.
+  - **Why:** A queued request shouldn't time out before the user has even seen it. Otherwise a long-running first confirmation would silently deny everything queued behind it.
+  - **Rejected:** Timeout starts at enqueue — produces surprising mass-denials on contention.
+
+- **Decision:** `cancel_pending_confirmation(conv_id)` (no id arg) continues to cancel **only the active confirmation**. Cancelling does not drop queued items — they promote naturally as today.
+  - **Why:** The existing cancel API has no notion of "which one"; it cancels what the user sees. After cancel, the next queued item promotes and the user sees that one.
+  - **Rejected:** Cancel-all (clear active + queue) — too aggressive; not what cancel means today.
+
+- **Decision:** Promote-the-next-queued is centralized in a single helper, `_promote_next_confirmation(state, conv_id)`. Every code path that clears the active slot (`respond_to_confirmation`, `cancel_pending_confirmation`, `request_confirmation`'s post-wait timeout/cancel-raced branches) calls it under the lock immediately after clearing.
+  - **Why:** Single source of truth for promotion ordering; avoids three near-identical inlinings.
+  - **Rejected:** Inlining promotion at each call site — invites drift bugs.
+
+- **Decision:** If a queued waiter's task is cancelled (asyncio.CancelledError raised mid-`event.wait()`), it removes its own entry from the queue in a `finally` block before re-raising.
+  - **Why:** A dead waiter must not get promoted later. The cleanup needs to happen even on cancel.
+  - **Rejected:** Lazy cleanup at promote time (skip dead entries) — leaves stale entries lying around indefinitely and complicates queue ordering.
+
+- **Decision:** Pre-`request_confirmation`-overwrite logic now treats a non-None `state.pending_confirmation` as "must enqueue" — the **current** trailing-state setup at L790–794 becomes the "no-active-confirmation" branch of an if/else.
+  - **Why:** Keeps the no-contention path identical to today's behavior.
+
+- **Decision:** No change to the existing `confirmation_id` shape (12-char hex from uuid4), to the archive message format, to the `confirmation_request` / `confirmation_response` wire events, or to `ConfirmationRequest` / `ConfirmationResponse` dataclasses.
+  - **Why:** Out of scope; this PR is a concurrency fix, not a contract change.
+
+- **Decision:** #486 stays separate. Queueing does not subsume #486's L527 identity-check fix because a fresh queued request can still land between L498 (lock released after archive+emit) and L517 (lock re-acquired for the identity check) in the recovery branch.
+  - **Why:** Issue #486 explicitly states: "If #485 is resolved by queuing, this specific path still needs Option B (drop the re-check) or Option A (compare by confirmation_id)."
+  - **How to apply:** Don't touch the L527 identity-check logic in this PR. Leave #486 open for follow-up.
+
+## Patterns to follow
+
+- **Single lock per state, fine-grained mutations.** Existing pattern in `conversation_manager.py:186` — all confirmation mutations happen under `state.lock`. The queue list (and any promotion logic) lives there too.
+- **Archive on outer thread / before lock.** Existing pattern at `conversation_manager.py:785–786` — `append_message` is sync I/O, runs outside the lock to avoid holding it across disk writes. Enqueue follows the same pattern: archive first (outside lock), then enqueue (inside lock).
+- **Release lock across `event.wait()`.** Existing pattern at L809–812. The queue waiter follows the same: release lock, wait for own event, re-acquire for state inspection.
+- **Test patterns for race conditions.** `tests/test_conversation_manager.py:1283` (`test_concurrent_confirmation_responses_dont_double_dispatch`) and L1699 / L1802 — use `asyncio.create_task` + explicit `asyncio.wait` / `asyncio.gather` to force interleaving, not `asyncio.sleep`. Match the deterministic style for the new regression tests.
+- **Per-tool ctx fork in `execute_tool_calls`.** `tool_execution.py:297` — this is the reproduction surface; the regression test can call the manager directly with two tasks if mirroring the full tool path is overkill.
+
+## What we're NOT doing
+
+- **Not fixing #486.** The L527 identity check in `respond_to_confirmation`'s recovery branch keeps its current logic. Queueing reduces but does not eliminate the #486 race window. Tracked there, handled separately.
+- **Not exposing queue depth or "you are #N in line" semantics** to the UI or transports. Queue is invisible; only the active confirmation surfaces. UX iteration on this can come later if it matters.
+- **Not changing `cancel_pending_confirmation`'s API** to take a `confirmation_id` or to support cancel-all. Today's API is "cancel what's pending"; that meaning is preserved.
+- **Not changing the timeout default or the timeout contract.** `request.timeout` is still the post-promote countdown.
+- **Not changing the archive format** (no new `queued: true` marker, no per-request ordinal). Archive entries look identical to today.
+- **Not changing how startup recovery scans for unresolved confirmations.** Recovery picks up requests with no matching response; queued requests that were archived but never promoted before crash will look identical to unresolved active confirmations. On restart, only one becomes "active"; if more land, the new queue logic handles them naturally. The edge case where multiple unresolved confirmations exist on restart and *no* new request_confirmation calls land is consistent with today (only one ends up "live"); we accept this and don't change recovery.
+- **Not adding metrics, structured logging, or observability hooks** for queue depth. Standard `log.debug` / `log.info` at queue/promote points is sufficient.
+
+## Open questions
+
+None blocking. Defaults below; plan/execute proceed under these.
+
+- _Default:_ promotion's `confirmation_request` event is emitted outside the lock (matching today's pattern at L798–807). Inside `_promote_next_confirmation`: set active fields under lock, return the promoted request, caller emits after lock release.
+- _Default:_ logging level for queue enqueue/promote is `log.info` (matches today's confirmation-lifecycle log volume).
+- _Default:_ no separate config flag for queue behavior; queueing is always-on. The behavior is strictly safer than the current overwrite.

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -138,6 +138,43 @@ _PERSISTED_FIELD_NAMES: frozenset[str] = frozenset(
 
 
 @dataclass
+class _QueuedConfirmation:
+    """A confirmation request waiting to become active.
+
+    Holds the request, a per-request asyncio.Event the waiter blocks
+    on (``promoted_event``), and a slot for the freshly-installed
+    active ``confirmation_event`` (``active_event``). The promote
+    helper writes ``active_event`` BEFORE signalling ``promoted_event``
+    so the waiter never has to re-read ``state.confirmation_event``
+    after waking — that re-read had a narrow race window where a
+    concurrent caller could null the field out between wake and lock
+    re-acquisition (Copilot review on #485 PR). Issue #485.
+    """
+    request: ConfirmationRequest
+    promoted_event: asyncio.Event = field(default_factory=asyncio.Event)
+    active_event: asyncio.Event | None = None
+
+
+def _confirmation_request_payload(request: ConfirmationRequest) -> dict:
+    """Build the ``confirmation_request`` emit payload for a request.
+
+    Shared by the initial-active emit and every promote-emit in
+    request_confirmation / respond_to_confirmation /
+    cancel_pending_confirmation (issue #485).
+    """
+    return {
+        "type": "confirmation_request",
+        "confirmation_id": request.confirmation_id,
+        "action_type": request.action_type.value,
+        "action_data": request.action_data,
+        "message": request.message,
+        "approve_label": request.approve_label,
+        "deny_label": request.deny_label,
+        "tool_call_id": request.tool_call_id,
+    }
+
+
+@dataclass
 class ConversationState:
     """Per-conversation state managed by the ConversationManager."""
     conv_id: str = ""
@@ -170,6 +207,13 @@ class ConversationState:
     #     clear (all under the lock for the same durability reason)
     #   - cancel_turn's paired read of cancel_event/agent_task
     #   - recover_confirmation's atomic pop of pending_confirmation
+    #   - confirmation_queue mutations and
+    #     _promote_next_confirmation_unlocked side-effects (issue #485)
+    #     — enqueue-on-collision, promote-on-clear, and queued-waiter
+    #     cleanup all happen under the lock so the queue ordering and
+    #     the active-slot transitions stay consistent for concurrent
+    #     request_confirmation / respond_to_confirmation /
+    #     cancel_pending_confirmation callers
     # NOT held during:
     #   - the agent task body itself (asyncio.create_task returns
     #     immediately so the caller's lock-acquire is released before
@@ -189,6 +233,12 @@ class ConversationState:
     pending_confirmation: ConfirmationRequest | None = None
     confirmation_event: asyncio.Event | None = None
     confirmation_response: ConfirmationResponse | None = None
+
+    # FIFO queue of confirmations awaiting their turn (issue #485). Each
+    # entry is a request that arrived while another was active; the waiter
+    # blocks on the entry's ``promoted_event`` until
+    # ``_promote_next_confirmation_unlocked`` moves it to the active slot.
+    confirmation_queue: list[_QueuedConfirmation] = field(default_factory=list)
 
     # Per-conversation persistent state (survives across turns).
     # See PersistedTurnState for what lives here and how save/restore
@@ -503,6 +553,19 @@ class ConversationManager:
             state.confirmation_response = response
             state.pending_confirmation = None
             state.confirmation_event = None
+            # Queue-promotion ownership splits on waiter presence:
+            #   * Live waiter: it clears ``confirmation_response``
+            #     itself and calls
+            #     ``_clear_active_and_promote_unlocked`` from its
+            #     post-wait block.
+            #   * No waiter (recovery path below): we clear
+            #     ``confirmation_response`` and explicitly call
+            #     ``_promote_next_confirmation_unlocked`` after the
+            #     recovery handler dispatches, so queued entries
+            #     don't get orphaned.
+            # We do NOT promote here under the same lock as the claim,
+            # because that would clobber a live waiter's view of
+            # ``confirmation_response``. (Issue #485.)
 
         # Emit to subscribers outside the lock (subscriber awaits may
         # do arbitrary I/O). If emit fails, the response is already
@@ -529,7 +592,8 @@ class ConversationManager:
             # state.confirmation_response under the lock (we already
             # cleared pending_confirmation / confirmation_event
             # above; request_confirmation's success path tolerates
-            # those being None) and then clear confirmation_response.
+            # those being None) and then clear confirmation_response
+            # and promote the next queued confirmation (issue #485).
             waiter_event.set()
         else:
             # No running loop — dispatch recovery using the request
@@ -556,6 +620,17 @@ class ConversationManager:
                     if state.pending_confirmation is None:
                         state.pending_confirmation = claimed_request
                 raise
+            # Recovery dispatched successfully. There's no running
+            # waiter to promote the queue, so do it ourselves: if any
+            # request_confirmation calls landed while the recovered
+            # confirmation was active, they're queued and need
+            # promotion. ``_promote_next_confirmation_unlocked`` is a
+            # no-op if a parallel request_confirmation already won the
+            # active slot. The promoted request's own queued waiter
+            # will emit its ``confirmation_request`` payload when it
+            # wakes; we don't emit here. (Issue #485.)
+            async with state.lock:
+                self._promote_next_confirmation_unlocked(state, conv_id)
 
     async def cancel_pending_confirmation(self, conv_id: str) -> bool:
         """Drop a pending confirmation without triggering recovery.
@@ -619,16 +694,35 @@ class ConversationManager:
                     "for conv %s; pending state untouched",
                     conv_id[:8])
                 raise
-            # Archive succeeded — claim the slot for the live waiter
-            # (so request_confirmation's post-wait block observes our
-            # denial) and clear pending state atomically.
-            state.confirmation_response = response
-            state.pending_confirmation = None
-            state.confirmation_event = None
+            # Archive succeeded. Behavior splits on whether a live
+            # waiter is present:
+            #   * Live waiter: claim the slot (set
+            #     ``confirmation_response``) so the waiter's post-wait
+            #     block observes our denial when it re-acquires the
+            #     lock, then clear pending/event. The waiter promotes
+            #     any queued entry from there.
+            #   * No live waiter: nothing will consume a claim, so
+            #     just clear pending/event and promote the next queued
+            #     confirmation directly. Setting and then clearing
+            #     ``confirmation_response`` in this branch would be a
+            #     dead write under the same lock (Copilot review on
+            #     this PR). Skipping it makes the no-waiter case
+            #     symmetric with the recovery-path promotion in
+            #     ``respond_to_confirmation``. The promoted request's
+            #     own queued waiter emits its ``confirmation_request``
+            #     when it wakes; we don't emit here.
+            if waiter_event is not None:
+                state.confirmation_response = response
+                state.pending_confirmation = None
+                state.confirmation_event = None
+            else:
+                state.pending_confirmation = None
+                state.confirmation_event = None
+                self._promote_next_confirmation_unlocked(state, conv_id)
         # Signal the live waiter outside the lock so its post-wait
         # block can acquire the lock and consume our denial.
         # request_confirmation will null out confirmation_response
-        # itself under the lock.
+        # itself under the lock and promote the next queued entry.
         if waiter_event is not None:
             waiter_event.set()
         return True
@@ -760,6 +854,70 @@ class ConversationManager:
         state.history = history
         return history
 
+    def _promote_next_confirmation_unlocked(
+        self, state: "ConversationState", conv_id: str,
+    ) -> ConfirmationRequest | None:
+        """Move the next queued confirmation (if any) into the active slot.
+
+        Caller must hold ``state.lock``. Returns the promoted request so
+        the caller can emit the ``confirmation_request`` event outside
+        the lock, or None when there is nothing to promote (issue #485).
+
+        Defensive precondition: if ``state.pending_confirmation`` is
+        already non-None, the active slot is still claimed (e.g. the
+        recovery branch's failed-dispatch restored the prior request,
+        or a parallel ``request_confirmation`` already won the empty
+        slot). In that case promote is a no-op so we don't clobber the
+        active claim; the next clear-and-promote pass will pick the
+        queue back up.
+
+        Side effects under the caller's lock when a queued entry is
+        promoted:
+          - ``state.pending_confirmation = queued.request``
+          - ``state.confirmation_event = asyncio.Event()``  (fresh)
+          - ``state.confirmation_response = None``
+          - ``queued.active_event = state.confirmation_event`` (so the
+            waker doesn't need to re-read ``state.confirmation_event``
+            after wake, avoiding a race window where a concurrent caller
+            could null the field; Copilot review on #485 PR)
+          - ``queued.promoted_event.set()``  (wakes the queued waiter)
+        """
+        if state.pending_confirmation is not None:
+            return None
+        if not state.confirmation_queue:
+            return None
+        queued = state.confirmation_queue.pop(0)
+        state.pending_confirmation = queued.request
+        state.confirmation_event = asyncio.Event()
+        state.confirmation_response = None
+        # Hand the freshly-installed event to the queued waiter
+        # directly. Setting active_event BEFORE promoted_event.set()
+        # ensures the wake-and-read sequence is race-free even though
+        # the lock is released across the waiter's await.
+        queued.active_event = state.confirmation_event
+        queued.promoted_event.set()
+        log.info("Promoted queued confirmation for conv %s: %s",
+                 conv_id[:8], queued.request.action_type.value)
+        return queued.request
+
+    def _clear_active_and_promote_unlocked(
+        self, state: "ConversationState", conv_id: str,
+    ) -> None:
+        """Null out the active-confirmation triple and promote the next
+        queued entry (if any).
+
+        Caller must hold ``state.lock``. This is the post-resolution
+        cleanup pattern shared by the three branches of
+        ``request_confirmation``'s post-wait claim block and the
+        already-promoted limb of the queued-waiter cancellation cleanup
+        (issue #485). Extracting it ensures every clear-active path
+        drives queue promotion the same way.
+        """
+        state.pending_confirmation = None
+        state.confirmation_event = None
+        state.confirmation_response = None
+        self._promote_next_confirmation_unlocked(state, conv_id)
+
     async def request_confirmation(
         self,
         conv_id: str,
@@ -778,34 +936,86 @@ class ConversationManager:
         callers observe a consistent view (issue #440). The lock is
         released across the ``confirmation_event.wait()`` await so the
         responder can acquire it to set the event.
+
+        Queueing (issue #485): if another confirmation is already active
+        on this conv, the new request is appended to
+        ``state.confirmation_queue`` and the caller blocks on its own
+        ``promoted_event`` (no timeout — ``request.timeout`` only starts
+        once the request becomes active). When the active confirmation
+        resolves (respond / cancel / timeout) the
+        ``_promote_next_confirmation_unlocked`` helper moves the next
+        queued request into the active slot and signals its waiter.
         """
         state = self._get_or_create(conv_id)
 
-        # Persist to archive (outside the lock — sync I/O).
+        # Persist to archive (outside the lock — sync I/O). Archive at
+        # enqueue time so crash recovery sees every requested
+        # confirmation, not only the currently-active one.
         from .archive import append_message
         append_message(self.config, conv_id, request.to_archive_message())
 
-        # Set up waiting state under the lock so concurrent responders
-        # see all three fields consistently.
+        # Install as the active confirmation, or queue behind it.
         async with state.lock:
-            state.pending_confirmation = request
-            state.confirmation_event = asyncio.Event()
-            state.confirmation_response = None
-            event = state.confirmation_event
+            if state.pending_confirmation is None:
+                state.pending_confirmation = request
+                state.confirmation_event = asyncio.Event()
+                state.confirmation_response = None
+                event = state.confirmation_event
+                queued: _QueuedConfirmation | None = None
+            else:
+                queued = _QueuedConfirmation(request=request)
+                state.confirmation_queue.append(queued)
+                event = None  # filled in after promotion
+                log.info(
+                    "Conv %s has active confirmation; queued new request "
+                    "(%d in queue)",
+                    conv_id[:8], len(state.confirmation_queue))
 
-        # Emit to subscribers so transports can show the confirmation UI
-        # (outside the lock — emit awaits subscribers).
-        await self.emit(conv_id, {
-            "type": "confirmation_request",
-            "confirmation_id": request.confirmation_id,
-            "action_type": request.action_type.value,
-            "action_data": request.action_data,
-            "message": request.message,
-            "approve_label": request.approve_label,
-            "deny_label": request.deny_label,
-            "tool_call_id": request.tool_call_id,
-        })
+        if queued is None:
+            # Active path: emit the confirmation_request event for the
+            # transports to render UI (outside the lock — emit awaits
+            # subscribers).
+            await self.emit(
+                conv_id, _confirmation_request_payload(request))
+        else:
+            # Queued path: wait (no timeout) for promotion. The promote
+            # helper will assign state.confirmation_event for our turn
+            # before signalling, so we re-read it under the lock.
+            #
+            # Cancellation handling has two shapes (issue #485):
+            #   1. Still queued: just drop our entry so no later
+            #      promotion picks the dead waiter.
+            #   2. Already promoted but cancel landed before we
+            #      consumed the active slot: clear the slot and
+            #      promote the next queued entry so the queue doesn't
+            #      stall on our corpse. (state.pending_confirmation is
+            #      ``request`` only in the just-promoted case — if a
+            #      racing path already replaced it, leave the slot
+            #      alone.)
+            try:
+                await queued.promoted_event.wait()
+            except asyncio.CancelledError:
+                async with state.lock:
+                    if queued in state.confirmation_queue:
+                        state.confirmation_queue.remove(queued)
+                    elif state.pending_confirmation is request:
+                        self._clear_active_and_promote_unlocked(
+                            state, conv_id)
+                raise
+            # The promote helper assigned our active event to
+            # ``queued.active_event`` BEFORE signalling
+            # ``promoted_event``, so we can capture it directly
+            # without re-reading ``state.confirmation_event``. That
+            # re-read had a narrow race window where a concurrent
+            # caller could null the field (Copilot review on this PR).
+            event = queued.active_event
+            await self.emit(
+                conv_id, _confirmation_request_payload(request))
 
+        # By either path (active or queued-then-promoted) ``event`` is
+        # bound to the live ``state.confirmation_event`` for this
+        # request.
+        assert event is not None
         # Wait for response or timeout (lock not held — responder
         # needs to acquire it to claim the slot and set the event).
         try:
@@ -827,20 +1037,16 @@ class ConversationManager:
         #    raced and cleared the slot; treat as denial without
         #    archiving (cancel already wrote its own denial)
         # (Copilot review on #484.)
-        # Hold the lock across the timeout archive write to keep the
-        # in-memory state and the archive in sync — if the write
-        # fails, we leave pending state intact so the caller (or a
-        # later retry / startup recovery) can try again. Other paths
-        # (claimed / cancel-raced) don't archive here so the read-
-        # and-clear stays cheap (Copilot review on #484).
+        # Each branch ends by promoting the next queued confirmation
+        # (if any) under the same lock so the queue can't stall (issue
+        # #485). The promote helper signals the queued waiter; the
+        # caller (us) emits the new confirmation_request after lock
+        # release.
         needs_timeout_emit = False
         async with state.lock:
             claimed = state.confirmation_response
             if claimed is not None:
                 response = claimed
-                state.pending_confirmation = None
-                state.confirmation_event = None
-                state.confirmation_response = None
             elif timed_out:
                 log.info("Confirmation timed out for conv %s: %s",
                          conv_id[:8], request.message)
@@ -859,10 +1065,6 @@ class ConversationManager:
                         "leaving pending state intact for retry",
                         conv_id[:8])
                     raise
-                # Archive succeeded — now safe to clear pending state.
-                state.pending_confirmation = None
-                state.confirmation_event = None
-                state.confirmation_response = None
                 needs_timeout_emit = True
             else:
                 # Signaled but no response — `cancel_pending_confirmation`
@@ -872,12 +1074,14 @@ class ConversationManager:
                     confirmation_id=request.confirmation_id,
                     approved=False,
                 )
-                state.pending_confirmation = None
-                state.confirmation_event = None
-                state.confirmation_response = None
                 log.info("Confirmation for conv %s was cancelled out "
                          "from under the waiter; returning denial",
                          conv_id[:8])
+            # All three branches converge on the same post-resolution
+            # cleanup: null out the active-confirmation triple and
+            # promote the next queued entry. The shared helper keeps
+            # the three branches from drifting (issue #485).
+            self._clear_active_and_promote_unlocked(state, conv_id)
 
         if needs_timeout_emit:
             await self.emit(conv_id, {
@@ -885,6 +1089,12 @@ class ConversationManager:
                 "confirmation_id": request.confirmation_id,
                 "approved": False,
             })
+        # Note: when ``_promote_next_confirmation_unlocked`` promoted
+        # an entry, the promoted request's own queued waiter (in
+        # another ``request_confirmation`` call) is now awake and will
+        # emit its own ``confirmation_request`` payload — we
+        # deliberately don't emit here to avoid duplicate emits per
+        # promotion (issue #485).
 
         return response
 

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1917,3 +1917,435 @@ async def test_cancel_pending_confirmation_wakes_live_waiter(manager):
     # Waiter unblocked with the cancellation denial.
     assert response.approved is False
     assert response.confirmation_id == request.confirmation_id
+
+
+# -- Confirmation queue (issue #485) ------------------------------------------
+
+@pytest.mark.asyncio
+async def test_concurrent_request_confirmation_serializes(manager):
+    """Two concurrent request_confirmation calls on the same conv resolve
+    to their own responses in submission order. Regression for issue #485
+    — the second call used to clobber the first's pending slot, orphaning
+    the first waiter on a dead event.
+    """
+    conv_id = "conv-queue-serialize"
+    manager._get_or_create(conv_id)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=5.0,
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    # Yield so task A reaches its "install active" point.
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    # Yield so task B reaches its "enqueue" point.
+    await asyncio.sleep(0)
+
+    # B must NOT be done yet — it's queued behind A.
+    assert not task_b.done(), "B should be queued while A is active"
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is req_a
+    assert len(state.confirmation_queue) == 1
+    assert state.confirmation_queue[0].request is req_b
+
+    # Respond to A first.
+    await manager.respond_to_confirmation(
+        conv_id, req_a.confirmation_id, approved=True)
+    resp_a = await asyncio.wait_for(task_a, timeout=2.0)
+    assert resp_a.approved is True
+    assert resp_a.confirmation_id == req_a.confirmation_id
+
+    # B should now be promoted and observable in state.
+    assert state.pending_confirmation is req_b
+    assert state.confirmation_queue == []
+    assert not task_b.done(), "B should be active but still awaiting response"
+
+    # Respond to B.
+    await manager.respond_to_confirmation(
+        conv_id, req_b.confirmation_id, approved=True)
+    resp_b = await asyncio.wait_for(task_b, timeout=2.0)
+    assert resp_b.approved is True
+    assert resp_b.confirmation_id == req_b.confirmation_id
+
+    # Pending state fully cleared.
+    assert state.pending_confirmation is None
+    assert state.confirmation_response is None
+
+
+@pytest.mark.asyncio
+async def test_promoted_confirmation_emits_request_event(manager):
+    """Each queued confirmation gets its own confirmation_request emit
+    when it promotes to active — the UI sees the second request only
+    after the first resolves. Issue #485.
+    """
+    conv_id = "conv-queue-emit"
+    manager._get_or_create(conv_id)
+
+    events = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=5.0,
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    await asyncio.sleep(0)
+
+    # Only A's request event so far.
+    req_events = [e for e in events if e["type"] == "confirmation_request"]
+    assert len(req_events) == 1
+    assert req_events[0]["confirmation_id"] == req_a.confirmation_id
+
+    await manager.respond_to_confirmation(
+        conv_id, req_a.confirmation_id, approved=True)
+    await asyncio.wait_for(task_a, timeout=2.0)
+    # Yield so the post-respond emit for B's promotion happens.
+    await asyncio.sleep(0)
+
+    req_events = [e for e in events if e["type"] == "confirmation_request"]
+    assert len(req_events) == 2, (
+        f"expected two confirmation_request emits, got {len(req_events)}"
+    )
+    assert req_events[1]["confirmation_id"] == req_b.confirmation_id
+
+    await manager.respond_to_confirmation(
+        conv_id, req_b.confirmation_id, approved=True)
+    await asyncio.wait_for(task_b, timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_queued_waiter_removed_from_queue(manager):
+    """A queued waiter task that gets cancelled mid-await must drop its
+    own queue entry so it isn't promoted later. Issue #485.
+    """
+    conv_id = "conv-queue-cancel"
+    manager._get_or_create(conv_id)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=5.0,
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    await asyncio.sleep(0)
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is req_a
+    assert len(state.confirmation_queue) == 1
+
+    # Cancel B's task while it's still queued.
+    task_b.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_b
+    # B's entry should be gone.
+    assert state.confirmation_queue == []
+
+    # A still resolves normally and no ghost-promotion happens.
+    await manager.respond_to_confirmation(
+        conv_id, req_a.confirmation_id, approved=True)
+    resp_a = await asyncio.wait_for(task_a, timeout=2.0)
+    assert resp_a.approved is True
+    assert state.pending_confirmation is None
+    assert state.confirmation_queue == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_after_promote_drains_to_next(manager):
+    """If a queued waiter is cancelled after it has been promoted to the
+    active slot (but before it consumed the promote signal), its active
+    slot must be cleared and the next queued entry must be promoted —
+    otherwise the queue stalls. Issue #485.
+    """
+    conv_id = "conv-queue-cancel-after-promote"
+    manager._get_or_create(conv_id)
+
+    events: list[dict] = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=5.0,
+    )
+    req_c = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "echo c"},
+        message="C?",
+        timeout=5.0,
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    await asyncio.sleep(0)
+    task_c = asyncio.create_task(manager.request_confirmation(conv_id, req_c))
+    await asyncio.sleep(0)
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert len(state.confirmation_queue) == 2
+
+    # Approve A — B gets promoted, but before B's task observes the
+    # promote signal and emits its own confirmation_request, cancel B.
+    # We approve A then immediately cancel B; the run-order of A's
+    # post-wait promote vs B's wakeup is implementation-defined, but
+    # the post-condition we test (C is promoted, queue drains) must
+    # hold either way.
+    await manager.respond_to_confirmation(
+        conv_id, req_a.confirmation_id, approved=True)
+    task_b.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_b
+    await asyncio.wait_for(task_a, timeout=2.0)
+    # Yield so any pending promote work completes.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    # C must have been promoted to active. The queue must be empty.
+    assert state.pending_confirmation is req_c
+    assert state.confirmation_queue == []
+
+    # C is resolvable.
+    await manager.respond_to_confirmation(
+        conv_id, req_c.confirmation_id, approved=True)
+    resp_c = await asyncio.wait_for(task_c, timeout=2.0)
+    assert resp_c.approved is True
+
+
+@pytest.mark.asyncio
+async def test_queued_confirmation_timeout_starts_at_promote(manager):
+    """A queued confirmation's ``request.timeout`` is the post-promote
+    countdown, not the post-submission countdown. While queued, the
+    waiter blocks on its ``promoted_event`` indefinitely so a
+    long-running active confirmation doesn't silently deny everything
+    queued behind it. Issue #485.
+    """
+    import time
+
+    conv_id = "conv-queue-timeout-promote"
+    manager._get_or_create(conv_id)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,  # long; we control resolution explicitly
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=0.1,  # short post-promote deadline
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    await asyncio.sleep(0)
+    submitted_at = time.monotonic()
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    await asyncio.sleep(0)
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is req_a
+    assert len(state.confirmation_queue) == 1
+
+    # Wait longer than B's timeout while A is still active. B must NOT
+    # time out while queued.
+    await asyncio.sleep(0.25)
+    assert not task_b.done(), (
+        "B should still be queued and not timed out — "
+        "timeout countdown should only start post-promote"
+    )
+
+    # Resolve A. B promotes; its 0.1s timeout starts now.
+    await manager.respond_to_confirmation(
+        conv_id, req_a.confirmation_id, approved=True)
+    await asyncio.wait_for(task_a, timeout=2.0)
+    promoted_at = time.monotonic()
+
+    # B times out. Its task returns a denial. The time-from-promotion
+    # must be roughly request.timeout (0.1s), not the time-from-submit.
+    resp_b = await asyncio.wait_for(task_b, timeout=2.0)
+    timed_out_at = time.monotonic()
+
+    assert resp_b.approved is False, "B should time out post-promote"
+    assert resp_b.confirmation_id == req_b.confirmation_id
+
+    post_promote_elapsed = timed_out_at - promoted_at
+    post_submit_elapsed = timed_out_at - submitted_at
+    # post-promote elapsed should be approximately 0.1s; allow a wide
+    # margin for CI jitter.
+    assert 0.05 < post_promote_elapsed < 0.5, (
+        f"B timeout should fire ~0.1s after promote, got "
+        f"{post_promote_elapsed:.3f}s"
+    )
+    # post-submit elapsed must clearly exceed the 0.1s timeout — proves
+    # the waiter wasn't ticking while queued.
+    assert post_submit_elapsed > 0.3, (
+        f"B timeout fired too quickly post-submit ({post_submit_elapsed:.3f}s)"
+        " — queued waiter may have been ticking instead of awaiting promote"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_promotes_next_queued(manager):
+    """``cancel_pending_confirmation`` cancels the active confirmation
+    and the next queued entry promotes. Cancel-as-cleanup must not
+    drain the queue or skip the queued entries. Issue #485.
+    """
+    conv_id = "conv-cancel-promote"
+    manager._get_or_create(conv_id)
+
+    events: list[dict] = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    req_a = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+    req_b = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "pwd"},
+        message="B?",
+        timeout=5.0,
+    )
+
+    task_a = asyncio.create_task(manager.request_confirmation(conv_id, req_a))
+    await asyncio.sleep(0)
+    task_b = asyncio.create_task(manager.request_confirmation(conv_id, req_b))
+    await asyncio.sleep(0)
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.pending_confirmation is req_a
+
+    cleared = await manager.cancel_pending_confirmation(conv_id)
+    assert cleared is True
+
+    # A receives denial; B promotes and is resolvable.
+    resp_a = await asyncio.wait_for(task_a, timeout=2.0)
+    assert resp_a.approved is False
+    assert resp_a.confirmation_id == req_a.confirmation_id
+
+    # Yield so B's queued waiter wakes and the post-promote emit fires.
+    await asyncio.sleep(0)
+    assert state.pending_confirmation is req_b
+    assert state.confirmation_queue == []
+
+    # Emit ordering: two confirmation_request events (A's active, then
+    # B's promoted). cancel_pending_confirmation itself does not emit a
+    # confirmation_response (pre-existing behavior — cancel is a
+    # cleanup side-channel), so we only assert on the request stream.
+    request_events = [
+        e for e in events if e["type"] == "confirmation_request"
+    ]
+    assert [e["confirmation_id"] for e in request_events] == [
+        req_a.confirmation_id, req_b.confirmation_id,
+    ], "expected A's request then B's promoted request"
+
+    await manager.respond_to_confirmation(
+        conv_id, req_b.confirmation_id, approved=True)
+    resp_b = await asyncio.wait_for(task_b, timeout=2.0)
+    assert resp_b.approved is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_with_empty_queue_unchanged(manager):
+    """``cancel_pending_confirmation`` with no queued entries behaves
+    exactly as before — the active confirmation gets a denial and no
+    extra emits fire. Regression guard for the no-queue path. Issue
+    #485.
+    """
+    conv_id = "conv-cancel-empty-queue"
+    manager._get_or_create(conv_id)
+
+    events: list[dict] = []
+
+    async def cb(event):
+        events.append(event)
+
+    manager.subscribe(conv_id, cb)
+
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "ls"},
+        message="A?",
+        timeout=5.0,
+    )
+
+    task = asyncio.create_task(manager.request_confirmation(conv_id, request))
+    await asyncio.sleep(0)
+
+    state = manager.get_state(conv_id)
+    assert state is not None
+    assert state.confirmation_queue == []
+
+    cleared = await manager.cancel_pending_confirmation(conv_id)
+    assert cleared is True
+
+    response = await asyncio.wait_for(task, timeout=2.0)
+    assert response.approved is False
+    assert response.confirmation_id == request.confirmation_id
+
+    assert state.pending_confirmation is None
+    assert state.confirmation_queue == []
+
+    # Only one confirmation_request emit (the initial one) — no
+    # spurious promote-emit on the empty queue.
+    request_emits = [e for e in events if e["type"] == "confirmation_request"]
+    assert len(request_emits) == 1


### PR DESCRIPTION
## Summary

- Replace ``request_confirmation``'s unconditional pending-slot overwrite with a per-conversation FIFO queue. Concurrent approval requests on the same conversation (common with delegated background tasks producing parallel prompts) are now serialized — the user sees them one at a time, each waits for its own response.
- Why: the pre-#484 race made the second concurrent call clobber the first's ``pending_confirmation`` / ``confirmation_event`` / ``confirmation_response`` triple. The lock from #484 made the transition atomic but didn't stop the overwrite, leaving the first waiter parked on a dead event indefinitely.

## Design Decisions

- **Queue, not reject or block.** Background-task workloads legitimately produce parallel approval prompts; rejecting would silently deny tools that actually need user approval, and blocking would tie up turn latency under contention. Queueing is transparent to callers.
- **Active slot stays canonical.** ``state.pending_confirmation`` / ``confirmation_event`` / ``confirmation_response`` keep their meaning. Queue is the list of *not-yet-active* requests. Existing code paths (respond, cancel, startup recovery, archive) keep working on the active slot.
- **Per-entry event.** Each ``_QueuedConfirmation`` carries its own ``asyncio.Event``. A single ``_promote_next_confirmation_unlocked`` helper pops the head, installs it in the active slot, signals its event, and is called from every clear-active path.
- **Archive at enqueue, emit at promote.** Crash recovery sees every requested confirmation in submission order; UI sees exactly one active confirmation at a time.
- **Timeout starts at promote.** ``request.timeout`` is the post-promote countdown. While queued, the waiter blocks on ``promoted_event`` with no timeout — a long-running active confirmation can't silently deny everything queued behind it.
- **#486 stays separate.** Queueing reduces but does not eliminate the recovery-dispatch L527 identity-check race window. Tracked there, fixed separately.

## Changes

- ``src/decafclaw/conversation_manager.py``:
  - New module-level ``_QueuedConfirmation`` dataclass.
  - New module-level ``_confirmation_request_payload`` helper (the existing emit payload, shared across emit sites).
  - New ``confirmation_queue: list[_QueuedConfirmation]`` field on ``ConversationState``.
  - New ``_promote_next_confirmation_unlocked`` method on ``ConversationManager`` with a defensive precondition that returns ``None`` if the active slot is still claimed.
  - ``request_confirmation`` restructured into active vs. queued paths. The queued path blocks on ``promoted_event`` without a timeout, then runs the existing post-wait claim block. Cancellation cleanup handles both still-queued and just-promoted shapes.
  - ``respond_to_confirmation``'s recovery branch and ``cancel_pending_confirmation``'s no-waiter branch each call promote after their cleanup so queued items behind a recovered or unsignaled active confirmation aren't orphaned.
  - Lock-contract comment on ``ConversationState.lock`` extended to cover queue mutations.
- ``tests/test_conversation_manager.py``: 7 new tests under the "Confirmation queue (issue #485)" section.
- ``docs/architecture.md``: one-line note in the Confirmations section.

## Test Plan

- [x] ``make check`` (lint, typecheck, JS check)
- [x] ``make test`` (2514 passed, +7 new)
- [ ] Live test in web UI: trigger two delegated background tasks that each request approval; confirm both prompts surface serially, each gets its own response.

## References

- Spec: ``docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/spec.md``
- Plan: ``docs/dev-sessions/2026-05-15-1218-fix-485-request-confirmation-overwrite/plan.md``
- Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)