### PR TITLE
feat(workflow): durable replay engine (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,9 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 ### Skills (bundled)
 `skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
 
+### Workflows
+`workflow/` — Durable replay engine ([docs/workflows.md](docs/workflows.md)): `registry.py` (`@workflow` decorator), `engine.py` (`run_workflow`), `journal.py` (positional keyed journal + fingerprint), `handle.py` (`WorkflowHandle` — the `wf` object with `llm_call`/`user_input` primitives), `llm.py` (forced-tool structured-output), `errors.py` (`WorkflowSuspended`, `WorkflowNonDeterministic`), `paths.py` (per-conv file paths), `resume.py` (harness glue: `run_workflow_turn` + `WorkflowUserInputHandler`), `workflows/interview.py` (hero orchestrator).
+
 ### Other
 - `prompts/` — System prompt assembly
 - `commands.py` — User-invokable commands

--- a/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/notes.md
+++ b/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/notes.md
@@ -1,0 +1,151 @@
+# Session notes — workflow replay engine (#255)
+
+## Summary
+
+Implemented a first-class workflow replay engine in `src/decafclaw/workflow/`. The core
+insight is that code must own control flow, and the LLM must only be invoked as a
+constrained structured-output worker. The engine re-runs the orchestrator from the top on
+every resume, fast-forwarding through journaled results — the same model as Temporal, DBOS,
+and Claude Code dynamic workflows.
+
+Key deliverables: `@workflow` registry, `WorkflowHandle` with `llm_call` + `user_input`
+primitives, positional-keyed journal with determinism guard, suspend/resume through the
+existing confirmation infrastructure, `TurnKind.WORKFLOW` dispatch in
+`ConversationManager`, `/interview` command bridge in `web/websocket.py`, full unit test
+suite including restart-durability.
+
+Docs: `docs/workflows.md`, linked from `docs/index.md` and `CLAUDE.md`.
+
+---
+
+## Live smoke checklist
+
+Run this manually against `vertex-gemini-flash` in the web UI after merging.
+This is the bar no prior iteration cleared — including a mid-interview restart.
+
+### Setup
+
+- [ ] Confirm no other bot instance is connected to Mattermost (a second silently misses
+  WebSocket events — check with `ps aux | grep decafclaw`).
+- [ ] Start the dev server: `make dev` (auto-restart on file changes, 10s graceful shutdown).
+- [ ] Open the web UI and create a **new conversation**.
+
+### Happy path
+
+- [ ] Type `/interview` and submit.
+- [ ] The bot should post: *"What should this interview be about?"*
+- [ ] Paste a topic answer (e.g., "my experience learning Rust").
+- [ ] The bot asks question 1. Answer it.
+- [ ] The bot asks question 2 (or declares done). Answer if asked.
+
+### Restart durability (the critical bar)
+
+- [ ] While the bot is waiting for a question answer (pending confirmation visible in the
+  UI), hit **Ctrl-C** to stop the dev process.
+- [ ] Restart: `make dev` (or `make run`).
+- [ ] **Reload the web UI** in the browser.
+- [ ] The pending question should still be displayed (confirmation persisted across restart).
+- [ ] Answer the pending question.
+- [ ] The workflow resumes and continues — LLM calls replay from the journal; only the
+  post-restart steps run live.
+
+### Completion
+
+- [ ] Continue answering until the model says it has enough (or MAX_Q=6 is hit).
+- [ ] The bot synthesizes and posts the final artifact (title + markdown body).
+- [ ] Artifact renders correctly in the conversation as a markdown block.
+
+### Observed output (paste here)
+
+```
+# tool_status lines observed during the run:
+
+
+# Final artifact:
+
+```
+
+---
+
+## Deferred follow-up items
+
+1. **WORKFLOW turn Context-kind semantics.** WORKFLOW turns currently reuse the USER-style
+   Context path (full interactive Context with per-conv state). Comment in
+   `conversation_manager.py` near `TurnKind.WORKFLOW` dispatch notes this may want
+   `Context.for_task` semantics. Revisit after the live smoke confirms the current path works.
+
+2. **Batch/fan-out primitives.** `subagent`, `parallel`, `pipeline`, `tool_call` wrappers
+   are the natural next journaled primitives. They arrive when there is a concrete use case
+   (batch fan-out); the engine does not preclude them.
+
+3. **Sidecar directory migration.** Only `workflow.json` uses the `conversations/{conv_id}/`
+   directory layout. The flat `{conv_id}.*` sidecars (`.notes.md`, `.decisions.json`,
+   `.context.json`, `.archive.jsonl`) migrate later. Two conventions coexist until then.
+
+4. **Eval case.** No eval case needed yet — the interview flow has no LLM-driven routing
+   branch worth guarding. Add one if an orchestrator gains such a branch.
+
+---
+
+## Implementation complete (2026-06-08)
+
+All 16 tasks landed on `feat/255-workflow-replay` (24 → 40 commits from spec/plan through the
+final review fixes). Built via subagent-driven development: implement → spec-review →
+code-quality-review per task, with a final whole-implementation review by the most-capable model.
+
+**Final gate:** `make check` passes (ruff, pyright, tsc --checkJs, message-types drift);
+full suite **2814 passed**. Workflow module: 34 tests; the durable-resume test reconstructs
+the engine from disk only and proves replay continues to completion with the journaled answer.
+
+**Critical gap caught by the final review (now fixed — Task 15):** the `/interview`
+*invocation* bridge existed, but there was no UI path to *deliver* the user's answer — a
+`workflow_user_input` confirmation rendered as a plain approve/deny card, so the answer was
+always empty. Fixed by rendering a text input (+ choice buttons when `action_data.choices`
+is set) in `confirm-view.js` and routing the typed value as `data={"value": …}` through
+`confirm_response` → `respond_to_confirmation` → the handler → the journal. So in the smoke
+below, the topic/question prompts now show a **text field**, not Approve/Deny.
+
+**Run the smoke BEFORE opening/merging a PR** — it's the gate, not a post-merge check (the
+checklist above predates this note; "after merging" should read "before merging").
+
+**Deferred follow-ups (tracked, not blocking):**
+- WORKFLOW turns reuse the USER `Context` path; revisit whether `Context.for_task` semantics
+  fit better once the smoke confirms behavior.
+- Batch primitives (`subagent`/`parallel`/`pipeline`/`tool_call`) — the fan-out case.
+- LLM-generated per-task workflows (the Claude Code dynamic-workflow model).
+- Migrate the existing flat conversation sidecars into `conversations/{conv_id}/` (only
+  `workflow.json` uses the directory layout now).
+- Per-call `model=` override on `llm_call` must be deterministic (documented in handle.py;
+  not enforced by the fingerprint).
+
+## Live smoke (2026-06-10): PASS
+
+The bar three prior iterations never cleared. Drove `/interview` end-to-end on
+`vertex-gemini-flash` via `decafclaw-client`, restarted the server mid-interview with a
+pending question, and confirmed the workflow resumed cleanly and synthesized the final
+artifact. Server logged `Recovered pending confirmation for conv web-lmor:
+workflow_user_input` on restart; journal grew to 13 entries across the run; no
+`WorkflowNonDeterministic` ever fired.
+
+**Two integration findings surfaced and fixed in the same pass:**
+
+1. **`decafclaw-client respond` had no `--value` / `--data` flag**, so the documented
+   client couldn't actually deliver a `workflow_user_input` answer. The wire schema
+   (`CliConfirmResponse.data: NotRequired[dict]`) and the server handler at
+   `websocket.py:480-491` both supported it; only the CLI didn't expose it. Smoke needed
+   a 35-line ad-hoc driver to walk through. Fixed by adding `--value VALUE` to the
+   `respond` subparser and forwarding `data={"value": value}` from `run_respond`.
+
+2. **The WORKFLOW turn dispatch path bypassed the conversation archive on both ends.**
+   The `/interview` invocation was never archived (workflow-command intercept in
+   `_handle_send` called `enqueue_turn` directly), and the final artifact emitted by
+   `run_workflow_turn` was streamed live as a `message_complete` event but never
+   persisted. Net effect: after the workflow ran, reloading the conversation showed
+   zero messages (load_history filters confirmation rows). Fixed by adding
+   `append_message` calls at both ends: `role: "user"` at the intercept site,
+   `role: "assistant"` inside `run_workflow_turn` on `outcome.status == "done"`.
+
+Both fixes landed with red-then-green tests (`test_respond_value_*`,
+`test_run_respond_forwards_value_as_data`, `test_workflow_command_archives_user_invocation`,
+`test_run_workflow_turn_done_archives_artifact`). Full suite still passes — **2819**
+(was 2814; +5 new tests, no regressions). `make check` clean.

--- a/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/plan.md
+++ b/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/plan.md
@@ -1,0 +1,1742 @@
+# Workflow Replay Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a first-class `TurnKind.WORKFLOW` that runs an authored async-Python orchestrator with durable, restart-surviving suspend/resume via deterministic replay, proven by an interview→artifact workflow.
+
+**Architecture:** A workflow is a registered async function (`@workflow("interview")`) the harness runs as its own turn kind. Control flow is plain Python; the only journaled boundary crossings are two primitives — `llm_call` and `user_input`. The engine re-runs the orchestrator from the top on resume, replaying journaled results, so a `user_input` suspension that *ends the turn* resumes correctly even across a server restart. Suspend posts a pending confirmation with no awaiting waiter; resolution routes through the existing confirmation **recovery** path to a handler that journals the answer and enqueues a resume turn.
+
+**Tech Stack:** Python 3, asyncio, existing decafclaw `llm.call_llm`, `ConversationManager`, `ConfirmationRegistry`, JSONL archive. Tests via pytest (`pytest-xdist -n auto`).
+
+**Spec:** `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/spec.md`
+
+**The load-bearing rule (from the spec):** every call that crosses to the outside world goes through the journal; everything else is ordinary Python. For the MVP that is exactly two journaled wrappers: `llm_call`, `user_input`.
+
+---
+
+## File Structure
+
+**New module `src/decafclaw/workflow/`:**
+
+| File | Responsibility |
+|---|---|
+| `__init__.py` | Public exports (`workflow`, `run_workflow`, `WorkflowHandle`, errors) |
+| `paths.py` | `workflow_dir()` / `workflow_path()` — `conversations/{conv_id}/workflow.json`, sandboxed |
+| `errors.py` | `WorkflowSuspended`, `WorkflowNonDeterministic`, `WorkflowError` |
+| `journal.py` | `Journal` + `JournalEntry` + `fingerprint()` + load/save |
+| `llm.py` | `call_structured()` — forced-tool structured-output helper (lifted from the spike) |
+| `handle.py` | `WorkflowHandle` — replay/suspend/determinism protocol + `llm_call` + `user_input` |
+| `engine.py` | `run_workflow()` + `WorkflowOutcome` |
+| `registry.py` | `@workflow` decorator + `REGISTRY` + `get_workflow()` + `workflow_commands()` |
+| `resume.py` | `WorkflowUserInputHandler` (confirmation handler) + `run_workflow_turn()` glue |
+| `workflows/__init__.py` | Imports orchestrators so the decorator registers them |
+| `workflows/interview.py` | The hero orchestrator |
+
+**Edited existing files:**
+
+| File | Change |
+|---|---|
+| `src/decafclaw/confirmations.py:14-21` | Add `WORKFLOW_USER_INPUT` to `ConfirmationAction` |
+| `src/decafclaw/conversation_manager.py:73-80` | Add `TurnKind.WORKFLOW` |
+| `src/decafclaw/conversation_manager.py:~1449-1456` | `_start_turn.run()` dispatch: WORKFLOW → `run_workflow_turn` |
+| `src/decafclaw/conversation_manager.py` (new method) | `post_confirmation()` (post-without-await) |
+| `src/decafclaw/conversation_manager.py` (`__init__`) | Register `WorkflowUserInputHandler` |
+| `src/decafclaw/web/websocket.py:~302` | `/interview` command bridge → enqueue WORKFLOW turn |
+
+**New tests:** `tests/test_workflow_paths.py`, `test_workflow_journal.py`, `test_workflow_llm.py`, `test_workflow_handle.py`, `test_workflow_engine.py`, `test_workflow_registry.py`, `test_workflow_interview.py`, `test_workflow_resume.py`, `test_workflow_turn_integration.py`.
+
+---
+
+## Task 1: Conversation-scoped workflow path
+
+**Files:**
+- Create: `src/decafclaw/workflow/__init__.py` (empty for now)
+- Create: `src/decafclaw/workflow/paths.py`
+- Test: `tests/test_workflow_paths.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_paths.py
+from types import SimpleNamespace
+from pathlib import Path
+from decafclaw.workflow.paths import workflow_dir, workflow_path
+
+
+def _cfg(tmp_path):
+    return SimpleNamespace(workspace_path=tmp_path)
+
+
+def test_workflow_path_is_in_conv_subdirectory(tmp_path):
+    cfg = _cfg(tmp_path)
+    assert workflow_path(cfg, "abc123") == (
+        tmp_path / "conversations" / "abc123" / "workflow.json"
+    )
+
+
+def test_workflow_dir_is_created(tmp_path):
+    cfg = _cfg(tmp_path)
+    d = workflow_dir(cfg, "abc123", create=True)
+    assert d.is_dir()
+    assert d == tmp_path / "conversations" / "abc123"
+
+
+def test_path_sandboxed_against_traversal(tmp_path):
+    cfg = _cfg(tmp_path)
+    p = workflow_path(cfg, "../../etc/passwd")
+    base = (tmp_path / "conversations").resolve()
+    assert p.resolve().is_relative_to(base)
+
+
+def test_empty_conv_id_falls_back(tmp_path):
+    cfg = _cfg(tmp_path)
+    p = workflow_path(cfg, "")
+    assert p.name == "workflow.json"
+    assert (tmp_path / "conversations").resolve() in p.resolve().parents
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_paths.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.paths`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/paths.py
+"""Per-conversation workflow file paths.
+
+New convention (#255): per-conversation files live in a directory named
+for the conversation id — ``conversations/{conv_id}/workflow.json`` —
+rather than the flat ``{conv_id}.*`` sidecar pattern. Only the workflow
+file adopts this now; existing sidecars migrate later (see spec).
+"""
+from pathlib import Path
+
+
+def _safe_conv_id(conv_id: str) -> str:
+    safe = conv_id.replace("/", "").replace("\\", "").replace("..", "")
+    return safe or "_invalid"
+
+
+def workflow_dir(config, conv_id: str, *, create: bool = False) -> Path:
+    base = (config.workspace_path / "conversations").resolve()
+    d = (base / _safe_conv_id(conv_id)).resolve()
+    if not d.is_relative_to(base):
+        d = base / "_invalid"
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def workflow_path(config, conv_id: str) -> Path:
+    return workflow_dir(config, conv_id) / "workflow.json"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_paths.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/__init__.py src/decafclaw/workflow/paths.py tests/test_workflow_paths.py
+git commit -m "feat(workflow): conversation-scoped workflow.json path"
+```
+
+---
+
+## Task 2: Errors + the Journal
+
+**Files:**
+- Create: `src/decafclaw/workflow/errors.py`
+- Create: `src/decafclaw/workflow/journal.py`
+- Test: `tests/test_workflow_journal.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_journal.py
+from types import SimpleNamespace
+from decafclaw.workflow.journal import (
+    Journal, JournalEntry, fingerprint, load_journal, save_journal,
+)
+
+
+def _cfg(tmp_path):
+    return SimpleNamespace(workspace_path=tmp_path)
+
+
+def test_fingerprint_is_stable_and_order_insensitive():
+    a = fingerprint("llm_call", {"prompt": "hi", "schema": {"x": 1}})
+    b = fingerprint("llm_call", {"schema": {"x": 1}, "prompt": "hi"})
+    assert a == b
+    assert a != fingerprint("llm_call", {"prompt": "bye", "schema": {"x": 1}})
+
+
+def test_append_is_contiguous_and_get_by_seq():
+    j = Journal(workflow_name="t")
+    j.append(0, "llm_call", "fp0", {"a": 1})
+    j.append(1, "user_input", "fp1", "answer")
+    assert j.get(0).result == {"a": 1}
+    assert j.get(1).result == "answer"
+    assert j.get(2) is None
+
+
+def test_append_rejects_non_contiguous_seq():
+    j = Journal(workflow_name="t")
+    try:
+        j.append(1, "llm_call", "fp", None)
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_save_and_load_round_trip(tmp_path):
+    cfg = _cfg(tmp_path)
+    j = Journal(workflow_name="interview", status="suspended")
+    j.append(0, "user_input", "fp0", "topic")
+    save_journal(cfg, "conv1", j)
+
+    loaded = load_journal(cfg, "conv1")
+    assert loaded.workflow_name == "interview"
+    assert loaded.status == "suspended"
+    assert loaded.get(0).kind == "user_input"
+    assert loaded.get(0).result == "topic"
+    assert loaded.get(0).args_fingerprint == "fp0"
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_journal(_cfg(tmp_path), "nope") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_journal.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.journal`
+
+- [ ] **Step 3: Implement errors + journal**
+
+```python
+# src/decafclaw/workflow/errors.py
+"""Workflow engine exceptions."""
+
+
+class WorkflowError(Exception):
+    """Base for workflow engine failures."""
+
+
+class WorkflowSuspended(Exception):
+    """Raised by a journaled primitive that needs to suspend for the user.
+
+    Carries everything the harness needs to post a confirmation and, on
+    response, journal the answer at the right position.
+    """
+
+    def __init__(self, *, seq: int, args_fingerprint: str, prompt: str,
+                 choices: list[str] | None = None):
+        super().__init__(f"workflow suspended at step {seq}: {prompt!r}")
+        self.seq = seq
+        self.args_fingerprint = args_fingerprint
+        self.prompt = prompt
+        self.choices = choices
+
+
+class WorkflowNonDeterministic(WorkflowError):
+    """Replay reached a journaled call whose args don't match the record.
+
+    Means control flow diverged between runs — a determinism bug in the
+    orchestrator. Fail loudly rather than return a stale result.
+    """
+
+    def __init__(self, seq: int, recorded_kind: str, recorded_fp: str,
+                 got_kind: str, got_fp: str):
+        super().__init__(
+            f"workflow non-deterministic at step {seq}: recorded "
+            f"{recorded_kind}/{recorded_fp}, replay produced {got_kind}/{got_fp}"
+        )
+        self.seq = seq
+```
+
+```python
+# src/decafclaw/workflow/journal.py
+"""Durable, ordered record of journaled-call results for one workflow run.
+
+Entries are keyed positionally by execution order: the Nth journaled call
+executed gets sequence N. This is what makes loops replay correctly — same
+control flow produces the same execution order, hence the same keys.
+"""
+import dataclasses
+import hashlib
+import json
+from typing import Any
+
+from .paths import workflow_dir, workflow_path
+
+
+def fingerprint(kind: str, args: dict) -> str:
+    """Stable hash of a journaled call's kind + args (order-insensitive)."""
+    payload = json.dumps({"kind": kind, "args": args},
+                         sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclasses.dataclass
+class JournalEntry:
+    seq: int
+    kind: str
+    args_fingerprint: str
+    result: Any
+
+
+@dataclasses.dataclass
+class Journal:
+    workflow_name: str
+    status: str = "running"  # running | suspended | done | error
+    entries: list[JournalEntry] = dataclasses.field(default_factory=list)
+
+    def get(self, seq: int) -> JournalEntry | None:
+        if 0 <= seq < len(self.entries):
+            return self.entries[seq]
+        return None
+
+    def append(self, seq: int, kind: str, args_fingerprint: str,
+               result: Any) -> None:
+        if seq != len(self.entries):
+            raise ValueError(
+                f"non-contiguous journal append: seq={seq}, "
+                f"len={len(self.entries)}")
+        self.entries.append(JournalEntry(seq, kind, args_fingerprint, result))
+
+    def to_dict(self) -> dict:
+        return {
+            "workflow_name": self.workflow_name,
+            "status": self.status,
+            "entries": [dataclasses.asdict(e) for e in self.entries],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Journal":
+        j = cls(workflow_name=d["workflow_name"],
+                status=d.get("status", "running"))
+        j.entries = [JournalEntry(**e) for e in d.get("entries", [])]
+        return j
+
+
+def save_journal(config, conv_id: str, journal: Journal) -> None:
+    """Persist the journal. Flushed on every call for crash-safety."""
+    workflow_dir(config, conv_id, create=True)
+    path = workflow_path(config, conv_id)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(journal.to_dict(), indent=2))
+    tmp.replace(path)  # atomic on POSIX
+
+
+def load_journal(config, conv_id: str) -> Journal | None:
+    path = workflow_path(config, conv_id)
+    if not path.exists():
+        return None
+    return Journal.from_dict(json.loads(path.read_text()))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_journal.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/errors.py src/decafclaw/workflow/journal.py tests/test_workflow_journal.py
+git commit -m "feat(workflow): journal with positional keying + fingerprints"
+```
+
+---
+
+## Task 3: Structured-output LLM helper
+
+**Files:**
+- Create: `src/decafclaw/workflow/llm.py`
+- Test: `tests/test_workflow_llm.py`
+
+Lifted from the spike (`spike_research_brief/tools.py` on the closed `feat/255-workflow-engine` branch), generalized to take the model as an argument instead of a module constant.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_llm.py
+import pytest
+from types import SimpleNamespace
+from decafclaw.workflow import llm as wf_llm
+
+
+@pytest.mark.asyncio
+async def test_returns_parsed_tool_args(monkeypatch):
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        return {"tool_calls": [{"function": {"arguments": '{"q": "why?"}'}}]}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    out = await wf_llm.call_structured(
+        SimpleNamespace(config=object()),
+        system="s", user_msg="u", schema={"type": "object"},
+        tool_name="submit", model="m",
+    )
+    assert out == {"q": "why?"}
+
+
+@pytest.mark.asyncio
+async def test_retries_on_narrate_then_succeeds(monkeypatch):
+    calls = []
+
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        calls.append(messages)
+        if len(calls) == 1:
+            return {"content": "I think the answer is...", "tool_calls": None}
+        return {"tool_calls": [{"function": {"arguments": '{"ok": true}'}}]}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    out = await wf_llm.call_structured(
+        SimpleNamespace(config=object()),
+        system="s", user_msg="u", schema={}, tool_name="submit", model="m",
+    )
+    assert out == {"ok": True}
+    assert len(calls) == 2  # one narrate-stall, one nudged retry
+
+
+@pytest.mark.asyncio
+async def test_raises_after_exhausting_retries(monkeypatch):
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        return {"content": "prose", "tool_calls": None}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    with pytest.raises(RuntimeError):
+        await wf_llm.call_structured(
+            SimpleNamespace(config=object()),
+            system="s", user_msg="u", schema={}, tool_name="submit",
+            model="m", retries=1,
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_llm.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.llm`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/llm.py
+"""Forced-tool structured-output helper for workflow llm_call.
+
+Exposes exactly one tool the model MUST call, parses its args, and retries
+once with a stricter nudge on narrate-stall. Provider-agnostic; proven on
+vertex-gemini-flash by the #255 spike.
+"""
+import json
+import logging
+
+from decafclaw.llm import call_llm
+
+log = logging.getLogger(__name__)
+
+
+async def call_structured(ctx, *, system: str, user_msg: str, schema: dict,
+                          tool_name: str, model: str, description: str = "",
+                          retries: int = 1) -> dict:
+    """Force a structured response. Returns parsed tool args, or raises."""
+    base_user = user_msg
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": base_user},
+    ]
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "description": description or (
+                "Submit the structured result for this step. "
+                "You MUST call this — do not respond with prose."),
+            "parameters": schema,
+        },
+    }]
+    last_error: str | None = None
+    for _ in range(retries + 1):
+        result = await call_llm(ctx.config, messages, tools=tools,
+                                model_name=model)
+        tool_calls = result.get("tool_calls") or []
+        if tool_calls:
+            args_raw = tool_calls[0].get("function", {}).get("arguments") or "{}"
+            try:
+                return json.loads(args_raw)
+            except json.JSONDecodeError as e:
+                last_error = f"invalid JSON in tool args: {e}; raw={args_raw[:200]!r}"
+        else:
+            last_error = (
+                f"model emitted text instead of calling {tool_name!r}: "
+                f"{(result.get('content') or '')[:200]!r}")
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": (
+                base_user + f"\n\nIMPORTANT: You MUST call the tool "
+                f"`{tool_name}` now. Do not narrate. Emit only the call.")},
+        ]
+    raise RuntimeError(
+        f"structured call to {tool_name} failed after {retries + 1} "
+        f"attempts: {last_error}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_llm.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/llm.py tests/test_workflow_llm.py
+git commit -m "feat(workflow): forced-tool structured-output helper"
+```
+
+---
+
+## Task 4: WorkflowHandle — the replay/suspend/determinism core
+
+**Files:**
+- Create: `src/decafclaw/workflow/handle.py`
+- Test: `tests/test_workflow_handle.py`
+
+This is the heart. `llm_call` and `user_input` both consult the journal positionally: an already-journaled call returns its cached result (after a fingerprint check); a new `llm_call` runs live and journals; a new `user_input` raises `WorkflowSuspended`. The `llm_caller` is injectable so tests need no real LLM.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_handle.py
+import pytest
+from types import SimpleNamespace
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal
+from decafclaw.workflow.errors import WorkflowSuspended, WorkflowNonDeterministic
+
+
+def _ctx(tmp_path):
+    # conv_id "" keeps save_journal writing under tmp_path/conversations/_invalid
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convX")
+
+
+@pytest.mark.asyncio
+async def test_llm_call_executes_live_and_journals(tmp_path):
+    j = Journal(workflow_name="t")
+    hits = []
+
+    async def fake_llm(ctx, **kw):
+        hits.append(kw["user_msg"])
+        return {"answer": 42}
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
+    out = await h.llm_call(prompt="q1", schema={}, model="m")
+    assert out == {"answer": 42}
+    assert j.get(0).kind == "llm_call"
+    assert hits == ["q1"]
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_cached_without_executing(tmp_path):
+    # Seed a journal as if llm_call already ran.
+    j = Journal(workflow_name="t")
+    from decafclaw.workflow.journal import fingerprint
+    fp = fingerprint("llm_call", {"prompt": "q1", "schema": {}, "system": ""})
+    j.append(0, "llm_call", fp, {"answer": 42})
+
+    async def boom(ctx, **kw):
+        raise AssertionError("live LLM path must NOT run during replay")
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=boom)
+    out = await h.llm_call(prompt="q1", schema={}, model="m")
+    assert out == {"answer": 42}  # sabotage check: cached, not re-executed
+
+
+@pytest.mark.asyncio
+async def test_user_input_suspends_when_unanswered(tmp_path):
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
+    with pytest.raises(WorkflowSuspended) as ei:
+        await h.user_input("What topic?")
+    assert ei.value.seq == 0
+    assert ei.value.prompt == "What topic?"
+
+
+@pytest.mark.asyncio
+async def test_user_input_replays_recorded_answer(tmp_path):
+    from decafclaw.workflow.journal import fingerprint
+    j = Journal(workflow_name="t")
+    fp = fingerprint("user_input", {"prompt": "What topic?", "choices": None})
+    j.append(0, "user_input", fp, "tide pools")
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
+    assert await h.user_input("What topic?") == "tide pools"
+
+
+@pytest.mark.asyncio
+async def test_determinism_guard_fires_on_divergent_args(tmp_path):
+    from decafclaw.workflow.journal import fingerprint
+    j = Journal(workflow_name="t")
+    fp = fingerprint("llm_call", {"prompt": "ORIGINAL", "schema": {}, "system": ""})
+    j.append(0, "llm_call", fp, {"x": 1})
+
+    async def fake_llm(ctx, **kw):
+        return {"x": 1}
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
+    with pytest.raises(WorkflowNonDeterministic):
+        await h.llm_call(prompt="CHANGED", schema={}, model="m")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_handle.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.handle`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/handle.py
+"""WorkflowHandle — the `wf` object an orchestrator drives.
+
+Exposes the two journaled primitives. Positional cursor advances once per
+journaled call. Replay returns cached results (after a determinism check);
+new llm_calls run live and journal; new user_inputs raise WorkflowSuspended.
+"""
+import logging
+
+from . import llm as wf_llm
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .journal import fingerprint, save_journal
+
+log = logging.getLogger(__name__)
+
+
+async def _default_llm_call(ctx, **kw):
+    return await wf_llm.call_structured(ctx, **kw)
+
+
+class WorkflowHandle:
+    def __init__(self, ctx, journal, *, llm_caller=None,
+                 model: str = "vertex-gemini-flash"):
+        self.ctx = ctx
+        self.journal = journal
+        self._cursor = 0
+        self._llm_caller = llm_caller or _default_llm_call
+        self._model = model
+
+    def _check_or_none(self, seq: int, kind: str, fp: str):
+        """Return cached result for an already-journaled call at seq, or None.
+
+        Raises WorkflowNonDeterministic if the recorded call doesn't match.
+        """
+        existing = self.journal.get(seq)
+        if existing is None:
+            return None, False
+        if existing.kind != kind or existing.args_fingerprint != fp:
+            raise WorkflowNonDeterministic(
+                seq, existing.kind, existing.args_fingerprint, kind, fp)
+        return existing.result, True
+
+    async def llm_call(self, *, prompt: str, schema: dict, system: str = "",
+                       tool_name: str = "submit", model: str | None = None):
+        seq = self._cursor
+        self._cursor += 1
+        fp = fingerprint("llm_call",
+                         {"prompt": prompt, "schema": schema, "system": system})
+        cached, hit = self._check_or_none(seq, "llm_call", fp)
+        if hit:
+            return cached
+        result = await self._llm_caller(
+            self.ctx, system=system, user_msg=prompt, schema=schema,
+            tool_name=tool_name, model=model or self._model)
+        self.journal.append(seq, "llm_call", fp, result)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return result
+
+    async def user_input(self, prompt: str, *, choices: list[str] | None = None):
+        seq = self._cursor
+        self._cursor += 1
+        fp = fingerprint("user_input", {"prompt": prompt, "choices": choices})
+        cached, hit = self._check_or_none(seq, "user_input", fp)
+        if hit:
+            return cached
+        # New, unanswered → suspend. The journal (entries 0..seq-1) is already
+        # persisted by the preceding live call (or empty on a fresh start).
+        raise WorkflowSuspended(seq=seq, args_fingerprint=fp, prompt=prompt,
+                                choices=choices)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_handle.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/handle.py tests/test_workflow_handle.py
+git commit -m "feat(workflow): WorkflowHandle replay/suspend/determinism core"
+```
+
+---
+
+## Task 5: The engine — run_workflow
+
+**Files:**
+- Create: `src/decafclaw/workflow/engine.py`
+- Test: `tests/test_workflow_engine.py`
+
+`run_workflow` builds a handle, runs the orchestrator, and classifies the outcome: completion, suspension, or error. It persists the journal status at each terminal state.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_engine.py
+import pytest
+from types import SimpleNamespace
+from decafclaw.workflow.engine import run_workflow
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convE")
+
+
+@pytest.mark.asyncio
+async def test_suspends_on_first_user_input(tmp_path):
+    async def wf(h):
+        topic = await h.user_input("topic?")
+        return {"topic": topic}
+
+    j = Journal(workflow_name="t")
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "suspended"
+    assert outcome.suspend.prompt == "topic?"
+    assert j.status == "suspended"
+
+
+@pytest.mark.asyncio
+async def test_completes_when_journal_fully_seeded(tmp_path):
+    async def wf(h):
+        topic = await h.user_input("topic?")
+        return {"topic": topic, "done": True}
+
+    j = Journal(workflow_name="t")
+    fp = fingerprint("user_input", {"prompt": "topic?", "choices": None})
+    j.append(0, "user_input", fp, "tide pools")
+
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "done"
+    assert outcome.result == {"topic": "tide pools", "done": True}
+    assert j.status == "done"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_exception_becomes_error_outcome(tmp_path):
+    async def wf(h):
+        raise ValueError("boom")
+
+    j = Journal(workflow_name="t")
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "error"
+    assert "boom" in outcome.error
+    assert j.status == "error"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_engine.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.engine`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/engine.py
+"""run_workflow — runs an orchestrator once, classifying the outcome.
+
+The engine owns control flow only in the trivial sense that it invokes the
+orchestrator and interprets how it returned: completed, suspended for user
+input, or errored. The orchestrator itself is plain async Python.
+"""
+import dataclasses
+import logging
+from typing import Any, Awaitable, Callable
+
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .handle import WorkflowHandle
+from .journal import Journal, save_journal
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class WorkflowOutcome:
+    status: str  # "done" | "suspended" | "error"
+    result: Any = None
+    suspend: WorkflowSuspended | None = None
+    error: str = ""
+
+
+async def run_workflow(
+    ctx,
+    workflow_fn: Callable[[WorkflowHandle], Awaitable[Any]],
+    journal: Journal,
+    *,
+    llm_caller=None,
+    model: str = "vertex-gemini-flash",
+) -> WorkflowOutcome:
+    handle = WorkflowHandle(ctx, journal, llm_caller=llm_caller, model=model)
+
+    def _persist(status: str) -> None:
+        journal.status = status
+        save_journal(ctx.config, ctx.conv_id, journal)
+
+    try:
+        result = await workflow_fn(handle)
+    except WorkflowSuspended as s:
+        _persist("suspended")
+        return WorkflowOutcome(status="suspended", suspend=s)
+    except WorkflowNonDeterministic as e:
+        log.error("workflow non-deterministic: %s", e)
+        _persist("error")
+        return WorkflowOutcome(status="error", error=str(e))
+    except Exception as e:  # noqa: BLE001 — terminal classification
+        log.exception("workflow orchestrator raised")
+        _persist("error")
+        return WorkflowOutcome(status="error", error=str(e))
+
+    _persist("done")
+    return WorkflowOutcome(status="done", result=result)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_engine.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/engine.py tests/test_workflow_engine.py
+git commit -m "feat(workflow): run_workflow engine with outcome classification"
+```
+
+---
+
+## Task 6: Registry + decorator
+
+**Files:**
+- Create: `src/decafclaw/workflow/registry.py`
+- Modify: `src/decafclaw/workflow/__init__.py`
+- Test: `tests/test_workflow_registry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_registry.py
+import pytest
+from decafclaw.workflow.registry import workflow, get_workflow, REGISTRY
+
+
+def test_decorator_registers_and_lookup_works():
+    @workflow("demo_wf")
+    async def demo(h):
+        return "ok"
+
+    spec = get_workflow("demo_wf")
+    assert spec is not None
+    assert spec.name == "demo_wf"
+    assert spec.fn is demo
+
+
+def test_unknown_workflow_returns_none():
+    assert get_workflow("does_not_exist_xyz") is None
+
+
+def test_duplicate_name_raises():
+    @workflow("dup_wf")
+    async def a(h):
+        return 1
+    with pytest.raises(ValueError):
+        @workflow("dup_wf")
+        async def b(h):
+            return 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_registry.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.registry`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/registry.py
+"""Workflow registry + @workflow decorator.
+
+A workflow is its own first-class concept — NOT a skill. It borrows only
+the command-invocation plumbing. Orchestrators register at import time.
+"""
+import dataclasses
+from typing import Any, Awaitable, Callable
+
+
+@dataclasses.dataclass
+class WorkflowSpec:
+    name: str
+    fn: Callable[[Any], Awaitable[Any]]
+    model: str = "vertex-gemini-flash"
+
+
+REGISTRY: dict[str, WorkflowSpec] = {}
+
+
+def workflow(name: str, *, model: str = "vertex-gemini-flash"):
+    def deco(fn):
+        if name in REGISTRY:
+            raise ValueError(f"workflow {name!r} already registered")
+        REGISTRY[name] = WorkflowSpec(name=name, fn=fn, model=model)
+        return fn
+    return deco
+
+
+def get_workflow(name: str) -> WorkflowSpec | None:
+    return REGISTRY.get(name)
+
+
+def workflow_commands() -> list[str]:
+    """Names invocable as /<name>. Used by the command bridge."""
+    return list(REGISTRY.keys())
+```
+
+```python
+# src/decafclaw/workflow/__init__.py
+"""Workflow replay engine (#255)."""
+from .engine import WorkflowOutcome, run_workflow
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .handle import WorkflowHandle
+from .registry import REGISTRY, get_workflow, workflow, workflow_commands
+
+__all__ = [
+    "run_workflow", "WorkflowOutcome", "WorkflowHandle",
+    "WorkflowSuspended", "WorkflowNonDeterministic",
+    "workflow", "get_workflow", "workflow_commands", "REGISTRY",
+]
+```
+
+> **Note for the engineer:** `tests/test_workflow_registry.py::test_duplicate_name_raises` registers `dup_wf` once successfully then expects the second to raise — if you re-run with `-p no:randomly` ordering issues, each test name is unique so the module-level `REGISTRY` won't collide across tests. Do not add an autouse fixture that clears `REGISTRY` (later tests rely on `workflows/` imports having registered).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_registry.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/registry.py src/decafclaw/workflow/__init__.py tests/test_workflow_registry.py
+git commit -m "feat(workflow): registry + @workflow decorator"
+```
+
+---
+
+## Task 7: The interview orchestrator
+
+**Files:**
+- Create: `src/decafclaw/workflow/workflows/__init__.py`
+- Create: `src/decafclaw/workflow/workflows/interview.py`
+- Test: `tests/test_workflow_interview.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_interview.py
+import pytest
+from types import SimpleNamespace
+from decafclaw.workflow.engine import run_workflow
+from decafclaw.workflow.journal import Journal, fingerprint
+from decafclaw.workflow.registry import get_workflow
+import decafclaw.workflow.workflows  # noqa: F401 — registers interview
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convI")
+
+
+@pytest.mark.asyncio
+async def test_interview_suspends_for_topic_first(tmp_path):
+    spec = get_workflow("interview")
+    assert spec is not None
+    outcome = await run_workflow(_ctx(tmp_path), spec.fn, Journal(workflow_name="interview"))
+    assert outcome.status == "suspended"
+    assert "about" in outcome.suspend.prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_interview_replays_to_artifact(tmp_path):
+    """Seed a full journal (topic + one Q/A + done + synth) → pure replay,
+    no LLM, reaches the artifact."""
+    spec = get_workflow("interview")
+    j = Journal(workflow_name="interview")
+
+    def fp_user(prompt):
+        return fingerprint("user_input", {"prompt": prompt, "choices": None})
+
+    def fp_llm(prompt, schema, system):
+        return fingerprint("llm_call",
+                           {"prompt": prompt, "schema": schema, "system": system})
+
+    # The orchestrator's call order must match these seq positions exactly.
+    # Engineer: if a fingerprint mismatch (WorkflowNonDeterministic) fires,
+    # the seeded args don't match the orchestrator's actual prompt/schema —
+    # align them, do not loosen the guard.
+    from decafclaw.workflow.workflows.interview import (
+        _ask_prompt, _synth_prompt, _SYS_ASK, _SYS_SYNTH,
+        _DECISION_SCHEMA, _ARTIFACT_SCHEMA,
+    )
+    j.append(0, "user_input", fp_user("What should this interview be about?"), "tide pools")
+    q1_prompt = _ask_prompt("tide pools", [])
+    j.append(1, "llm_call", fp_llm(q1_prompt, _DECISION_SCHEMA, _SYS_ASK),
+             {"done": False, "question": "What draws you to them?"})
+    j.append(2, "user_input", fp_user("What draws you to them?"), "the creatures")
+    q2_prompt = _ask_prompt("tide pools", [{"q": "What draws you to them?", "a": "the creatures"}])
+    j.append(3, "llm_call", fp_llm(q2_prompt, _DECISION_SCHEMA, _SYS_ASK),
+             {"done": True, "question": ""})
+    synth_prompt = _synth_prompt("tide pools",
+                                 [{"q": "What draws you to them?", "a": "the creatures"}])
+    j.append(4, "llm_call", fp_llm(synth_prompt, _ARTIFACT_SCHEMA, _SYS_SYNTH),
+             {"title": "Tide Pools", "body": "..."})
+
+    outcome = await run_workflow(_ctx(tmp_path), spec.fn, j)
+    assert outcome.status == "done"
+    assert outcome.result["title"] == "Tide Pools"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_interview.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.workflows`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/workflows/__init__.py
+"""Importing this package registers all bundled orchestrators."""
+from . import interview  # noqa: F401
+```
+
+```python
+# src/decafclaw/workflow/workflows/interview.py
+"""Interview → artifact: the #255 hero workflow.
+
+Asks one question at a time, looping until the model says it has enough (or a
+cap), then synthesizes an artifact. The whole thing is plain Python — the
+only journaled boundary crossings are wf.user_input and wf.llm_call.
+"""
+from ..registry import workflow
+
+MAX_Q = 6
+
+_SYS_ASK = (
+    "You are conducting a focused interview to gather material for a written "
+    "artifact. Ask ONE good next question at a time. Decide when you have "
+    "enough to write something useful."
+)
+_SYS_SYNTH = (
+    "You synthesize an interview transcript into a clear, well-structured "
+    "written artifact."
+)
+
+_DECISION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "done": {"type": "boolean",
+                 "description": "True when you have enough to synthesize."},
+        "question": {"type": "string",
+                     "description": "The next question (empty if done)."},
+    },
+    "required": ["done", "question"],
+}
+
+_ARTIFACT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body": {"type": "string", "description": "Markdown body."},
+    },
+    "required": ["title", "body"],
+}
+
+
+def _ask_prompt(topic: str, answers: list[dict]) -> str:
+    lines = [f"Topic: {topic}", ""]
+    if answers:
+        lines.append("Answers so far:")
+        for a in answers:
+            lines.append(f"- Q: {a['q']}\n  A: {a['a']}")
+        lines.append("")
+    lines.append("Decide whether you have enough. If not, ask the next question.")
+    return "\n".join(lines)
+
+
+def _synth_prompt(topic: str, answers: list[dict]) -> str:
+    lines = [f"Topic: {topic}", "", "Interview transcript:"]
+    for a in answers:
+        lines.append(f"- Q: {a['q']}\n  A: {a['a']}")
+    lines.append("")
+    lines.append("Write a titled markdown artifact synthesizing this.")
+    return "\n".join(lines)
+
+
+@workflow("interview")
+async def interview(wf):
+    topic = await wf.user_input("What should this interview be about?")
+
+    answers: list[dict] = []
+    while len(answers) < MAX_Q:
+        decision = await wf.llm_call(
+            prompt=_ask_prompt(topic, answers),
+            schema=_DECISION_SCHEMA, system=_SYS_ASK)
+        if decision.get("done"):
+            break
+        reply = await wf.user_input(decision["question"])
+        answers.append({"q": decision["question"], "a": reply})
+
+    return await wf.llm_call(
+        prompt=_synth_prompt(topic, answers),
+        schema=_ARTIFACT_SCHEMA, system=_SYS_SYNTH)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_interview.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/workflows/ tests/test_workflow_interview.py
+git commit -m "feat(workflow): interview orchestrator"
+```
+
+---
+
+## Task 8: ConfirmationAction.WORKFLOW_USER_INPUT
+
+**Files:**
+- Modify: `src/decafclaw/confirmations.py:14-21`
+- Test: `tests/test_workflow_resume.py` (created here, extended in Task 9)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_resume.py
+from decafclaw.confirmations import ConfirmationAction
+
+
+def test_workflow_user_input_action_exists():
+    assert ConfirmationAction.WORKFLOW_USER_INPUT.value == "workflow_user_input"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_resume.py -v`
+Expected: FAIL — `AttributeError: WORKFLOW_USER_INPUT`
+
+- [ ] **Step 3: Implement** — add one line to the enum
+
+```python
+# src/decafclaw/confirmations.py — inside class ConfirmationAction
+    WIDGET_RESPONSE = "widget_response"
+    WORKFLOW_USER_INPUT = "workflow_user_input"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_resume.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/confirmations.py tests/test_workflow_resume.py
+git commit -m "feat(workflow): WORKFLOW_USER_INPUT confirmation action"
+```
+
+---
+
+## Task 9: Resume handler + turn glue
+
+**Files:**
+- Create: `src/decafclaw/workflow/resume.py`
+- Test: `tests/test_workflow_resume.py` (extend)
+
+`run_workflow_turn` is the harness entry point (called from `_start_turn`). `WorkflowUserInputHandler` resolves a posted confirmation: journals the answer at the suspended seq, then enqueues a resume WORKFLOW turn. The handler captures the manager so the recovery ctx (which lacks `.manager`) is sufficient.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/test_workflow_resume.py`)
+
+```python
+import pytest
+from types import SimpleNamespace
+from decafclaw.confirmations import ConfirmationRequest, ConfirmationResponse, ConfirmationAction
+from decafclaw.workflow.journal import Journal, save_journal, load_journal, fingerprint
+from decafclaw.workflow.resume import WorkflowUserInputHandler, run_workflow_turn
+
+
+def _ctx(tmp_path, conv_id="convR"):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id=conv_id)
+
+
+@pytest.mark.asyncio
+async def test_handler_journals_answer_and_enqueues_resume(tmp_path):
+    # A suspended interview: topic question posted, journal has no entries yet.
+    cfg = SimpleNamespace(workspace_path=tmp_path)
+    j = Journal(workflow_name="interview", status="suspended")
+    save_journal(cfg, "convR", j)
+
+    fp = fingerprint("user_input",
+                     {"prompt": "What should this interview be about?",
+                      "choices": None})
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="What should this interview be about?",
+        action_data={"workflow_name": "interview", "seq": 0,
+                     "args_fingerprint": fp, "prompt": "...", "choices": None},
+        timeout=None,
+    )
+    response = ConfirmationResponse(confirmation_id="x", approved=True,
+                                    data={"value": "tide pools"})
+
+    enqueued = []
+
+    class FakeManager:
+        config = cfg
+        async def enqueue_turn(self, conv_id, **kw):
+            enqueued.append((conv_id, kw))
+
+    handler = WorkflowUserInputHandler(FakeManager())
+    out = await handler.on_approve(_ctx(tmp_path), request, response)
+
+    reloaded = load_journal(cfg, "convR")
+    assert reloaded.get(0).kind == "user_input"
+    assert reloaded.get(0).result == "tide pools"
+    assert reloaded.status == "running"
+    assert enqueued and enqueued[0][1]["metadata"]["resume"] is True
+    assert out == {"continue_loop": False}
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_turn_fresh_start_suspends_and_posts(tmp_path):
+    posted = []
+
+    class FakeManager:
+        config = SimpleNamespace(workspace_path=tmp_path)
+        async def post_confirmation(self, conv_id, request):
+            posted.append(request)
+
+    ctx = _ctx(tmp_path, "convT")
+    result = await run_workflow_turn(
+        ctx, FakeManager(), "convT",
+        workflow_name="interview", resume=False)
+    assert posted, "a confirmation should be posted on suspend"
+    assert posted[0].action_type == ConfirmationAction.WORKFLOW_USER_INPUT
+    assert posted[0].action_data["seq"] == 0
+    assert hasattr(result, "text")  # ToolResult-like
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_resume.py -v`
+Expected: FAIL — `ModuleNotFoundError: decafclaw.workflow.resume`
+
+- [ ] **Step 3: Implement**
+
+```python
+# src/decafclaw/workflow/resume.py
+"""Harness glue: run a workflow turn, and resume it after user input.
+
+run_workflow_turn is invoked by ConversationManager._start_turn for
+TurnKind.WORKFLOW. WorkflowUserInputHandler is registered on the
+ConfirmationRegistry; it fires via the confirmation *recovery* path
+(no awaiting waiter) because a workflow suspend ends the turn.
+"""
+import logging
+
+from decafclaw.confirmations import (
+    ConfirmationAction, ConfirmationRequest, ConfirmationResponse,
+)
+from decafclaw.media import ToolResult
+
+from .engine import run_workflow
+from .journal import Journal, load_journal, save_journal
+from .registry import get_workflow
+
+log = logging.getLogger(__name__)
+
+
+def _render_artifact(result) -> str:
+    if isinstance(result, dict) and "title" in result and "body" in result:
+        return f"# {result['title']}\n\n{result['body']}"
+    return str(result)
+
+
+async def run_workflow_turn(ctx, manager, conv_id: str, *,
+                            workflow_name: str, resume: bool) -> ToolResult:
+    spec = get_workflow(workflow_name)
+    if spec is None:
+        return ToolResult(text=f"[workflow error: unknown workflow "
+                               f"{workflow_name!r}]")
+
+    journal = load_journal(ctx.config, conv_id)
+    if journal is None:
+        if resume:
+            return ToolResult(text="[workflow error: no journal to resume]")
+        journal = Journal(workflow_name=workflow_name)
+
+    await ctx.publish("tool_status", tool="workflow",
+                      message=f"[workflow: {workflow_name}] running")
+    outcome = await run_workflow(ctx, spec.fn, journal, model=spec.model)
+
+    if outcome.status == "done":
+        await ctx.publish("tool_status", tool="workflow",
+                          message=f"[workflow: {workflow_name}] complete")
+        return ToolResult(text=_render_artifact(outcome.result))
+
+    if outcome.status == "suspended":
+        s = outcome.suspend
+        request = ConfirmationRequest(
+            action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+            message=s.prompt,
+            action_data={
+                "workflow_name": workflow_name,
+                "seq": s.seq,
+                "args_fingerprint": s.args_fingerprint,
+                "prompt": s.prompt,
+                "choices": s.choices,
+            },
+            timeout=None,  # user answers when ready
+        )
+        await manager.post_confirmation(conv_id, request)
+        return ToolResult(text=f"_{s.prompt}_")
+
+    return ToolResult(text=f"[workflow error: {outcome.error}]")
+
+
+class WorkflowUserInputHandler:
+    """Resolves a WORKFLOW_USER_INPUT confirmation via the recovery path."""
+
+    def __init__(self, manager):
+        self.manager = manager
+
+    async def on_approve(self, ctx, request: ConfirmationRequest,
+                         response: ConfirmationResponse) -> dict:
+        ad = request.action_data
+        answer = (response.data or {}).get("value", "")
+        journal = load_journal(ctx.config, ctx.conv_id)
+        if journal is None:
+            log.error("workflow resume: no journal for conv %s", ctx.conv_id)
+            return {"continue_loop": False}
+        journal.append(ad["seq"], "user_input", ad["args_fingerprint"], answer)
+        journal.status = "running"
+        save_journal(ctx.config, ctx.conv_id, journal)
+
+        from decafclaw.conversation_manager import TurnKind
+        await self.manager.enqueue_turn(
+            ctx.conv_id, kind=TurnKind.WORKFLOW, prompt="",
+            metadata={"workflow_name": ad["workflow_name"], "resume": True})
+        return {"continue_loop": False}
+
+    async def on_deny(self, ctx, request: ConfirmationRequest,
+                      response: ConfirmationResponse) -> dict:
+        journal = load_journal(ctx.config, ctx.conv_id)
+        if journal is not None:
+            journal.status = "error"
+            save_journal(ctx.config, ctx.conv_id, journal)
+        return {"continue_loop": False}
+```
+
+> **Engineer note:** `ToolResult` is in `decafclaw.media` (confirmed). `enqueue_turn`'s `metadata` kwarg is threaded into `_start_turn` (signature at `conversation_manager.py:1299`). The handler imports `TurnKind` lazily to avoid an import cycle (`conversation_manager` will import `resume`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_resume.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/workflow/resume.py tests/test_workflow_resume.py
+git commit -m "feat(workflow): resume handler + run_workflow_turn glue"
+```
+
+---
+
+## Task 10: ConversationManager — post_confirmation
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py` (new method near `request_confirmation`, ~line 1103)
+- Test: `tests/test_workflow_turn_integration.py`
+
+`post_confirmation` sets `pending_confirmation` but deliberately **leaves `confirmation_event` None**, so `respond_to_confirmation` takes the recovery branch (no waiter) → dispatches to our handler.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_workflow_turn_integration.py
+import pytest
+from decafclaw.confirmations import ConfirmationRequest, ConfirmationAction
+
+
+@pytest.mark.asyncio
+async def test_post_confirmation_sets_pending_without_waiter(make_manager):
+    # make_manager: a fixture building a real ConversationManager on tmp config.
+    manager = make_manager()
+    conv_id = "convP"
+    req = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="topic?", action_data={"seq": 0}, timeout=None)
+
+    await manager.post_confirmation(conv_id, req)
+
+    state = manager._conversations[conv_id]
+    assert state.pending_confirmation is req
+    assert state.confirmation_event is None  # forces recovery dispatch
+```
+
+> **Engineer note:** add a `make_manager` fixture to `tests/conftest.py` if one doesn't exist, building `ConversationManager(config=..., event_bus=EventBus())` on a `tmp_path` workspace. Search existing tests (`tests/test_confirmations*.py`, `tests/test_conversation_manager*.py`) for the established construction pattern and reuse it rather than inventing a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_turn_integration.py::test_post_confirmation_sets_pending_without_waiter -v`
+Expected: FAIL — `AttributeError: 'ConversationManager' object has no attribute 'post_confirmation'`
+
+- [ ] **Step 3: Implement** — add method to `ConversationManager` (after `request_confirmation`)
+
+```python
+    async def post_confirmation(
+        self,
+        conv_id: str,
+        request: ConfirmationRequest,
+    ) -> None:
+        """Post a pending confirmation WITHOUT awaiting it.
+
+        Used by workflow suspends: the workflow turn ENDS at a user_input,
+        so there is no live waiter. We persist + install the request as the
+        active confirmation but deliberately leave ``confirmation_event``
+        None, so ``respond_to_confirmation`` routes resolution through the
+        recovery dispatch path (registered handler), not a waiter wake.
+        """
+        from .archive import append_message
+        append_message(self.config, conv_id, request.to_archive_message())
+        state = self._get_or_create(conv_id)
+        async with state.lock:
+            if state.pending_confirmation is not None:
+                # A workflow turn is serialized by the busy flag, so the slot
+                # should be free. If not, queue rather than clobber.
+                queued = _QueuedConfirmation(request=request)
+                state.confirmation_queue.append(queued)
+                log.warning("post_confirmation: slot busy on conv %s; queued",
+                            conv_id[:8])
+                return
+            state.pending_confirmation = request
+            state.confirmation_event = None  # no waiter — recovery path
+            state.confirmation_response = None
+        await self.emit(conv_id, _confirmation_request_payload(request))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_turn_integration.py::test_post_confirmation_sets_pending_without_waiter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/conversation_manager.py tests/test_workflow_turn_integration.py
+git commit -m "feat(workflow): ConversationManager.post_confirmation (no-waiter)"
+```
+
+---
+
+## Task 11: TurnKind.WORKFLOW + dispatch + handler registration
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py:73-80` (enum), `__init__` (register handler), `_start_turn.run()` (~1449-1456)
+- Test: `tests/test_workflow_turn_integration.py` (extend)
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+@pytest.mark.asyncio
+async def test_workflow_turn_runs_and_suspends_end_to_end(make_manager):
+    """Enqueue an interview WORKFLOW turn → it suspends posting a
+    WORKFLOW_USER_INPUT confirmation for the topic question."""
+    import decafclaw.workflow.workflows  # noqa: F401 — register interview
+    manager = make_manager()
+    conv_id = "convW"
+
+    fut = await manager.enqueue_turn(
+        conv_id, kind=manager_turnkind_workflow(), prompt="",
+        metadata={"workflow_name": "interview", "resume": False})
+    await fut  # wait for the turn to finish (it suspends, then ends)
+
+    state = manager._conversations[conv_id]
+    assert state.pending_confirmation is not None
+    assert state.pending_confirmation.action_type.value == "workflow_user_input"
+    assert state.pending_confirmation.action_data["workflow_name"] == "interview"
+
+
+def manager_turnkind_workflow():
+    from decafclaw.conversation_manager import TurnKind
+    return TurnKind.WORKFLOW
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_workflow_turn_integration.py::test_workflow_turn_runs_and_suspends_end_to_end -v`
+Expected: FAIL — `AttributeError: WORKFLOW` (enum) or dispatch falls through to `run_agent_turn`.
+
+- [ ] **Step 3a: Add the enum variant** (`conversation_manager.py:73-80`)
+
+```python
+class TurnKind(Enum):
+    """Classification of agent turn origins."""
+
+    USER = "user"
+    HEARTBEAT_SECTION = "heartbeat_section"
+    SCHEDULED_TASK = "scheduled_task"
+    CHILD_AGENT = "child_agent"
+    WAKE = "wake"
+    WORKFLOW = "workflow"
+```
+
+WORKFLOW is NOT added to `TASK_KINDS`/`STATE_PERSIST_KINDS` — it builds a regular `Context` (the `else` branch at line ~1353), loads history, and does not need per-conv skill-state persistence.
+
+- [ ] **Step 3b: Register the handler in `ConversationManager.__init__`**
+
+Find where `self.confirmation_registry` is created in `__init__` and, right after, register the workflow handler. (Search for `self.confirmation_registry =` or `ConfirmationRegistry(`.)
+
+```python
+        # Workflow user-input resumes via the confirmation recovery path.
+        from .workflow.resume import WorkflowUserInputHandler
+        from .confirmations import ConfirmationAction
+        self.confirmation_registry.register(
+            ConfirmationAction.WORKFLOW_USER_INPUT,
+            WorkflowUserInputHandler(self))
+```
+
+- [ ] **Step 3c: Dispatch WORKFLOW turns in `_start_turn.run()`** (~line 1449-1456)
+
+Replace the body that calls `run_agent_turn` with a kind branch. The surrounding `run()` machinery (emit `message_complete`, finally cleanup) is unchanged — `run_workflow_turn` returns a `ToolResult` with `.text`, satisfying the existing `result.text` access at line 1458.
+
+```python
+        async def run():
+            try:
+                if kind is TurnKind.WORKFLOW:
+                    from .workflow.resume import run_workflow_turn
+                    md = metadata or {}
+                    result = await run_workflow_turn(
+                        ctx, self, conv_id,
+                        workflow_name=md.get("workflow_name", ""),
+                        resume=md.get("resume", False))
+                else:
+                    from .agent import run_agent_turn
+                    result = await run_agent_turn(
+                        ctx, text, history,
+                        archive_text=archive_text,
+                        attachments=attachments,
+                    )
+                # ... existing response_text / emit message_complete block unchanged
+```
+
+> **Engineer note:** make the *minimal* edit — wrap only the `run_agent_turn` call in the `if/else`; leave every line after `result = ...` (the `response_text = result.text ...` block, the `except`/`finally`) exactly as-is. Read `conversation_manager.py:1449-1556` before editing.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_workflow_turn_integration.py -v`
+Expected: PASS. Then full module: `pytest tests/test_workflow_*.py -v` → all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/conversation_manager.py tests/test_workflow_turn_integration.py
+git commit -m "feat(workflow): TurnKind.WORKFLOW dispatch + handler registration"
+```
+
+---
+
+## Task 12: /interview command bridge
+
+**Files:**
+- Modify: `src/decafclaw/web/websocket.py` (command handling, ~line 302)
+- Test: covered by manual smoke (Task 14); add a thin unit test if a command-dispatch seam exists.
+
+The web UI sends user text; commands are detected before a normal turn. Workflows aren't skills, so `dispatch_command` won't find `/interview`. Add a pre-check: if the text is `/<name>` where `<name>` in `workflow_commands()`, enqueue a WORKFLOW turn instead of a normal message.
+
+- [ ] **Step 1: Read the current command path**
+
+Read `src/decafclaw/web/websocket.py:295-365` (the `dispatch_command` call + `manager.send_message`). Identify the point right after the text is known and before `dispatch_command`.
+
+- [ ] **Step 2: Implement the bridge** — insert before the existing `dispatch_command(cmd_ctx, text)` call
+
+```python
+        # Workflow commands (#255) are first-class, not skills — intercept
+        # before the skill command dispatch.
+        from decafclaw.workflow.registry import workflow_commands
+        wf_trigger = None
+        if text.startswith("/"):
+            name = text[1:].split()[0] if len(text) > 1 else ""
+            if name in workflow_commands():
+                wf_trigger = name
+        if wf_trigger:
+            await ws_send({
+                "type": WSMessageType.COMMAND_ACK, "conv_id": conv_id,
+                "command": f"/{wf_trigger}", "skill": wf_trigger,
+            })
+            await manager.enqueue_turn(
+                conv_id, kind=TurnKind.WORKFLOW, prompt="",
+                user_id=username, context_setup=context_setup,
+                metadata={"workflow_name": wf_trigger, "resume": False})
+            return
+```
+
+> **Engineer note:** confirm the names in scope at this point in `websocket.py`: `text`, `conv_id`, `username`, `context_setup`, `ws_send`, `WSMessageType`, `manager`, and that `TurnKind` is imported (add `from decafclaw.conversation_manager import TurnKind` if not). Match the existing `enqueue_turn` call's kwargs for transport context (`user_id`, `context_setup`) so progress events render in the UI. Read the surrounding handler before editing.
+
+- [ ] **Step 3: Lint + run the workflow tests**
+
+Run: `make lint && pytest tests/test_workflow_*.py -v`
+Expected: clean lint; all workflow tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/decafclaw/web/websocket.py
+git commit -m "feat(workflow): /interview command bridge in web UI"
+```
+
+---
+
+## Task 13: Restart-durability integration test
+
+**Files:**
+- Test: `tests/test_workflow_turn_integration.py` (extend)
+
+Proves the core promise: a journal persisted mid-suspend resumes from a fresh manager (simulating a restart) with no lost state.
+
+- [ ] **Step 1: Write the test**
+
+```python
+@pytest.mark.asyncio
+async def test_resume_after_simulated_restart(make_manager, tmp_path_factory):
+    """Run interview to first suspend, persist; build a NEW manager on the
+    same workspace; respond to the confirmation → resume turn replays and
+    advances to the next suspension. No in-memory state carried over."""
+    import decafclaw.workflow.workflows  # noqa: F401
+    from decafclaw.workflow.journal import load_journal
+
+    ws = tmp_path_factory.mktemp("ws")
+    conv_id = "convRestart"
+
+    mgr1 = make_manager(workspace=ws)
+    fut = await mgr1.enqueue_turn(
+        conv_id, kind=manager_turnkind_workflow(), prompt="",
+        metadata={"workflow_name": "interview", "resume": False})
+    await fut
+    req = mgr1._conversations[conv_id].pending_confirmation
+    assert req is not None and req.action_data["seq"] == 0
+
+    # Simulate restart: brand-new manager, same workspace on disk.
+    mgr2 = make_manager(workspace=ws)
+    # Startup recovery would normally re-install pending_confirmation from the
+    # archive; do that explicitly here via the public recovery entry point.
+    mgr2._recover_pending_confirmations(conv_id)  # see engineer note
+
+    await mgr2.respond_to_confirmation(
+        conv_id, req.confirmation_id, approved=True,
+        data={"value": "tide pools"})
+
+    # Give the enqueued resume turn a moment to run to its next suspension.
+    fut2 = mgr2._conversations[conv_id].agent_task
+    if fut2 is not None:
+        await fut2
+
+    journal = load_journal(mgr2.config, conv_id)
+    assert journal.get(0).result == "tide pools"  # answer journaled
+    # Resume replayed past seq 0 and either suspended again (next question)
+    # or progressed — journal must have grown beyond the single answer.
+    assert len(journal.entries) >= 1
+```
+
+> **Engineer note:** the exact restart-recovery entry point may be named differently — search `conversation_manager.py` for the startup confirmation scan (around line 1734/1814, `role == "confirmation_request"`). Use whatever public method re-installs a pending confirmation from the archive; if it only runs as part of a broader startup routine, call that. The assertion that matters: after responding on a fresh manager, the answer is journaled and the workflow advanced. If `respond_to_confirmation` needs `pending_confirmation` set, ensure recovery installed it first. Adjust the waiting mechanism to the codebase's test conventions (avoid fixed sleeps — await the `agent_task`).
+
+- [ ] **Step 2: Run, iterate to green**
+
+Run: `pytest tests/test_workflow_turn_integration.py::test_resume_after_simulated_restart -v`
+Expected: PASS. If the recovery entry point differs, fix the call per the engineer note; do not weaken the journal assertions.
+
+- [ ] **Step 3: Full suite + durations check**
+
+Run: `make test` then `pytest tests/test_workflow_*.py --durations=10`
+Expected: all green; no workflow test in the slow tail (no fixed sleeps).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_workflow_turn_integration.py
+git commit -m "test(workflow): resume survives simulated restart"
+```
+
+---
+
+## Task 14: Live smoke (manual) + docs
+
+**Files:**
+- Create: `docs/workflows.md` (feature doc)
+- Modify: `docs/index.md` (link), `CLAUDE.md` key-files list (add `workflow/`)
+- Manual: live smoke against Mattermost/web UI
+
+- [ ] **Step 1: Write `docs/workflows.md`** — cover: what a workflow is (first-class `TurnKind.WORKFLOW`), the journaled-vs-pure rule, the two primitives, the journal at `conversations/{conv_id}/workflow.json`, suspend/resume via the confirmation recovery path, the determinism guard, and how to author one (`@workflow` + the interview as worked example). Add the "explicitly later" scope list from the spec.
+
+- [ ] **Step 2: Link from `docs/index.md`** and add `src/decafclaw/workflow/` to the CLAUDE.md key-files list under a new "### Workflows" heading.
+
+- [ ] **Step 3: Live smoke (the bar no prior iteration cleared).** Ask Les to confirm no other bot instance is connected, then in the web UI:
+  1. New conversation → `/interview`.
+  2. Answer the topic question, then 1–2 follow-up questions.
+  3. **Restart the server mid-interview** (Ctrl-C the dev process, restart).
+  4. Reload the UI; the pending question should still be there. Answer it.
+  5. Continue to completion; confirm the artifact renders.
+
+  Capture the phase `tool_status` lines and the final artifact in `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/notes.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/workflows.md docs/index.md CLAUDE.md docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/notes.md
+git commit -m "docs(workflow): feature doc + live restart smoke notes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `workflow/` module (registry/engine/journal/primitives) → Tasks 1–7 ✓
+- `TurnKind.WORKFLOW` + engine-routed resume → Tasks 9, 11 ✓
+- `llm_call` + `user_input` journaled primitives → Tasks 3, 4 ✓
+- Journal positional keying + determinism guard at `conversations/{conv_id}/workflow.json` → Tasks 1, 2, 4 ✓
+- Interview orchestrator + `/interview` command → Tasks 7, 12 ✓
+- Unit tests, restart-durability test, live restart smoke → Tasks 1–11 (unit), 13 (restart), 14 (live) ✓
+- Load-bearing journaled-vs-pure rule → enforced by the determinism guard (Task 4) + documented (Task 14) ✓
+- Error handling (retry-once then fail; loud determinism failure) → Tasks 3, 4, 5 ✓
+
+**Type/name consistency check:** `WorkflowHandle.llm_call(prompt=, schema=, system=, tool_name=, model=)` and `user_input(prompt, choices=)` are used identically in `interview.py` (Task 7), the handle tests (Task 4), and the interview tests (Task 7). `call_structured(ctx, system=, user_msg=, schema=, tool_name=, model=, retries=)` matches between Task 3 def and the `_default_llm_call` call in Task 4. `WorkflowOutcome(status, result, suspend, error)` is consistent across Tasks 5, 9. `WorkflowSuspended(seq, args_fingerprint, prompt, choices)` consistent across Tasks 2, 4, 9. `action_data` keys (`workflow_name`, `seq`, `args_fingerprint`, `prompt`, `choices`) match between Task 9's `run_workflow_turn` (writer) and `WorkflowUserInputHandler` (reader). `Journal.append(seq, kind, args_fingerprint, result)` consistent everywhere.
+
+**Known soft spots flagged inline for the engineer (not placeholders):** the `make_manager` fixture (Task 10), the exact restart-recovery entry point (Task 13), and the `websocket.py` in-scope names (Task 12) require reading the surrounding code — each is marked with an engineer note and a concrete search target, because those bodies are large existing functions this plan deliberately does not reproduce in full.

--- a/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/spec.md
+++ b/docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/spec.md
@@ -1,0 +1,207 @@
+# Workflow replay engine — spec
+
+**Issue:** [#255](https://github.com/lmorchard/decafclaw/issues/255) (fresh approach;
+supersedes PR #557, which is being closed).
+
+## Why this exists
+
+#255 asked for a first-class workflow abstraction. Four iterations on PR #557 built an
+LLM-driven phase engine (cross-conv → conv-scoped → phase-turn → code-driven spike) that
+**never walked a multi-phase workflow end-to-end against a live LLM** until the spike. The
+diagnosis (Sophie analysis, in `docs/workflow-engine-255-redesign-proposal.md`): the engine
+made the **LLM responsible for cranking the state machine forward** (emit `phase_advance`),
+and the model reliably narrates instead of firing the tool.
+
+The lesson — confirmed by the spike and mirrored by Claude Code's "dynamic workflows"
+feature — is that **a workflow needs a programmatic control scaffold.** Code drives the
+process; the LLM is invoked only as a constrained structured-output worker on focused
+problems. This project builds that scaffold as a first-class concept.
+
+The goal is **practically useful learning**: how to empower an agent harness to run
+*semi-deterministic* workflows — durable, human-in-the-loop processes where code owns
+control flow. The transferable systems concept is **durable execution via deterministic
+replay** (the model behind Temporal, DBOS, and Claude Code workflows).
+
+## The load-bearing rule (record this prominently)
+
+The engine re-runs the orchestrator function **from the top** on every resume. So the
+dividing line for every operation in an orchestrator is:
+
+- **Pure / deterministic / side-effect-free → plain Python, not journaled.** Re-runs on
+  every replay, harmlessly, because it always produces the same result. **Control flow lives
+  here**: `if`/`while`/`for`, string formatting, accumulating answers in a list, "routing"
+  (an `if` on a journaled result). Re-running it during replay is free and correct.
+- **Crosses the boundary to the outside world → must go through a journaled wrapper.**
+  Anything nondeterministic or with side effects: the LLM, the user, tool calls, subagent
+  spawns, the clock, randomness, the network. Recorded on first execution; **replayed from
+  the journal** on re-run — never re-executed. A raw `await some_tool(...)` would fire twice
+  (double write/email) or return a different value and diverge control flow.
+
+> **Every call that crosses to the outside world goes through the journal; everything else
+> is ordinary code.** That single rule is the entire discipline. It is Temporal's
+> "activities vs. workflow code" line, DBOS's, and Claude Code's.
+
+For the MVP that means exactly **two** journaled wrappers: `llm_call` and `user_input`.
+Subagent/tool/`parallel`/`pipeline` wrappers join them later under the same rule.
+
+## Architecture
+
+A **workflow** is a registered async Python function (the *orchestrator*) the harness runs
+as its own `TurnKind.WORKFLOW`. The orchestrator owns control flow. The LLM is never the
+orchestrator — it is invoked only *inside* journaled primitives. Skills shape what the
+*LLM* does; workflows are what the *harness* runs. Two clean concepts, no overload.
+
+New module `src/decafclaw/workflow/` (fresh — not the #557 tree):
+
+| File | Purpose |
+|---|---|
+| `registry.py` | `@workflow("interview", allowed_tools=[...])` decorator + startup discovery |
+| `engine.py` | Replay executor: runs an orchestrator, manages the journal, raises/catches suspension |
+| `journal.py` | Durable, ordered record of journaled-call results for one run |
+| `primitives.py` | `llm_call`, `user_input` — the two journaled wrappers (MVP) |
+| `workflows/interview.py` | The hero orchestrator |
+
+## The replay engine + journal
+
+The **journal** is a durable, ordered list of completed journaled-call results for one
+workflow run, persisted as a per-conversation file at
+`workspace/conversations/{conv_id}/workflow.json`. Each entry:
+`{seq, kind, args_fingerprint, result}`, **keyed positionally by execution order** (the
+*N*th journaled call executed gets sequence *N*). Positional keying is what makes loops
+replay correctly: same control flow → same execution order → same keys.
+
+- **Run:** the engine calls the orchestrator. Each journaled primitive, on first execution,
+  runs live, appends its result to the journal (flushed to disk), and returns it. Pure
+  Python between primitives runs normally.
+- **Suspend:** `user_input` appends nothing — it raises `WorkflowSuspended` carrying the
+  input-widget spec. The engine catches it, persists the journal, emits the widget, ends the
+  turn.
+- **Resume:** the user's answer is recorded as the journal entry for that `user_input`, then
+  a new `WORKFLOW` turn re-runs the orchestrator **from the top**. Every prior journaled call
+  returns its cached result instantly (no LLM calls, no re-spawns); control flow
+  fast-forwards deterministically to just past the answered `user_input`; execution continues
+  live. **Durable across restart** because the journal is just a file — a restart mid-suspend
+  loses nothing.
+- **Completion:** orchestrator returns; the engine marks the run done, writes the returned
+  artifact, ends the turn.
+
+## Harness integration
+
+- New `TurnKind.WORKFLOW` in `ConversationManager`;
+  `enqueue_turn(kind=WORKFLOW, workflow=..., resume=bool)`.
+- Suspend reuses the **existing confirmation / `WidgetInputPause` persistence** for
+  durability and page-reload recovery — but the resume callback routes to the **engine, not
+  the agent loop.** That single difference is what keeps the LLM off the crank (the failure
+  mode of #557's model and of the rejected "workflow-as-tool" approach).
+- Invocation: a user command (`/interview`) enqueues the first `WORKFLOW` turn.
+- Per-primitive `tool_status` events stream progress to the conversation timeline (as the
+  spike did).
+
+## Authoring surface — the interview, concretely
+
+The whole orchestrator reads as ordinary Python:
+
+```python
+@workflow("interview", allowed_tools=[...])
+async def interview(wf):
+    topic = await wf.user_input("What should this interview be about?")
+
+    answers = []
+    while True:
+        # pure-Python branching on a journaled result — no `route` primitive
+        decision = await wf.llm_call(
+            prompt=ask_next_question_prompt(topic, answers),
+            schema={"done": bool, "question": str},
+        )
+        if decision["done"] or len(answers) >= MAX_Q:
+            break
+        reply = await wf.user_input(decision["question"])   # suspends here
+        answers.append((decision["question"], reply))
+
+    artifact = await wf.llm_call(
+        prompt=synthesize_prompt(topic, answers),
+        schema={"title": str, "body": str},
+    )
+    return artifact   # engine writes it, ends the run
+```
+
+`wf` is the engine handle exposing the journaled primitives. The `while`, the `if`, and the
+`answers` list are plain Python — re-run freely on replay, always identical because they are
+driven by journaled results. The two `await wf.*` calls are the only journaled boundary
+crossings. The entire mental model fits on one screen — that is the lesson.
+
+`llm_call` uses the spike's forced-tool structured-output pattern (one tool, "you MUST call
+this" framing, parse args, retry once with a stricter nudge on narrate-stall). Provider-
+agnostic; no `vertex.py` changes. Reference: `_call_structured` in the spike
+(`src/decafclaw/skills/spike_research_brief/tools.py`, on the #557 branch).
+
+## Error handling & the determinism guard
+
+- **Primitive failure** (LLM error, schema-parse fail after one retry): run goes to `ERROR`
+  status, journal preserved, user surfaced via the turn output. No silent fall-through.
+- **Determinism guard:** each journal entry stores an `args_fingerprint`. On replay, when the
+  orchestrator reaches journaled call *N*, the engine checks the replay's args against the
+  recorded fingerprint. Mismatch ⇒ control flow diverged (a nondeterminism bug) ⇒ **fail
+  loudly** ("workflow non-deterministic at step N") rather than silently returning a stale
+  result. This is what makes the discipline *enforced*, not hoped-for — and it is the part
+  that teaches the lesson.
+- **Cancellation:** the orchestrator checks `ctx.cancelled` between primitives (as the spike
+  does); a cancel ends the run cleanly.
+
+## Testing
+
+- **Unit (deterministic, no LLM):** journal round-trip; replay returns cached results without
+  re-executing (sabotage check: assert a primitive's live path is *not* hit on replay);
+  suspend raises and persists; resume fast-forwards past the answered input; determinism
+  guard fires on a deliberately non-deterministic orchestrator. LLM/user primitives are
+  faked.
+- **Restart durability:** persist the journal mid-suspend, construct a fresh engine from
+  disk, resume — assert it continues with no lost state.
+- **Live smoke (the bar):** `/interview` against `vertex-gemini-flash` in the web UI; answer
+  2–3 questions; **restart the server mid-interview**; resume; reach the artifact. That is the
+  bar no prior iteration cleared, now including a restart.
+- An eval case is premature in v1 (no LLM routing decision to guard); revisit when an
+  orchestrator gains a real LLM-driven branch.
+
+## Scope
+
+**This project ships:**
+
+- `src/decafclaw/workflow/` module (registry, engine, journal, primitives)
+- `TurnKind.WORKFLOW` + engine-routed resume in `ConversationManager`
+- `llm_call` + `user_input` journaled primitives
+- The journal with positional keying + determinism guard, persisted at
+  `conversations/{conv_id}/workflow.json`
+- The `interview` orchestrator + `/interview` command
+- Unit tests, restart-durability test, and the live restart smoke
+
+**PR #557 disposition:** closed, not reworked. The new engine is replay-shaped, not
+graph/DSL-shaped — different enough that a fresh branch is cleaner than reworking ~15k lines.
+#557's commits stay as the record of what didn't work; ideas are salvaged as reference
+(conv-scoped persistence + lock, `RunStatus` lifecycle), not code.
+
+**Explicitly NOT in v1:**
+
+- `subagent` / `parallel` / `pipeline` / `tool_call` primitives (these arrive with the batch
+  fan-out case; they are real journaled wrappers, just not needed for the interview)
+- LLM-generated per-task workflows (the Claude Code model — the engine should not preclude
+  it, but we do not build it now)
+- Migrating the existing flat sidecars (`.notes.md`, `.decisions.json`, `.context.json`) and
+  the archive into the `conversations/{conv_id}/` directory layout. Only the new
+  `workflow.json` adopts the directory now; two conventions coexist temporarily. **Deferred
+  follow-up.**
+- A declarative step-primitive DSL / typed-step vocabulary / template language (the direction
+  explored in the shelved `2026-06-01-1055-workflow-step-primitive-design` notes). We
+  deliberately reject this: control flow *is* the host language, so `route`/`branch`/`loop`/
+  `set` as data-primitives would re-import a DSL we have decided not to build.
+
+## Open questions (resolve during planning, none blocking)
+
+- Exact `WorkflowSuspended` → `WidgetInputPause` wiring: does the engine construct the pause
+  directly, or go through the existing confirmation registry? (Lean: reuse the registry's
+  persistence; add a workflow-resume `ConfirmationAction`.)
+- Journal flush granularity: per-entry fsync vs. flush-on-suspend. (Lean: flush on every
+  append for crash-safety; revisit if it is a perf problem.)
+- Where the final artifact is written for the interview (workspace path + naming).
+- `user_input` affordances in v1: free-text only, or also button choices? (Lean: free-text
+  for the interview; button choices fold in trivially since both ride `WidgetInputPause`.)

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ These docs are as much for me as they are for agents working on this project. Th
 
 ## Agent Behavior
 
+- [Workflow Replay Engine](workflows.md) — Durable, human-in-the-loop workflows with deterministic replay; code owns control flow, LLM is a structured-output worker
 - [Self-Reflection](reflection.md) — Binary judge + critique + retry before delivering responses (Reflexion pattern)
 - [Sub-Agent Delegation](delegation.md) — Fork child agents for concurrent subtasks
 - [Heartbeat](heartbeat.md) — Periodic agent wake-up for monitoring and recurring tasks

--- a/docs/websocket-messages.md
+++ b/docs/websocket-messages.md
@@ -276,6 +276,7 @@ User's decision on a pending confirm_request.
 - `approved` — boolean
 - `always` — boolean
 - `add_pattern` — boolean
+- `data` — object?
 
 ### `load_history`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,319 @@
+# Workflow Replay Engine
+
+DecafClaw supports first-class **workflows** — durable, human-in-the-loop processes where
+code owns control flow and the LLM is invoked only as a structured-output worker on focused
+sub-problems.
+
+Issue: [#255](https://github.com/lmorchard/decafclaw/issues/255).
+
+## What a workflow is (and what it is not)
+
+A **workflow** is a registered async Python function (the *orchestrator*) that the harness
+runs as its own `TurnKind.WORKFLOW` — completely separate from the LLM agent loop.
+
+The key distinction:
+
+| Concept | What it is | LLM role |
+|---|---|---|
+| **Agent turn** | LLM drives the loop, picks tools, decides what to do next | The orchestrator |
+| **Skill** | Capability package the agent activates; shapes what the LLM does | The orchestrator |
+| **Workflow** | Python function the harness runs; code owns control flow | A constrained worker called on demand |
+
+**Skills shape what the LLM does; workflows are what the harness runs.** Two clean concepts,
+no overload.
+
+The prior approach (PR #557) put the LLM in charge of advancing the state machine by emitting
+a `phase_advance` tool call. The model reliably narrated instead of calling the tool. The
+lesson: the LLM must not be the orchestrator. Code must be.
+
+This design mirrors how [Temporal](https://temporal.io), [DBOS](https://www.dbos.dev), and
+Claude Code's dynamic workflows work — durable execution via deterministic replay.
+
+## The load-bearing rule
+
+The engine re-runs the orchestrator **from the top** on every resume. So for every operation
+in an orchestrator, the rule is:
+
+**Pure / deterministic / side-effect-free → plain Python, not journaled.** It re-runs on
+every replay harmlessly, because it always produces the same result. Control flow lives here:
+`if`, `while`, `for`, string formatting, accumulating results in a list, branching on a
+journaled result. Re-running this during replay is free and correct.
+
+**Crosses the boundary to the outside world → must go through a journaled wrapper.**
+Anything nondeterministic or with side effects: the LLM, user input, tool calls, the clock,
+randomness, the network. Recorded on first execution; **replayed from the journal** on
+re-run — never re-executed. A raw `await some_tool(...)` would fire twice or return a
+different value and diverge control flow.
+
+> **Every call that crosses to the outside world goes through the journal; everything else
+> is ordinary code.** That single rule is the entire discipline. It is Temporal's "activities
+> vs. workflow code" line, DBOS's, and Claude Code's.
+
+For the MVP there are exactly **two** journaled wrappers: `wf.llm_call(...)` and
+`wf.user_input(...)`. Subagent, tool, parallel, and pipeline wrappers are deferred to future
+work.
+
+## The journal and deterministic replay
+
+The **journal** is a durable, ordered list of completed journaled-call results for one
+workflow run, persisted as a per-conversation file at
+`workspace/conversations/{conv_id}/workflow.json`.
+
+Each entry:
+
+```json
+{
+  "seq": 0,
+  "kind": "llm_call",
+  "args_fingerprint": "a3f1c2d8b4e7f9a1",
+  "result": { "done": false, "question": "What's your background?" }
+}
+```
+
+Entries are **keyed positionally by execution order** — the Nth journaled call gets
+sequence N. This is what makes loops replay correctly: the same control flow produces the
+same execution order and therefore the same keys.
+
+### Execution lifecycle
+
+1. **Run:** the engine calls the orchestrator. Each journaled primitive, on first execution,
+   runs live, appends its result to the journal (flushed to disk), and returns.
+
+2. **Suspend:** `wf.user_input(...)` raises `WorkflowSuspended` when it encounters a step
+   with no journal entry. The engine catches it, posts the pending question as a
+   `ConfirmationRequest`, and ends the turn. The journal is already persisted from prior
+   steps.
+
+3. **Resume:** the user's answer is journaled at the suspended sequence position, then a
+   fresh `TurnKind.WORKFLOW` turn re-runs the orchestrator from the top. Every prior journaled
+   call returns its cached result instantly (no LLM calls, no re-prompting). Control flow
+   fast-forwards deterministically to just past the answered `user_input`; execution continues
+   live.
+
+4. **Complete:** the orchestrator returns a value. The engine marks the run `done`, renders
+   the artifact, and ends the turn.
+
+### Durability across restart
+
+Because the journal is just a file on disk, a server restart mid-suspend loses nothing.
+The user reloads the UI; the pending confirmation (the unanswered question) is recovered by
+the existing confirmation-persistence machinery. The next answer journals at the right
+position and a resume turn re-runs from the top.
+
+### Determinism guard
+
+Each journal entry stores an `args_fingerprint` (a 16-char SHA-256 of the call's kind and
+args). On replay, when the orchestrator reaches journaled call N, the engine compares the
+replay's fingerprint to the recorded one. A mismatch means control flow diverged — a
+determinism bug in the orchestrator — and the engine raises `WorkflowNonDeterministic` rather
+than silently returning a stale result.
+
+**Orchestrators MUST NOT catch `WorkflowSuspended`.** Swallowing it (e.g. with a broad
+`except Exception`) lets the cursor advance past a step the journal never recorded,
+desynchronizing every later positional key.
+
+## The two journaled primitives
+
+### `wf.llm_call(*, prompt, schema, system="", tool_name="submit", model=None)`
+
+Calls the LLM with a forced-tool structured-output pattern. The model is given exactly one
+tool it **must** call; the args are parsed as the result. Retries once with a stricter nudge
+on narrate-stall.
+
+- `prompt` — user-role message.
+- `schema` — JSON Schema dict for the tool's `parameters`. The result is the parsed tool args.
+- `system` — optional system message.
+- `tool_name` — cosmetic label for the forced tool (not part of the fingerprint).
+- `model` — named model config; falls back to the workflow's registered model.
+
+### `wf.user_input(prompt, *, choices=None)`
+
+Asks the user a question. On the first (unanswered) encounter raises `WorkflowSuspended`
+and ends the turn. On replay after the user has answered, returns the cached answer from the
+journal.
+
+- `prompt` — the question shown to the user.
+- `choices` — optional list of button labels (free-text if omitted).
+
+## Authoring a workflow
+
+### Registration
+
+```python
+from decafclaw.workflow.registry import workflow
+
+@workflow("my-workflow", model="vertex-gemini-flash")
+async def my_workflow(wf):
+    ...
+```
+
+The `@workflow` decorator registers the function in `REGISTRY` at import time. The `model`
+parameter sets the default for `wf.llm_call` calls (defaults to `vertex-gemini-flash`).
+
+Place new orchestrators in `src/decafclaw/workflow/workflows/` and ensure they are imported
+by the package (via `workflows/__init__.py`). Bundled orchestrators are discovered
+automatically on startup.
+
+### The interview workflow — a walkthrough
+
+`src/decafclaw/workflow/workflows/interview.py` is the hero example. The full orchestrator:
+
+```python
+@workflow("interview")
+async def interview(wf):
+    topic = await wf.user_input("What should this interview be about?")
+
+    answers: list[dict] = []
+    while len(answers) < MAX_Q:
+        decision = await wf.llm_call(
+            prompt=_ask_prompt(topic, answers),
+            schema=_DECISION_SCHEMA, system=_SYS_ASK)
+        if decision.get("done"):
+            break
+        reply = await wf.user_input(decision["question"])
+        answers.append({"q": decision["question"], "a": reply})
+
+    return await wf.llm_call(
+        prompt=_synth_prompt(topic, answers),
+        schema=_ARTIFACT_SCHEMA, system=_SYS_SYNTH)
+```
+
+Key observations:
+
+- `topic = await wf.user_input(...)` — the first suspension. The journal is empty; the
+  question is posted to the user; the turn ends. On resume, `topic` is the cached answer.
+
+- `while len(answers) < MAX_Q` — plain Python. Re-runs on every replay; always identical
+  because `answers` is driven by journaled results.
+
+- `decision = await wf.llm_call(...)` — live on first pass; cached on replay.
+
+- `if decision.get("done"): break` — plain Python branching on a journaled result.
+
+- `reply = await wf.user_input(decision["question"])` — a second suspension point, inside the
+  loop. Every iteration is a distinct journal position (the cursor is positional).
+
+- `return await wf.llm_call(...)` — the final synthesis call. Returns `{"title": ...,
+  "body": ...}`; the engine renders it as markdown and ends the turn.
+
+The entire mental model fits on one screen. The `while`, `if`, and `answers` list are
+ordinary Python. The only journaled boundary crossings are the two `wf.*` primitives.
+
+## Suspend/resume mechanics and the confirmation path
+
+The suspend/resume cycle reuses DecafClaw's existing confirmation persistence infrastructure,
+with one important difference: the resume callback routes to the **workflow engine**, not
+the agent loop.
+
+1. `wf.user_input(...)` raises `WorkflowSuspended`.
+2. `run_workflow_turn` (in `workflow/resume.py`) catches it and calls
+   `manager.post_confirmation(conv_id, request)` with a
+   `ConfirmationAction.WORKFLOW_USER_INPUT` request — **without awaiting a waiter**. The turn
+   ends immediately after.
+3. The confirmation is persisted as a conversation message. It survives page reload and server
+   restart.
+4. The user answers. The confirmation response routes to `WorkflowUserInputHandler.on_approve`,
+   which:
+   - Journals the answer at the suspended sequence position.
+   - Calls `manager.enqueue_turn(conv_id, kind=TurnKind.WORKFLOW, ..., resume=True)`.
+5. The new WORKFLOW turn calls `run_workflow_turn` again. `run_workflow` replays the
+   orchestrator from the top; all prior calls return cached; execution continues past the
+   answered input.
+
+This is what keeps the LLM off the crank. The confirmation round-trip is purely between the
+user and the harness; the LLM only runs when an orchestrator explicitly calls `wf.llm_call`.
+
+## Invoking a workflow
+
+In the web UI, type `/interview` (or the name of any registered workflow). The WebSocket
+handler in `web/websocket.py` checks `workflow_commands()`, recognizes it as a workflow
+trigger, and calls `manager.enqueue_turn(conv_id, kind=TurnKind.WORKFLOW, ...)`.
+
+Progress events stream to the conversation timeline via `tool_status` events during execution.
+
+The final artifact (for the interview: `{"title": ..., "body": ...}`) is rendered as a
+markdown `# Title\n\nbody` block in the conversation.
+
+**Conversation archive writes.** The WORKFLOW turn path bypasses the agent loop, so the
+two ends of the run are archived explicitly:
+
+- The `/<workflow-name>` invocation is written as a `role: "user"` message at the
+  intercept point in `_handle_send` (before `enqueue_turn`).
+- The rendered artifact is written as a `role: "assistant"` message inside
+  `run_workflow_turn` when the outcome is `done`.
+
+Without these writes, the conversation history would be empty on reload (the only other
+archive rows from a workflow run are `confirmation_request` / `confirmation_response`,
+which `load_history` filters via `_HIDDEN_ROLES`).
+
+## Module structure
+
+```
+src/decafclaw/workflow/
+  __init__.py          re-exports public surface; imports workflows/ to register orchestrators
+  registry.py          @workflow decorator + REGISTRY + workflow_commands()
+  engine.py            run_workflow(): calls orchestrator, classifies outcome
+  journal.py           Journal dataclass + save_journal/load_journal + fingerprint()
+  handle.py            WorkflowHandle — the wf object; llm_call + user_input primitives
+  llm.py               call_structured() — forced-tool structured-output LLM helper
+  errors.py            WorkflowSuspended, WorkflowNonDeterministic, WorkflowError
+  paths.py             workflow_dir() + workflow_path() — per-conv file location helpers
+  resume.py            run_workflow_turn() + WorkflowUserInputHandler (harness glue)
+  workflows/
+    interview.py       The hero orchestrator (@workflow("interview"))
+```
+
+## What is not in v1
+
+The following are explicitly deferred:
+
+- **`subagent` / `parallel` / `pipeline` / `tool_call` primitives.** These arrive with the
+  batch fan-out case; they are real journaled wrappers, just not needed for the interview.
+
+- **LLM-generated per-task workflows.** The engine does not preclude it, but this is not
+  built yet.
+
+- **Migrating existing flat sidecars** (`.notes.md`, `.decisions.json`, `.context.json`,
+  `.archive.jsonl`) into the `conversations/{conv_id}/` directory layout. Only `workflow.json`
+  uses the directory convention now; two conventions coexist temporarily.
+
+- **A declarative step DSL** (`route`/`branch`/`loop`/`set` as data-primitives). Deliberately
+  rejected: control flow *is* the host language (`if`/`while`). A DSL re-imports the exact
+  complexity the replay model was designed to eliminate.
+
+- **WORKFLOW turn Context-kind semantics.** WORKFLOW turns currently reuse the USER-style
+  Context path (full interactive Context with per-conversation state). Whether they should use
+  `Context.for_task` semantics instead is an open item to revisit after the live smoke.
+
+## Error handling
+
+- **Primitive failure** (LLM error, schema-parse failure after retry): the run goes to
+  `ERROR` status, the journal is preserved for inspection, and the error is surfaced as the
+  turn output.
+
+- **`WorkflowNonDeterministic`:** raised when a replay fingerprint mismatch is detected.
+  Fail-loud — the run goes to `ERROR` rather than silently returning a stale result.
+
+- **Cancellation (deny):** `WorkflowUserInputHandler.on_deny` marks the journal `error` and
+  appends a cancellation message to the archive.
+
+## Testing
+
+Unit tests cover the core contracts without LLM calls:
+
+- `tests/test_workflow_journal.py` — round-trip and fingerprint correctness.
+- `tests/test_workflow_handle.py` — replay returns cached results (sabotage check confirms
+  the live path is not re-executed on replay); determinism guard fires on deliberate mismatch.
+- `tests/test_workflow_engine.py` — suspension raises and persists; completion returns result.
+- `tests/test_workflow_resume.py` — harness glue: suspend posts confirmation, answer journals
+  and enqueues a resume turn.
+- `tests/test_workflow_turn_integration.py` — TurnKind.WORKFLOW dispatch end-to-end.
+- `tests/test_workflow_interview.py` — interview orchestrator logic.
+- `tests/test_workflow_paths.py` / `test_workflow_registry.py` / `test_workflow_llm.py` — path
+  helpers, registry decorator, structured-output helper.
+
+The restart-durability test persists a journal mid-suspend, constructs a fresh engine from
+disk, and asserts continuation with no lost state.
+
+Evals are deferred until an orchestrator gains a real LLM-driven routing branch worth
+guarding (there is no tool-disambiguation question for the current `interview` flow).

