### PR TITLE
fix(schedules): expand $SKILL_DIR via required-skill location for overlays

### DIFF
--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -360,6 +360,31 @@ def is_due(config, task: ScheduleTask) -> bool:
 _SCHEDULE_ESCAPE_HATCH_TOOLS = frozenset({"tool_search", "activate_skill"})
 
 
+def _resolve_skill_dir(config, task: "ScheduleTask") -> str:
+    """Resolve `$SKILL_DIR` substitutions for a scheduled task.
+
+    Overlay schedules at `data/{agent_id}/schedules/{name}.md` shadow a
+    skill's SCHEDULE.md but no longer sit next to the skill's scripts,
+    so `task.path.parent` is the wrong anchor for `$SKILL_DIR` — the
+    pattern would whitelist the schedules dir while the SKILL.md body
+    (expanded via `info.location` in `_render_required_skill_bodies`)
+    points the agent at the original skill dir, and the preapproval
+    check fails to match.
+
+    Resolution order: discovered SkillInfo matching `task.name` (which
+    equals the original skill dir name for skill-derived schedules,
+    including overlays) > first `required-skills` entry > task file's
+    parent dir as fallback for genuinely skill-independent schedules.
+    """
+    skill_map = {s.name: s for s in (config.discovered_skills or [])}
+    info = skill_map.get(task.name)
+    if info is None and task.required_skills:
+        info = skill_map.get(task.required_skills[0])
+    if info is not None:
+        return str(info.location.resolve())
+    return str(task.path.parent.resolve())
+
+
 def _render_required_skill_bodies(config, skill_names: list[str]) -> str:
     """Render `<loaded_skills>` block for pre-activated required-skills.
 
@@ -417,7 +442,7 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
         allowed_tools_set |= _SCHEDULE_ESCAPE_HATCH_TOOLS
         preapproved = set(task.allowed_tools)
 
-    skill_dir = str(task.path.parent.resolve())
+    skill_dir = _resolve_skill_dir(config, task)
     shell_patterns = None
     if task.shell_patterns:
         shell_patterns = [
@@ -461,7 +486,7 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
     from .polling import build_task_preamble
 
     preamble = build_task_preamble("scheduled task", task.name)
-    body = substitute_body(task.body, skill_dir=str(task.path.parent.resolve()))
+    body = substitute_body(task.body, skill_dir=skill_dir)
     loaded_skills = _render_required_skill_bodies(config, required_skills)
     prompt = preamble + (f"{loaded_skills}\n\n" if loaded_skills else "") + body
 

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -373,13 +373,23 @@ def _resolve_skill_dir(config, task: "ScheduleTask") -> str:
 
     Resolution order: discovered SkillInfo matching `task.name` (which
     equals the original skill dir name for skill-derived schedules,
-    including overlays) > first `required-skills` entry > task file's
-    parent dir as fallback for genuinely skill-independent schedules.
+    including overlays) > first `required-skills` entry that resolves
+    against `discovered_skills` > task file's parent dir as fallback for
+    genuinely skill-independent schedules.
+
+    Iterating all `required-skills` (not just the first) matches
+    `_render_required_skill_bodies`, which silently skips unresolvable
+    names and injects whatever else resolves. Stopping at index 0 here
+    would let an unresolvable primary entry quietly desync the shell
+    pattern from a body that still got injected from a later entry.
     """
     skill_map = {s.name: s for s in (config.discovered_skills or [])}
     info = skill_map.get(task.name)
-    if info is None and task.required_skills:
-        info = skill_map.get(task.required_skills[0])
+    if info is None:
+        for name in task.required_skills:
+            info = skill_map.get(name)
+            if info is not None:
+                break
     if info is not None:
         return str(info.location.resolve())
     return str(task.path.parent.resolve())

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -609,6 +609,67 @@ class TestRunScheduleTask:
         assert "current_time" in captured["allowed"]
 
     @pytest.mark.asyncio
