### PR TITLE
feat(skills): auto-populate $DECAFCLAW_REPO from detected source-checkout root

### DIFF
--- a/contrib/skills/README.md
+++ b/contrib/skills/README.md
@@ -12,13 +12,7 @@ Add the skill's directory to your agent's `extra_skill_paths` so the loader pick
 
 **Why `$VAR` over relative paths.** Relative entries in `extra_skill_paths` are anchored to `data/{agent_id}/`, not to the repo or the CWD. That only reaches the repo's `contrib/skills/` when `data_home` happens to live inside the repo (the default `./data` dev layout). Production deployments usually keep `data_home` somewhere stable like `~/.decafclaw/`, which is nowhere near the repo — relative paths will silently miss. A `$VAR` decouples the two.
 
-Add to `.env`:
-
-```bash
-DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
-```
-
-Then in `data/{agent_id}/config.json`:
+In `data/{agent_id}/config.json`:
 
 ```json
 {
@@ -28,6 +22,17 @@ Then in `data/{agent_id}/config.json`:
   ]
 }
 ```
+
+`$DECAFCLAW_REPO` is auto-populated by the skill loader when running from a source checkout — it walks up from the installed package and uses the parent directory that contains both `contrib/` and `pyproject.toml`. No `.env` setting required for the common case.
+
+If you need to override (point at a different checkout, run from a wheel-only install without `contrib/` adjacent, etc.), set it explicitly:
+
+```bash
+# .env
+DECAFCLAW_REPO=/absolute/path/to/decafclaw-repo
+```
+
+An explicit env value always wins over auto-detection.
 
 Each entry points at a single skill directory (one with `SKILL.md` at its root). The loader runs `os.path.expandvars` + `~` expansion on every entry before scanning, so plain absolute paths and `~/...` also work. Use whichever fits your deployment.
 

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -15,6 +15,25 @@ log = logging.getLogger(__name__)
 _BUNDLED_SKILLS_DIR = Path(__file__).parent
 
 
+def _detect_repo_root() -> Path | None:
+    """Auto-detect the DecafClaw repo root for `$DECAFCLAW_REPO`.
+
+    Walks up from this file looking for a directory that has BOTH
+    ``contrib/`` and ``pyproject.toml`` — the signature of a source
+    checkout. Returns ``None`` when those markers aren't found (e.g.
+    a wheel-only install), in which case `$DECAFCLAW_REPO` is left
+    unset and `extra_skill_paths` entries that reference it will
+    miss as before.
+    """
+    for parent in [_BUNDLED_SKILLS_DIR, *_BUNDLED_SKILLS_DIR.parents]:
+        if (parent / "contrib").is_dir() and (parent / "pyproject.toml").is_file():
+            return parent
+    return None
+
+
+_AUTO_REPO_ROOT = _detect_repo_root()
+
+
 @dataclass
 class SkillInfo:
     """Metadata for a discovered skill."""
@@ -181,7 +200,15 @@ def _resolve_extra_skill_paths(config) -> list[Path]:
 
     For each entry: expand $VARS and ~, then anchor relative paths to
     config.agent_path (matching vault_root). Order is preserved.
+
+    `$DECAFCLAW_REPO` is auto-populated from the detected source-checkout
+    root when unset (see ``_detect_repo_root``), so `extra_skill_paths`
+    entries like ``$DECAFCLAW_REPO/contrib/skills/<name>`` work out of
+    the box. An explicit env-var setting always wins.
     """
+    if "DECAFCLAW_REPO" not in os.environ and _AUTO_REPO_ROOT is not None:
+        os.environ["DECAFCLAW_REPO"] = str(_AUTO_REPO_ROOT)
+
     resolved: list[Path] = []
     for raw in config.extra_skill_paths:
         expanded = os.path.expandvars(str(raw))

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -505,6 +505,38 @@ def test_discover_extra_path_skipped_when_missing(tmp_path, config, caplog):
     )
 
 
+def test_decafclaw_repo_auto_populated_when_unset(
+    tmp_path, config, monkeypatch
+):
+    """`$DECAFCLAW_REPO` resolves against the auto-detected source root
+    when the env var is unset — letting `extra_skill_paths` entries
+    work without a manual `.env` setting."""
+    monkeypatch.delenv("DECAFCLAW_REPO", raising=False)
+    # The detected root is the repo we're running tests from; place a
+    # marker skill there relative to its `contrib/skills/` and verify
+    # discovery picks it up via `$DECAFCLAW_REPO`.
+    from decafclaw.skills import _AUTO_REPO_ROOT
+
+    assert _AUTO_REPO_ROOT is not None, "test must run from a source checkout"
+    # Use a real existing contrib skill as the target so we don't have
+    # to write into the repo from a test.
+    config.extra_skill_paths = ["$DECAFCLAW_REPO/contrib/skills/writing-clearly"]
+    skills = discover_skills(config)
+    assert any(s.name == "writing-clearly" for s in skills)
+
+
+def test_decafclaw_repo_explicit_env_wins(tmp_path, config, monkeypatch):
+    """An explicit `$DECAFCLAW_REPO` env value overrides auto-detection."""
+    _write_skill(
+        tmp_path / "elsewhere" / "contrib" / "skills" / "elsewhere-skill",
+        "name: elsewhere-skill\ndescription: Marker skill.",
+    )
+    monkeypatch.setenv("DECAFCLAW_REPO", str(tmp_path / "elsewhere"))
+    config.extra_skill_paths = ["$DECAFCLAW_REPO/contrib/skills/elsewhere-skill"]
+    skills = discover_skills(config)
+    assert any(s.name == "elsewhere-skill" for s in skills)
+
+
 def test_discover_skips_dirs_without_skill_md(tmp_path, config):
     """Directories without SKILL.md are ignored."""
     skills_dir = config.workspace_path / "skills"


### PR DESCRIPTION
## Summary

Stacked on top of #543 (writing-clearly skill). Discovered while testing the install instructions for that skill: setting `DECAFCLAW_REPO` manually in `.env` is awkward for something we ship in the repo at a known location.

The skill loader now walks up from its own package location looking for a parent that has both `contrib/` and `pyproject.toml` — the signature of a source checkout — and uses that as `$DECAFCLAW_REPO` when the env var is unset. Existing explicit env values always win.

## Behavior

- **Source checkout (the common case):** `$DECAFCLAW_REPO` resolves automatically. `extra_skill_paths` entries like `$DECAFCLAW_REPO/contrib/skills/writing-clearly` work without any `.env` setup.
- **Wheel-only install (no `contrib/` adjacent):** auto-detection finds nothing, `$DECAFCLAW_REPO` stays unset. `extra_skill_paths` entries that reference it silently miss (existing behavior).
- **Explicit override:** `DECAFCLAW_REPO=/some/other/checkout` in `.env` still wins — useful for pointing at a different working tree or testing.

## Files

- `src/decafclaw/skills/__init__.py` — `_detect_repo_root()` + auto-populate in `_resolve_extra_skill_paths()`
- `tests/test_skills.py` — two new tests (auto-populated path discovers a real contrib skill; explicit env override wins)
- `contrib/skills/README.md` — updated install docs to call out the auto-detection and when you'd still want to set the var manually

## Test plan

- [x] `make lint` / `make typecheck` pass
- [x] `uv run pytest tests/test_skills.py` — 59/59 pass, including 2 new tests
- [ ] Live verification: remove `DECAFCLAW_REPO` from `.env`, restart the agent, confirm `writing-clearly` activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)