### PR TITLE
fix(schedules): inject required-skill bodies + escape-hatch tools (closes #558)

### DIFF
--- a/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/notes.md
+++ b/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/notes.md
@@ -1,0 +1,43 @@
+# Notes
+
+## Summary
+
+Fixed the regression filed as #558: thin-trigger SCHEDULE.md (introduced in #556) was failing because `setup_schedule_ctx` pre-activated `required-skills` but discarded their body strings. Activated-by-tool-call bodies normally arrive as a `activate_skill` tool-result message; in a fresh scheduled-task conversation that path never fires, so the LLM saw only the one-line trigger.
+
+## Changes
+
+- `src/decafclaw/schedules.py`
+  - New `_render_required_skill_bodies(config, names)` helper builds a `<loaded_skills><skill name="…">…</skill></loaded_skills>` block, mirroring the always-loaded pattern in `prompts/__init__.py:107`. Substitutes `$SKILL_DIR` and HTML-escapes the skill name attribute. Returns `""` on no resolved bodies (unknown name → warning + skip; empty body → skip).
+  - `run_schedule_task` prepends the rendered block to `prompt` between `preamble` and the trigger body.
+  - `setup_schedule_ctx` allow-list union'd with `{tool_search, activate_skill}` so the model has an escape hatch if a future schedule misconfig drops the body. Not added to `preapproved` (they don't gate on confirmation).
+- `tests/test_schedules.py` — three regression tests under `TestRunScheduleTask`:
+  - `test_required_skill_body_injected_into_prompt` — asserts the SKILL.md body marker, `<loaded_skills>` wrapper, and ordering (body before trigger) appear in the user message routed to the agent loop.
+  - `test_unknown_required_skill_skipped_gracefully` — no crash, no empty wrapper.
+  - `test_escape_hatch_tools_exempt_from_allow_list` — both meta-tools land in `ctx.tools.allowed` alongside the schedule's explicit allow-list entries.
+- `docs/schedules.md` — documented body injection + escape-hatch exemption.
+
+## Test results
+
+`make check` clean. `make test`: 2705 passed, ~12s.
+
+## Out of scope (followups)
+
+- Same body-discard gap *may* exist in `commands.py:execute_command` for fork-context commands with `required-skills` that don't restate their dependency's instructions. Different failure mode (fork commands often inline their full body), but worth a separate audit.
+- The HEARTBEAT_OK sentinel issue (#553) is tangentially related — would have surfaced this regression louder if structured signaling existed. Not addressed here.
+
+## Retrospective
+
+### What went well
+
+- Root cause was clean: the diagnostic walk (commit log → SCHEDULE.md diff → `setup_schedule_ctx` → `activate_skill_internal` return-value path → `context_composer.py:495` comment confirming the design assumption) landed on the bug in one pass. The composer comment about "tool-result delivery" was load-bearing — without it, the fix could have gone in five different places.
+- Per-conversation activated bodies are explicitly *not* in the system prompt, so the fix had to live in the prompt assembly path for scheduled tasks specifically. Resisted the urge to generalize.
+- Escape-hatch exemption bundled in with the body fix. Different mechanism, same root-cause class ("the task is under-spec'd and the model has no way out"), so it belongs in the same PR.
+
+### Friction
+
+- The `setup_schedule_ctx` closure structure forced the body injection to live in the outer `run_schedule_task` scope, not inside the context-setup callback. That was the right split (prompt is finalized before enqueue) but took a moment to see.
+- No test caught this when #556 shipped. The existing `test_fork_required_skills_activated` only checks that `activate_skill_internal` was *called*, not that its return value reached the LLM. Worth a memory: when activation-by-side-effect is the design, test the body delivery, not just the call.
+
+### Memory candidates
+
+- **Pre-activated skill bodies are delivered via tool-result messages, not the system prompt.** Implication: any code path that pre-activates a skill in a fresh conversation must inject the body explicitly. Affects `setup_schedule_ctx`, possibly `commands.py:execute_command`. Anchor: `context_composer.py:495-497` comment.

--- a/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/plan.md
+++ b/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/plan.md
@@ -1,0 +1,27 @@
+# Plan
+
+1. **Implement body injection in `schedules.py:run_schedule_task`.**
+   - Add a helper that takes `config` + a list of required-skill names and returns a `<loaded_skills>...</loaded_skills>` block string (empty string if no resolved bodies).
+   - Resolve skills via `config.discovered_skills`; skip unknown names with a warning log.
+   - Substitute `$SKILL_DIR` using `skill_info.location.resolve()` (match `activate_skill_internal`).
+   - HTML-escape the skill name in the `<skill name="…">` attribute (match `prompts/__init__.py:106`).
+   - Prepend the block to `prompt` between `preamble` and `body`.
+
+2. **Escape-hatch exemption in `setup_schedule_ctx`.**
+   - When `allowed_tools_set is not None`, unconditionally `.update({"tool_search", "activate_skill"})`.
+   - Do NOT add to `preapproved` — those are user-confirmation bypasses for tools that would otherwise prompt; these tools don't need that treatment.
+
+3. **Regression test** in `tests/test_schedules.py`:
+   - Build a `SkillInfo` with `body="MASTODON-SKILL-BODY-MARKER"` and `name="mastodon-ingest"`.
+   - Build a `ScheduleTask` with `required_skills=["mastodon-ingest"]`, body `"Follow the mastodon-ingest skill instructions to completion."`.
+   - Patch `manager.enqueue_turn` (AsyncMock) to capture kwargs and resolve with a future returning `"ok"`.
+   - Stub `config.discovered_skills`.
+   - Run `run_schedule_task` and assert `kwargs["prompt"]` contains `"MASTODON-SKILL-BODY-MARKER"` and `"<loaded_skills>"`.
+   - Second test: ensure missing required-skill name is skipped without raising.
+   - Third test: assert `tool_search` and `activate_skill` are added to `ctx.tools.allowed` when a schedule has an allow-list.
+
+4. **Lint + typecheck + tests.** `make check && make test`.
+
+5. **Docs.** Update `docs/schedules.md` to mention the body-injection behavior and the escape-hatch exemption.
+
+6. **Commit + PR.** Branch already created (`fix-558-schedule-skill-body`). Single commit. PR closes #558.

--- a/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/spec.md
+++ b/docs/dev-sessions/2026-05-20-1508-schedule-skill-body-fix/spec.md
@@ -1,0 +1,59 @@
+# Fix scheduled-task skill body delivery (#558)
+
+## Problem
+
+After PR #556 made `SCHEDULE.md` a thin trigger, scheduled tasks run with no skill instructions in context. The LLM receives only the one-line trigger, has no skill body, and can't recover because the schedule's `allowed-tools` allow-list strips `tool_search` and `activate_skill`.
+
+Affected: bundled `dream` / `garden` / `newsletter`, contrib `kindle` / `linkding-ingest` / `mastodon-ingest`.
+
+Root cause: `schedules.py:setup_schedule_ctx` calls `activate_skill_internal` and discards the returned body. The composer-rendered system prompt only contains always-loaded skill bodies; per-conversation activated bodies normally arrive as tool-result messages, which doesn't happen for pre-activated skills in a fresh scheduled-task conversation.
+
+## Goals
+
+1. Pre-activated `required-skills` deliver their full SKILL.md body to the LLM in scheduled tasks.
+2. `tool_search` and `activate_skill` are not filtered out by the schedule allow-list, so future misconfigs aren't dead-ends.
+3. Regression test prevents silent recurrence.
+
+## Non-goals
+
+- Re-architecting context composition or moving per-conversation activated bodies into the system prompt for the general case.
+- Changing the command path (`commands.py`) — same gap exists in principle but the failure mode there is different and out of scope for this fix.
+- HEARTBEAT_OK sentinel restructuring (#553).
+
+## Design
+
+### Body injection
+
+Inject pre-activated skill bodies into the user prompt for scheduled tasks, before the trigger text, wrapped in the same `<loaded_skills><skill name="…">…</skill></loaded_skills>` pattern that `prompts/__init__.py` uses for always-loaded skills.
+
+`$SKILL_DIR` substitution must match what `activate_skill_internal` does (uses `skill_info.location.resolve()`).
+
+### Where to inject
+
+`run_schedule_task` already builds the prompt before calling `manager.enqueue_turn`. The cleanest split:
+
+- `setup_schedule_ctx` continues to call `activate_skill_internal` (tools wiring, init, mark activated).
+- `run_schedule_task` separately resolves the SkillInfo objects for the task's required-skills and renders their bodies into a `<loaded_skills>` block prepended to the prompt.
+
+That keeps the body string outside the context-setup callback (which runs after enqueue) and avoids re-encoding through the agent loop.
+
+If a required skill name doesn't resolve to a discovered SkillInfo, log and skip — same fail-open behavior as the activation path.
+
+### Escape hatch
+
+In `setup_schedule_ctx` where `allowed_tools_set` is built, unconditionally add `tool_search` and `activate_skill` to the set before assigning to `ctx.tools.allowed`. These don't grant capabilities by themselves — they're meta-tools the model needs to recover from an under-spec'd task. Same `preapproved` shape (no confirmation needed).
+
+### Test
+
+Add to `tests/test_schedules.py`: build a fake SkillInfo with a recognizable body string, build a `ScheduleTask` with `required_skills=[name]` and a thin-trigger body, mock `manager.enqueue_turn` to capture the `prompt` arg, run `run_schedule_task`, assert the captured prompt contains both the `<loaded_skills>` wrapper and the skill body.
+
+## Out of scope follow-ups
+
+- Same gap may exist in `commands.py:execute_command` for fork-context commands with `required-skills` that don't restate the dependency's instructions. Worth a separate audit.
+
+## Acceptance
+
+- `make check` passes.
+- `make test` passes.
+- New regression test covers the thin-trigger + required-skills path.
+- Manual verification: a scheduled run of mastodon-ingest produces a prompt with the SKILL.md body inline.

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -165,7 +165,11 @@ required-skills:
   - health
 ```
 
-Skills are activated without permission checks (same as heartbeat admin sections).
+Skills are activated without permission checks (same as heartbeat admin sections). The full `SKILL.md` body of each listed skill is rendered as a `<loaded_skills><skill name="…">…</skill></loaded_skills>` block prepended to the task prompt, so a thin trigger body (e.g. *"Time for the scheduled Mastodon ingestion. Follow the mastodon-ingest skill instructions to completion."*) has the skill's instructions inline rather than relying on the LLM to ask for them. `$SKILL_DIR` is substituted to the skill's absolute location, matching `activate_skill`.
+
+### Allow-list escape hatch
+
+When a schedule supplies `allowed-tools`, the resulting allow-list is automatically extended with `tool_search` and `activate_skill`. Both are no-cost meta-tools that let the model recover if a task is under-spec'd (e.g. a required skill body fails to inject, or the allow-list misses a needed dependency). They do not grant capabilities by themselves.
 
 ## Examples
 

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -1,6 +1,7 @@
 """Scheduled tasks — cron-style task files with per-task scheduling."""
 
 import asyncio
+import html
 import logging
 import re
 import time
@@ -352,6 +353,44 @@ def is_due(config, task: ScheduleTask) -> bool:
 # -- Task execution -----------------------------------------------------------
 
 
+# tool_search lets the model recover deferred tools; activate_skill lets it
+# load additional skill bodies. Scheduled tasks pre-activate required-skills
+# and ship a tight allowed-tools list, so without this exemption the model
+# has no escape hatch if the task is under-spec'd or the body fails to land.
+_SCHEDULE_ESCAPE_HATCH_TOOLS = frozenset({"tool_search", "activate_skill"})
+
+
+def _render_required_skill_bodies(config, skill_names: list[str]) -> str:
+    """Render `<loaded_skills>` block for pre-activated required-skills.
+
+    Scheduled tasks ship a thin trigger in SCHEDULE.md and rely on
+    `required-skills` to bring the SKILL.md body into context. Always-loaded
+    skill bodies make it into the prompt via `prompts/__init__.py`, but
+    per-conversation activated bodies normally arrive as `activate_skill`
+    tool-result messages — a path that doesn't fire for scheduled tasks
+    (no prior turn). This helper builds the equivalent block so a thin
+    trigger has something to act on. Returns "" if nothing resolves.
+    """
+    if not skill_names:
+        return ""
+    skill_map = {s.name: s for s in (config.discovered_skills or [])}
+    blocks: list[str] = []
+    for name in skill_names:
+        info = skill_map.get(name)
+        if info is None:
+            log.warning(f"Schedule references unknown required-skill {name!r}; "
+                        f"skipping body injection")
+            continue
+        if not info.body:
+            continue
+        body = info.body.replace("$SKILL_DIR", str(info.location.resolve()))
+        safe_name = html.escape(info.name, quote=True)
+        blocks.append(f'<skill name="{safe_name}">\n{body}\n</skill>')
+    if not blocks:
+        return ""
+    return "<loaded_skills>\n" + "\n".join(blocks) + "\n</loaded_skills>"
+
+
 async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
                              conv_id: str | None = None) -> dict:
     """Run a single scheduled task as an agent turn via ConversationManager.
@@ -372,6 +411,10 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
         allowed_tools_set = set(task.allowed_tools)
         if task.shell_patterns:
             allowed_tools_set.add("shell")  # ensure shell tool is visible
+        # Keep tool_search / activate_skill reachable so the model has
+        # an escape hatch if the task is under-spec'd. They don't grant
+        # capabilities on their own.
+        allowed_tools_set |= _SCHEDULE_ESCAPE_HATCH_TOOLS
         preapproved = set(task.allowed_tools)
 
     skill_dir = str(task.path.parent.resolve())
@@ -419,7 +462,8 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
 
     preamble = build_task_preamble("scheduled task", task.name)
     body = substitute_body(task.body, skill_dir=str(task.path.parent.resolve()))
-    prompt = preamble + body
+    loaded_skills = _render_required_skill_bodies(config, required_skills)
+    prompt = preamble + (f"{loaded_skills}\n\n" if loaded_skills else "") + body
 
     try:
         future = await manager.enqueue_turn(

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -501,6 +501,114 @@ class TestRunScheduleTask:
         assert result["channel"] == "#reports"
 
     @pytest.mark.asyncio
+    async def test_required_skill_body_injected_into_prompt(self, config):
+        """Thin-trigger SCHEDULE.md must deliver the required-skill body to the LLM.
+
+        Regression test for #558: pre-activated required-skills were being
+        marked activated but their body was discarded, so the LLM saw only
+        the one-line trigger.
+        """
+        from decafclaw.conversation_manager import ConversationManager
+        from decafclaw.skills import SkillInfo
+
+        config.discovered_skills = [
+            SkillInfo(
+                name="mastodon-ingest",
+                description="Mastodon ingest",
+                location=Path("/fake/skill/dir"),
+                body="MASTODON-SKILL-BODY-MARKER\nFetch and summarize posts.",
+            ),
+        ]
+
+        manager = ConversationManager(config, EventBus())
+        task = ScheduleTask(
+            name="mastodon-ingest", schedule="* * * * *",
+            body="Time for the scheduled Mastodon ingestion. "
+                 "Follow the mastodon-ingest skill instructions to completion.",
+            source="extra", path=Path("/fake"),
+            required_skills=["mastodon-ingest"],
+        )
+
+        captured: dict = {}
+
+        async def fake_run(ctx, user_message, history, **kwargs):
+            from decafclaw.media import ToolResult
+            captured["user_message"] = user_message
+            return ToolResult(text="done")
+
+        with patch("decafclaw.agent.run_agent_turn", side_effect=fake_run):
+            await run_schedule_task(config, EventBus(), manager, task)
+
+        prompt = captured["user_message"]
+        assert "MASTODON-SKILL-BODY-MARKER" in prompt
+        assert "<loaded_skills>" in prompt
+        assert '<skill name="mastodon-ingest">' in prompt
+        # Trigger text still present, body comes before trigger
+        assert "Follow the mastodon-ingest skill instructions" in prompt
+        assert prompt.index("MASTODON-SKILL-BODY-MARKER") < prompt.index(
+            "Follow the mastodon-ingest skill instructions"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_required_skill_skipped_gracefully(self, config):
+        """Missing required-skill name logs a warning but doesn't raise."""
+        from decafclaw.conversation_manager import ConversationManager
+
+        config.discovered_skills = []  # nothing resolves
+        manager = ConversationManager(config, EventBus())
+        task = ScheduleTask(
+            name="ghost-task", schedule="* * * * *",
+            body="trigger", source="admin", path=Path("/fake"),
+            required_skills=["does-not-exist"],
+        )
+
+        captured: dict = {}
+
+        async def fake_run(ctx, user_message, history, **kwargs):
+            from decafclaw.media import ToolResult
+            captured["user_message"] = user_message
+            return ToolResult(text="done")
+
+        with patch("decafclaw.agent.run_agent_turn", side_effect=fake_run):
+            result = await run_schedule_task(config, EventBus(), manager, task)
+
+        # No body to inject, but no crash and no <loaded_skills> wrapper
+        assert "<loaded_skills>" not in captured["user_message"]
+        assert result["response"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_escape_hatch_tools_exempt_from_allow_list(self, config):
+        """tool_search + activate_skill must pass the schedule allow-list filter.
+
+        Regression test for #558: without this exemption the model has no way
+        to recover from an under-spec'd task.
+        """
+        from decafclaw.conversation_manager import ConversationManager
+
+        manager = ConversationManager(config, EventBus())
+        task = ScheduleTask(
+            name="locked-down", schedule="* * * * *",
+            body="trigger", source="admin", path=Path("/fake"),
+            allowed_tools=["vault_read", "current_time"],
+        )
+
+        captured: dict = {}
+
+        async def fake_run(ctx, user_message, history, **kwargs):
+            captured["allowed"] = set(ctx.tools.allowed or set())
+            from decafclaw.media import ToolResult
+            return ToolResult(text="done")
+
+        with patch("decafclaw.agent.run_agent_turn", side_effect=fake_run):
+            await run_schedule_task(config, EventBus(), manager, task)
+
+        assert "tool_search" in captured["allowed"]
+        assert "activate_skill" in captured["allowed"]
+        # Original allow-list entries preserved
+        assert "vault_read" in captured["allowed"]
+        assert "current_time" in captured["allowed"]
+
+    @pytest.mark.asyncio
     async def test_routes_through_manager(self, config):
         """run_schedule_task routes turns through ConversationManager.enqueue_turn."""
         from decafclaw.conversation_manager import ConversationManager, TurnKind


### PR DESCRIPTION
## Summary

- After #556 made `SCHEDULE.md` a thin trigger relying on `required-skills`, scheduled tasks ran with no skill instructions in context — the LLM saw only the one-line trigger and returned `HEARTBEAT_OK` without doing anything. Affected: bundled `dream` / `garden` / `newsletter` and contrib `kindle` / `linkding-ingest` / `mastodon-ingest`.
- Root cause: `setup_schedule_ctx` called `activate_skill_internal` (wiring up tools + marking activated) but discarded the returned body. Per-conversation activated bodies only reach the LLM as `activate_skill` tool-result messages — a path that doesn't fire for fresh scheduled-task conversations. Confirmed by `context_composer.py:495-497`.
- Compounding: the schedule's `allowed-tools` allow-list stripped `tool_search` and `activate_skill`, so the model had no way to recover.

## Changes

- New `_render_required_skill_bodies` helper in `schedules.py` builds a `<loaded_skills><skill name="…">…</skill></loaded_skills>` block from each required skill's `SkillInfo.body`, mirroring the always-loaded pattern in `prompts/__init__.py:107`. `$SKILL_DIR` is substituted to the skill's absolute location and the name attribute is HTML-escaped.
- `run_schedule_task` prepends the block to the task prompt between preamble and trigger body.
- `setup_schedule_ctx` unions `{tool_search, activate_skill}` into the schedule allow-list so future under-spec'd tasks aren't dead-ends. Not added to `preapproved` — these meta-tools don't gate on confirmation.
- Three regression tests in `tests/test_schedules.py::TestRunScheduleTask`: body injection, missing-skill graceful skip, and escape-hatch exemption.
- Docs updated in `docs/schedules.md` (Pre-activated skills + Allow-list escape hatch sections).

## Test plan

- [x] `make check` clean (ruff, pyright, tsc, message-types).
- [x] `make test` — 2705 passed in ~12s.
- [x] `uv run pytest tests/test_schedules.py` — 45 passed.
- [ ] Manual: trigger a scheduled mastodon-ingest run after merge + deploy; verify the LLM sees the SKILL.md body inline and actually performs the ingest.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)