+    async def test_overlay_resolves_skill_dir_via_required_skill(self, config):
+        """$SKILL_DIR in overlay shell_patterns resolves to the original skill dir.
+
+        Regression test: when an admin overlay at
+        ``data/{agent_id}/schedules/{name}.md`` shadows a contrib skill's
+        SCHEDULE.md, ``task.path.parent`` is the schedules dir — not where
+        the skill's scripts live. ``_render_required_skill_bodies`` expands
+        ``$SKILL_DIR`` in the SKILL.md body via ``info.location``, so the
+        agent runs the real script path, but the preapproval pattern was
+        anchored to the schedules dir and never matched — confirmation
+        popped and the scheduled turn denied it.
+        """
+        from decafclaw.conversation_manager import ConversationManager
+        from decafclaw.skills import SkillInfo
+
+        real_skill_dir = Path("/real/contrib/skills/mastodon-ingest")
+        config.discovered_skills = [
+            SkillInfo(
+                name="mastodon-ingest",
+                description="Mastodon ingest",
+                location=real_skill_dir,
+                body="Run $SKILL_DIR/fetch.sh and ingest posts.",
+            ),
+        ]
+
+        manager = ConversationManager(config, EventBus())
+        overlay_path = config.agent_path / "schedules" / "mastodon-ingest.md"
+        task = ScheduleTask(
+            name="mastodon-ingest", schedule="* * * * *",
+            body="Run the scheduled cycle.",
+            source="admin", path=overlay_path,
+            required_skills=["mastodon-ingest"],
+            shell_patterns=["$SKILL_DIR/fetch.sh*"],
+            allowed_tools=["vault_read"],
+        )
+
+        captured: dict = {}
+
+        async def fake_run(ctx, user_message, history, **kwargs):
+            from decafclaw.media import ToolResult
+            captured["shell_patterns"] = list(
+                ctx.tools.preapproved_shell_patterns or []
+            )
+            captured["prompt"] = user_message
+            return ToolResult(text="done")
+
+        with patch("decafclaw.agent.run_agent_turn", side_effect=fake_run):
+            await run_schedule_task(config, EventBus(), manager, task)
+
+        # Pattern anchored on the actual skill dir, not the overlay's parent.
+        assert captured["shell_patterns"] == [
+            f"{real_skill_dir}/fetch.sh*"
+        ]
+        # SCHEDULE.md body substitution uses the same anchor — important once
+        # SCHEDULE.md bodies start referencing $SKILL_DIR themselves.
+        assert "fetch.sh and ingest posts." in captured["prompt"]
+        assert str(overlay_path.parent) not in captured["prompt"].split(
+            "Run the scheduled cycle."
+        )[0]
+
+    @pytest.mark.asyncio
     async def test_routes_through_manager(self, config):
         """run_schedule_task routes turns through ConversationManager.enqueue_turn."""
         from decafclaw.conversation_manager import ConversationManager, TurnKind

--- a/tests/test_schedules.py
+++ b/tests/test_schedules.py
@@ -670,6 +670,58 @@ class TestRunScheduleTask:
         )[0]
 
     @pytest.mark.asyncio
