### PR TITLE
feat(tabstack): SDK 2.6.1 refresh + interactive form-fill

### DIFF
--- a/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/notes.md
+++ b/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/notes.md
@@ -1,0 +1,80 @@
+# Notes — Tabstack interactive automate + SDK refresh
+
+## Investigation (2026-05-31)
+
+- Installed `tabstack` is **2.3.0** (pin `>=2.3.0`); local checkout at
+  `~/devel/tabstack-python` is **2.6.1**.
+- Changelog gap:
+  - 2.4.0 added the `automate_input` endpoint (interactive form-data handshake).
+  - 2.6.0 swapped the `/automate` SSE root to a typed discriminated-union event model.
+- **Current skill breakage:** `tools.py` reads `event.message/finalAnswer/report/
+  metadata` at the top level; real payload is under `event.data` (both 2.3.0 dict and
+  2.6.1 typed). `extract.json`/`generate.json` now return plain dicts, so `result.data`
+  is also broken.
+- Event envelope (2.6.1): `AutomateEvent` and `ResearchEvent` both = union of
+  `{event: <discriminator>, data: <typed payload>}`.
+  - automate final answer: `.data.final_answer` on `complete`/`task:completed`/
+    `task:validated`/`task:aborted`.
+  - research final answer: `.data.report` on `complete`.
+- Interactive: `automate(interactive=True, data={...})`; on
+  `interactive:form_data:request` (and `:error` re-request) the stream carries
+  `request_id` + `fields[{ref,label,fieldType,required,options}]`. Answer via
+  `agent.automate_input(request_id, fields=[{ref,value}])` or `cancelled=True`.
+  Request expires after 2 min (`410 Gone`).
+
+## Design decisions (from Les)
+
+- **Scope:** agent-supplied data (not live human-in-the-loop — infeasible in the turn
+  model: stream dies across a turn pause, 2-min request expiry).
+- **Safety:** confirmation gate before submitting personal data into a form, using the
+  inline-blocking `request_confirmation` pattern (same as `send_email`).
+- **Process:** tracked dev session on a worktree from main.
+
+## Progress log
+
+- **Phase 1+2 (commit `00f716d`)** — bumped pin to `>=2.6.1`; rewrote automate/research
+  event handling against the typed `.data` envelope (dispatch on `event` discriminator);
+  fixed `extract_json`/`generate` plain-dict responses; added `data`+`interactive` params,
+  `_match_fields`, confirmation gate via `request_confirmation`, graceful cancel + missing-
+  field reporting, `_safe_input` (swallows 410 Gone); raised `tabstack_automate` per-tool
+  timeout to 300s.
+- **Phase 3 (commit `ea03992`)** — SKILL.md interactive docs; `tests/test_tabstack_tools.py`
+  (12 tests incl. a guard sabotage-check); two `tool_choice` eval cases.
+- **Phase 4** — `docs/skills.md` tabstack section updated; PR opened (#569).
+- **Follow-up (richer progress)** — expanded `_automate_progress` to narrate the
+  high-signal events the typed union now exposes (step counter, navigation title,
+  action + ref, action failures, extraction, waiting, reconnect, validation). Two
+  fixes folded in: (a) the top-level `error` event and unsuccessful `complete` nest
+  the message under `data.error.message` (was reading `data.message` → hard errors
+  surfaced nothing); now `_automate_error_text` extracts it and `_compose_automate_result`
+  reports `[error: ...]`. (b) **Safety:** `agent:action`/`browser:action_started` carry
+  the typed-in `value` (potentially the personal data we just confirmed) — progress
+  never echoes `value`. Form handling now narrates the field *labels*, never values.
+  Tests + guards added (value-leak guard, error extraction).
+
+## Findings during execution
+
+- **Default model is `vertex-gemini-flash`.** `make eval-tools` is noisy on Flash — a
+  `<no_tool>` epidemic across unrelated pre-existing cases (web-fetch, vault-notes,
+  workspace-write, ask-choice, delegate). Baseline isn't all-green; this is the
+  "evals guard structure, tuning from live smoke testing" reality.
+- **First eval case draft was bad.** "fill out the form with my email and name" (no
+  values) → the model reasonably *asks for the data* (`<no_tool>`) rather than calling a
+  tool. Lesson: tool_choice form-fill scenarios must include concrete data inline, or the
+  correct behavior is to pause-and-ask. Revised cases pass 2/2 stably on Flash.
+- Verified the guard with a real sabotage edit (`if False and missing:`) — the
+  missing-required test fails as intended, then reverted.
+
+## Live validation
+
+- **Happy path confirmed (Les, live).** `interactive=true` form-fill against a real form
+  worked end-to-end: the `interactive:form_data:request` fired, the confirmation gate
+  appeared, and submission completed. This was the #1 open caveat — the typed
+  interactive request path is verified against live tabstack.
+
+## Remaining smoke-test TODOs
+
+- Missing-field retry loop (omit a required value → cancel + report → re-run).
+- Confirmation deny path (decline → cancelled, nothing submitted).
+- Confirm non-interactive automate + research still extract answers correctly.
+- Watch for `410 Gone` if approval is slow (>2 min); confirm it's reported, not crashed.

--- a/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/plan.md
+++ b/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/plan.md
@@ -1,0 +1,73 @@
+# Plan — Tabstack interactive automate + SDK refresh
+
+Worktree: `.claude/worktrees/tabstack-interactive-automate`
+Branch: `worktree-tabstack-interactive-automate`
+
+## Phase 1 — SDK bump + event/response rewrite (foundation, fixes existing breakage)
+
+1. Bump pin in `pyproject.toml`: `tabstack>=2.3.0` → `tabstack>=2.6.1`. `uv sync`.
+2. Rewrite `src/decafclaw/skills/tabstack/tools.py` event handling:
+   - Add `_event_payload(event)` → `event.data`; dispatch on `event.event`.
+   - `tool_tabstack_automate`: progress from `agent:status`/`agent:reasoned`/
+     `agent:action`/`browser:*`/`done`; final answer = first non-empty
+     `.data.final_answer` across `complete`/`task:completed`/`task:validated`/
+     `task:aborted`; surface `error`/`ai:generation:error` `.data.message`.
+   - `tool_tabstack_research`: progress from `.data.message`; final answer =
+     `complete` event `.data.report`; surface `error` `.data.message`.
+   - Delete `_get_field` / `_get_report` / `_log_stream_event` getattr poking.
+   - Fix `extract_json` / `generate` to use `result` (plain dict), drop `result.data`
+     and the `# type: ignore`.
+3. `make lint && make typecheck` clean.
+4. **Commit:** "refresh(tabstack): SDK 2.6.1 typed events + dict extract/generate".
+
+## Phase 2 — Interactive form-fill with agent-supplied data + confirmation gate
+
+1. Add params to `tool_tabstack_automate`: `data: dict | None = None`,
+   `interactive: bool = False`. Pass `data=`/`interactive=` through to
+   `agent.automate(...)` (omit when not given).
+2. Handle `interactive:form_data:request` / `interactive:form_data:error` events:
+   - `_match_fields(requested_fields, data)` → (`matched=[{ref,value}]`, `missing=[labels]`)
+     by case-insensitive label/key match (exact-key fallback).
+   - If required fields missing → `await client.agent.automate_input(request_id,
+     cancelled=True)`; accumulate missing labels into the result summary.
+   - Else → `request_confirmation(ctx, tool_name="tabstack_automate", command=...,
+     message=<form_description + page_url + field→value pairs>)`. Approve →
+     `automate_input(request_id, fields=matched)`. Deny → `automate_input(request_id,
+     cancelled=True)` + note denial. Honor `always`/preapproval return for the run.
+   - Wrap `automate_input` in try/except for `410 Gone` (expired window) → report.
+3. Raise `tabstack_automate` per-tool `timeout` in `TOOL_DEFINITIONS` to ~300s.
+4. Update `tabstack_automate` TOOL_DEFINITIONS: add `data` (object) + `interactive`
+   (boolean) params with descriptions; note confirmation gating in the description.
+5. `make lint && make typecheck` clean.
+6. **Commit:** "feat(tabstack): interactive form-fill with agent-supplied data + gate".
+
+## Phase 3 — SKILL.md + tests + evals
+
+1. SKILL.md: document interactive mode, the `data` param shape (keys ≈ field labels),
+   the confirmation behavior, and the "supply data up front, retry with missing fields"
+   loop. Update the `tabstack_automate` section + choosing-the-right-tool guidance.
+2. Unit tests (`tests/`): mock `AsyncTabstack` async stream emitting typed events.
+   - Final-answer + progress extraction for automate and research (2.6.1 shapes).
+   - Interactive: all-required-present → gate fires → approve → `automate_input(fields=)`.
+   - Missing required field → `automate_input(cancelled=True)` + missing reported.
+   - Deny → `automate_input(cancelled=True)` + denial reported.
+   - Sabotage-check: break the required-field guard, confirm a test fails.
+   - extract_json / generate return-shape (plain dict) round-trip.
+3. Eval: `evals/tool_choice/` — keep/sharpen a case routing browser-interaction /
+   form-fill tasks to `tabstack_automate` (not `tabstack_research`). Minimal; prompt
+   tuning comes from live smoke testing per project norms.
+4. `make test` green; check `pytest --durations=25` for the new tests.
+5. **Commit:** "docs+test(tabstack): interactive mode docs, unit tests, tool_choice eval".
+
+## Phase 4 — Retro
+
+- Update `notes.md` with a final summary, surprises, and live-smoke-test TODOs.
+- Open PR. Live-test in web UI / Mattermost after merge (real form-fill behavior).
+
+## Risk notes
+
+- Confirmation round-trip must resolve inside tabstack's 2-min input window; default
+  60s confirmation timeout fits. Catch `410 Gone` on slow approvals.
+- Field-matching is intentionally simple; the missing-fields report + agent retry loop
+  is the safety net, not a fuzzy matcher.
+- Don't break non-interactive automate (default `interactive=False`, no `data`).

--- a/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/spec.md
+++ b/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/spec.md
@@ -1,0 +1,139 @@
+# Spec — Tabstack interactive automate + SDK refresh
+
+## Problem
+
+The `tabstack` skill targets `tabstack>=2.3.0`, but the SDK has advanced two minor
+versions and our usage is now stale and partly broken:
+
+- **2.4.0** added the `automate_input` endpoint — the interactive human-in-the-loop
+  form-data handshake.
+- **2.6.0** replaced the `/automate` SSE root with a fully-typed discriminated-union
+  event model (`AutomateEvent` = union of envelopes discriminated on `event`, payload
+  in `.data`).
+
+Our `tools.py` reads `event.message`, `event.finalAnswer`, `event.report`,
+`event.metadata` at the **top level** of each event via `getattr` poking
+(`_get_field` / `_get_report`). In both 2.3.0 (untyped `event.data` dict) and 2.6.1
+(typed `event.data`) the payload lives under `.data`, so this poking returns `None` —
+progress messages and final-answer extraction don't line up with the real shape. It's
+also exactly the "getattr-fallback maintenance trap" the project conventions warn
+against.
+
+Observed symptom: an agent using `tabstack_automate` against a form-bearing page
+(Google Maps transit) hit "request_user_data was cancelled". That is the tabstack
+server cancelling its own form-data request because nothing answered it in time — we
+never enabled `interactive=True` and never wired up `automate_input`, so any form-fill
+the server attempts dies after the 2-minute input window.
+
+## Goals
+
+1. **Refresh the SDK** to `>=2.6.1` and rewrite event handling against the typed
+   discriminated-union model. Read payloads from `event.data` keyed off the `event`
+   discriminator instead of `getattr` poking. This alone fixes the current breakage.
+2. **Support interactive form-fill with agent-supplied data.** The agent passes a
+   `data` blob (personal info gathered beforehand) plus `interactive=True`; when the
+   stream emits an `interactive:form_data:request` (or `:error`) event, the tool
+   matches requested fields against `data`, submits matched values via `automate_input`,
+   and cancels gracefully for missing required fields — reporting which fields were
+   missing so the agent can ask the user and retry.
+3. **Gate form submission behind a confirmation.** Submitting personal data into a web
+   form is an outward-facing, sensitive action; route it through `request_confirmation`
+   (the same inline-blocking pattern `send_email` uses) showing the form description,
+   page URL, and the field→value pairs about to be submitted.
+
+## Non-goals
+
+- **Live human-in-the-loop** (pause the turn, show the user a form widget, resume the
+  live SSE stream). Infeasible in DecafClaw's turn model: a tool returns a single
+  result, and `WidgetInputPause` *ends* the turn and resumes on a *new* turn — by then
+  the SSE stream is dead and the 2-minute `request_id` has expired. Keeping the tabstack
+  stream alive across a turn pause is background-task machinery and out of scope.
+- Changing `extract`/`generate` behavior beyond what the SDK bump requires.
+
+## Design
+
+### Event handling (both automate and research)
+
+The new events are typed pydantic models with an `event` string discriminator and a
+typed `data` payload. Switch on `event.event`:
+
+- **Progress** (publish `tool_status`): `agent:status` (`.data.message`),
+  `agent:reasoned` (`.data.reasoning`), `agent:action` (`.data.action`),
+  `browser:navigated` / `browser:action_started` (human-readable), `done`/`error`
+  (`.data.message`).
+- **Final answer** (automate): first non-empty `.data.final_answer` seen across
+  `complete`, `task:completed`, `task:validated`, `task:aborted`.
+- **Final answer** (research): `ResearchEvent` — report on the final/complete event
+  (mirror the automate approach against that union).
+- **Errors**: `error` / `ai:generation:error` → surface `.data.message`.
+
+Both `AutomateEvent` and `ResearchEvent` use the same envelope (`event` discriminator +
+typed `.data`). Research final answer = the `complete` event's `.data.report`; progress
+= each event's `.data.message`. Replace `_get_field` / `_get_report` getattr poking with
+discriminator-keyed access. A tiny `_event_payload(event)` helper returning `event.data`
+is fine; the dispatch keys off `event.event`.
+
+### Extract / generate response-shape fix (also broken)
+
+In 2.6.1 `extract.json()` and `generate.json()` return **plain dicts**
+(`ExtractJsonResponse` / `GenerateJsonResponse` are now `Dict[str, object]`), not
+objects with a `.data` attribute. The current `result.data` access (carrying a
+`# type: ignore[attr-defined]`) is broken — use `result` directly. `extract.markdown()`
+still returns `ExtractMarkdownResponse` with `.content` (unchanged).
+
+### Interactive form-fill
+
+`tool_tabstack_automate(ctx, task, url=None, data=None, interactive=False)`:
+
+- `data`: dict of personal/contextual info for form filling. Passed through to the SDK
+  `data=` param (tabstack's own agent uses it as context) **and** used by our handler to
+  answer `form_data:request` events.
+- `interactive`: when `True`, pass `interactive=True` to the SDK and handle
+  `interactive:form_data:request` / `interactive:form_data:error` events:
+  1. For each requested field (`ref`, `label`, `field_type`, `required`, `options`),
+     match against `data` by case-insensitive key/label correspondence.
+  2. Build the `fields=[{ref, value}, ...]` list from matches.
+  3. If any **required** field is unmatched → cancel via
+     `automate_input(request_id, cancelled=True)`, record the missing field labels, and
+     let the run end; the tool result reports the missing fields back to the agent.
+  4. Otherwise route through the **confirmation gate** (`request_confirmation`,
+     `tool_name="tabstack_automate"`) showing `form_description`, `page_url`, and the
+     field→value pairs. On approve → `automate_input(request_id, fields=...)`. On deny →
+     `automate_input(request_id, cancelled=True)` and report the denial.
+
+`interactive` defaults `False`, so existing read-only/search automate calls are
+unaffected and never prompt.
+
+### Timeout
+
+`tabstack_automate` currently uses the default 180s per-tool timeout. Interactive runs
+add a confirmation round-trip plus tabstack's input window and can exceed 180s. Raise
+the per-tool `timeout` for `tabstack_automate` in `TOOL_DEFINITIONS` (target ~300s) so
+interactive runs don't get killed mid-handshake. (The SDK's own request timeout already
+defaults to 600s for streaming endpoints.)
+
+## Acceptance criteria
+
+- Pin is `tabstack>=2.6.1`; `make lint` / `make typecheck` clean against the typed events.
+- `tabstack_automate` and `tabstack_research` extract final answers and publish progress
+  correctly against the 2.6.1 event shapes (unit tests with mocked streams).
+- A `form_data:request` event with all required fields present in `data` → confirmation
+  gate fires → on approve, `automate_input` called with matched `{ref, value}` fields.
+- Missing required field → `automate_input(cancelled=True)`; tool result names the
+  missing fields.
+- Confirmation deny → `automate_input(cancelled=True)`; tool result reports denial.
+- Non-interactive automate calls never prompt and behave as before.
+- `tool_choice` eval still routes form-fill / browser-interaction tasks to
+  `tabstack_automate` (not `tabstack_research`).
+- SKILL.md documents interactive mode, the `data` param, and the confirmation behavior.
+
+## Open questions / risks
+
+- **Field matching heuristic.** Start simple: case-insensitive match of `data` keys
+  against field `label` (and exact-key fallback). Document that `data` keys should
+  mirror field labels. Fuzzy matching deferred.
+- **Multiple forms in one run.** Each `form_data:request` gets its own gate; the
+  confirmation `always` return can pre-approve for the rest of the run (mirrors
+  shell/email preapproval).
+- **2-minute expiry.** Confirmation default timeout (60s) fits inside the window; if the
+  user is slow, tabstack returns `410 Gone` on `automate_input` — catch and report.

--- a/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/todo.md
+++ b/docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/todo.md
@@ -1,0 +1,39 @@
+# TODO — Tabstack interactive automate + SDK refresh
+
+## Phase 1 — SDK bump + event/response rewrite
+- [x] Bump pin `tabstack>=2.6.1` in pyproject.toml; `uv sync`
+- [x] `_event_payload`/discriminator dispatch (via `_automate_progress` + kind checks)
+- [x] Rewrite automate event handling (progress + final answer + errors)
+- [x] Rewrite research event handling (progress + report + errors)
+- [x] Delete `_get_field` / `_get_report` / `_log_stream_event`
+- [x] Fix extract_json / generate to use plain-dict result
+- [x] lint + typecheck clean
+- [x] Commit
+
+## Phase 2 — Interactive form-fill + gate
+- [x] Add `data` + `interactive` params to tabstack_automate
+- [x] `_match_fields` (matched / missing)
+- [x] Missing required → automate_input(cancelled=True) + report
+- [x] Confirmation gate → approve → automate_input(fields=)
+- [x] Deny → automate_input(cancelled=True) + report
+- [x] 410 Gone handling (`_safe_input` swallows + logs)
+- [x] Raise per-tool timeout 300s
+- [x] Update TOOL_DEFINITIONS (data + interactive params, gate note)
+- [x] lint + typecheck clean
+- [x] Commit
+
+## Phase 3 — Docs + tests + evals
+- [x] SKILL.md: interactive mode, data param, gate, retry loop
+- [x] Unit tests: automate/research extraction (2.6.1 shapes)
+- [x] Unit tests: interactive approve / missing / deny
+- [x] Sabotage-check on required-field guard (verified by breaking prod code)
+- [x] Unit tests: extract_json / generate dict shape
+- [x] tool_choice eval cases (2/2 pass on Flash, ran twice)
+- [x] make test green (2719 passed); durations clean
+- [x] Commit
+
+## Phase 4 — Retro
+- [x] notes.md final summary + live-smoke TODOs
+- [x] docs/skills.md tabstack section updated
+- [ ] Open PR
+- [ ] Live test web UI / Mattermost (post-merge)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -317,9 +317,11 @@ Activated skills and their tools are scoped to the current conversation. Other c
 
 ### tabstack
 
-Web browsing, content extraction, research, and browser automation via the Tabstack API. Requires `TABSTACK_API_KEY`.
+Web browsing, content extraction, research, and browser automation via the Tabstack API (SDK >= 2.6.1). Requires `TABSTACK_API_KEY`.
 
 Tools: `tabstack_extract_markdown`, `tabstack_extract_json`, `tabstack_generate`, `tabstack_automate`, `tabstack_research`
+
+`tabstack_automate` supports **interactive form-fill**: pass `interactive: true` plus a `data` dict (keyed by form field label) and the browser agent's form-data requests are answered from `data`, gated by a per-submission user confirmation. Missing required fields cancel the request and are reported back for a retry. See the skill's `SKILL.md` for details.
 
 ### claude_code
 

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -159,6 +159,30 @@
     The "PREFER canvas_new_tab" guidance applies to interactive web
     content the user wants displayed, not to authoring file artifacts.
 
+# -- tabstack_automate vs tabstack_research ----------------------------------
+
+- name: tabstack-automate-vs-research-form-fill
+  scenario: "Go to https://example.com/signup and submit the newsletter signup form for me — use the email ada@example.com and the name Ada Lovelace."
+  expected: tabstack_automate
+  near_miss: [tabstack_research]
+  notes: |
+    Submitting a web form on a specific URL is browser interaction —
+    tabstack_automate (with interactive form-fill). tabstack_research only
+    searches and synthesizes sources; it can't click or submit a form. The
+    data is given inline so the model has no reason to pause and ask for it
+    first — keep concrete values in the scenario, or the model reasonably
+    answers with a question instead of a tool call.
+
+- name: tabstack-research-vs-automate-multi-source
+  scenario: "Research and write me a cited comparison of the privacy practices of Signal, Telegram, and WhatsApp, drawing on multiple expert sources."
+  expected: tabstack_research
+  near_miss: [tabstack_automate]
+  notes: |
+    Multi-source synthesis with explicit citations is the deep-research
+    case. No URL and "drawing on multiple expert sources" pushes past
+    tabstack_automate's built-in single search — automate has no synthesis
+    or citation step.
+
 # -- ask_user_multiple_choice vs ask_user_text -------------------------------
 
 - name: ask-text-vs-choice-free-form-name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "requests>=2.0.0",
     "sqlite-vec>=0.1.7",
     "starlette>=0.52.1",
-    "tabstack>=2.3.0",
+    "tabstack>=2.6.1",
     "uvicorn>=0.41.0",
     "websockets>=16.0",
 ]

