### PR TITLE
feat(skills): true skill-level progressive disclosure — trust by placement, hide tools until activation

### DIFF
--- a/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/notes.md
+++ b/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/notes.md
@@ -1,0 +1,13 @@
+# Session notes — 547 skill autoload
+
+## Phase 0 survey (read-only)
+
+- **`auto-approve: false` cases**: None found. Only `auto-approve: true` in `src/decafclaw/skills/background/SKILL.md` and `src/decafclaw/skills/mcp/SKILL.md`. No backwards-compat risk from the trust-tier bypass.
+- **`always-loaded` baseline**: vault, background, mcp (all bundled). Expected.
+- **`tool_search` callers that need updating**:
+  - `tests/test_search_tools.py` — direct unit tests of tool_search behavior. Full rewrite needed for new skill-level semantics.
+  - `tests/test_eval_reflect.py` — only counts `tool_search` invocations; should still work regardless of return shape.
+  - `tests/test_tool_registry.py:307` — asserts "## Available tools (use tool_search to load)" header text. Still applies but the section content shrinks.
+  - No other code callers — `tool_search` is only invoked by the LLM as a tool.
+- **Existing rejection paths in `discover_skills`**: `_BUNDLED_SKILLS_DIR`-only checks at lines 294-308 already strip `auto-approve` and `always-loaded` from non-bundled skills with a warning. The new code relaxes these checks to "workspace-only rejection" (keep the warning for workspace skills).
+- **Tier-path mapping**: `discover_skills` iterates a fixed-order `scan_paths` list (workspace, admin, bundled, *extra_paths). Tier annotation is straightforward — track which scan group produced each `SkillInfo`. Resolved-symlink paths don't matter for tier; user intent comes from the configured scan path.

--- a/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/notes.md
+++ b/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/notes.md
@@ -11,3 +11,21 @@
   - No other code callers — `tool_search` is only invoked by the LLM as a tool.
 - **Existing rejection paths in `discover_skills`**: `_BUNDLED_SKILLS_DIR`-only checks at lines 294-308 already strip `auto-approve` and `always-loaded` from non-bundled skills with a warning. The new code relaxes these checks to "workspace-only rejection" (keep the warning for workspace skills).
 - **Tier-path mapping**: `discover_skills` iterates a fixed-order `scan_paths` list (workspace, admin, bundled, *extra_paths). Tier annotation is straightforward — track which scan group produced each `SkillInfo`. Resolved-symlink paths don't matter for tier; user intent comes from the configured scan path.
+
+## Implementation notes
+
+- **Phase 1 and 2 collapsed.** Originally split as "discovery foundations" vs "relax always-loaded eligibility." In practice the trust-tier annotation only buys anything once the gates that consume it are relaxed; splitting created an intermediate state that broke existing tests with no test for the new behavior. Combined into one atomic commit.
+- **Phase 6 found an auto-fetch gap.** `execute_tool` auto-fetches deferred tools when the agent calls them. Hiding skill tools from the visible deferred list (Phase 3) wasn't enough — the auto-fetch path would still resurrect them. Added a `skill_tool_owners` lookup to skip auto-fetch for skill tools and route through the new targeted error message instead.
+- **Process slip on git add**. Twice during the session, `git add docs/` or `git add -A` swept up two untracked PNG files left over from a prior dev session. Both times I caught it after committing and used `git reset --soft HEAD~1` to recover. Lesson: stage explicit file paths, not directories or `-A`, in any repo where someone else's untracked files might be present.
+
+## Phase 9 — smoke test deferred
+
+The plan called for manual end-to-end verification on a real DecafClaw instance (start the agent, run an editing flow with Flash as parent, confirm the trace shows the expected 4-call sequence with silent activations). The configured `DATA_HOME` on this branch points outside the repo, so the agent can't be launched from here.
+
+Coverage is on Les for the live run. Unit tests cover the equivalent behavior end-to-end:
+- Trusted-tier activation skips confirmation (`tests/test_skills.py::test_activate_trusted_*`).
+- Workspace tier still confirms (`tests/test_skills.py::test_workspace_skill_still_requires_confirmation`).
+- Skill tools absent from the visible deferred list (`tests/test_tool_registry.py::test_skill_tools_hidden`).
+- `tool_search` returns the owning skill for hidden-tool-name matches (`tests/test_search_tools.py::TestSkillResults`).
+- Targeted unknown-tool error (`tests/test_tools.py::test_execute_tool_unknown_skill_tool_*`).
+- Auto-fetch bypass for skill tools (`tests/test_tools.py::test_execute_tool_skill_tool_not_auto_fetched_from_deferred_pool`).