--- a/src/decafclaw/client/cli.py
+++ b/src/decafclaw/client/cli.py
@@ -19,6 +19,7 @@ class SmokeArgs:
     prompts: list[str] | None = None
     confirmation_id: str | None = None
     approved: bool = True
+    value: str = ""
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -63,6 +64,10 @@ def build_parser() -> argparse.ArgumentParser:
                           default=True, help="Approve (default).")
     decision.add_argument("--deny", dest="approved", action="store_false",
                           help="Deny.")
+    p_resp.add_argument("--value", default="",
+                        help="Payload forwarded as data={'value': VALUE}. "
+                             "Required by workflow_user_input confirmations "
+                             "(the answer text); ignored when omitted.")
 
     return parser
 
@@ -91,5 +96,5 @@ def parse_args(argv: list[str] | None = None) -> SmokeArgs:
     return SmokeArgs(
         action="respond", token=token, host=host, timeout=ns.timeout,
         fmt=ns.fmt, conv=ns.conv, confirmation_id=ns.confirmation_id,
-        approved=ns.approved,
+        approved=ns.approved, value=ns.value,
     )

--- a/src/decafclaw/client/run.py
+++ b/src/decafclaw/client/run.py
@@ -82,11 +82,14 @@ async def run_respond(transport, args: SmokeArgs) -> list[TurnSummary]:
     conv_id = args.conv or ""
     await _select(transport, conv_id)
     recorder = TurnRecorder(conv_id)