--- a/src/decafclaw/skills/tabstack/SKILL.md
+++ b/src/decafclaw/skills/tabstack/SKILL.md
@@ -30,6 +30,22 @@ Best for: tasks needing real browser interaction — clicking, navigating across
 
 Takes 30-120 seconds.
 
+**Interactive form-fill.** To let the browser agent fill a form that needs personal data, set `interactive: true` and pass the values in `data`, keyed by field label:
+
+```json
+{"task": "Sign up for the newsletter", "url": "https://example.com",
+ "interactive": true,
+ "data": {"Email": "ada@example.com", "Full name": "Ada Lovelace"}}
+```
+
+When the browser hits a form it answers from `data`. Each submission is shown to the user for **confirmation** before any personal data is sent — so don't put secrets you wouldn't want surfaced in a prompt into `data`. Behavior:
+
+- **Match by field label** (case-insensitive). `data` keys should mirror the form's field labels.
+- **Missing required field** → that form request is cancelled and the missing field name(s) are reported back in the result. Gather the values (ask the user) and re-run with them added to `data`.
+- **User declines the confirmation** → the submission is cancelled and reported.
+
+Gather the data you can up front (from the user, USER.md, or the vault) before calling — the missing-field report is a fallback, not the happy path. Without `interactive: true`, `tabstack_automate` never prompts and behaves as a normal read/search/click task.
+
 ### 5. `tabstack_research` — AI-powered deep web research
 
 Searches the web, analyzes multiple sources, and synthesizes a comprehensive answer with citations. For simple factual lookups, `tabstack_automate` without a URL is faster and cheaper. Use `tabstack_research` when you need depth, multiple perspectives, or cited sources.

