### PR TITLE
fix(tui): --help routing + argv missing-value detection + conv_history test

### DIFF
--- a/docs/dev-sessions/2026-05-15-1345-tui-512-polish/notes.md
+++ b/docs/dev-sessions/2026-05-15-1345-tui-512-polish/notes.md
@@ -1,0 +1,18 @@
+# Session notes — TUI #512
+
+## Setup findings (2026-05-15 ~13:40)
+
+- Worktree at `.claude/worktrees/tui-512-polish/`, branch `tui-512-polish` tracking `origin/main`.
+- `uv sync` + `cd tui && npm install` both clean.
+- Baseline: TUI `npm test` 12/12; `npm run typecheck` clean; `make check` clean.
+
+## Scope adjustment during setup
+
+- The original #512 body included a fourth item: "Tighten `CliConfirmResponse.decision` to literal union." PR #493 (manifest typed codegen, merged 2026-05-14) restructured the wire shape; the `decision` field no longer exists. Issue body updated to drop the item; spec.md reflects the smaller scope.
+- I'd also just-filed #499 (F3 codegen swap) without realizing PR #493 had already done that work. Closed #499 as already-implemented.
+
+## TODO
+
+- Plan
+- Execute
+- PR

--- a/docs/dev-sessions/2026-05-15-1345-tui-512-polish/plan.md
+++ b/docs/dev-sessions/2026-05-15-1345-tui-512-polish/plan.md
@@ -1,0 +1,77 @@
+# Plan — #512 entry-point polish + dispatcher test
+
+## Approach
+
+Extract `parseArgs` from `entry.tsx` into its own module so it's unit-testable as a pure function (`argv`, `env`) → discriminated union. Refactor `main()` to call `parseArgs` BEFORE the TTY gate, so `--help` prints to stdout and exits 0 even on a non-TTY pipe. Add bounds-checks to flag-parsing so `--token` at end-of-argv produces a clear error rather than silently consuming `undefined`. Add a `conv_history` dispatcher test that mirrors existing test style.
+
+The extraction is the load-bearing change — it's the prerequisite for both items 1 and 2 being testable without `child_process` shenanigans. Two files added, one modified, plus one test added to `dispatcher.test.ts`.
+
+## File changes
+
+| File | Action | Why |
+|---|---|---|
+| `tui/src/parseArgs.ts` | **new** | Pure function: `parseArgs(argv: string[], env: Record<string, string \| undefined>) → ParseResult`. Discriminated union `{kind: "ok", args} \| {kind: "help", message} \| {kind: "error", message}`. Bounds-checks flag values. |
+| `tui/src/parseArgs.test.ts` | **new** | Vitest tests covering: --help / -h, valid args, missing values for each flag, missing token, token from env. |
+| `tui/src/entry.tsx` | modify | Import parseArgs from new module. Reorder `main()`: parseArgs first → help (stdout, exit 0) → error (stderr, exit 1) → TTY check → client/render. |
+| `tui/src/dispatcher.test.ts` | modify | Add `conv_history` test: fixture with user + assistant messages → transcript populated in order. |
+
+## Step-by-step
+
+### Step 1 — Extract + test `parseArgs` (TDD)
+
+1. Write `tui/src/parseArgs.test.ts` first with tests for:
+   - `parseArgs(["--help"], {})` → `{kind: "help", message: <usage>}`
+   - `parseArgs(["-h"], {})` → `{kind: "help", message: <usage>}`
+   - `parseArgs(["--token", "t1", "--host", "http://x", "--conv", "c1"], {})` → `{kind: "ok", args: {token: "t1", host: "http://x", conv: "c1"}}`
+   - `parseArgs(["--token"], {})` → `{kind: "error", message: /--token/}` (missing value)
+   - `parseArgs(["--host"], {DECAFCLAW_TOKEN: "t1"})` → `{kind: "error", message: /--host/}` (missing value)
+   - `parseArgs(["--conv"], {DECAFCLAW_TOKEN: "t1"})` → `{kind: "error", message: /--conv/}` (missing value)
+   - `parseArgs([], {})` → `{kind: "error", message: /token/}` (missing required)
+   - `parseArgs([], {DECAFCLAW_TOKEN: "t1"})` → `{kind: "ok", args: {token: "t1", host: "http://localhost:8088", conv: null}}` (env fallback)
+   - `parseArgs([], {DECAFCLAW_TOKEN: "t1", DECAFCLAW_HOST: "http://example:9000"})` → `{kind: "ok", args: {..., host: "http://example:9000"}}` (env host)
+2. Watch tests fail (no module yet).
+3. Create `tui/src/parseArgs.ts` exporting `parseArgs(argv, env)` returning `ParseResult`. Bounds-check via `if (i + 1 >= argv.length) return {kind: "error", message: \`Missing value for ${a}\`}`. Help message lifted from current entry.tsx usage line.
+4. Watch tests pass.
+5. Commit.
+
+### Step 2 — Refactor `entry.tsx` to use new parseArgs + reorder
+
+1. Update `entry.tsx`:
+   - Remove local `parseArgs` (and `Args` interface — re-export from parseArgs.ts).
+   - Import `parseArgs` from `./parseArgs.js`.
+   - `main()` order: parseArgs → if `help`: console.log(message), exit 0 → if `error`: console.error(message), exit 1 → TTY check → client/render.
+2. Verify `npm run typecheck` clean.
+3. Live smoke (manual):
+   - `echo | npx tsx src/entry.tsx --help` → prints usage to stdout, exits 0.
+   - `npx tsx src/entry.tsx --token` → prints error to stderr, exits 1.
+4. Commit.
+
+### Step 3 — Add `conv_history` dispatcher test
+
+1. Add a test to `tui/src/dispatcher.test.ts` mirroring the existing style:
+   - Construct `conv_history` message with two messages (user + assistant) carrying `role` + `text` fields.
+   - Dispatch on `initialState`.
+   - Assert `transcript` matches `[{kind: "user", text: "hi"}, {kind: "assistant", text: "hello"}]`.
+   - Bonus: a second test with three messages (user + assistant + tool) confirming tool role is skipped per spike intent.
+2. Run `npm test` — all green (was 12, now 14+).
+3. Commit.
+
+### Step 4 — Verify
+
+1. `cd tui && npm test` clean.
+2. `cd tui && npm run typecheck` clean.
+3. `make check` clean (no Python regression; the manifest didn't change so no codegen drift).
+4. Branch self-review (per express phase 3d).
+
+## Risks / open notes
+
+- The `extractText` helper in `dispatcher.ts` reads from a flexible shape (`raw as Record<string, unknown>`). My `conv_history` test must use a shape that `extractText` can handle — probably `{role, text}` based on the user_message test. Verify against `extractText` source before writing the fixture.
+- Help message text: I'll keep it identical to today's wording (`"Usage: decafclaw-tui [--token <t>] [--host <url>] [--conv <id>]\nEnv: DECAFCLAW_TOKEN, DECAFCLAW_HOST"`) so the change is purely about routing (stdout vs stderr) and exit code, not content.
+- No new dependencies. Stays consistent with the spike's "dependency-light" intent.
+
+## Plan self-review
+
+- **Placeholders?** None.
+- **Internal consistency?** Steps 1–3 match spec acceptance criteria; nothing dangling.
+- **Scope?** XS — three files modified, one new test file, one new source file. Three independent commits possible.
+- **Ambiguity?** `extractText` shape is the only point that needs verification at execute time. Noted.

--- a/docs/dev-sessions/2026-05-15-1345-tui-512-polish/spec.md
+++ b/docs/dev-sessions/2026-05-15-1345-tui-512-polish/spec.md
@@ -1,0 +1,44 @@
+# TUI #512 — entry-point polish + missing dispatcher test
+
+**Issue:** [#512](https://github.com/lmorchard/decafclaw/issues/512)
+**Branch:** `tui-512-polish` (worktree at `.claude/worktrees/tui-512-polish/`)
+**Type:** Bug-fix bundle. XS.
+
+## Context
+
+Three small items flagged during the TUI spike retro (`docs/dev-sessions/2026-05-13-1039-tui-spike/notes.md`, "Retro candidates"). All in the TUI client surface, none affecting the bot. PR #493's manifest typed codegen already addressed the wire-shape concerns in the original issue; the remaining three items are pure client-side polish.
+
+## Goals
+
+Three independent fixes:
+
+1. **TTY check should let `--help` through.** Today, `decafclaw-tui --help` on a non-TTY (piped stdin) exits with "requires a TTY stdin" before usage prints. Cause: in `tui/src/entry.tsx`, the TTY check at `main()` line 44 runs before `parseArgs()` at line 49, where `--help` is recognized. Fix: parse argv (or at least scan for `--help`/`-h`) first, exit-with-usage if present, then TTY-gate.
+
+2. **argv parsing: detect missing values.** `--token` (or `--host`/`--conv`) at end of argv silently assigns `undefined` to the flag's value, because `argv[++i]` blindly increments past the end of the array. Result: `decafclaw-tui --token` falls through to the `DECAFCLAW_TOKEN` env-var lookup, masking the user's intent. Fix: when `++i >= argv.length`, exit with a clear "missing value for --X" error.
+
+3. **Add `conv_history` dispatcher test.** The dispatcher's `conv_history` case (`tui/src/dispatcher.ts:133`) has no unit test — explicitly deferred during the spike. Add a fixture with two messages → assert transcript populates with both, in order.
+
+## Non-goals
+
+- Refactoring `parseArgs` into a third-party argv library (e.g. `arg`, `commander`). Hand-rolled detection is sufficient and keeps the TUI dependency-light. (Originally tabled during the spike for the same reason.)
+- Restructuring the TUI surface area or wire types — those are separate issues.
+- Tightening `CliConfirmResponse.decision` to a literal union — obsolete; the field no longer exists after #493.
+- Help-text overhaul. Just ensure existing usage prints in the right place; don't expand it.
+
+## Acceptance criteria
+
+- [ ] `decafclaw-tui --help | cat` shows usage and exits 0.
+- [ ] `decafclaw-tui --help > /dev/null` shows usage and exits 0.
+- [ ] `decafclaw-tui --token` (no value) exits non-zero with a clear error mentioning `--token`.
+- [ ] `decafclaw-tui --host` (no value) — same.
+- [ ] `decafclaw-tui --conv` (no value) — same.
+- [ ] `tui/src/dispatcher.test.ts` has at least one test for `conv_history`.
+- [ ] `cd tui && npm test` clean (13+ tests, was 12).
+- [ ] `cd tui && npm run typecheck` clean.
+- [ ] `make check` clean (no Python or JS regression).
+
+## Files affected
+
+- `tui/src/entry.tsx` — fix #1 and #2.
+- `tui/src/dispatcher.test.ts` — fix #3.
+- No production-code change in `dispatcher.ts`; the existing `conv_history` case already works (live-smoked during the spike).

--- a/tui/src/dispatcher.test.ts
+++ b/tui/src/dispatcher.test.ts
@@ -157,6 +157,57 @@ describe("dispatcher", () => {
     });
   });
 