-    await transport.send({
+    payload: dict = {
         "type": "confirm_response", "conv_id": conv_id,
         "confirmation_id": args.confirmation_id or "",
         "approved": args.approved, "always": False, "add_pattern": False,
-    })
+    }
+    if args.value:
+        payload["data"] = {"value": args.value}
+    await transport.send(payload)
     reason = await drive_turn(transport, recorder, timeout=args.timeout,
                               sink=_sink_for(args.fmt))
     return [recorder.finalize(reason)]

--- a/src/decafclaw/confirmations.py
+++ b/src/decafclaw/confirmations.py
@@ -18,6 +18,7 @@ class ConfirmationAction(str, Enum):
     CONTINUE_TURN = "continue_turn"
     ADVANCE_PROJECT_PHASE = "advance_project_phase"
     WIDGET_RESPONSE = "widget_response"
+    WORKFLOW_USER_INPUT = "workflow_user_input"
 
 
 @dataclass

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 from .archive import append_message
 from .confirmations import (
+    ConfirmationAction,
     ConfirmationRegistry,
     ConfirmationRequest,
     ConfirmationResponse,
@@ -78,6 +79,7 @@ class TurnKind(Enum):
     SCHEDULED_TASK = "scheduled_task"
     CHILD_AGENT = "child_agent"
     WAKE = "wake"
+    WORKFLOW = "workflow"
 
 
 # Kinds that use Context.for_task (sensible skip defaults for background work).
@@ -348,6 +350,13 @@ class ConversationManager:
         self.config = config
         self.event_bus = event_bus
         self.confirmation_registry = confirmation_registry or ConfirmationRegistry()
+
+        # Workflow user-input resumes via the confirmation recovery path.
+        from .workflow.resume import WorkflowUserInputHandler
+        self.confirmation_registry.register(
+            ConfirmationAction.WORKFLOW_USER_INPUT,
+            WorkflowUserInputHandler(self))
+
         self._conversations: dict[str, ConversationState] = {}
 
         # Circuit breaker config (from Mattermost config for now —
@@ -1280,6 +1289,47 @@ class ConversationManager:
 
         return response
 
+    async def post_confirmation(
+        self,
+        conv_id: str,
+        request: ConfirmationRequest,
+    ) -> None:
+        """Post a pending confirmation WITHOUT awaiting it.
+
+        Used by workflow suspends: the workflow turn ENDS at a user_input,
+        so there is no live waiter. We persist + install the request as the
+        active confirmation but deliberately leave ``confirmation_event``
+        None, so ``respond_to_confirmation`` routes resolution through the
+        recovery dispatch path (registered handler), not a waiter wake.
+        """
+        from .archive import append_message
+        state = self._get_or_create(conv_id)
+        async with state.lock:
+            if state.pending_confirmation is not None:
+                # Unreachable by design: a workflow suspend ENDS the turn and
+                # the per-conversation busy flag serializes turns, so the slot
+                # is always free when a workflow posts. If we somehow get here,
+                # fail loudly — queuing a no-waiter confirmation would let
+                # promotion install a live event and route resolution to the
+                # waiter-wake branch (nobody listening), silently stalling the
+                # workflow. A loud error is diagnosable; a silent stall is not.
+                raise RuntimeError(
+                    f"post_confirmation: conversation {conv_id[:8]} already has "
+                    f"a pending confirmation; workflow-turn serialization "
+                    f"invariant violated")
+            # Archive under the lock so the durable record is installed
+            # atomically with the in-memory state — never one without the
+            # other. Without this, the busy-raise branch above would leave
+            # an orphan confirmation_request row that startup_scan would
+            # later recover as a ghost pending confirmation with no backing
+            # workflow (Copilot review on PR #573, mirroring the prior fix
+            # to respond_to_confirmation from review on PR #484).
+            append_message(self.config, conv_id, request.to_archive_message())
+            state.pending_confirmation = request
+            state.confirmation_event = None  # no waiter — recovery path
+            state.confirmation_response = None
+        await self.emit(conv_id, _confirmation_request_payload(request))
+
     # -- Internal methods ------------------------------------------------------
 
     async def _start_turn(
@@ -1351,7 +1401,12 @@ class ConversationManager:
             if kind is TurnKind.WAKE:
                 self._restore_per_conv_state(state, ctx)
         else:
-            # USER turn — existing behavior.
+            # USER (and WORKFLOW) turns — full interactive Context with
+            # per-conv state restored. WORKFLOW deliberately reuses this path
+            # for now: the orchestrator only needs ctx.config + ctx.conv_id,
+            # and running on the user conv keeps phases visible in the timeline.
+            # (Revisit after live smoke: WORKFLOW may want Context.for_task
+            # semantics — if so, add it to TASK_KINDS with a KIND_TASK_MODE entry.)
             ctx = Context(config=self.config, event_bus=self.event_bus)
             ctx.user_id = user_id
             ctx.channel_id = conv_id
@@ -1448,12 +1503,20 @@ class ConversationManager:
 
         async def run():
             try:
-                from .agent import run_agent_turn
-                result = await run_agent_turn(
-                    ctx, text, history,
-                    archive_text=archive_text,
-                    attachments=attachments,
-                )
+                if kind is TurnKind.WORKFLOW:
+                    from .workflow.resume import run_workflow_turn
+                    md = metadata or {}
+                    result = await run_workflow_turn(
+                        ctx, self,
+                        workflow_name=md.get("workflow_name", ""),
+                        resume=md.get("resume", False))
+                else:
+                    from .agent import run_agent_turn
+                    result = await run_agent_turn(
+                        ctx, text, history,
+                        archive_text=archive_text,
+                        attachments=attachments,
+                    )
 
                 response_text = result.text if hasattr(result, "text") else str(result)
                 response_text_holder.append(response_text)

--- a/src/decafclaw/web/message_types.json
+++ b/src/decafclaw/web/message_types.json
@@ -126,7 +126,7 @@
     "confirm_response": {
       "direction": "client_to_server",
       "description": "User's decision on a pending confirm_request.",
-      "fields": {"conv_id": "string", "confirmation_id": "string", "approved": "boolean", "always": "boolean", "add_pattern": "boolean"}
+      "fields": {"conv_id": "string", "confirmation_id": "string", "approved": "boolean", "always": "boolean", "add_pattern": "boolean", "data": "object?"}
     },
     "load_history": {
       "direction": "client_to_server",

--- a/src/decafclaw/web/message_types.py
+++ b/src/decafclaw/web/message_types.py
@@ -255,6 +255,7 @@ class CliConfirmResponse(TypedDict):
     approved: bool
     always: bool
     add_pattern: bool
+    data: NotRequired[dict[str, object]]
 
 class CliLoadHistory(TypedDict):
     type: Literal[WSMessageType.LOAD_HISTORY]

--- a/src/decafclaw/web/static/components/confirm-view.js
+++ b/src/decafclaw/web/static/components/confirm-view.js
@@ -3,11 +3,14 @@ import { LitElement, html } from 'lit';
 /**
  * Inline confirmation prompt for tool permissions.
  * Renders approve/deny/always buttons and dispatches the response.
+ * For workflow_user_input action_type, renders a text input (or choice
+ * buttons) so the user's answer is forwarded as data.value.
  */
 export class ConfirmView extends LitElement {
   static properties = {
     store: { type: Object, attribute: false },
     confirms: { type: Array, attribute: false },
+    _inputValues: { type: Object, state: true },
   };
 
   createRenderRoot() { return this; }
@@ -17,6 +20,8 @@ export class ConfirmView extends LitElement {
     this.store = null;
     /** @type {Array} */
     this.confirms = [];
+    /** @type {Object<string,string>} Map of confirmation_id -> current text value */
+    this._inputValues = {};
   }
 
   /**
@@ -30,6 +35,88 @@ export class ConfirmView extends LitElement {
     this.store?.respondToConfirm(contextId, tool, toolCallId, approved, extra);
   }
 
+  /**
+   * @param {string} confirmationId
+   * @param {string} value
+   */
+  #setInputValue(confirmationId, value) {
+    this._inputValues = { ...this._inputValues, [confirmationId]: value };
+  }
+
+  /**
+   * Render a workflow_user_input confirmation card with a text input
+   * (or choice buttons if action_data.choices is non-empty).
+   * @param {object} c
+   */
+  #renderWorkflowInput(c) {
+    const choices = Array.isArray(c.action_data?.choices) ? c.action_data.choices : [];
+    const confirmId = c.confirmation_id;
+
+    if (choices.length > 0) {
+      // Render a button per choice, plus a cancel button
+      return html`
+        <div class="confirm-card">
+          <div class="confirm-header">
+            <strong>${c.message}</strong>
+          </div>
+          <div class="confirm-buttons">
+            ${choices.map(choice => html`
+              <button class="outline" @click=${() =>
+                this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true,
+                  { data: { value: choice } })}>
+                ${choice}
+              </button>
+            `)}
+            <button class="outline secondary" @click=${() =>
+              this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, false)}>
+              Cancel
+            </button>
+          </div>
+        </div>`;
+    }
+
+    // Free-text input
+    const currentValue = this._inputValues[confirmId] || '';
+    const canSubmit = currentValue.trim().length > 0;
+
+    /** @param {KeyboardEvent} e */
+    const onKeyDown = (e) => {
+      if (e.key === 'Enter' && canSubmit) {
+        e.preventDefault();
+        this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true,
+          { data: { value: currentValue.trim() } });
+      }
+    };
+
+    return html`
+      <div class="confirm-card">
+        <div class="confirm-header">
+          <strong>${c.message}</strong>
+        </div>
+        <div class="confirm-input">
+          <input
+            type="text"
+            placeholder="Your answer…"
+            .value=${currentValue}
+            @input=${(e) => this.#setInputValue(confirmId, e.target.value)}
+            @keydown=${onKeyDown}
+          />
+        </div>
+        <div class="confirm-buttons">
+          <button class="outline" ?disabled=${!canSubmit}
+            @click=${() =>
+              this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true,
+                { data: { value: currentValue.trim() } })}>
+            Submit
+          </button>
+          <button class="outline secondary" @click=${() =>
+            this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, false)}>
+            Cancel
+          </button>
+        </div>
+      </div>`;
+  }
+
   render() {
     if (!this.confirms?.length) return '';
 
@@ -40,31 +127,37 @@ export class ConfirmView extends LitElement {
       c => c.action_type !== 'widget_response');
     if (!visible.length) return '';
 
-    return html`${visible.map(c => html`
-      <div class="confirm-card">
-        <div class="confirm-header">
-          <strong>Confirm ${c.tool}:</strong>
-          <pre class="confirm-command">${c.command}</pre>
-        </div>
-        <div class="confirm-buttons">
-          <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true)}>
-            ${c.approve_label || 'Approve'}
-          </button>
-          <button class="outline secondary" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, false)}>
-            ${c.deny_label || 'Deny'}
-          </button>
-          ${c.approve_label ? '' : c.tool === 'shell' && c.suggested_pattern ? html`
-            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { add_pattern: true })}>
-              Allow: ${c.suggested_pattern}
+    return html`${visible.map(c => {
+      // Workflow user-input pauses get a dedicated text/choice affordance.
+      if (c.action_type === 'workflow_user_input') {
+        return this.#renderWorkflowInput(c);
+      }
+
+      return html`
+        <div class="confirm-card">
+          <div class="confirm-header">
+            <strong>Confirm ${c.tool}:</strong>
+            <pre class="confirm-command">${c.command}</pre>
+          </div>
+          <div class="confirm-buttons">
+            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true)}>
+              ${c.approve_label || 'Approve'}
             </button>
-          ` : html`
-            <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { always: true })}>
-              Always
+            <button class="outline secondary" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, false)}>
+              ${c.deny_label || 'Deny'}
             </button>
-          `}
-        </div>
-      </div>
-    `)}`;
+            ${c.approve_label ? '' : c.tool === 'shell' && c.suggested_pattern ? html`
+              <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { add_pattern: true })}>
+                Allow: ${c.suggested_pattern}
+              </button>
+            ` : html`
+              <button class="outline" @click=${() => this.#handleConfirm(c.context_id, c.tool, c.tool_call_id, true, { always: true })}>
+                Always
+              </button>
+            `}
+          </div>
+        </div>`;
+    })}`;
   }
 }
 

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -12,6 +12,7 @@ import re
 
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from decafclaw.conversation_manager import TurnKind
 from decafclaw.skills.vault._events import VAULT_CHANGED_EVENT_TYPE
 from decafclaw.web.message_types import (
     ServerMessage,
@@ -298,6 +299,37 @@ async def _handle_send(ws_send: WSSendCallable, index, username, msg, state) -> 
         await ws_send({"type": WSMessageType.ERROR, "message": "Chat service unavailable"})
         return
 
+    # -- Workflow-command interception (#255): workflows are first-class, not
+    # skills, so intercept /<name> before skill command dispatch.
+    from decafclaw.workflow.registry import workflow_commands
+    wf_trigger = None
+    if text.startswith("/"):
+        name = text[1:].split()[0] if len(text) > 1 else ""
+        if name in workflow_commands():
+            wf_trigger = name
+    if wf_trigger:
+        def context_setup(ctx):
+            from ..media import LocalFileMediaHandler
+            ctx.media_handler = LocalFileMediaHandler(state["config"])
+            ctx.channel_name = "web"
+            ctx.thread_id = ""
+        _subscribe_to_conv(state, conv_id)
+        # Persist the user's invocation so a conversation reload renders
+        # the typed command (the WORKFLOW turn path bypasses the agent
+        # loop's normal user-message archive write).
+        from ..archive import append_message
+        append_message(state["config"], conv_id,
+                       {"role": "user", "content": text})
+        await ws_send({
+            "type": WSMessageType.COMMAND_ACK, "conv_id": conv_id,
+            "command": f"/{wf_trigger}", "skill": wf_trigger,
+        })
+        await manager.enqueue_turn(
+            conv_id, kind=TurnKind.WORKFLOW, prompt="",
+            user_id=username, context_setup=context_setup,
+            metadata={"workflow_name": wf_trigger, "resume": False})
+        return
+
     # -- Command dispatch (centralized in commands.py) --
     from ..commands import dispatch_command
     from ..context import Context
@@ -451,6 +483,9 @@ async def _handle_confirm_response(ws_send: WSSendCallable, index, username, msg
     conv_id = msg.get("conv_id", "")
     confirmation_id = msg.get("confirmation_id", "")
 
+    raw_data = msg.get("data")
+    data = raw_data if isinstance(raw_data, dict) else None
+
     if manager and conv_id and confirmation_id:
         await manager.respond_to_confirmation(
             conv_id,
@@ -458,6 +493,7 @@ async def _handle_confirm_response(ws_send: WSSendCallable, index, username, msg
             approved=msg.get("approved", False),
             always=msg.get("always", False),
             add_pattern=msg.get("add_pattern", False),
+            data=data,
         )
     else:
         # Legacy fallback: publish to event bus for non-manager confirmations

--- a/src/decafclaw/workflow/__init__.py
+++ b/src/decafclaw/workflow/__init__.py
@@ -1,0 +1,12 @@
+"""Workflow replay engine (#255)."""
+from . import workflows as _workflows  # noqa: F401 — registers bundled orchestrators
+from .engine import WorkflowOutcome, run_workflow
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .handle import WorkflowHandle
+from .registry import REGISTRY, get_workflow, workflow, workflow_commands
+
+__all__ = [
+    "run_workflow", "WorkflowOutcome", "WorkflowHandle",
+    "WorkflowSuspended", "WorkflowNonDeterministic",
+    "workflow", "get_workflow", "workflow_commands", "REGISTRY",
+]

--- a/src/decafclaw/workflow/engine.py
+++ b/src/decafclaw/workflow/engine.py
@@ -1,0 +1,55 @@
+"""run_workflow — runs an orchestrator once, classifying the outcome.
+
+The engine owns control flow only in the trivial sense that it invokes the
+orchestrator and interprets how it returned: completed, suspended for user
+input, or errored. The orchestrator itself is plain async Python.
+"""
+import dataclasses
+import logging
+from typing import Any, Awaitable, Callable
+
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .handle import WorkflowHandle
+from .journal import Journal, save_journal
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class WorkflowOutcome:
+    status: str  # "done" | "suspended" | "error"
+    result: Any = None
+    suspend: WorkflowSuspended | None = None
+    error: str = ""
+
+
+async def run_workflow(
+    ctx,
+    workflow_fn: Callable[[WorkflowHandle], Awaitable[Any]],
+    journal: Journal,
+    *,
+    llm_caller=None,
+    model: str = "vertex-gemini-flash",
+) -> WorkflowOutcome:
+    handle = WorkflowHandle(ctx, journal, llm_caller=llm_caller, model=model)
+
+    def _persist(status: str) -> None:
+        journal.status = status
+        save_journal(ctx.config, ctx.conv_id, journal)
+
+    try:
+        result = await workflow_fn(handle)
+    except WorkflowSuspended as s:
+        _persist("suspended")
+        return WorkflowOutcome(status="suspended", suspend=s)
+    except WorkflowNonDeterministic as e:
+        log.error("workflow non-deterministic: %s", e)
+        _persist("error")
+        return WorkflowOutcome(status="error", error=str(e))
+    except Exception as e:  # noqa: BLE001 — terminal classification
+        log.exception("workflow orchestrator raised")
+        _persist("error")
+        return WorkflowOutcome(status="error", error=str(e))
+
+    _persist("done")
+    return WorkflowOutcome(status="done", result=result)

--- a/src/decafclaw/workflow/errors.py
+++ b/src/decafclaw/workflow/errors.py
@@ -1,0 +1,46 @@
+"""Workflow engine exceptions."""
+
+
+class WorkflowError(Exception):
+    """Base for workflow engine failures."""
+
+
+class WorkflowSuspended(Exception):
+    """Raised by a journaled primitive that needs to suspend for the user.
+
+    Deliberately extends Exception, NOT WorkflowError: a suspension is normal
+    control flow (the engine catches it and posts a confirmation), not a
+    failure. Do not change the base class to WorkflowError — `except
+    WorkflowError` in the engine must NOT swallow suspensions.
+
+    Carries everything the harness needs to post a confirmation and, on
+    response, journal the answer at the right position.
+    """
+
+    def __init__(self, *, seq: int, args_fingerprint: str, prompt: str,
+                 choices: list[str] | None = None):
+        super().__init__(f"workflow suspended at step {seq}: {prompt!r}")
+        self.seq = seq
+        self.args_fingerprint = args_fingerprint
+        self.prompt = prompt
+        self.choices = choices
+
+
+class WorkflowNonDeterministic(WorkflowError):
+    """Replay reached a journaled call whose args don't match the record.
+
+    Means control flow diverged between runs — a determinism bug in the
+    orchestrator. Fail loudly rather than return a stale result.
+    """
+
+    def __init__(self, seq: int, recorded_kind: str, recorded_fp: str,
+                 got_kind: str, got_fp: str):
+        super().__init__(
+            f"workflow non-deterministic at step {seq}: recorded "
+            f"{recorded_kind}/{recorded_fp}, replay produced {got_kind}/{got_fp}"
+        )
+        self.seq = seq
+        self.recorded_kind = recorded_kind
+        self.recorded_fp = recorded_fp
+        self.got_kind = got_kind
+        self.got_fp = got_fp

--- a/src/decafclaw/workflow/handle.py
+++ b/src/decafclaw/workflow/handle.py
@@ -1,0 +1,87 @@
+"""WorkflowHandle — the `wf` object an orchestrator drives.
+
+Exposes the two journaled primitives. Positional cursor advances once per
+journaled call. Replay returns cached results (after a determinism check);
+new llm_calls run live and journal; new user_inputs raise WorkflowSuspended.
+
+Replay invariants the orchestrator author must respect:
+  * The engine re-runs the orchestrator from the top on every resume; the
+    cursor is reconstructed from 0 each run (it is NOT persisted). Re-running
+    after a failed live llm_call is therefore safe — nothing was journaled, so
+    the next run reaches the same step and runs it live again.
+  * Orchestrators MUST NOT catch WorkflowSuspended. Swallowing it (e.g. a broad
+    `except Exception`) lets the cursor advance past a step the journal never
+    recorded, desynchronizing every later positional key. (Same constraint as
+    Temporal's "don't catch workflow control-flow exceptions" rule.)
+  * Any per-call `model=` override passed to `llm_call` must be deterministic
+    (it is not part of the journal fingerprint).
+"""
+import logging
+
+from . import llm as wf_llm
+from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .journal import fingerprint, save_journal
+
+log = logging.getLogger(__name__)
+
+
+async def _default_llm_call(ctx, **kw):
+    return await wf_llm.call_structured(ctx, **kw)
+
+
+class WorkflowHandle:
+    def __init__(self, ctx, journal, *, llm_caller=None,
+                 model: str = "vertex-gemini-flash"):
+        self.ctx = ctx
+        self.journal = journal
+        self._cursor = 0
+        self._llm_caller = llm_caller or _default_llm_call
+        self._model = model
+
+    def _check_or_none(self, seq: int, kind: str, fp: str):
+        """Return (cached_result, True) for an already-journaled call at seq,
+        else (None, False). Raises WorkflowNonDeterministic on a mismatch.
+        """
+        existing = self.journal.get(seq)
+        if existing is None:
+            return None, False
+        if existing.kind != kind or existing.args_fingerprint != fp:
+            raise WorkflowNonDeterministic(
+                seq, existing.kind, existing.args_fingerprint, kind, fp)
+        return existing.result, True
+
+    async def llm_call(self, *, prompt: str, schema: dict, system: str = "",
+                       tool_name: str = "submit", model: str | None = None):
+        seq = self._cursor
+        self._cursor += 1
+        # tool_name and the per-call `model` override are intentionally NOT
+        # part of the fingerprint: tool_name is a cosmetic label for the single
+        # forced tool, and model is an execution detail. prompt + schema +
+        # system fully determine the call's logical identity. CONSTRAINT: a
+        # per-call model override therefore MUST be deterministic across
+        # replays — computing it from nondeterministic state would let replay
+        # reuse a result produced under a different model without the
+        # determinism guard firing. (v1 orchestrators pass no per-call model.)
+        fp = fingerprint("llm_call",
+                         {"prompt": prompt, "schema": schema, "system": system})
+        cached, hit = self._check_or_none(seq, "llm_call", fp)
+        if hit:
+            return cached
+        result = await self._llm_caller(
+            self.ctx, system=system, user_msg=prompt, schema=schema,
+            tool_name=tool_name, model=model or self._model)
+        self.journal.append(seq, "llm_call", fp, result)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return result
+
+    async def user_input(self, prompt: str, *, choices: list[str] | None = None):
+        seq = self._cursor
+        self._cursor += 1
+        fp = fingerprint("user_input", {"prompt": prompt, "choices": choices})
+        cached, hit = self._check_or_none(seq, "user_input", fp)
+        if hit:
+            return cached
+        # New, unanswered → suspend. The journal (entries 0..seq-1) is already
+        # persisted by the preceding live call (or empty on a fresh start).
+        raise WorkflowSuspended(seq=seq, args_fingerprint=fp, prompt=prompt,
+                                choices=choices)

--- a/src/decafclaw/workflow/journal.py
+++ b/src/decafclaw/workflow/journal.py
@@ -1,0 +1,77 @@
+"""Durable, ordered record of journaled-call results for one workflow run.
+
+Entries are keyed positionally by execution order: the Nth journaled call
+executed gets sequence N. This is what makes loops replay correctly — same
+control flow produces the same execution order, hence the same keys.
+"""
+import dataclasses
+import hashlib
+import json
+from typing import Any
+
+from .paths import workflow_dir, workflow_path
+
+
+def fingerprint(kind: str, args: dict) -> str:
+    """Stable hash of a journaled call's kind + args (order-insensitive).
+
+    args must be JSON-serializable; non-serializable values raise TypeError by
+    design (a replay guard must fail loudly rather than risk a silent
+    fingerprint collision).
+    """
+    payload = json.dumps({"kind": kind, "args": args}, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclasses.dataclass
+class JournalEntry:
+    seq: int
+    kind: str
+    args_fingerprint: str
+    result: Any
+
+
+@dataclasses.dataclass
+class Journal:
+    workflow_name: str
+    status: str = "running"  # running | suspended | done | error
+    entries: list[JournalEntry] = dataclasses.field(default_factory=list)
+
+    def get(self, seq: int) -> JournalEntry | None:
+        if 0 <= seq < len(self.entries):
+            return self.entries[seq]
+        return None
+
+    def append(self, seq: int, kind: str, args_fingerprint: str,
+               result: Any) -> None:
+        if seq != len(self.entries):
+            raise ValueError(
+                f"non-contiguous journal append: seq={seq}, "
+                f"len={len(self.entries)}")
+        self.entries.append(JournalEntry(seq, kind, args_fingerprint, result))
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Journal":
+        j = cls(workflow_name=d["workflow_name"],
+                status=d.get("status", "running"))
+        j.entries = [JournalEntry(**e) for e in d.get("entries", [])]
+        return j
+
+
+def save_journal(config, conv_id: str, journal: Journal) -> None:
+    """Persist the journal. Flushed on every call for crash-safety."""
+    workflow_dir(config, conv_id, create=True)
+    path = workflow_path(config, conv_id)
+    tmp = path.parent / (path.name + ".tmp")
+    tmp.write_text(json.dumps(journal.to_dict(), indent=2))
+    tmp.replace(path)  # atomic on POSIX
+
+
+def load_journal(config, conv_id: str) -> Journal | None:
+    path = workflow_path(config, conv_id)
+    if not path.exists():
+        return None
+    return Journal.from_dict(json.loads(path.read_text()))

--- a/src/decafclaw/workflow/llm.py
+++ b/src/decafclaw/workflow/llm.py
@@ -1,0 +1,58 @@
+"""Forced-tool structured-output helper for workflow llm_call.
+
+Exposes exactly one tool the model MUST call, parses its args, and retries
+once with a stricter nudge on narrate-stall. Provider-agnostic; proven on
+vertex-gemini-flash by the #255 spike.
+"""
+import json
+import logging
+
+from decafclaw.llm import call_llm
+
+log = logging.getLogger(__name__)
+
+
+async def call_structured(ctx, *, system: str, user_msg: str, schema: dict,
+                          tool_name: str, model: str, description: str = "",
+                          retries: int = 1) -> dict:
+    """Force a structured response. Returns parsed tool args, or raises."""
+    base_user = user_msg
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": base_user},
+    ]
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "description": description or (
+                "Submit the structured result for this step. "
+                "You MUST call this — do not respond with prose."),
+            "parameters": schema,
+        },
+    }]
+    last_error: str | None = None
+    for _ in range(retries + 1):
+        result = await call_llm(ctx.config, messages, tools=tools,
+                                model_name=model)
+        tool_calls = result.get("tool_calls") or []
+        if tool_calls:
+            args_raw = tool_calls[0].get("function", {}).get("arguments") or "{}"
+            try:
+                return json.loads(args_raw)
+            except json.JSONDecodeError as e:
+                last_error = f"invalid JSON in tool args: {e}; raw={args_raw[:200]!r}"
+        else:
+            last_error = (
+                f"model emitted text instead of calling {tool_name!r}: "
+                f"{(result.get('content') or '')[:200]!r}")
+        log.debug("call_structured(%s) attempt failed: %s", tool_name, last_error)
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": (
+                base_user + f"\n\nIMPORTANT: You MUST call the tool "
+                f"`{tool_name}` now. Do not narrate. Emit only the call.")},
+        ]
+    raise RuntimeError(
+        f"structured call to {tool_name} failed after {retries + 1} "
+        f"attempts: {last_error}")