--- a/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/plan.md
+++ b/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/plan.md
@@ -1,0 +1,189 @@
+# Plan — true skill-level progressive disclosure
+
+Implementation plan for `./spec.md`. One PR scope (#547). Commit per phase.
+
+## Phase 0 — Survey callers and edge cases
+
+Quick read-only pass before touching code. No commit.
+
+1. `grep` for callers of `tool_search` and direct deferred-tool fetch — any test or eval that asserts loading an individual skill tool by name will break and needs updating.
+2. `grep` for `auto-approve:` in skill frontmatter (bundled + contrib) — confirm no skill explicitly sets `auto-approve: false` expecting confirmation, which the new tier-bypass would silently swallow.
+3. `grep` for `always_loaded:` to confirm current set (vault, background, mcp expected) and verify no surprises.
+4. Confirm tier-path mapping plan: read `_resolve_extra_skill_paths` and the discovery walker to pin down which path each `SkillInfo.location` actually represents (resolved-symlink path vs. configured path). The tier check has to inspect a stable path that reflects user intent, not whatever symlink resolution happened.
+
+Record findings in `notes.md` as we go.
+
+## Phase 1 — Discovery foundations: trust_tier, skill_tool_owners, config field
+
+Goal: data structures and discovery-time precomputation. Pure addition, no behavior change yet.
+
+1. **`SkillInfo.trust_tier`** in `src/decafclaw/skills/__init__.py`:
+   - Add field `trust_tier: Literal["bundled", "admin", "extra", "workspace"] = "bundled"` (with a sensible default for tests that mint SkillInfos directly).
+   - In `discover_skills`, set `trust_tier` per the scan tier: workspace scan → `"workspace"`, admin scan → `"admin"`, bundled scan → `"bundled"`, extra-paths scan → `"extra"`.
+   - The tier reflects which scan loop produced the entry; resolved-symlink paths don't override the user's intent.
+2. **`config.skills_always_loaded: list[str]`** in `src/decafclaw/config_types.py` (or wherever the agent config lives):
+   - New field with default `[]`.
+   - Wire through the JSON config loader (env override via `SKILLS_ALWAYS_LOADED` comma-separated list — match the existing convention).
+3. **`config.skill_tool_owners: dict[str, str]`** built at skill discovery:
+   - Iterates `config.discovered_skills`, imports each skill's `tools.py` (only if `has_native_tools`), indexes `TOOL_DEFINITIONS` entries → owning skill name.
+   - Mirrors the existing `config.always_loaded_skill_tools` cache pattern.
+   - Importing tools.py for every skill at discovery has a startup cost. Acceptable — same work activate_skill does eventually anyway, just front-loaded. Profile if it bites.
+4. Tests:
+   - `SkillInfo` discovered from each tier has the correct `trust_tier`.
+   - `config.skill_tool_owners` populated correctly across tiers.
+   - `config.skills_always_loaded` loads from JSON and env.
+
+Commit: `feat(skills): add trust_tier, skill_tool_owners, skills_always_loaded foundations`
+
+## Phase 2 — Relax `always_loaded` eligibility to all trusted tiers + honor config list
+
+Goal: extend the always-loaded path to admin/extra tiers via frontmatter or config. Behavior change visible at startup if any non-bundled skill declares `always_loaded` (today silently ignored).
+
+1. In `build_catalog_text` (`src/decafclaw/skills/__init__.py`):
+   - Replace the `bundled-only` filter with `trust_tier != "workspace"` AND (frontmatter-`always_loaded` OR name in `config.skills_always_loaded`).
+2. In `agent.py`'s always-loaded auto-activation loop (~lines 396-410):
+   - Same eligibility check. Apply to all trusted tiers via either path.
+3. Tests:
+   - Admin-tier skill with `always_loaded: true` auto-loads.
+   - Extra-tier skill named in `config.skills_always_loaded` auto-loads.
+   - Workspace-tier skill with `always_loaded: true` rejected (with a warning log).
+   - Workspace-tier skill named in `config.skills_always_loaded` rejected.
+   - Bundled+`always_loaded` still works as today.
+
+Commit: `feat(skills): always_loaded works for trusted tiers via frontmatter or config`
+
+## Phase 3 — Hide skill tools from the agent's deferred-tool list
+
+Goal: skill tools no longer appear in the system prompt's "Available tools" list. They enter `ctx.tools.extra` only via `activate_skill`.
+
+1. In `src/decafclaw/tools/tool_registry.py`:
+   - `build_deferred_list_text` already separates `skill_tools` from `core_tools` / `mcp_tools` for grouping. Change: omit the "### Skills" section from the rendered output entirely. The skill tools array still exists for internal classification but doesn't render to the agent.
+   - Decide whether to keep the data structure (for `tool_search`'s catalog match) or rename it. Keep it — `tool_search` needs it.
+2. In `src/decafclaw/tool_definitions.py`:
+   - Verify that classification still records skill tools in `ctx.tools.deferred_pool` so `tool_search` can search them. They just don't render.
+3. Update the skill catalog text in `build_catalog_text` to remove the "you MUST activate" accusatory wording and replace with neutral "call activate_skill(name) to load tools."
+4. Tests:
+   - System-prompt deferred-tool list contains no skill-tool entries.
+   - `ctx.tools.deferred_pool` still contains skill tool defs (for tool_search).
+   - Always-loaded skill tools still appear in the active tool list.
+
+Commit: `feat(skills): hide skill tools from system prompt until activation`
+
+## Phase 4 — Trust-tier bypass in `tool_activate_skill`
+
+Goal: bundled / admin / extra skills skip confirmation; workspace still confirms.
+
+1. In `src/decafclaw/tools/skill_tools.py`, `tool_activate_skill` (~lines 147-165):
+   - Insert the tier rung in the precedence chain. After `"deny"` check, before the existing `"always"` perms check: if `skill_info.trust_tier != "workspace"`, treat as approved without confirmation. Do NOT write to `skill_permissions.json` (the trust is implicit in placement).
+2. Update the docstring describing the precedence chain.
+3. Tests:
+   - Trusted-tier skill: activates without confirmation, no `skill_permissions.json` write.
+   - Workspace skill: today's confirmation flow runs.
+   - Workspace skill with prior `"always"` perm: still activates without confirmation.
+   - Workspace skill with `"deny"` perm: refused.
+   - `"deny"` for a trusted-tier skill: still wins (precedence: deny > tier).
+
+Commit: `feat(skills): bypass activate_skill confirmation for trusted tiers`
+
+## Phase 5 — `tool_search` returns skill names
+
+Goal: keyword search matches catalog + hidden tool inventory; returns skills.
+
+1. In `src/decafclaw/tools/search_tools.py`:
+   - Rework `tool_search` to:
+     - Match user query against (a) skill catalog (name + description) and (b) hidden skill-tool inventory (name + description per skill tool).
+     - For tool-name/description matches, look up the owning skill via `config.skill_tool_owners` and surface the skill, not the tool.
+     - Return skill names (with their descriptions) and an instruction to call `activate_skill(name)`.
+   - Non-skill deferred tools (if any exist) still surface as today.
+2. Update the tool definition for `tool_search` (description + parameters) to reflect new behavior — "find skills (and tools they provide) by keyword; activate the skill to use its tools."
+3. Tests:
+   - `tool_search("edit prose")` returns the writing-clearly skill, not edit_with_strunk.
+   - `tool_search("edit_with_strunk")` (recalled tool name) returns writing-clearly via the hidden-inventory match.
+   - Duplicate matches (multiple tools in the same skill match the same keyword) dedupe to one skill entry.
+   - `tool_search` on always-loaded skill tools either returns the skill or treats it as already-active (whichever pattern fits — decide during implementation).
+
+Commit: `feat(skills): tool_search returns skills, not individual tools`
+
+## Phase 6 — Unknown-tool error names the owning skill
+
+Goal: agent that guesses a hidden tool name gets a direct pointer to recovery.
+
+1. In `src/decafclaw/tools/__init__.py`, `execute_tool` unknown-tool branch (~lines 252-275):
+   - Look up the failed `name` in `config.skill_tool_owners`.
+   - If found, look up the owning skill in `ctx.config.discovered_skills`:
+     - Skill not in `ctx.skills.activated`, trust tier non-workspace OR perms approved: `[error: '{name}' is provided by the '{skill}' skill, which is not activated. Call activate_skill('{skill}') first.]`
+     - Skill is workspace and unapproved: `[error: '{name}' is provided by the workspace skill '{skill}', which has not been approved. Call activate_skill('{skill}') to request user approval.]`
+     - Skill denied: `[error: '{name}' is provided by skill '{skill}', which has been denied. Tool unavailable.]`
+   - If not in `skill_tool_owners`: existing close-match suggestion path.
+2. Tests:
+   - Each branch above triggers the right error wording.
+   - Existing close-match suggestion path still fires for typos that don't match any skill tool.
+
+Commit: `feat(skills): unknown-tool error names the owning skill`
+
+## Phase 7 — Preempt-skill hint cleanup
+
+Goal: keep the hint, sharpen wording, drop tool enumeration (no longer makes sense — those tools are hidden).
+
+1. In `src/decafclaw/context_composer.py`, `_compose_preempt_skill_matches`:
+   - Update the rendered hint text. Keep it short; remove the "their tools are NOT loaded yet" framing (the agent never sees them either way). Use imperative phrasing: "These skills look relevant to the current message. Call activate_skill(name) to load their tools." then a bullet list of skill names.
+   - No tool enumeration.
+2. Tests (existing tests on this function exist — verify):
+   - Hint emitted when keyword overlap ≥ 1 with any non-active skill.
+   - Hint includes matched skill names.
+   - Hint suppressed when no matches.
+
+Commit: `feat(skills): sharpen preempt-skill hint, drop tool enumeration`
+
+## Phase 8 — Docs
+
+1. Update `docs/skills.md`:
+   - Document the four trust tiers and what they imply for activation.
+   - Document `config.skills_always_loaded` and how it composes with frontmatter `always_loaded`.
+   - Update the section describing skill discoverability — emphasize the catalog as the disclosure surface.
+2. Update `docs/tool-search.md`:
+   - Rewrite to describe skill-level results.
+3. Update `docs/preemptive-tool-search.md`:
+   - Reflect the simplified hint and the dropped tool enumeration.
+4. Update `docs/tool-priority.md` if it references the deferred-tool list rendering — verify.
+5. Update `CLAUDE.md` only if the convention changes — likely a small note in the skills section about progressive disclosure being skill-level, plus the trust-tier vocabulary.
+
+Commit: `docs(skills): document trust tiers, skill-level disclosure, skills_always_loaded config`
+
+## Phase 9 — Smoke test
+
+Manual end-to-end verification (no commit unless something needs fixing):
+
+1. Build a fresh checkout, run the agent, ask Flash to edit a blog post (the original failure case).
+2. Verify trace:
+   - Agent reads the catalog, no skill tool names visible.
+   - Agent calls `activate_skill('tabstack')` — silent, no confirmation, body delivered.
+   - Agent calls `tabstack_extract_markdown` — works.
+   - Agent calls `activate_skill('writing-clearly')` — silent.
+   - Agent calls `edit_with_strunk` — works.
+   - Total: 4 tool calls in the happy path.
+3. Add both skills to `config.skills_always_loaded`. Re-run the same prompt. Verify trace:
+   - Agent calls `tabstack_extract_markdown` directly — works (skill auto-loaded at turn start).
+   - Agent calls `edit_with_strunk` — works.
+   - Total: 2 tool calls.
+4. Test the unknown-tool error: prompt Flash to call a tool name from a not-yet-activated skill, verify the error suggests `activate_skill`.
+5. Test `tool_search`: prompt "find me a skill for editing prose", verify it returns writing-clearly.
+6. Record findings in `notes.md`.
+
+## Phase 10 — Lint, typecheck, full test sweep, PR
+
+1. `make lint`, `make typecheck`, `make check`, `make test` — full clean run.
+2. `uv run pytest tests/test_skills.py contrib/skills/ -v` — focused suite.
+3. Push branch, open PR against main with `Closes #547`.
+4. PR body covers: motivation (system prompt led agent into invisible-gate calls), architecture (skill-level disclosure, trust tiers, always_loaded extension), failure modes (workspace approval, deny precedence), and the smoke-test result. Reference dev-session artifacts.
+
+## Out of scope (deferred to follow-ups)
+
+- Deprecating the `auto-approve` frontmatter flag.
+- Per-skill `trust_tier` override frontmatter.
+- "Batch activation" tool that activates multiple skills in one call. Always-loaded covers the common case.
+- An auto-load eviction mechanism if `always_loaded` skills cause context bloat. Wait for it to bite.
+
+## Open question to revisit if it surfaces during implementation
+
+- **Subagent / child-context inheritance**: today child agents inherit the parent's activated skills (`delegate_task` copies `ctx.tools.extra` and `ctx.skills.data` but clears `ctx.skills.activated`). With skill tools now hidden until activation, the inheritance semantics need to stay consistent — child still has access to parent's tools, but can't activate new skills itself (existing restriction). Verify Phase 4-5 changes don't break this.

--- a/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/spec.md
+++ b/docs/dev-sessions/2026-05-17-1442-547-skill-autoload/spec.md
@@ -1,0 +1,197 @@
+# skills: true skill-level progressive disclosure
+
+Closes #547.
+
+## Problem
+
+The agent consistently tries to call skill-provided tools before activating their skills. Every conversation burns extra turns on the dance: try tool → "unknown tool" error → activate → retry.
+
+Root cause: the system prompt currently shows skill tool **names and descriptions** in the deferred-tool list under "## Available tools (use tool_search to load)". A small model like Gemini Flash sees `tabstack_extract_markdown` advertised there and reasonably concludes "I should call this." The unknown-tool error is the agent hitting a gate that the system prompt itself led it to walk into.
+
+The fix is to remove the contradiction: skill tools should not be visible to the agent until the skill is activated. The **skill** is the unit of progressive disclosure — its tools are an implementation detail revealed by activation.
+
+## Goal
+
+Restructure the agent's view so:
+
+- The skill catalog (name + description per skill) is the only skill-related thing visible at conversation start.
+- Skill tools become discoverable only after `activate_skill` loads the skill into context.
+- `tool_search` and the unknown-tool error help the agent find the right skill to activate when it knows what capability it wants but not where it lives.
+
+## Architecture
+
+### `always_loaded` opens up — two paths
+
+Today the `always_loaded: true` frontmatter flag only takes effect for bundled skills — both `build_catalog_text` and the auto-activation loop in `agent.py` gate on bundled placement. That restriction made sense when bundled was the only tier the project author controlled.
+
+In the new trust-tier model, `always_loaded` becomes available via two paths:
+
+1. **In the skill's frontmatter** (`always_loaded: true`) — works for any trusted tier (bundled / admin / extra). The skill author or someone editing a local copy declares the intent.
+2. **In the agent's config** (`config.skills_always_loaded: list[str]`) — a list of skill names the agent should treat as always-loaded regardless of their frontmatter. Lets a user opt a contrib skill into always-loaded without editing its source (which `git pull` would clobber for `extra_skill_paths` installations).
+
+Example config entry:
+```json
+{
+  "skills_always_loaded": ["writing-clearly", "tabstack"]
+}
+```
+
+A skill is always-loaded if EITHER path applies AND the skill is in a trusted tier. Workspace skills are denied via either path — they can't force themselves into the system prompt for the same reason they can't self-approve.
+
+This is the escape hatch for "I use this skill so often the 4-call dance is annoying": opt it into always-loaded in whichever path fits the deployment.
+
+### Trust tiers — derived from placement
+
+Each `SkillInfo` gets a `trust_tier: Literal["bundled", "admin", "extra", "workspace"]` field set at discovery time from the source path:
+
+| Tier | Location | Confirmation on `activate_skill` |
+|---|---|---|
+| `bundled` | `src/decafclaw/skills/` | Skipped — trusted by project |
+| `admin` | `data/{agent_id}/skills/` | Skipped — trusted by placement |
+| `extra` | `extra_skill_paths` entries | Skipped — trusted by config |
+| `workspace` | `data/{agent_id}/workspace/skills/` | Required — agent could have authored this |
+
+The `tool_activate_skill` precedence chain gains one rung:
+
+```
+"deny"  >  trusted tier (bundled/admin/extra)  >  "always" in perms  >  auto-approve flag  >  interactive confirmation
+```
+
+For trusted-tier skills, `activate_skill` proceeds immediately. For workspace skills, today's confirmation flow runs unchanged.
+
+### Skill tools hidden until activation
+
+Skill tools are removed from the **deferred pool** entirely. The system prompt's deferred-tool list no longer contains an "### Skills" section. Skill tools enter the agent's visible tool surface only after `activate_skill` mutates `ctx.tools.extra` / `ctx.tools.extra_definitions`.
+
+What the agent sees about an unactivated skill is exactly what the catalog shows:
+
+```
+### Available Skills
+
+The following skills can be activated. Each skill's tools become available
+after you call activate_skill(name).
+
+- tabstack: Web execution API for reading, extracting, and transforming web pages and PDFs.
+- writing-clearly: Edit prose for clarity and concision using Strunk's *The Elements of Style*.
+```
+
+The catalog text shifts from "you MUST activate before using tools" (today's slightly accusatory tone, which assumed the agent already knew the tool names from the deferred list) to a plain statement of how to discover the tools. The agent has no other path to those tool names — calling activate_skill is the only way forward.
+
+Always-loaded bundled skills (`vault`, `background`, `mcp`) stay in their existing "Active Skills" section with their tools fully visible — they're already activated.
+
+### `tool_search` — searches the catalog, returns skills
+
+Today `tool_search` searches the full deferred pool, including skill-tool names and descriptions, and lets the agent fetch individual tools. After this change:
+
+- `tool_search` searches the skill catalog (name + description) AND the **hidden** skill-tool inventory (name + description per skill tool), but **returns skill names**, not individual tool names. A match on a hidden tool name surfaces its owning skill.
+- The agent's only action after a `tool_search` result is `activate_skill(name)`. There's no auto-fetch for skill tools (auto-fetch stays for any genuinely deferred non-skill tools, if those exist).
+
+This preserves discoverability — an agent that "knows what it wants" by recalled tool name can still find the skill — without re-exposing tool surfaces the spec is trying to hide.
+
+### Preempt-skill hint — keyword-driven activation nudge
+
+Today's `_compose_preempt_skill_matches` already emits a hint when user-message keywords overlap with a skill's name + description. It stays. Sharpen the wording so small models actually act on it:
+
+```
+<preempt_skill_hint>
+The following skills look relevant to the current message. Call activate_skill(name) to load their tools.
+
+- tabstack
+- writing-clearly
+</preempt_skill_hint>
+```
+
+No tool enumeration (we just hid those). The hint is a routing signal: "consider activating these skills."
+
+### Unknown-tool error — suggests owning skill
+
+If the agent attempts to call a tool name it shouldn't know — recalled from training data, a previous conversation, or guessed — the unknown-tool error should help it recover. Use a precomputed `config.skill_tool_owners: dict[str, str]` map (tool name → owning skill name) built at skill discovery:
+
+| Failed tool name | Error |
+|---|---|
+| Belongs to a discovered skill, not activated | `[error: 'edit_with_strunk' is provided by the 'writing-clearly' skill, which is not activated. Call activate_skill('writing-clearly') first.]` |
+| Belongs to a workspace skill, denied | `[error: 'foo_tool' is provided by the workspace skill 'foo', which has been denied. Tool unavailable.]` |
+| Not in any skill | Existing close-match suggestion + `tool_search` hint. |
+
+This is the safety net for hidden-tool guesses. The same `skill_tool_owners` map serves both this error and `tool_search`'s hidden-tool-name lookup.
+
+## What stays the same
+
+- Progressive disclosure: only the catalog is visible at conv start. (Now stricter — also no per-tool entries for unactivated skills.)
+- `activate_skill` as the loading mechanism.
+- Skill body + tool list delivered as the `activate_skill` tool result, persisted in conversation history.
+- Always-loaded bundled skills (`vault`, `background`, `mcp`).
+- `skill_permissions.json` format and location.
+- Workspace-skill confirmation flow.
+- `ctx.skills.activated` lifecycle and persistence.
+- MCP tool dispatch (MCP tools are not skill tools; they keep their existing visibility).
+- The diagnostics sidecar.
+
+## What changes
+
+- `SkillInfo` gains `trust_tier`, set at discovery.
+- `tool_activate_skill` precedence chain gains the trusted-tier rung — bundled / admin / extra skills skip confirmation.
+- Skill tools removed from the deferred pool — never enter the system prompt's "Available tools" list. Tool classification (`tool_registry.py`) needs to treat skill tools as `skill-locked` rather than `deferred`.
+- `tool_search` searches the skill catalog + hidden skill-tool inventory; returns skill names.
+- `config.skill_tool_owners: dict[str, str]` precomputed at discovery; used by `tool_search` and the unknown-tool error.
+- Skill catalog text updated to reflect the new model (no implicit accusation; just "call activate_skill to load tools").
+- Preempt-skill hint sharpened — still names matched skills, omits the tool list.
+- Unknown-tool error names the owning skill when the failed name belongs to a discovered skill.
+- `always_loaded` eligibility extended from bundled-only to all trusted tiers (bundled / admin / extra). Workspace skills remain ineligible. Two specific gates relax: the filter in `build_catalog_text` and the auto-activation loop in `agent.py`.
+- New top-level `config.skills_always_loaded: list[str]` setting. Skills listed here are treated as always-loaded if they're in a trusted tier. Composes with the frontmatter flag — either path triggers always-loading.
+
+## What goes away
+
+- The activation dance for any skill: `unknown tool` failures preceded by visible-but-uncallable tool names. The agent literally cannot reference an unactivated skill's tools.
+- Confirmation prompts on first activation of trusted-tier skills.
+- The "### Skills" section in the deferred-tool list. Skill tools never appear there.
+
+## Configuration
+
+No new knobs. The change is uniformly correct — there's no use case for showing the agent tool names it can't call.
+
+## Failure modes and edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Agent reads the catalog, decides to use a skill, calls `activate_skill` | Trusted tier: skill loads immediately; tools become visible. Workspace tier: confirmation runs. |
+| Agent recalls a skill tool name from prior context / training, tries to call it directly | Unknown-tool error names the owning skill and tells the agent to call `activate_skill(name)`. One extra turn instead of two (no "did you mean" round-trip, just a direct pointer). |
+| Agent uses `tool_search` with a capability keyword | Matches against catalog descriptions AND hidden tool descriptions. Returns matching skill names. Agent calls `activate_skill`. |
+| Agent calls `activate_skill('foo')` for an unactivated trusted-tier skill | Loads immediately, no confirmation. Body + tool list as tool result. |
+| Agent calls `activate_skill('foo')` for an unapproved workspace skill | Confirmation flow runs as today. |
+| Skill body references a tool that the skill no longer has | Catalog entry is still useful; activation reveals the actual current tool set. |
+| Existing `skill_permissions.json` records for trusted-tier skills | Honored at read time; writes for trusted tiers stop. Records become harmless. |
+| `"deny"` record for a trusted-tier skill | Still wins. Skill cannot activate. |
+| Always-loaded bundled skill | Unchanged. Tools visible in active set. |
+
+## Acceptance criteria
+
+- [ ] `SkillInfo.trust_tier` populated at discovery from the source path.
+- [ ] Skill tools no longer appear in the system prompt's deferred-tool list ("### Skills" section gone).
+- [ ] `tool_activate_skill` skips confirmation for trusted-tier skills.
+- [ ] Workspace-skill confirmation flow unchanged.
+- [ ] `config.skill_tool_owners` precomputed at discovery.
+- [ ] `tool_search` matches against catalog + hidden tool inventory; returns skill names.
+- [ ] Unknown-tool error names the owning skill for hidden-skill-tool guesses.
+- [ ] Preempt-skill hint sharpened; no tool enumeration.
+- [ ] Catalog text updated to remove "you MUST activate" accusatory tone.
+- [ ] `always_loaded: true` (frontmatter) honored for trusted-tier skills, denied for workspace skills.
+- [ ] `config.skills_always_loaded` (config list) honored for trusted-tier skills, denied for workspace skills. Composes with the frontmatter path.
+- [ ] Manual verification with Flash as the parent: editing flow ("read this blog post and edit it") completes in 4 tool calls — `activate_skill('tabstack')` → `tabstack_extract_markdown` → `activate_skill('writing-clearly')` → `edit_with_strunk`. Each activation succeeds silently (no user prompt). No "unknown tool" errors in the happy path.
+- [ ] With both skills in `config.skills_always_loaded` (or frontmatter-declared), the same flow completes in 2 tool calls — `tabstack_extract_markdown` → `edit_with_strunk`. No activations needed.
+- [ ] Tests cover: skill tools absent from deferred list, `tool_search` returning skills not individual tools, trusted-tier activation skipping confirmation, workspace-tier still confirming, unknown-tool error naming the owning skill, deny record still wins, `always_loaded` working for non-bundled trusted tiers via both paths, `always_loaded` rejected for workspace tier via both paths.
+
+## Out of scope
+
+- Auto-activation on tool call. Discarded after considering it — exposes the skill body to a tool call that's already happening, which defeats progressive disclosure (the agent's call didn't read the body first).
+- Eagerly loading all trusted skills at conv start. Discarded — preserves progressive disclosure.
+- Deprecating the `auto-approve` frontmatter flag. Becomes shadowed for trusted tiers; cleanup is a separate PR.
+- Per-skill `trust_tier` override in frontmatter. No real case yet.
+
+## Risks
+
+1. **4 tool calls vs the idealized 2.** The unavoidable cost of progressive disclosure: the agent must read the skill body before using its tools. The spec accepts this because the body genuinely informs correct tool use (multi-step workflows, required args, gotchas). For skills the user uses constantly, the escape hatch is `always_loaded: true` in the SKILL.md frontmatter — opt the skill into the system prompt and skip both activation turns. Available for any trusted-tier skill under the relaxed rule above.
+2. **Existing `auto-approve: false` on bundled skills (if any) silently bypassed by the tier check.** Grep before merging.
+3. **Path-to-tier mapping edge cases.** Symlinks, `..` traversal, `extra_skill_paths` that point inside `data/{agent_id}/workspace/skills/`. The plan needs to pin down which path the tier check inspects (the discovered-source path, not a resolved/symlinked path) so the user's stated configuration controls the tier.
+4. **`tool_search` behavior change is observable.** Today it can fetch individual tools; after this it returns skills. Any test or eval that asserted "tool_search loads tool X" will break. Need to grep for callers.
+5. **Hidden tool-name awareness in agent training.** A model trained on DecafClaw transcripts (or that's seen similar tool names before) might still try to call a hidden tool. The improved unknown-tool error catches this and routes to `activate_skill` — but it's worth manually testing with a "name a tool" prompt to see what happens.

--- a/docs/preemptive-tool-search.md
+++ b/docs/preemptive-tool-search.md
@@ -26,12 +26,16 @@ For each remaining skill, score is `|input_tokens ∩ tokenize(name + descriptio
 
 ```
 <preempt_skill_hint>
-These skills look relevant to the current message: project, ingest.
-Their tools are NOT loaded yet — call activate_skill(name) before trying to use any of their tools.
+These skills look relevant to the current message. Call activate_skill(name) to load their tools.
+
+- project
+- ingest
 </preempt_skill_hint>
 ```
 
-Unlike the tool match, this is purely a **hint** — no auto-activation. The agent still calls `activate_skill` (which respects the user-confirmation flow for non-`auto-approve` skills). The hint just means the agent doesn't have to call a skill-provided tool, hit "unknown tool", search, then activate. The skill name is right there with a directive to activate it.
+Unlike the tool match, this is purely a **hint** — no auto-activation. The agent still calls `activate_skill` (which is frictionless for trusted-tier skills; workspace-tier skills still route through the user confirmation flow). The hint pairs with the skill-level progressive disclosure model from [skills.md](skills.md): the catalog tells the agent which skills exist, the preempt hint flags which look relevant for the current message, and `activate_skill` is the loading mechanism.
+
+The wording is intentionally bulleted (one skill per line) rather than comma-joined inline — small parent models attend to visual structure more reliably than to running prose, and the activation directive sits at the top where the model is most likely to read it.
 
 Diagnostics surface as a parallel source entry, `preempt_skill_matches`, with the same shape as `preempt_matches` (matched skills with score and matched tokens).
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,11 +4,26 @@ DecafClaw supports the [Agent Skills](https://agentskills.io) open standard for 
 
 ## How skills work
 
-1. **Discovery**: on startup, DecafClaw scans skill directories for `SKILL.md` files
-2. **Catalog**: skill names and descriptions are injected into the system prompt
-3. **Activation**: the agent calls `activate_skill("name")` when it needs a skill's tools
-4. **Confirmation**: user must approve activation (yes/no/always)
-5. **Loading**: native Python skills register structured tools; shell-based skills provide instructions for the `shell` tool
+1. **Discovery**: on startup, DecafClaw scans skill directories for `SKILL.md` files. Each discovered skill is tagged with a **trust tier** (see below) based on which directory it came from.
+2. **Catalog**: skill names and descriptions (only) are injected into the system prompt. The agent does NOT see the names of tools provided by unactivated skills — progressive disclosure happens at the skill level, not the tool level.
+3. **Activation**: the agent calls `activate_skill("name")` when it needs a skill's tools.
+4. **Confirmation**: required only for workspace-tier skills (which the agent itself could have written). Trusted-tier skills (bundled / admin / extra) activate without a prompt — placement is the trust signal.
+5. **Loading**: native Python skills register structured tools; shell-based skills provide instructions for the `shell` tool. The skill body lands as the `activate_skill` tool result so the agent reads it before using the tools.
+
+## Trust tiers
+
+Each discovered skill is annotated with a `trust_tier` based on where it was found:
+
+| Tier | Location | Trust source | Activation flow |
+|---|---|---|---|
+| `bundled` | `src/decafclaw/skills/` | Project author | No confirmation — trusted by project |
+| `admin` | `data/{agent_id}/skills/` | User placed the file | No confirmation — trusted by placement |
+| `extra` | `extra_skill_paths` entries (e.g. `contrib/skills/`) | User edited config | No confirmation — trusted by config |
+| `workspace` | `data/{agent_id}/workspace/skills/` | **Agent could have authored this** | Confirmation required on first use |
+
+The trust tier determines whether the activation confirmation flow runs. Workspace skills remain the security boundary — the agent can write into `workspace/`, so it could mint a SKILL.md and grant itself capabilities. Confirmation is the user's gate against that.
+
+Trusted-tier skills declaring `always-loaded: true` or `auto-approve: true` in frontmatter have those flags honored. Workspace-tier skills declaring either flag get it stripped at discovery with a warning logged.
 
 ## Skill format
 
@@ -53,11 +68,23 @@ These are loaded into context only when the skill is activated.
 | `allowed-tools` | No | Comma-separated tool names pre-approved for this skill. |
 | `model` | No | Named model config for `context: fork` skills. See [Model Selection](model-selection.md). |
 | `argument-hint` | No | Hint text for command argument substitution. |
-| `always-loaded` | No | Bool, default false. **Bundled-only.** Skill is auto-activated at startup and its tools are always present. |
+| `always-loaded` | No | Bool, default false. **Trusted-tier-only** (bundled / admin / extra). Skill is auto-activated at startup and its tools are always present in the system prompt. |
 | `schedule` | No | Cron expression. **Bundled and admin-only.** Runs the skill on a schedule. |
-| `auto-approve` | No | Bool, default false. **Bundled-only.** Skill activates without a user confirmation prompt. User's explicit `"deny"` in `skill_permissions.json` still overrides. |
+| `auto-approve` | No | Bool, default false. **Effectively shadowed** by the trust-tier check — trusted-tier skills already skip confirmation, so the flag matters only for the (currently unsupported) case of forcing confirmation on a trusted-tier skill. Workspace skills declaring it get the flag stripped. |
 
-**Trust boundary:** `always-loaded`, `schedule`, and `auto-approve` are only honored for skills bundled under `src/decafclaw/skills/`. Admin-level (`data/{agent_id}/skills/`) and workspace-level skills declaring these fields get them silently stripped with a warning log. This prevents escalation from less-trusted skill locations.
+**Trust boundary:** `always-loaded` and `auto-approve` are honored for skills in trusted tiers (bundled / admin / extra). Workspace-level skills declaring them get them stripped with a warning log. This prevents an agent-authored skill from elevating itself.
+
+### `config.skills_always_loaded`
+
+Top-level config field (also `SKILLS_ALWAYS_LOADED` env, comma-separated): a list of skill names to treat as always-loaded regardless of frontmatter. Lets a user opt a contrib skill into always-loaded without editing its source file (which `git pull` would clobber):
+
+```json
+{
+  "skills_always_loaded": ["writing-clearly", "tabstack"]
+}
+```
+
+A skill is always-loaded if EITHER its frontmatter declares `always-loaded: true` OR its name appears in `skills_always_loaded`, AND its trust tier is non-workspace. Workspace skills are denied via either path.
 
 ### Native Python tools (tools.py)
 

--- a/docs/tool-search.md
+++ b/docs/tool-search.md
@@ -40,28 +40,35 @@ Use `CRITICAL_TOOLS` to force-promote additional tools (extends, does not replac
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `query` | string | (required) | Keyword, or `select:name1,name2` for exact selection |
-| `max_results` | integer | 10 | Max tools returned for keyword search |
+| `query` | string | (required) | Keyword, or `select:name1,name2` for exact selection by skill or tool name |
+| `max_results` | integer | 10 | Max combined skill + tool matches for keyword search |
 
-**Keyword search**: case-insensitive substring match on tool name and description.
+**Keyword search** matches against three sources, case-insensitive substring on names and descriptions:
 
-**Exact selection**: `select:vault_read,vault_show_sections` fetches those specific tools.
+1. Non-skill deferred tools (core demoted + MCP) — returns the tool schema and fetches the tool.
+2. Skill catalog entries (skill name + description) — returns the skill name, NOT the individual tools. The agent must call `activate_skill(name)` to load the skill's body and tools.
+3. Hidden skill-tool inventory (tool names + descriptions of tools provided by unactivated skills) — surfaces the OWNING SKILL, so an agent that recalled a specific tool name still gets routed to `activate_skill` rather than a bypass-load that would skip the skill body.
 
-Returns full JSON schema definitions. Tools become callable on the next LLM iteration.
+**Exact selection**: `select:writing-clearly,workspace_edit` accepts both skill names (returns skill) and tool names. Hidden skill-tool names also surface their owning skill.
+
+Tools become callable on the next LLM iteration. Skills must be explicitly activated via `activate_skill`.
 
 ## Deferred Catalog Layout
 
 The deferred tool list sent to the LLM is grouped into sections:
 
 - `### Core` — core tools deferred by priority
-- `### Skills` — tools from activated skills that were deferred (rare; skill tools are usually critical)
 - `### MCP: <server>` — one section per connected MCP server
 
-Within each section, tools sort by `(priority desc, source asc, name asc)` so that high-priority tools appear first and tools from the same skill or MCP server cluster together.
+Skill-owned tools are NOT rendered in the deferred list — they remain in the deferred pool (so `tool_search` can match against them and surface the owning skill) but their names are never advertised directly to the agent. This is the skill-level progressive disclosure model: the catalog (in the main system prompt, not the deferred list) advertises skills, not individual tools.
+
+Within each rendered section, tools sort by `(priority desc, source asc, name asc)`.
 
 ## Auto-Fetch
 
-If the model calls a deferred tool without searching first (by inferring the name from the deferred list), `execute_tool` auto-fetches it — the call succeeds and the tool is added to the fetched set.
+If the model calls a deferred non-skill tool without searching first, `execute_tool` auto-fetches it — the call succeeds and the tool is added to the fetched set.
+
+**Skill-owned tools are exempt from auto-fetch.** Calling a skill tool directly produces a targeted error naming the owning skill and suggesting `activate_skill(...)`. This preserves the invariant that the skill body lands in context before any of the skill's tools execute.
 
 ## Child Agents
 

--- a/src/decafclaw/__init__.py
+++ b/src/decafclaw/__init__.py
@@ -45,7 +45,9 @@ def main():
 
     # Assemble system prompt from markdown files (bundled + workspace overrides)
     from .prompts import load_system_prompt
+    from .skills import build_skill_tool_owners
     config.system_prompt, config.discovered_skills = load_system_prompt(config)
+    config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
 
     bus = EventBus()
     app_ctx = Context(config=config, event_bus=bus)

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -15,7 +15,6 @@ import contextlib
 import logging
 import re as _re
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -393,15 +392,17 @@ async def _setup_turn_state(ctx, config, history) -> dict[str, str]:
         ctx.skills.data = {**persisted_data, **existing_data}
     await restore_skills(ctx)
 
-    # Auto-activate always-loaded skills (bundled only — trust boundary)
-    from .skills import _BUNDLED_SKILLS_DIR
-    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
+    # Auto-activate always-loaded skills. Trusted tiers (bundled /
+    # admin / extra) are eligible; workspace skills already had the
+    # always-loaded flag stripped at discovery, so the check below
+    # also defends against a workspace skill that somehow slipped
+    # through.
     discovered = config.discovered_skills
     for skill_info in discovered:
         if not skill_info.always_loaded or skill_info.name in ctx.skills.activated:
             continue
-        if not Path(skill_info.location).resolve().is_relative_to(bundled_dir):
-            continue  # only bundled skills can be always-loaded
+        if skill_info.trust_tier == "workspace":
+            continue
         from .tools.skill_tools import activate_skill_internal
         try:
             await activate_skill_internal(ctx, skill_info)

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -166,6 +166,11 @@ class Config:
     model_configs: dict[str, ModelConfig] = field(default_factory=dict)
     default_model: str = ""
     extra_skill_paths: list[str] = field(default_factory=list)
+    # Skill names to treat as always-loaded regardless of frontmatter.
+    # Lets a user opt a trusted-tier skill (bundled / admin / extra)
+    # into the system prompt without editing its SKILL.md. Workspace
+    # skills are ignored — they cannot self-elevate via either path.
+    skills_always_loaded: list[str] = field(default_factory=list)
     vault_retrieval: VaultRetrievalConfig = field(default_factory=VaultRetrievalConfig)
     relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
@@ -180,6 +185,11 @@ class Config:
     system_prompt: str = ""
     discovered_skills: list = field(default_factory=list)
     always_loaded_skill_tools: set[str] = field(default_factory=set)
+    # Tool name → owning skill name. Built at skill discovery for the
+    # subset of skills with has_native_tools. Used by the unknown-tool
+    # error path and by tool_search to route hidden-tool-name guesses
+    # back to the skill that owns the tool.
+    skill_tool_owners: dict[str, str] = field(default_factory=dict)
 
     def apply_env(self) -> None:
         """Apply env vars from the config. Only sets vars not already in the environment.
@@ -457,6 +467,16 @@ def load_config() -> Config:
             [str(p) for p in raw_extra] if isinstance(raw_extra, list) else []
         )
 
+    env_always_loaded = os.getenv("SKILLS_ALWAYS_LOADED", "")
+    if env_always_loaded:
+        skills_always_loaded = _parse_list(env_always_loaded)
+    else:
+        raw_always_loaded = file_data.get("skills_always_loaded", [])
+        skills_always_loaded = (
+            [str(s) for s in raw_always_loaded]
+            if isinstance(raw_always_loaded, list) else []
+        )
+
     # Migration: if no providers/model_configs but old-style llm config exists,
     # auto-generate a "default" openai-compat provider + model config
     from .llm.types import PROVIDER_OPENAI_COMPAT
@@ -498,6 +518,7 @@ def load_config() -> Config:
         model_configs=model_configs,
         default_model=default_model,
         extra_skill_paths=extra_skill_paths,
+        skills_always_loaded=skills_always_loaded,
         vault_retrieval=vault_retrieval,
         relevance=relevance,
         vault=vault,

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -986,12 +986,12 @@ class ContextComposer:
         # An unescaped `</preempt_skill_hint>` (or stray newline) in a
         # name could break out of the wrapper and inject prompt content.
         safe_names = sorted(html.escape(name, quote=False) for name in matched_names)
-        name_list = ", ".join(safe_names)
+        bullets = "\n".join(f"- {n}" for n in safe_names)
         hint_text = (
             "<preempt_skill_hint>\n"
-            f"These skills look relevant to the current message: {name_list}.\n"
-            "Their tools are NOT loaded yet — call activate_skill(name) "
-            "before trying to use any of their tools.\n"
+            "These skills look relevant to the current message. "
+            "Call activate_skill(name) to load their tools.\n\n"
+            f"{bullets}\n"
             "</preempt_skill_hint>"
         )
 

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -339,7 +339,9 @@ async def run_test(config: Config, test_case: dict) -> dict:
     """
     # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
     if not config.discovered_skills:
+        from ..skills import build_skill_tool_owners
         config.discovered_skills = _discover_skills_fn(config)
+        config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
 
     bus = EventBus()
     ctx = Context(config=config, event_bus=bus)

--- a/src/decafclaw/prompts/__init__.py
+++ b/src/decafclaw/prompts/__init__.py
@@ -85,19 +85,19 @@ def load_system_prompt(config):
     if wrapped:
         sections.append(wrapped)
 
-    # Append always-loaded skill bodies to system prompt (bundled only —
-    # trust boundary). Each body nests inside <loaded_skills> as a
-    # <skill name="…"> block so the model can tell which body goes with
-    # which skill.
-    from ..skills import _BUNDLED_SKILLS_DIR
-    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
+    # Append always-loaded skill bodies to system prompt. Trusted
+    # tiers (bundled / admin / extra) are eligible; workspace skills
+    # already had the always-loaded flag stripped at discovery, but
+    # the trust_tier check below also defends against a workspace
+    # skill that slipped through. Each body nests inside
+    # <loaded_skills> as a <skill name="…"> block.
     skill_blocks: list[str] = []
     for skill in skills:
         if not skill.always_loaded or not skill.body:
             continue
-        if not Path(skill.location).resolve().is_relative_to(bundled_dir):
-            log.warning(f"Ignoring always-loaded on non-bundled skill '{skill.name}' "
-                        f"at {skill.location}")
+        if skill.trust_tier == "workspace":
+            log.warning(f"Ignoring always-loaded on workspace skill "
+                        f"'{skill.name}' at {skill.location}")
             continue
         # Escape the name for XML attribute safety. Skill names come from
         # YAML frontmatter with no character validation at ingest today,

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -417,8 +417,9 @@ def build_catalog_text(skills: list[SkillInfo]) -> str:
         lines.extend([
             "## Available Skills",
             "",
-            "The following skills can be activated. Their tools are NOT available until you "
-            "call activate_skill first. You MUST activate a skill before using any of its tools.",
+            "The following skills exist but are not yet loaded. Call "
+            "activate_skill(name) to load a skill's body and tools — "
+            "the tools are not visible until the skill is activated.",
             "",
         ])
         for skill in on_demand:

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -55,6 +55,15 @@ class SkillInfo:
     schedule: str = ""  # cron expression, empty = not scheduled
     enabled: bool = True  # can be disabled via frontmatter
     auto_approve: bool = False  # bundled-only — skip activation confirmation
+    # Trust tier derived from placement at discovery time:
+    #   "bundled" — src/decafclaw/skills/ (project author)
+    #   "admin"   — data/{agent_id}/skills/ (user placed)
+    #   "extra"   — extra_skill_paths entries (user configured)
+    #   "workspace" — data/{agent_id}/workspace/skills/ (agent writable)
+    # The bundled/admin/extra tiers are "trusted" — activation skips
+    # confirmation, always-loaded is permitted. Workspace remains the
+    # security boundary requiring explicit user approval.
+    trust_tier: str = "bundled"
 
 
 def parse_skill_md(path: Path) -> SkillInfo | None:
@@ -265,18 +274,20 @@ def discover_skills(config) -> list[SkillInfo]:
     `extra_skill_paths`, where deployments opt into shared skills
     from `contrib/skills/` by referencing them directly.
     """
-    scan_paths = [
-        config.workspace_path / "skills",
-        config.agent_path / "skills",
-        _BUNDLED_SKILLS_DIR,
-        *_resolve_extra_skill_paths(config),
+    # Each scan entry carries its trust tier so SkillInfo can record
+    # where the skill came from. Extra-paths entries all share the
+    # "extra" tier regardless of how many were configured.
+    scan_entries: list[tuple[str, Path]] = [
+        ("workspace", config.workspace_path / "skills"),
+        ("admin", config.agent_path / "skills"),
+        ("bundled", _BUNDLED_SKILLS_DIR),
+        *(("extra", p) for p in _resolve_extra_skill_paths(config)),
     ]
 
     seen_names: dict[str, Path] = {}
     skills: list[SkillInfo] = []
-    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
 
-    for base_path in scan_paths:
+    for tier, base_path in scan_entries:
         for skill_dir in _iter_skill_dirs(base_path):
             skill_md = skill_dir / "SKILL.md"
             if not skill_md.exists():
@@ -286,26 +297,39 @@ def discover_skills(config) -> list[SkillInfo]:
             if info is None:
                 continue
 
-            # auto-approve and always-loaded are bundled-only (trust
-            # boundary). Admin, workspace, and external skills declaring
-            # them get the flag stripped and a warning logged so the
-            # documented "bundled-only" trust posture is enforced
-            # uniformly (catalog text + activation-time tool caching).
-            is_bundled = skill_dir.resolve().is_relative_to(bundled_dir)
-            if info.auto_approve and not is_bundled:
+            info.trust_tier = tier
+
+            # auto-approve and always-loaded are allowed for trusted
+            # tiers (bundled / admin / extra) but denied for workspace —
+            # workspace skills could be agent-authored, so they can't
+            # self-approve or force themselves into the system prompt.
+            if info.auto_approve and tier == "workspace":
                 log.warning(
-                    "Ignoring 'auto-approve: true' on non-bundled skill "
-                    "'%s' at %s — only bundled skills may auto-approve.",
+                    "Ignoring 'auto-approve: true' on workspace skill "
+                    "'%s' at %s — workspace skills cannot auto-approve.",
                     info.name, skill_dir,
                 )
                 info.auto_approve = False
-            if info.always_loaded and not is_bundled:
+            if info.always_loaded and tier == "workspace":
                 log.warning(
-                    "Ignoring 'always-loaded: true' on non-bundled skill "
-                    "'%s' at %s — only bundled skills may always-load.",
+                    "Ignoring 'always-loaded: true' on workspace skill "
+                    "'%s' at %s — workspace skills cannot always-load.",
                     info.name, skill_dir,
                 )
                 info.always_loaded = False
+
+            # `skills_always_loaded` config: opt a trusted-tier skill
+            # into always-loaded without editing its SKILL.md. Same
+            # workspace restriction applies.
+            if info.name in (config.skills_always_loaded or []):
+                if tier == "workspace":
+                    log.warning(
+                        "Ignoring config.skills_always_loaded entry for "
+                        "workspace skill '%s' — workspace skills cannot "
+                        "always-load.", info.name,
+                    )
+                else:
+                    info.always_loaded = True
 
             # Check requires.env
             missing_env = [v for v in info.requires_env if not os.environ.get(v)]
@@ -327,17 +351,52 @@ def discover_skills(config) -> list[SkillInfo]:
     return skills
 
 
+def build_skill_tool_owners(skills: list[SkillInfo]) -> dict[str, str]:
+    """Map every skill-provided tool name to its owning skill name.
+
+    Imports each skill's ``tools.py`` (only for skills with
+    ``has_native_tools``) and indexes their ``TOOL_DEFINITIONS``. Used
+    by the unknown-tool error path and by ``tool_search`` to route
+    hidden-tool-name guesses back to the skill that owns the tool.
+
+    Importing tools.py here has a startup cost — same work as
+    ``_load_native_tools`` (which the activation path runs eventually
+    anyway), just front-loaded. ``init()`` is NOT called during the
+    indexing; only the module is imported and ``TOOL_DEFINITIONS``
+    is read.
+    """
+    owners: dict[str, str] = {}
+    for skill in skills:
+        if not skill.has_native_tools:
+            continue
+        try:
+            from ..tools.skill_tools import _load_native_tools
+            _, tool_defs, _ = _load_native_tools(skill)
+        except Exception as exc:
+            log.warning(
+                "build_skill_tool_owners: failed to import tools.py for "
+                "skill '%s': %s",
+                skill.name, exc,
+            )
+            continue
+        for td in tool_defs:
+            tool_name = td.get("function", {}).get("name", "")
+            if tool_name:
+                # First-discovered wins on duplicate names (matches the
+                # runtime resolution order).
+                owners.setdefault(tool_name, skill.name)
+    return owners
+
+
 def build_catalog_text(skills: list[SkillInfo]) -> str:
     """Build the skill catalog text for injection into the system prompt."""
     if not skills:
         return ""
 
-    # Separate always-loaded (bundled only) from on-demand skills
-    bundled_dir = _BUNDLED_SKILLS_DIR.resolve()
-    always_loaded = [
-        s for s in skills
-        if s.always_loaded and Path(s.location).resolve().is_relative_to(bundled_dir)
-    ]
+    # Separate always-loaded skills from on-demand. Always-loaded is
+    # available to any trusted-tier skill (bundled / admin / extra);
+    # workspace skills have already had the flag stripped at discovery.
+    always_loaded = [s for s in skills if s.always_loaded]
     always_loaded_names = {s.name for s in always_loaded}
     on_demand = [s for s in skills if s.name not in always_loaded_names]
 

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -241,17 +241,64 @@ async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
     extra_tools = ctx.tools.extra
     fn = extra_tools.get(name) or TOOLS.get(name) or SEARCH_TOOLS.get(name)
     if fn is None:
-        # Check if tool is in the deferred pool — auto-fetch if so
+        # Check if tool is in the deferred pool — auto-fetch if so.
+        # Exception: skill-owned tools are NOT auto-fetched. The skill
+        # body documents how to use them; bypassing activation would
+        # let the agent call a tool without ever reading the body.
+        # Phase 3 hides skill tools from the visible deferred list;
+        # this guard hides them from auto-fetch too.
         deferred_pool = ctx.tools.deferred_pool
         deferred_names = {td.get("function", {}).get("name") for td in deferred_pool}
-        if name in deferred_names:
+        skill_tool_owners = getattr(ctx.config, "skill_tool_owners", {}) or {}
+        is_skill_tool = name in skill_tool_owners
+        if name in deferred_names and not is_skill_tool:
             log.debug(f"Auto-fetching deferred tool: {name}")
             from .tool_registry import add_fetched_tools
             add_fetched_tools(ctx, {name})
             fn = extra_tools.get(name) or TOOLS.get(name)
         if fn is None:
-            # Unknown tool — suggest close matches from everything the
-            # agent could reach: active, skill, deferred pool, and MCP.
+            # Tool name belongs to a discovered skill — surface that
+            # specifically rather than suggesting close matches, since
+            # the agent guessed the right name but the skill isn't
+            # loaded yet.
+            if is_skill_tool:
+                owning_skill = skill_tool_owners[name]
+                # Determine the skill's status for a tailored message.
+                from ..tools.skill_tools import _load_permissions
+                perms = _load_permissions(ctx.config)
+                if perms.get(owning_skill) == "deny":
+                    return ToolResult(
+                        text=(
+                            f"[error: '{name}' is provided by skill "
+                            f"'{owning_skill}', which has been denied. "
+                            f"Tool unavailable.]"
+                        )
+                    )
+                # Look up tier to phrase the recovery accurately.
+                tier = "workspace"
+                for s in ctx.config.discovered_skills:
+                    if s.name == owning_skill:
+                        tier = s.trust_tier
+                        break
+                if tier == "workspace" and perms.get(owning_skill) != "always":
+                    return ToolResult(
+                        text=(
+                            f"[error: '{name}' is provided by the workspace "
+                            f"skill '{owning_skill}', which has not been "
+                            f"approved. Call activate_skill('{owning_skill}') "
+                            f"to request user approval.]"
+                        )
+                    )
+                return ToolResult(
+                    text=(
+                        f"[error: '{name}' is provided by the "
+                        f"'{owning_skill}' skill, which is not activated. "
+                        f"Call activate_skill('{owning_skill}') first.]"
+                    )
+                )
+
+            # Unknown tool name — suggest close matches from everything
+            # the agent could reach: active, skill, deferred pool, MCP.
             candidates: set[str] = set()
             candidates.update(extra_tools.keys())
             candidates.update(TOOLS.keys())

--- a/src/decafclaw/tools/search_tools.py
+++ b/src/decafclaw/tools/search_tools.py
@@ -1,4 +1,4 @@
-"""Tool search — deferred tool loading via keyword or exact name selection."""
+"""Tool search — deferred-tool loading + skill discovery via keyword or exact name."""
 
 import json
 import logging
@@ -10,57 +10,121 @@ log = logging.getLogger(__name__)
 
 
 def tool_search(ctx, query: str, max_results: int = 10) -> ToolResult:
-    """Search for and load tool definitions from the deferred pool."""
-    pool = ctx.tools.deferred_pool
-    if not pool:
-        return ToolResult(text="No deferred tools available.")
+    """Search for tools / skills and load matched tool definitions.
 
-    if query.startswith("select:"):
-        # Exact selection by name
-        names = {n.strip() for n in query[7:].split(",") if n.strip()}
-        matched = [
-            td for td in pool
-            if td.get("function", {}).get("name", "") in names
-        ]
-        found_names = {td["function"]["name"] for td in matched}
-        missing = names - found_names
+    Matches against:
+    - Non-skill deferred tools (core demoted + MCP) — fetches them as today.
+    - Skill catalog entries (name + description) — returns skill names; the
+      agent must call ``activate_skill`` to load the skill's body and tools.
+    - Hidden skill-tool names and descriptions — surfaces the OWNING skill,
+      not the individual tool, so the agent learns where the capability
+      lives even if it recalled a specific tool name from elsewhere.
+    """
+    pool = ctx.tools.deferred_pool or []
+    skill_tool_owners = ctx.config.skill_tool_owners or {}
+    discovered_skills = ctx.config.discovered_skills or []
+    activated = ctx.skills.activated
+
+    is_select = query.startswith("select:")
+    requested_names: set[str] = set()
+    keyword = ""
+    if is_select:
+        requested_names = {n.strip() for n in query[7:].split(",") if n.strip()}
     else:
-        # Keyword search: case-insensitive substring on name + description
         keyword = query.lower()
-        matched = []
-        for td in pool:
-            name = td.get("function", {}).get("name", "")
-            desc = get_description(td)
-            if keyword in name.lower() or keyword in desc.lower():
-                matched.append(td)
-        matched = matched[:max_results]
-        missing = set()
 
-    if not matched:
+    def _matches(name: str, desc: str) -> bool:
+        if is_select:
+            return name in requested_names
+        return keyword in name.lower() or keyword in desc.lower()
+
+    # 1. Match the skill catalog (name + description per skill).
+    matched_skills: dict[str, str] = {}  # skill name → description (deduped)
+    for skill in discovered_skills:
+        if skill.name in activated:
+            continue
+        if _matches(skill.name, skill.description):
+            matched_skills.setdefault(skill.name, skill.description)
+
+    # 2. Walk the deferred pool. Skill tools redirect to their owning
+    #    skill; non-skill deferred tools (core demoted + MCP) get
+    #    fetched into the active set as today.
+    fetched_tool_defs: list[dict] = []
+    for td in pool:
+        name = td.get("function", {}).get("name", "")
+        if not name:
+            continue
+        desc = get_description(td)
+        owning_skill = skill_tool_owners.get(name)
+        if owning_skill:
+            if owning_skill in activated:
+                continue
+            if _matches(name, desc):
+                # Surface the skill, not the tool. Look up the skill's
+                # description for the response.
+                if owning_skill not in matched_skills:
+                    for s in discovered_skills:
+                        if s.name == owning_skill:
+                            matched_skills[owning_skill] = s.description
+                            break
+        else:
+            if _matches(name, desc):
+                fetched_tool_defs.append(td)
+
+    # Bound keyword-mode results across the combined output. Exact
+    # `select:` queries return everything the user named.
+    if not is_select and (matched_skills or fetched_tool_defs):
+        total = len(matched_skills) + len(fetched_tool_defs)
+        if total > max_results:
+            # Prefer skills first (lighter — agent decides whether to
+            # activate), then fill remaining budget with tools.
+            keep_skills = list(matched_skills.items())[:max_results]
+            matched_skills = dict(keep_skills)
+            remaining = max_results - len(matched_skills)
+            fetched_tool_defs = fetched_tool_defs[: max(remaining, 0)]
+
+    missing: set[str] = set()
+    if is_select:
+        found = set(matched_skills.keys()) | {
+            td["function"]["name"] for td in fetched_tool_defs
+        }
+        missing = requested_names - found
+
+    if not matched_skills and not fetched_tool_defs:
         return ToolResult(
-            text=f"No tools found matching '{query}'. "
-            "Check the deferred tools list in the system prompt."
+            text=(
+                f"No matches for '{query}'. "
+                "Check the Available Skills catalog in your instructions, "
+                "or pass a different keyword."
+            )
         )
 
-    # Register matched tools as fetched
-    matched_names = {td["function"]["name"] for td in matched}
-    add_fetched_tools(ctx, matched_names)
+    # Register non-skill matches as fetched so they become callable.
+    if fetched_tool_defs:
+        add_fetched_tools(ctx, {td["function"]["name"] for td in fetched_tool_defs})
 
-    # Format result
-    parts = []
-    for td in matched:
-        parts.append(json.dumps(td, indent=2))
+    parts: list[str] = []
 
-    result_text = (
-        f"{len(matched)} tool(s) loaded. "
-        "These tools are now available to call.\n\n"
-        + "\n\n".join(parts)
-    )
+    if matched_skills:
+        parts.append(
+            f"{len(matched_skills)} skill(s) matched. Call "
+            "activate_skill(name) to load a skill's body and tools."
+        )
+        for skill_name in sorted(matched_skills):
+            parts.append(f"- **{skill_name}**: {matched_skills[skill_name]}")
+
+    if fetched_tool_defs:
+        parts.append(
+            f"{len(fetched_tool_defs)} tool(s) loaded. "
+            "These tools are now available to call."
+        )
+        for td in fetched_tool_defs:
+            parts.append(json.dumps(td, indent=2))
 
     if missing:
-        result_text += f"\n\nNot found: {', '.join(sorted(missing))}"
+        parts.append(f"Not found: {', '.join(sorted(missing))}")
 
-    return ToolResult(text=result_text)
+    return ToolResult(text="\n\n".join(parts))
 
 
 SEARCH_TOOLS = {
@@ -74,11 +138,14 @@ SEARCH_TOOL_DEFINITIONS = [
         "function": {
             "name": "tool_search",
             "description": (
-                "Search for and load tool definitions. Use 'select:name1,name2' "
-                "for exact tools by name, or a keyword to search tool names and "
-                "descriptions. Returns full tool schemas, making matched tools "
-                "callable. Check the deferred tools list in the system prompt "
-                "to see what's available."
+                "Find skills and deferred tools by keyword or exact name. "
+                "For SKILLS, returns the skill name and description — call "
+                "activate_skill(name) to load the skill's body and tools. "
+                "For non-skill deferred tools, returns the tool schema and "
+                "makes the tool immediately callable. Use 'select:name1,name2' "
+                "for exact lookup by name; otherwise the query is a "
+                "case-insensitive keyword matched against skill names, skill "
+                "descriptions, and hidden skill-tool names + descriptions."
             ),
             "parameters": {
                 "type": "object",
@@ -87,13 +154,14 @@ SEARCH_TOOL_DEFINITIONS = [
                         "type": "string",
                         "description": (
                             "Keyword search term, or 'select:name1,name2' "
-                            "for exact selection"
+                            "for exact selection by skill or tool name"
                         ),
                     },
                     "max_results": {
                         "type": "integer",
                         "description": (
-                            "Max tools to return for keyword search (default 10)"
+                            "Max combined skill+tool matches for keyword "
+                            "search (default 10)"
                         ),
                     },
                 },

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -251,7 +251,9 @@ def tool_refresh_skills(ctx) -> str | ToolResult:
     # object that the agent loop holds. dataclasses.replace() would create
     # a disconnected copy.
     config = ctx.config
+    from ..skills import build_skill_tool_owners
     config.system_prompt, config.discovered_skills = load_system_prompt(config)
+    config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
     invalidate_skill_cache(config)
     # List all discovered skills — text-only, native-tools, and user-invocable
     # are all valid activatable skills

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -147,17 +147,24 @@ async def tool_activate_skill(ctx, name: str) -> str | ToolResult:
     # Permission resolution, highest precedence first:
     # 1. User's explicit "deny" in skill_permissions.json — always wins
     # 2. Admin heartbeat turns auto-approve
-    # 3. User's explicit "always" permission
-    # 4. Bundled skill with `auto-approve: true` frontmatter
-    # 5. Interactive confirmation
+    # 3. Trusted tier (bundled / admin / extra) — placement is trust
+    # 4. User's explicit "always" permission
+    # 5. Skill with `auto-approve: true` frontmatter
+    # 6. Interactive confirmation
+    # Trust by placement: bundled/admin/extra skills are pre-trusted
+    # because the user opted them in by editing source, placing files,
+    # or editing config. Workspace skills could be agent-authored, so
+    # they still require explicit confirmation.
     is_heartbeat = ctx.user_id == "heartbeat-admin"
+    is_trusted_tier = skill_info.trust_tier != "workspace"
     perms = _load_permissions(ctx.config)
     if perms.get(name) == "deny":
         return ToolResult(text=f"[error: activation of skill '{name}' was denied by user]")
     if (not is_heartbeat
+            and not is_trusted_tier
             and perms.get(name) != "always"
             and not skill_info.auto_approve):
-        # Need confirmation
+        # Need confirmation (workspace tier only at this point)
         approved, always = await _request_skill_confirmation(ctx, name)
         if not approved:
             return ToolResult(text=f"[error: activation of skill '{name}' was denied by user]")

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -223,7 +223,6 @@ def build_deferred_list_text(
 
     core_tools: list[dict] = []
     mcp_tools: dict[str, list[dict]] = {}
-    skill_tools: list[dict] = []
 
     for td in deferred_defs:
         name = td.get("function", {}).get("name", "")
@@ -234,8 +233,8 @@ def build_deferred_list_text(
             mcp_tools.setdefault(server, []).append(td)
         elif name in core_names:
             core_tools.append(td)
-        else:
-            skill_tools.append(td)
+        # Else: skill tools — kept in the deferred pool for tool_search
+        # to match against, but not rendered into the visible catalog.
 
     def _render(defs: list[dict]) -> list[str]:
         defs_sorted = sorted(defs, key=_deferred_sort_key)
@@ -251,10 +250,14 @@ def build_deferred_list_text(
         lines.extend(_render(core_tools))
         lines.append("")
 
-    if skill_tools:
-        lines.append("### Skills")
-        lines.extend(_render(skill_tools))
-        lines.append("")
+    # Skill tools are intentionally NOT rendered here. Skills are
+    # disclosed via the skill catalog (name + description in the
+    # system prompt) and their tools become visible only after
+    # activate_skill. The agent shouldn't see hidden tool names it
+    # cannot call — that produced consistent failed-tool errors with
+    # small parent models. Skill-tool defs remain in the deferred
+    # pool so tool_search can match against them and surface the
+    # owning skill.
 
     for server in sorted(mcp_tools):
         lines.append(f"### Tools from MCP server `{server}`")

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -97,6 +97,7 @@ def classify_tools(
     fetched_names = fetched_names or set()
     skill_tool_names = skill_tool_names or set()
     preempt_matches = preempt_matches or set()
+    skill_tool_owners = getattr(config, "skill_tool_owners", {}) or {}
 
     # Build the "force critical" set
     force_critical = get_critical_names(config)
@@ -110,12 +111,23 @@ def classify_tools(
     # Bucket by resolved priority, preserving input order. Compute
     # each tool's token cost once up front — classify_tools runs every
     # agent iteration, so avoid re-encoding JSON per tool per fill loop.
+    # Skill tools from non-activated skills bypass the priority buckets
+    # entirely and go straight to deferred. They stay in the deferred
+    # pool so tool_search can match against them, but they MUST NOT
+    # appear in the active list (which becomes the LLM's tools parameter)
+    # because seeing the schema there teaches the agent to call the tool
+    # directly, skipping the skill body that documents how to use it.
+    hidden_skill_tools: list[dict] = []
     critical: list[dict] = []
     normal: list[dict] = []
     low: list[dict] = []
     token_cost: dict[int, int] = {}
     for td in all_tool_defs:
+        name = td.get("function", {}).get("name", "")
         token_cost[id(td)] = estimate_tool_tokens([td])
+        if name in skill_tool_owners and name not in skill_tool_names:
+            hidden_skill_tools.append(td)
+            continue
         prio = get_priority(td, config, force_critical)
         if prio == Priority.CRITICAL.value:
             critical.append(td)
@@ -151,10 +163,16 @@ def classify_tools(
     _fill(normal)
     _fill(low)
 
+    # Hidden skill tools (from non-activated skills) always land in
+    # deferred regardless of budget — they're for tool_search lookup,
+    # never for direct callability via the active set.
+    deferred.extend(hidden_skill_tools)
+
     if deferred:
         log.info(
-            "Tool classification: %d active (%d tokens), %d deferred",
-            len(active), active_tokens, len(deferred),
+            "Tool classification: %d active (%d tokens), %d deferred "
+            "(%d hidden skill tools)",
+            len(active), active_tokens, len(deferred), len(hidden_skill_tools),
         )
     return active, deferred
 

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -810,6 +810,26 @@ class TestComposePreemptSkillMatches:
         assert hint.count("<preempt_skill_hint>") == 1
         assert hint.count("</preempt_skill_hint>") == 1
 
+    def test_hint_renders_bullets_per_skill(self, ctx, config):
+        """The hint lists matched skills as bullets, not a comma-joined
+        inline list — sharpens the visual cue for small models."""
+        config.discovered_skills = [
+            _make_skill_info("background", "Run things in the background"),
+            _make_skill_info("vault-search", "Search the background knowledge vault"),
+        ]
+        composer = ContextComposer()
+        _, hint = composer._compose_preempt_skill_matches(
+            ctx, config, "search background vault", [],
+            ComposerMode.INTERACTIVE,
+        )
+        assert hint is not None
+        assert "- background" in hint
+        assert "- vault-search" in hint
+        # The old inline comma-joined form must not appear.
+        assert "background, vault-search" not in hint
+        # New wording doesn't say "their tools are NOT loaded yet".
+        assert "NOT loaded" not in hint
+
 
 # -- Full compose() ------------------------------------------------------------
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -174,13 +174,13 @@ class TestSkillSections:
         # Body still made it through the wrapper.
         assert "NASTY_BODY" in prompt
 
-    def test_non_bundled_always_loaded_skill_body_excluded(
+    def test_workspace_always_loaded_skill_body_excluded(
         self, config, monkeypatch, tmp_path,
     ):
-        """The trust-boundary check still excludes a skill whose
-        location is outside the bundled dir, even if its frontmatter
-        sets always_loaded: true. Body must NOT appear inside
-        <loaded_skills>."""
+        """The trust-boundary check excludes always_loaded bodies from
+        workspace-tier skills. The discovery walker normally strips the
+        flag from workspace skills, but the prompts loader also defends
+        against an in-memory SkillInfo that slipped through."""
         outside_location = tmp_path / "rogue" / "SKILL.md"
         outside_location.parent.mkdir(parents=True)
         outside_location.write_text("# rogue body\n")
@@ -191,6 +191,7 @@ class TestSkillSections:
             location=outside_location,
             body="ROGUE_BODY_MARKER",
             always_loaded=True,
+            trust_tier="workspace",
         )
 
         # Keep the bundled discovery but prepend the rogue; the loader

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -1,7 +1,15 @@
-"""Tests for tool_search — keyword search and exact selection."""
+"""Tests for tool_search — keyword search and exact selection.
+
+After PR #547 tool_search distinguishes:
+- Non-skill deferred tools (core demoted + MCP) — fetched and made callable.
+- Skill-owned tools (hidden by default) — surface the OWNING skill so the
+  agent calls activate_skill, not the individual tool.
+- Skill-catalog matches (skill name or description) — surface the skill.
+"""
 
 import pytest
 
+from decafclaw.skills import SkillInfo
 from decafclaw.tools.search_tools import tool_search
 from decafclaw.tools.tool_registry import get_fetched_tools
 
@@ -17,10 +25,8 @@ def _make_tool_def(name, description="A tool."):
     }
 
 
+# Pool of plain (non-skill) deferred tools — fetched as today.
 SAMPLE_POOL = [
-    _make_tool_def("vault_read", "Read an entire markdown file as text."),
-    _make_tool_def("vault_show", "Show a section's content or document outline."),
-    _make_tool_def("vault_items", "List checklist items with their indices."),
     _make_tool_def("workspace_edit", "Edit a file by exact string replacement."),
     _make_tool_def("workspace_search", "Search for a regex pattern across files."),
     _make_tool_def("mcp__playwright__click", "Click an element on the page."),
@@ -31,47 +37,46 @@ SAMPLE_POOL = [
 
 @pytest.fixture
 def search_ctx(ctx):
-    """Ctx with a deferred pool set."""
+    """Ctx with a deferred pool set and no skills."""
     ctx.tools.deferred_pool = list(SAMPLE_POOL)
+    ctx.config.skill_tool_owners = {}
+    ctx.config.discovered_skills = []
     return ctx
 
 
-class TestKeywordSearch:
+class TestKeywordSearchNonSkillTools:
     def test_matches_name(self, search_ctx):
-        result = tool_search(search_ctx, "vault")
-        assert "vault_read" in result.text
-        assert "vault_show" in result.text
-        assert "vault_items" in result.text
+        result = tool_search(search_ctx, "workspace")
+        assert "workspace_edit" in result.text
+        assert "workspace_search" in result.text
 
     def test_matches_description(self, search_ctx):
         result = tool_search(search_ctx, "regex")
         assert "workspace_search" in result.text
 
     def test_case_insensitive(self, search_ctx):
-        result = tool_search(search_ctx, "VAULT")
-        assert "vault_read" in result.text
+        result = tool_search(search_ctx, "WORKSPACE")
+        assert "workspace_edit" in result.text
 
     def test_respects_max_results(self, search_ctx):
-        result = tool_search(search_ctx, "vault", max_results=1)
-        # Should have exactly 1 tool loaded
+        result = tool_search(search_ctx, "workspace", max_results=1)
         assert "1 tool(s) loaded" in result.text
 
     def test_no_matches(self, search_ctx):
         result = tool_search(search_ctx, "xyznonexistent")
-        assert "No tools found" in result.text
+        assert "No matches" in result.text
 
     def test_fetched_tools_updated(self, search_ctx):
-        tool_search(search_ctx, "vault")
+        tool_search(search_ctx, "workspace")
         fetched = get_fetched_tools(search_ctx)
-        assert "vault_read" in fetched
-        assert "vault_show" in fetched
-        assert "vault_items" in fetched
+        assert "workspace_edit" in fetched
+        assert "workspace_search" in fetched
 
 
-class TestExactSelection:
+class TestExactSelectionNonSkillTools:
     def test_select_by_name(self, search_ctx):
-        result = tool_search(search_ctx, "select:vault_read,checklist_create")
-        assert "vault_read" in result.text
+        result = tool_search(search_ctx, "select:workspace_edit,checklist_create")
+        assert "workspace_edit" in result.text
         assert "checklist_create" in result.text
         assert "2 tool(s) loaded" in result.text
 
@@ -81,13 +86,13 @@ class TestExactSelection:
         assert "1 tool(s) loaded" in result.text
 
     def test_select_unknown_name(self, search_ctx):
-        result = tool_search(search_ctx, "select:vault_read,nonexistent_tool")
-        assert "vault_read" in result.text
+        result = tool_search(search_ctx, "select:workspace_edit,nonexistent_tool")
+        assert "workspace_edit" in result.text
         assert "Not found: nonexistent_tool" in result.text
 
     def test_select_all_unknown(self, search_ctx):
         result = tool_search(search_ctx, "select:fake1,fake2")
-        assert "No tools found" in result.text
+        assert "No matches" in result.text
 
     def test_fetched_tools_updated(self, search_ctx):
         tool_search(search_ctx, "select:mcp__playwright__click")
@@ -97,10 +102,86 @@ class TestExactSelection:
 
 class TestEmptyPool:
     def test_no_pool(self, ctx):
+        ctx.config.skill_tool_owners = {}
+        ctx.config.discovered_skills = []
         result = tool_search(ctx, "anything")
-        assert "No deferred tools" in result.text
+        assert "No matches" in result.text
 
     def test_empty_pool(self, ctx):
         ctx.tools.deferred_pool = []
+        ctx.config.skill_tool_owners = {}
+        ctx.config.discovered_skills = []
         result = tool_search(ctx, "anything")
-        assert "No deferred tools" in result.text
+        assert "No matches" in result.text
+
+
+class TestSkillResults:
+    """Skill catalog matches and hidden-tool-name guesses surface the
+    owning skill rather than the individual tool."""
+
+    @pytest.fixture
+    def search_ctx_with_skill(self, ctx, tmp_path):
+        skill = SkillInfo(
+            name="writing-clearly",
+            description="Edit prose for clarity using Strunk's Elements of Style.",
+            location=tmp_path / "writing-clearly",
+            trust_tier="extra",
+        )
+        skill.location.mkdir()
+        ctx.config.discovered_skills = [skill]
+        ctx.config.skill_tool_owners = {"edit_with_strunk": "writing-clearly"}
+        ctx.tools.deferred_pool = [
+            _make_tool_def("edit_with_strunk", "Revise a prose draft for clarity."),
+            _make_tool_def("workspace_edit", "Edit a file."),
+        ]
+        return ctx
+
+    def test_skill_name_match_returns_skill(self, search_ctx_with_skill):
+        result = tool_search(search_ctx_with_skill, "writing-clearly")
+        assert "writing-clearly" in result.text
+        assert "skill(s) matched" in result.text
+        assert "activate_skill" in result.text
+
+    def test_skill_description_match_returns_skill(self, search_ctx_with_skill):
+        result = tool_search(search_ctx_with_skill, "clarity")
+        assert "writing-clearly" in result.text
+
+    def test_hidden_tool_name_returns_owning_skill(
+        self, search_ctx_with_skill,
+    ):
+        """An agent that recalls a hidden skill-tool name gets routed to
+        the owning skill, not the tool — preserves the progressive-
+        disclosure invariant."""
+        result = tool_search(search_ctx_with_skill, "edit_with_strunk")
+        assert "writing-clearly" in result.text
+        assert "activate_skill" in result.text
+        # The raw tool schema must NOT be in the result.
+        assert '"name": "edit_with_strunk"' not in result.text
+        # The tool must not have been added to fetched.
+        assert "edit_with_strunk" not in get_fetched_tools(search_ctx_with_skill)
+
+    def test_select_hidden_tool_name_returns_owning_skill(
+        self, search_ctx_with_skill,
+    ):
+        result = tool_search(search_ctx_with_skill, "select:edit_with_strunk")
+        assert "writing-clearly" in result.text
+        assert "skill(s) matched" in result.text
+        assert "edit_with_strunk" not in get_fetched_tools(search_ctx_with_skill)
+
+    def test_mixed_results(self, search_ctx_with_skill):
+        """A query matching both a skill and a non-skill tool surfaces both."""
+        # "edit" matches edit_with_strunk's description (clarity)? No —
+        # "edit" appears in workspace_edit's description ("Edit a file").
+        # And it also appears in the writing-clearly description ("Edit prose").
+        result = tool_search(search_ctx_with_skill, "edit")
+        assert "writing-clearly" in result.text  # skill match
+        assert "workspace_edit" in result.text  # plain tool match
+
+    def test_already_activated_skill_not_returned(
+        self, search_ctx_with_skill,
+    ):
+        """A skill already in ctx.skills.activated isn't surfaced — its
+        tools are already in the active set, so re-activating is noise."""
+        search_ctx_with_skill.skills.activated.add("writing-clearly")
+        result = tool_search(search_ctx_with_skill, "writing-clearly")
+        assert "No matches" in result.text

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -319,18 +319,18 @@ def test_discover_strips_auto_approve_from_workspace_skill(config, caplog):
     assert any("auto-approve" in r.message for r in caplog.records)
 
 
-def test_discover_strips_auto_approve_from_admin_skill(config, caplog):
-    """auto-approve on an admin-level skill is ignored with a warning."""
+def test_discover_keeps_auto_approve_on_admin_skill(config):
+    """Admin-tier skills are trusted by placement; auto-approve is honored."""
     skills_dir = config.agent_path / "skills"
     _write_skill(
         skills_dir / "admin-auto",
         "name: admin-auto\ndescription: Admin.\nauto-approve: true",
     )
-    with caplog.at_level("WARNING"):
-        skills = discover_skills(config)
+    skills = discover_skills(config)
     matching = [s for s in skills if s.name == "admin-auto"]
     assert len(matching) == 1
-    assert matching[0].auto_approve is False
+    assert matching[0].auto_approve is True
+    assert matching[0].trust_tier == "admin"
 
 
 def test_discover_honors_auto_approve_on_bundled(config):
@@ -349,43 +349,69 @@ def test_discover_honors_auto_approve_on_bundled(config):
     )
 
 
-def test_discover_strips_auto_approve_from_extra_path_skill(tmp_path, config, caplog):
-    """auto-approve on an external-path skill is stripped, same as workspace."""
+def test_discover_keeps_auto_approve_on_extra_path_skill(tmp_path, config):
+    """Extra-path skills are trusted by user config; auto-approve is honored."""
     extra = tmp_path / "external"
     _write_skill(
         extra / "ext-auto",
         "name: ext-auto\ndescription: External.\nauto-approve: true",
     )
     config.extra_skill_paths = [str(extra)]
-    with caplog.at_level("WARNING"):
-        skills = discover_skills(config)
+    skills = discover_skills(config)
     matching = [s for s in skills if s.name == "ext-auto"]
     assert len(matching) == 1
-    assert matching[0].auto_approve is False
-    assert any("auto-approve" in r.message for r in caplog.records)
+    assert matching[0].auto_approve is True
+    assert matching[0].trust_tier == "extra"
 
 
-def test_discover_strips_always_loaded_from_extra_path_skill(tmp_path, config, caplog):
-    """always-loaded on an external-path skill is stripped at discovery so
-    activation-time tool caching also treats the skill as on-demand, not
-    just the catalog text."""
+def test_discover_keeps_always_loaded_on_extra_path_skill(tmp_path, config):
+    """Extra-path skills can declare always-loaded; tier is trusted."""
     extra = tmp_path / "external"
     _write_skill(
         extra / "ext-al",
-        "name: ext-al\ndescription: Pretender.\nalways-loaded: true",
+        "name: ext-al\ndescription: Always-on contrib.\nalways-loaded: true",
     )
     config.extra_skill_paths = [str(extra)]
-    with caplog.at_level("WARNING"):
-        skills = discover_skills(config)
+    skills = discover_skills(config)
     matching = [s for s in skills if s.name == "ext-al"]
     assert len(matching) == 1
-    assert matching[0].always_loaded is False
-    assert any("always-loaded" in r.message for r in caplog.records)
+    assert matching[0].always_loaded is True
     catalog = build_catalog_text(skills)
-    assert "ext-al" in catalog
-    if "## Active Skills" in catalog:
-        active_block = catalog.split("## Active Skills")[1].split("##")[0]
-        assert "ext-al" not in active_block
+    # Should appear under Active Skills, not Available Skills.
+    assert "## Active Skills" in catalog
+    active_block = catalog.split("## Active Skills")[1].split("##")[0]
+    assert "ext-al" in active_block
+
+
+def test_skills_always_loaded_config_promotes_extra_skill(tmp_path, config):
+    """config.skills_always_loaded promotes a trusted-tier skill into the
+    always-loaded set without editing its frontmatter."""
+    extra = tmp_path / "external"
+    _write_skill(
+        extra / "promoted",
+        "name: promoted\ndescription: Default on-demand contrib.",
+    )
+    config.extra_skill_paths = [str(extra)]
+    config.skills_always_loaded = ["promoted"]
+    skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "promoted"]
+    assert matching[0].always_loaded is True
+
+
+def test_skills_always_loaded_config_denied_for_workspace(config, caplog):
+    """config.skills_always_loaded entry for a workspace skill is rejected
+    with a warning."""
+    _write_skill(
+        config.workspace_path / "skills" / "ws-promo",
+        "name: ws-promo\ndescription: Workspace.",
+    )
+    config.skills_always_loaded = ["ws-promo"]
+    with caplog.at_level("WARNING"):
+        skills = discover_skills(config)
+    matching = [s for s in skills if s.name == "ws-promo"]
+    assert matching[0].always_loaded is False
+    assert any("workspace skill" in r.message and "always-load" in r.message
+               for r in caplog.records)
 
 
 def test_discover_strips_always_loaded_from_workspace_skill(config, caplog):
@@ -562,6 +588,62 @@ def test_contrib_follows_explicit_decafclaw_repo(
     config.extra_skill_paths = ["$CONTRIB/skills/alt-skill"]
     skills = discover_skills(config)
     assert any(s.name == "alt-skill" for s in skills)
+
+
+def test_trust_tier_assigned_per_scan_path(tmp_path, config):
+    """Each skill gets a trust_tier reflecting which scan path produced it."""
+    # workspace tier
+    _write_skill(
+        config.workspace_path / "skills" / "ws-skill",
+        "name: ws-skill\ndescription: Workspace skill.",
+    )
+    # admin tier
+    _write_skill(
+        config.agent_path / "skills" / "admin-skill",
+        "name: admin-skill\ndescription: Admin skill.",
+    )
+    # extra tier
+    extra = tmp_path / "extra-root"
+    _write_skill(extra / "extra-skill", "name: extra-skill\ndescription: Extra.")
+    config.extra_skill_paths = [str(extra)]
+
+    skills = {s.name: s for s in discover_skills(config)}
+    assert skills["ws-skill"].trust_tier == "workspace"
+    assert skills["admin-skill"].trust_tier == "admin"
+    assert skills["extra-skill"].trust_tier == "extra"
+    # Bundled skills come from src/decafclaw/skills/ — at least one
+    # should be present and tagged "bundled".
+    bundled = [s for s in skills.values() if s.trust_tier == "bundled"]
+    assert bundled, "expected at least one bundled skill discovered"
+
+
+def test_skill_tool_owners_built_from_native_tools(tmp_path, config):
+    """build_skill_tool_owners maps each tool name to its owning skill."""
+    from decafclaw.skills import build_skill_tool_owners
+
+    skill_dir = tmp_path / "skills-root" / "ownertest"
+    _write_skill(
+        skill_dir,
+        "name: ownertest\ndescription: Owner test.",
+        tools_py=False,
+    )
+    (skill_dir / "tools.py").write_text(
+        "TOOLS = {'foo_one': lambda ctx: None, 'foo_two': lambda ctx: None}\n"
+        "TOOL_DEFINITIONS = ["
+        "{'type': 'function', 'function': {'name': 'foo_one'}},"
+        "{'type': 'function', 'function': {'name': 'foo_two'}},"
+        "]\n"
+    )
+    config.extra_skill_paths = [str(tmp_path / "skills-root")]
+    skills = discover_skills(config)
+    owners = build_skill_tool_owners(skills)
+    assert owners.get("foo_one") == "ownertest"
+    assert owners.get("foo_two") == "ownertest"
+
+
+def test_skills_always_loaded_config_field_default(config):
+    """config.skills_always_loaded defaults to empty list."""
+    assert config.skills_always_loaded == []
 
 
 def test_contrib_explicit_env_wins(tmp_path, config, monkeypatch):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -738,7 +738,7 @@ def test_save_permission_preserves_existing(config):
 
 
 def _make_skill_info(tmp_path, name="test-skill", body="Instructions here.",
-                     has_native_tools=False):
+                     has_native_tools=False, trust_tier="bundled"):
     """Create a SkillInfo for testing."""
     location = tmp_path / name
     location.mkdir(parents=True, exist_ok=True)
@@ -746,6 +746,7 @@ def _make_skill_info(tmp_path, name="test-skill", body="Instructions here.",
         name=name, description=f"{name} description",
         location=location, body=body,
         has_native_tools=has_native_tools,
+        trust_tier=trust_tier,
     )
 
 
@@ -806,6 +807,73 @@ async def test_auto_approve_blocked_by_explicit_deny(ctx, tmp_path):
 
     result = await tool_activate_skill(ctx, name=skill.name)
     assert "[error:" in _text(result)
+    assert "denied" in _text(result)
+    assert skill.name not in ctx.skills.activated
+
+
+@pytest.mark.asyncio
+async def test_activate_trusted_admin_tier_bypasses_confirmation(ctx, tmp_path):
+    """Admin-tier skill activates without confirmation (trust by placement)."""
+    skill = _make_skill_info(tmp_path, trust_tier="admin")
+    ctx.config.discovered_skills = [skill]
+    # No permission record, no auto_approve flag — only the trust tier
+    # should allow activation to proceed.
+    result = await tool_activate_skill(ctx, name=skill.name)
+    assert "Instructions here." in _text(result)
+    assert skill.name in ctx.skills.activated
+
+
+@pytest.mark.asyncio
+async def test_activate_trusted_extra_tier_bypasses_confirmation(ctx, tmp_path):
+    """Extra-path-tier skill activates without confirmation."""
+    skill = _make_skill_info(tmp_path, trust_tier="extra")
+    ctx.config.discovered_skills = [skill]
+    result = await tool_activate_skill(ctx, name=skill.name)
+    assert "Instructions here." in _text(result)
+    assert skill.name in ctx.skills.activated
+
+
+@pytest.mark.asyncio
+async def test_activate_trusted_tier_no_permission_write(ctx, tmp_path):
+    """Trusted-tier activation does NOT write to skill_permissions.json —
+    placement is implicit trust, no need to record it."""
+    skill = _make_skill_info(tmp_path, trust_tier="extra")
+    ctx.config.discovered_skills = [skill]
+    await tool_activate_skill(ctx, name=skill.name)
+    perms = _load_permissions(ctx.config)
+    assert skill.name not in perms
+
+
+@pytest.mark.asyncio
+async def test_deny_still_wins_over_trust_tier(ctx, tmp_path):
+    """A user's explicit 'deny' record overrides the trust-tier bypass."""
+    skill = _make_skill_info(tmp_path, trust_tier="extra")
+    ctx.config.discovered_skills = [skill]
+    _save_permission(ctx.config, skill.name, "deny")
+    result = await tool_activate_skill(ctx, name=skill.name)
+    assert "[error:" in _text(result)
+    assert "denied" in _text(result)
+    assert skill.name not in ctx.skills.activated
+
+
+@pytest.mark.asyncio
+async def test_workspace_skill_still_requires_confirmation(
+    ctx, tmp_path, monkeypatch,
+):
+    """Workspace-tier skill activation routes through the confirmation flow
+    even when no permission record exists. (Test mocks the confirmation
+    handler to deny, verifying activation does NOT proceed.)"""
+    skill = _make_skill_info(tmp_path, trust_tier="workspace")
+    ctx.config.discovered_skills = [skill]
+
+    async def fake_request(_ctx, _name):
+        return (False, False)  # denied, not always
+
+    monkeypatch.setattr(
+        "decafclaw.tools.skill_tools._request_skill_confirmation",
+        fake_request,
+    )
+    result = await tool_activate_skill(ctx, name=skill.name)
     assert "denied" in _text(result)
     assert skill.name not in ctx.skills.activated
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -378,6 +378,81 @@ class TestBuildDeferredListText:
         b_idx = github_section.index("issue_b")
         assert a_idx < b_idx
 
+    def test_classify_hidden_skill_tools_forced_to_deferred(self):
+        """Skill tools whose owning skill is not in the activated set
+        must NEVER land in the active list, even when budget would allow
+        them. The active list becomes the LLM's tools parameter; seeing
+        a skill tool there teaches the agent to call it directly,
+        bypassing the skill body."""
+        from decafclaw.tools.tool_registry import classify_tools
+
+        class _FakeAgentConfig:
+            critical_tools: list[str] = []
+            max_active_tools = 40
+
+        class _FakeConfig:
+            agent = _FakeAgentConfig()
+            tool_context_budget = 1_000_000  # generous; would normally fit
+            discovered_skills: list = []
+            skill_tool_owners = {"edit_with_strunk": "writing-clearly"}
+
+        config = _FakeConfig()
+
+        skill_tool = _make_tool_def(
+            "edit_with_strunk",
+            "Revise a prose draft.",
+            priority="normal",
+        )
+        core_tool = _make_tool_def(
+            "workspace_read", "Read a file.", priority="critical",
+        )
+
+        # skill_tool_names is empty → owning skill 'writing-clearly' is
+        # NOT activated. edit_with_strunk should be force-deferred.
+        active, deferred = classify_tools(
+            [skill_tool, core_tool],
+            config,
+            fetched_names=set(),
+            skill_tool_names=set(),
+        )
+        active_names = {td["function"]["name"] for td in active}
+        deferred_names = {td["function"]["name"] for td in deferred}
+
+        assert "edit_with_strunk" not in active_names, (
+            "hidden skill tool leaked into active list — LLM would see "
+            "its schema and call it directly"
+        )
+        assert "edit_with_strunk" in deferred_names
+        assert "workspace_read" in active_names
+
+    def test_classify_activated_skill_tools_stay_critical(self):
+        """When a skill IS activated (its tool names appear in
+        skill_tool_names), its tools enter the active set normally —
+        the hidden-tool gate only applies to non-activated skills."""
+        from decafclaw.tools.tool_registry import classify_tools
+
+        class _FakeAgentConfig:
+            critical_tools: list[str] = []
+            max_active_tools = 40
+
+        class _FakeConfig:
+            agent = _FakeAgentConfig()
+            tool_context_budget = 1_000_000
+            discovered_skills: list = []
+            skill_tool_owners = {"edit_with_strunk": "writing-clearly"}
+
+        config = _FakeConfig()
+        skill_tool = _make_tool_def("edit_with_strunk", "Revise prose.")
+
+        active, deferred = classify_tools(
+            [skill_tool],
+            config,
+            fetched_names=set(),
+            skill_tool_names={"edit_with_strunk"},  # skill activated
+        )
+        active_names = {td["function"]["name"] for td in active}
+        assert "edit_with_strunk" in active_names
+
     def test_skill_tools_never_in_visible_output(self):
         """Even when _source_skill is set and multiple skill tools exist,
         none of them appear in the visible deferred-tool list. (Previously

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -296,8 +296,10 @@ class TestBuildDeferredListText:
         assert text.endswith("\n</deferred_tools>")
 
     def test_inner_markdown_preserved(self):
-        """The wrapping is additive: all the existing section headings
-        (## Available tools, ### Core, etc.) remain visible inside."""
+        """The wrapping is additive: the existing section headings
+        for Core and MCP remain visible inside. Skill tools are
+        intentionally not rendered — they're disclosed via the skill
+        catalog, not the deferred-tool list."""
         tools = [
             _make_tool_def("workspace_edit", "Edit a file"),
             _make_tool_def("vault_read", "Read a file"),
@@ -306,8 +308,10 @@ class TestBuildDeferredListText:
         text = build_deferred_list_text(tools, core_names={"workspace_edit"})
         assert "## Available tools (use tool_search to load)" in text
         assert "### Core" in text
-        assert "### Skills" in text
+        assert "### Skills" not in text
         assert "### Tools from MCP server `github`" in text
+        # Skill tool name must not leak into the visible catalog.
+        assert "vault_read" not in text
 
     def test_core_tools(self):
         core_names = {"workspace_edit", "checklist_create"}
@@ -330,13 +334,17 @@ class TestBuildDeferredListText:
         assert "### Tools from MCP server `playwright`" in text
         assert "### Tools from MCP server `slack`" in text
 
-    def test_skill_tools(self):
+    def test_skill_tools_hidden(self):
+        """Skill tools never render to the visible catalog. They stay in
+        the deferred pool so tool_search can match against them and
+        surface the owning skill, but the agent doesn't see tool names
+        it cannot call without first activating the skill."""
         tools = [
             _make_tool_def("vault_read", "Read a file"),
         ]
         text = build_deferred_list_text(tools, core_names=set())
-        assert "### Skills" in text
-        assert "vault_read" in text
+        assert "### Skills" not in text
+        assert "vault_read" not in text
 
     def test_core_sorted_by_priority_desc_then_name(self):
         """Within Core, priority desc then alpha by name."""
@@ -370,8 +378,10 @@ class TestBuildDeferredListText:
         b_idx = github_section.index("issue_b")
         assert a_idx < b_idx
 
-    def test_skill_tools_cluster_by_source_skill(self):
-        """When _source_skill is set, skill tools cluster by skill name."""
+    def test_skill_tools_never_in_visible_output(self):
+        """Even when _source_skill is set and multiple skill tools exist,
+        none of them appear in the visible deferred-tool list. (Previously
+        they were clustered under '### Skills'; that section is gone.)"""
         def with_source(td, skill):
             return {**td, "_source_skill": skill}
 
@@ -381,13 +391,9 @@ class TestBuildDeferredListText:
             with_source(_make_tool_def("tool_b"), "skill_alpha"),
         ]
         text = build_deferred_list_text(tools, core_names=set())
-        skills_section = text.split("### Skills")[1].split("###")[0]
-        # skill_alpha tools should appear before skill_beta tools
-        # within skill_alpha: tool_b before tool_z (alphabetical)
-        b_idx = skills_section.index("tool_b")
-        z_idx = skills_section.index("tool_z")
-        a_idx = skills_section.index("tool_a")
-        assert b_idx < z_idx < a_idx
+        assert "### Skills" not in text
+        for name in ("tool_a", "tool_b", "tool_z"):
+            assert name not in text
 
 
 # -- Fetched tools helpers -----------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -26,6 +26,115 @@ async def test_execute_tool_unknown(ctx):
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_unknown_skill_tool_names_owning_skill(ctx, tmp_path):
+    """A tool that belongs to a non-activated trusted-tier skill produces
+    an error that names the owning skill and suggests activate_skill."""
+    from decafclaw.skills import SkillInfo
+
+    skill = SkillInfo(
+        name="writing-clearly",
+        description="Edit prose.",
+        location=tmp_path / "writing-clearly",
+        trust_tier="extra",
+    )
+    skill.location.mkdir()
+    ctx.config.discovered_skills = [skill]
+    ctx.config.skill_tool_owners = {"edit_with_strunk": "writing-clearly"}
+
+    result = await execute_tool(ctx, "edit_with_strunk", {})
+    assert "writing-clearly" in result.text
+    assert "activate_skill('writing-clearly')" in result.text
+    # The agent shouldn't be told to call tool_search — the recovery
+    # is direct.
+    assert "tool_search" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_unknown_workspace_skill_tool_unapproved(
+    ctx, tmp_path,
+):
+    """An unapproved workspace-tier skill's tool produces a 'request user
+    approval' error."""
+    from decafclaw.skills import SkillInfo
+
+    skill = SkillInfo(
+        name="ws-skill",
+        description="Workspace.",
+        location=tmp_path / "ws-skill",
+        trust_tier="workspace",
+    )
+    skill.location.mkdir()
+    ctx.config.discovered_skills = [skill]
+    ctx.config.skill_tool_owners = {"ws_tool": "ws-skill"}
+
+    result = await execute_tool(ctx, "ws_tool", {})
+    assert "workspace skill 'ws-skill'" in result.text
+    assert "approval" in result.text
+    assert "activate_skill('ws-skill')" in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_unknown_denied_skill_tool(ctx, tmp_path):
+    """A denied skill's tool produces a tool-unavailable error."""
+    from decafclaw.skills import SkillInfo
+    from decafclaw.tools.skill_tools import _save_permission
+
+    skill = SkillInfo(
+        name="denied-skill",
+        description="Denied.",
+        location=tmp_path / "denied-skill",
+        trust_tier="extra",
+    )
+    skill.location.mkdir()
+    ctx.config.discovered_skills = [skill]
+    ctx.config.skill_tool_owners = {"denied_tool": "denied-skill"}
+    _save_permission(ctx.config, "denied-skill", "deny")
+
+    result = await execute_tool(ctx, "denied_tool", {})
+    assert "denied-skill" in result.text
+    assert "denied" in result.text.lower()
+    assert "unavailable" in result.text
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_skill_tool_not_auto_fetched_from_deferred_pool(
+    ctx, tmp_path,
+):
+    """Skill tools in the deferred pool are NOT auto-fetched. The agent
+    must go through activate_skill so the skill body lands in context."""
+    from decafclaw.skills import SkillInfo
+
+    skill = SkillInfo(
+        name="my-skill",
+        description="My skill.",
+        location=tmp_path / "my-skill",
+        trust_tier="extra",
+    )
+    skill.location.mkdir()
+    ctx.config.discovered_skills = [skill]
+    ctx.config.skill_tool_owners = {"my_skill_tool": "my-skill"}
+    # Put the tool in the deferred pool — pre-Phase 6 this would have
+    # triggered auto-fetch and silent execution.
+    ctx.tools.deferred_pool = [
+        {
+            "type": "function",
+            "function": {
+                "name": "my_skill_tool",
+                "description": "A tool from my-skill.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+    result = await execute_tool(ctx, "my_skill_tool", {})
+    # The error should name the owning skill, not execute the tool.
+    assert "my-skill" in result.text
+    assert "activate_skill" in result.text
+    # The tool should NOT have been added to the active set.
+    assert "my_skill_tool" not in ctx.tools.extra
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_unknown_suggests_close_match(ctx):
     """When the unknown name is close to a real tool, the error includes it as a suggestion."""
     # workspace_read is a real core tool; try a typo.


### PR DESCRIPTION
Closes #547.

## Summary

Restructures the skill system so the agent's progressive-disclosure unit is the **skill** (not the tool). Skill tool names are no longer advertised in the system prompt; trusted-tier activation bypasses confirmation; unknown-tool errors and `tool_search` route the agent to `activate_skill` for skill-owned tools.

## Why

Previously the system prompt rendered a "## Available tools (use tool_search to load)" list under "### Skills" that enumerated every skill-owned tool name and description. Small parent models (Gemini Flash) consistently saw those names labeled "Available tools" and called them directly, hitting "unknown tool" errors followed by the activation dance. The error was the agent running into a gate the system prompt itself advertised.

## Architecture

**Trust tiers.** Each `SkillInfo` carries a `trust_tier` set at discovery from the source path:

| Tier | Source | Activation confirmation |
|---|---|---|
| `bundled` | `src/decafclaw/skills/` | Skipped — trusted by project |
| `admin` | `data/{agent_id}/skills/` | Skipped — trusted by placement |
| `extra` | `extra_skill_paths` entries | Skipped — trusted by config |
| `workspace` | `data/{agent_id}/workspace/skills/` | Required (agent could have authored this) |

**Skill-level disclosure.** Skill tools are removed from the system prompt's visible deferred-tool list. They remain in `ctx.tools.deferred_pool` only so `tool_search` can match against them and surface the owning skill. The agent sees the skill catalog (name + description) and uses `activate_skill` to reveal a skill's tools.

**No auto-fetch for skill tools.** `execute_tool`'s auto-fetch path skips tools whose names are in `config.skill_tool_owners`. Calling a hidden skill tool produces a targeted error pointing at `activate_skill(owning_skill)`.

**Always-loaded extended.** `always-loaded: true` works for any trusted tier (bundled / admin / extra), not just bundled. New `config.skills_always_loaded: list[str]` config field (plus `SKILLS_ALWAYS_LOADED` env) opts a contrib skill into always-loaded without editing its source.

## What changed

7 commits, each independently reviewable:

1. **trust_tier + always_loaded for trusted tiers** — `SkillInfo.trust_tier`, `config.skill_tool_owners` precomputed map, `config.skills_always_loaded`, relaxed always-loaded eligibility.
2. **Hide skill tools from the visible deferred list** — `build_deferred_list_text` omits the "### Skills" section.
3. **Bypass `activate_skill` confirmation for trusted tiers** — precedence chain gains the tier rung.
4. **`tool_search` returns skills for skill-tool matches** — three match sources (non-skill deferred, skill catalog, hidden skill-tool inventory) with skill-level routing for the latter two.
5. **Unknown-tool error names the owning skill** — three branches (not-activated trusted, unapproved workspace, denied) plus auto-fetch bypass for skill tools.
6. **Sharpen preempt-skill hint with bulleted list** — drops "tools are NOT loaded" framing (agent never sees them either way); renders matched skills as bullets.
7. **Docs**: `docs/skills.md`, `docs/tool-search.md`, `docs/preemptive-tool-search.md` updated.

## Test plan

- [x] `make lint`, `make typecheck`, `make check-js` clean.
- [x] `uv run pytest` — 2673 passed.
- [x] Unit tests cover: trust_tier assignment per scan path; admin/extra/bundled keeping auto-approve and always-loaded flags; workspace rejection of both; `skills_always_loaded` config promoting trusted skills and rejecting workspace; trusted-tier activation skipping confirmation with no permission-file write; workspace tier still confirming; deny still winning over tier; skill tools absent from rendered deferred list; `tool_search` returning skills for skill-name + hidden-tool-name matches; non-skill tools fetched as before; targeted unknown-tool errors per branch; auto-fetch bypass for skill tools; existing preempt-skill match tests still pass plus new bullet-format assertion.
- [ ] **Manual verification with Flash as the parent**: build branch, restart agent, ask "read this blog post and edit it" with `tabstack` and `writing-clearly` enabled but unactivated. Expected trace:
  - `activate_skill('tabstack')` → silent, no confirmation
  - `tabstack_extract_markdown(...)` → success
  - `activate_skill('writing-clearly')` → silent
  - `edit_with_strunk(...)` → success
  - Total: 4 tool calls, no "unknown tool" errors.
- [ ] **Manual verification with `skills_always_loaded`**: add both to `config.skills_always_loaded`, re-run. Expected: 2 tool calls, no activations needed.

## Notes

- Dev session artifacts under `docs/dev-sessions/2026-05-17-1442-547-skill-autoload/` (spec.md, plan.md, notes.md). The spec went through several iterations as the design narrowed; notes.md captures the implementation slips (Phase 1+2 collapse, Phase 6 auto-fetch gap, twice-recovered `git add` mistakes).
- The `auto-approve` frontmatter flag becomes shadowed by the tier check for trusted tiers. Left in place for backward compat; deprecation is a separate cleanup PR.
- Existing `skill_permissions.json` records for trusted-tier skills become dead entries — honored at read time but no longer written. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)