+  it("conv_history populates transcript with user + assistant messages in order", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "conv_history",
+      conv_id: CONV,
+      messages: [
+        { role: "user", text: "hi" },
+        { role: "assistant", text: "hello" },
+      ],
+      has_more: false,
+      context_limit: 0,
+    });
+    expect(s1.transcript).toEqual([
+      { kind: "user", text: "hi" },
+      { kind: "assistant", text: "hello" },
+    ]);
+  });
+
+  it("conv_history skips tool/system roles per spike intent", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "conv_history",
+      conv_id: CONV,
+      messages: [
+        { role: "user", text: "first" },
+        { role: "tool", text: "tool output" },
+        { role: "system", text: "system note" },
+        { role: "assistant", text: "second" },
+      ],
+      has_more: false,
+      context_limit: 0,
+    });
+    expect(s1.transcript).toEqual([
+      { kind: "user", text: "first" },
+      { kind: "assistant", text: "second" },
+    ]);
+  });
+
+  it("conv_history adopts active_model when present", () => {
+    const s0 = { ...initialState };
+    const s1 = dispatch(s0, {
+      type: "conv_history",
+      conv_id: CONV,
+      messages: [],
+      has_more: false,
+      context_limit: 0,
+      active_model: "claude-opus-4-7",
+    });
+    expect(s1.model).toBe("claude-opus-4-7");
+  });
+
   it("unknown type returns state unchanged (forward-compat)", () => {
     const s0 = { ...initialState, conv_id: CONV };
     const unknown = { type: "future_message", conv_id: CONV } as unknown as ServerMessage;

--- a/tui/src/entry.tsx
+++ b/tui/src/entry.tsx
@@ -10,53 +10,31 @@ import React from "react";
 import { render } from "ink";
 import { WSClient } from "./wsClient.js";
 import { App } from "./App.js";
-
-interface Args {
-  token: string;
-  host: string;
-  conv: string | null;
-}
-
-function parseArgs(argv: string[]): Args | { error: string } {
-  const args: Partial<Args> = {};
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === "--token") args.token = argv[++i];
-    else if (a === "--host") args.host = argv[++i];
-    else if (a === "--conv") args.conv = argv[++i];
-    else if (a === "--help" || a === "-h") {
-      return {
-        error:
-          "Usage: decafclaw-tui [--token <t>] [--host <url>] [--conv <id>]\n" +
-          "Env: DECAFCLAW_TOKEN, DECAFCLAW_HOST",
-      };
-    }
-  }
-  const token = args.token ?? process.env.DECAFCLAW_TOKEN;
-  const host = args.host ?? process.env.DECAFCLAW_HOST ?? "http://localhost:8088";
-  if (!token) {
-    return { error: "Missing token. Use --token <t> or DECAFCLAW_TOKEN." };
-  }
-  return { token, host, conv: args.conv ?? null };
-}
+import { parseArgs } from "./parseArgs.js";
 
 function main(): void {
+  const parsed = parseArgs(process.argv.slice(2), process.env);
+
+  if (parsed.kind === "help") {
+    console.log(parsed.message);
+    process.exit(0);
+  }
+  if (parsed.kind === "error") {
+    console.error(parsed.message);
+    process.exit(1);
+  }
+
   if (!process.stdin.isTTY) {
     console.error("decafclaw-tui requires a TTY stdin.");
     process.exit(1);
   }
 
-  const parsed = parseArgs(process.argv.slice(2));
-  if ("error" in parsed) {
-    console.error(parsed.error);
-    process.exit(1);
-  }
-
-  const client = new WSClient({ host: parsed.host, token: parsed.token });
+  const { token, host, conv } = parsed.args;
+  const client = new WSClient({ host, token });
   client.connect();
 
   render(
-    <App client={client} initialConvId={parsed.conv} host={parsed.host} token={parsed.token} />,
+    <App client={client} initialConvId={conv} host={host} token={token} />,
     { exitOnCtrlC: false }
   );
 }

