### PR TITLE
fix(web): restore third confirmation button (Allow/Always)

### DIFF
--- a/src/decafclaw/confirmations.py
+++ b/src/decafclaw/confirmations.py
@@ -30,8 +30,12 @@ class ConfirmationRequest:
     action_type: ConfirmationAction
     action_data: dict = field(default_factory=dict)
     message: str = ""
-    approve_label: str = "Approve"
-    deny_label: str = "Deny"
+    # Empty defaults so the web UI can distinguish "no custom label set"
+    # from a tool-supplied label. confirm-view.js falls back to "Approve" /
+    # "Deny" at render time and gates the third (Allow / Always) button on
+    # `approve_label` being falsy — a truthy default here hides the button.
+    approve_label: str = ""
+    deny_label: str = ""
     tool_call_id: str = ""
     timeout: float | None = 300.0
     confirmation_id: str = field(default_factory=lambda: uuid4().hex[:12])

--- a/src/decafclaw/tools/confirmation.py
+++ b/src/decafclaw/tools/confirmation.py
@@ -49,8 +49,8 @@ async def _request_via_manager(ctx, tool_name, command, message, timeout,
         message=message,
         tool_call_id=ctx.tools.current_call_id,
         timeout=timeout,
-        approve_label=extra_event_fields.get("approve_label", "Approve"),
-        deny_label=extra_event_fields.get("deny_label", "Deny"),
+        approve_label=extra_event_fields.get("approve_label", ""),
+        deny_label=extra_event_fields.get("deny_label", ""),
     )
 
     response = await ctx.request_confirmation(request)

--- a/tests/test_web_confirm.py
+++ b/tests/test_web_confirm.py
@@ -149,3 +149,95 @@ async def test_publish_no_tool_call_id_when_unset(ctx):
     await ctx.publish("tool_status", tool="shell", message="running...")
 
     assert "tool_call_id" not in published[0]
+
+
+# -- approve_label / deny_label defaults --------------------------------------
+#
+# The web UI gates its third confirmation button ("Allow: <pattern>" for shell,
+# otherwise "Always") on `c.approve_label` being falsy — `confirm-view.js`
+# treats a non-empty label as a signal that the tool wants a custom UI gate
+# and suppresses the extra button. So a truthy default ("Approve" / "Deny")
+# coming over the wire silently hides the third button for every shell
+# confirmation, even though the rest of the plumbing (suggested_pattern,
+# add_pattern, always) is wired up correctly.
+
+
+def test_confirmation_to_dict_omits_default_labels():
+    """Defaulted ConfirmationRequest yields empty labels on the wire so the
+    web UI's `c.approve_label ? '' : ...` conditional correctly enables the
+    third button (Allow / Always)."""
+    from decafclaw.confirmations import ConfirmationAction, ConfirmationRequest
+    from decafclaw.web.websocket import _confirmation_to_dict
+
+    req = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        action_data={"command": "tv list-screens",
+                     "suggested_pattern": "tv list-screens *"},
+        message="Shell command: `tv list-screens`",
+    )
+    payload = _confirmation_to_dict(req)
+    assert payload["approve_label"] == ""
+    assert payload["deny_label"] == ""
+    assert payload["suggested_pattern"] == "tv list-screens *"
+
+
+def test_confirmation_to_dict_preserves_custom_labels():
+    """When a tool sets custom labels (EndTurnConfirm flow), they pass through
+    unchanged. The web UI's third button stays hidden — the tool is asking
+    for a specific UI gate, not a generic shell allow."""
+    from decafclaw.confirmations import ConfirmationAction, ConfirmationRequest
+    from decafclaw.web.websocket import _confirmation_to_dict
+
+    req = ConfirmationRequest(
+        action_type=ConfirmationAction.CONTINUE_TURN,
+        message="Approve project state?",
+        approve_label="Approve",
+        deny_label="Needs Feedback",
+    )
+    payload = _confirmation_to_dict(req)
+    assert payload["approve_label"] == "Approve"
+    assert payload["deny_label"] == "Needs Feedback"
+
+
+def test_request_via_manager_uses_empty_label_defaults():
+    """When `request_confirmation` is called without `approve_label` /
+    `deny_label` extras (the shell path), the ConfirmationRequest that lands
+    at the manager has empty labels so the wire payload preserves them."""
+    import asyncio
+
+    from decafclaw.confirmations import (
+        ConfirmationAction,
+        ConfirmationRequest,
+        ConfirmationResponse,
+    )
+
+    captured: list[ConfirmationRequest] = []
+
+    async def fake_request_confirmation(request: ConfirmationRequest):
+        captured.append(request)
+        return ConfirmationResponse(
+            confirmation_id=request.confirmation_id, approved=False)
+
+    # Reach into the manager helper directly with a stub ctx — covers the
+    # default-label propagation without needing a full ConversationManager.
+    from decafclaw.tools.confirmation import _request_via_manager
+
+    class _ToolsState:
+        current_call_id = "call_test"
+
+    class _StubCtx:
+        tools = _ToolsState()
+        request_confirmation = staticmethod(fake_request_confirmation)
+
+    asyncio.run(_request_via_manager(
+        _StubCtx(), tool_name="shell", command="tv list-screens",
+        message="Shell command: `tv list-screens`", timeout=1.0,
+        suggested_pattern="tv list-screens *",
+    ))
+
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.action_type is ConfirmationAction.RUN_SHELL_COMMAND
+    assert req.approve_label == ""
+    assert req.deny_label == ""
+    assert req.action_data["suggested_pattern"] == "tv list-screens *"


### PR DESCRIPTION
## Summary

- `confirm-view.js` hides the third confirmation button (`Allow: <pattern>` for shell with a suggested pattern, `Always` otherwise) when `c.approve_label` is truthy — interpreting a non-empty label as "this tool wants a custom UI gate."
- Upstream defaulted `ConfirmationRequest.approve_label` and the `_request_via_manager` fallback to the literal strings `"Approve"` / `"Deny"`, so the JS condition always evaluated truthy and the third button never rendered for shell confirmations.
- Effect: every repeated CLI invocation (surfaced while exercising Television's `tv` CLI through bundled skills) required a fresh confirmation every turn, with no way to grant a pattern-scoped or blanket allow.
- Fix flips both defaults to empty strings. Wire-side consumers (`confirm-view.js:51,54`, `tool-status-store.js:203-204`, `websocket.py:618`) already use `||` / `.get(..., "")` fallbacks — empty was always the "no custom label" sentinel the contract expected.

### Scope notes

- `media.py:EndTurnConfirm` keeps its `"Approve"` / `"Deny"` defaults. All production callers (`skills/project/tools.py`) pass explicit labels, so changing it would be a no-op in practice and broaden the PR.
- Three regression tests added covering the wire contract directly (`_confirmation_to_dict` produces empty labels by default, preserves custom labels when set, and `_request_via_manager` propagates the empty default through).

## Test plan

- [x] `make check` passes (ruff + pyright + tsc + message-types drift)
- [x] `make test` passes (2646 tests)
- [x] New regression tests fail against pre-fix code, pass after the fix
- [ ] Manual: in the web UI, trigger any shell confirmation (e.g. via Television's `tv` CLI through a skill) and confirm the third button now appears as `Allow: <pattern>` (shell + suggested pattern present) or `Always` (no pattern)
- [ ] Manual: confirm `EndTurnConfirm`-based gates (e.g. project skill state advancement) still render only Approve / Deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)