--- a/src/decafclaw/workflow/paths.py
+++ b/src/decafclaw/workflow/paths.py
@@ -1,0 +1,27 @@
+"""Per-conversation workflow file paths.
+
+New convention (#255): per-conversation files live in a directory named
+for the conversation id — ``conversations/{conv_id}/workflow.json`` —
+rather than the flat ``{conv_id}.*`` sidecar pattern. Only the workflow
+file adopts this now; existing sidecars migrate later (see spec).
+"""
+from pathlib import Path
+
+
+def _safe_conv_id(conv_id: str) -> str:
+    safe = conv_id.replace("/", "").replace("\\", "").replace("..", "")
+    return safe if safe not in ("", ".") else "_invalid"
+
+
+def workflow_dir(config, conv_id: str, *, create: bool = False) -> Path:
+    base = (config.workspace_path / "conversations").resolve()
+    d = (base / _safe_conv_id(conv_id)).resolve()
+    if not d.is_relative_to(base):
+        d = base / "_invalid"
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def workflow_path(config, conv_id: str) -> Path:
+    return workflow_dir(config, conv_id) / "workflow.json"

--- a/src/decafclaw/workflow/registry.py
+++ b/src/decafclaw/workflow/registry.py
@@ -1,0 +1,35 @@
+"""Workflow registry + @workflow decorator.
+
+A workflow is its own first-class concept — NOT a skill. It borrows only
+the command-invocation plumbing. Orchestrators register at import time.
+"""
+import dataclasses
+from typing import Any, Awaitable, Callable
+
+
+@dataclasses.dataclass
+class WorkflowSpec:
+    name: str
+    fn: Callable[[Any], Awaitable[Any]]
+    model: str = "vertex-gemini-flash"
+
+
+REGISTRY: dict[str, WorkflowSpec] = {}
+
+
+def workflow(name: str, *, model: str = "vertex-gemini-flash"):
+    def deco(fn):
+        if name in REGISTRY:
+            raise ValueError(f"workflow {name!r} already registered")
+        REGISTRY[name] = WorkflowSpec(name=name, fn=fn, model=model)
+        return fn
+    return deco
+
+
+def get_workflow(name: str) -> WorkflowSpec | None:
+    return REGISTRY.get(name)
+
+
+def workflow_commands() -> list[str]:
+    """Names invocable as /<name>. Used by the command bridge."""
+    return list(REGISTRY.keys())