--- a/src/decafclaw/skills/tabstack/tools.py
+++ b/src/decafclaw/skills/tabstack/tools.py
@@ -1,12 +1,18 @@
-"""Tabstack skill tools — web browsing, extraction, research, and automation."""
+"""Tabstack skill tools — web browsing, extraction, research, and automation.
+
+Targets tabstack SDK >= 2.6.1, where `/automate` and `/research` stream a typed
+discriminated union of events (`event` discriminator + typed `.data` payload), and
+`extract.json` / `generate.json` return plain dicts.
+"""
 
 import json
 import logging
 from dataclasses import dataclass, field
 
-from tabstack import AsyncTabstack
+from tabstack import APIStatusError, AsyncTabstack
 
 from decafclaw.media import ToolResult
+from decafclaw.tools.confirmation import request_confirmation
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +46,7 @@ def _get_client() -> AsyncTabstack:
     return _client
 
 
-# -- Tool implementations ---------------------------------------------------
+# -- Read / extract tools ---------------------------------------------------
 
 async def tool_tabstack_extract_markdown(ctx, url: str) -> ToolResult:
     """Extract clean Markdown from a web page or PDF."""
@@ -59,12 +65,11 @@ async def tool_tabstack_extract_json(ctx, url: str, json_schema: dict) -> ToolRe
     """Extract structured JSON data from a web page or PDF."""
     log.info(f"[tool:tabstack_extract_json] {url}")
     try:
