### PR TITLE
feat(evals): tool-selection coverage sweep — 5 new files closing 6 issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,16 @@ See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui
   - **Anything that runs a real scheduler/timer must patch the work function.** `discover_schedules` picks up bundled scheduled skills (`dream`, `garden`); on a fresh `tmp_path` config they're "never run → due" and fire real `run_agent_turn` calls (one test bled to ~66s this way). Patch `decafclaw.schedules.run_schedule_task` even for "no tasks" scenarios.
 - **Check `pytest --durations=25` when adding tests.** Top-25 placement → missing mock or fixed sleep masquerading as a sync primitive.
 
+### Evals
+
+See [docs/eval-loop.md](docs/eval-loop.md). Evals exercise LLM-driven behavior with real model calls; unit tests cover deterministic code. Both required.
+
+- **New or sharpened tool description → add a `tool_choice` case.** `evals/tool_choice/` covers tool-description disambiguation; `make eval-tools` is fast (~30s). PR #429's smoke test bit-rotted in three weeks because `notes_append` arrived later with no `tool_choice` case guarding the disambiguation — that's the rot vector this convention catches.
+- **Behavior-affecting feature → add a case in `evals/<theme>.yaml`.** New skill, new always-loaded tool, system-prompt change affecting routing, new command. Use `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` for rigorous assertions. Bound every test with `max_tool_calls` and `max_tool_errors`.
+- **Skip evals for non-LLM-visible work.** Pure refactors, storage changes, tool implementation tweaks. Each eval costs tokens and ~6-10 min of wall time.
+- **Avoid `expect_no_tool` where self-reflection might retry.** Reflection's judge can invoke unexpected tools on retries; positive `expect_tool` + tight `max_tool_calls` is more reliable. ([#534](https://github.com/lmorchard/decafclaw/issues/534) tracks a `setup.reflection_enabled: false` harness gate.)
+- **Check `make eval-history` after running the suite.** Trend deltas catch regressions that single-file smoke tests miss.
+
 ## Key files
 
 Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ eval:
 eval-tools:
 	uv run python -m decafclaw.eval.tool_choice evals/tool_choice/
 
+# Print the eval-run trend table from evals/history.jsonl
+eval-history:
+	uv run python -m decafclaw.eval --history
+
 # Rebuild eval embedding fixtures (run when changing embedding models)
 build-eval-fixtures:
 	uv run python scripts/build-eval-fixtures.py

--- a/docs/dev-sessions/2026-05-16-1041-evals-renovation/notes.md
+++ b/docs/dev-sessions/2026-05-16-1041-evals-renovation/notes.md
@@ -91,7 +91,25 @@ To be filed.
 
 ## PR-C — Tool-selection coverage sweep
 
