### PR TITLE
fix(web): copy/history/context 404 on system conversations

### DIFF
--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -559,12 +559,11 @@ async def rename_conversation(request: Request, username: str) -> JSONResponse:
 @_authenticated
 async def get_conversation_history(request: Request, username: str) -> JSONResponse:
     """Load paginated conversation history."""
-    from .web.conversations import ConversationIndex
+    from .web.conversations import ConversationIndex, can_read_conversation
     config = request.app.state.config
     conv_id = request.path_params["id"]
     index = ConversationIndex(config)
-    conv = index.get(conv_id)
-    if not conv or conv.user_id != username:
+    if not can_read_conversation(config, index, conv_id, username):
         return JSONResponse({"error": "not found"}, status_code=404)
     limit = int(request.query_params.get("limit", "50"))
     before = request.query_params.get("before", "")
@@ -576,12 +575,11 @@ async def get_conversation_history(request: Request, username: str) -> JSONRespo
 async def get_context_diagnostics(request: Request, username: str) -> JSONResponse:
     """Return context composer diagnostics for a conversation."""
     from .context_composer import read_context_sidecar
-    from .web.conversations import ConversationIndex
+    from .web.conversations import ConversationIndex, can_read_conversation
     config = request.app.state.config
     conv_id = request.path_params["id"]
     index = ConversationIndex(config)
-    conv = index.get(conv_id)
-    if not conv or conv.user_id != username:
+    if not can_read_conversation(config, index, conv_id, username):
         return JSONResponse({"error": "not found"}, status_code=404)
     data = read_context_sidecar(config, conv_id)
     if data is None:
@@ -599,7 +597,7 @@ async def export_conversation(request: Request, username: str) -> Response:
     """
     from .archive import archive_path, read_archive
     from .conversation_export import render_markdown
-    from .web.conversations import ConversationIndex
+    from .web.conversations import ConversationIndex, can_read_conversation
     config = request.app.state.config
     conv_id = request.path_params["id"]
     fmt = request.query_params.get("format", "")
@@ -609,8 +607,7 @@ async def export_conversation(request: Request, username: str) -> Response:
             status_code=400,
         )
     index = ConversationIndex(config)
-    conv = index.get(conv_id)
-    if not conv or conv.user_id != username:
+    if not can_read_conversation(config, index, conv_id, username):
         return JSONResponse({"error": "not found"}, status_code=404)
     # Both formats gate on the archive file existing; an empty or corrupt
     # file is still a legitimate (if uninteresting) export — the markdown

--- a/src/decafclaw/web/conversations.py
+++ b/src/decafclaw/web/conversations.py
@@ -97,6 +97,29 @@ def list_system_conversations(config, username: str = "",
     return results[:limit]
 
 
+def can_read_conversation(config, index: "ConversationIndex", conv_id: str,
+                          username: str) -> bool:
+    """Whether ``username`` may read the conversation ``conv_id``.
+
+    Web conversations (those tracked in ``web_conversations.json``) are
+    gated by ``user_id``; another user's web conversation is rejected
+    even if its archive happens to exist on disk. System conversations
+    (schedule, heartbeat, delegated children) live only as archive
+    files — they're readable by any authenticated user as long as the
+    archive exists, mirroring the on-disk discovery model used by
+    ``list_system_conversations``.
+    """
+    from ..archive import archive_path
+    conv = index.get(conv_id)
+    if conv and conv.user_id == username:
+        return True
+    # A `web-` prefix without `--child-` is a top-level web conversation
+    # owned by some other user — never fall through to the on-disk check.
+    if conv_id.startswith("web-") and "--child-" not in conv_id:
+        return False
+    return archive_path(config, conv_id).exists()
+
+
 @dataclass
 class ConversationMeta:
     """Metadata for a web UI conversation."""

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -199,18 +199,12 @@ async def _handle_load_history(ws_send: WSSendCallable, index, username, msg, st
     if not _is_safe_conv_id(conv_id):
         await ws_send({"type": WSMessageType.ERROR, "message": "Invalid conversation ID"})
         return
+    from .conversations import can_read_conversation
     conv = index.get(conv_id)
-    is_owner = conv and conv.user_id == username
-    if not is_owner:
-        # Reject other users' web conversations
-        if conv_id.startswith("web-") and "--child-" not in conv_id:
-            await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
-            return
-        # Allow read-only access if archive exists on disk (system conversations)
-        from ..archive import archive_path
-        if not archive_path(config, conv_id).exists():
-            await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
-            return
+    is_owner = bool(conv and conv.user_id == username)
+    if not can_read_conversation(config, index, conv_id, username):
+        await ws_send({"type": WSMessageType.ERROR, "message": "Conversation not found"})
+        return
     try:
         limit = min(max(1, int(msg.get("limit", 50))), 500)
     except (TypeError, ValueError):

--- a/tests/test_web_conversations.py
+++ b/tests/test_web_conversations.py
@@ -379,6 +379,97 @@ async def test_export_no_archive_file_is_404(authed_client):
 
 
 @pytest.mark.asyncio
+async def test_export_system_conv_with_archive(authed_client, http_config):
+    """System conversations (schedule/heartbeat) live on disk without a
+    ConversationIndex entry. Export should still work — read access is
+    granted by archive-on-disk for non-`web-` conv IDs, mirroring the
+    behavior of the WS load_history handler."""
+    conv_dir = http_config.workspace_path / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    conv_id = "schedule-mastodon-ingest-20260520-053002"
+    archive = conv_dir / f"{conv_id}.jsonl"
+    archive.write_text(
+        '{"role":"user","content":"run the ingest","timestamp":"2026-05-20T05:30:02Z"}\n'
+        '{"role":"assistant","content":"done","timestamp":"2026-05-20T05:30:10Z"}\n'
+    )
+
+    resp = await authed_client.get(
+        f"/api/conversations/{conv_id}/export?format=jsonl"
+    )
+    assert resp.status_code == 200
+    assert resp.content == archive.read_bytes()
+
+    resp = await authed_client.get(
+        f"/api/conversations/{conv_id}/export?format=markdown"
+    )
+    assert resp.status_code == 200
+    assert resp.text.startswith(f"# Conversation {conv_id}")
+    assert "run the ingest" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_history_system_conv_with_archive(authed_client, http_config):
+    """REST /history should also serve system conversations (same access
+    model as WS load_history and /export)."""
+    conv_dir = http_config.workspace_path / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    conv_id = "heartbeat-20260520-053000-0"
+    (conv_dir / f"{conv_id}.jsonl").write_text(
+        '{"role":"user","content":"tick"}\n'
+    )
+
+    resp = await authed_client.get(f"/api/conversations/{conv_id}/history")
+    assert resp.status_code == 200
+    assert len(resp.json()["messages"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_context_diagnostics_system_conv(authed_client, http_config):
+    """REST /context should also serve system conversations."""
+    conv_dir = http_config.workspace_path / "conversations"
+    conv_dir.mkdir(parents=True, exist_ok=True)
+    conv_id = "schedule-newsletter-20260520-080000"
+    (conv_dir / f"{conv_id}.jsonl").write_text("{}\n")
+    # /context reads a sidecar; write a minimal one so the endpoint returns 200.
+    import json
+    (conv_dir / f"{conv_id}.context.json").write_text(
+        json.dumps({"messages": [], "tools": [], "diagnostics": {}})
+    )
+
+    resp = await authed_client.get(f"/api/conversations/{conv_id}/context")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_export_other_user_web_conv_is_404(app, http_config):
+    """A `web-` conv owned by someone else must remain inaccessible even
+    if the archive happens to exist on disk — the system-conv fallback
+    must not leak cross-user web conversations."""
+    http_config.workspace_path.mkdir(parents=True, exist_ok=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as alice:
+        token = create_token(http_config, "alice")
+        resp = await alice.post("/api/auth/login", json={"token": token})
+        alice.cookies = resp.cookies
+        create_resp = await alice.post(
+            "/api/conversations", json={"title": "alice's"}
+        )
+        conv_id = create_resp.json()["conv_id"]
+        append_message(http_config, conv_id, {"role": "user", "content": "secret"})
+
+    async with AsyncClient(transport=transport, base_url="http://test") as bob:
+        token = create_token(http_config, "bob")
+        resp = await bob.post("/api/auth/login", json={"token": token})
+        bob.cookies = resp.cookies
+        # Archive exists on disk, but the conv is owned by alice — bob
+        # must not get read access via the system-conv fallback.
+        resp = await bob.get(
+            f"/api/conversations/{conv_id}/export?format=jsonl"
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_export_empty_archive_file_renders_header(authed_client, http_config):
     """Archive file exists but is empty (e.g. corrupt or never appended-to):
     JSONL returns the empty bytes, markdown returns the header-only doc.