+        # SDK >= 2.6: extract.json returns the parsed object directly (a dict).
         result = await _get_client().extract.json(url=url, json_schema=json_schema)
-        # `text` keeps the human-readable rendering; `data["result"]` is
-        # the parsed object so scripts skip the `json.loads` step.
         return ToolResult(
-            text=json.dumps(result.data, indent=2),  # type: ignore[attr-defined]
-            data={"url": url, "result": result.data},  # type: ignore[attr-defined]
+            text=json.dumps(result, indent=2),
+            data={"url": url, "result": result},
         )
     except Exception as e:
         return ToolResult(text=f"[error: {e}]")
@@ -74,41 +79,301 @@ async def tool_tabstack_generate(ctx, url: str, json_schema: dict, instructions:
     """Transform web/PDF content into structured JSON using LLM instructions."""
     log.info(f"[tool:tabstack_generate] {url}")
     try:
+        # SDK >= 2.6: generate.json returns the parsed object directly (a dict).
         result = await _get_client().generate.json(
             url=url, json_schema=json_schema, instructions=instructions
         )
-        return json.dumps(result.data, indent=2)  # type: ignore[attr-defined]
+        return json.dumps(result, indent=2)
     except Exception as e:
         return f"[error: {e}]"
 
 
-async def tool_tabstack_automate(ctx, task: str, url: str | None = None) -> str:
-    """Run a multi-step browser automation task."""
-    log.info(f"[tool:tabstack_automate] task={task} url={url}")
+# -- Automate (with optional interactive form-fill) -------------------------
+
+# Events whose payload carries a `final_answer` (alias finalAnswer).
+_AUTOMATE_FINAL_EVENTS = frozenset(
+    {"complete", "task:completed", "task:validated", "task:aborted"}
+)
+_AUTOMATE_FORM_EVENTS = frozenset(
+    {"interactive:form_data:request", "interactive:form_data:error"}
+)
+
+
+async def tool_tabstack_automate(
+    ctx,
+    task: str,
+    url: str | None = None,
+    data: dict | None = None,
+    interactive: bool = False,
+) -> str:
+    """Run a multi-step browser automation task.
+
+    When ``interactive`` is true, the browser agent may pause on a form and request
+    field values. Those requests are answered from the supplied ``data`` dict — gated
+    by a user confirmation before any personal data is submitted. Required fields not
+    found in ``data`` cause the request to be cancelled and reported back so the caller
+    can gather them and retry.
+    """
+    log.info(
+        "[tool:tabstack_automate] task=%s url=%s interactive=%s data_keys=%s",
+        task, url, interactive, sorted((data or {}).keys()),
+    )
     try:
-        kwargs = {"task": task}
+        client = _get_client()
+        kwargs: dict = {"task": task}
         if url:
             kwargs["url"] = url
-        stream = await _get_client().agent.automate(**kwargs)  # type: ignore[arg-type]
+        if interactive:
+            kwargs["interactive"] = True
+            # `data` is only meaningful for interactive form-fill; never forward it
+            # otherwise, so a non-interactive call can't leak personal data.
+            if data:
+                kwargs["data"] = data
+        stream = await client.agent.automate(**kwargs)
 
-        final_answer = None
+        final_answer: str | None = None
+        error_message: str | None = None
+        form_notes: list[str] = []
         async for event in stream:
-            _log_stream_event("automate", event)
+            kind = getattr(event, "event", None)
 
-            # Publish progress
-            msg = _get_field(event, "message")
+            msg = _automate_progress(event)
             if msg:
+                log.info("[tool:tabstack_automate] %s", msg)
                 await ctx.publish("tool_status", tool="tabstack_automate", message=msg)
 
-            # SDK v2: fields are directly on the event object
-            answer = _get_field(event, "finalAnswer") or _get_report(event)
-            if answer:
-                final_answer = answer
+            if kind in _AUTOMATE_FINAL_EVENTS:
+                # final_answer is consistently aliased across these payload types;
+                # getattr keeps us off per-variant isinstance branches for the union.
+                answer = getattr(event.data, "final_answer", None)
+                if answer:
+                    final_answer = answer
+                error_message = _automate_error_text(event) or error_message
+            elif kind == "error":
+                # Top-level uncaught error escaping the task runner.
+                error_message = _automate_error_text(event) or error_message
+            elif kind in _AUTOMATE_FORM_EVENTS:
+                note = await _handle_form_request(ctx, client, event, data or {})
+                if note:
+                    form_notes.append(note)
 
-        return final_answer or "[error: automate stream ended without a final answer]"
+        return _compose_automate_result(final_answer, error_message, form_notes)
     except Exception as e:
         return f"[error: {e}]"
 
+
+# Progress lines are trimmed to keep the live narration tidy.
+_PROGRESS_MAX = 200
+
+
+def _truncate(text: str, limit: int = _PROGRESS_MAX) -> str:
+    text = " ".join(str(text).split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _automate_progress(event) -> str | None:
+    """Extract a human-readable progress line from an automate stream event.
+
+    Surfaces the high-signal events as a running narration. Deliberately omits
+    the typed-in ``value`` on action events — it can contain the personal data we
+    just confirmed — and skips the noisy/huge events (screenshots, raw LLM
+    generations, metrics, debug). Unmapped events return None and are dropped.
+    """
+    kind = getattr(event, "event", None)
+    data = getattr(event, "data", None)
+    if data is None:
+        return None
+    if kind == "agent:step":
+        n = getattr(data, "current_iteration", None)
+        return f"step {int(n)}" if n is not None else None
+    if kind == "agent:status":
+        return getattr(data, "message", None)
+    if kind == "agent:reasoned":
+        reasoning = getattr(data, "reasoning", None)
+        return _truncate(reasoning) if reasoning else None
+    if kind == "agent:action":
+        # Note: data.value (text typed into a field) is intentionally NOT shown.
+        action = getattr(data, "action", None)
+        ref = getattr(data, "ref", None)
+        if not action:
+            return None
+        return f"→ {action} ({ref})" if ref else f"→ {action}"
+    if kind == "browser:action_completed":
+        # Success is implied by forward progress; only surface failures.
+        if getattr(data, "success", True):
+            return None
+        err = getattr(data, "error", None)
+        return f"action failed: {_truncate(err)}" if err else "action failed"
+    if kind == "browser:navigated":
+        title = getattr(data, "title", None)
+        nav_url = getattr(data, "url", None)
+        if title and nav_url:
+            return f"opened {title} — {nav_url}"
+        return f"opened {nav_url}" if nav_url else None
+    if kind == "agent:extracted":
+        extracted = getattr(data, "extracted_data", None)
+        return f"extracted: {_truncate(extracted, 120)}" if extracted else None
+    if kind == "agent:waiting":
+        secs = getattr(data, "seconds", None)
+        return f"waiting {int(secs)}s" if secs is not None else None
+    if kind == "browser:reconnected":
+        return "browser reconnected"
+    if kind == "task:validated":
+        quality = getattr(data, "completion_quality", None)
+        return f"validated ({quality})" if quality else "validated"
+    if kind == "task:validation_error":
+        return "validation retry"
+    if kind == "error":
+        return _automate_error_text(event)
+    return None
+
+
+def _automate_error_text(event) -> str | None:
+    """Pull a human-readable error message out of an error-bearing event.
+
+    Handles task:aborted (``reason``), the top-level ``error`` event and an
+    unsuccessful ``complete`` (both nest the message under ``data.error.message``).
+    """
+    kind = getattr(event, "event", None)
+    data = getattr(event, "data", None)
+    if data is None:
+        return None
+    if kind == "task:aborted":
+        reason = getattr(data, "reason", None)
+        return f"task aborted: {_truncate(reason)}" if reason else "task aborted"
+    err = getattr(data, "error", None)
+    if err is not None:
+        message = getattr(err, "message", None)
+        if message:
+            return _truncate(message)
+    return None
+
+
+def _compose_automate_result(
+    final_answer: str | None, error_message: str | None, form_notes: list[str],
+) -> str:
+    parts: list[str] = []
+    if final_answer:
+        parts.append(final_answer)
+    elif error_message:
+        parts.append(f"[error: {error_message}]")
+    if form_notes:
+        parts.append("\n".join(form_notes))
+    if not parts:
+        return "[error: automate stream ended without a final answer]"
+    return "\n\n".join(parts)
+
+
+async def _handle_form_request(ctx, client, event, data: dict) -> str | None:
+    """Answer (or cancel) an interactive form-data request.
+
+    Returns a human-readable note to fold into the tool result, or None.
+    """
+    fd = event.data
+    request_id = getattr(fd, "request_id", None)
+    page_url = getattr(fd, "page_url", "") or ""
+    form_description = getattr(fd, "form_description", "") or ""
+    fields = list(getattr(fd, "fields", []) or [])
+
+    if not request_id:
+        return None
+
+    # Narrate the form, never the values being entered.
+    label_list = ", ".join(getattr(f, "label", "?") for f in fields) or "(no fields)"
+    await ctx.publish(
+        "tool_status", tool="tabstack_automate",
+        message=_truncate(f"form on {page_url}: {label_list}"),
+    )
+
+    matched, missing = _match_fields(fields, data)
+
+    if missing:
+        await _safe_input(client, request_id, cancelled=True)
+        labels = ", ".join(missing)
+        return (
+            f"[interactive: could not fill required field(s) on {page_url}: {labels}. "
+            f"Re-run tabstack_automate with these values in `data` to continue.]"
+        )
+
+    approval = await request_confirmation(
+        ctx,
+        tool_name="tabstack_automate",
+        command=f"submit form on {page_url}" if page_url else "submit web form",
+        message=_format_form_confirmation(form_description, page_url, fields, matched),
+    )
+    if not approval.get("approved"):
+        await _safe_input(client, request_id, cancelled=True)
+        return f"[interactive: form submission on {page_url} was declined by the user.]"
+
+    await _safe_input(client, request_id, fields=matched)
+    return None
+
+
+def _match_fields(fields, data: dict) -> tuple[list[dict], list[str]]:
+    """Match requested form fields against the supplied data dict.
+
+    Matching is case-insensitive on the field label (with an exact-key fallback).
+    Returns ``(matched, missing)`` where ``matched`` is a list of ``{ref, value}``
+    pairs and ``missing`` lists the labels of unmatched *required* fields.
+    """
+    lookup = {str(k).strip().lower(): v for k, v in (data or {}).items()}
+    matched: list[dict] = []
+    missing: list[str] = []
+    for f in fields:
+        label = getattr(f, "label", "") or ""
+        ref = getattr(f, "ref", None)
+        required = bool(getattr(f, "required", False))
+        value = lookup.get(label.strip().lower())
+        if value is None or ref is None:
+            if required:
+                missing.append(label or (ref or "?"))
+            continue
+        matched.append({"ref": ref, "value": str(value)})
+    return matched, missing
+
+
+def _format_form_confirmation(
+    form_description: str, page_url: str, fields, matched: list[dict],
+) -> str:
+    """Render the confirmation body shown before submitting form data."""
+    # Map ref -> field for label/type lookup when rendering submitted values.
+    by_ref = {getattr(f, "ref", None): f for f in fields}
+    lines = []
+    if form_description:
+        lines.append(form_description)
+    if page_url:
+        lines.append(f"Page: {page_url}")
+    lines.append("--- submitting ---")
+    for pair in matched:
+        f = by_ref.get(pair["ref"])
+        label = getattr(f, "label", pair["ref"]) if f else pair["ref"]
+        field_type = getattr(f, "field_type", None) if f else None
+        shown = "••••" if field_type == "password" else pair["value"]
+        lines.append(f"{label}: {shown}")
+    return "\n".join(lines)
+
+
+async def _safe_input(client, request_id, *, fields=None, cancelled=False) -> None:
+    """POST a form-input response.
+
+    Swallows only an expired/consumed input window (HTTP 410 Gone) — the one error
+    that's expected when the user is slow to confirm. Every other failure
+    (network, auth, 5xx) propagates so it surfaces as a tool error instead of
+    leaving the run in an undefined state.
+    """
+    try:
+        if cancelled:
+            await client.agent.automate_input(request_id, cancelled=True)
+        else:
+            await client.agent.automate_input(request_id, fields=fields or [])
+    except APIStatusError as e:
+        if e.status_code == 410:
+            log.info("automate_input window expired (request_id=%s)", request_id)
+            return
+        raise
+
+
+# -- Research ---------------------------------------------------------------
 
 async def tool_tabstack_research(ctx, query: str, mode: str = "balanced") -> ToolResult:
     """Search the web, analyze multiple sources, and synthesize an answer."""
@@ -116,21 +381,32 @@ async def tool_tabstack_research(ctx, query: str, mode: str = "balanced") -> Too
     try:
         stream = await _get_client().agent.research(query=query, mode=mode)  # type: ignore[arg-type]
 
-        final_answer = None
+        final_answer: str | None = None
+        error_message: str | None = None
         async for event in stream:
-            _log_stream_event("research", event)
+            kind = getattr(event, "event", None)
+            data = getattr(event, "data", None)
 
-            # Publish progress
-            msg = _get_field(event, "message")
+            msg = getattr(data, "message", None) if data is not None else None
             if msg:
+                log.info("[tool:tabstack_research] %s", msg)
                 await ctx.publish("tool_status", tool="tabstack_research", message=msg)
 
-            # SDK v2: the report is in metadata.report on the final event
-            report = _get_report(event)
-            if report:
-                final_answer = report
+            if kind == "complete" and data is not None:
+                report = getattr(data, "report", None)
+                if report:
+                    final_answer = report
+            elif kind == "error" and data is not None:
+                # Research-failed event carries a human-readable message plus a
+                # nested data.error.message; prefer the top-level one.
+                err = getattr(data, "error", None)
+                error_message = (
+                    msg or (getattr(err, "message", None) if err else None) or error_message
+                )
 
         if not final_answer:
+            if error_message:
+                return ToolResult(text=f"[error: {_truncate(error_message)}]")
             return ToolResult(text="[error: research stream ended without a final answer]")
         return ToolResult(
             text=final_answer,
@@ -138,45 +414,6 @@ async def tool_tabstack_research(ctx, query: str, mode: str = "balanced") -> Too
         )
     except Exception as e:
         return ToolResult(text=f"[error: {e}]")
-
-
-# -- Helpers ----------------------------------------------------------------
-
-def _get_field(obj, key):
-    """Get a field from an object, handling both dict and attribute access."""
-    if obj is None:
-        return None
-    if isinstance(obj, dict):
-        return obj.get(key)
-    return getattr(obj, key, None)
-
-
-def _get_report(event):
-    """Extract the report/answer from a stream event.
-
-    SDK v2 puts the report in metadata.report on the final event.
-    """
-    # Direct report field
-    report = _get_field(event, "report")
-    if report:
-        return report
-
-    # Nested in metadata
-    metadata = _get_field(event, "metadata")
-    if metadata:
-        report = _get_field(metadata, "report")
-        if report:
-            return report
-
-    # finalAnswer (automate)
-    return _get_field(event, "finalAnswer")
-
-
-def _log_stream_event(prefix, event):
-    """Log a streaming event for debugging."""
-    msg = _get_field(event, "message")
-    if msg:
-        log.info(f"[tool:{prefix}] {msg}")
 
 
 # -- Registry ---------------------------------------------------------------
@@ -255,9 +492,12 @@ TOOL_DEFINITIONS = [
     },
     {
         "type": "function",
+        # Interactive runs add a user-confirmation round-trip plus tabstack's form-input
+        # window (up to ~2 min), which can exceed the default 180s tool timeout.
+        "timeout": 300,
         "function": {
             "name": "tabstack_automate",
-            "description": "Automate web tasks using natural language. Has its own built-in web search — great for quick lookups like addresses, hours, prices, or simple facts. Also handles browser interactions: clicking, navigating, filling forms. Prefer this over tabstack_research for simple questions that just need a quick search. Takes 30-120 seconds.",
+            "description": "Automate web tasks using natural language. Has its own built-in web search — great for quick lookups like addresses, hours, prices, or simple facts. Also handles browser interactions: clicking, navigating, filling forms. Prefer this over tabstack_research for simple questions that just need a quick search. Takes 30-120 seconds.\n\nINTERACTIVE FORM-FILL: To let the browser agent fill a form with personal data, set interactive=true and pass the values in `data` (keys should match the form field labels, e.g. {\"Email\": \"a@b.com\", \"Full name\": \"Ada\"}). Each submission is shown to the user for confirmation before personal data is sent. If a required field is missing from `data`, the request is cancelled and the missing field names are reported back — gather them and re-run.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -268,6 +508,14 @@ TOOL_DEFINITIONS = [
                     "url": {
                         "type": "string",
                         "description": "Starting URL (optional — omit to let the browser search)",
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Personal/contextual values for form filling, keyed by field label (e.g. {\"Email\": \"a@b.com\"}). Only used when interactive=true.",
+                    },
+                    "interactive": {
+                        "type": "boolean",
+                        "description": "Enable interactive form-fill: answer the agent's form-data requests from `data`, gated by user confirmation. Default false.",
                     },
                 },
                 "required": ["task"],

--- a/tests/test_tabstack_tools.py
+++ b/tests/test_tabstack_tools.py
@@ -1,0 +1,439 @@
+"""Tests for the tabstack skill tool implementations.
+
+Exercises the SDK >= 2.6.1 typed-event handling (automate / research), the
+plain-dict extract/generate responses, and the interactive form-fill flow with
+its confirmation gate — without real network calls.
+"""
+
+import types
+
+import httpx
+import pytest
+from tabstack import APIStatusError
+
+from decafclaw.media import ToolResult
+from decafclaw.skills.tabstack import tools
+
+# -- Fakes ------------------------------------------------------------------
+
+
+def _event(kind, **data_fields):
+    """Build a fake SSE event: discriminator + typed-ish .data payload."""
+    return types.SimpleNamespace(
+        event=kind, data=types.SimpleNamespace(**data_fields)
+    )
+
+
+def _field(label, ref, required, field_type="text"):
+    return types.SimpleNamespace(
+        label=label, ref=ref, required=required, field_type=field_type
+    )
+
+
+class _AsyncIter:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+class _FakeAgent:
+    def __init__(self, automate_events=None, research_events=None):
+        self._automate_events = automate_events or []
+        self._research_events = research_events or []
+        self.input_calls = []  # list of (request_id, kwargs)
+
+    async def automate(self, **kwargs):
+        self.last_automate_kwargs = kwargs
+        return _AsyncIter(self._automate_events)
+
+    async def research(self, **kwargs):
+        return _AsyncIter(self._research_events)
+
+    async def automate_input(self, request_id, **kwargs):
+        self.input_calls.append((request_id, kwargs))
+        return types.SimpleNamespace(status="accepted")
+
+
+class _FakeExtract:
+    def __init__(self, json_result):
+        self._json_result = json_result
+
+    async def json(self, **kwargs):
+        return self._json_result
+
+
+class _FakeGenerate:
+    def __init__(self, json_result):
+        self._json_result = json_result
+
+    async def json(self, **kwargs):
+        return self._json_result
+
+
+class _FakeClient:
+    def __init__(self, agent=None, extract=None, generate=None):
+        self.agent = agent
+        self.extract = extract
+        self.generate = generate
+
+
+class _FakeCtx:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, event, **kwargs):
+        self.published.append((event, kwargs))
+
+
+@pytest.fixture
+def ctx():
+    return _FakeCtx()
+
+
+@pytest.fixture
+def use_client(monkeypatch):
+    """Install a fake tabstack client as the module-global _client."""
+    def _install(client):
+        monkeypatch.setattr(tools, "_client", client)
+        return client
+    return _install
+
+
+# -- _match_fields ----------------------------------------------------------
+
+
+def test_match_fields_matches_by_label_case_insensitive():
+    fields = [_field("Email", "E1", True), _field("Full Name", "E2", True)]
+    matched, missing = tools._match_fields(
+        fields, {"email": "a@b.com", "full name": "Ada"}
+    )
+    assert missing == []
+    assert {"ref": "E1", "value": "a@b.com"} in matched
+    assert {"ref": "E2", "value": "Ada"} in matched
+
+
+def test_match_fields_reports_missing_required_only():
+    fields = [
+        _field("Email", "E1", True),
+        _field("Phone", "E2", True),
+        _field("Company", "E3", False),  # optional, absent → not missing
+    ]
+    matched, missing = tools._match_fields(fields, {"Email": "a@b.com"})
+    assert matched == [{"ref": "E1", "value": "a@b.com"}]
+    assert missing == ["Phone"]
+
+
+# -- automate event handling ------------------------------------------------
+
+
+async def test_automate_extracts_final_answer_and_publishes(ctx, use_client):
+    agent = _FakeAgent(automate_events=[
+        _event("agent:status", message="working"),
+        _event("agent:reasoned", reasoning="thinking"),
+        _event("task:completed", final_answer="the answer"),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_automate(ctx, task="do a thing")
+
+    assert result == "the answer"
+    # progress published for status + reasoned
+    msgs = [k["message"] for e, k in ctx.published if e == "tool_status"]
+    assert "working" in msgs and "thinking" in msgs
+
+
+async def test_automate_no_final_answer_returns_error(ctx, use_client):
+    agent = _FakeAgent(automate_events=[_event("agent:status", message="working")])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_automate(ctx, task="do a thing")
+    assert "without a final answer" in result
+
+
+async def test_automate_non_interactive_omits_interactive_kwarg(ctx, use_client):
+    agent = _FakeAgent(automate_events=[_event("complete", final_answer="x")])
+    use_client(_FakeClient(agent=agent))
+
+    await tools.tool_tabstack_automate(ctx, task="t", url="http://x")
+    assert "interactive" not in agent.last_automate_kwargs
+    assert "data" not in agent.last_automate_kwargs
+
+
+async def test_automate_non_interactive_drops_data(ctx, use_client):
+    """`data` must not reach tabstack unless interactive=true — otherwise personal
+    data leaks without the caller opting into the confirmation-gated form-fill."""
+    agent = _FakeAgent(automate_events=[_event("complete", final_answer="x")])
+    use_client(_FakeClient(agent=agent))
+
+    await tools.tool_tabstack_automate(
+        ctx, task="t", data={"Email": "a@b.com"}, interactive=False
+    )
+    assert "data" not in agent.last_automate_kwargs
+    assert "interactive" not in agent.last_automate_kwargs
+
+
+async def test_automate_uninitialized_client_returns_error(ctx, monkeypatch):
+    """A missing/unactivated skill must return a formatted error like the other
+    tabstack tools, not raise out of the tool call."""
+    monkeypatch.setattr(tools, "_client", None)
+
+    result = await tools.tool_tabstack_automate(ctx, task="t")
+    assert result.startswith("[error:")
+
+
+# -- progress narration -----------------------------------------------------
+
+
+async def test_automate_progress_surfaces_rich_events(ctx, use_client):
+    agent = _FakeAgent(automate_events=[
+        _event("agent:step", current_iteration=2),
+        _event("browser:navigated", title="Signup", url="http://x/s"),
+        _event("agent:extracted", extracted_data="price is $5"),
+        _event("browser:action_completed", success=True),  # success → no line
+        _event("browser:action_completed", success=False, error="element gone"),
+        _event("task:validated", completion_quality="excellent"),
+        _event("complete", final_answer="done"),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    await tools.tool_tabstack_automate(ctx, task="t")
+    msgs = [k["message"] for e, k in ctx.published if e == "tool_status"]
+
+    assert "step 2" in msgs
+    assert "opened Signup — http://x/s" in msgs
+    assert "extracted: price is $5" in msgs
+    assert "action failed: element gone" in msgs
+    assert "validated (excellent)" in msgs
+    # the successful action_completed must NOT emit a line
+    assert msgs.count("action failed: element gone") == 1
+
+
+async def test_automate_progress_never_leaks_typed_value(ctx, use_client):
+    """agent:action carries the text typed into a field — it must not be echoed."""
+    agent = _FakeAgent(automate_events=[
+        _event("agent:action", action="type", ref="E1", value="ada@secret.com"),
+        _event("complete", final_answer="done"),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    await tools.tool_tabstack_automate(ctx, task="t")
+    msgs = [k["message"] for e, k in ctx.published if e == "tool_status"]
+
+    assert "→ type (E1)" in msgs
+    assert not any("ada@secret.com" in m for m in msgs)
+
+
+# -- error reporting --------------------------------------------------------
+
+
+async def test_automate_top_level_error_event_surfaced(ctx, use_client):
+    agent = _FakeAgent(automate_events=[
+        _event("error", error=types.SimpleNamespace(
+            message="navigation blocked by policy", code="E", timestamp="t")),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_automate(ctx, task="t")
+    assert "navigation blocked by policy" in result
+    assert "without a final answer" not in result
+
+
+async def test_automate_unsuccessful_complete_reports_structured_error(ctx, use_client):
+    agent = _FakeAgent(automate_events=[
+        _event("complete", final_answer=None, success=False,
+               error=types.SimpleNamespace(message="ran out of iterations", code="MAX_ITERATIONS")),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_automate(ctx, task="t")
+    assert "ran out of iterations" in result
+
+
+# -- interactive form-fill --------------------------------------------------
+
+
+async def test_interactive_approve_submits_matched_fields(ctx, use_client, monkeypatch):
+    form = _event(
+        "interactive:form_data:request",
+        request_id="req-1",
+        page_url="http://x/form",
+        form_description="Signup",
+        fields=[_field("Email", "E1", True)],
+    )
+    agent = _FakeAgent(automate_events=[form, _event("complete", final_answer="done")])
+    use_client(_FakeClient(agent=agent))
+
+    approvals = []
+
+    async def fake_confirm(ctx, **kwargs):
+        approvals.append(kwargs)
+        return {"approved": True}
+
+    monkeypatch.setattr(tools, "request_confirmation", fake_confirm)
+
+    result = await tools.tool_tabstack_automate(
+        ctx, task="sign up", interactive=True, data={"Email": "a@b.com"}
+    )
+
+    assert result == "done"
+    assert agent.last_automate_kwargs["interactive"] is True
+    # interactive=true → data is forwarded so tabstack can request matching fields
+    assert agent.last_automate_kwargs["data"] == {"Email": "a@b.com"}
+    # confirmation was shown, then matched fields submitted
+    assert approvals and approvals[0]["tool_name"] == "tabstack_automate"
+    assert agent.input_calls == [("req-1", {"fields": [{"ref": "E1", "value": "a@b.com"}]})]
+
+
+async def test_interactive_missing_required_cancels_without_confirmation(
+    ctx, use_client, monkeypatch
+):
+    """Guard sabotage-check: a missing required field must cancel the request and
+    must NOT reach the confirmation gate. Removing the missing-field branch in
+    _handle_form_request makes this fail."""
+    form = _event(
+        "interactive:form_data:request",
+        request_id="req-2",
+        page_url="http://x/form",
+        form_description="Signup",
+        fields=[_field("Email", "E1", True), _field("Phone", "E2", True)],
+    )
+    agent = _FakeAgent(automate_events=[form, _event("task:aborted", final_answer="aborted")])
+    use_client(_FakeClient(agent=agent))
+
+    confirm_called = False
+
+    async def fake_confirm(ctx, **kwargs):
+        nonlocal confirm_called
+        confirm_called = True
+        return {"approved": True}
+
+    monkeypatch.setattr(tools, "request_confirmation", fake_confirm)
+
+    result = await tools.tool_tabstack_automate(
+        ctx, task="sign up", interactive=True, data={"Email": "a@b.com"}
+    )
+
+    assert confirm_called is False
+    assert agent.input_calls == [("req-2", {"cancelled": True})]
+    assert "Phone" in result and "could not fill" in result
+
+
+async def test_interactive_denied_cancels_and_reports(ctx, use_client, monkeypatch):
+    form = _event(
+        "interactive:form_data:request",
+        request_id="req-3",
+        page_url="http://x/form",
+        form_description="Signup",
+        fields=[_field("Email", "E1", True)],
+    )
+    agent = _FakeAgent(automate_events=[form, _event("complete", final_answer="done")])
+    use_client(_FakeClient(agent=agent))
+
+    async def fake_confirm(ctx, **kwargs):
+        return {"approved": False}
+
+    monkeypatch.setattr(tools, "request_confirmation", fake_confirm)
+
+    result = await tools.tool_tabstack_automate(
+        ctx, task="sign up", interactive=True, data={"Email": "a@b.com"}
+    )
+
+    assert agent.input_calls == [("req-3", {"cancelled": True})]
+    assert "declined" in result
+
+
+# -- _safe_input ------------------------------------------------------------
+
+
+def _status_error(code: int):
+    request = httpx.Request("POST", "http://x/input")
+    response = httpx.Response(code, request=request)
+    return APIStatusError("boom", response=response, body=None)
+
+
+async def test_safe_input_swallows_410_gone():
+    """An expired/consumed input window (410 Gone) is expected — swallow it."""
+    class _Agent:
+        async def automate_input(self, request_id, **kwargs):
+            raise _status_error(410)
+
+    client = types.SimpleNamespace(agent=_Agent())
+    # must not raise
+    await tools._safe_input(client, "req", cancelled=True)
+
+
+async def test_safe_input_reraises_non_410():
+    """Network/auth/5xx failures leave the run in an undefined state — surface them."""
+    class _Agent:
+        async def automate_input(self, request_id, **kwargs):
+            raise _status_error(500)
+
+    client = types.SimpleNamespace(agent=_Agent())
+    with pytest.raises(APIStatusError):
+        await tools._safe_input(client, "req", fields=[])
+
+
+# -- research ---------------------------------------------------------------
+
+
+async def test_research_extracts_report(ctx, use_client):
+    agent = _FakeAgent(research_events=[
+        _event("planning:start", message="planning"),
+        _event("complete", message="done", report="the report"),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_research(ctx, query="q")
+    assert isinstance(result, ToolResult)
+    assert result.text == "the report"
+    assert result.data["query"] == "q"
+
+
+async def test_research_no_report_returns_error(ctx, use_client):
+    agent = _FakeAgent(research_events=[_event("planning:start", message="planning")])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_research(ctx, query="q")
+    assert "without a final answer" in result.text
+
+
+async def test_research_error_event_surfaced(ctx, use_client):
+    agent = _FakeAgent(research_events=[
+        _event("planning:start", message="planning"),
+        _event("error", message="research failed: rate limited",
+               error=types.SimpleNamespace(message="429", name="RateLimit")),
+    ])
+    use_client(_FakeClient(agent=agent))
+
+    result = await tools.tool_tabstack_research(ctx, query="q")
+    assert "research failed: rate limited" in result.text
+    assert "without a final answer" not in result.text
+
+
+# -- extract / generate dict shapes -----------------------------------------
+
+
+async def test_extract_json_returns_plain_dict(ctx, use_client):
+    use_client(_FakeClient(extract=_FakeExtract({"price": 42})))
+
+    result = await tools.tool_tabstack_extract_json(
+        ctx, url="http://x", json_schema={"type": "object"}
+    )
+    assert result.data["result"] == {"price": 42}
+    assert '"price": 42' in result.text
+
+
+async def test_generate_returns_plain_dict_json(ctx, use_client):
+    use_client(_FakeClient(generate=_FakeGenerate({"summary": "hi"})))
+
+    result = await tools.tool_tabstack_generate(
+        ctx, url="http://x", json_schema={"type": "object"}, instructions="summarize"
+    )
+    assert '"summary": "hi"' in result

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -377,7 +377,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.0.0" },
     { name = "sqlite-vec", specifier = ">=0.1.7" },
     { name = "starlette", specifier = ">=0.52.1" },
-    { name = "tabstack", specifier = ">=2.3.0" },
+    { name = "tabstack", specifier = ">=2.6.1" },
     { name = "uvicorn", specifier = ">=0.41.0" },
     { name = "watchfiles", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "websockets", specifier = ">=16.0" },
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "tabstack"
-version = "2.3.0"
+version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1128,9 +1128,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/08/6198d1bd5b23ac40a199db6e26a74cdb2a66e0ef99a572a6ab7e971e1c43/tabstack-2.3.0.tar.gz", hash = "sha256:a323dc2573d910b132f4fbbc3ed83b026a3eac4aea8ca0f18f6b2c439b73f668", size = 230017, upload-time = "2026-03-12T21:29:25.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/ba/8c407b9db5ba0a86c810c3d1615d38a215fe2c660cd2a96638f9ceef596b/tabstack-2.6.1.tar.gz", hash = "sha256:cef80d66d663f75b4ea475395a5f419316897acabead9665ac5fd32d789759af", size = 251429, upload-time = "2026-05-05T16:29:42.619Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/43/43ea9e7d98436d069c967d8340253e3e1a98c2a9847e76d393e0c1ac5274/tabstack-2.3.0-py3-none-any.whl", hash = "sha256:bbe2dc88bafcdeb79b5d1d2154a6029da2739b23f0645e8bb3f43840c930e19e", size = 86404, upload-time = "2026-03-12T21:29:24.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/dc/c19318c8e0a26ea0b99ecc6aaf3ea1b01f0df126e62144f1299b095e906d/tabstack-2.6.1-py3-none-any.whl", hash = "sha256:00fa099929a5e12347633883ca14ba2f98fef42baca428c1e564d3fd3151a362", size = 106914, upload-time = "2026-05-05T16:29:44.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Refreshes the `tabstack` skill for SDK **2.6.1** and adds **interactive form-fill** with agent-supplied data, gated by a user confirmation.

The skill pinned `>=2.3.0` and read `event.message`/`finalAnswer`/`report` at the top level via `getattr` poking, but tabstack moved on:
- **2.4.0** added the `automate_input` endpoint (interactive form-data handshake).
- **2.6.0** swapped `/automate` (and `/research`) to a typed discriminated-union event model — payloads now live under `event.data`, so the old top-level poking never lined up. `extract.json`/`generate.json` also now return plain dicts, so `result.data` was broken too.

## What changed

**Phase 1 — SDK refresh / breakage fix**
- Pin `tabstack>=2.6.1`.
- Rewrote automate/research event handling against the typed `.data` envelope, dispatching on the `event` discriminator; dropped `_get_field`/`_get_report`.
- Fixed `extract_json`/`generate` to use the plain-dict result.

**Phase 2 — Interactive form-fill (agent-supplied data + confirmation gate)**
- New `data` + `interactive` params on `tabstack_automate`. On `interactive:form_data:request`/`:error`, matched fields are submitted via `agent.automate_input`, **gated by `request_confirmation`** (same inline-blocking pattern as `send_email`) showing the form + field→value pairs (passwords masked).
- Missing required fields → cancel + report which fields were missing, so the agent can gather them and retry. Denied confirmation → cancel + report.
- `_safe_input` swallows `410 Gone` (expired 2-min input window).
- Raised `tabstack_automate` per-tool timeout to 300s (confirmation + input window can exceed the 180s default).

**Phase 3 — Docs + tests + evals**
- SKILL.md + docs/skills.md document interactive mode, the `data` param, the per-submission confirmation, and the missing-field retry loop.
- `tests/test_tabstack_tools.py`: 12 tests covering typed-event extraction (automate/research), plain-dict extract/generate, and interactive approve / missing-required (guard sabotage-check) / denied paths.
- Two `tool_choice` eval cases (form-fill→automate, multi-source→research), verified 2/2 on the configured Flash model.

## Design notes

- **Not** live human-in-the-loop: that's infeasible in DecafClaw's turn model (a tool returns once; `WidgetInputPause` ends the turn and resumes on a new one, by which point the SSE stream is dead and the 2-min `request_id` expired). Agent-supplied data keeps everything in one turn.
- `interactive` defaults `false`, so existing read/search/click automate calls are unaffected and never prompt.

## Testing

- `make lint` / `make typecheck` clean; `make test` → 2719 passed.
- Guard verified by sabotaging the missing-required branch (test fails, then reverted).
- ⚠️ Not yet live-tested against a real form — see session notes for post-merge smoke-test TODOs.

Session: `docs/dev-sessions/2026-05-31-1920-tabstack-interactive-automate/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)