--- a/src/decafclaw/workflow/resume.py
+++ b/src/decafclaw/workflow/resume.py
@@ -1,0 +1,118 @@
+"""Harness glue: run a workflow turn, and resume it after user input.
+
+run_workflow_turn is invoked by ConversationManager._start_turn for
+TurnKind.WORKFLOW. WorkflowUserInputHandler is registered on the
+ConfirmationRegistry; it fires via the confirmation *recovery* path
+(no awaiting waiter) because a workflow suspend ends the turn.
+"""
+import logging
+
+from decafclaw.confirmations import (
+    ConfirmationAction,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+from decafclaw.media import ToolResult
+
+from .engine import run_workflow
+from .journal import Journal, load_journal, save_journal
+from .registry import get_workflow
+
+log = logging.getLogger(__name__)
+
+
+def _render_artifact(result) -> str:
+    if isinstance(result, dict) and "title" in result and "body" in result:
+        return f"# {result['title']}\n\n{result['body']}"
+    return str(result)
+
+
+async def run_workflow_turn(ctx, manager, *,
+                            workflow_name: str, resume: bool) -> ToolResult:
+    spec = get_workflow(workflow_name)
+    if spec is None:
+        return ToolResult(text=f"[error: unknown workflow {workflow_name!r}]")
+
+    journal = load_journal(ctx.config, ctx.conv_id)
+    if journal is None:
+        if resume:
+            return ToolResult(text="[error: no workflow journal to resume]")
+        journal = Journal(workflow_name=workflow_name)
+
+    await ctx.publish("tool_status", tool="workflow",
+                      message=f"[workflow: {workflow_name}] running")
+    outcome = await run_workflow(ctx, spec.fn, journal, model=spec.model)
+
+    if outcome.status == "done":
+        await ctx.publish("tool_status", tool="workflow",
+                          message=f"[workflow: {workflow_name}] complete")
+        artifact_text = _render_artifact(outcome.result)
+        # Persist the rendered artifact so a conversation reload still
+        # shows the workflow's final output (the WORKFLOW turn path bypasses
+        # the agent loop's normal assistant-message archive write).
+        from decafclaw.archive import append_message  # noqa: PLC0415
+        append_message(ctx.config, ctx.conv_id,
+                       {"role": "assistant", "content": artifact_text})
+        return ToolResult(text=artifact_text)
+
+    if outcome.status == "suspended":
+        assert outcome.suspend is not None  # guaranteed by engine when status="suspended"
+        s = outcome.suspend
+        request = ConfirmationRequest(
+            action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+            message=s.prompt,
+            action_data={
+                "workflow_name": workflow_name,
+                "seq": s.seq,
+                "args_fingerprint": s.args_fingerprint,
+                "prompt": s.prompt,
+                "choices": s.choices,
+            },
+            timeout=None,
+        )
+        await manager.post_confirmation(ctx.conv_id, request)
+        return ToolResult(text=f"_{s.prompt}_")
+
+    return ToolResult(text=f"[error: workflow failed: {outcome.error}]")
+
+
+class WorkflowUserInputHandler:
+    """Resolves a WORKFLOW_USER_INPUT confirmation via the recovery path."""
+
+    def __init__(self, manager):
+        self.manager = manager
+
+    async def on_approve(self, ctx, request: ConfirmationRequest,
+                         response: ConfirmationResponse) -> dict:
+        ad = request.action_data
+        answer = (response.data or {}).get("value", "")
+        journal = load_journal(ctx.config, ctx.conv_id)
+        if journal is None:
+            log.error("workflow resume: no journal for conv %s", ctx.conv_id)
+            return {"continue_loop": False}
+        journal.append(ad["seq"], "user_input", ad["args_fingerprint"], answer)
+        journal.status = "running"
+        save_journal(ctx.config, ctx.conv_id, journal)
+
+        # Lazy import to avoid a circular import (conversation_manager
+        # will import this module once TurnKind.WORKFLOW dispatch is wired).
+        from decafclaw.conversation_manager import TurnKind  # noqa: PLC0415
+        await self.manager.enqueue_turn(
+            ctx.conv_id, kind=TurnKind.WORKFLOW, prompt="",
+            metadata={"workflow_name": ad["workflow_name"], "resume": True})
+        return {"continue_loop": False}
+
+    async def on_deny(self, ctx, request: ConfirmationRequest,
+                      response: ConfirmationResponse) -> dict:
+        ad = request.action_data
+        journal = load_journal(ctx.config, ctx.conv_id)
+        if journal is not None:
+            journal.status = "error"
+            save_journal(ctx.config, ctx.conv_id, journal)
+        from decafclaw.archive import append_message  # noqa: PLC0415
+        append_message(ctx.config, ctx.conv_id, {
+            "role": "assistant",
+            "source": "workflow_cancelled",
+            "content": f"Workflow {ad.get('workflow_name', '?')!r} cancelled.",
+        })
+        return {"continue_loop": False}

--- a/src/decafclaw/workflow/workflows/__init__.py
+++ b/src/decafclaw/workflow/workflows/__init__.py
@@ -1,0 +1,2 @@
+"""Importing this package registers all bundled orchestrators."""
+from . import interview  # noqa: F401

--- a/src/decafclaw/workflow/workflows/interview.py
+++ b/src/decafclaw/workflow/workflows/interview.py
@@ -1,0 +1,78 @@
+"""Interview → artifact: the #255 hero workflow.
+
+Asks one question at a time, looping until the model says it has enough (or a
+cap), then synthesizes an artifact. The whole thing is plain Python — the
+only journaled boundary crossings are wf.user_input and wf.llm_call.
+"""
+from ..registry import workflow
+
+MAX_Q = 6
+
+_SYS_ASK = (
+    "You are conducting a focused interview to gather material for a written "
+    "artifact. Ask ONE good next question at a time. Decide when you have "
+    "enough to write something useful."
+)
+_SYS_SYNTH = (
+    "You synthesize an interview transcript into a clear, well-structured "
+    "written artifact."
+)
+
+_DECISION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "done": {"type": "boolean",
+                 "description": "True when you have enough to synthesize."},
+        "question": {"type": "string",
+                     "description": "The next question (empty if done)."},
+    },
+    "required": ["done", "question"],
+}
+
+_ARTIFACT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body": {"type": "string", "description": "Markdown body."},
+    },
+    "required": ["title", "body"],
+}
+
+
+def _ask_prompt(topic: str, answers: list[dict]) -> str:
+    lines = [f"Topic: {topic}", ""]
+    if answers:
+        lines.append("Answers so far:")
+        for a in answers:
+            lines.append(f"- Q: {a['q']}\n  A: {a['a']}")
+        lines.append("")
+    lines.append("Decide whether you have enough. If not, ask the next question.")
+    return "\n".join(lines)
+
+
+def _synth_prompt(topic: str, answers: list[dict]) -> str:
+    lines = [f"Topic: {topic}", "", "Interview transcript:"]
+    for a in answers:
+        lines.append(f"- Q: {a['q']}\n  A: {a['a']}")
+    lines.append("")
+    lines.append("Write a titled markdown artifact synthesizing this.")
+    return "\n".join(lines)
+
+
+@workflow("interview")
+async def interview(wf):
+    topic = await wf.user_input("What should this interview be about?")
+
+    answers: list[dict] = []
+    while len(answers) < MAX_Q:
+        decision = await wf.llm_call(
+            prompt=_ask_prompt(topic, answers),
+            schema=_DECISION_SCHEMA, system=_SYS_ASK)
+        if decision.get("done"):
+            break
+        reply = await wf.user_input(decision["question"])
+        answers.append({"q": decision["question"], "a": reply})
+
+    return await wf.llm_call(
+        prompt=_synth_prompt(topic, answers),
+        schema=_ARTIFACT_SCHEMA, system=_SYS_SYNTH)

