### PR TITLE
docs(dev-sessions): retro notes for #517 turn_aborted marker session

### DIFF
--- a/docs/dev-sessions/2026-05-17-1139-fix-517-turn-closure-archive-markers/notes.md
+++ b/docs/dev-sessions/2026-05-17-1139-fix-517-turn-closure-archive-markers/notes.md
@@ -2,15 +2,124 @@
 
 ## Issue summary
 
-Follow-up to #491. Three turn-abort paths besides cancel may leave the archive without a clear "turn closed" signal, so the next user turn sees an open prior request and may re-fulfill it:
+Follow-up to #491. Three turn-abort paths besides cancel may leave the
+archive without a clear "turn closed" signal, so the next user turn
+sees an open prior request and may re-fulfill it:
 
-1. **Generic exception handler** in `conversation_manager.py` (confirmed missing archive write).
-2. **Max-iterations exhaustion** (needs verification — likely OK but trace edge cases).
+1. **Generic exception handler** in `conversation_manager.py`
+   (confirmed missing archive write).
+2. **Max-iterations exhaustion** (needs verification — likely OK but
+   trace edge cases).
 3. **Circuit breaker** (probably non-issue; just confirm).
 
-Cross-link: the `abort_recovery.yaml` eval suite in #528 depends on this fix.
+Cross-link: the `abort_recovery.yaml` eval suite in #528 depends on
+this fix.
 
 ## Pattern reference
-- `_write_cancel_archive` + `_write_cancel_marker_once` in `conversation_manager.py`
+- `_write_cancel_archive` + `_write_cancel_marker_once` in
+  `conversation_manager.py`
 - `cancel_marker` role in `context_composer.ROLE_REMAP`
 - Spec/notes: `docs/dev-sessions/2026-05-15-1219-fix-491-cancelled-turn-archive/`
+
+---
+
+## Retro (2026-05-17 → 2026-05-18, merged as df6e755)
+
+### Recap
+
+- **Brainstorm**: 4 design questions (marker role shape, scope, partial
+  archival, latch structure) → spec converged in one pass with no
+  surprises.
+- **Scope narrowed during brainstorm**: spec started at "fix all three
+  abort paths" per the issue text, finished at "exception path only"
+  after tracing the code:
+  - Max-iterations: `_finalize_max_iterations` already archives a
+    normal `assistant` row with the limit notice — that IS the
+    closure signal.
+  - Circuit breaker: only declines new turns; never aborts mid-flight.
+- **Plan**: 5 phases, each ending in lint+test+commit. Plan matched
+  spec exactly — no improvisation during execution.
+- **Execution**: clean run through all 5 phases. ~1 hour wall time
+  from brainstorm to PR.
+- **Copilot review**: 2 comments. Fixed 1 (placeholder reset test
+  upgraded to a real two-turn integration test). Skipped 1 (nit on a
+  dev-session spec doc — frozen-in-time artifact).
+- **Sabotage check**: temporarily commented out the production reset
+  line, confirmed the new test fails, restored. Validated the test
+  actually exercises the code path Copilot flagged.
+- **Merge**: squash-merged as commit `df6e755`. Issue #517 auto-closed.
+
+### What diverged from the plan
+
+- **Nothing in implementation diverged.** Spec → plan → code mapped
+  one-to-one.
+- **Test #5 (the reset test) was weak.** I copied the shape of the
+  existing `test_partial_assistant_chunks_resets_each_turn`, which is
+  also a placeholder-style "assert the field is mutable" test. The
+  pattern was already in the codebase, so the weak form felt
+  precedented — Copilot caught that precedent doesn't justify
+  shipping a non-exercising test for *new* state. Worth pushing
+  back on inherited weak tests rather than perpetuating the pattern.
+
+### Key insights
+
+- **Sabotage-checking new tests against the production code they're
+  meant to guard.** When Copilot flagged the placeholder reset test,
+  I upgraded it to an integration test AND verified by commenting out
+  the production reset that the new test fails. This is a cheap,
+  high-confidence way to prove the test isn't tautological. Worth
+  doing whenever a test asserts "behavior X is preserved across some
+  reset" — placeholder shape often slips through code review by
+  passing trivially.
+- **Spec self-review during brainstorm caught the scope reduction.**
+  Asking "does max-iterations actually need a marker?" surfaced that
+  the existing `_finalize_max_iterations` assistant row already
+  serves as closure. Without that pass, the plan would have included
+  unnecessary work.
+- **Origin/main drift during planning is the rule, not the
+  exception.** Two unrelated PRs (writing-clearly skill #543 / #545)
+  merged while I was brainstorming. A `git rebase origin/main` before
+  starting execution caught it; fast-forward because no commits on
+  the branch yet. Cheap habit.
+- **Two-stage commit hygiene.** I made 5 small commits during
+  execution (one per phase) then squashed before PR. Lets each phase
+  be small and reviewable in case I needed to back out a step, but
+  the PR ships as one logical change. Same shape as the cancel-marker
+  PR (#491-fix).
+
+### Process improvements
+
+- **Sabotage check should be habit, not reaction.** I only did it
+  because Copilot pushed back. For any test asserting "this reset
+  fires," "this guard catches," "this latch prevents" — verify by
+  temporarily breaking the production code, not just by running the
+  test. Worth adding to the plan template for state-machine work.
+- **The "weak-test-by-precedent" trap.** The existing partial-chunks
+  reset test was a placeholder. Copying its shape inherited the
+  weakness. Lesson: when a parallel test exists in the codebase but
+  the new state is *different in risk*, evaluate whether the parallel
+  test was actually doing its job — don't just copy.
+
+### Numbers
+
+- **Diff**: 6 production/test/doc files, +287 / −1 (excluding the
+  +458 lines of session docs).
+- **Production code**: 5 lines of wiring (constant + field + helper
+  + reset + call site) + 64 lines of helper boilerplate. Mostly
+  parallel to the #491 cancel helper.
+- **Tests**: 6 new (5 in test_conversation_manager.py, 1 in
+  test_context_composer.py). Test suite: 2613 → 2619 passing.
+- **Wall time**: roughly 1 hour brainstorm-to-merge.
+- **Phases**: 5 commits during execution, squashed to 1 for the PR.
+
+### Out of scope (deferred)
+
+- The `abort_recovery.yaml` eval suite in #528 — this PR is its
+  prerequisite. That eval will exercise the new marker end-to-end
+  through real LLM calls.
+- Refactoring the cancel and turn-aborted helpers to share a generic
+  latch/helper. Deliberately deferred — the parallel structure is
+  intentional and re-evaluatable later if a third path appears.
+- Updating the older `test_partial_assistant_chunks_resets_each_turn`
+  to a real integration test. Out of scope for this PR; worth a
+  follow-up issue if the pattern bites again.


### PR DESCRIPTION
## Summary

Fills in the retro section of `notes.md` for the #517 dev session,
after PR #549 merged. The brainstorm / plan / issue summary were
already on main from #549; this captures:

- Recap of execution
- What diverged from the plan (nothing in implementation; one inherited
  weak-test pattern that Copilot's review caught)
- Key insights — notably the sabotage-check pattern for state-machine
  tests (temporarily break the production reset/guard, confirm the
  test fails, restore — proves the test isn't tautological)
- Process improvements
- Numbers

No product behavior or convention changes — pure dev-session prose.

## Test plan

- [x] `notes.md` reads coherently next to the existing `spec.md` /
      `plan.md`
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)