+    async def test_skill_dir_iterates_required_skills_for_first_resolvable(
+        self, config,
+    ):
+        """`$SKILL_DIR` resolution skips unresolvable required-skill entries.
+
+        `_render_required_skill_bodies` iterates all `required-skills` and
+        silently skips names that aren't in `discovered_skills` (logging a
+        warning). If `required_skills[0]` is missing but `required_skills[1]`
+        resolves, the body still gets injected — so the shell-pattern and
+        body-substitution `$SKILL_DIR` anchor must follow the same rule, or
+        a body successfully expanded to a real skill dir would land next to
+        a preapproval pattern anchored on the schedule file's parent.
+        """
+        from decafclaw.conversation_manager import ConversationManager
+        from decafclaw.skills import SkillInfo
+
+        secondary_dir = Path("/real/contrib/skills/tabstack")
+        # Only the second required-skill is discovered.
+        config.discovered_skills = [
+            SkillInfo(
+                name="tabstack",
+                description="Tabstack",
+                location=secondary_dir,
+                body="Tabstack body.",
+            ),
+        ]
+
+        manager = ConversationManager(config, EventBus())
+        task = ScheduleTask(
+            name="missing-primary", schedule="* * * * *",
+            body="trigger", source="admin", path=Path("/fake"),
+            required_skills=["never-discovered", "tabstack"],
+            shell_patterns=["$SKILL_DIR/run.sh*"],
+        )
+
+        captured: dict = {}
+
+        async def fake_run(ctx, user_message, history, **kwargs):
+            from decafclaw.media import ToolResult
+            captured["shell_patterns"] = list(
+                ctx.tools.preapproved_shell_patterns or []
+            )
+            return ToolResult(text="done")
+
+        with patch("decafclaw.agent.run_agent_turn", side_effect=fake_run):
+            await run_schedule_task(config, EventBus(), manager, task)
+
+        # Anchored on tabstack's location (the first resolvable required-skill),
+        # not the unresolvable primary and not the schedule file's parent.
+        assert captured["shell_patterns"] == [f"{secondary_dir}/run.sh*"]
+
+    @pytest.mark.asyncio
     async def test_routes_through_manager(self, config):
         """run_schedule_task routes turns through ConversationManager.enqueue_turn."""
         from decafclaw.conversation_manager import ConversationManager, TurnKind


### PR DESCRIPTION
## Summary

- `run_schedule_task` was expanding `$SKILL_DIR` in shell patterns via `task.path.parent.resolve()`. For SCHEDULE.md sitting next to its skill that's correct, but for an admin overlay at `data/{agent_id}/schedules/{name}.md` (the path the new sidebar UI writes when you enable a contrib schedule) it resolves to the schedules dir, not the contrib skill dir.
- The SKILL.md body — injected by `_render_required_skill_bodies` since #558 — correctly expands `$SKILL_DIR` via `info.location`, so the agent runs the real `…/contrib/skills/mastodon-ingest/fetch.sh`. The scoped shell pattern, anchored on the overlay dir, never matched that path → `check_shell_approval` falls through to confirmation → `SCHEDULED_TASK` mode denies it → cycle aborts with `[error: shell command was denied by user]`.
- Fix: new `_resolve_skill_dir(config, task)` resolves `$SKILL_DIR` via discovered-skill lookup. Order: SkillInfo matching `task.name` (equals the original skill dir name for skill-derived schedules, including overlays) > first `required-skills` entry > `task.path.parent` fallback for genuine standalone schedules. Both the shell-pattern expansion and the `substitute_body` call route through it so they stay consistent with the SKILL.md body expansion.
- Live impact: mastodon-ingest and linkding-ingest overlay schedules in my deployment have been denying their own fetch scripts since the overlay system shipped in #554.

## Test plan

- [x] Added regression test `TestRunScheduleTask::test_overlay_resolves_skill_dir_via_required_skill` — constructs an overlay-shaped `ScheduleTask` whose path lives in the schedules dir but whose `required_skills[0]` points at a SkillInfo with a different location; asserts the resulting `preapproved_shell_patterns` are anchored on the discovered skill's dir, not the overlay's parent.
- [x] Sabotage-checked the test by reverting to the old `task.path.parent.resolve()` expansion — the new test fails with the expected diff (`/tmp/.../schedules/fetch.sh*` vs `/real/contrib/skills/mastodon-ingest/fetch.sh*`).
- [x] `pytest tests/test_schedules.py` — 46 pass.
- [x] Full suite `pytest tests/` — 2651 pass.
- [x] `make lint` clean; pyright clean.
- [ ] Verify in live deployment: trigger mastodon-ingest / linkding-ingest manually via Run now in the sidebar and confirm fetch.sh executes without the denial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)