--- a/tests/test_client_cli.py
+++ b/tests/test_client_cli.py
@@ -74,6 +74,19 @@ def test_respond_deny(monkeypatch):
     assert args.approved is False
 
 
+def test_respond_value_default_empty(monkeypatch):
+    monkeypatch.setenv("DECAFCLAW_TOKEN", "dfc_x")
+    args = parse_args(["respond", "--conv", "web-1", "--confirmation-id", "c1"])
+    assert args.value == ""
+
+
+def test_respond_value_captured(monkeypatch):
+    monkeypatch.setenv("DECAFCLAW_TOKEN", "dfc_x")
+    args = parse_args(["respond", "--conv", "web-1", "--confirmation-id", "c1",
+                       "--value", "tide pools"])
+    assert args.value == "tide pools"
+
+
 def test_respond_requires_conv(monkeypatch):
     monkeypatch.setenv("DECAFCLAW_TOKEN", "dfc_x")
     with pytest.raises(SystemExit):

--- a/tests/test_client_run.py
+++ b/tests/test_client_run.py
@@ -162,7 +162,20 @@ async def test_run_respond_sends_confirm_response():
     summaries = await run_respond(t, args)
     cr = [m for m in t.sent if m["type"] == "confirm_response"]
     assert cr and cr[0]["confirmation_id"] == "c1" and cr[0]["approved"] is True