--- a/tui/src/parseArgs.test.ts
+++ b/tui/src/parseArgs.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "./parseArgs.js";
+
+describe("parseArgs", () => {
+  it("--help returns help result", () => {
+    const r = parseArgs(["--help"], {});
+    expect(r.kind).toBe("help");
+    if (r.kind === "help") expect(r.message).toMatch(/Usage/);
+  });
+
+  it("-h returns help result", () => {
+    const r = parseArgs(["-h"], {});
+    expect(r.kind).toBe("help");
+  });
+
+  it("returns ok with all flags supplied", () => {
+    const r = parseArgs(["--token", "t1", "--host", "http://x", "--conv", "c1"], {});
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.args.token).toBe("t1");
+      expect(r.args.host).toBe("http://x");
+      expect(r.args.conv).toBe("c1");
+    }
+  });
+
+  it("--token at end of argv is a missing-value error", () => {
+    const r = parseArgs(["--token"], {});
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.message).toMatch(/--token/);
+  });
+
+  it("--host at end of argv is a missing-value error", () => {
+    const r = parseArgs(["--host"], { DECAFCLAW_TOKEN: "t1" });
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.message).toMatch(/--host/);
+  });
+
+  it("--conv at end of argv is a missing-value error", () => {
+    const r = parseArgs(["--conv"], { DECAFCLAW_TOKEN: "t1" });
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.message).toMatch(/--conv/);
+  });
+
+  it("missing token (no flag, no env) is an error", () => {
+    const r = parseArgs([], {});
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") expect(r.message).toMatch(/token/i);
+  });
+
+  it("token from env is accepted", () => {
+    const r = parseArgs([], { DECAFCLAW_TOKEN: "envtoken" });
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.args.token).toBe("envtoken");
+      expect(r.args.host).toBe("http://localhost:8088");
+      expect(r.args.conv).toBeNull();
+    }
+  });
+
+  it("host from env is used when flag absent", () => {
+    const r = parseArgs([], {
+      DECAFCLAW_TOKEN: "t1",
+      DECAFCLAW_HOST: "http://example:9000",
+    });
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.args.host).toBe("http://example:9000");
+  });
+
+  it("flag value beats env value", () => {
+    const r = parseArgs(["--token", "flag"], { DECAFCLAW_TOKEN: "env" });
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.args.token).toBe("flag");
+  });
+});