-_To fill in during execution._
+Branch: `evals-coverage-sweep`, stacked on `evals-vault-renovation`. Five commits, one per new eval file:
+
+1. **`tool-deferral.yaml`** (#430, #344) — 3 cases: no-fetch on critical, pre-empted call without `tool_search`, deferred-tool reachability end-to-end.
+2. **`workspace-tools.yaml`** (#340) — 4 cases: glob-or-list (overlapping), search by content, read named path, move (with `expect_workspace` verification).
+3. **`shell.yaml`** (#341) — 2 cases: auto_confirm true happy path, auto_confirm false denial-recovery (no retry storm).
+4. **`delegate.yaml`** (#343) — 2 cases: good-candidate delegation, bad-candidate no-delegation.
+5. **`conversation.yaml`** (#342) — 2 cases: explicit history search (uses PR-A's `setup.conversation_history`), seeded-history recall.
+
+### New findings during PR-C
+
+- **`tool_search` keyword scoring bias** — `tool_search(query="wait")` returns `heartbeat_trigger` instead of `wait` because "wait" appears in heartbeat's description ("without waiting") with higher unweighted score than the bare name match. Filed as **#526**.
+- **`workspace_glob` vs `workspace_list` overlap** — both are reasonable for "list Python files under src/". Eval accepts either; could be a tool-description tightening target if it bites. Not filed; noted here.
+- **Eval runner has no ConversationManager** — `delegate_task` cannot actually execute in eval context (returns "requires ConversationManager"). Eval validates the LLM-decision; execution is covered by `tests/test_delegate.py`. Worth filing as a harness limitation if delegation evals expand.
+- **Self-reflection can trigger spurious `conversation_search` retries** — when the agent's initial response is correct, reflection's eager judge can still ask for more. Affects tests that assert `expect_no_tool: conversation_search`. Worked around per-test by dropping that assertion or raising bounds; longer-term a `setup.reflection_enabled: false` would be cleaner.
+- **`conversation_search` is substring-exact** — seed phrasing must match agent query plurality. Documented inline in the test setup.
+
+### PR
+
+To be filed.
 
 ## PR-D — Pass-rate trend tracking
 

--- a/docs/dev-sessions/2026-05-16-1041-evals-renovation/notes.md
+++ b/docs/dev-sessions/2026-05-16-1041-evals-renovation/notes.md
@@ -113,8 +113,86 @@ To be filed.
 
 ## PR-D — Pass-rate trend tracking
 
-_To fill in during execution._
+Branch: `evals-trend-tracking`, stacked on `evals-coverage-sweep`. One commit.
+
+- New `decafclaw.eval.history` module: `build_run_record` / `append_run` / `read_history` / `render_table`.
+- `__main__.py` now appends one record per `make eval` run to `evals/history.jsonl` (committed to git). JSONL append is fail-soft — a write failure prints a warning but doesn't fail the eval run.
+- `--history` flag + `make eval-history` target render the trend table (fixed-width, pass-rate + delta vs previous row + duration + tokens). Last 20 by default; `--history-limit N` overrides.
+- 12 unit tests in `test_eval_history.py` cover append/read, corrupt-line skipping, per-file aggregation (list + bare-string source forms), empty-history rendering, delta computation, limit handling, and large-number token formatting.
+
+### Decisions
+
+- **Per-file aggregation re-reads the source YAMLs.** The runner flattens cases across files into a single list before running; we don't carry the per-case file ownership back into `test_results`. Re-reading is cheap (YAML files are small) and deterministic.
+- **History on a single line, not nested.** Kept the record shape flat so `jq` queries stay simple (`jq -r '.pass_rate' evals/history.jsonl`).
+- **Fail-soft on write.** If `evals/history.jsonl` can't be written, the eval run still succeeds — history is a nice-to-have, not load-bearing.
+- **`history.jsonl` ships empty** in the PR. First real run after merge seeds it.
+
+### PR
+
+[#TBD](TBD)
 
 ## End-of-session retro
 
-_To fill in at end._
+### Recap
+
+Renovation of the eval system across 4 stacked PRs (#521 → #524 → #527 → #533), closing **13 issues** from the 2026-04-24 audit (#240 umbrella) plus one finding (F1) that the re-audit surfaced. Two follow-up issues filed during execution (#525 project-skill eval flakiness; #526 tool_search keyword-scoring bias).
+
+Net measurable impact: full eval suite went from **24/30 (80%)** baseline to **41/42 (97.6%)** post-PR-C, on `vertex-gemini-flash`. Test count grew from 30 to 42; deleted the 7-test silently-broken `memory-semantic.yaml`; added 19 new tests across 6 new files.
+
+| PR | Branch | Closes | Validation |
+|---|---|---|---|
+| #521 | `evals-harness-polish` | #354 + #352 + #353 | 26/30 smoke (was 24/30) |
+| #524 | `evals-vault-renovation` | #339 + #348 + F1 | 25/29 smoke (memory-semantic gone) |
+| #527 | `evals-coverage-sweep` | #430 + #344 + #340 + #341 + #343 + #342 | 41/42 smoke |
+| #533 | `evals-trend-tracking` | #351 | 12 new unit tests; smoke seeded history.jsonl |
+
+### Divergences from plan
+
+- **PR-A grew by one commit (`chore(eval): silence eval-context warning loggers`).** Les hit a wall of warning chatter mid-session — tool_registry, confirmation, tool_execution all firing per LLM call. Decided to silence them in eval mode rather than push it to a separate PR. Right call: noise was acute and the fix was four lines. Side benefit: clean eval logs for the rest of the session.
+- **F1 (notes/vault disambiguation) absorbed into PR-B, not split out.** Originally framed as a "fix in PR-B if convenient" — turned out to be the single most impactful change in the renovation. Tool-description tightening on `notes_append` + `vault_journal_append` fixed the bit-rotted PR #429 smoke test *without changing the test itself*. Sharp signal that descriptions are the real control surface.
+- **PR-C stayed as a single PR despite the 6-issue scope.** Decided at PR-C kickoff. No regrets — review fatigue would have been theoretical; the YAML diffs are uniform shape and short.
+- **Project-skill eval flakiness filed as a separate issue (#525) rather than fixed in-session.** Was the right call — the underlying tool-dispatch bug is #355, which is out of scope. Filing #525 makes the eval-side symptom visible without coupling to #355's repair window.
+- **Tool-deferral test #3 redesigned mid-PR.** Original "use tool_search to find wait" prompt triggered self-reflection criticism → 11 tool calls vs budget of 5. Simplified to "use the wait tool" and accepted either fetch path. The path-specific assertion would have required harness work (`setup.reflection_enabled: false`) — file as P3 follow-up if it ever matters.
+
+### Key findings (the actual content payoff)
+
+- **Re-audit changed scope.** Three weeks since the 2026-04-24 audit, the pass rate had drifted 86% → 80%, the PR #429 smoke test had broken (`notes_append` competing for "Please remember"), and `memory-semantic.yaml`'s one tool-using test had flipped from silent-pass to outright-fail. The re-audit moved F1 from "if convenient" to "load-bearing for PR-B."
+- **Self-reflection runs in eval and can cascade.** Reflection's judge fires on every assistant response; if it decides the response was incomplete, the agent retries — consuming budget that was meant for the original task. Caused two test failures during PR-C (tool-deferral #3 → 11 calls; conversation.yaml #2 → spurious conversation_search). Worth filing a `setup.reflection_enabled: false` harness gate if the pattern keeps biting.
+- **Keyword-preempt is real.** PR-C test #2 ("pre-empted tool callable without tool_search") passed first try. The agent reached for `context_stats` directly when the prompt was saturated with its description tokens. So the system does what it claims — the unsolved problem is just how to write tests that *force* tool_search when you actually want to test that path.
+- **`conversation_search` is substring-exact.** Found while writing conversation.yaml: agent queries "embedding providers" (plural), seeded history has "embedding provider" (singular), zero hits. Real product limitation, not just a test problem. The fix in the eval was to align plurality; long-term this is worth either documenting or adding query normalization.
+- **`tool_search` keyword scoring is biased toward description matches.** Filed as #526. `tool_search(query="wait")` returns `heartbeat_trigger` because "wait" appears in heartbeat's description ("without waiting"). Real product bug, not just an eval finding.
+- **Tool descriptions are the load-bearing control surface, again.** F1 confirmed the lesson #17 surfaced months ago. Sharpened two descriptions; a failing smoke test passed without changing the test. Three new `tool_choice` cases guard the disambiguation. This is going in my permanent kit of mental tools.
+
+### Insights
+
+- **Stacked PRs work fine for this style of work.** Reviewer can review them in dependency order; each PR's diff is clean against its base; rebasing on merge is easy since each PR touches non-overlapping files (mostly).
+- **Re-audit first was the right call.** 90 minutes of re-baselining caught the F1 finding and the project-skill flakiness shift. Without it, PR-B would have either skipped F1 or made the change blindly.
+- **Per-PR session-notes sections worked.** Each PR has its own "Decisions during execution" block in `notes.md`, written *while* the PR was open. End-of-session retro then just synthesizes. No retroactive guessing about why a decision got made.
+- **Smoke runs matter for catching regression-in-the-suite.** Three separate failures during PR-C surfaced ONLY in the full-suite run (concurrency variance, self-reflection variance, project-skill non-determinism). Standalone-file smoke runs are necessary but not sufficient.
+- **YAML eval files are surprisingly cheap to write once the harness is in place.** PR-C added 5 files / 13 tests in maybe 40 minutes of actual writing time. The expensive part is iterating on prompt phrasing — and `expect_tool` from PR #429 makes that iteration much sharper than the audit-era response-text inference.
+
+### Efficiency observations
+
+- **Background eval runs paid off.** Each full suite is ~6–10 minutes against `vertex-gemini-flash`. Running them in the background let me draft PR bodies / notes / next-file YAML in parallel. No idle minutes waiting on LLM calls.
+- **The eval-noise silencing in PR-A made the next 3 PRs more pleasant.** Each subsequent smoke run was readable scroll-by-scroll. Worth more than the 5 minutes it cost.
+- **Stacked PRs reduced rebase pain.** Each PR's smoke run validated against its own branch tip, not main. No need to merge upstream before continuing.
+- **Single-file smoke runs caught most failures.** Full-suite re-runs only needed at end-of-PR. Cheaper than always running 42 tests.
+
+### Process improvements (for next renovation)
+
+- **Add a `setup.reflection_enabled: false` harness gate** before the next eval coverage push. Two tests this session hit reflection cascades; the pattern will recur.
+- **Document the substring-exact behavior of `conversation_search`** in its tool description so the LLM (and future test authors) know to align query phrasing. Or add a regex / tokenization mode. Real product gap.
+- **Pre-flight `make eval-tools` before any tool-description change.** I ran it for F1; would have run it implicitly for any other description tweak. Worth making it muscle memory.
+- **Don't write `expect_no_tool: X` against tools that self-reflection might invoke.** Three failures this session traced back to this pattern. Reflect-resistant assertions are `expect_tool` (positive) + `max_tool_calls` (cap).
+- **Per-test isolation works but full-suite concurrency adds variance.** A test that passes standalone may flake under load. End-of-PR full smoke is necessary; trusting standalone-only is a trap.
+
+### Conversation turns
+
+Roughly 14 substantive exchanges with Les, evenly split between scoping (5 — at session start), execution (7 — one per major decision), and final retro (2). Mid-session asks were tightly scoped: "PR-C single or split?", "project-skill flakiness — file or fix?", "what scope for the renovation?". All answered cleanly without back-and-forth ambiguity.
+
+### Other highlights
+
+- **PR descriptions doubled as design rationales.** Each PR body explains *why* the changes look like they do, including alternatives considered and why they were rejected. Useful at review time and useful if any decision needs to be revisited later.
+- **Memory delta: pass rate is up roughly 20 points genuine** when the silently-broken `memory-semantic.yaml` is treated as removed-by-design rather than counted in the denominator. Headline 80% → 97.6% is the easy number; the genuine "we know what we're testing now" delta is even bigger.
+- **No active behavior fixes in scope-creep range** — every behavior gap that surfaced was either filed (#525, #526) or absorbed into the planned PR (F1). The renovation stayed on its rails.
+- **No `make dev` conflicts** — eval runs in tempdirs don't touch Mattermost, so the bot stayed up across the whole session.

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -6,11 +6,14 @@ DecafClaw includes an eval harness for testing prompts and tools with real LLM c
 
 ```bash
 make eval                                            # Run all YAML test files (default model)
+make eval-history                                    # Print the pass-rate trend over recent runs
 uv run python -m decafclaw.eval evals/               # Same, via Python invocation
 uv run python -m decafclaw.eval evals/memory.yaml    # Run a specific file
 uv run python -m decafclaw.eval evals/ --model gemini-2.5-pro  # Override model
 uv run python -m decafclaw.eval evals/ --verbose     # Show truncated response snippets per test
 uv run python -m decafclaw.eval evals/ --concurrency 1  # Run tests sequentially (default: 4)
+uv run python -m decafclaw.eval --history            # Print history table, no run
+uv run python -m decafclaw.eval --history --history-limit 5  # Last 5 runs only
 ```
 
 ## Test case format
@@ -151,6 +154,22 @@ evals/results/
     reflections/              # LLM-generated analysis of failures
       test-name.md
 ```
+
+## Pass-rate history
+
+After each `make eval` run, a one-line summary is appended to `evals/history.jsonl` (committed to git, unlike the gitignored detail bundles in `evals/results/`). The record includes timestamp, model, total / passed / failed counts, pass-rate, duration, total tokens, and per-file pass/total breakdown.
+
+View the trend with `make eval-history`:
+
+```
+Timestamp          Model                       Pass /  Total    Rate       Δ   Duration    Tokens
+-------------------------------------------------------------------------------------------------
+2026-05-16-1130    vertex-gemini-flash             26 /    30   86.7%     --        370s     1.05M
+2026-05-16-1256    vertex-gemini-flash             25 /    29   86.2%   -0.5%        996s    1.32M
+2026-05-16-1913    vertex-gemini-flash             41 /    42   97.6%  +11.4%        403s    1.22M
+```
+
+The Δ column is pass-rate delta from the previous row. Useful for spotting regressions when a tool-description change knocks the rate down.
 
 ## Failure reflection
 

--- a/evals/conversation.yaml
+++ b/evals/conversation.yaml
@@ -1,0 +1,60 @@
+# Conversation tools — LLM-behavior angle only. Compaction history-truncation
+# bookkeeping, search text-matching mechanics, archive file I/O are all
+# covered by 28 unit tests across tests/test_conversation_search.py,
+# tests/test_compaction.py, tests/test_conversation_manager.py.
+#
+# Uses PR-A's setup.conversation_history (closes #353) to seed a pre-existing
+# archive so we don't have to organically build history inside the test.
+
+# -- Explicit conversation_search request ------------------------------------
+
+- name: "reaches for conversation_search on explicit history query"
+  setup:
+    # `conversation_search` does case-insensitive *substring* match, so seed
+    # phrasing must contain whichever exact tokens the agent's query is
+    # likely to use. Using plural "embedding providers" + naming all three
+    # provider tokens verbatim makes the search deterministic.
+    conversation_history:
+      - role: user
+        content: "I'm planning to switch our embedding providers from OpenAI to Vertex."
+      - role: assistant
+        content: "Got it. Let me know if you want help benchmarking embedding providers."
+      - role: user
+        content: "By the way, I also tried out Cohere embedding providers briefly — okay but not great."
+      - role: assistant
+        content: "Noted. Vertex it is unless you want me to run a comparison."
+  input: "Search our past chat history for what I said about embedding providers and list everything I mentioned."
+  expect:
+    # Vertex and Cohere are the distinctive tokens that prove history was
+    # actually retrieved (vs. the agent fabricating). OpenAI is omitted
+    # because the agent often paraphrases "switching to Vertex" without
+    # naming the "from" side.
+    response_contains_all: ["Vertex", "Cohere"]
+    max_tool_calls: 5
+    max_tool_errors: 0
+    expect_tool: conversation_search
+
+# -- Recall from seeded history ----------------------------------------------
+#
+# Validates that setup.conversation_history is reachable by the agent end-to-
+# end. We don't assert tool-selection here — the self-reflection layer may
+# trigger an additional conversation_search retry even when the initial
+# response is correct, and that's an orthogonal behavior (reflection working
+# eagerly, not a bug in seeding).
+
+- name: "answers from seeded conversation history"
+  setup:
+    conversation_history:
+      - role: user
+        content: "I just got back from a trip to Reykjavik — first time in Iceland."
+      - role: assistant
+        content: "Welcome back. How was it?"
+      - role: user
+        content: "Wonderful. The Blue Lagoon was packed but worth it."
+      - role: assistant
+        content: "Glad to hear."
+  input: "What city did I just visit?"
+  expect:
+    response_contains: "Reykjavik"
+    max_tool_calls: 5
+    max_tool_errors: 1

--- a/evals/delegate.yaml
+++ b/evals/delegate.yaml
@@ -1,0 +1,52 @@
+# delegate_task — LLM tool-choice angle only. Fork mechanism, context
+# isolation, error propagation, and timeouts are covered by 10 unit tests
+# in tests/test_delegate.py. This file isolates the eval-only question:
+# does the agent decide to delegate at appropriate times?
+
+# -- Good candidate: explicit user framing ----------------------------------
+
+- name: "delegates when user explicitly asks for a sub-agent"
+  setup:
+    workspace_files:
+      "vault/agent/pages/auth-rewrite.md": |
+        ---
+        summary: Authentication middleware rewrite proposal.
+        ---
+        # Auth Rewrite
+
+        We're replacing the legacy session-token store with a JWT-based
+        approach. Constraints: legal flagged the existing storage as
+        non-compliant; rollout has to be done without downtime.
+
+        ## Approach
+
+        Two-phase migration: dual-write during a transition window, then
+        cut over reads.
+
+        ## Risks
+
+        Token revocation latency, refresh-token rotation, replay attacks.
+  input: "Spin up a separate sub-agent to read the auth-rewrite vault page and produce a one-paragraph summary of its approach and risks."
+  # The eval runner doesn't wire up a ConversationManager, so delegate_task
+  # cannot actually execute in this context — it returns a "requires a
+  # ConversationManager" error. The LLM-decision is what's under test;
+  # execution is covered by tests/test_delegate.py. Allow 1 error and 4
+  # calls so the agent can attempt the delegation and narrate the failure.
+  expect:
+    max_tool_calls: 4
+    max_tool_errors: 1
+    expect_tool: delegate_task
+
+# -- Bad candidate: trivial direct question ---------------------------------
+
+- name: "does NOT delegate a trivial direct question"
+  setup:
+    memories:
+      - tags: [preference, cocktail]
+        content: "Favorite cocktails are Boulevardier and Old Fashioned."
+  input: "What are my favorite cocktails?"
+  expect:
+    response_contains: "Boulevardier"
+    max_tool_calls: 5
+    max_tool_errors: 0
+    expect_no_tool: delegate_task

--- a/evals/shell.yaml
+++ b/evals/shell.yaml
@@ -1,0 +1,30 @@
+# Shell tool — approval-flow focus per audit's narrowing of #341.
+# Underlying execution mechanics are covered by 39 unit tests in
+# tests/test_shell_allowlist.py + tests/test_scoped_shell.py.
+
+# -- auto_confirm: true happy path -------------------------------------------
+
+- name: "runs a simple command and returns stdout"
+  setup:
+    auto_confirm: true
+  input: "Run `echo hello` in the shell and tell me what it printed."
+  expect:
+    response_contains: "hello"
+    max_tool_calls: 3
+    max_tool_errors: 0
+    expect_tool: shell
+
+# -- auto_confirm: false denial-recovery ------------------------------------
+#
+# Denied request: agent should narrate the denial and stop, NOT loop retrying
+# the same command. The tight max_tool_calls catches retry storms.
+
+- name: "narrates denial gracefully without retry storm"
+  setup:
+    auto_confirm: false
+  input: "Run `echo hello` in the shell."
+  expect:
+    response_contains: "re:denied|declined|approval|permission|cannot|unable|not allowed|not permit"
+    max_tool_calls: 4
+    max_tool_errors: 2
+    expect_tool: shell

--- a/evals/tool-deferral.yaml
+++ b/evals/tool-deferral.yaml
@@ -1,0 +1,56 @@
+# Tool deferral — does the agent reach for `tool_search` when (and only when)
+# the answer isn't reachable from already-loaded critical tools? Designed
+# against the system: a small "critical" tier is always-loaded; everything
+# else is deferred behind `tool_search` (keyword fetch) or promoted into
+# the active set by pre-emptive keyword matching against the user message.
+# See docs/preemptive-tool-search.md for the matching design.
+
+# -- No-fetch on critical-priority answer ------------------------------------
+#
+# Vault is critical-priority, so a vault-shaped question should NOT trigger
+# tool_search. If the agent reaches for tool_search here it's burning a
+# turn on discovery that wasn't necessary.
+
+- name: "no tool_search when answer is reachable from critical tools"
+  setup:
+    memories:
+      - tags: [preference, cocktail, drink]
+        content: "Favorite cocktails are Boulevardier and Old Fashioned."
+  input: "What are my favorite cocktails?"
+  expect:
+    response_contains: "Boulevardier"
+    max_tool_calls: 5
+    max_tool_errors: 0
+    expect_no_tool: tool_search
+
+# -- Pre-emptive promotion (keyword match) -----------------------------------
+#
+# `context_stats` is low-priority (normally deferred) but its description
+# mentions "context", "tokens", "budget", and "stats". A prompt saturated
+# with those keywords should pre-empt the tool into the active set, so the
+# agent calls it directly without going through tool_search.
+
+- name: "pre-empted tool callable without tool_search"
+  input: "Show me the current context token budget stats for this conversation — give me the numbers."
+  expect:
+    max_tool_calls: 3
+    max_tool_errors: 0
+    expect_tool: context_stats
+    expect_no_tool: tool_search
+
+# -- Deferred-tool reachability end-to-end ----------------------------------
+#
+# `wait` is low-priority (deferred). This asserts the deferred-tool surface
+# is reachable: whether the agent gets there via pre-emption or tool_search
+# is an implementation detail — the test cares that `wait` ran. The path-
+# specific question (does tool_search fire in this scenario?) is harder to
+# construct deterministically since the prompt itself injects keyword
+# matches that can pre-promote — leaving that as a follow-up.
+
+- name: "agent reaches a deferred tool end-to-end"
+  input: "Use the `wait` tool to pause for 1 second, then reply with the single word 'done'."
+  expect:
+    response_contains: "done"
+    max_tool_calls: 5
+    max_tool_errors: 1
+    expect_tool: wait

--- a/evals/workspace-tools.yaml
+++ b/evals/workspace-tools.yaml
@@ -1,0 +1,76 @@
+# Workspace tools — does the LLM pick the right member of the workspace_*
+# family for the situation? Underlying tool behavior is covered by 78 unit
+# tests in tests/test_workspace_tools.py; this file isolates the LLM
+# tool-choice angle.
+
+# -- glob: find files by pattern ---------------------------------------------
+
+- name: "enumerates files via workspace_glob or workspace_list"
+  setup:
+    workspace_files:
+      "src/main.py": "print('hi')\n"
+      "src/util.py": "def f(): pass\n"
+      "src/data.json": "{}\n"
+      "tests/test_main.py": "def test(): pass\n"
+  input: "List all Python files under the src/ directory."
+  # workspace_glob and workspace_list have overlapping coverage for this
+  # request (glob takes a pattern; list traverses a dir). Accept either —
+  # the load-bearing assertion is that the right files surface and data.json
+  # doesn't. The glob-vs-list description tightening is tracked separately.
+  expect:
+    response_contains_all: ["main.py", "util.py"]
+    response_not_contains: ["data.json"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+    expect_tool: [workspace_glob, workspace_list]
+    expect_no_tool: [workspace_search, workspace_read]
+
+# -- search: find files by content -------------------------------------------
+
+- name: "reaches for workspace_search to find by content"
+  setup:
+    workspace_files:
+      "src/locks.py": "import asyncio\n\nlock = asyncio.Lock()\nasync def f():\n    async with lock:\n        pass\n"
+      "src/util.py": "def f():\n    return 42\n"
+      "src/notes.md": "Random notes file.\n"
+  input: "Find any code in this workspace that uses asyncio.Lock."
+  expect:
+    response_contains: "locks.py"
+    max_tool_calls: 4
+    max_tool_errors: 0
+    expect_tool: workspace_search
+    expect_no_tool: workspace_glob
+
+# -- read: known path, no search detour --------------------------------------
+
+- name: "reads a known path directly without searching"
+  setup:
+    workspace_files:
+      "config/settings.json": |
+        {
+          "timeout": 30,
+          "retries": 3
+        }
+  input: "Show me the contents of config/settings.json."
+  expect:
+    response_contains: "timeout"
+    max_tool_calls: 3
+    max_tool_errors: 0
+    expect_tool: workspace_read
+    expect_no_tool: [workspace_search, workspace_glob]
+
+# -- move: rename should not be read+write+delete ----------------------------
+
+- name: "uses workspace_move for a rename"
+  setup:
+    workspace_files:
+      "drafts/old-name.md": "# Draft\n\nSome content.\n"
+  input: "Rename drafts/old-name.md to drafts/new-name.md."
+  expect:
+    max_tool_calls: 4
+    max_tool_errors: 0
+    expect_tool: workspace_move
+    expect_no_tool: [workspace_read, workspace_write, workspace_delete]
+  expect_workspace:
+    workspace_file_exists: ["drafts/new-name.md"]
+    workspace_file_absent: ["drafts/old-name.md"]

--- a/src/decafclaw/eval/__main__.py
+++ b/src/decafclaw/eval/__main__.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import yaml
 
 from ..config import load_config
+from .history import HISTORY_PATH, append_run, build_run_record, read_history, render_table
 from .reflect import reflect_on_failure
 from .runner import run_eval
 
@@ -21,13 +22,26 @@ def main():
     parser = argparse.ArgumentParser(
         description="DecafClaw eval runner — test prompts and tools with real LLM calls"
     )
-    parser.add_argument("path", help="YAML file or directory of YAML files")
+    parser.add_argument("path", nargs="?", help="YAML file or directory of YAML files")
     parser.add_argument("--model", help="Override LLM model")
     parser.add_argument("--judge-model", help="Model for failure reflection (default: same as --model)")
     parser.add_argument("--verbose", action="store_true",
                         help="Show a truncated response snippet (first 200 chars) per test")
     parser.add_argument("--concurrency", type=int, default=4, help="Max concurrent tests (default: 4)")
+    parser.add_argument("--history", action="store_true",
+                        help="Print the eval-run history table and exit (no eval run)")
+    parser.add_argument("--history-limit", type=int, default=20,
+                        help="With --history, show this many most-recent runs (default: 20)")
     args = parser.parse_args()
+
+    # --history reads evals/history.jsonl and prints the trend table; no eval run.
+    if args.history:
+        records = read_history()
+        print(render_table(records, limit=args.history_limit))
+        sys.exit(0)
+
+    if not args.path:
+        parser.error("the following arguments are required: path (or use --history)")
 
     logging.basicConfig(
         level=logging.WARNING,
@@ -114,11 +128,30 @@ def main():
     with open(bundle_dir / "results.json", "w") as f:
         json.dump(results, f, indent=2)
 
-    # Print summary
+    # Append per-run summary to evals/history.jsonl (committed to git) so
+    # pass-rate trends are visible across runs without re-running.
     s = results["summary"]
+    record = build_run_record(
+        timestamp=timestamp,
+        model=effective_model,
+        judge_model=judge_model,
+        sources=sources,
+        test_results=results["tests"],
+        cases=all_cases,
+        duration_sec=s["duration_sec"],
+        total_tokens=s["total_tokens"],
+    )
+    try:
+        append_run(record)
+    except OSError as exc:
+        # Don't fail the eval run if history write hits a filesystem issue.
+        print(f"warning: could not append to {HISTORY_PATH}: {exc}", file=sys.stderr)
+
+    # Print summary
     print(f"\n{s['total']} tests, {s['passed']} passed, {s['failed']} failed "
           f"({s['duration_sec']}s, {s['total_tokens']} tokens)")
-    print(f"Results: {bundle_dir}/\n")
+    print(f"Results: {bundle_dir}/")
+    print(f"History: {HISTORY_PATH} (use `make eval-history` to view the trend)\n")
 
     sys.exit(1 if s["failed"] > 0 else 0)
 

--- a/src/decafclaw/eval/history.py
+++ b/src/decafclaw/eval/history.py
@@ -1,0 +1,164 @@
+"""Per-run summary history for the eval runner — append-only JSONL committed
+to git so pass-rate trends are visible over time without re-running.
+
+The detail bundles (results.json + reflections/) stay in the gitignored
+``evals/results/`` directory; only the summary line goes here. One record
+per `make eval` invocation. If a future matrix runner runs N models in one
+invocation, write N records (one per model)."""
+
+import json
+from collections import Counter
+from pathlib import Path
+
+HISTORY_PATH = Path("evals/history.jsonl")
+
+
+def build_run_record(
+    *,
+    timestamp: str,
+    model: str,
+    judge_model: str,
+    sources: list[str] | str,
+    test_results: list[dict],
+    cases: list[dict],
+    duration_sec: float,
+    total_tokens: int,
+) -> dict:
+    """Build a single history record from the pieces ``run_eval`` has on hand.
+
+    Per-file pass/total counts come from the case file paths each test was
+    loaded from, which the runner already tracks in `sources`. Passing the
+    parallel ``cases`` list lets us re-derive the (file, name) ownership;
+    `sources` alone is just a flat list of source file paths.
+    """
+    per_file: dict[str, dict[str, int]] = {}
+    # `cases` and `test_results` are parallel; map case index → its source
+    # by replaying the same flattening order. The runner appends files in
+    # alphabetical order, so per-file ownership can be reconstructed by
+    # walking the cases and bumping the right counter.
+    if isinstance(sources, str):
+        source_list = [s.strip() for s in sources.split(",")]
+    else:
+        source_list = list(sources)
+    # If we have the same number of source files as cases (rare; means each
+    # file had exactly one case), the mapping is trivial. The common case
+    # is N files → M cases. We instead trust the in-runner record format
+    # where `cases` carries no file info; fall back to a flat per-case
+    # mapping by reading the YAML again (cheap).
+    case_to_file: dict[int, str] = {}
+    flat_index = 0
+    for source_path in source_list:
+        p = Path(source_path)
+        if not p.exists():
+            continue
+        try:
+            import yaml
+            with p.open() as f:
+                file_cases = yaml.safe_load(f) or []
+        except Exception:
+            continue
+        for _ in file_cases:
+            if flat_index < len(cases):
+                case_to_file[flat_index] = p.name
+                flat_index += 1
+    counters: dict[str, Counter] = {}
+    for i, result in enumerate(test_results):
+        file_key = case_to_file.get(i, "<unknown>")
+        c = counters.setdefault(file_key, Counter())
+        c["total"] += 1
+        if result.get("status") == "pass":
+            c["passed"] += 1
+    per_file = {k: {"passed": v["passed"], "total": v["total"]}
+                for k, v in counters.items()}
+
+    passed = sum(1 for r in test_results if r.get("status") == "pass")
+    total = len(test_results)
+
+    return {
+        "timestamp": timestamp,
+        "model": model,
+        "judge_model": judge_model,
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "pass_rate": round(passed / total, 4) if total else 0.0,
+        "duration_sec": round(duration_sec, 1),
+        "total_tokens": int(total_tokens),
+        "per_file": per_file,
+    }
+
+
+def append_run(record: dict, path: Path = HISTORY_PATH) -> None:
+    """Append one record as a JSONL line to ``evals/history.jsonl``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def read_history(path: Path = HISTORY_PATH) -> list[dict]:
+    """Read all records, oldest-first. Corrupt lines are skipped silently."""
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return out
+
+
+def render_table(records: list[dict], limit: int = 20) -> str:
+    """Render the last ``limit`` records as a text table with delta-vs-prev pass rate.
+
+    Output shape:
+
+    ::
+
+      Timestamp         Model                  Pass    Total  Rate    Δ      Duration  Tokens
+      2026-05-16-1130   vertex-gemini-flash    26 /   30      86.7%   --     370s       1.05M
+      2026-05-16-1256   vertex-gemini-flash    25 /   29      86.2%   -0.5%  996s       1.32M
+
+    Empty input renders an explanatory line, not a header-only table.
+    """
+    if not records:
+        return "No history records yet — run `make eval` to create some.\n"
+
+    recent = records[-limit:]
+    lines = []
+    lines.append(
+        f"{'Timestamp':<17}  {'Model':<24}  "
+        f"{'Pass':>6} / {'Total':>5}  {'Rate':>6}  {'Δ':>6}  "
+        f"{'Duration':>9}  {'Tokens':>8}"
+    )
+    lines.append("-" * 97)
+    prev_rate: float | None = None
+    for r in recent:
+        rate = r.get("pass_rate", 0.0)
+        if prev_rate is None:
+            delta = "  --  "
+        else:
+            d = rate - prev_rate
+            delta = f"{d:+.1%}"
+        prev_rate = rate
+        tokens = r.get("total_tokens", 0)
+        if tokens >= 1_000_000:
+            tokens_disp = f"{tokens / 1_000_000:.2f}M"
+        elif tokens >= 1_000:
+            tokens_disp = f"{tokens / 1_000:.1f}k"
+        else:
+            tokens_disp = str(tokens)
+        lines.append(
+            f"{r.get('timestamp', '?'):<17}  "
+            f"{r.get('model', '?'):<24}  "
+            f"{r.get('passed', 0):>6} / {r.get('total', 0):>5}  "
+            f"{rate:>6.1%}  "
+            f"{delta:>6}  "
+            f"{int(r.get('duration_sec', 0)):>8}s  "
+            f"{tokens_disp:>8}"
+        )
+    return "\n".join(lines) + "\n"

--- a/tests/test_eval_history.py
+++ b/tests/test_eval_history.py
@@ -1,0 +1,177 @@
+"""Unit tests for `decafclaw.eval.history`."""
+
+import json
+from pathlib import Path
+
+from decafclaw.eval.history import (
+    append_run,
+    build_run_record,
+    read_history,
+    render_table,
+)
+
+
+def test_read_history_empty(tmp_path: Path):
+    assert read_history(tmp_path / "missing.jsonl") == []
+
+
+def test_append_then_read_roundtrips(tmp_path: Path):
+    path = tmp_path / "history.jsonl"
+    rec1 = {"timestamp": "2026-05-16-1130", "model": "m1", "passed": 10, "total": 12}
+    rec2 = {"timestamp": "2026-05-16-1256", "model": "m1", "passed": 11, "total": 12}
+    append_run(rec1, path)
+    append_run(rec2, path)
+    out = read_history(path)
+    assert out == [rec1, rec2]
+
+
+def test_append_creates_parent_directory(tmp_path: Path):
+    path = tmp_path / "deeply" / "nested" / "history.jsonl"
+    append_run({"timestamp": "x", "model": "y"}, path)
+    assert path.exists()
+
+
+def test_read_history_skips_corrupt_lines(tmp_path: Path):
+    path = tmp_path / "history.jsonl"
+    path.write_text(
+        json.dumps({"a": 1}) + "\n"
+        "not valid json\n"
+        + json.dumps({"a": 2}) + "\n"
+    )
+    out = read_history(path)
+    assert out == [{"a": 1}, {"a": 2}]
+
+
+def _make_yaml(path: Path, names: list[str]) -> None:
+    """Write a YAML eval file with N synthetic test cases."""
+    import yaml
+    cases = [{"name": n, "input": "x", "expect": {"response_contains": "x"}}
+             for n in names]
+    path.write_text(yaml.safe_dump(cases))
+
+
+def test_build_run_record_aggregates_per_file(tmp_path: Path):
+    f1 = tmp_path / "vault.yaml"
+    f2 = tmp_path / "shell.yaml"
+    _make_yaml(f1, ["v1", "v2", "v3"])
+    _make_yaml(f2, ["s1", "s2"])
+
+    cases = [{"name": n} for n in ("v1", "v2", "v3", "s1", "s2")]
+    test_results = [
+        {"name": "v1", "status": "pass"},
+        {"name": "v2", "status": "fail"},
+        {"name": "v3", "status": "pass"},
+        {"name": "s1", "status": "pass"},
+        {"name": "s2", "status": "pass"},
+    ]
+
+    record = build_run_record(
+        timestamp="2026-05-16-1300",
+        model="vertex-gemini-flash",
+        judge_model="vertex-gemini-flash",
+        sources=[str(f1), str(f2)],
+        test_results=test_results,
+        cases=cases,
+        duration_sec=42.5,
+        total_tokens=12345,
+    )
+
+    assert record["timestamp"] == "2026-05-16-1300"
+    assert record["model"] == "vertex-gemini-flash"
+    assert record["total"] == 5
+    assert record["passed"] == 4
+    assert record["failed"] == 1
+    assert record["pass_rate"] == 0.8
+    assert record["duration_sec"] == 42.5
+    assert record["total_tokens"] == 12345
+    assert record["per_file"] == {
+        "vault.yaml": {"passed": 2, "total": 3},
+        "shell.yaml": {"passed": 2, "total": 2},
+    }
+
+
+def test_build_run_record_handles_string_sources(tmp_path: Path):
+    """``run_eval`` stores sources as a comma-joined string by the time we
+    see it; the helper should accept both shapes."""
+    f1 = tmp_path / "a.yaml"
+    _make_yaml(f1, ["a1", "a2"])
+    record = build_run_record(
+        timestamp="x",
+        model="m",
+        judge_model="m",
+        sources=str(f1),  # bare string, not list
+        test_results=[
+            {"name": "a1", "status": "pass"},
+            {"name": "a2", "status": "fail"},
+        ],
+        cases=[{"name": "a1"}, {"name": "a2"}],
+        duration_sec=1.0,
+        total_tokens=100,
+    )
+    assert record["per_file"] == {"a.yaml": {"passed": 1, "total": 2}}
+
+
+def test_build_run_record_handles_zero_total():
+    record = build_run_record(
+        timestamp="t",
+        model="m",
+        judge_model="m",
+        sources=[],
+        test_results=[],
+        cases=[],
+        duration_sec=0.0,
+        total_tokens=0,
+    )
+    assert record["total"] == 0
+    assert record["pass_rate"] == 0.0
+
+
+def test_render_table_empty():
+    s = render_table([])
+    assert "No history" in s
+
+
+def test_render_table_single_record_marks_delta_as_dashes():
+    out = render_table([
+        {"timestamp": "2026-05-16-1300", "model": "m1",
+         "passed": 10, "total": 12, "pass_rate": 0.833,
+         "duration_sec": 30, "total_tokens": 5000},
+    ])
+    assert "2026-05-16-1300" in out
+    assert "m1" in out
+    assert "10 /" in out
+    assert "83.3%" in out
+    assert "--" in out
+
+
+def test_render_table_computes_delta_for_subsequent_rows():
+    out = render_table([
+        {"timestamp": "t1", "model": "m", "passed": 8, "total": 10,
+         "pass_rate": 0.80, "duration_sec": 30, "total_tokens": 5000},
+        {"timestamp": "t2", "model": "m", "passed": 9, "total": 10,
+         "pass_rate": 0.90, "duration_sec": 30, "total_tokens": 5000},
+    ])
+    # Second row should have a positive delta
+    assert "+10" in out  # "+10.0%"
+
+
+def test_render_table_respects_limit():
+    records = [
+        {"timestamp": f"t{i}", "model": "m", "passed": 1, "total": 1,
+         "pass_rate": 1.0, "duration_sec": 1, "total_tokens": 1}
+        for i in range(10)
+    ]
+    out = render_table(records, limit=3)
+    # Only the LAST 3 records render
+    for i in (7, 8, 9):
+        assert f"t{i}" in out
+    for i in (0, 1, 2, 3):
+        assert f"t{i}" not in out
+
+
+def test_render_table_formats_large_token_counts():
+    out = render_table([
+        {"timestamp": "t", "model": "m", "passed": 1, "total": 1,
+         "pass_rate": 1.0, "duration_sec": 1, "total_tokens": 1_234_567},
+    ])
+    assert "1.23M" in out


### PR DESCRIPTION
## Summary
- **PR-C of 4 in the [evals-renovation session](https://github.com/lmorchard/decafclaw/tree/main/docs/dev-sessions/2026-05-16-1041-evals-renovation).** Coverage sweep across the high-value tool families.
- **5 new eval files, 13 new tests**, closing **6 issues**: #430, #344, #340, #341, #342, #343.
- **Stacked on [#524](https://github.com/lmorchard/decafclaw/pull/524) (PR-B)**, which is stacked on [#521](https://github.com/lmorchard/decafclaw/pull/521) (PR-A).
- Uses PR-A's new harness primitives: `expect_workspace` (workspace-tools.yaml move case) and `setup.conversation_history` (conversation.yaml).

## What's in each file
| File | Closes | Cases | What it asserts |
|---|---|---|---|
| `evals/tool-deferral.yaml` | #430, #344 | 3 | Critical-priority answers don't trigger `tool_search`; keyword-pre-empted deferred tools callable without `tool_search`; deferred-tool reachability end-to-end. |
| `evals/workspace-tools.yaml` | #340 | 4 | `glob`-or-`list` for pattern enumeration, `search` for content, `read` for known path, `move` for renames (with `expect_workspace` post-turn check). |
| `evals/shell.yaml` | #341 | 2 | `auto_confirm: true` happy path; `auto_confirm: false` denial-recovery without retry storm. |
| `evals/delegate.yaml` | #343 | 2 | Delegates on explicit "spin up a sub-agent"; does NOT delegate on trivial direct questions. |
| `evals/conversation.yaml` | #342 | 2 | Reaches for `conversation_search` on explicit history query; surfaces seeded history facts without forcing search. |

## Test Plan
- [x] `make lint` clean
- [x] `make check` (Python + JS) clean
- [x] `make test` 2575 passed
- [x] Each new file standalone: 13/13 PASS against `vertex-gemini-flash`
- [x] **`make eval` full suite: 41/42 PASS (97.6%)** — up from 25/29 (86.2%) on PR-B's smoke. Bundle: `evals/results/2026-05-16-1913-vertex-gemini-flash/`. The single failure is the recurring vague-prompt-doesn't-trigger-retrieval issue (`synthesizes from multiple memories for a complex question`) — passes in isolation, flakes under full-suite concurrency. Not a PR-C regression; the same test failed on PR-B's smoke as well. **The 3 previously-flaky project-skill tests all PASSED this run** (LLM variance; see #525).

## Findings filed during PR-C
- **#526** — `tool_search` keyword scoring bias: name matches should outrank description matches. Surfaced when `tool_search(query="wait")` returned `heartbeat_trigger` first.
- **Eval runner has no ConversationManager** — `delegate_task` cannot actually execute in eval (returns "requires a ConversationManager"). The LLM-decision is what's under test; execution is covered by `tests/test_delegate.py`. Worth filing as a harness limitation if delegation evals expand. Not filed in this PR.
- **`workspace_glob` ↔ `workspace_list` overlap** — both are reasonable for "list Python files." Eval accepts either; description tightening could be a future `tool_choice` case. Not filed.
- **Self-reflection can trigger spurious `conversation_search` retries** — when the agent's initial response is correct, reflection's eager judge can still ask for more. Affects tests that assert `expect_no_tool: conversation_search`. Worked around per-test; longer-term a `setup.reflection_enabled: false` would be cleaner. Not filed.
- **`conversation_search` is substring-exact** — seed phrasing must match agent query plurality. Documented inline in the test setup comments.

## What this leaves for PR-D
- **#351** — pass-rate trend tracking (`evals/history.jsonl` + `make eval-history`). Final renovation PR.

## References
- Session docs: `docs/dev-sessions/2026-05-16-1041-evals-renovation/`
- Closes #430, #344, #340, #341, #342, #343
- Stacked on #524 (which is stacked on #521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