+    # Default empty value → no data field (preserves existing behavior).
+    assert "data" not in cr[0]
     assert summaries[0].status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_run_respond_forwards_value_as_data():
+    t = FakeTransport([[{"type": "turn_complete", "conv_id": "web-1"}]])
+    args = SmokeArgs(action="respond", token="dfc_x", host="http://h",
+                     timeout=5.0, fmt="summary", conv="web-1",
+                     confirmation_id="c1", approved=True, value="tide pools")
+    await run_respond(t, args)
+    cr = [m for m in t.sent if m["type"] == "confirm_response"]
+    assert cr[0]["data"] == {"value": "tide pools"}
 
 
 def test_exit_code_mapping():

--- a/tests/test_web_websocket_confirm_response.py
+++ b/tests/test_web_websocket_confirm_response.py
@@ -1,0 +1,110 @@
+"""Tests for _handle_confirm_response data forwarding.
+
+Verifies that a confirm_response message carrying a `data` dict is
+forwarded as-is to manager.respond_to_confirmation, which is the
+mechanism the workflow_user_input affordance relies on to deliver the
+user's typed answer to the backend handler.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from decafclaw.web.websocket import _handle_confirm_response
+
+
+@pytest.fixture
+def ws_send():
+    return AsyncMock()
+
+
+@pytest.fixture
+def ws_state():
+    """Minimal WebSocket handler state with a mock manager."""
+    manager = MagicMock()
+    manager.respond_to_confirmation = AsyncMock()
+    return {
+        "config": MagicMock(),
+        "event_bus": MagicMock(),
+        "manager": manager,
+    }
+
+
+@pytest.fixture
+def index():
+    return MagicMock()
+
+
+class TestConfirmResponseDataForwarding:
+    @pytest.mark.asyncio
+    async def test_data_forwarded_to_manager(self, ws_send, index, ws_state):
+        """data dict rides through _handle_confirm_response to respond_to_confirmation."""
+        msg = {
+            "type": "confirm_response",
+            "conv_id": "conv-1",
+            "confirmation_id": "cfm-abc",
+            "approved": True,
+            "always": False,
+            "add_pattern": False,
+            "data": {"value": "tide pools"},
+        }
+
+        await _handle_confirm_response(ws_send, index, "testuser", msg, ws_state)
+
+        ws_state["manager"].respond_to_confirmation.assert_awaited_once_with(
+            "conv-1",
+            "cfm-abc",
+            approved=True,
+            always=False,
+            add_pattern=False,
+            data={"value": "tide pools"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_data_passes_none(self, ws_send, index, ws_state):
+        """When no data field is present, data=None is forwarded (not missing kwarg)."""
+        msg = {
+            "type": "confirm_response",
+            "conv_id": "conv-1",
+            "confirmation_id": "cfm-xyz",
+            "approved": True,
+            "always": False,
+            "add_pattern": False,
+        }
+
+        await _handle_confirm_response(ws_send, index, "testuser", msg, ws_state)
+
+        ws_state["manager"].respond_to_confirmation.assert_awaited_once_with(
+            "conv-1",
+            "cfm-xyz",
+            approved=True,
+            always=False,
+            add_pattern=False,
+            data=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_dict_data_coerced_to_none(self, ws_send, index, ws_state):
+        """A non-dict data value (e.g. a string) is coerced to None, not forwarded raw."""
+        msg = {
+            "type": "confirm_response",
+            "conv_id": "conv-1",
+            "confirmation_id": "cfm-bad",
+            "approved": True,
+            "always": False,
+            "add_pattern": False,
+            "data": "not-a-dict",
+        }
+
+        await _handle_confirm_response(ws_send, index, "testuser", msg, ws_state)
+
+        ws_state["manager"].respond_to_confirmation.assert_awaited_once_with(
+            "conv-1",
+            "cfm-bad",
+            approved=True,
+            always=False,
+            add_pattern=False,
+            data=None,
+        )

--- a/tests/test_web_websocket_workflow.py
+++ b/tests/test_web_websocket_workflow.py
@@ -1,0 +1,64 @@
+"""WebSocket workflow-command intercept tests.
+
+Regression coverage for #573 verification finding #2: the workflow-command
+intercept in `_handle_send` enqueues a TurnKind.WORKFLOW turn but must also
+archive the user's invocation as a `role: "user"` message, otherwise a
+conversation reload shows zero messages for the entire workflow run.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_workflow_command_archives_user_invocation(config):
+    """Sending `/interview` should write a role=user archive row with the
+    typed text BEFORE enqueueing the WORKFLOW turn, so a conversation reload
+    has something to render."""
+    import decafclaw.workflow.workflows  # noqa: F401 — register interview
+    from decafclaw.archive import read_archive
+    from decafclaw.events import EventBus
+    from decafclaw.web import websocket
+
+    conv_id = "conv-wf-archive"
+
+    enqueued: list[dict] = []
+
+    class FakeManager:
+        # `subscribe` is invoked by _subscribe_to_conv; return a sentinel id.
+        def subscribe(self, conv_id, callback):
+            return "sub-id"
+
+        async def enqueue_turn(self, conv_id, **kw):
+            enqueued.append({"conv_id": conv_id, **kw})
+
+    async def ws_send(_msg):
+        pass
+
+    state = {
+        "config": config,
+        "event_bus": EventBus(),
+        "manager": FakeManager(),
+        "ws_send": ws_send,
+    }
+    index = MagicMock()
+    conv = MagicMock()
+    conv.user_id = "testuser"
+    index.get.return_value = conv
+
+    await websocket._handle_send(
+        ws_send, index, "testuser",
+        {"conv_id": conv_id, "text": "/interview"},
+        state,
+    )
+
+    assert enqueued, "workflow intercept should enqueue a WORKFLOW turn"
+    msgs = read_archive(config, conv_id)
+    user_msgs = [m for m in msgs if m.get("role") == "user"]
+    assert user_msgs, (
+        "expected a role=user archive row for the /interview invocation"
+    )
+    assert user_msgs[0].get("content") == "/interview"

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.workflow.engine import run_workflow
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convE")
+
+
+@pytest.mark.asyncio
+async def test_suspends_on_first_user_input(tmp_path):
+    async def wf(h):
+        topic = await h.user_input("topic?")
+        return {"topic": topic}
+
+    j = Journal(workflow_name="t")
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "suspended"
+    assert outcome.suspend.prompt == "topic?"
+    assert j.status == "suspended"
+
+
+@pytest.mark.asyncio
+async def test_completes_when_journal_fully_seeded(tmp_path):
+    async def wf(h):
+        topic = await h.user_input("topic?")
+        return {"topic": topic, "done": True}
+
+    j = Journal(workflow_name="t")
+    fp = fingerprint("user_input", {"prompt": "topic?", "choices": None})
+    j.append(0, "user_input", fp, "tide pools")
+
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "done"
+    assert outcome.result == {"topic": "tide pools", "done": True}
+    assert j.status == "done"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_exception_becomes_error_outcome(tmp_path):
+    async def wf(h):
+        raise ValueError("boom")
+
+    j = Journal(workflow_name="t")
+    outcome = await run_workflow(_ctx(tmp_path), wf, j)
+    assert outcome.status == "error"
+    assert "boom" in outcome.error
+    assert j.status == "error"

--- a/tests/test_workflow_handle.py
+++ b/tests/test_workflow_handle.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.workflow.errors import WorkflowNonDeterministic, WorkflowSuspended
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convX")
+
+
+@pytest.mark.asyncio
+async def test_llm_call_executes_live_and_journals(tmp_path):
+    j = Journal(workflow_name="t")
+    hits = []
+
+    async def fake_llm(ctx, **kw):
+        hits.append(kw["user_msg"])
+        return {"answer": 42}
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
+    out = await h.llm_call(prompt="q1", schema={}, model="m")
+    assert out == {"answer": 42}
+    assert j.get(0).kind == "llm_call"
+    assert hits == ["q1"]
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_cached_without_executing(tmp_path):
+    j = Journal(workflow_name="t")
+    fp = fingerprint("llm_call", {"prompt": "q1", "schema": {}, "system": ""})
+    j.append(0, "llm_call", fp, {"answer": 42})
+
+    async def boom(ctx, **kw):
+        raise AssertionError("live LLM path must NOT run during replay")
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=boom)
+    out = await h.llm_call(prompt="q1", schema={}, model="m")
+    assert out == {"answer": 42}  # sabotage check: cached, not re-executed
+
+
+@pytest.mark.asyncio
+async def test_user_input_suspends_when_unanswered(tmp_path):
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
+    with pytest.raises(WorkflowSuspended) as ei:
+        await h.user_input("What topic?")
+    assert ei.value.seq == 0
+    assert ei.value.prompt == "What topic?"
+
+
+@pytest.mark.asyncio
+async def test_user_input_replays_recorded_answer(tmp_path):
+    j = Journal(workflow_name="t")
+    fp = fingerprint("user_input", {"prompt": "What topic?", "choices": None})
+    j.append(0, "user_input", fp, "tide pools")
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
+    assert await h.user_input("What topic?") == "tide pools"
+
+
+@pytest.mark.asyncio
+async def test_determinism_guard_fires_on_divergent_args(tmp_path):
+    j = Journal(workflow_name="t")
+    fp = fingerprint("llm_call", {"prompt": "ORIGINAL", "schema": {}, "system": ""})
+    j.append(0, "llm_call", fp, {"x": 1})
+
+    async def fake_llm(ctx, **kw):
+        return {"x": 1}
+
+    h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
+    with pytest.raises(WorkflowNonDeterministic):
+        await h.llm_call(prompt="CHANGED", schema={}, model="m")

--- a/tests/test_workflow_interview.py
+++ b/tests/test_workflow_interview.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+import pytest
+
+import decafclaw.workflow.workflows  # noqa: F401 — registers interview
+from decafclaw.workflow.engine import run_workflow
+from decafclaw.workflow.journal import Journal, fingerprint
+from decafclaw.workflow.registry import get_workflow
+
+
+def _ctx(tmp_path):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id="convI")
+
+
+@pytest.mark.asyncio
+async def test_interview_suspends_for_topic_first(tmp_path):
+    spec = get_workflow("interview")
+    assert spec is not None
+    outcome = await run_workflow(_ctx(tmp_path), spec.fn,
+                                 Journal(workflow_name="interview"))
+    assert outcome.status == "suspended"
+    assert "about" in outcome.suspend.prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_interview_replays_to_artifact(tmp_path):
+    """Seed a full journal (topic + one Q/A + done + synth) → pure replay,
+    no LLM, reaches the artifact."""
+    spec = get_workflow("interview")
+    j = Journal(workflow_name="interview")
+
+    def fp_user(prompt):
+        return fingerprint("user_input", {"prompt": prompt, "choices": None})
+
+    def fp_llm(prompt, schema, system):
+        return fingerprint("llm_call",
+                           {"prompt": prompt, "schema": schema, "system": system})
+
+    from decafclaw.workflow.workflows.interview import (
+        _ARTIFACT_SCHEMA,
+        _DECISION_SCHEMA,
+        _SYS_ASK,
+        _SYS_SYNTH,
+        _ask_prompt,
+        _synth_prompt,
+    )
+    j.append(0, "user_input", fp_user("What should this interview be about?"),
+             "tide pools")
+    q1_prompt = _ask_prompt("tide pools", [])
+    j.append(1, "llm_call", fp_llm(q1_prompt, _DECISION_SCHEMA, _SYS_ASK),
+             {"done": False, "question": "What draws you to them?"})
+    j.append(2, "user_input", fp_user("What draws you to them?"), "the creatures")
+    q2_prompt = _ask_prompt(
+        "tide pools", [{"q": "What draws you to them?", "a": "the creatures"}])
+    j.append(3, "llm_call", fp_llm(q2_prompt, _DECISION_SCHEMA, _SYS_ASK),
+             {"done": True, "question": ""})
+    synth_prompt = _synth_prompt(
+        "tide pools", [{"q": "What draws you to them?", "a": "the creatures"}])
+    j.append(4, "llm_call", fp_llm(synth_prompt, _ARTIFACT_SCHEMA, _SYS_SYNTH),
+             {"title": "Tide Pools", "body": "..."})
+
+    outcome = await run_workflow(_ctx(tmp_path), spec.fn, j)
+    assert outcome.status == "done"
+    assert outcome.result["title"] == "Tide Pools"

--- a/tests/test_workflow_journal.py
+++ b/tests/test_workflow_journal.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.workflow.journal import (
+    Journal,
+    JournalEntry,
+    fingerprint,
+    load_journal,
+    save_journal,
+)
+
+
+def _cfg(tmp_path):
+    return SimpleNamespace(workspace_path=tmp_path)
+
+
+def test_fingerprint_is_stable_and_order_insensitive():
+    a = fingerprint("llm_call", {"prompt": "hi", "schema": {"x": 1}})
+    b = fingerprint("llm_call", {"schema": {"x": 1}, "prompt": "hi"})
+    assert a == b
+    assert a != fingerprint("llm_call", {"prompt": "bye", "schema": {"x": 1}})
+
+
+def test_append_is_contiguous_and_get_by_seq():
+    j = Journal(workflow_name="t")
+    j.append(0, "llm_call", "fp0", {"a": 1})
+    j.append(1, "user_input", "fp1", "answer")
+    assert j.get(0).result == {"a": 1}
+    assert j.get(1).result == "answer"
+    assert j.get(2) is None
+
+
+def test_append_rejects_non_contiguous_seq():
+    j = Journal(workflow_name="t")
+    with pytest.raises(ValueError):
+        j.append(1, "llm_call", "fp", None)
+
+
+def test_save_and_load_round_trip(tmp_path):
+    cfg = _cfg(tmp_path)
+    j = Journal(workflow_name="interview", status="suspended")
+    j.append(0, "user_input", "fp0", "topic")
+    save_journal(cfg, "conv1", j)
+
+    loaded = load_journal(cfg, "conv1")
+    assert loaded.workflow_name == "interview"
+    assert loaded.status == "suspended"
+    assert loaded.get(0).kind == "user_input"
+    assert loaded.get(0).result == "topic"
+    assert loaded.get(0).args_fingerprint == "fp0"
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_journal(_cfg(tmp_path), "nope") is None