--- a/tui/src/parseArgs.ts
+++ b/tui/src/parseArgs.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure argv/env parser for decafclaw-tui. Lives outside entry.tsx so it can
+ * be unit-tested without booting the React render.
+ */
+
+export interface Args {
+  token: string;
+  host: string;
+  conv: string | null;
+}
+
+export type ParseResult =
+  | { kind: "ok"; args: Args }
+  | { kind: "help"; message: string }
+  | { kind: "error"; message: string };
+
+const USAGE =
+  "Usage: decafclaw-tui [--token <t>] [--host <url>] [--conv <id>]\n" +
+  "Env: DECAFCLAW_TOKEN, DECAFCLAW_HOST";
+
+export function parseArgs(
+  argv: string[],
+  env: Record<string, string | undefined>,
+): ParseResult {
+  const partial: Partial<Args> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+
+    if (a === "--help" || a === "-h") {
+      return { kind: "help", message: USAGE };
+    }
+
+    if (a === "--token" || a === "--host" || a === "--conv") {
+      if (i + 1 >= argv.length) {
+        return { kind: "error", message: `Missing value for ${a}` };
+      }
+      const value = argv[++i];
+      if (a === "--token") partial.token = value;
+      else if (a === "--host") partial.host = value;
+      else partial.conv = value;
+    }
+  }
+
+  const token = partial.token ?? env.DECAFCLAW_TOKEN;
+  const host = partial.host ?? env.DECAFCLAW_HOST ?? "http://localhost:8088";
+
+  if (!token) {
+    return {
+      kind: "error",
+      message: "Missing token. Use --token <t> or DECAFCLAW_TOKEN.",
+    };
+  }
+
+  return { kind: "ok", args: { token, host, conv: partial.conv ?? null } };
+}