### PR DESCRIPTION
## Summary

Two fixes for the Copy ▾ menu on the deployed agent (plain-HTTP, system conversation):

**1. Server-side 404 on system conversations (`3f7b6d9`)**

The Copy ▾ button on a schedule-*/heartbeat-* conversation 404'd because `export_conversation` gated read access on `ConversationIndex.get()`, which only contains web-created conversations (`web_conversations.json`). System conversations live as archive files on disk and are discovered via `list_system_conversations`, so the index lookup always returned `None`. Same bug existed in the REST `/history` and `/context` endpoints; only the WS `_handle_load_history` had the correct on-disk fallback.

Extracted `can_read_conversation(config, index, conv_id, username)` in `web/conversations.py` mirroring the WS handler's logic (own web conv → allow; other-user `web-` non-child → reject; otherwise grant if archive exists on disk). Adopted in all four call sites (3 REST + 1 WS) so the check can't drift back into open-coded copies.

Regression tests cover export / history / context on schedule and heartbeat archives that aren't in the conversation index, plus a cross-user `web-` privacy case ensuring the on-disk fallback doesn't leak other users' web conversations.

**2. Clipboard fallback for non-secure contexts (`363a500`)**

Once the 404 was fixed, the next error was `can't access property "writeText", navigator.clipboard is undefined` — the deployed agent runs on plain `http://decafclaw:18880/` and `navigator.clipboard` is only defined in secure contexts (HTTPS/localhost). Extracted `copyToClipboard(text)` in `web/static/lib/clipboard.js` that prefers the modern API in secure contexts and falls back to a hidden-textarea + `document.execCommand('copy')` path otherwise. Adopted in both the Copy ▾ menu and the per-code-block Copy button on assistant messages (which had the same latent bug).

Reported by Les: clicking Copy on `schedule-mastodon-ingest-20260520-053002` produced first the `404 not found` toast, then the clipboard-undefined toast.

## Test plan

- [x] `make check` clean (ruff + pyright + tsc)
- [x] `make test` — 2702 passed
- [ ] Manual on deployed agent: open a `schedule-*` conversation, click Copy ▾ → Copy as JSONL and Copy as markdown — both should land in the clipboard with a success toast (no 404, no clipboard-undefined error)
- [ ] Manual on deployed agent: open the context-inspector popover on the same conversation — diagnostics should render instead of "no context data"
- [ ] Manual on deployed agent: per-code-block Copy button on a long assistant response still works