--- a/tests/test_workflow_llm.py
+++ b/tests/test_workflow_llm.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.workflow import llm as wf_llm
+
+
+@pytest.mark.asyncio
+async def test_returns_parsed_tool_args(monkeypatch):
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        return {"tool_calls": [{"function": {"arguments": '{"q": "why?"}'}}]}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    out = await wf_llm.call_structured(
+        SimpleNamespace(config=object()),
+        system="s", user_msg="u", schema={"type": "object"},
+        tool_name="submit", model="m",
+    )
+    assert out == {"q": "why?"}
+
+
+@pytest.mark.asyncio
+async def test_retries_on_narrate_then_succeeds(monkeypatch):
+    calls = []
+
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        calls.append(messages)
+        if len(calls) == 1:
+            return {"content": "I think the answer is...", "tool_calls": None}
+        return {"tool_calls": [{"function": {"arguments": '{"ok": true}'}}]}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    out = await wf_llm.call_structured(
+        SimpleNamespace(config=object()),
+        system="s", user_msg="u", schema={}, tool_name="submit", model="m",
+    )
+    assert out == {"ok": True}
+    assert len(calls) == 2  # one narrate-stall, one nudged retry
+
+
+@pytest.mark.asyncio
+async def test_raises_after_exhausting_retries(monkeypatch):
+    async def fake_call_llm(config, messages, *, tools, model_name):
+        return {"content": "prose", "tool_calls": None}
+    monkeypatch.setattr(wf_llm, "call_llm", fake_call_llm)
+
+    with pytest.raises(RuntimeError):
+        await wf_llm.call_structured(
+            SimpleNamespace(config=object()),
+            system="s", user_msg="u", schema={}, tool_name="submit",
+            model="m", retries=1,
+        )

--- a/tests/test_workflow_paths.py
+++ b/tests/test_workflow_paths.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from decafclaw.workflow.paths import workflow_dir, workflow_path
+
+
+def _cfg(tmp_path):
+    return SimpleNamespace(workspace_path=tmp_path)
+
+
+def test_workflow_path_is_in_conv_subdirectory(tmp_path):
+    cfg = _cfg(tmp_path)
+    assert workflow_path(cfg, "abc123") == (
+        tmp_path / "conversations" / "abc123" / "workflow.json"
+    )
+
+
+def test_workflow_dir_is_created(tmp_path):
+    cfg = _cfg(tmp_path)
+    d = workflow_dir(cfg, "abc123", create=True)
+    assert d.is_dir()
+    assert d == tmp_path / "conversations" / "abc123"
+
+
+def test_path_sandboxed_against_traversal(tmp_path):
+    cfg = _cfg(tmp_path)
+    p = workflow_path(cfg, "../../etc/passwd")
+    base = (tmp_path / "conversations").resolve()
+    assert p.resolve().is_relative_to(base)
+
+
+def test_empty_conv_id_falls_back(tmp_path):
+    cfg = _cfg(tmp_path)
+    p = workflow_path(cfg, "")
+    assert p.name == "workflow.json"
+    assert (tmp_path / "conversations").resolve() in p.resolve().parents
+
+
+def test_single_dot_conv_id_falls_back(tmp_path):
+    cfg = _cfg(tmp_path)
+    p = workflow_path(cfg, ".")
+    base = (tmp_path / "conversations").resolve()
+    assert p.resolve().is_relative_to(base)
+    # must land in a subdirectory, not directly in base
+    assert p.resolve().parent != base

--- a/tests/test_workflow_registry.py
+++ b/tests/test_workflow_registry.py
@@ -1,0 +1,28 @@
+import pytest
+
+from decafclaw.workflow.registry import REGISTRY, get_workflow, workflow
+
+
+def test_decorator_registers_and_lookup_works():
+    @workflow("demo_wf")
+    async def demo(h):
+        return "ok"
+
+    spec = get_workflow("demo_wf")
+    assert spec is not None
+    assert spec.name == "demo_wf"
+    assert spec.fn is demo
+
+
+def test_unknown_workflow_returns_none():
+    assert get_workflow("does_not_exist_xyz") is None
+
+
+def test_duplicate_name_raises():
+    @workflow("dup_wf")
+    async def a(h):
+        return 1
+    with pytest.raises(ValueError):
+        @workflow("dup_wf")
+        async def b(h):
+            return 2

--- a/tests/test_workflow_resume.py
+++ b/tests/test_workflow_resume.py
@@ -1,0 +1,161 @@
+from types import SimpleNamespace
+
+import pytest
+
+from decafclaw.confirmations import (
+    ConfirmationAction,
+    ConfirmationRequest,
+    ConfirmationResponse,
+)
+from decafclaw.workflow.journal import (
+    Journal,
+    fingerprint,
+    load_journal,
+    save_journal,
+)
+
+
+def test_workflow_user_input_action_exists():
+    assert ConfirmationAction.WORKFLOW_USER_INPUT.value == "workflow_user_input"
+
+
+async def _noop(*args, **kwargs):
+    pass
+
+
+def _ctx(tmp_path, conv_id="convR"):
+    return SimpleNamespace(config=SimpleNamespace(workspace_path=tmp_path),
+                           conv_id=conv_id,
+                           publish=_noop)
+
+
+@pytest.mark.asyncio
+async def test_handler_journals_answer_and_enqueues_resume(tmp_path):
+    from decafclaw.workflow.resume import WorkflowUserInputHandler
+
+    cfg = SimpleNamespace(workspace_path=tmp_path)
+    j = Journal(workflow_name="interview", status="suspended")
+    save_journal(cfg, "convR", j)
+
+    fp = fingerprint("user_input",
+                     {"prompt": "What should this interview be about?",
+                      "choices": None})
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="What should this interview be about?",
+        action_data={"workflow_name": "interview", "seq": 0,
+                     "args_fingerprint": fp, "prompt": "...", "choices": None},
+        timeout=None,
+    )
+    response = ConfirmationResponse(confirmation_id="x", approved=True,
+                                    data={"value": "tide pools"})
+
+    enqueued = []
+
+    class FakeManager:
+        config = cfg
+        async def enqueue_turn(self, conv_id, **kw):
+            enqueued.append((conv_id, kw))
+
+    handler = WorkflowUserInputHandler(FakeManager())
+    out = await handler.on_approve(_ctx(tmp_path), request, response)
+
+    reloaded = load_journal(cfg, "convR")
+    assert reloaded.get(0).kind == "user_input"
+    assert reloaded.get(0).result == "tide pools"
+    assert reloaded.status == "running"
+    assert enqueued and enqueued[0][1]["metadata"]["resume"] is True
+    assert enqueued[0][1]["metadata"]["workflow_name"] == "interview"
+    assert out == {"continue_loop": False}
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_turn_fresh_start_suspends_and_posts(tmp_path):
+    import decafclaw.workflow.workflows  # noqa: F401 — register interview
+    from decafclaw.workflow.resume import run_workflow_turn
+
+    posted = []
+
+    class FakeManager:
+        config = SimpleNamespace(workspace_path=tmp_path)
+        async def post_confirmation(self, conv_id, request):
+            posted.append(request)
+
+    ctx = _ctx(tmp_path, "convT")
+    result = await run_workflow_turn(
+        ctx, FakeManager(),
+        workflow_name="interview", resume=False)
+    assert posted, "a confirmation should be posted on suspend"
+    assert posted[0].action_type == ConfirmationAction.WORKFLOW_USER_INPUT
+    assert posted[0].action_data["seq"] == 0
+    assert posted[0].action_data["workflow_name"] == "interview"
+    from decafclaw.media import ToolResult
+    assert isinstance(result, ToolResult)
+    assert result.text.startswith("_")  # italic-wrapped prompt
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_turn_done_archives_artifact(config):
+    """On status=done, run_workflow_turn must persist the rendered artifact
+    as a role=assistant archive row, so a conversation reload still has the
+    final output visible (verification finding #2 for PR #573)."""
+    from decafclaw.archive import read_archive
+    from decafclaw.workflow.journal import Journal, save_journal
+    from decafclaw.workflow.registry import workflow as register_workflow
+    from decafclaw.workflow.resume import run_workflow_turn
+
+    conv_id = "convDone"
+
+    @register_workflow("artifact_done_test")
+    async def _wf(wf):
+        return {"title": "Tide Pools", "body": "Brief notes."}
+
+    # Pre-seed an empty journal so run_workflow_turn treats this as a resume
+    # path without needing user_input — the workflow returns immediately.
+    save_journal(config, conv_id, Journal(workflow_name="artifact_done_test"))
+
+    from types import SimpleNamespace
+
+    async def _noop(*args, **kwargs):
+        pass
+
+    class FakeManager:
+        async def post_confirmation(self, conv_id, request):
+            raise AssertionError("done path should not post a confirmation")
+
+    ctx = SimpleNamespace(config=config, conv_id=conv_id, publish=_noop)
+    result = await run_workflow_turn(
+        ctx, FakeManager(),
+        workflow_name="artifact_done_test", resume=True)
+    assert "Tide Pools" in result.text
+
+    msgs = read_archive(config, conv_id)
+    assistant_msgs = [m for m in msgs if m.get("role") == "assistant"]
+    assert assistant_msgs, (
+        "expected a role=assistant archive row for the workflow artifact"
+    )
+    assert "Tide Pools" in (assistant_msgs[-1].get("content") or "")
+
+
+@pytest.mark.asyncio
+async def test_handler_deny_marks_error_and_archives(tmp_path):
+    from decafclaw.workflow.resume import WorkflowUserInputHandler
+
+    cfg = SimpleNamespace(workspace_path=tmp_path)
+    j = Journal(workflow_name="interview", status="suspended")
+    save_journal(cfg, "convD", j)
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="q?", action_data={"workflow_name": "interview", "seq": 0,
+        "args_fingerprint": "fp", "prompt": "q?", "choices": None}, timeout=None)
+    response = ConfirmationResponse(confirmation_id="x", approved=False)
+
+    class FakeManager:
+        config = cfg
+        async def enqueue_turn(self, conv_id, **kw):
+            raise AssertionError("deny must NOT enqueue a resume turn")
+
+    handler = WorkflowUserInputHandler(FakeManager())
+    out = await handler.on_deny(_ctx(tmp_path, "convD"), request, response)
+    assert out == {"continue_loop": False}
+    assert load_journal(cfg, "convD").status == "error"

--- a/tests/test_workflow_turn_integration.py
+++ b/tests/test_workflow_turn_integration.py
@@ -1,0 +1,173 @@
+"""Integration tests for workflow turn support in ConversationManager."""
+
+import pytest
+
+from decafclaw.confirmations import ConfirmationAction, ConfirmationRequest
+from decafclaw.conversation_manager import ConversationManager
+from decafclaw.events import EventBus
+
+
+@pytest.fixture
+def make_manager(config):
+    """Factory fixture: returns a callable that builds a ConversationManager
+    pointing at the test tmp workspace."""
+    def _make():
+        return ConversationManager(config=config, event_bus=EventBus())
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_post_confirmation_sets_pending_without_waiter(make_manager):
+    manager = make_manager()
+    conv_id = "convP"
+    req = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="topic?", action_data={"seq": 0}, timeout=None)
+
+    await manager.post_confirmation(conv_id, req)
+
+    state = manager._conversations[conv_id]
+    assert state.pending_confirmation is req
+    assert state.confirmation_event is None  # forces recovery dispatch
+    assert state.confirmation_response is None
+
+
+@pytest.mark.asyncio
+async def test_post_confirmation_raises_when_slot_busy(make_manager):
+    import pytest
+    manager = make_manager()
+    conv_id = "convBusy"
+    req = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="q1?", action_data={"seq": 0}, timeout=None)
+    await manager.post_confirmation(conv_id, req)
+    req2 = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="q2?", action_data={"seq": 1}, timeout=None)
+    with pytest.raises(RuntimeError):
+        await manager.post_confirmation(conv_id, req2)
+
+
+@pytest.mark.asyncio
+async def test_post_confirmation_busy_raise_does_not_leave_archive_orphan(
+        make_manager, config):
+    """Regression: if post_confirmation raises on a busy slot, the rejected
+    request must NOT appear in the archive. Otherwise startup_scan would
+    recover it as a ghost pending confirmation with no backing workflow
+    (Copilot review on PR #573)."""
+    import pytest
+
+    from decafclaw.archive import read_archive
+    manager = make_manager()
+    conv_id = "convOrphan"
+
+    first = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="first", action_data={"seq": 0}, timeout=None)
+    await manager.post_confirmation(conv_id, first)
+
+    rejected = ConfirmationRequest(
+        action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
+        message="rejected", action_data={"seq": 1}, timeout=None)
+    with pytest.raises(RuntimeError):
+        await manager.post_confirmation(conv_id, rejected)
+
+    msgs = read_archive(config, conv_id)
+    req_rows = [m for m in msgs if m.get("role") == "confirmation_request"]
+    assert len(req_rows) == 1, (
+        f"expected only the first (installed) confirmation_request in archive; "
+        f"the busy-raised request must not leak. Found {len(req_rows)} rows: "
+        f"{[r.get('confirmation_id') for r in req_rows]}"
+    )
+    assert req_rows[0].get("confirmation_id") == first.confirmation_id
+
+
+@pytest.mark.asyncio
+async def test_workflow_turn_runs_and_suspends_end_to_end(make_manager):
+    """Enqueue an interview WORKFLOW turn → it suspends, posting a
+    WORKFLOW_USER_INPUT confirmation for the topic question."""
+    import decafclaw.workflow.workflows  # noqa: F401 — register interview
+    from decafclaw.conversation_manager import TurnKind
+    manager = make_manager()
+    conv_id = "convWF"
+
+    fut = await manager.enqueue_turn(
+        conv_id, kind=TurnKind.WORKFLOW, prompt="",
+        metadata={"workflow_name": "interview", "resume": False})
+    await fut  # wait for the turn to finish (it suspends, then ends)
+
+    state = manager._conversations[conv_id]
+    assert state.pending_confirmation is not None
+    from decafclaw.confirmations import ConfirmationAction
+    assert state.pending_confirmation.action_type is ConfirmationAction.WORKFLOW_USER_INPUT
+    assert state.pending_confirmation.action_data["workflow_name"] == "interview"
+    assert state.pending_confirmation.action_data["seq"] == 0
+
+
+@pytest.mark.asyncio
+async def test_durable_resume_after_simulated_restart(tmp_path):
+    """A journal persisted mid-suspend resumes from a freshly reconstructed
+    engine (simulating a server restart) with no lost state: the journaled
+    answer is replayed (the user is NOT re-asked) and the workflow continues
+    to completion."""
+    from types import SimpleNamespace
+
+    import decafclaw.workflow.workflows  # noqa: F401 — register interview
+    from decafclaw.workflow.engine import run_workflow
+    from decafclaw.workflow.journal import Journal, load_journal, save_journal
+    from decafclaw.workflow.registry import get_workflow
+
+    cfg = SimpleNamespace(workspace_path=tmp_path)
+    conv_id = "convRestart"
+
+    def fresh_ctx():
+        # A brand-new ctx each "process" — nothing carried in memory.
+        return SimpleNamespace(config=cfg, conv_id=conv_id)
+
+    spec = get_workflow("interview")
+
+    # --- Process 1: start; suspends at the topic question; journal hits disk ---
+    out1 = await run_workflow(fresh_ctx(), spec.fn, Journal(workflow_name="interview"))
+    assert out1.status == "suspended"
+    assert out1.suspend.seq == 0
+
+    # --- "Restart": reconstruct ONLY from the on-disk journal ---
+    reloaded = load_journal(cfg, conv_id)
+    assert reloaded is not None
+    assert reloaded.status == "suspended"
+    assert len(reloaded.entries) == 0  # nothing journaled yet for the unanswered input
+
+    # --- The resume handler would journal the user's answer at the suspend seq ---
+    reloaded.append(out1.suspend.seq, "user_input",
+                    out1.suspend.args_fingerprint, "tide pools")
+    reloaded.status = "running"
+    save_journal(cfg, conv_id, reloaded)
+
+    # --- Process 2 (fresh engine): reload from disk, replay + continue live ---
+    live_calls = []
+
+    async def fake_llm(ctx, **kw):
+        live_calls.append(kw)
+        # One canned dict satisfies BOTH the decision schema {done, question}
+        # and the synth schema {title, body}: done=True ends the loop, then the
+        # synth call returns the artifact.
+        return {"done": True, "question": "",
+                "title": "Tide Pools", "body": "A brief."}
+
+    j2 = load_journal(cfg, conv_id)
+    out2 = await run_workflow(fresh_ctx(), spec.fn, j2, llm_caller=fake_llm)
+
+    assert out2.status == "done"
+    assert out2.result["title"] == "Tide Pools"
+    # The recovered answer was REPLAYED from the journal (user_input at seq 0 was
+    # NOT re-raised as a suspension), and only llm_calls ran live:
+    final = load_journal(cfg, conv_id)
+    assert final.get(0).kind == "user_input"
+    assert final.get(0).result == "tide pools"
+    # Live calls were the decision + synth llm_calls only (2), never a user_input.
+    # Trace: seq0 user_input → cached (no live call); seq1 llm_call decision →
+    # live (done=True, break); seq2 llm_call synth → live (artifact). Total: 2.
+    assert len(live_calls) == 2
+    # The replayed topic actually flowed into the LLM prompts (guards against a
+    # wrong-replay-value regression that fake_llm would otherwise mask).
+    assert any("tide pools" in (c.get("user_msg") or "") for c in live_calls)

--- a/tui/src/types.generated.ts
+++ b/tui/src/types.generated.ts
@@ -190,6 +190,7 @@ export interface CliConfirmResponse {
   approved: boolean;
   always: boolean;
   add_pattern: boolean;
+  data?: Record<string, unknown>;
 }
 
 export interface CliLoadHistory {


### PR DESCRIPTION
## Summary

Fresh approach to #255 (supersedes the closed #557). A first-class **workflow** abstraction built on **durable execution via deterministic replay** — the model behind Temporal, DBOS, and Claude Code dynamic workflows.

The lesson from #557's four failed iterations: a workflow needs a *programmatic control scaffold*. Code owns control flow; the LLM is invoked only as a constrained structured-output worker. #557 made the LLM crank the state machine (emit `phase_advance`) and it reliably narrated instead — never walked end-to-end against a live model. This engine flips that.

Design: `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/spec.md`. Feature doc: `docs/workflows.md`.

## How it works

- A workflow is a registered async Python function (`@workflow("name")`) the harness runs as its own `TurnKind.WORKFLOW` — **not** the LLM agent loop. Control flow is plain Python (`if`/`while`); the LLM is invoked only inside two journaled primitives: `wf.llm_call` and `wf.user_input`.
- **The load-bearing rule:** every call that crosses to the outside world goes through the journal; everything else is ordinary code. The engine re-runs the orchestrator from the top on resume, replaying journaled results from `conversations/{conv_id}/workflow.json` (positionally keyed), fast-forwarding to the suspension point.
- **Durable across restart:** a `user_input` suspension posts a confirmation *without* a waiter (`post_confirmation`) and ends the turn; the user's answer routes through the confirmation **recovery** path to a handler that journals the answer and enqueues a fresh replay turn. The journal is just a file, so a mid-interview server restart loses nothing.
- **Determinism guard:** each journal entry stores an `args_fingerprint`; a replay mismatch raises `WorkflowNonDeterministic` (fail loud, never return a stale result).
- **Hero workflow:** `/interview` — asks a topic, loops one question at a time until the model is satisfied (capped), then synthesizes a `{title, body}` artifact. The web UI renders a text field (or choice buttons) for each question.

## What ships

- `src/decafclaw/workflow/` — `paths`, `errors`, `journal`, `llm` (forced-tool structured output), `handle` (the replay core), `engine`, `registry`, `resume`, `workflows/interview`
- `TurnKind.WORKFLOW` dispatch + `post_confirmation` + `WorkflowUserInputHandler` in `conversation_manager.py`
- `WORKFLOW_USER_INPUT` confirmation action; workflow-question input affordance in `web/static/components/confirm-view.js`; `/interview` bridge in `web/websocket.py`
- Unit suite (34 workflow tests) incl. a restart-durability test that reconstructs the engine from disk and proves replay completes
- `docs/workflows.md` + index/CLAUDE links

## Status

- `make check` clean (ruff, pyright, tsc --checkJs, message-types drift); full suite **2814 passed**.
- Built via subagent-driven development (implement → spec-review → code-quality-review per task; final whole-implementation review).
- **Draft pending the live smoke** — the bar no prior iteration cleared. Checklist in the session `notes.md`: `/interview`, answer a couple of questions, **restart the server mid-interview**, reload, confirm it resumes to the artifact. Should be run before marking ready.

## Deferred (tracked in notes, not blocking)

- WORKFLOW-as-task-kind reconsideration after smoke (currently reuses the USER `Context` path)
- Batch primitives (`subagent`/`parallel`/`pipeline`/`tool_call`) — the fan-out case
- LLM-generated per-task workflows (the Claude Code dynamic-workflow model)
- Migrating the remaining flat conversation sidecars into `conversations/{conv_id}/` (only `workflow.json` uses the directory layout now)

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)