### PR DESCRIPTION
Closes #512.

## Summary

Three small TUI client polish items from the spike retro:

- **`--help` works on non-TTY.** Previously `decafclaw-tui --help | cat` exited with \"requires a TTY stdin\" because the TTY gate ran before argv parsing. Reordered: parseArgs → help (stdout, exit 0) → error (stderr, exit 1) → TTY check → render.
- **argv missing-value detection.** `--token` (or `--host`/`--conv`) at end of argv used to silently store `undefined` and fall through to env fallback. Now emits `Missing value for --X` and exits 1.
- **`conv_history` dispatcher test.** Three cases mirroring existing style: user+assistant ordering, tool/system skip per spike intent, `active_model` adoption. Dispatcher coverage: 12 → 15. Suite total: 22 → 25 (10 new parseArgs + 3 new dispatcher).

The load-bearing refactor is extracting `parseArgs` from `entry.tsx` into its own pure module (`parseArgs(argv, env)` returning a discriminated `ParseResult` union). That makes items 1 + 2 unit-testable without booting React render.

## What's NOT in this PR

- Originally #512 also proposed tightening `CliConfirmResponse.decision` to a literal union. PR #493 (manifest typed codegen, 2026-05-14) restructured the wire shape entirely — the `decision` field no longer exists. Issue body updated to drop the item; this PR's scope is the remaining three.
- No new argv-parsing library — hand-rolled stays consistent with the spike's dependency-light intent.

## Spec / plan / notes

[`docs/dev-sessions/2026-05-15-1345-tui-512-polish/`](docs/dev-sessions/2026-05-15-1345-tui-512-polish/) — spec, plan, retro notes.

## Test plan

- [x] \`cd tui && npm test\` — 25/25 (was 22/22).
- [x] \`cd tui && npm run typecheck\` — clean.
- [x] \`make check\` — clean (Python ruff + pyright + JS tsc).
- [x] \`make test\` — 2507/2507 (no Python regression).
- [x] Smoke: \`echo \"\" | npx tsx src/entry.tsx --help\` → usage to stdout, exit 0.
- [x] Smoke: \`echo \"\" | npx tsx src/entry.tsx --token\` → \"Missing value for --token\" to stderr, exit 1.
- [x] Smoke: \`echo \"\" | npx tsx src/entry.tsx\` → \"Missing token...\" to stderr, exit 1.
- [ ] Optional reviewer smoke: live TUI launch with a real token — behavior unchanged from spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)