### PR TITLE
feat(workflow): batch primitives — tool_call, subagent, parallel, pipeline (#574)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 `skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
 
 ### Workflows
-`workflow/` — Durable replay engine ([docs/workflows.md](docs/workflows.md)): `registry.py` (`@workflow` decorator), `engine.py` (`run_workflow`), `journal.py` (positional keyed journal + fingerprint), `handle.py` (`WorkflowHandle` — the `wf` object with `llm_call`/`user_input` primitives), `llm.py` (forced-tool structured-output), `errors.py` (`WorkflowSuspended`, `WorkflowNonDeterministic`), `paths.py` (per-conv file paths), `resume.py` (harness glue: `run_workflow_turn` + `WorkflowUserInputHandler`), `workflows/interview.py` (hero orchestrator).
+`workflow/` — Durable replay engine ([docs/workflows.md](docs/workflows.md)): `registry.py` (`@workflow` decorator), `engine.py` (`run_workflow`), `journal.py` (positional keyed journal + fingerprint), `handle.py` (`WorkflowHandle` — the `wf` object with `llm_call`/`user_input`/`tool_call`/`subagent`/`parallel`/`pipeline` primitives), `llm.py` (forced-tool structured-output), `errors.py` (`WorkflowSuspended`, `WorkflowNonDeterministic`, `WorkflowToolNotAllowed`), `paths.py` (per-conv file paths), `resume.py` (harness glue: `run_workflow_turn` + `WorkflowUserInputHandler`), `workflows/interview.py` (suspend/resume hero), `workflows/research.py` (multi-primitive hero — fan-out + pipeline + subagent).
 
 ### Other
 - `prompts/` — System prompt assembly

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/notes.md
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/notes.md
@@ -1,0 +1,68 @@
+# Notes — Workflow batch primitives (#574)
+
+## Session start — 2026-06-10 17:32
+
+- Branch: `feat/574-workflow-batch-primitives` (from `origin/main` @ `024175d`)
+- Worktree: `/Users/lorchard/devel/decafclaw/.claude/worktrees/feat-574-workflow-batch-primitives`
+- Session dir: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/`
+- HTTP_PORT: 18892 (main uses default 18880, conversation-sidecar-dirs worktree uses 18891)
+- Baseline: `make test` — 2820 passing in 52s
+
+## Pre-flight reading queue (per user)
+
+1. `gh issue view 574` — done; sketch in spec.md
+2. `docs/workflows.md` — engine substrate (research.md §5 captures the "What is not in v1" verbatim)
+3. `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/` — prior session's spec/plan/notes (research.md §5)
+4. PR #573 — what just shipped + smoke checklist
+
+## Brainstorm — design decisions
+
+### Round 1 (locked)
+
+- **Sub-keying:** hierarchical sub-handles. `wf.parallel` allocates outer seq N, each thunk gets a sub-handle keyed by `(N, thunk_idx)` with its own `_cursor` starting at 0. Journal entry `seq` becomes a tuple-path. Outer entry caches the aggregate result for fast-path full-replay; child entries enable mid-parallel resume. Nests naturally for parallels-of-parallels and pipelines-of-parallels.
+- **Subagent dispatch:** wrap `delegate._run_child_turn` directly (not via tool). Fingerprint includes prompt + schema + allowed_tools. Journal stores text + optional structured data. Reuses the mature child-dispatch path.
+- **Error policy in `wf.parallel`:** propagate (raise out) by default. Callers wrap individual thunks in try/except for tolerant collection. Matches decafclaw's "fail loud" posture.
+- **Tool visibility for `wf.tool_call`:** parent ctx's `allowed_tools` — same set the orchestrator's parent agent could invoke at this turn. Uses existing `tools.execute_tool` plus current allowed_tools gate.
+
+### Round 2 (locked)
+
+- **Cancellation propagation:** cooperative cancel via `ctx.cancelled`. Mirrors `tool_execution.py:307-311`'s pattern — outer cancellation cancels in-flight sub-thunks; completed journal entries are kept; resume continues from where it stopped.
+- **Pipeline stage signature:** `async def stage(prev, item, idx, sub)`. Originally locked as `(prev, item, idx)` in round 2 to match Claude Code's Workflow tool, but plan self-review surfaced that durable replay requires stages to access a per-item sub-handle for journaled calls. Departed from Claude Code's signature deliberately — their workflows aren't journaled, ours are.
+- **Hero workflow:** `/research <topic>` — exercises all four primitives (user_input → parallel fetches → pipeline extract/summarize → subagent synthesis).
+- **Subagent schema:** yes — `wf.subagent(prompt, schema=...)` forces structured output via `_run_child_turn`'s existing `return_schema` mechanic. Symmetric with `wf.llm_call`.
+
+### Plan complete
+
+`plan.md` has 8 phases. Foundation first (tuple-path journal + sub-handles), then primitives in increasing complexity (`tool_call` → `subagent` → `parallel` → `pipeline`), then hero workflow, then live smoke + docs.
+
+## Execution complete
+
+All 8 phases landed as separate commits on `feat/574-workflow-batch-primitives`:
+
+| Phase | Commit | Test delta |
+| --- | --- | --- |
+| 1: Tuple-path journal | `ea31413` | 2820 → 2824 (+4) |
+| 2: Sub-handle factory | `66314a0` | 2824 → 2831 (+7) |
+| 3: `wf.tool_call` | `da3be9a` | 2831 → 2838 (+7) |
+| 4: `wf.subagent` | `8907ec3` | 2838 → 2845 (+7) |
+| 5: `wf.parallel` | `e32b742` | 2845 → 2854 (+9, incl. exception-unmasking regression test) |
+| 6: `wf.pipeline` | `ae25dee` | 2854 → 2866 (+12) |
+| 7: `/research` hero workflow | `3cc4de3` | 2866 → 2870 (+4) |
+| 8a: `docs/workflows.md` contracts | `93166ef` | no test change |
+| 8b: live smoke + findings | (this commit) | no test change |
+
+### Execute-phase highlights
+
+- **Phase 5 bug-find:** the spec's reference code for `wf.parallel` had `asyncio.wait(..., FIRST_EXCEPTION)` watching a cancel-watcher that returned normally on `event.wait()`. `FIRST_EXCEPTION` only triggers on raising tasks, so the watcher needed to raise a sentinel — fixed with an inner `_CancelSignal` class. Spec-compliance reviewer reproduced the bug from a 2-line script before approving the fix.
+- **Phase 5 exception-masking bug:** the code-quality reviewer caught that `[t.result() for t in tasks]` in `wf.parallel` would surface a cleanup-induced `CancelledError` from a lower-index pending task instead of the higher-index task that actually raised. Fixed by iterating in index order and skipping cancelled tasks before re-raising the first real exception. Regression test added; Phase 6 mirrored the fix.
+- **Phase 6 stage signature:** initially locked as `(prev, item, idx)` in brainstorm to match Claude Code's Workflow tool. Plan self-review caught that durable-replay stages need a per-item sub-handle for journaled calls; spec + plan updated to `(prev, item, idx, sub)` before any code touched.
+
+### Live smoke (Phase 8b)
+
+See [smoke.md](smoke.md) for the full transcript. Headlines:
+
+- **Proven:** tuple-path on-disk serialization, sub-handle key composition under live load (`(3, idx, 0)` per parallel child), mid-run SIGINT preserves journal state faithfully, all four primitives wire through the transport, `/research` is user-invokable via existing `/<name>` slash dispatch.
+- **Three follow-up findings** (filed for future work, not blockers for this PR):
+  1. Skill-bundled tools (e.g., `tabstack_research`) aren't reachable from workflow contexts — `execute_tool` returns "unknown tool" because skills aren't activated for `TurnKind.WORKFLOW`. Surfaces correctly through `wf.tool_call` as an error-shaped result dict.
+  2. No auto-resume on server restart for `status=running` workflows. Replay machinery is correct; the wiring gap is just "scan for in-flight journals at startup and re-enqueue."
+  3. A 3-minute hang during pipeline summarize against error-text input — needs more instrumentation to diagnose (could be Vertex throttling on degenerate prompts, could be a primitive issue we missed).

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/plan.md
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/plan.md
@@ -1,0 +1,626 @@
+# Workflow batch primitives Implementation Plan
+
+**Goal:** Add four journaled fan-out primitives (`tool_call`, `subagent`, `parallel`, `pipeline`) to the workflow replay engine, with a `/research` hero workflow exercising all four and a mid-run-restart live smoke.
+
+**Approach:** Foundation refactor (tuple-path journal keys + sub-handles) before any new primitive. Then build up from simplest (`tool_call` — no sub-handle needed) to most complex (`pipeline` — sub-handles + stages). Hero workflow last. TDD per phase: failing live + replay test before implementation.
+
+**Tech stack:** Python 3.12, asyncio, pytest-xdist. New code in `src/decafclaw/workflow/`. Tests in `tests/test_workflow_*.py`.
+
+---
+
+## Phase 1: Tuple-path journal keys
+
+Foundation: change `Journal` keying from integer `seq` to tuple-path `seq`. Existing primitives keep working (their seqs become 1-tuples). Existing on-disk journals upgrade transparently. No new primitives in this phase.
+
+**Files:**
+- Modify: `src/decafclaw/workflow/journal.py` — change `JournalEntry.seq: tuple[int, ...]`, `Journal.entries: dict[tuple, JournalEntry]`, `Journal.get/append`, `to_dict/from_dict` with dotted-string path serialization and int→1-tuple upgrade.
+- Modify: `src/decafclaw/workflow/errors.py` — `WorkflowSuspended.seq: tuple[int, ...]`, `WorkflowNonDeterministic` if it stores seq.
+- Modify: `src/decafclaw/workflow/handle.py` — `_check_or_none` takes tuple; `llm_call`/`user_input` build `seq = (self._cursor,)`.
+- Modify: `src/decafclaw/workflow/resume.py` — store/load tuple seq via dotted string in `action_data`; pass tuple to `journal.append`.
+- Test: `tests/test_workflow_journal.py` — extend with tuple-path round-trip, dotted-string JSON, int→1-tuple upgrade. Existing tests adapt to tuple keys.
+- Test: `tests/test_workflow_handle.py` — adapt existing tests to tuple-path seqs.
+- Test: `tests/test_workflow_resume.py` — adapt to tuple-path seq in action_data.
+
+**Key changes:**
+
+```python
+# journal.py
+@dataclasses.dataclass
+class JournalEntry:
+    seq: tuple[int, ...]
+    kind: str
+    args_fingerprint: str
+    result: Any
+
+@dataclasses.dataclass
+class Journal:
+    workflow_name: str
+    status: str = "running"
+    entries: dict[tuple[int, ...], JournalEntry] = dataclasses.field(default_factory=dict)
+
+    def get(self, seq: tuple[int, ...]) -> JournalEntry | None:
+        return self.entries.get(seq)
+
+    def append(self, seq: tuple[int, ...], kind: str,
+               args_fingerprint: str, result: Any) -> None:
+        if seq in self.entries:
+            raise ValueError(f"duplicate journal append at seq={seq}")
+        self.entries[seq] = JournalEntry(seq, kind, args_fingerprint, result)
+
+    def to_dict(self) -> dict:
+        return {
+            "workflow_name": self.workflow_name,
+            "status": self.status,
+            "entries": [
+                {"seq": _path_to_str(e.seq), "kind": e.kind,
+                 "args_fingerprint": e.args_fingerprint, "result": e.result}
+                for e in self.entries.values()
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Journal":
+        j = cls(workflow_name=d["workflow_name"],
+                status=d.get("status", "running"))
+        for entry_d in d.get("entries", []):
+            seq = _path_from_any(entry_d["seq"])
+            j.entries[seq] = JournalEntry(seq, entry_d["kind"],
+                                          entry_d["args_fingerprint"],
+                                          entry_d["result"])
+        return j
+
+
+def _path_to_str(path: tuple[int, ...]) -> str:
+    return ".".join(str(i) for i in path)
+
+
+def _path_from_any(v) -> tuple[int, ...]:
+    """Accept tuple (in-memory), int (legacy flat seq), or dotted str (new on-disk)."""
+    if isinstance(v, int):
+        return (v,)
+    if isinstance(v, str):
+        return tuple(int(p) for p in v.split("."))
+    if isinstance(v, (tuple, list)):
+        return tuple(int(p) for p in v)
+    raise TypeError(f"unrecognized journal seq: {v!r}")
+```
+
+- The contiguity check (`seq != len(entries)`) is dropped. Tuple paths can land out of order (parallel thunks finish in any order); duplicate-key check replaces it.
+- `WorkflowSuspended.seq: tuple[int, ...]` — `resume.py` serializes the path as a dotted string for `action_data`, deserializes back to tuple via `_path_from_any`.
+- `WorkflowHandle.llm_call/user_input` build `seq = (self._cursor,)` and pass tuple to `_check_or_none`/`journal.append`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes (existing workflow tests pass with tuple-path seqs)
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_journal.py -v` — new tests for tuple round-trip, dotted-string JSON, int→1-tuple legacy upgrade
+
+**Verification — manual:**
+- [ ] Inspect a freshly-generated `workflow.json` from a `/interview` run: confirm seqs serialize as dotted strings like `"0"`, `"1"`, etc.
+- [ ] If a legacy `workflow.json` exists in `data/lorchard/workspace/conversations/`, load it via `load_journal` — entries upgrade cleanly.
+
+---
+
+## Phase 2: Sub-handle factory
+
+Add a sub-handle pattern to `WorkflowHandle` so primitives like `parallel`/`pipeline` can dispatch work to thunks under their own key namespace.
+
+**Files:**
+- Modify: `src/decafclaw/workflow/handle.py` — add `_key_prefix: tuple[int, ...] = ()` to `WorkflowHandle`; add `_make_subhandle(idx: int) -> WorkflowHandle`; refactor `llm_call`/`user_input` to use `self._key_prefix + (self._cursor,)`.
+- Test: `tests/test_workflow_handle.py` — sub-handle key composition (parent at `(5,)`, sub-handle at `(5, 0)`, grand-sub at `(5, 0, 2)`).
+
+**Key changes:**
+
+```python
+class WorkflowHandle:
+    def __init__(self, ctx, journal, *, llm_caller=None,
+                 model: str = "vertex-gemini-flash",
+                 _key_prefix: tuple[int, ...] = ()):
+        self.ctx = ctx
+        self.journal = journal
+        self._cursor = 0
+        self._llm_caller = llm_caller or _default_llm_call
+        self._model = model
+        self._key_prefix = _key_prefix
+
+    def _next_seq(self) -> tuple[int, ...]:
+        seq = self._key_prefix + (self._cursor,)
+        self._cursor += 1
+        return seq
+
+    def _make_subhandle(self, idx: int) -> "WorkflowHandle":
+        """Create a sub-handle with extended key prefix, fresh cursor.
+
+        Used by parallel/pipeline to give each thunk/item its own key
+        namespace. Sub-handles share ctx, journal, llm_caller, model.
+        """
+        sub_prefix = self._key_prefix + (self._cursor, idx)
+        return WorkflowHandle(self.ctx, self.journal,
+                              llm_caller=self._llm_caller,
+                              model=self._model,
+                              _key_prefix=sub_prefix)
+
+    async def llm_call(self, *, prompt, schema, system="", tool_name="submit",
+                       model=None):
+        seq = self._next_seq()
+        fp = fingerprint("llm_call",
+                         {"prompt": prompt, "schema": schema, "system": system})
+        cached, hit = self._check_or_none(seq, "llm_call", fp)
+        if hit:
+            return cached
+        result = await self._llm_caller(
+            self.ctx, system=system, user_msg=prompt, schema=schema,
+            tool_name=tool_name, model=model or self._model)
+        self.journal.append(seq, "llm_call", fp, result)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return result
+
+    async def user_input(self, prompt, *, choices=None):
+        seq = self._next_seq()
+        fp = fingerprint("user_input", {"prompt": prompt, "choices": choices})
+        cached, hit = self._check_or_none(seq, "user_input", fp)
+        if hit:
+            return cached
+        raise WorkflowSuspended(seq=seq, args_fingerprint=fp, prompt=prompt,
+                                choices=choices)
+```
+
+- `_make_subhandle(idx)` builds prefix `self._key_prefix + (self._cursor, idx)`. The parent's `self._cursor` is NOT advanced here — parallel/pipeline call this for each thunk/item, then later record their own outer entry which DOES advance the cursor (see Phase 5 / 6).
+- Sub-handles inherit ctx, journal, llm_caller, model. Each gets a fresh `_cursor = 0`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes (existing tests adapted to new `_next_seq` indirection)
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_handle.py -v` — new tests cover sub-handle key composition (single level + nested)
+
+**Verification — manual:**
+- [ ] Re-run `/interview` end-to-end (or its test) and confirm journal entries still come out at `(0,), (1,), (2,)…`.
+
+---
+
+## Phase 3: `wf.tool_call`
+
+Direct journaled tool dispatch. Gated by parent ctx's `allowed_tools`. Result serialized as JSON-friendly dict, media stripped.
+
+**Files:**
+- Modify: `src/decafclaw/workflow/handle.py` — add `WorkflowHandle.tool_call(name, **args)`.
+- Test: `tests/test_workflow_tool_call.py` (new) — live path, replay path, allowed_tools gate rejection, ToolResult-with-media is stripped to text+data.
+
+**Key changes:**
+
+```python
+async def tool_call(self, name: str, **args) -> dict:
+    """Invoke a tool by name. Gated by ctx.allowed_tools.
+
+    Returns a dict with at least {"text": str, "data": Any|None}. Media
+    attachments on the underlying ToolResult are stripped — the journal
+    captures only the JSON-serializable surface.
+    """
+    seq = self._next_seq()
+    allowed = self.ctx.allowed_tools or set()
+    if name not in allowed:
+        raise WorkflowToolNotAllowed(
+            f"tool {name!r} not in ctx.allowed_tools for workflow")
+    fp = fingerprint("tool_call", {"name": name, "args": args})
+    cached, hit = self._check_or_none(seq, "tool_call", fp)
+    if hit:
+        return cached
+    from decafclaw.tools import execute_tool  # noqa: PLC0415 — break import cycle
+    result = await execute_tool(self.ctx, name, args)
+    serialized = {"text": result.text, "data": result.data}
+    self.journal.append(seq, "tool_call", fp, serialized)
+    save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+    return serialized
+```
+
+- New exception in `errors.py`: `class WorkflowToolNotAllowed(Exception): pass`. Caught by the engine in `except Exception` (terminal error).
+- The `execute_tool` import is function-level — same justification as the `archive.append_message` lazy import in `resume.py` (avoids workflow → tools → workflow cycles).
+- Tests use a fake tool registered into `ctx.allowed_tools` and dispatched via `execute_tool`; the test-side registration uses the existing test pattern from `tests/test_workflow_resume.py`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_tool_call.py -v` — covers live, replay, allowed_tools rejection, media-stripping
+
+**Verification — manual:**
+- [ ] Construct a minimal orchestrator that calls `await wf.tool_call("vault_read", path="foo.md")` against a real workspace, confirm the journal records `kind: tool_call` and the result text.
+
+---
+
+## Phase 4: `wf.subagent`
+
+Dispatch a child agent loop via `delegate._run_child_turn` directly. Optional `schema=` for forced structured output.
+
+**Files:**
+- Modify: `src/decafclaw/tools/delegate.py` — promote `_run_child_turn` to module-public `run_child_turn` (or expose via a re-export); no behavior change.
+- Modify: `src/decafclaw/workflow/handle.py` — add `WorkflowHandle.subagent(prompt, *, schema=None, allowed_tools=None, allow_vault_retrieval=False, allow_vault_read=False, model=None)`.
+- Test: `tests/test_workflow_subagent.py` (new) — live path (mock `run_child_turn`), replay path, schema path returns structured dict, allowed_tools override threaded through.
+
+**Key changes:**
+
+```python
+# handle.py
+async def subagent(
+    self, prompt: str, *,
+    schema: dict | None = None,
+    allowed_tools: list[str] | None = None,
+    allow_vault_retrieval: bool = False,
+    allow_vault_read: bool = False,
+    model: str | None = None,
+) -> dict | str:
+    """Dispatch a child agent loop as a journaled boundary crossing.
+
+    Returns the child's final text, OR the schema-validated structured
+    object if `schema` is given. The child agent inherits delegate's
+    standard restrictions (no vault writes, no further delegations) plus
+    any explicit allowed_tools override.
+    """
+    seq = self._next_seq()
+    fp = fingerprint("subagent", {
+        "prompt": prompt,
+        "schema": schema,
+        "allowed_tools": sorted(allowed_tools) if allowed_tools else None,
+        "allow_vault_retrieval": allow_vault_retrieval,
+        "allow_vault_read": allow_vault_read,
+    })
+    cached, hit = self._check_or_none(seq, "subagent", fp)
+    if hit:
+        return cached
+    from decafclaw.tools.delegate import run_child_turn  # noqa: PLC0415
+    text, data = await run_child_turn(
+        self.ctx,
+        task=prompt,
+        return_schema=schema,
+        allowed_tools=allowed_tools,
+        allow_vault_retrieval=allow_vault_retrieval,
+        allow_vault_read=allow_vault_read,
+        model=model,
+    )
+    result = data if schema is not None else text
+    self.journal.append(seq, "subagent", fp, result)
+    save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+    return result
+```
+
+- `delegate.run_child_turn` may need to return `(text, structured_data)` for the schema branch — Phase 4's first edit to `delegate.py` aligns the return signature for both `tool_delegate_task` (which currently wraps it) and this new caller.
+- `schema=None` → returns text; `schema` is present → returns the parsed-and-validated structured dict (the same value `tool_delegate_task` returns in its `data` field today).
+- Fingerprint sorts `allowed_tools` to canonicalize (order shouldn't break replay).
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes (existing delegate tests adapt to the unified `run_child_turn` return shape)
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_subagent.py -v` — covers live (text + schema), replay, allowed_tools threading
+
+**Verification — manual:**
+- [ ] Inspect the journal of an orchestrator that called `wf.subagent("explain", schema={...})` — the recorded `result` should be the structured dict.
+
+---
+
+## Phase 5: `wf.parallel`
+
+Fan out N thunks concurrently via sub-handles. Propagate errors. Cooperative cancel via `ctx.cancelled`. Outer entry caches assembled result.
+
+**Files:**
+- Modify: `src/decafclaw/workflow/handle.py` — add `WorkflowHandle.parallel(thunks)`.
+- Test: `tests/test_workflow_parallel.py` (new) — live path (3 thunks each doing 2 llm_calls), replay (all cached), mid-fan-out resume (some thunks completed, others not, on second run the engine fills in remainder), error propagation, cooperative cancel.
+
+**Key changes:**
+
+```python
+async def parallel(
+    self, thunks: list[Callable[["WorkflowHandle"], Awaitable[Any]]]
+) -> list[Any]:
+    """Run N thunks concurrently under sub-handles. Returns results in
+    thunk-index order. Errors propagate — wrap individual thunks in
+    try/except for tolerant collection.
+    """
+    import asyncio  # already imported; explicit for clarity
+    seq = self._next_seq()
+    fp = fingerprint("parallel", {"count": len(thunks)})
+    cached, hit = self._check_or_none(seq, "parallel", fp)
+    if hit:
+        return cached
+    sub_handles = [self._make_subhandle_at(seq, idx) for idx in range(len(thunks))]
+    tasks = [asyncio.create_task(thunks[i](sub_handles[i]))
+             for i in range(len(thunks))]
+    # Cancellation watcher: if outer ctx is cancelled, cancel in-flight tasks.
+    cancel_watcher = asyncio.create_task(self.ctx.cancelled.wait())
+    try:
+        done, pending = await asyncio.wait(
+            tasks + [cancel_watcher],
+            return_when=asyncio.FIRST_EXCEPTION)
+        if cancel_watcher in done and not cancel_watcher.cancelled():
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            # Let cancellations settle (best-effort).
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise asyncio.CancelledError()
+        # If any task raised, gather all to surface the first exception.
+        # Outstanding tasks are cancelled to avoid leaks.
+        for t in pending:
+            if t is not cancel_watcher:
+                t.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        results = [t.result() for t in tasks]  # raises on the first exception
+    finally:
+        if not cancel_watcher.done():
+            cancel_watcher.cancel()
+    self.journal.append(seq, "parallel", fp, results)
+    save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+    return results
+```
+
+- `_make_subhandle_at(outer_seq, idx)` is a variant of `_make_subhandle` that takes the outer seq explicitly (so the parent's cursor isn't double-advanced). Add this helper alongside `_make_subhandle`:
+
+```python
+def _make_subhandle_at(self, outer_seq: tuple[int, ...], idx: int) -> "WorkflowHandle":
+    sub_prefix = outer_seq + (idx,)
+    return WorkflowHandle(self.ctx, self.journal,
+                          llm_caller=self._llm_caller,
+                          model=self._model,
+                          _key_prefix=sub_prefix)
+```
+
+(`_make_subhandle` from Phase 2 can be removed once Phase 5 lands — `_make_subhandle_at` is the only call site. Defer that cleanup until end of phase.)
+
+- Fingerprint includes only `count`, not the thunks themselves (callables aren't serializable). Determinism is the orchestrator author's responsibility — same control flow path → same number of thunks → same fingerprint. The child entries provide the actual replay safety per-thunk.
+- Mid-fan-out resume works because the outer entry is missing — the thunks re-dispatch, each sub-handle's calls hit the partial journal, completed thunks fast-path through their sub-entries, in-progress ones resume from their next-uncached call.
+- Error propagation: `tasks[i].result()` raises if thunk i raised; that bubbles up out of `parallel`. Outstanding tasks are cancelled.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_parallel.py -v` — covers concurrent live (mock llm_caller with per-thunk delays), full replay (all cached), mid-fan-out resume, error propagation, cancellation
+- [ ] `pytest --durations=25` — confirm no parallel test lands in top 25 by wall time (the cancellation test in particular shouldn't `asyncio.sleep`)
+
+**Verification — manual:**
+- [ ] Inspect the journal from a 3-thunk parallel run: keys `(0, 0, 0)`, `(0, 0, 1)`, `(0, 1, 0)`, `(0, 2, 0)`, `(0,)` (outer last).
+
+---
+
+## Phase 6: `wf.pipeline`
+
+Fan out N items through M stages, no barrier. Stage signature `async def stage(prev, item, idx, sub)`. Sub-handles per item; stages share that sub-handle's cursor sequentially. Propagate errors.
+
+**Files:**
+- Modify: `src/decafclaw/workflow/handle.py` — add `WorkflowHandle.pipeline(items, *stages)`.
+- Test: `tests/test_workflow_pipeline.py` (new) — live path (3 items × 2 stages), replay path, mid-pipeline resume (item 0 finished stage 2, item 1 still in stage 1), error propagation (item 1 stage 2 raises → out), and a nested test (`pipeline` items where stage 2 uses `sub.parallel`).
+
+**Key changes:**
+
+```python
+async def pipeline(
+    self,
+    items: list,
+    *stages: Callable[[Any, Any, int, "WorkflowHandle"], Awaitable[Any]],
+) -> list:
+    """Per-item run of stage1 → stage2 → … → stageN. No barrier between
+    stages. Returns the final-stage result per item, in item-index order.
+
+    Each stage receives `(prev, item, idx, sub)` where `sub` is the
+    per-item sub-handle stages must use for journaled calls.
+    """
+    import asyncio
+    seq = self._next_seq()
+    fp = fingerprint("pipeline", {
+        "items": items,
+        "stage_count": len(stages),
+    })
+    cached, hit = self._check_or_none(seq, "pipeline", fp)
+    if hit:
+        return cached
+
+    async def _run_one(item, idx):
+        sub = self._make_subhandle_at(seq, idx)
+        # Stages share `sub`'s cursor; each stage's journaled calls
+        # advance it via `sub.llm_call(...)`, `sub.tool_call(...)`, etc.
+        prev = item
+        for stage in stages:
+            prev = await stage(prev, item, idx, sub)
+        return prev
+
+    tasks = [asyncio.create_task(_run_one(items[i], i)) for i in range(len(items))]
+    cancel_watcher = asyncio.create_task(self.ctx.cancelled.wait())
+    try:
+        done, pending = await asyncio.wait(
+            tasks + [cancel_watcher],
+            return_when=asyncio.FIRST_EXCEPTION)
+        if cancel_watcher in done and not cancel_watcher.cancelled():
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise asyncio.CancelledError()
+        for t in pending:
+            if t is not cancel_watcher:
+                t.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        results = [t.result() for t in tasks]
+    finally:
+        if not cancel_watcher.done():
+            cancel_watcher.cancel()
+    self.journal.append(seq, "pipeline", fp, results)
+    save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+    return results
+```
+
+- Items list IS fingerprinted (`items` plus `stage_count`). Items must be JSON-serializable for the fingerprint to compute.
+- Stages aren't fingerprinted (they're code, not data). Re-arranging stages between runs is a replay-fragility the author owns — same posture as the `prompt` text in `llm_call`.
+- Cancellation/error semantics mirror `parallel` exactly. Worth factoring into a shared `_run_concurrent_tasks` helper if both phases land; defer the refactor decision to end of Phase 6.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_pipeline.py -v` — covers live, full replay, mid-pipeline resume (different items at different stages), error propagation, nested with parallel
+- [ ] `pytest --durations=25` — confirm pipeline tests don't `asyncio.sleep`
+
+**Verification — manual:**
+- [ ] Inspect the journal from a 3-item × 2-stage pipeline: keys `(0, 0, 0)`, `(0, 0, 1)`, `(0, 1, 0)`, `(0, 1, 1)`, `(0, 2, 0)`, `(0, 2, 1)`, `(0,)`.
+
+---
+
+## Phase 7: `/research` hero workflow
+
+Build the second hero workflow that exercises all four primitives end-to-end. User-invocable as `/research <topic>` (web UI) / `!research <topic>` (Mattermost).
+
+**Files:**
+- Create: `src/decafclaw/workflow/workflows/research.py` — the orchestrator. Uses `wf.user_input`, `wf.llm_call`, `wf.parallel`, `wf.tool_call`, `wf.pipeline`, `wf.subagent`.
+- Modify: `src/decafclaw/workflow/workflows/__init__.py` — register the new workflow.
+- Modify: `src/decafclaw/commands.py` (or wherever workflow commands are wired — verify in execute) — register `/research` user-invocable command that dispatches to the workflow.
+- Test: `tests/test_workflow_research.py` (new) — unit test the orchestrator with mocked `wf` primitives (live + replay).
+
+**Key changes:**
+
+```python
+# workflows/research.py
+from ..registry import workflow
+
+_CLARIFY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "queries": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 3,
+            "maxItems": 6,
+        },
+    },
+    "required": ["queries"],
+}
+
+_SUMMARY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "key_points": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["title", "key_points"],
+}
+
+_REPORT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body": {"type": "string"},
+    },
+    "required": ["title", "body"],
+}
+
+
+@workflow("research")
+async def research(wf):
+    topic = await wf.user_input("What topic should I research?")
+    scope = await wf.user_input(
+        "Any specific angle, audience, or constraint?")
+
+    plan = await wf.llm_call(
+        prompt=f"Topic: {topic}\nScope: {scope}\n\n"
+               "Generate 3-6 focused search queries for this research.",
+        schema=_CLARIFY_SCHEMA,
+        system="You plan focused research sweeps.")
+    queries = plan["queries"]
+
+    # Fan out fetches via parallel. Each thunk receives a sub-handle.
+    async def _fetch(query):
+        async def _thunk(sub):
+            return await sub.tool_call("http_fetch_search", query=query)
+        return _thunk
+
+    fetches = await wf.parallel([_fetch(q) for q in queries])
+
+    # Pipeline each fetched result through extract → summarize.
+    # Stages receive (prev, item, idx, sub) — sub is the per-item sub-handle.
+    async def _extract(prev, item, idx, sub):
+        return item_to_text(prev)  # plain Python, no journaling
+
+    async def _summarize(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=f"Summarize:\n\n{prev[:8000]}",
+            schema=_SUMMARY_SCHEMA,
+            system="You write tight summaries.")
+
+    summaries = await wf.pipeline(fetches, _extract, _summarize)
+
+    # Synthesize via subagent (multi-turn reasoning over the summaries).
+    report = await wf.subagent(
+        prompt=f"Topic: {topic}\nScope: {scope}\n\nSummaries:\n"
+               + "\n\n".join(str(s) for s in summaries)
+               + "\n\nSynthesize a report.",
+        schema=_REPORT_SCHEMA,
+    )
+
+    return report
+```
+
+- `item_to_text` is a plain helper that extracts text from an `http_fetch_search` result — defined inline in `research.py`, not journaled.
+- `http_fetch_search` is the tool name; verify the actual tool exists in `tools/http_tools.py` during execute. If it doesn't, fall back to `tabstack_research` (per the Tabstack-via-tabstack skill).
+- Command registration: workflows are user-invokable via `/research <topic>`. Look at how `interview` is registered (currently bare workflow registry, no slash command) — `/research` may need a small wiring step in `commands.py` to call `enqueue_turn(kind=TurnKind.WORKFLOW, metadata={"workflow_name": "research"}, prompt=arguments)`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] `pytest tests/test_workflow_research.py -v` — unit-level walk with mocked primitives + replay
+
+**Verification — manual:**
+- [ ] `/research` appears in the slash-command list in the web UI.
+- [ ] Manually trigger `/research foo` (no live LLM yet — just confirm the user_input prompt appears).
+
+---
+
+## Phase 8: Live smoke + docs update
+
+Walk `/research` end-to-end on `vertex-gemini-flash`, restart the server mid-run, confirm resume. Update `docs/workflows.md` to replace the "What is not in v1" entries for these primitives with proper contract documentation.
+
+**Files:**
+- Modify: `docs/workflows.md` — replace the `subagent` / `parallel` / `pipeline` / `tool_call` bullet under "What is not in v1" with new sections under the existing "Primitives" / "Replay semantics" structure. One section per primitive: signature, fingerprint shape, replay behavior, error/cancel semantics.
+- Create: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md` — capture the smoke walk's transcript (commands, journal-file inspection, restart timing). Sidecar to `notes.md`, not a permanent doc.
+- Modify: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/notes.md` — append per-phase notes, surprises, and a session retro.
+
+**Key changes:**
+
+The smoke walk per `reference_workflow_smoke_pattern`:
+1. Start a local web-only server in the worktree: `MATTERMOST_ENABLED=false HTTP_PORT=18892 make run` (or background equivalent).
+2. Drive a conversation with `decafclaw-client`: `/research artificial reefs in the Mediterranean`.
+3. Answer the two `user_input` rounds.
+4. Mid-way through the `wf.parallel` fetches OR mid-`wf.pipeline`, `kill -INT` the server.
+5. Restart server, reload the conversation, confirm the workflow resumes from the journal — no duplicated fetches, no duplicated summaries.
+6. Confirm the final report lands.
+7. Inspect `workflow.json` on disk: tuple-path keys present (e.g., `"0.1.0"`), `parallel`/`pipeline` outer entries present, status `done`.
+
+`docs/workflows.md` outline of the new sections (one each):
+
+```markdown
+### `wf.tool_call(name, **args) -> dict`
+
+[Description, fingerprint shape, error/replay semantics, allowed_tools gate.]
+
+### `wf.subagent(prompt, *, schema=None, ...) -> dict | str`
+
+[Description, fingerprint shape, schema behavior, child agent restrictions.]
+
+### `wf.parallel(thunks) -> list`
+
+[Description, sub-handle keying, error propagation, cancellation, mid-fan-out resume semantics.]
+
+### `wf.pipeline(items, *stages) -> list`
+
+[Description, stage signature, sub-handle keying, error propagation, cancellation, mid-pipeline resume semantics.]
+```
+
+**Verification — automated:**
+- [ ] `make lint` passes (docs change is markdown, no impact)
+- [ ] `make test` passes
+- [ ] `make check` passes
+
+**Verification — manual:**
+- [ ] Live smoke walk completes: `/research` runs on Flash, mid-run restart resumes, final report lands.
+- [ ] `workflow.json` inspection confirms tuple-path keys + outer entries for parallel/pipeline.
+- [ ] `docs/workflows.md` reads coherently: the 4 new sections match the implementation; "What is not in v1" no longer mentions these primitives.
+- [ ] No stale references to "deferred" / "not in v1" for these primitives anywhere in `docs/`.

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/research.md
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/research.md
@@ -1,0 +1,119 @@
+# Research — Existing workflow engine & adjacent dispatch paths
+
+Documentarian sweep, 2026-06-10. Source: `Explore` subagent run against the worktree.
+
+## 1. Journal mechanics
+
+**Storage shape.** `JournalEntry(seq, kind, args_fingerprint, result)` — `src/decafclaw/workflow/journal.py:26-31`. Entries stored in `Journal.entries` list, keyed by seq via array indexing — `journal.py:40-51`.
+
+**Fingerprint.** `fingerprint(kind, args)` at `journal.py:15-23` — SHA-256 of `{"kind", "args"}` with sorted keys, returns 16-char hex. Non-JSON-serializable args raise TypeError by design (loud catch).
+
+**Mismatch detection.** `WorkflowHandle._check_or_none(seq, kind, fp)` at `handle.py:41-51` — if stored entry's `kind` or `args_fingerprint` differ from current call, raises `WorkflowNonDeterministic`.
+
+**Live vs replay branch (per primitive).**
+- Live (no entry at seq): call runs → `journal.append(seq, kind, fp, result)` → `save_journal(ctx.config, ctx.conv_id, journal)` — `handle.py:73-74`.
+- Replay (entry exists at seq): `_check_or_none` returns `(cached_result, True)` — `handle.py:51`. Primitive returns cached without re-executing.
+
+**`WorkflowHandle.user_input(prompt)`** — `handle.py:77-87`:
+1. `seq = self._cursor; self._cursor += 1`
+2. `fp = fingerprint("user_input", {"prompt", "choices"})`
+3. `_check_or_none(seq, "user_input", fp)` — hit → return cached
+4. Miss → `raise WorkflowSuspended(seq, fp, prompt, choices)`. Turn ends; result lands in journal *after* the user answers and the workflow resumes.
+
+**`WorkflowHandle.llm_call(prompt, schema, system, tool_name, model)`** — `handle.py:53-75`:
+1. `seq = self._cursor; self._cursor += 1`
+2. `fp = fingerprint("llm_call", {"prompt", "schema", "system"})` — **`tool_name` and per-call `model` are NOT in the fingerprint.**
+3. Hit → return cached.
+4. Miss → `self._llm_caller(ctx, system, user_msg, schema, tool_name, model)`; `journal.append(seq, "llm_call", fp, result)`; `save_journal(...)`.
+
+**Cursor reconstruction on replay.** Engine re-runs the orchestrator from the top on every resume (`engine.py:41`). `_cursor` starts at 0 each run (`handle.py:37`). Journaled calls consume cursor positions in identical order; cached results return instantly; execution fast-forwards past completed steps.
+
+## 2. WorkflowHandle lifecycle
+
+**State** — `handle.py:32-39`:
+- `ctx: Context`
+- `journal: Journal`
+- `_cursor: int = 0`
+- `_llm_caller: Callable` (defaults to `_default_llm_call`)
+- `_model: str = "vertex-gemini-flash"`
+
+**Construction per turn.** `engine.py:34` in `run_workflow()`: `WorkflowHandle(ctx, journal, llm_caller=llm_caller, model=model)`. Called from `resume.py:44` in `run_workflow_turn()`, which `ConversationManager._start_turn` dispatches for `TurnKind.WORKFLOW`.
+
+**Resume.** Same `run_workflow()` rebuilds the handle from the persisted journal + same ctx.
+
+**Context access.** Handle carries `config` (Config with workspace_path), `conv_id` (journal file location), `ctx.publish()` for events, `ctx.cancelled` (asyncio.Event).
+
+**Suspension flow.**
+1. `handle.py:86-87`: `raise WorkflowSuspended(seq, fp, prompt, choices)`.
+2. `engine.py:42`: `except WorkflowSuspended as s` returns outcome with `.suspend`.
+3. `resume.py:58-74`: receives outcome, builds `ConfirmationRequest(action_type=WORKFLOW_USER_INPUT, action_data={...})`, calls `manager.post_confirmation(conv_id, request)` (no await), returns `ToolResult`. Turn ends.
+
+## 3. Subagent / child-agent dispatch
+
+**Existing tool.** `tool_delegate_task(ctx, task, model="", allow_vault_retrieval=False, allow_vault_read=False, return_schema=None)` — `src/decafclaw/tools/delegate.py:261-318`. Batch variant: `tool_delegate_tasks(ctx, tasks, ...)` — `delegate.py:406-515`, parallel via semaphore.
+
+**`_run_child_turn` internals** — `delegate.py:112-258`:
+- Child config via `dataclasses.replace(config, agent=..., system_prompt=child_system_prompt, discovered_skills=[])`.
+- Unique child id: `f"{parent_conv}--child-{secrets.token_hex(4)}"`.
+- Context setup: swap child config, `skip_vault_retrieval = not allow_vault_retrieval`, block vault WRITE tools, restrict `allowed_tools` to `parent − {delegate_task, activate_skill, tool_search, ...VAULT_WRITE}`.
+- Event routing: child events forwarded to parent's subscriber via `event_context_id` — `delegate.py:194-197`.
+- Dispatch: `manager.enqueue_turn(child_conv_id, kind=TurnKind.CHILD_AGENT, prompt=task, context_setup=setup, user_id=parent_ctx.user_id)`.
+- Wait: `asyncio.wait_for(future, timeout=config.agent.child_timeout_sec)` — `delegate.py:253`.
+
+**Context inheritance/reset.**
+- Inherits: parent tools (minus delegations), parent's activated skills (bundled in system prompt).
+- Reset: `discovered_skills=[]` (no new discovery), `skills.activated` cleared, `skip_reflection=True`, vault retrieval opt-in only.
+
+**Return.** `_run_child_turn` returns text. `tool_delegate_task` wraps in `ToolResult(text=...)`. `tool_delegate_tasks` returns `ToolResult(data={"summary": {...}, "results": [{"index", "ok", "text", "data"}, ...]})`.
+
+**TurnKind.** Uses `TurnKind.CHILD_AGENT` (`conversation_manager.py:74-82`).
+
+## 4. Tool execution path
+
+**Call signature.** Tool functions: `(ctx, **kwargs)` where `ctx` is a forked Context (`fork_for_tool_call()`) — `src/decafclaw/tool_execution.py:232`.
+
+**`execute_single_tool(call_ctx, tc, semaphore)`** — `tool_execution.py:210-279`:
+- Acquires semaphore, publishes `tool_start`.
+- `tools.execute_tool(call_ctx, fn_name, fn_args)` — `tool_execution.py:232`.
+- Catches `asyncio.CancelledError` and `Exception` → error `ToolResult`.
+- Processes media via `process_tool_media` — `tool_execution.py:236`.
+- Validates widget via `resolve_widget` — `tool_execution.py:248`.
+- Publishes `tool_end`.
+
+**`execute_tool_calls`** — `tool_execution.py:282-364`:
+- `asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)` — `tool_execution.py:292`.
+- Per-call fork via `ctx.fork_for_tool_call(tc["id"])` — `tool_execution.py:297`.
+- `asyncio.create_task(execute_single_tool(...))` — `tool_execution.py:298-301`.
+- Cancellation watcher cancels in-flight on `ctx.cancelled.wait()` — `tool_execution.py:307-311`.
+- Collects via `asyncio.gather(*tasks, return_exceptions=True)` — `tool_execution.py:316`.
+- Returns `(None, end_turn_signal)`.
+
+**ToolResult serialization.** `result.text` + optional `result.data` rendered as fenced `\`\`\`json\n...\n\`\`\``. `display_short_text` and widget payload copied to tool message if present.
+
+**Tool lookup by name.** `tools.execute_tool()` in `src/decafclaw/tools/__init__.py` dispatches by name from a registry built at startup (`TOOL_DEFINITIONS` + skill tools + MCP). **No exported "call by name from outside the agent loop" is publicly documented** — invocation is via `execute_tool` directly.
+
+## 5. Prior-session record (what's already been said about these primitives)
+
+### From `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/spec.md`
+
+> Line 44: "For the MVP that means exactly **two** journaled wrappers: `llm_call` and `user_input`. Subagent/tool/`parallel`/`pipeline` wrappers join them later under the same rule."
+
+> Line 183: "**Explicitly NOT in v1:** ... - `subagent` / `parallel` / `pipeline` / `tool_call` primitives (these arrive with the batch fan-out case; they are real journaled wrappers, just not needed for the interview) ..."
+
+### From `docs/dev-sessions/2026-06-05-1455-workflow-replay-engine/notes.md`
+
+> Lines 79-80: "2. **Batch/fan-out primitives.** `subagent`, `parallel`, `pipeline`, `tool_call` wrappers are the natural next journaled primitives. They arrive when there is a concrete use case (batch fan-out); the engine does not preclude them."
+
+### From `docs/workflows.md` "What is not in v1" (lines 266-286)
+
+> "The following are explicitly deferred:
+>
+> - **`subagent` / `parallel` / `pipeline` / `tool_call` primitives.** These arrive with the batch fan-out case; they are real journaled wrappers, just not needed for the interview.
+>
+> - **LLM-generated per-task workflows.** The engine does not preclude it, but this is not built yet.
+>
+> - **Migrating existing flat sidecars** (`.notes.md`, `.decisions.json`, `.context.json`, `.archive.jsonl`) into the `conversations/{conv_id}/` directory layout. Only `workflow.json` uses the directory convention now; two conventions coexist temporarily.
+>
+> - **A declarative step DSL** (`route`/`branch`/`loop`/`set` as data-primitives). Deliberately rejected: control flow *is* the host language (`if`/`while`). A DSL re-imports the exact complexity the replay model was designed to eliminate.
+>
+> - **WORKFLOW turn Context-kind semantics.** WORKFLOW turns currently reuse the USER-style Context path (full interactive Context with per-conversation state). Whether they should use `Context.for_task` semantics instead is an open item to revisit after the live smoke."

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke-journal-snapshot.json
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke-journal-snapshot.json
@@ -1,0 +1,67 @@
+{
+  "workflow_name": "research",
+  "status": "running",
+  "entries": [
+    {
+      "seq": "0",
+      "kind": "user_input",
+      "args_fingerprint": "6dfb9c243a409066",
+      "result": "artificial coral reefs in the Mediterranean"
+    },
+    {
+      "seq": "1",
+      "kind": "user_input",
+      "args_fingerprint": "1d5831b730324642",
+      "result": "for a general audience; focus on ecological effectiveness"
+    },
+    {
+      "seq": "2",
+      "kind": "llm_call",
+      "args_fingerprint": "d1d0279b8437cddf",
+      "result": {
+        "queries": [
+          "artificial reefs Mediterranean ecological benefits for marine life",
+          "biodiversity impact of artificial coral reefs in Mediterranean",
+          "challenges and limitations of artificial reefs in the Mediterranean",
+          "successful artificial reef projects Mediterranean Sea examples"
+        ]
+      }
+    },
+    {
+      "seq": "3.0.0",
+      "kind": "tool_call",
+      "args_fingerprint": "1749650f5d2012e6",
+      "result": {
+        "text": "[error: unknown tool 'tabstack_research'. Did you mean: workspace_search. Use the exact name from your tool list. To discover available tools, call tool_search.]",
+        "data": null
+      }
+    },
+    {
+      "seq": "3.1.0",
+      "kind": "tool_call",
+      "args_fingerprint": "c3c185850106762f",
+      "result": {
+        "text": "[error: unknown tool 'tabstack_research'. Did you mean: workspace_search. Use the exact name from your tool list. To discover available tools, call tool_search.]",
+        "data": null
+      }
+    },
+    {
+      "seq": "3.2.0",
+      "kind": "tool_call",
+      "args_fingerprint": "97866325932182d2",
+      "result": {
+        "text": "[error: unknown tool 'tabstack_research'. Did you mean: workspace_search. Use the exact name from your tool list. To discover available tools, call tool_search.]",
+        "data": null
+      }
+    },
+    {
+      "seq": "3.3.0",
+      "kind": "tool_call",
+      "args_fingerprint": "e9f8044652346150",
+      "result": {
+        "text": "[error: unknown tool 'tabstack_research'. Did you mean: workspace_search. Use the exact name from your tool list. To discover available tools, call tool_search.]",
+        "data": null
+      }
+    }
+  ]
+}

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md
@@ -1,0 +1,122 @@
+# Phase 8b — Live smoke transcript
+
+Date: 2026-06-11
+Worktree: `.claude/worktrees/feat-574-workflow-batch-primitives` on `feat/574-workflow-batch-primitives` @ `3cc4de3`.
+Model: `vertex-gemini-flash` (default for the `research` workflow).
+
+## Setup
+
+- Worktree `.env` had `HTTP_PORT=18892` already; added `MATTERMOST_ENABLED=false` to stay off the shared Mattermost token (the deployed agent is on the same token).
+- Provider creds + tabstack key resolved from `data/decafclaw/config.json` (shared via `DATA_HOME`).
+- Server: `uv run decafclaw` web-only on `0.0.0.0:18892`.
+- Client: `decafclaw-client send/respond` against `http://localhost:18892` with the existing `lmorchard` web token.
+
+## Run 1 — mid-run SIGINT (conv `web-lmorchard-2730ab34`)
+
+The crash-resilience leg of the smoke. Drove `/research artificial coral reefs` interactively, answered both user_inputs (`"artificial coral reefs in the Mediterranean"` and `"for a general audience; focus on ecological effectiveness"`), then watched the journal file evolve. At T+10s after the second response, the journal looked like:
+
+```
+status: "running"  (8 entries)
+  (0,)    user_input
+  (1,)    user_input
+  (2,)    llm_call          ← plan stage
+  (3, 0, 0)  tool_call       ← parallel child 0
+  (3, 1, 0)  tool_call       ← parallel child 1
+  (3, 2, 0)  tool_call       ← parallel child 2
+  (3, 3, 0)  tool_call       ← parallel child 3
+```
+
+The outer parallel entry at seq `(3,)` is correctly absent — `wf.parallel` hadn't yet returned. Issued `kill -INT` to the uvicorn worker mid-fan-out.
+
+**Post-kill journal contents (saved as `/tmp/decafclaw-574-journal-pre-restart.json`):**
+
+```json
+{
+  "workflow_name": "research",
+  "status": "running",
+  "entries": [
+    { "seq": "0",     "kind": "user_input", "args_fingerprint": "6dfb9c243a409066" },
+    { "seq": "1",     "kind": "user_input", "args_fingerprint": "1d5831b730324642" },
+    { "seq": "2",     "kind": "llm_call",   "args_fingerprint": "d1d0279b8437cddf" },
+    { "seq": "3.0.0", "kind": "tool_call",  "args_fingerprint": "1749650f5d2012e6" },
+    { "seq": "3.1.0", "kind": "tool_call",  "args_fingerprint": "c3c185850106762f" },
+    { "seq": "3.2.0", "kind": "tool_call",  "args_fingerprint": "97866325932182d2" },
+    { "seq": "3.3.0", "kind": "tool_call",  "args_fingerprint": "e9f8044652346150" }
+  ]
+}
+```
+
+**What this proves:**
+
+1. **Tuple-path on-disk serialization is correct.** Seq is a dotted string (`"3.0.0"`); the loader's `path_from_any` reverses it back to a tuple on read.
+2. **Sub-handle key composition is correct end-to-end.** The `wf.parallel` at outer seq `(3,)` allocates sub-handles at `(3, idx)`; each sub-handle's first `tool_call` lands at `(3, idx, 0)`. Phase 2's `_make_subhandle_at` works under live load.
+3. **Mid-fan-out state is faithfully preserved.** All 4 thunks that completed have their child entries on disk; the outer wasn't yet written; status is `running`. Resume would re-dispatch the thunks; each would hit cache via its sub-handle's first call.
+
+## Run 2 — fresh complete walk (conv `web-lmorchard-e585ecdd`)
+
+Restarted the server clean, issued a second `/research kelp forest restoration techniques` to exercise the plan → parallel → pipeline → subagent path on a fresh journal.
+
+Workflow reached the parallel stage and recorded **5 children** at `(3, 0..4, 0)`. Then it hung. Inspecting the children:
+
+```
+{
+  "seq": "3.0.0",
+  "result": {
+    "text": "[error: unknown tool 'tabstack_research'. Did you mean: workspace_search. Use the exact name from your tool list. To discover available tools, call tool_search.]",
+    "data": null
+  }
+}
+```
+
+All five queries got the same error.
+
+## Findings (file as follow-ups)
+
+### Finding 1 — Skill tools are not reachable from workflow contexts
+
+`tabstack_research` is registered under `src/decafclaw/skills/tabstack/tools.py:378` and is only loaded when the tabstack skill is activated. The agent loop activates skills via `activate_skill`. A workflow's `TurnKind.WORKFLOW` path doesn't go through that activation, so `execute_tool("tabstack_research", ...)` returns the "unknown tool" error — which `wf.tool_call` returns as the dict `{"text": "[error: ...]", "data": null}` (NOT an exception, because the tool returned a result; it's just an error-shaped result).
+
+This isn't a primitive bug — `wf.tool_call` correctly surfaces whatever `execute_tool` returns. It's a wiring gap between workflows and skill-bundled tools.
+
+Two reasonable fixes (out of scope for #574):
+- Pre-activate a configurable skill set when a workflow turn starts.
+- Let `@workflow(...)` declare required skills/tools as a decoration parameter, and have the engine activate them before invoking the orchestrator.
+
+The current orchestrator could be rewritten to use a non-skill tool (`workspace_search` is suggested in the error; `http_fetch` would also work if it exists), but that loses the higher-fidelity Tabstack output. Better to file a follow-up.
+
+### Finding 2 — No auto-resume on startup for `status=running` journals
+
+A `kill -INT` mid-LLM leaves the journal in `status="running"`. On server restart, the conversation manager doesn't scan for in-flight workflows; `resume.py`'s `run_workflow_turn(resume=True)` is only triggered as the `on_approve` of a `WORKFLOW_USER_INPUT` confirmation. So a crashed-mid-fan-out workflow stays stuck unless someone manually re-enqueues a workflow turn.
+
+The replay machinery itself is correct (Phase 5/6 unit tests cover full-cache + mid-fan-out resume, validated against synthetic journals). The on-disk journal we captured here would replay correctly if re-enqueued — that's a property of `run_workflow`'s cursor-from-zero replay.
+
+The wiring gap: a startup scan that re-enqueues `status=running` workflows, OR a client-side "resume workflow" command, would close this.
+
+### Finding 3 — Workflow appeared to hang after parallel completed with error-results
+
+After the 5 `tool_call` children landed with their error texts at mtime 17:02:34, the journal didn't grow further for 3+ minutes. The server was at 0% CPU. No Vertex POST after the plan stage.
+
+The expected behavior: `wf.parallel` returns the list of 5 error-shaped dicts, then `wf.pipeline` starts — first stage `_extract_stage` is sync (pulls `.text` from the dict), then `_summarize_stage` does `sub.llm_call(...)` against Vertex. Either (a) `wf.parallel`'s outer entry write hung between completing and recording, or (b) the workflow advanced into pipeline but `sub.llm_call` for the summarize stage hasn't returned and hasn't been journaled yet.
+
+Likely (b) — the journal only records *after* a journaled call returns. A 3-minute Vertex stall on the first summarize stage is plausible if Vertex is throttling or the request is silently retrying. Without more instrumentation, this is a "needs follow-up" rather than a confirmed primitive bug.
+
+## What the smoke proves vs what it leaves open
+
+**Proven:**
+- Tuple-path keys serialize and round-trip correctly on disk.
+- Sub-handle key composition works under live load (5 distinct `(3, idx, 0)` paths recorded).
+- Mid-run SIGINT preserves journal state faithfully.
+- All four new primitives wire up through the existing transport (websocket → workflow turn → engine → handle).
+- `/research` is user-invokable via the existing `/<name>` slash-command dispatch — no new wiring was needed.
+
+**Open (follow-up issues):**
+- Skill-tools-from-workflows wiring gap (Finding 1).
+- No auto-resume of in-flight workflows on server restart (Finding 2).
+- The 3-minute hang during pipeline summarize against error-text input (Finding 3) — could be Vertex behavior, could be an issue in `wf.parallel`/`wf.pipeline` we missed.
+
+## Artifacts
+
+- Pre-restart journal snapshot: `/tmp/decafclaw-574-journal-pre-restart.json`
+- Server log: `/tmp/decafclaw-574-smoke.log`
+- Client logs: `/tmp/decafclaw-574-fresh-start.log`, `/tmp/decafclaw-574-fresh-final.log`
+- Replay-validation script (incomplete — server contention prevented running): `/tmp/decafclaw-574-replay-check.py`

--- a/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/spec.md
+++ b/docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/spec.md
@@ -1,0 +1,112 @@
+# Workflow batch primitives Spec
+
+**Goal:** Extend the workflow replay engine with four new journaled primitives — `wf.tool_call`, `wf.subagent`, `wf.parallel`, `wf.pipeline` — so orchestrators can fan out work (research, audit, sweep, transform) without giving up durable replay. Ship a second hero workflow (`/research`) that exercises all four end-to-end and walks the same mid-run-restart smoke bar as `/interview`.
+
+**Source:** [Issue #574](https://github.com/lmorchard/decafclaw/issues/574)
+
+## Current state
+
+PR #573 landed two journaled primitives on `WorkflowHandle`: `user_input` and `llm_call` (see `research.md` §1 — `src/decafclaw/workflow/handle.py:53-87`). Both follow the same shape: increment the integer `_cursor`, fingerprint args, check the journal, return cached on hit, run+record on miss. `WorkflowSuspended` raises out of `user_input` on a miss; `llm_call` invokes the LLM inline.
+
+The journal is a flat list of `JournalEntry(seq, kind, args_fingerprint, result)` (`journal.py:26-31`), indexed by integer `seq`. Mismatches raise `WorkflowNonDeterministic` (`handle.py:41-51`). Persistence is a single `workflow.json` per conversation (`paths.py`).
+
+Adjacent infrastructure already exists:
+- **Child-agent dispatch**: `delegate._run_child_turn` (`delegate.py:112-258`) — forked config, restricted tool allowlist, `TurnKind.CHILD_AGENT`, configurable `return_schema`. Used today by `tool_delegate_task` / `tool_delegate_tasks`.
+- **Tool execution by name**: `tools.execute_tool(ctx, fn_name, fn_args)` (`tools/__init__.py`) dispatches by name from a registry built at startup (`TOOL_DEFINITIONS` + skill tools + MCP). Used today from inside `tool_execution.execute_single_tool` (`tool_execution.py:232`).
+- **Concurrent dispatch under semaphore**: `tool_execution.execute_tool_calls` (`tool_execution.py:282-364`) uses `asyncio.gather(..., return_exceptions=True)` with a `ctx.cancelled.wait()` watcher (`tool_execution.py:307-311`).
+
+The hero workflow today is `workflow/workflows/interview.py` — single-orchestrator, sequential, one user input and one llm_call at a time. There is no fan-out test surface.
+
+## Desired end state
+
+Four new methods on `WorkflowHandle`, each a journaled boundary crossing:
+
+1. **`wf.tool_call(name, **args) -> ToolResult-equivalent dict`** — invokes a tool by name via `tools.execute_tool` against the parent ctx's `allowed_tools`. Records `{"text", "data"}` (and any other JSON-serializable fields from `ToolResult`) to the journal. Fingerprint: `(name, args)`.
+
+2. **`wf.subagent(prompt, *, schema=None, allowed_tools=None, allow_vault_retrieval=False, allow_vault_read=False, model=None) -> dict | str`** — dispatches a child agent loop via `delegate._run_child_turn` (direct call, not via the `delegate_task` tool wrapper). Returns the child's final text, OR the schema-validated structured result if `schema` is given (forced-tool output, same mechanic as `llm_call`). Fingerprint: `(prompt, schema, allowed_tools, allow_vault_retrieval, allow_vault_read)` — `model` excluded to match `llm_call`'s convention.
+
+3. **`wf.parallel(thunks: list[Callable[[WorkflowHandle], Awaitable[T]]]) -> list[T]`** — runs N thunks concurrently. Each thunk receives a **sub-handle** (its own `_cursor`, journal key prefix `(parent_seq, thunk_idx)`). `asyncio.gather(*tasks)` with cancellation propagation via `ctx.cancelled`. Default error policy: propagate. Outer journal entry caches the aggregate result list on completion; child entries record each thunk's journaled calls for mid-parallel resume.
+
+4. **`wf.pipeline(items: list, *stages: Callable[[Any, Any, int, WorkflowHandle], Awaitable[Any]]) -> list`** — for each item, runs `stage1 → stage2 → … → stageN` independently (no barrier). Wall-clock is the slowest single-item chain. Each item gets a sub-handle keyed `(parent_seq, item_idx)`; stages share that sub-handle's cursor sequentially. **Stage signature: `async def stage(prev, item, idx, sub)`** where `sub` is the per-item sub-handle stages must use for journaled calls. Fingerprint: `(items, stage_count)` — items must be JSON-serializable. Default error policy: propagate (any failed item raises out).
+
+**Journal extension.** `JournalEntry.seq` becomes a path (tuple of ints). Storage shifts from list to dict keyed by tuple. On-disk JSON: path serialized as `"5.0.2"`-style dotted string for stable JSON keys. Migration: existing flat-int journals load by upgrading `seq: N → (N,)`.
+
+**Sub-handle.** A `WorkflowHandle` variant carrying a key prefix tuple. All journaled-method seq computation prepends the prefix. Sub-handles are transient (lifetime of the thunk); they share `ctx`, `journal`, `_llm_caller`, and `_model` with the parent.
+
+**Second hero workflow.** `/research <topic>`:
+1. `wf.user_input` for clarifying questions (1-3 rounds).
+2. `wf.llm_call` to expand the topic into N parallel search queries (forced-tool structured output).
+3. `wf.parallel` fans out N `wf.tool_call("http_fetch", url=...)` or web-search tools.
+4. `wf.pipeline` runs each fetched page through `extract` → `summarize` stages (each `wf.llm_call`).
+5. Final `wf.llm_call` synthesizes the report; `wf.tool_call("vault_write", ...)` saves it.
+
+**Smoke checklist.** Same bar as PR #573 (per `reference_workflow_smoke_pattern`):
+- Live walk on `vertex-gemini-flash`, mid-run server restart, workflow resumes from journal.
+- Headless `decafclaw-client` drives the conversation; web-only server via `MATTERMOST_ENABLED=false`.
+- Verify journal entries on disk look correct under the new tuple-path scheme.
+
+## Design decisions
+
+- **Decision:** Hierarchical sub-handles with tuple-path journal keys.
+  - **Why:** Issue body explicitly calls for "positional sub-keys"; nested fan-out (parallel-of-pipelines, etc.) needs to compose without re-numbering the global seq. Sub-handle pattern keeps each thunk's cursor local while preserving global determinism.
+  - **Rejected:** Flat seqs + thunk index in fingerprint (order-fragile under refactoring); flat seqs with reserved range (caps nesting, picks an arbitrary block size).
+
+- **Decision:** `wf.subagent` wraps `delegate._run_child_turn` directly.
+  - **Why:** Mature dispatch path — restricted tools, blocked vault writes, child conv_id, event forwarding, timeout enforcement all exist. Direct call avoids tool-wrapper ergonomics (tool args go through JSON, schema handling is in the tool wrapper). Schema support comes free via `return_schema`.
+  - **Rejected:** Aliasing as `wf.tool_call("delegate_task", ...)` (loses schema ergonomics); a fresh workflow-specific child-dispatch path (divergent semantics from delegate).
+
+- **Decision:** Propagate errors out of `wf.parallel` and `wf.pipeline` by default.
+  - **Why:** Decafclaw's general posture is fail-loud (`CLAUDE.md`: "Zero tolerance for warnings/traceback noise"). Drop-null silently swallows failures the workflow author may not have anticipated. Callers wrap individual thunks in try/except for tolerant collection.
+  - **Rejected:** Drop-null (Claude Code's choice) — silent error swallowing; per-call `on_error` config — premature flexibility, biggest API surface, can be added later if needed.
+
+- **Decision:** `wf.tool_call` is gated by the parent ctx's `allowed_tools`.
+  - **Why:** Workflows shouldn't gain capabilities the parent agent didn't have. Predictable from an audit standpoint and reuses the existing gate.
+  - **Rejected:** Workflow-declared allowlist (declaration friction now, can be added later); full registry no-gate (surprise capabilities).
+
+- **Decision:** Cooperative cancellation via `ctx.cancelled` event.
+  - **Why:** Matches `tool_execution.py:307-311`'s pattern. In-flight tasks check between journaled calls. Completed journal entries are kept; resume continues from where it stopped.
+  - **Rejected:** Block-until-settle (slower shutdown); force-cancel + drop partial journal (idempotency-violating tools become unsafe).
+
+- **Decision:** Pipeline stage signature is `async def stage(prev, item, idx, sub)`. Later stages see the original item and index, plus a per-item sub-handle for journaled calls.
+  - **Why:** Stages need to make journaled calls (`sub.llm_call`, `sub.tool_call`) under the per-item sub-handle so replay keys stay positionally addressable. Claude Code's 3-arg signature works for them because their workflows aren't durable; ours are, so explicit sub-handle access is required. `item` and `idx` let later stages label work without threading context through stage 1's return value.
+  - **Rejected:** `stage(prev, item, idx)` with implicit contextvar-bound `wf` (hidden inversion-of-control); journaling stages themselves as single units (coarser replay granularity — a partially-completed stage's tokens are lost on resume); `stage(prev)` only (loses item identity).
+
+- **Decision:** `wf.subagent` supports `schema=` like `wf.llm_call`.
+  - **Why:** `delegate.tool_delegate_task` already supports `return_schema`. The child's intermediate tool use is unconstrained; only the final output is gated. Symmetric with `llm_call` for the workflow author.
+  - **Rejected:** Text-only subagent (loses an existing capability); separate `wf.subagent_structured(...)` method (doubles surface area).
+
+- **Decision:** `model` excluded from `wf.subagent` and `wf.tool_call` fingerprints (consistent with `wf.llm_call`).
+  - **Why:** Per-call model swap shouldn't invalidate the journal — the orchestrator's intent is the same. Operational latitude to upgrade models without breaking resume.
+  - **Rejected:** Including `model` in fingerprint (resume-fragile when model defaults shift).
+
+## Patterns to follow
+
+- **Primitive structure:** mirror `WorkflowHandle.llm_call` (`handle.py:53-75`) — cursor increment, fingerprint, `_check_or_none`, journal append, save.
+- **Sub-handle key prefix application:** every journaled method on a sub-handle constructs its seq as `prefix + (sub_cursor,)`. Top-level handle uses `prefix = ()`.
+- **Subagent dispatch:** import `_run_child_turn` from `src/decafclaw/tools/delegate.py:112-258` and call directly (mark non-private once promoted to a primitive). Inherit its tool-restriction defaults; expose `allowed_tools` / `allow_vault_retrieval` / `allow_vault_read` as kwargs.
+- **Tool call:** call `tools.execute_tool(ctx, name, args)` from `src/decafclaw/tools/__init__.py`. Pre-validate name against `ctx.allowed_tools`. Convert returned `ToolResult` to a JSON-serializable dict before journal storage.
+- **Concurrent dispatch:** model on `tool_execution.execute_tool_calls` (`tool_execution.py:282-364`) — `asyncio.gather` + ctx-cancellation watcher. No semaphore: parallel sizing is the workflow author's responsibility (the agent's `max_concurrent_tools` is an agent-loop concern, not a workflow one).
+- **Test pattern:** mirror `tests/test_workflow_engine.py` style — live path test + replay test per primitive. For sub-handle tests, exercise nested parallel-in-pipeline once to confirm key composition.
+- **Hero workflow:** model `/research` on `workflow/workflows/interview.py` for command registration / orchestrator entry. Register as a user-invocable workflow with `$ARGUMENTS` for the topic.
+
+## What we're NOT doing
+
+- **Resolving WORKFLOW Context-kind semantics (#575).** The subagent decision uses `_run_child_turn` which already uses `TurnKind.CHILD_AGENT`; the parent workflow Context kind isn't forced by this work. Punt #575 as a separate ADR.
+- **Sidecar directory migration (#576).** `workflow.json` continues to use the directory layout; flat sidecars stay flat for now.
+- **LLM-generated workflows (#577).** Out of scope; downstream of this work.
+- **A declarative step DSL.** Already rejected in PR #573 (`docs/workflows.md`). Control flow is the host language.
+- **Per-call error policy config (`on_error="raise"|"null"|"tuple"`).** Defer until a real workflow demands it. Default propagate is enough.
+- **Workflow-declared `allowed_tools` at `@workflow` decoration time.** Parent ctx's allowlist is the gate. Can be tightened later.
+- **A "workflow-of-workflows" primitive.** Subagent already covers it (a subagent's prompt could trigger another workflow). No fresh primitive.
+- **Performance tuning / per-primitive timeouts beyond inherited ones.** Tool calls inherit `TOOL_TIMEOUT_SEC`; subagents inherit `child_timeout_sec`. Parallel/pipeline have no timeout of their own.
+
+## Open questions
+
+- **Q: Should `wf.subagent`'s default `allowed_tools` be the parent ctx's allowlist (like `wf.tool_call`), or the existing `_run_child_turn` default (parent's allowed_tools minus delegations/vault-writes)?**
+  - **Default:** match `_run_child_turn`'s existing default. Re-using established semantics; the workflow author can override via the kwarg.
+
+- **Q: What does `wf.tool_call`'s journal entry store for tools that return media (images, files)?**
+  - **Default:** strip media from the journal entry, keep `text` + `data`. Media bytes are large and rebuildable from upstream; the journal is for replay correctness, not full reconstruction of side-channel outputs.
+
+- **Q: Should the outer journal entry for `wf.parallel` / `wf.pipeline` store the assembled result, or only a completion marker (delegating to child entries)?**
+  - **Default:** outer entry stores the assembled list. Fast-path full-replay returns instantly; child entries are still present for crash-resume mid-fanout. Storage cost is the assembly itself — a list of already-journaled values.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ These docs are as much for me as they are for agents working on this project. Th
 
 ## Agent Behavior
 
-- [Workflow Replay Engine](workflows.md) — Durable, human-in-the-loop workflows with deterministic replay; code owns control flow, LLM is a structured-output worker
+- [Workflow Replay Engine](workflows.md) — Durable, human-in-the-loop workflows with deterministic replay; code owns control flow, LLM is a structured-output worker; primitives include `llm_call`, `user_input`, `tool_call`, `subagent`, `parallel`, `pipeline`
 - [Self-Reflection](reflection.md) — Binary judge + critique + retry before delivering responses (Reflexion pattern)
 - [Sub-Agent Delegation](delegation.md) — Fork child agents for concurrent subtasks
 - [Heartbeat](heartbeat.md) — Periodic agent wake-up for monitoring and recurring tasks

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -49,9 +49,10 @@ different value and diverge control flow.
 > is ordinary code.** That single rule is the entire discipline. It is Temporal's "activities
 > vs. workflow code" line, DBOS's, and Claude Code's.
 
-For the MVP there are exactly **two** journaled wrappers: `wf.llm_call(...)` and
-`wf.user_input(...)`. Subagent, tool, parallel, and pipeline wrappers are deferred to future
-work.
+There are six journaled wrappers: `wf.llm_call(...)`, `wf.user_input(...)`,
+`wf.tool_call(...)`, `wf.subagent(...)`, `wf.parallel(...)`, and `wf.pipeline(...)`. The first
+two are the suspend/resume backbone; the last four are boundary-crossing wrappers for tools,
+child agents, and fan-out. Each one journals at a positional key and replays from cache.
 
 ## The journal and deterministic replay
 
@@ -112,7 +113,7 @@ than silently returning a stale result.
 `except Exception`) lets the cursor advance past a step the journal never recorded,
 desynchronizing every later positional key.
 
-## The two journaled primitives
+## The journaled primitives
 
 ### `wf.llm_call(*, prompt, schema, system="", tool_name="submit", model=None)`
 
@@ -126,6 +127,14 @@ on narrate-stall.
 - `tool_name` — cosmetic label for the forced tool (not part of the fingerprint).
 - `model` — named model config; falls back to the workflow's registered model.
 
+**Fingerprint:** `(prompt, schema, system)`. `tool_name` is cosmetic; `model` is an execution
+detail. A per-call `model` override therefore MUST be deterministic across replays.
+
+**Replay:** cache hit returns the parsed dict verbatim. The LLM is NOT re-invoked.
+
+**Error:** schema-parse failures retry once with a stricter nudge; persistent failures
+propagate and the run goes to `ERROR` status.
+
 ### `wf.user_input(prompt, *, choices=None)`
 
 Asks the user a question. On the first (unanswered) encounter raises `WorkflowSuspended`
@@ -134,6 +143,204 @@ journal.
 
 - `prompt` — the question shown to the user.
 - `choices` — optional list of button labels (free-text if omitted).
+
+**Fingerprint:** `(prompt, choices)`.
+
+**Replay:** cache hit returns the cached answer.
+
+**Suspend / resume:** see [Suspend/resume mechanics](#suspendresume-mechanics-and-the-confirmation-path).
+
+### `wf.tool_call(name, **args) -> dict`
+
+Invokes a registered decafclaw tool by name and returns its result. The result shape is
+`{"text": str, "data": Any | None}` — `ToolResult.media` is intentionally stripped from the
+journal (media bytes can be large and are rebuildable from upstream sources; the journal
+exists for replay correctness, not full reconstruction).
+
+- `name` — tool name (e.g. `tabstack_research`).
+- `**args` — keyword arguments forwarded to the tool.
+
+**Gating:** the call is gated by `ctx.tools.allowed`, mirroring `execute_tool`'s semantics.
+`allowed is None` means no restriction; a non-empty set narrows. A name missing from the
+allowlist raises `WorkflowToolNotAllowed` *before* the journal is consulted, so orchestrator
+bugs fail loud rather than burning a journal slot. The gate also fires during replay — if the
+allowlist shrinks between turns, the caller hears about it.
+
+**Fingerprint:** `(name, args)`.
+
+**Replay:** cache hit returns the dict verbatim. The tool is NOT re-invoked.
+
+**Error:** the tool's `ToolResult.text` is captured verbatim, including the `[error: ...]`
+prefix when the underlying tool failed. `tool_call` itself only raises `WorkflowToolNotAllowed`.
+
+**Cancellation:** in-flight tool execution is subject to the tool's own per-call timeout and
+`ctx.cancelled` propagation.
+
+**Example:**
+
+```python
+result = await wf.tool_call("tabstack_research", query="climate adaptation 2026")
+text = result["text"]
+```
+
+### `wf.subagent(prompt, *, schema=None, allowed_tools=None, allow_vault_retrieval=False, allow_vault_read=False, model=None) -> dict | str`
+
+Dispatches a child agent loop via `delegate.run_child_turn` (the mature child-agent
+infrastructure: restricted tools, no further delegation, no skill activation, no vault writes
+by default). Returns the child's final text when `schema` is None, or the parsed structured
+dict when a schema is supplied (with a silent fallback to raw text on parse failure).
+
+- `prompt` — task description handed to the child.
+- `schema` — optional JSON Schema; when supplied, the child is prompted to emit a fenced JSON
+  block matching the shape, and the parsed dict is returned.
+- `allowed_tools` — narrows the tool allowlist further than the standard delegate excludes.
+- `allow_vault_retrieval` — opt in to vault retrieval inside the child turn (default `False`).
+- `allow_vault_read` — opt in to `vault_read` in the child's allowed tools (default `False`).
+- `model` — per-call model override (NOT part of the fingerprint; must be deterministic).
+
+**Fingerprint:** `(prompt, schema, sorted(allowed_tools), allow_vault_retrieval, allow_vault_read)`.
+`model` is excluded, matching `llm_call`'s convention.
+
+**Replay:** cache hit returns the cached value (dict or str). The child agent is NOT
+re-invoked.
+
+**Error:** the child's `[error: ...]`-prefixed text is returned as-is; `subagent` never raises
+on child-turn failures.
+
+**Cancellation:** the child turn participates in the parent's `ctx.cancelled` propagation
+through `run_child_turn`.
+
+**Example:**
+
+```python
+report = await wf.subagent(
+    prompt="Synthesize these summaries into a titled markdown report:\n\n…",
+    schema={"type": "object", "properties": {"title": {"type": "string"},
+                                              "body": {"type": "string"}},
+            "required": ["title", "body"]},
+)
+```
+
+### `wf.parallel(thunks) -> list`
+
+Runs N thunks concurrently under sub-handles. Returns results in thunk-index order.
+
+```python
+async def parallel(
+    self,
+    thunks: list[Callable[[WorkflowHandle], Awaitable[Any]]],
+) -> list[Any]
+```
+
+Each thunk receives a sub-handle whose key prefix is `(outer_seq, thunk_idx)`, so its own
+journaled calls land at hierarchical keys like `(outer, idx, 0)`, `(outer, idx, 1)`, ...
+Sub-handles share `ctx`, `journal`, `llm_caller`, and `model` with the parent and start with
+`_cursor = 0`.
+
+**Fingerprint:** `(count,)`. Callables aren't JSON-serializable; per-thunk replay determinism
+comes from the child entries inside each sub-handle's namespace.
+
+**Replay (full hit):** the outer entry caches the assembled result list; on a cache hit the
+list is returned verbatim and thunks are NOT re-dispatched.
+
+**Replay (mid-fan-out resume):** if the outer entry was never written (e.g. the run crashed
+or was cancelled mid-flight), replay re-dispatches every thunk. Each thunk's sub-handle hits
+its existing journal entries (cached per inner call) and resumes execution from the first
+non-cached call.
+
+**Error:** the first thunk to raise a real (non-`CancelledError`) exception propagates out
+in thunk-index order. Outstanding in-flight thunks are cancelled and their `CancelledError`s
+are absorbed during cleanup so they cannot mask the real failure. The outer entry is NOT
+written when an exception escapes. Wrap individual thunks in `try/except` for tolerant
+collection.
+
+**Cancellation:** `ctx.cancelled.set()` triggers an internal watcher that cancels all
+in-flight thunks and raises `asyncio.CancelledError` out of `parallel`. The outer entry is
+NOT written.
+
+**Example:**
+
+```python
+def _make_search_thunk(query: str):
+    async def _thunk(sub):
+        return await sub.tool_call("tabstack_research", query=query)
+    return _thunk
+
+results = await wf.parallel([_make_search_thunk(q) for q in queries])
+```
+
+### `wf.pipeline(items, *stages) -> list`
+
+Per-item run of `stage1 → stage2 → … → stageN`, with no barrier between stages: each item
+flows through every stage independently. Item A can be in stage 3 while item B is still in
+stage 1; wall-clock cost equals the slowest single-item chain.
+
+```python
+async def pipeline(
+    self,
+    items: list,
+    *stages: Callable[[Any, Any, int, WorkflowHandle], Awaitable[Any]],
+) -> list
+```
+
+Each stage receives `(prev, item, idx, sub)`:
+
+- `prev` — the previous stage's return (or `item` itself for the first stage).
+- `item` — `items[idx]`, the per-row input.
+- `idx` — item index in the input list.
+- `sub` — the per-item sub-handle. Stages MUST use this for any journaled call so keys land
+  under `(outer_seq, idx, ...)`. Stages share their per-item sub-handle's cursor
+  sequentially, so `sub.llm_call` in stage 1 and stage 2 of item 0 land at `(outer, 0, 0)`
+  and `(outer, 0, 1)` respectively.
+
+Items must be JSON-serializable (they go into the fingerprint).
+
+**Fingerprint:** `(items, stage_count)`. Stages themselves are not in the fingerprint.
+
+**Replay (full hit):** the outer entry caches the assembled per-item final-stage results;
+on a cache hit the list is returned verbatim and stages are NOT re-run.
+
+**Replay (mid-pipeline resume):** if the outer entry was never written, replay re-dispatches
+every item; each item's sub-handle hits its already-journaled stage results and resumes from
+the first non-cached call within that item's chain.
+
+**Error:** the first item-stage to raise a real exception propagates out in item-index order;
+other items' in-flight stages are cancelled. The outer entry is NOT written.
+
+**Cancellation:** same as `parallel` — `ctx.cancelled.set()` cancels all in-flight items and
+raises `asyncio.CancelledError`.
+
+**Edge cases:** zero stages → items pass through unchanged. Zero items → returns `[]`
+(written to the journal as a `pipeline` entry with an empty list).
+
+**Example:**
+
+```python
+async def _extract_stage(prev, item, idx, sub):
+    return prev.get("text", "") if isinstance(prev, dict) else str(prev)
+
+async def _summarize_stage(prev, item, idx, sub):
+    return await sub.llm_call(
+        prompt=_summarize_prompt(prev),
+        schema=_SUMMARY_SCHEMA, system=_SYS_SUMMARIZE)
+
+summaries = await wf.pipeline(search_results, _extract_stage, _summarize_stage)
+```
+
+### Multi-primitive example: `/research`
+
+See `src/decafclaw/workflow/workflows/research.py` for a hero orchestrator that exercises
+all six primitives end-to-end. Outline:
+
+1. `wf.user_input` to collect topic + scope from the user.
+2. `wf.llm_call` to plan 3–5 search queries (forced-tool structured output).
+3. `wf.parallel` to fan out the searches — each thunk uses `sub.tool_call("tabstack_research", query=q)`.
+4. `wf.pipeline` for per-result extract → summarize — stage 1 is a plain dict→str transform
+   (not journaled), stage 2 uses `sub.llm_call` to journal the structured summary.
+5. `wf.subagent` for final synthesis with a `{title, body}` schema.
+
+Trigger via `/research` in the web UI. The final artifact is rendered as a markdown
+`# Title\n\nbody` block.
 
 ## Authoring a workflow
 
@@ -254,21 +461,21 @@ src/decafclaw/workflow/
   registry.py          @workflow decorator + REGISTRY + workflow_commands()
   engine.py            run_workflow(): calls orchestrator, classifies outcome
   journal.py           Journal dataclass + save_journal/load_journal + fingerprint()
-  handle.py            WorkflowHandle — the wf object; llm_call + user_input primitives
+  handle.py            WorkflowHandle — the wf object; llm_call + user_input +
+                       tool_call + subagent + parallel + pipeline primitives
   llm.py               call_structured() — forced-tool structured-output LLM helper
-  errors.py            WorkflowSuspended, WorkflowNonDeterministic, WorkflowError
+  errors.py            WorkflowSuspended, WorkflowNonDeterministic,
+                       WorkflowToolNotAllowed, WorkflowError
   paths.py             workflow_dir() + workflow_path() — per-conv file location helpers
   resume.py            run_workflow_turn() + WorkflowUserInputHandler (harness glue)
   workflows/
-    interview.py       The hero orchestrator (@workflow("interview"))
+    interview.py       Suspend/resume hero orchestrator (@workflow("interview"))
+    research.py        Multi-primitive hero orchestrator (@workflow("research"))
 ```
 
 ## What is not in v1
 
 The following are explicitly deferred:
-
-- **`subagent` / `parallel` / `pipeline` / `tool_call` primitives.** These arrive with the
-  batch fan-out case; they are real journaled wrappers, just not needed for the interview.
 
 - **LLM-generated per-task workflows.** The engine does not preclude it, but this is not
   built yet.

--- a/src/decafclaw/commands.py
+++ b/src/decafclaw/commands.py
@@ -417,16 +417,15 @@ async def execute_command(ctx, skill: SkillInfo, arguments: str) -> tuple[str, s
                            skill_dir=str(skill.location.resolve()))
 
     if skill.context == "fork":
-        from .tools.delegate import _run_child_turn
+        from .tools.delegate import run_child_turn
         # Fork mode: hard-restrict tools since the child turn is isolated
         if skill.allowed_tools:
             ctx.tools.allowed = set(skill.allowed_tools)
         # User-invoked commands use the full iteration limit, not the child limit
-        result = await _run_child_turn(
+        text, _data = await run_child_turn(
             ctx, body, model=skill.model or "",
             max_iterations=ctx.config.agent.max_tool_iterations)
-        from .media import ToolResult as _TR
-        return "fork", result.text if isinstance(result, _TR) else str(result)
+        return "fork", text
 
     # Inline mode: return the substituted body as the user message
     return "inline", body

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -20,6 +20,11 @@ DEFAULT_CHILD_SYSTEM_PROMPT = (
     "When a skill below shows bash/curl commands, run them with the shell tool."
 )
 
+# `run_child_turn` surfaces failure via text starting with this prefix.
+# Batch error classification (`_run_one_delegated`) and external callers rely
+# on this convention — keep all error returns in sync with the prefix.
+ERROR_TEXT_PREFIX = "[error:"
+
 # Vault-access policy for child agents (#396). Default is no-access;
 # the parent opts the child in via flags on ``delegate_task``. Vault
 # WRITE tools are categorically blocked — if a child's work should
@@ -109,19 +114,29 @@ def _parse_structured_output(text: str) -> tuple[Any | None, str]:
     return parsed, prose
 
 
-async def _run_child_turn(parent_ctx, task, model: str = "",
-                          max_iterations: int = 0,
-                          *,
-                          allow_vault_retrieval: bool = False,
-                          allow_vault_read: bool = False,
-                          return_schema: dict | None = None,
-                          event_context_id_override: str | None = None):
+async def run_child_turn(parent_ctx, task, model: str = "",
+                         max_iterations: int = 0,
+                         *,
+                         allowed_tools: list[str] | None = None,
+                         allow_vault_retrieval: bool = False,
+                         allow_vault_read: bool = False,
+                         return_schema: dict | None = None,
+                         event_context_id_override: str | None = None
+                         ) -> tuple[str, dict | None]:
     """Run a child agent turn via ConversationManager, preserving the
     parent's tools, skills, and event routing.
 
     Args:
         model: Override model for the child. Empty = inherit parent's.
         max_iterations: Override max tool iterations. 0 = use child_max_tool_iterations.
+        allowed_tools: Optional explicit allowlist for the child. When
+            provided, the child sees ONLY these tools (still minus the
+            categorical excludes: ``delegate_task``,
+            ``activate_skill``, ``refresh_skills``, ``tool_search``,
+            and the vault-write set). Use this from workflows to
+            constrain a child agent narrowly. ``None`` (default) means
+            the child inherits the parent's full tool set minus the
+            standard excludes.
         allow_vault_retrieval: When False (default), the child runs
             with ``skip_vault_retrieval=True`` — no proactive memory
             injection. Set True to opt the child INTO the parent's
@@ -135,15 +150,23 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         return_schema: Optional JSON-schema-shaped dict (#395). When
             supplied, the child system prompt gets an addendum
             instructing it to emit a fenced JSON block matching the
-            shape after any prose. The caller is responsible for
-            parsing the JSON out of the response.
+            shape after any prose. The fenced JSON block is parsed and
+            returned alongside the prose-only text.
         event_context_id_override: When non-None, the child's
             ``event_context_id`` is set to this value instead of
             inheriting the parent's subscriber id. Used by
             ``delegate_tasks`` (#397) to suppress per-child progress
             events from the parent UI.
 
-    Returns the child's text response, or an error string on failure.
+    Returns ``(text, data)``:
+        * On success without ``return_schema``: ``(child_text, None)``.
+        * On success WITH ``return_schema`` and a parseable JSON block:
+          ``(prose_with_block_stripped, parsed_dict)``.
+        * On success WITH ``return_schema`` but no parseable block:
+          ``(raw_text, None)`` (silent fallback).
+        * On timeout / missing manager / child exception: the text is
+          an ``[error: ...]`` string and data is ``None``. Callers can
+          detect the error path via that prefix.
     """
     from ..conversation_manager import TurnKind  # deferred: circular dep
     from . import TOOLS  # deferred: circular dep
@@ -198,6 +221,8 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
 
         # Child inherits parent's tools minus delegation/activation.
         # If parent has restricted allowed_tools, respect that restriction.
+        # If an explicit `allowed_tools` was passed (workflow callers),
+        # that narrows further.
         excluded = {"delegate_task", "activate_skill", "refresh_skills", "tool_search"}
         # Vault policy (#396): writes are categorically blocked for
         # children regardless of flags; reads require explicit opt-in.
@@ -208,6 +233,8 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
         parent_allowed = parent_ctx.tools.allowed
         if parent_allowed is not None:
             all_tools = all_tools & parent_allowed
+        if allowed_tools is not None:
+            all_tools = all_tools & set(allowed_tools)
         child_ctx.tools.allowed = all_tools - excluded
 
         # Carry over parent's activated skill tools and data
@@ -234,9 +261,10 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
 
     manager = parent_ctx.manager
     if manager is None:
-        return ToolResult(
-            text="[error: delegate_task requires a ConversationManager; "
-                 "no manager on parent ctx]"
+        return (
+            "[error: delegate_task requires a ConversationManager; "
+            "no manager on parent ctx]",
+            None,
         )
 
     timeout = config.agent.child_timeout_sec
@@ -251,11 +279,22 @@ async def _run_child_turn(parent_ctx, task, model: str = "",
             user_id=parent_ctx.user_id,
         )
         result_text = await asyncio.wait_for(future, timeout=timeout)
-        return result_text or ""
     except asyncio.TimeoutError:
-        return ToolResult(text=f"[error: subtask timed out after {timeout}s]")
+        return (f"[error: subtask timed out after {timeout}s]", None)
     except Exception as e:
-        return ToolResult(text=f"[error: subtask failed: {e}]")
+        return (f"[error: subtask failed: {e}]", None)
+
+    raw_text = result_text or ""
+    if return_schema is None:
+        return (raw_text, None)
+    parsed, prose = _parse_structured_output(raw_text)
+    if parsed is None:
+        log.debug(
+            "run_child_turn: child response had no parseable JSON block; "
+            "falling back to prose-only return",
+        )
+        return (raw_text, None)
+    return (prose or raw_text, parsed)
 
 
 async def tool_delegate_task(
@@ -294,28 +333,19 @@ async def tool_delegate_task(
     if not task or not task.strip():
         return ToolResult(text="[error: task description is required]")
 
-    raw = await _run_child_turn(
+    text, data = await run_child_turn(
         ctx, task, model=model,
         allow_vault_retrieval=allow_vault_retrieval,
         allow_vault_read=allow_vault_read,
         return_schema=return_schema,
     )
-    # Error paths in _run_child_turn return ToolResult directly; pass through.
-    if isinstance(raw, ToolResult):
-        return raw
-
-    raw_text = raw or ""
-    if return_schema is None:
-        return ToolResult(text=raw_text)
-
-    parsed, prose = _parse_structured_output(raw_text)
-    if parsed is None:
-        log.debug(
-            "delegate_task: child response had no parseable JSON block; "
-            "falling back to prose-only return",
-        )
-        return ToolResult(text=raw_text)
-    return ToolResult(text=prose or raw_text, data=parsed)
+    # `run_child_turn` returns the error string in `text` (prefixed
+    # with "[error: ...]") and data=None for failures. Pass it through
+    # as a text-only ToolResult so the agent sees the same shape it
+    # always did.
+    if data is None:
+        return ToolResult(text=text)
+    return ToolResult(text=text, data=data)
 
 
 async def _run_one_delegated(
@@ -343,7 +373,7 @@ async def _run_one_delegated(
     """
     async with semaphore:
         try:
-            raw = await _run_child_turn(
+            text, data = await run_child_turn(
                 parent_ctx, task, model=model,
                 allow_vault_retrieval=allow_vault_retrieval,
                 allow_vault_read=allow_vault_read,
@@ -361,31 +391,19 @@ async def _run_one_delegated(
                 "error": f"delegate_tasks internal error: {exc}",
             }
         else:
-            if isinstance(raw, ToolResult):
-                # _run_child_turn surfaces failure as a ToolResult with
-                # an "[error: ...]" prefix; preserve it as the error
-                # field so callers can inspect it.
-                entry = {"index": idx, "ok": False, "error": raw.text or ""}
+            # `run_child_turn` surfaces failure via an ERROR_TEXT_PREFIX-tagged
+            # text + data=None; preserve it as the entry's error field.
+            if data is None and text.startswith(ERROR_TEXT_PREFIX):
+                entry = {"index": idx, "ok": False, "error": text}
+            elif data is None:
+                entry = {"index": idx, "ok": True, "text": text}
             else:
-                raw_text = raw or ""
-                if return_schema is None:
-                    entry = {"index": idx, "ok": True, "text": raw_text}
-                else:
-                    parsed, prose = _parse_structured_output(raw_text)
-                    if parsed is None:
-                        log.debug(
-                            "delegate_tasks: child %d had no parseable "
-                            "JSON block; falling back to prose-only.",
-                            idx,
-                        )
-                        entry = {"index": idx, "ok": True, "text": raw_text}
-                    else:
-                        entry = {
-                            "index": idx,
-                            "ok": True,
-                            "text": prose or raw_text,
-                            "data": parsed,
-                        }
+                entry = {
+                    "index": idx,
+                    "ok": True,
+                    "text": text,
+                    "data": data,
+                }
 
         async with progress_lock:
             progress["done"] += 1

--- a/src/decafclaw/workflow/errors.py
+++ b/src/decafclaw/workflow/errors.py
@@ -17,13 +17,24 @@ class WorkflowSuspended(Exception):
     response, journal the answer at the right position.
     """
 
-    def __init__(self, *, seq: int, args_fingerprint: str, prompt: str,
-                 choices: list[str] | None = None):
+    def __init__(self, *, seq: tuple[int, ...], args_fingerprint: str,
+                 prompt: str, choices: list[str] | None = None):
         super().__init__(f"workflow suspended at step {seq}: {prompt!r}")
-        self.seq = seq
+        self.seq: tuple[int, ...] = seq
         self.args_fingerprint = args_fingerprint
         self.prompt = prompt
         self.choices = choices
+
+
+class WorkflowToolNotAllowed(WorkflowError):
+    """Raised when `wf.tool_call` requests a tool not in ctx.tools.allowed.
+
+    A workflow's allowlist is a hard gate: a tool name missing from it is
+    a programming error in the orchestrator, not a workflow desync, so we
+    fail loud before consulting the journal. The check still fires during
+    replay — if the allowlist shrinks between turns, the caller should
+    hear about it.
+    """
 
 
 class WorkflowNonDeterministic(WorkflowError):
@@ -33,13 +44,13 @@ class WorkflowNonDeterministic(WorkflowError):
     orchestrator. Fail loudly rather than return a stale result.
     """
 
-    def __init__(self, seq: int, recorded_kind: str, recorded_fp: str,
-                 got_kind: str, got_fp: str):
+    def __init__(self, seq: tuple[int, ...], recorded_kind: str,
+                 recorded_fp: str, got_kind: str, got_fp: str):
         super().__init__(
             f"workflow non-deterministic at step {seq}: recorded "
             f"{recorded_kind}/{recorded_fp}, replay produced {got_kind}/{got_fp}"
         )
-        self.seq = seq
+        self.seq: tuple[int, ...] = seq
         self.recorded_kind = recorded_kind
         self.recorded_fp = recorded_fp
         self.got_kind = got_kind

--- a/src/decafclaw/workflow/handle.py
+++ b/src/decafclaw/workflow/handle.py
@@ -16,10 +16,19 @@ Replay invariants the orchestrator author must respect:
   * Any per-call `model=` override passed to `llm_call` must be deterministic
     (it is not part of the journal fingerprint).
 """
+import asyncio
 import logging
+from typing import Any, Awaitable, Callable, Coroutine
+
+from decafclaw.tools import delegate as _delegate
+from decafclaw.tools import execute_tool
 
 from . import llm as wf_llm
-from .errors import WorkflowNonDeterministic, WorkflowSuspended
+from .errors import (
+    WorkflowNonDeterministic,
+    WorkflowSuspended,
+    WorkflowToolNotAllowed,
+)
 from .journal import fingerprint, save_journal
 
 log = logging.getLogger(__name__)
@@ -31,14 +40,54 @@ async def _default_llm_call(ctx, **kw):
 
 class WorkflowHandle:
     def __init__(self, ctx, journal, *, llm_caller=None,
-                 model: str = "vertex-gemini-flash"):
+                 model: str = "vertex-gemini-flash",
+                 _key_prefix: tuple[int, ...] = ()):
+        # `_key_prefix` is engine-internal: leading underscore signals it's
+        # not for orchestrator authors. The top-level handle uses the default
+        # `()`; sub-handles (Phase 2+) supply a path-shaped prefix so their
+        # journaled calls land at hierarchical seqs like (outer, idx, ...).
         self.ctx = ctx
         self.journal = journal
         self._cursor = 0
         self._llm_caller = llm_caller or _default_llm_call
         self._model = model
+        self._key_prefix = _key_prefix
 
-    def _check_or_none(self, seq: int, kind: str, fp: str):
+    def _next_seq(self) -> tuple[int, ...]:
+        """Advance the cursor and return the next journal key for this handle.
+
+        Composes `_key_prefix` with the current cursor so a top-level handle
+        yields `(0,)`, `(1,)`, ... while a sub-handle at prefix `(5, 2)`
+        yields `(5, 2, 0)`, `(5, 2, 1)`, ...
+        """
+        seq = self._key_prefix + (self._cursor,)
+        self._cursor += 1
+        return seq
+
+    def _make_subhandle_at(self, outer_seq: tuple[int, ...],
+                           idx: int) -> "WorkflowHandle":
+        """Create a sub-handle whose journal-key prefix is `outer_seq + (idx,)`.
+
+        Used by Phase 5/6 primitives (`parallel`, `pipeline`) to give each
+        thunk / pipeline stage its own key namespace. The caller is
+        responsible for passing the already-computed `outer_seq` (typically
+        the result of the parent's own `_next_seq()` for the outer entry) —
+        this method does NOT advance the parent's cursor, so the parent's
+        cursor flow stays legible at the call site:
+
+            seq = self._next_seq()                # outer entry
+            subs = [self._make_subhandle_at(seq, i) for i in range(n)]
+
+        Sub-handles share `ctx`, `journal`, `llm_caller`, and `model` with
+        the parent; each starts with `_cursor = 0`.
+        """
+        sub_prefix = outer_seq + (idx,)
+        return WorkflowHandle(self.ctx, self.journal,
+                              llm_caller=self._llm_caller,
+                              model=self._model,
+                              _key_prefix=sub_prefix)
+
+    def _check_or_none(self, seq: tuple[int, ...], kind: str, fp: str):
         """Return (cached_result, True) for an already-journaled call at seq,
         else (None, False). Raises WorkflowNonDeterministic on a mismatch.
         """
@@ -52,8 +101,7 @@ class WorkflowHandle:
 
     async def llm_call(self, *, prompt: str, schema: dict, system: str = "",
                        tool_name: str = "submit", model: str | None = None):
-        seq = self._cursor
-        self._cursor += 1
+        seq = self._next_seq()
         # tool_name and the per-call `model` override are intentionally NOT
         # part of the fingerprint: tool_name is a cosmetic label for the single
         # forced tool, and model is an execution detail. prompt + schema +
@@ -74,14 +122,385 @@ class WorkflowHandle:
         save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
         return result
 
+    async def tool_call(self, name: str, **args) -> dict:
+        """Invoke a decafclaw tool by name. Journaled for replay.
+
+        The tool is gated by `ctx.tools.allowed`: a name missing from the
+        allowlist raises `WorkflowToolNotAllowed` before the journal is
+        consulted, so orchestrator bugs fail loud rather than burning a
+        journal slot. The gate also fires during replay — if the allowlist
+        shrinks between turns, the caller hears about it.
+
+        The result is captured as `{"text": str, "data": Any|None}`. Media
+        attachments on the underlying `ToolResult` are intentionally
+        stripped: media bytes can be large and are rebuildable from
+        upstream sources; the journal exists for replay correctness, not
+        full reconstruction. Both live and replay paths return this dict
+        shape so orchestrators see a single result schema.
+        """
+        # Mirror `execute_tool`'s semantics: `allowed is None` means "no
+        # restriction" (the orchestrator's parent agent could invoke any
+        # registered tool). A non-empty set narrows; an empty set means
+        # nothing is allowed. Check BEFORE consuming a cursor slot so the
+        # docstring's "doesn't burn a journal slot" claim holds even if an
+        # orchestrator catches `WorkflowToolNotAllowed` and continues.
+        allowed = self.ctx.tools.allowed
+        if allowed is not None and name not in allowed:
+            raise WorkflowToolNotAllowed(
+                f"tool {name!r} not in workflow's tool allowlist")
+        seq = self._next_seq()
+        fp = fingerprint("tool_call", {"name": name, "args": args})
+        cached, hit = self._check_or_none(seq, "tool_call", fp)
+        if hit:
+            # Narrow for the type checker: a hit always carries the dict the
+            # live path journaled (see `serialized` below).
+            assert isinstance(cached, dict)
+            return cached
+        result = await execute_tool(self.ctx, name, args)
+        serialized = {"text": result.text, "data": result.data}
+        self.journal.append(seq, "tool_call", fp, serialized)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return serialized
+
+    async def subagent(self, prompt: str, *,
+                       schema: dict | None = None,
+                       allowed_tools: list[str] | None = None,
+                       allow_vault_retrieval: bool = False,
+                       allow_vault_read: bool = False,
+                       model: str | None = None) -> dict | str:
+        """Dispatch a child agent loop as a journaled boundary crossing.
+
+        Reuses the existing `delegate.run_child_turn` infrastructure: the
+        child inherits the parent's tools and skills (minus the standard
+        excludes — no further delegation, no skill activation, no vault
+        writes); `allowed_tools` may narrow that further. The child runs as
+        its own forked agent turn with its own conv_id.
+
+        Returns the child's final text when `schema` is None. With `schema`
+        supplied, the child is prompted to emit a fenced JSON block matching
+        the shape; the parsed dict is returned (NOT the text). On a parse
+        failure the call silently falls back to returning the raw text.
+
+        Like `llm_call`'s model override, the per-call `model` is an
+        execution detail and is NOT part of the journal fingerprint —
+        callers may swap models between runs without busting the cache.
+        """
+        seq = self._next_seq()
+        fp = fingerprint("subagent", {
+            "prompt": prompt,
+            "schema": schema,
+            "allowed_tools": sorted(allowed_tools) if allowed_tools else None,
+            "allow_vault_retrieval": allow_vault_retrieval,
+            "allow_vault_read": allow_vault_read,
+        })
+        cached, hit = self._check_or_none(seq, "subagent", fp)
+        if hit:
+            # On replay, the cache is whatever the live path journaled: a
+            # dict (when schema produced parseable JSON) or str (text or
+            # error). Narrow for the type checker.
+            assert isinstance(cached, (dict, str))
+            return cached
+        text, data = await _delegate.run_child_turn(
+            self.ctx,
+            task=prompt,
+            # Default to the workflow handle's configured model (parallel to
+            # `llm_call`). Without this, `run_child_turn` falls through to
+            # `ctx.active_model`, which can differ from the workflow's intent.
+            model=model or self._model,
+            allowed_tools=allowed_tools,
+            allow_vault_retrieval=allow_vault_retrieval,
+            allow_vault_read=allow_vault_read,
+            return_schema=schema,
+        )
+        result: dict | str = data if schema is not None and data is not None else text
+        self.journal.append(seq, "subagent", fp, result)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return result
+
+    async def parallel(
+        self,
+        thunks: list[Callable[["WorkflowHandle"], Coroutine[Any, Any, Any]]],
+    ) -> list[Any]:
+        """Run N thunks concurrently under sub-handles. Returns results in
+        thunk-index order. Errors propagate — wrap individual thunks in
+        try/except for tolerant collection.
+
+        Each thunk receives a sub-handle keyed at (outer_seq, thunk_idx) so
+        its own journaled calls land at hierarchical seqs. Sub-handles share
+        ctx, journal, llm_caller, and model with the parent.
+
+        The outer journal entry caches the assembled result list. On replay:
+          * full-cache hit → return the list, no thunks run.
+          * mid-fan-out crash (outer entry missing) → re-dispatch every
+            thunk; each thunk's sub-handle hits its existing journal entries
+            (cached) and resumes from the first non-cached call.
+
+        Fingerprint includes only `count` — callables aren't JSON-serializable
+        and the child entries provide per-thunk replay safety.
+
+        Cooperative cancel: if `ctx.cancelled` is set during the fan-out, all
+        in-flight thunks are cancelled and `asyncio.CancelledError` is raised.
+        """
+        seq = self._next_seq()
+        fp = fingerprint("parallel", {"count": len(thunks)})
+        cached, hit = self._check_or_none(seq, "parallel", fp)
+        if hit:
+            assert isinstance(cached, list)
+            return cached
+
+        sub_handles = [self._make_subhandle_at(seq, idx)
+                       for idx in range(len(thunks))]
+        tasks: list[asyncio.Task] = [
+            asyncio.create_task(thunks[i](sub_handles[i]))
+            for i in range(len(thunks))
+        ]
+
+        # Cancel watcher: if ctx.cancelled fires, race it against the fan-out
+        # so we can preemptively cancel in-flight thunks. `ctx.cancelled is
+        # None` in contexts that never wire the event (e.g. unit tests that
+        # don't exercise cancellation) — skip the watcher there.
+        #
+        # We need the watcher to interrupt `asyncio.wait(..., FIRST_EXCEPTION)`
+        # so it raises after the event fires (FIRST_EXCEPTION ignores tasks
+        # that complete normally). The watcher raises an internal sentinel
+        # rather than CancelledError so the task transitions to "has exception"
+        # (not "cancelled"), which is what FIRST_EXCEPTION reacts to.
+        cancel_event = self.ctx.cancelled
+
+        class _CancelSignal(Exception):
+            """Internal sentinel: cancel_event fired. Never escapes."""
+
+        async def _cancel_watcher_body():
+            assert cancel_event is not None
+            await cancel_event.wait()
+            raise _CancelSignal()
+
+        cancel_watcher: asyncio.Task | None = None
+        if cancel_event is not None:
+            cancel_watcher = asyncio.create_task(_cancel_watcher_body())
+
+        try:
+            if not tasks:
+                # Zero thunks: nothing to await. (We must not wait on just
+                # the cancel watcher — it would block forever in the common
+                # case where cancellation never fires.)
+                results: list[Any] = []
+            else:
+                wait_set = list(tasks)
+                if cancel_watcher is not None:
+                    wait_set.append(cancel_watcher)
+                done, pending = await asyncio.wait(
+                    wait_set, return_when=asyncio.FIRST_EXCEPTION)
+
+                cancel_fired = (
+                    cancel_watcher is not None
+                    and cancel_watcher in done
+                    and not cancel_watcher.cancelled()
+                    and isinstance(cancel_watcher.exception(), _CancelSignal)
+                )
+                if cancel_fired:
+                    # Cancellation fired: tear down any in-flight thunks and
+                    # surface CancelledError to the caller.
+                    for t in tasks:
+                        if not t.done():
+                            t.cancel()
+                    # `return_exceptions=True` swallows the CancelledErrors
+                    # raised by the cancelled tasks — we re-raise our own
+                    # below after cleanup.
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise asyncio.CancelledError()
+
+                # No cancellation: either all tasks completed, or one raised
+                # and `pending` may still hold others (plus the cancel_watcher
+                # if no exception came from it). Cancel straggler thunks,
+                # drain them, then surface the first REAL exception (in
+                # thunk-index order). The cancel_watcher is cleaned up in
+                # the `finally` block, not gathered here.
+                stragglers = [t for t in pending if t is not cancel_watcher]
+                for t in stragglers:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*stragglers, return_exceptions=True)
+                # Locate the first task with a real (non-CancelledError)
+                # exception. Cancellation of pending tasks happens via our
+                # own cleanup gather above and must not mask the underlying
+                # failure: a naive `tasks[i].result()` in index order would
+                # raise the cleanup-induced CancelledError of a lower-index
+                # straggler instead of the higher-index thunk's real error.
+                first_exc: BaseException | None = None
+                for t in tasks:
+                    if t.done() and not t.cancelled():
+                        exc = t.exception()
+                        if exc is not None and not isinstance(
+                                exc, asyncio.CancelledError):
+                            first_exc = exc
+                            break
+                if first_exc is not None:
+                    raise first_exc
+                results = [t.result() for t in tasks]
+        finally:
+            if cancel_watcher is not None:
+                if not cancel_watcher.done():
+                    cancel_watcher.cancel()
+                    try:
+                        await cancel_watcher
+                    except asyncio.CancelledError:
+                        pass  # expected: we just cancelled it
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "parallel cancel-watcher cleanup error: %r", exc)
+                else:
+                    # Watcher already done — retrieve its exception (the
+                    # _CancelSignal sentinel) so asyncio doesn't log a
+                    # "Task exception was never retrieved" warning.
+                    if not cancel_watcher.cancelled():
+                        cancel_watcher.exception()
+
+        self.journal.append(seq, "parallel", fp, results)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return results
+
+    async def pipeline(
+        self,
+        items: list,
+        *stages: Callable[[Any, Any, int, "WorkflowHandle"], Awaitable[Any]],
+    ) -> list:
+        """Per-item run of stage1 → stage2 → … → stageN. No barrier between
+        stages: each item flows through every stage independently of the
+        other items. Returns the final-stage result per item in item-index
+        order.
+
+        Each stage receives `(prev, item, idx, sub)` where `prev` is the
+        previous stage's return (or `item` itself for the first stage),
+        `item` is `items[idx]`, and `sub` is the per-item sub-handle that
+        stages MUST use for any journaled call so keys land under
+        `(outer_seq, idx, ...)`.
+
+        Fingerprint includes `items` and `stage_count` (stages aren't
+        callable-serializable). On a mid-fan-out crash the outer entry is
+        NOT written, so replay re-dispatches every item; each item's
+        sub-handle hits its already-journaled stage results and resumes
+        from the first non-cached call.
+
+        Cooperative cancel: if `ctx.cancelled` is set during the fan-out,
+        all in-flight items are cancelled and `asyncio.CancelledError` is
+        raised.
+        """
+        seq = self._next_seq()
+        fp = fingerprint(
+            "pipeline", {"items": items, "stage_count": len(stages)})
+        cached, hit = self._check_or_none(seq, "pipeline", fp)
+        if hit:
+            assert isinstance(cached, list)
+            return cached
+
+        if not items:
+            results: list = []
+            self.journal.append(seq, "pipeline", fp, results)
+            save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+            return results
+
+        async def _run_one(item, idx):
+            sub = self._make_subhandle_at(seq, idx)
+            prev = item
+            for stage in stages:
+                prev = await stage(prev, item, idx, sub)
+            return prev
+
+        tasks: list[asyncio.Task] = [
+            asyncio.create_task(_run_one(items[i], i))
+            for i in range(len(items))
+        ]
+
+        # Cancel watcher mirrors `parallel`'s pattern. The watcher raises a
+        # private sentinel (not CancelledError) so the task transitions to
+        # "has exception", which is what FIRST_EXCEPTION reacts to.
+        cancel_event = self.ctx.cancelled
+
+        class _CancelSignal(Exception):
+            """Internal sentinel: cancel_event fired. Never escapes."""
+
+        async def _cancel_watcher_body():
+            assert cancel_event is not None
+            await cancel_event.wait()
+            raise _CancelSignal()
+
+        cancel_watcher: asyncio.Task | None = None
+        if cancel_event is not None:
+            cancel_watcher = asyncio.create_task(_cancel_watcher_body())
+
+        try:
+            wait_set = list(tasks)
+            if cancel_watcher is not None:
+                wait_set.append(cancel_watcher)
+            done, pending = await asyncio.wait(
+                wait_set, return_when=asyncio.FIRST_EXCEPTION)
+
+            cancel_fired = (
+                cancel_watcher is not None
+                and cancel_watcher in done
+                and not cancel_watcher.cancelled()
+                and isinstance(cancel_watcher.exception(), _CancelSignal)
+            )
+            if cancel_fired:
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise asyncio.CancelledError()
+
+            # No cancellation: cancel any pending stragglers and surface
+            # the first REAL exception in item-index order. Naive
+            # `tasks[i].result()` would raise the cleanup-induced
+            # CancelledError of a lower-index straggler and mask a
+            # higher-index item's actual failure — see `parallel`'s
+            # post-fix shape for the regression guard.
+            stragglers = [t for t in pending if t is not cancel_watcher]
+            for t in stragglers:
+                if not t.done():
+                    t.cancel()
+            await asyncio.gather(*stragglers, return_exceptions=True)
+            first_exc: BaseException | None = None
+            for t in tasks:
+                if t.done() and not t.cancelled():
+                    exc = t.exception()
+                    if exc is not None and not isinstance(
+                            exc, asyncio.CancelledError):
+                        first_exc = exc
+                        break
+            if first_exc is not None:
+                raise first_exc
+            results = [t.result() for t in tasks]
+        finally:
+            if cancel_watcher is not None:
+                if not cancel_watcher.done():
+                    cancel_watcher.cancel()
+                    try:
+                        await cancel_watcher
+                    except asyncio.CancelledError:
+                        pass  # expected: we just cancelled it
+                    except Exception as exc:  # noqa: BLE001
+                        log.debug(
+                            "pipeline cancel-watcher cleanup error: %r", exc)
+                else:
+                    # Watcher already done — retrieve its exception (the
+                    # _CancelSignal sentinel) so asyncio doesn't log a
+                    # "Task exception was never retrieved" warning.
+                    if not cancel_watcher.cancelled():
+                        cancel_watcher.exception()
+
+        self.journal.append(seq, "pipeline", fp, results)
+        save_journal(self.ctx.config, self.ctx.conv_id, self.journal)
+        return results
+
     async def user_input(self, prompt: str, *, choices: list[str] | None = None):
-        seq = self._cursor
-        self._cursor += 1
+        seq = self._next_seq()
         fp = fingerprint("user_input", {"prompt": prompt, "choices": choices})
         cached, hit = self._check_or_none(seq, "user_input", fp)
         if hit:
             return cached
-        # New, unanswered → suspend. The journal (entries 0..seq-1) is already
-        # persisted by the preceding live call (or empty on a fresh start).
+        # New, unanswered → suspend. The journal (entries prior to seq) is
+        # already persisted by the preceding live call (or empty on a fresh
+        # start).
         raise WorkflowSuspended(seq=seq, args_fingerprint=fp, prompt=prompt,
                                 choices=choices)

--- a/src/decafclaw/workflow/journal.py
+++ b/src/decafclaw/workflow/journal.py
@@ -1,8 +1,16 @@
 """Durable, ordered record of journaled-call results for one workflow run.
 
-Entries are keyed positionally by execution order: the Nth journaled call
-executed gets sequence N. This is what makes loops replay correctly — same
-control flow produces the same execution order, hence the same keys.
+Entries are keyed by a tuple-path "seq": a tuple of ints denoting the
+hierarchical position of the journaled call. Top-level calls are 1-tuples
+like (0,), (1,), …; nested calls inside a sub-handle (e.g. one branch of a
+parallel batch) use longer tuples like (3, 0), (3, 1), …. Same control flow
+produces the same execution order, hence the same keys — which is what makes
+loops replay correctly.
+
+On disk we serialize the tuple as a dotted string ("3.1.0") for readability
+and for forward compatibility with non-Python consumers. Legacy journals
+that wrote a bare int seq (pre-#574) are transparently upgraded to 1-tuples
+by `from_dict` so we don't need a migration step.
 """
 import dataclasses
 import hashlib
@@ -25,7 +33,7 @@ def fingerprint(kind: str, args: dict) -> str:
 
 @dataclasses.dataclass
 class JournalEntry:
-    seq: int
+    seq: tuple[int, ...]
     kind: str
     args_fingerprint: str
     result: Any
@@ -35,30 +43,66 @@ class JournalEntry:
 class Journal:
     workflow_name: str
     status: str = "running"  # running | suspended | done | error
-    entries: list[JournalEntry] = dataclasses.field(default_factory=list)
+    entries: dict[tuple[int, ...], JournalEntry] = dataclasses.field(
+        default_factory=dict)
 
-    def get(self, seq: int) -> JournalEntry | None:
-        if 0 <= seq < len(self.entries):
-            return self.entries[seq]
-        return None
+    def get(self, seq: tuple[int, ...]) -> JournalEntry | None:
+        return self.entries.get(seq)
 
-    def append(self, seq: int, kind: str, args_fingerprint: str,
-               result: Any) -> None:
-        if seq != len(self.entries):
+    def append(self, seq: tuple[int, ...], kind: str,
+               args_fingerprint: str, result: Any) -> None:
+        if seq in self.entries:
+            prev = self.entries[seq]
             raise ValueError(
-                f"non-contiguous journal append: seq={seq}, "
-                f"len={len(self.entries)}")
-        self.entries.append(JournalEntry(seq, kind, args_fingerprint, result))
+                f"duplicate journal append at seq={seq}: "
+                f"recorded {prev.kind}/{prev.args_fingerprint}, "
+                f"now {kind}/{args_fingerprint}")
+        self.entries[seq] = JournalEntry(seq, kind, args_fingerprint, result)
 
     def to_dict(self) -> dict:
-        return dataclasses.asdict(self)
+        # Hand-rolled rather than dataclasses.asdict: tuple dict-keys aren't
+        # JSON-serializable, and entries needs custom path serialization.
+        # Sort by seq so the on-disk order is stable — parallel branches can
+        # land out-of-order in `entries`, which would otherwise produce noisy
+        # diffs and confuse manual journal inspection.
+        return {
+            "workflow_name": self.workflow_name,
+            "status": self.status,
+            "entries": [
+                {"seq": path_to_str(e.seq), "kind": e.kind,
+                 "args_fingerprint": e.args_fingerprint, "result": e.result}
+                for e in sorted(self.entries.values(), key=lambda e: e.seq)
+            ],
+        }
 
     @classmethod
     def from_dict(cls, d: dict) -> "Journal":
         j = cls(workflow_name=d["workflow_name"],
                 status=d.get("status", "running"))
-        j.entries = [JournalEntry(**e) for e in d.get("entries", [])]
+        for entry_d in d.get("entries", []):
+            seq = path_from_any(entry_d["seq"])
+            if seq in j.entries:
+                raise ValueError(f"duplicate seq in journal file: {seq}")
+            j.entries[seq] = JournalEntry(
+                seq, entry_d["kind"], entry_d["args_fingerprint"],
+                entry_d["result"])
         return j
+
+
+def path_to_str(path: tuple[int, ...]) -> str:
+    return ".".join(str(i) for i in path)
+
+
+def path_from_any(v) -> tuple[int, ...]:
+    """Accept tuple (in-memory), int (legacy flat seq), or dotted str (new
+    on-disk)."""
+    if isinstance(v, int):
+        return (v,)
+    if isinstance(v, str):
+        return tuple(int(p) for p in v.split("."))
+    if isinstance(v, (tuple, list)):
+        return tuple(int(p) for p in v)
+    raise TypeError(f"unrecognized journal seq: {v!r}")
 
 
 def save_journal(config, conv_id: str, journal: Journal) -> None:

--- a/src/decafclaw/workflow/resume.py
+++ b/src/decafclaw/workflow/resume.py
@@ -15,7 +15,7 @@ from decafclaw.confirmations import (
 from decafclaw.media import ToolResult
 
 from .engine import run_workflow
-from .journal import Journal, load_journal, save_journal
+from .journal import Journal, load_journal, path_from_any, path_to_str, save_journal
 from .registry import get_workflow
 
 log = logging.getLogger(__name__)
@@ -63,7 +63,10 @@ async def run_workflow_turn(ctx, manager, *,
             message=s.prompt,
             action_data={
                 "workflow_name": workflow_name,
-                "seq": s.seq,
+                # action_data is JSON-bound (lives in the archive). Serialize
+                # the tuple-path seq as a dotted string here; the on-approve
+                # handler parses it back via path_from_any.
+                "seq": path_to_str(s.seq),
                 "args_fingerprint": s.args_fingerprint,
                 "prompt": s.prompt,
                 "choices": s.choices,
@@ -90,7 +93,8 @@ class WorkflowUserInputHandler:
         if journal is None:
             log.error("workflow resume: no journal for conv %s", ctx.conv_id)
             return {"continue_loop": False}
-        journal.append(ad["seq"], "user_input", ad["args_fingerprint"], answer)
+        seq = path_from_any(ad["seq"])
+        journal.append(seq, "user_input", ad["args_fingerprint"], answer)
         journal.status = "running"
         save_journal(ctx.config, ctx.conv_id, journal)
 

--- a/src/decafclaw/workflow/workflows/__init__.py
+++ b/src/decafclaw/workflow/workflows/__init__.py
@@ -1,2 +1,5 @@
 """Importing this package registers all bundled orchestrators."""
-from . import interview  # noqa: F401
+from . import (
+    interview,  # noqa: F401
+    research,  # noqa: F401
+)

--- a/src/decafclaw/workflow/workflows/research.py
+++ b/src/decafclaw/workflow/workflows/research.py
@@ -1,0 +1,188 @@
+"""Research → report: the multi-primitive hero workflow.
+
+User-invocable as /research (web UI). The orchestrator drives a focused
+research sweep end-to-end, exercising all four Phase 1-6 primitives:
+
+  * wf.user_input  — collect topic + scope from the user
+  * wf.llm_call    — plan a small set of search queries (structured output)
+  * wf.parallel    — fan out search queries via wf.tool_call inside thunks
+  * wf.pipeline    — per-source extract → summarize (structured output)
+  * wf.subagent    — final synthesis as a child agent turn with a schema
+
+The chosen search tool is `tabstack_research`: it accepts a single `query`
+string and synthesizes a markdown report. The orchestrator's pipeline
+extract stage simply pulls `text` out of the tool_call result dict, so
+swapping in a different fetch/search tool only requires changing the
+constant + the per-thunk `query=` keyword.
+"""
+from ..registry import workflow
+
+_SEARCH_TOOL = "tabstack_research"
+
+_SYS_PLAN = (
+    "You plan focused research sweeps. Given a topic and any scope notes, "
+    "generate 3-5 search queries that together cover the topic without "
+    "overlap. Each query should be specific enough to return a useful "
+    "single-page result."
+)
+_SYS_SUMMARIZE = (
+    "You write tight summaries of source material. Extract the 3-5 most "
+    "important specific points from the given content. Avoid generalities."
+)
+_SYS_SYNTH = (
+    "You synthesize a set of source summaries into a coherent written "
+    "report. Cite sources by their titles when relevant. Markdown body."
+)
+
+_PLAN_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "queries": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 3,
+            "maxItems": 5,
+            "description": "Search queries covering the topic.",
+        },
+    },
+    "required": ["queries"],
+}
+
+_SUMMARY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "key_points": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    },
+    "required": ["title", "key_points"],
+}
+
+_REPORT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "body": {"type": "string", "description": "Markdown body."},
+    },
+    "required": ["title", "body"],
+}
+
+
+def _research_plan_prompt(topic: str, scope: str) -> str:
+    lines = [f"Topic: {topic}"]
+    if scope:
+        lines.append(f"Scope / angle: {scope}")
+    lines.append("")
+    lines.append(
+        "Generate 3-5 search queries that together cover this topic.")
+    return "\n".join(lines)
+
+
+def _summarize_prompt(source_text: str) -> str:
+    # Cap the source to keep the summarize prompt comfortably under the
+    # model's input budget. Per-source cap is enough for a single-page
+    # research report; if a search tool ever returns much more, this is the
+    # knob to revisit.
+    capped = source_text[:8000]
+    return (
+        "Source content:\n\n"
+        f"{capped}\n\n"
+        "Summarize the 3-5 most important specific points."
+    )
+
+
+def _render_summary(s: dict) -> str:
+    """Plain helper — NOT journaled. Pure transformation over already-
+    journaled summary dicts, safe to re-run on every replay."""
+    if isinstance(s, dict) and "title" in s and "key_points" in s:
+        bullets = "\n".join(f"- {p}" for p in s.get("key_points", []))
+        return f"## {s['title']}\n{bullets}"
+    return str(s)
+
+
+def _is_error_result(r) -> bool:
+    """`wf.tool_call` returns `{"text", "data"}`; failed tools surface as
+    text starting with `[error:` (the decafclaw tool-failure convention)."""
+    return (isinstance(r, dict)
+            and r.get("data") is None
+            and isinstance(r.get("text"), str)
+            and r["text"].startswith("[error:"))
+
+
+def _synth_prompt(topic: str, scope: str, summaries: list[dict]) -> str:
+    lines = [f"Topic: {topic}"]
+    if scope:
+        lines.append(f"Scope / angle: {scope}")
+    lines.append("")
+    lines.append("Source summaries:")
+    lines.append("")
+    for s in summaries:
+        lines.append(_render_summary(s))
+        lines.append("")
+    lines.append("Synthesize a titled markdown report.")
+    return "\n".join(lines)
+
+
+def _make_search_thunk(query: str):
+    """Build a thunk for `wf.parallel`. Plain function returning an async
+    function (NOT `async def` returning the inner) — `wf.parallel` expects
+    `Callable[[sub], Awaitable[...]]`, not a coroutine."""
+    async def _thunk(sub):
+        return await sub.tool_call(_SEARCH_TOOL, query=query)
+    return _thunk
+
+
+@workflow("research")
+async def research(wf):
+    topic = await wf.user_input("What topic should I research?")
+    scope = await wf.user_input(
+        "Any specific angle, audience, or constraint? "
+        "(Press enter for none.)")
+
+    plan = await wf.llm_call(
+        prompt=_research_plan_prompt(topic, scope),
+        schema=_PLAN_SCHEMA,
+        system=_SYS_PLAN,
+    )
+    queries: list[str] = plan["queries"]
+
+    # Fan out the searches. Each thunk gets its own sub-handle from
+    # wf.parallel; the tool_call inside lands at (outer, idx, 0).
+    search_results = await wf.parallel(
+        [_make_search_thunk(q) for q in queries])
+
+    # Fail fast if the search tool isn't actually available in this
+    # workflow context (skill tools aren't reachable from workflow turns
+    # in v1 — see #574 smoke Finding 1). Without this check the pipeline
+    # would feed `[error: ...]` text into the summarizer, wasting tokens
+    # and producing low-quality output.
+    if all(_is_error_result(r) for r in search_results):
+        sample = search_results[0].get("text", "") if search_results else ""
+        raise RuntimeError(
+            f"/research: all {len(queries)} searches via {_SEARCH_TOOL!r} "
+            f"failed — tool likely unavailable in this workflow context. "
+            f"First error: {sample[:200]}")
+
+    # Per-result extract → summarize. Stage 1 is a pure dict→str
+    # transform (NOT journaled; safe to re-run on replay). Stage 2
+    # journals through sub.llm_call.
+    async def _extract_stage(prev, item, idx, sub):
+        return prev.get("text", "") if isinstance(prev, dict) else str(prev)
+
+    async def _summarize_stage(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=_summarize_prompt(prev),
+            schema=_SUMMARY_SCHEMA,
+            system=_SYS_SUMMARIZE,
+        )
+
+    summaries = await wf.pipeline(
+        search_results, _extract_stage, _summarize_stage)
+
+    # Final synthesis as a child agent turn with structured output.
+    return await wf.subagent(
+        prompt=_synth_prompt(topic, scope, summaries),
+        schema=_REPORT_SCHEMA,
+    )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -151,8 +151,8 @@ class TestExecuteCommand:
             body="Do $ARGUMENTS", context="fork",
             allowed_tools=["shell"],
         )
-        with patch("decafclaw.tools.delegate._run_child_turn", new_callable=AsyncMock) as mock:
-            mock.return_value = "child result"
+        with patch("decafclaw.tools.delegate.run_child_turn", new_callable=AsyncMock) as mock:
+            mock.return_value = ("child result", None)
             mode, result = await execute_command(ctx, skill, "the thing")
 
         assert mode == "fork"
@@ -208,8 +208,8 @@ class TestExecuteCommand:
         )
         with patch("decafclaw.tools.skill_tools.activate_skill_internal",
                     new_callable=AsyncMock, return_value="activated") as mock_activate, \
-             patch("decafclaw.tools.delegate._run_child_turn",
-                    new_callable=AsyncMock, return_value="child result"):
+             patch("decafclaw.tools.delegate.run_child_turn",
+                    new_callable=AsyncMock, return_value=("child result", None)):
             mode, result = await execute_command(ctx, skill, "")
 
         assert mode == "fork"
@@ -231,15 +231,15 @@ class TestExecuteCommand:
         )
         with patch("decafclaw.tools.skill_tools.activate_skill_internal",
                     new_callable=AsyncMock) as mock_activate, \
-             patch("decafclaw.tools.delegate._run_child_turn",
-                    new_callable=AsyncMock, return_value="done"):
+             patch("decafclaw.tools.delegate.run_child_turn",
+                    new_callable=AsyncMock, return_value=("done", None)):
             await execute_command(ctx, skill, "")
 
         mock_activate.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fork_mode_propagates_manager_to_child_turn(self, ctx):
-        """The ctx handed to _run_child_turn MUST carry the manager from the
+        """The ctx handed to run_child_turn MUST carry the manager from the
         parent ctx — otherwise delegate.py bails and the fork never runs."""
         sentinel_manager = object()
         ctx.manager = sentinel_manager
@@ -249,14 +249,14 @@ class TestExecuteCommand:
             body="Do $ARGUMENTS", context="fork",
         )
         with patch(
-            "decafclaw.tools.delegate._run_child_turn",
+            "decafclaw.tools.delegate.run_child_turn",
             new_callable=AsyncMock,
         ) as mock:
-            mock.return_value = "child result"
+            mock.return_value = ("child result", None)
             mode, result = await execute_command(ctx, skill, "go")
 
         assert mode == "fork"
-        # First positional arg to _run_child_turn is parent_ctx
+        # First positional arg to run_child_turn is parent_ctx
         called_ctx = mock.call_args.args[0]
         assert called_ctx.manager is sentinel_manager
 
@@ -271,7 +271,7 @@ class TestExecuteCommand:
             name="test-cmd", description="Test", location=Path("."),
             body="Do $ARGUMENTS", context="fork",
         )
-        # Do NOT mock _run_child_turn — let the real function hit its own
+        # Do NOT mock run_child_turn — let the real function hit its own
         # bail-out so the error text is the one real users would see.
         mode, result = await execute_command(ctx, skill, "go")
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -10,15 +10,19 @@ from decafclaw.events import EventBus
 from decafclaw.media import ToolResult
 from decafclaw.tools.delegate import (
     DEFAULT_CHILD_SYSTEM_PROMPT,
-    _run_child_turn,
+    run_child_turn,
     tool_delegate_task,
     tool_delegate_tasks,
 )
 
 
 def _text(result):
-    """Extract text from str or ToolResult."""
-    return result.text if isinstance(result, ToolResult) else result
+    """Extract text from a str / ToolResult / (text, data) tuple."""
+    if isinstance(result, ToolResult):
+        return result.text
+    if isinstance(result, tuple):
+        return result[0]
+    return result
 
 
 def _mock_llm_response(content="child result"):
@@ -47,13 +51,13 @@ def ctx(config):
 class TestRunChildTurn:
     @pytest.mark.asyncio
     async def test_basic_child_turn(self, ctx):
-        """Child agent runs and returns result text."""
+        """Child agent runs and returns (text, None) when no schema given."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="child says hello")
 
-            result = await _run_child_turn(ctx, "say hello")
+            result = await run_child_turn(ctx, "say hello")
 
-        assert result == "child says hello"
+        assert result == ("child says hello", None)
         mock_run.assert_called_once()
 
         # Check the child context passed to run_agent_turn
@@ -68,7 +72,7 @@ class TestRunChildTurn:
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert "delegate_task" not in child_ctx.tools.allowed
@@ -84,7 +88,7 @@ class TestRunChildTurn:
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.skills.data == {"vault_base_path": "obsidian/main"}
@@ -99,7 +103,7 @@ class TestRunChildTurn:
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert "some_skill_tool" in child_ctx.tools.extra
@@ -114,7 +118,7 @@ class TestRunChildTurn:
         ctx.config.agent.child_timeout_sec = 0.1
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock, side_effect=slow_turn):
-            result = await _run_child_turn(ctx, "slow task")
+            result = await run_child_turn(ctx, "slow task")
 
         assert "timed out" in _text(result)
 
@@ -123,7 +127,7 @@ class TestRunChildTurn:
         """Child that raises returns error text containing the exception message."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock,
                    side_effect=Exception("boom")):
-            result = await _run_child_turn(ctx, "bad task")
+            result = await run_child_turn(ctx, "bad task")
 
         # _start_turn catches the exception and forwards it as [error: boom]
         assert "boom" in _text(result)
@@ -137,7 +141,7 @@ class TestRunChildTurn:
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.cancelled is cancel
@@ -147,7 +151,7 @@ class TestRunChildTurn:
         """Missing manager on parent ctx returns an error."""
         ctx.manager = None
 
-        result = await _run_child_turn(ctx, "task")
+        result = await run_child_turn(ctx, "task")
 
         assert "error" in _text(result)
         assert "manager" in _text(result).lower()
@@ -166,7 +170,7 @@ class TestRunChildTurn:
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock,
                    side_effect=fake_run_agent_turn):
-            await _run_child_turn(ctx, "whatever")
+            await run_child_turn(ctx, "whatever")
 
         assert seen["user_id"] == "alice"
 
@@ -175,8 +179,8 @@ class TestToolDelegateTask:
     @pytest.mark.asyncio
     async def test_single_task(self, ctx):
         """Single task returns result wrapped in ToolResult."""
-        with patch("decafclaw.tools.delegate._run_child_turn",
-                   new_callable=AsyncMock, return_value="result one"):
+        with patch("decafclaw.tools.delegate.run_child_turn",
+                   new_callable=AsyncMock, return_value=("result one", None)):
             result = await tool_delegate_task(ctx, "do thing")
 
         assert isinstance(result, ToolResult)
@@ -261,22 +265,25 @@ class TestStructuredReturns:
     async def test_no_schema_text_only(self, ctx):
         """Without schema → text-only ToolResult, no data field
         (preserves byte-for-byte the existing single-task behaviour)."""
-        with patch("decafclaw.tools.delegate._run_child_turn",
-                   new_callable=AsyncMock, return_value="just prose"):
+        with patch("decafclaw.tools.delegate.run_child_turn",
+                   new_callable=AsyncMock, return_value=("just prose", None)):
             result = await tool_delegate_task(ctx, "do thing")
         assert result.text == "just prose"
         assert result.data is None
 
     @pytest.mark.asyncio
     async def test_schema_with_valid_json_populates_data(self, ctx):
-        child_response = (
-            "Analyzed the auth module — three issues found.\n\n"
-            "```json\n"
-            "{\"count\": 3, \"items\": [\"x\", \"y\", \"z\"]}\n"
-            "```"
-        )
-        with patch("decafclaw.tools.delegate._run_child_turn",
-                   new_callable=AsyncMock, return_value=child_response):
+        """With schema → prose lands on .text, parsed JSON on .data.
+        Parsing now happens inside run_child_turn, so the mock returns
+        the post-parsed tuple."""
+        with patch(
+            "decafclaw.tools.delegate.run_child_turn",
+            new_callable=AsyncMock,
+            return_value=(
+                "Analyzed the auth module — three issues found.",
+                {"count": 3, "items": ["x", "y", "z"]},
+            ),
+        ):
             result = await tool_delegate_task(
                 ctx, "audit auth",
                 return_schema={"count": "int", "items": "list[str]"},
@@ -288,9 +295,11 @@ class TestStructuredReturns:
 
     @pytest.mark.asyncio
     async def test_schema_with_no_json_falls_back_to_prose(self, ctx, caplog):
-        """Child forgot to emit JSON → silent fallback, debug log."""
-        with patch("decafclaw.tools.delegate._run_child_turn",
-                   new_callable=AsyncMock, return_value="forgot the json"):
+        """Child forgot to emit JSON → silent fallback, debug log.
+        With parsing moved into run_child_turn, the fallback shows up
+        as (raw_text, None)."""
+        with patch("decafclaw.tools.delegate.run_child_turn",
+                   new_callable=AsyncMock, return_value=("forgot the json", None)):
             result = await tool_delegate_task(
                 ctx, "audit", return_schema={"count": "int"},
             )
@@ -301,8 +310,8 @@ class TestStructuredReturns:
     async def test_schema_with_malformed_json_falls_back(self, ctx):
         """Bad JSON → silent fallback, raw text returned as-is."""
         bad = "prose\n```json\n{bad json,\n```"
-        with patch("decafclaw.tools.delegate._run_child_turn",
-                   new_callable=AsyncMock, return_value=bad):
+        with patch("decafclaw.tools.delegate.run_child_turn",
+                   new_callable=AsyncMock, return_value=(bad, None)):
             result = await tool_delegate_task(
                 ctx, "audit", return_schema={"count": "int"},
             )
@@ -311,15 +320,15 @@ class TestStructuredReturns:
 
     @pytest.mark.asyncio
     async def test_schema_passes_through_to_child_turn(self, ctx):
-        """Verify the schema reaches `_run_child_turn` so the addendum
+        """Verify the schema reaches `run_child_turn` so the addendum
         gets rendered into the child system prompt."""
         seen = {}
 
         async def fake_run(parent_ctx, task, model="", max_iterations=0, **kwargs):
             seen["schema"] = kwargs.get("return_schema")
-            return "ok"
+            return ("ok", None)
 
-        with patch("decafclaw.tools.delegate._run_child_turn",
+        with patch("decafclaw.tools.delegate.run_child_turn",
                    side_effect=fake_run):
             await tool_delegate_task(
                 ctx, "go", return_schema={"foo": "bar"},
@@ -419,7 +428,7 @@ class TestVaultAccessPolicy:
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         for tool in _VAULT_READ_TOOLS:
@@ -448,7 +457,7 @@ class TestVaultAccessPolicy:
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
-            await _run_child_turn(ctx, "task", allow_vault_read=True)
+            await run_child_turn(ctx, "task", allow_vault_read=True)
 
         child_ctx = mock_run.call_args[0][0]
         for tool in _VAULT_READ_TOOLS:
@@ -465,7 +474,7 @@ class TestVaultAccessPolicy:
         """Opt-in for proactive retrieval flips skip_vault_retrieval off."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
-            await _run_child_turn(ctx, "task", allow_vault_retrieval=True)
+            await run_child_turn(ctx, "task", allow_vault_retrieval=True)
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.skip_vault_retrieval is False
@@ -483,7 +492,7 @@ class TestVaultAccessPolicy:
 
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
-            await _run_child_turn(
+            await run_child_turn(
                 ctx, "task",
                 allow_vault_retrieval=True, allow_vault_read=True,
             )
@@ -497,15 +506,15 @@ class TestVaultAccessPolicy:
 
     @pytest.mark.asyncio
     async def test_tool_wrapper_threads_flags_through(self, ctx):
-        """`tool_delegate_task` parameters reach `_run_child_turn`."""
+        """`tool_delegate_task` parameters reach `run_child_turn`."""
         seen = {}
 
         async def fake_run(parent_ctx, task, model="", max_iterations=0, **kwargs):
             seen["allow_vault_retrieval"] = kwargs.get("allow_vault_retrieval")
             seen["allow_vault_read"] = kwargs.get("allow_vault_read")
-            return ToolResult(text="ok")
+            return ("ok", None)
 
-        with patch("decafclaw.tools.delegate._run_child_turn", side_effect=fake_run):
+        with patch("decafclaw.tools.delegate.run_child_turn", side_effect=fake_run):
             await tool_delegate_task(
                 ctx, "task",
                 allow_vault_retrieval=True,
@@ -521,7 +530,7 @@ class TestVaultAccessPolicy:
 class TestDelegateTasks:
     """Parallel batch dispatch via `delegate_tasks` (#397).
 
-    These tests patch ``_run_child_turn`` so we can control per-task
+    These tests patch ``run_child_turn`` so we can control per-task
     return values, simulate failures, and observe concurrency without
     spinning up real child agents.
     """
@@ -539,10 +548,10 @@ class TestDelegateTasks:
         ctx.publish = fake_publish
 
         async def fake_run(parent_ctx, task, **kwargs):
-            return f"result for {task}"
+            return (f"result for {task}", None)
 
         with patch(
-            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+            "decafclaw.tools.delegate.run_child_turn", side_effect=fake_run,
         ):
             result = await tool_delegate_tasks(ctx, ["a", "b", "c"])
 
@@ -569,11 +578,11 @@ class TestDelegateTasks:
             if task == "boom":
                 raise RuntimeError("kaboom")
             if task == "softfail":
-                return ToolResult(text="[error: subtask timed out]")
-            return f"ok for {task}"
+                return ("[error: subtask timed out]", None)
+            return (f"ok for {task}", None)
 
         with patch(
-            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+            "decafclaw.tools.delegate.run_child_turn", side_effect=fake_run,
         ):
             result = await tool_delegate_tasks(
                 ctx, ["fine", "softfail", "boom", "alsofine"],
@@ -642,10 +651,10 @@ class TestDelegateTasks:
             await cap_full.wait()
             async with state_lock:
                 state["in_flight"] -= 1
-            return f"done {task}"
+            return (f"done {task}", None)
 
         with patch(
-            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+            "decafclaw.tools.delegate.run_child_turn", side_effect=fake_run,
         ):
             result = await tool_delegate_tasks(
                 ctx, ["a", "b", "c", "d"],
@@ -657,17 +666,15 @@ class TestDelegateTasks:
     @pytest.mark.asyncio
     async def test_structured_return_parses_per_task(self, ctx):
         """When return_schema is supplied, each successful entry's
-        data is the parsed JSON and text is the prose."""
+        data is the parsed JSON and text is the prose.
+
+        Parsing happens inside run_child_turn now, so the mock returns
+        the post-parsed (prose, data) tuple."""
         async def fake_run(parent_ctx, task, **kwargs):
-            return (
-                f"prose for {task}\n\n"
-                "```json\n"
-                f'{{"task": "{task}", "score": 7}}\n'
-                "```\n"
-            )
+            return (f"prose for {task}", {"task": task, "score": 7})
 
         with patch(
-            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+            "decafclaw.tools.delegate.run_child_turn", side_effect=fake_run,
         ):
             result = await tool_delegate_tasks(
                 ctx, ["x", "y"], return_schema={"task": "string", "score": 0},
@@ -681,16 +688,16 @@ class TestDelegateTasks:
 
     @pytest.mark.asyncio
     async def test_event_override_routed_to_child_id(self, ctx):
-        """Each child's _run_child_turn call gets a unique override
+        """Each child's run_child_turn call gets a unique override
         for `event_context_id`, so parent UI doesn't get flooded."""
         seen_overrides: list[str | None] = []
 
         async def fake_run(parent_ctx, task, **kwargs):
             seen_overrides.append(kwargs.get("event_context_id_override"))
-            return f"ok {task}"
+            return (f"ok {task}", None)
 
         with patch(
-            "decafclaw.tools.delegate._run_child_turn", side_effect=fake_run,
+            "decafclaw.tools.delegate.run_child_turn", side_effect=fake_run,
         ):
             await tool_delegate_tasks(ctx, ["a", "b", "c"])
 
@@ -701,13 +708,13 @@ class TestDelegateTasks:
     @pytest.mark.asyncio
     async def test_run_child_turn_event_override_kwarg(self, ctx):
         """The new `event_context_id_override` kwarg on
-        `_run_child_turn` reaches the setup callback that
+        `run_child_turn` reaches the setup callback that
         `enqueue_turn` invokes — so the singular path stays unaffected
         and the plural override actually lands on the child ctx."""
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(
+            await run_child_turn(
                 ctx, "task",
                 event_context_id_override="custom-override-id",
             )
@@ -723,7 +730,7 @@ class TestDelegateTasks:
         with patch("decafclaw.agent.run_agent_turn", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = ToolResult(text="ok")
 
-            await _run_child_turn(ctx, "task")
+            await run_child_turn(ctx, "task")
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.event_context_id == "parent-subscriber-id"

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -32,7 +32,7 @@ async def test_completes_when_journal_fully_seeded(tmp_path):
 
     j = Journal(workflow_name="t")
     fp = fingerprint("user_input", {"prompt": "topic?", "choices": None})
-    j.append(0, "user_input", fp, "tide pools")
+    j.append((0,), "user_input", fp, "tide pools")
 
     outcome = await run_workflow(_ctx(tmp_path), wf, j)
     assert outcome.status == "done"

--- a/tests/test_workflow_handle.py
+++ b/tests/test_workflow_handle.py
@@ -24,7 +24,7 @@ async def test_llm_call_executes_live_and_journals(tmp_path):
     h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
     out = await h.llm_call(prompt="q1", schema={}, model="m")
     assert out == {"answer": 42}
-    assert j.get(0).kind == "llm_call"
+    assert j.get((0,)).kind == "llm_call"
     assert hits == ["q1"]
 
 
@@ -32,7 +32,7 @@ async def test_llm_call_executes_live_and_journals(tmp_path):
 async def test_replay_returns_cached_without_executing(tmp_path):
     j = Journal(workflow_name="t")
     fp = fingerprint("llm_call", {"prompt": "q1", "schema": {}, "system": ""})
-    j.append(0, "llm_call", fp, {"answer": 42})
+    j.append((0,), "llm_call", fp, {"answer": 42})
 
     async def boom(ctx, **kw):
         raise AssertionError("live LLM path must NOT run during replay")
@@ -48,7 +48,7 @@ async def test_user_input_suspends_when_unanswered(tmp_path):
     h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
     with pytest.raises(WorkflowSuspended) as ei:
         await h.user_input("What topic?")
-    assert ei.value.seq == 0
+    assert ei.value.seq == (0,)
     assert ei.value.prompt == "What topic?"
 
 
@@ -56,7 +56,7 @@ async def test_user_input_suspends_when_unanswered(tmp_path):
 async def test_user_input_replays_recorded_answer(tmp_path):
     j = Journal(workflow_name="t")
     fp = fingerprint("user_input", {"prompt": "What topic?", "choices": None})
-    j.append(0, "user_input", fp, "tide pools")
+    j.append((0,), "user_input", fp, "tide pools")
     h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None)
     assert await h.user_input("What topic?") == "tide pools"
 
@@ -65,7 +65,7 @@ async def test_user_input_replays_recorded_answer(tmp_path):
 async def test_determinism_guard_fires_on_divergent_args(tmp_path):
     j = Journal(workflow_name="t")
     fp = fingerprint("llm_call", {"prompt": "ORIGINAL", "schema": {}, "system": ""})
-    j.append(0, "llm_call", fp, {"x": 1})
+    j.append((0,), "llm_call", fp, {"x": 1})
 
     async def fake_llm(ctx, **kw):
         return {"x": 1}
@@ -73,3 +73,105 @@ async def test_determinism_guard_fires_on_divergent_args(tmp_path):
     h = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
     with pytest.raises(WorkflowNonDeterministic):
         await h.llm_call(prompt="CHANGED", schema={}, model="m")
+
+
+def test_top_level_handle_cursor(tmp_path):
+    """Top-level handle (_key_prefix=()) yields (0,), (1,), (2,) from _next_seq."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(_ctx(tmp_path), j)
+    assert h._key_prefix == ()
+    assert h._cursor == 0
+    assert h._next_seq() == (0,)
+    assert h._cursor == 1
+    assert h._next_seq() == (1,)
+    assert h._cursor == 2
+    assert h._next_seq() == (2,)
+    assert h._cursor == 3
+
+
+def test_sub_handle_key_composition_single_level(tmp_path):
+    """A sub-handle built from outer_seq=(5,), idx=2 has prefix (5, 2) and fresh cursor."""
+    j = Journal(workflow_name="t")
+    parent = WorkflowHandle(_ctx(tmp_path), j)
+    sub = parent._make_subhandle_at(outer_seq=(5,), idx=2)
+    assert sub._key_prefix == (5, 2)
+    assert sub._cursor == 0
+    assert sub._next_seq() == (5, 2, 0)
+    assert sub._next_seq() == (5, 2, 1)
+
+
+def test_sub_handle_key_composition_nested(tmp_path):
+    """A grandchild sub-handle composes prefixes across two levels."""
+    j = Journal(workflow_name="t")
+    parent = WorkflowHandle(_ctx(tmp_path), j)
+    child = parent._make_subhandle_at(outer_seq=(5,), idx=2)
+    grandchild = child._make_subhandle_at(outer_seq=(5, 2, 0), idx=3)
+    assert grandchild._key_prefix == (5, 2, 0, 3)
+    assert grandchild._cursor == 0
+    assert grandchild._next_seq() == (5, 2, 0, 3, 0)
+
+
+def test_sub_handle_shares_ctx_journal_llm_caller_model(tmp_path):
+    """Sub-handle shares ctx, journal, llm_caller, model by identity (not copies)."""
+    j = Journal(workflow_name="t")
+    ctx = _ctx(tmp_path)
+
+    async def custom_llm(ctx, **kw):
+        return {"ok": True}
+
+    parent = WorkflowHandle(ctx, j, llm_caller=custom_llm, model="custom-model")
+    sub = parent._make_subhandle_at(outer_seq=(0,), idx=0)
+    assert sub.ctx is ctx
+    assert sub.journal is j
+    assert sub._llm_caller is custom_llm
+    assert sub._model == "custom-model"
+
+
+def test_sub_handle_cursor_independent_from_parent(tmp_path):
+    """_make_subhandle_at MUST NOT advance the parent's cursor; sub starts at 0."""
+    j = Journal(workflow_name="t")
+    parent = WorkflowHandle(_ctx(tmp_path), j)
+    parent._next_seq()  # advance parent to cursor=1
+    assert parent._cursor == 1
+    sub = parent._make_subhandle_at(outer_seq=(0,), idx=0)
+    # Parent cursor unchanged by sub-handle creation.
+    assert parent._cursor == 1
+    # Sub-handle starts fresh.
+    assert sub._cursor == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_call_uses_key_prefix_via_next_seq(tmp_path):
+    """A sub-handle at prefix (7,) journals its llm_call at seq (7, 0)."""
+    j = Journal(workflow_name="t")
+
+    async def fake_llm(ctx, **kw):
+        return {"sentinel": "v"}
+
+    parent = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm)
+    sub = parent._make_subhandle_at(outer_seq=(7,), idx=0)
+    # Reset prefix to (7,) directly by constructing one explicitly: the
+    # contract is that a handle whose _key_prefix is (7,) journals at (7, 0).
+    sub2 = WorkflowHandle(_ctx(tmp_path), j, llm_caller=fake_llm,
+                          _key_prefix=(7,))
+    result = await sub2.llm_call(prompt="q", schema={})
+    assert result == {"sentinel": "v"}
+    entry = j.get((7, 0))
+    assert entry is not None
+    assert entry.kind == "llm_call"
+    # And the _make_subhandle_at construction path produces the same behavior
+    # at its own prefix (7, 0):
+    result2 = await sub.llm_call(prompt="q2", schema={})
+    assert result2 == {"sentinel": "v"}
+    assert j.get((7, 0, 0)) is not None
+
+
+@pytest.mark.asyncio
+async def test_user_input_uses_key_prefix_via_next_seq(tmp_path):
+    """A sub-handle at prefix (7,) raises WorkflowSuspended with seq (7, 0)."""
+    j = Journal(workflow_name="t")
+    sub = WorkflowHandle(_ctx(tmp_path), j, llm_caller=None, _key_prefix=(7,))
+    with pytest.raises(WorkflowSuspended) as ei:
+        await sub.user_input("Pick one")
+    assert ei.value.seq == (7, 0)
+    assert ei.value.prompt == "Pick one"

--- a/tests/test_workflow_interview.py
+++ b/tests/test_workflow_interview.py
@@ -45,19 +45,19 @@ async def test_interview_replays_to_artifact(tmp_path):
         _ask_prompt,
         _synth_prompt,
     )
-    j.append(0, "user_input", fp_user("What should this interview be about?"),
+    j.append((0,), "user_input", fp_user("What should this interview be about?"),
              "tide pools")
     q1_prompt = _ask_prompt("tide pools", [])
-    j.append(1, "llm_call", fp_llm(q1_prompt, _DECISION_SCHEMA, _SYS_ASK),
+    j.append((1,), "llm_call", fp_llm(q1_prompt, _DECISION_SCHEMA, _SYS_ASK),
              {"done": False, "question": "What draws you to them?"})
-    j.append(2, "user_input", fp_user("What draws you to them?"), "the creatures")
+    j.append((2,), "user_input", fp_user("What draws you to them?"), "the creatures")
     q2_prompt = _ask_prompt(
         "tide pools", [{"q": "What draws you to them?", "a": "the creatures"}])
-    j.append(3, "llm_call", fp_llm(q2_prompt, _DECISION_SCHEMA, _SYS_ASK),
+    j.append((3,), "llm_call", fp_llm(q2_prompt, _DECISION_SCHEMA, _SYS_ASK),
              {"done": True, "question": ""})
     synth_prompt = _synth_prompt(
         "tide pools", [{"q": "What draws you to them?", "a": "the creatures"}])
-    j.append(4, "llm_call", fp_llm(synth_prompt, _ARTIFACT_SCHEMA, _SYS_SYNTH),
+    j.append((4,), "llm_call", fp_llm(synth_prompt, _ARTIFACT_SCHEMA, _SYS_SYNTH),
              {"title": "Tide Pools", "body": "..."})
 
     outcome = await run_workflow(_ctx(tmp_path), spec.fn, j)

--- a/tests/test_workflow_journal.py
+++ b/tests/test_workflow_journal.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -9,6 +10,7 @@ from decafclaw.workflow.journal import (
     load_journal,
     save_journal,
 )
+from decafclaw.workflow.paths import workflow_dir, workflow_path
 
 
 def _cfg(tmp_path):
@@ -22,34 +24,129 @@ def test_fingerprint_is_stable_and_order_insensitive():
     assert a != fingerprint("llm_call", {"prompt": "bye", "schema": {"x": 1}})
 
 
-def test_append_is_contiguous_and_get_by_seq():
+def test_append_and_get_by_tuple_seq():
     j = Journal(workflow_name="t")
-    j.append(0, "llm_call", "fp0", {"a": 1})
-    j.append(1, "user_input", "fp1", "answer")
-    assert j.get(0).result == {"a": 1}
-    assert j.get(1).result == "answer"
-    assert j.get(2) is None
+    j.append((0,), "llm_call", "fp0", {"a": 1})
+    j.append((1,), "user_input", "fp1", "answer")
+    assert j.get((0,)).result == {"a": 1}
+    assert j.get((1,)).result == "answer"
+    assert j.get((2,)) is None
 
 
-def test_append_rejects_non_contiguous_seq():
+def test_append_rejects_duplicate_seq():
     j = Journal(workflow_name="t")
+    j.append((0,), "llm_call", "fp", None)
     with pytest.raises(ValueError):
-        j.append(1, "llm_call", "fp", None)
+        j.append((0,), "llm_call", "fp", None)
 
 
-def test_save_and_load_round_trip(tmp_path):
+def test_append_accepts_non_contiguous_tuple_paths():
+    """Tuple paths can land out of order (parallel thunks finish in any
+    order); the journal only enforces no-duplicates, not contiguity."""
+    j = Journal(workflow_name="t")
+    j.append((1, 0), "llm_call", "fp10", "a")
+    j.append((0,), "user_input", "fp0", "b")  # earlier seq, lands later
+    j.append((1, 2), "llm_call", "fp12", "c")  # gap at (1, 1) is fine
+    assert j.get((1, 0)).result == "a"
+    assert j.get((0,)).result == "b"
+    assert j.get((1, 2)).result == "c"
+
+
+def test_save_and_load_round_trip_tuple_seq(tmp_path):
     cfg = _cfg(tmp_path)
     j = Journal(workflow_name="interview", status="suspended")
-    j.append(0, "user_input", "fp0", "topic")
+    j.append((0,), "user_input", "fp0", "topic")
+    j.append((1, 2), "llm_call", "fp12", {"a": 1})
     save_journal(cfg, "conv1", j)
 
     loaded = load_journal(cfg, "conv1")
     assert loaded.workflow_name == "interview"
     assert loaded.status == "suspended"
-    assert loaded.get(0).kind == "user_input"
-    assert loaded.get(0).result == "topic"
-    assert loaded.get(0).args_fingerprint == "fp0"
+    assert loaded.get((0,)).kind == "user_input"
+    assert loaded.get((0,)).result == "topic"
+    assert loaded.get((0,)).args_fingerprint == "fp0"
+    assert loaded.get((1, 2)).result == {"a": 1}
+
+
+def test_on_disk_format_uses_dotted_string_seq(tmp_path):
+    """The persisted JSON encodes seq as a dotted string for human
+    readability and forward compatibility (per #574 spec)."""
+    cfg = _cfg(tmp_path)
+    j = Journal(workflow_name="t")
+    j.append((0,), "user_input", "fp0", "x")
+    j.append((1, 2, 3), "llm_call", "fp123", {"y": 1})
+    save_journal(cfg, "convDotted", j)
+
+    raw = json.loads(workflow_path(cfg, "convDotted").read_text())
+    seqs = [e["seq"] for e in raw["entries"]]
+    assert seqs == ["0", "1.2.3"]
+
+
+def test_to_dict_sorts_entries_by_seq():
+    """Parallel branches can land in any insertion order; serialize sorted
+    so on-disk diffs are stable and manual inspection is straightforward."""
+    j = Journal(workflow_name="t")
+    # Insert out of order: (1, 0, 0) before (0, 1, 0), etc.
+    j.append((1, 0, 0), "tool_call", "fpA", "a")
+    j.append((0, 1, 0), "tool_call", "fpB", "b")
+    j.append((0, 0, 0), "tool_call", "fpC", "c")
+    j.append((2,), "llm_call", "fpD", "d")
+    d = j.to_dict()
+    seqs = [e["seq"] for e in d["entries"]]
+    assert seqs == ["0.0.0", "0.1.0", "1.0.0", "2"]
+
+
+def test_legacy_int_seq_upgrades_to_one_tuple(tmp_path):
+    """Existing on-disk journals (pre-#574) wrote integer seq values.
+    from_dict must transparently upgrade those to 1-tuples so we don't
+    require a migration step."""
+    cfg = _cfg(tmp_path)
+    # Hand-build a legacy-format journal file (integer seq).
+    workflow_dir(cfg, "convLegacy", create=True)
+    path = workflow_path(cfg, "convLegacy")
+    path.write_text(json.dumps({
+        "workflow_name": "interview",
+        "status": "suspended",
+        "entries": [
+            {"seq": 0, "kind": "user_input",
+             "args_fingerprint": "fp0", "result": "topic"},
+            {"seq": 1, "kind": "llm_call",
+             "args_fingerprint": "fp1", "result": {"a": 1}},
+        ],
+    }))
+
+    loaded = load_journal(cfg, "convLegacy")
+    assert loaded is not None
+    assert loaded.get((0,)).result == "topic"
+    assert loaded.get((1,)).result == {"a": 1}
+    # And after a round-trip save, the on-disk format is the new dotted form.
+    save_journal(cfg, "convLegacy", loaded)
+    raw = json.loads(path.read_text())
+    assert [e["seq"] for e in raw["entries"]] == ["0", "1"]
 
 
 def test_load_missing_returns_none(tmp_path):
     assert load_journal(_cfg(tmp_path), "nope") is None
+
+
+def test_from_dict_rejects_duplicate_seq(tmp_path):
+    """A corrupted journal file with two entries that resolve to the same
+    tuple-path seq must raise rather than silently overwrite — symmetric
+    with Journal.append's duplicate guard. Mixing an int and a dotted-str
+    form of the same seq exercises the path normalization too."""
+    cfg = _cfg(tmp_path)
+    workflow_dir(cfg, "convDup", create=True)
+    path = workflow_path(cfg, "convDup")
+    path.write_text(json.dumps({
+        "workflow_name": "interview",
+        "status": "running",
+        "entries": [
+            {"seq": 0, "kind": "user_input",
+             "args_fingerprint": "fp0", "result": "first"},
+            {"seq": "0", "kind": "user_input",
+             "args_fingerprint": "fp0", "result": "second"},
+        ],
+    }))
+
+    with pytest.raises(ValueError, match="duplicate seq"):
+        load_journal(cfg, "convDup")

--- a/tests/test_workflow_parallel.py
+++ b/tests/test_workflow_parallel.py
@@ -1,0 +1,290 @@
+"""Tests for WorkflowHandle.parallel (Phase 5).
+
+Exercises the fan-out / fan-in primitive: outer entry caches the assembled
+result list; each thunk gets a sub-handle so its journaled calls land at
+hierarchical seqs. Mid-fan-out crash → re-dispatch, each thunk replays its
+own cached calls and resumes from the first non-cached one.
+"""
+import asyncio
+
+import pytest
+
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+@pytest.mark.asyncio
+async def test_parallel_live_path_basic(ctx):
+    """Three thunks each return their index; results come back in index order
+    and the outer entry caches the assembled list."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def make_thunk(i):
+        async def thunk(sub):
+            return i
+        return thunk
+
+    thunks = [await make_thunk(i) for i in range(3)]
+    out = await h.parallel(thunks)
+    assert out == [0, 1, 2]
+
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "parallel"
+    assert entry.result == [0, 1, 2]
+    expected_fp = fingerprint("parallel", {"count": 3})
+    assert entry.args_fingerprint == expected_fp
+
+
+@pytest.mark.asyncio
+async def test_parallel_live_path_with_journaled_calls(ctx):
+    """Each thunk does an llm_call. Sub-handle keying lands each at (0, i, 0);
+    outer entry at (0,) caches the assembled result list."""
+    j = Journal(workflow_name="t")
+
+    call_counter = {"n": 0}
+
+    async def fake_llm(ctx, **kw):
+        # Distinguish per-call by prompt; return a tagged dict.
+        call_counter["n"] += 1
+        return {"answer": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    def make_thunk(i):
+        async def thunk(sub):
+            return await sub.llm_call(
+                prompt=f"q{i}", schema={"type": "object"})
+        return thunk
+
+    thunks = [make_thunk(i) for i in range(3)]
+    out = await h.parallel(thunks)
+
+    assert out == [{"answer": "q0"}, {"answer": "q1"}, {"answer": "q2"}]
+    assert call_counter["n"] == 3
+
+    # Child entries at (0, i, 0).
+    for i in range(3):
+        child = j.get((0, i, 0))
+        assert child is not None, f"missing child entry at (0, {i}, 0)"
+        assert child.kind == "llm_call"
+        assert child.result == {"answer": f"q{i}"}
+
+    # Outer entry at (0,).
+    outer = j.get((0,))
+    assert outer is not None
+    assert outer.kind == "parallel"
+    assert outer.result == [{"answer": "q0"}, {"answer": "q1"}, {"answer": "q2"}]
+
+
+@pytest.mark.asyncio
+async def test_parallel_replay_path_full_cache(ctx):
+    """When the outer entry is already journaled, replay returns it without
+    invoking the thunks."""
+    j = Journal(workflow_name="t")
+    fp = fingerprint("parallel", {"count": 3})
+    j.append((0,), "parallel", fp, ["a", "b", "c"])
+
+    h = WorkflowHandle(ctx, j)
+
+    def boom_thunk_factory(label):
+        async def thunk(sub):
+            raise AssertionError(
+                f"thunk {label} MUST NOT run during full-cache replay")
+        return thunk
+
+    thunks = [boom_thunk_factory(i) for i in range(3)]
+    out = await h.parallel(thunks)
+    assert out == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_mid_fanout_resume(ctx):
+    """Pre-populate child entries for thunks 0 and 1 (their llm_call
+    journaled) but NOT the outer entry. On re-dispatch, thunks 0 and 1 hit
+    their cached calls; thunk 2 runs live."""
+    j = Journal(workflow_name="t")
+
+    # Each thunk does ONE llm_call. The fingerprint is computed from the
+    # same prompt/schema/system the thunk passes, so we mirror that here.
+    def thunk_fp(i):
+        return fingerprint(
+            "llm_call",
+            {"prompt": f"q{i}", "schema": {"type": "object"}, "system": ""},
+        )
+
+    # Pre-seed cache for thunks 0 and 1 only.
+    j.append((0, 0, 0), "llm_call", thunk_fp(0), {"cached": "q0"})
+    j.append((0, 1, 0), "llm_call", thunk_fp(1), {"cached": "q1"})
+
+    live_calls: list[str] = []
+
+    async def fake_llm(ctx, **kw):
+        live_calls.append(kw["user_msg"])
+        return {"live": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    def make_thunk(i):
+        async def thunk(sub):
+            return await sub.llm_call(
+                prompt=f"q{i}", schema={"type": "object"})
+        return thunk
+
+    out = await h.parallel([make_thunk(i) for i in range(3)])
+
+    # Cached calls return their cached payloads; thunk 2 runs live.
+    assert out == [{"cached": "q0"}, {"cached": "q1"}, {"live": "q2"}]
+    # Only thunk 2's llm_call hit the live caller.
+    assert live_calls == ["q2"]
+
+    # Outer entry now written.
+    outer = j.get((0,))
+    assert outer is not None
+    assert outer.kind == "parallel"
+    assert outer.result == out
+
+
+@pytest.mark.asyncio
+async def test_parallel_propagates_first_exception(ctx):
+    """If any thunk raises, the exception surfaces from `parallel` and the
+    outer entry is NOT written (so replay re-dispatches)."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def ok_thunk(sub):
+        return "ok"
+
+    async def bad_thunk(sub):
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError, match="nope"):
+        await h.parallel([ok_thunk, bad_thunk, ok_thunk])
+
+    # No outer entry → replay will re-dispatch.
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_surfaces_real_exception_over_cleanup_cancel(ctx):
+    """A higher-index thunk raising while a lower-index thunk is still in
+    flight must surface the REAL exception, not the CancelledError that the
+    cleanup gather raises against the still-pending lower-index thunk.
+
+    Regression: a naive `[t.result() for t in tasks]` in index order would
+    consult `tasks[0].result()` first and raise the straggler's cleanup
+    CancelledError, masking `tasks[1]`'s ValueError.
+    """
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    started = asyncio.Event()
+    never_finish = asyncio.Event()  # set only on cancellation path
+
+    async def slow_thunk(sub):
+        started.set()  # signal we're in flight
+        # Wait forever; will be cancelled by parallel's cleanup gather.
+        await never_finish.wait()
+        return "unreachable"
+
+    async def fast_raiser(sub):
+        await started.wait()  # ensure slow_thunk has started
+        raise ValueError("real-error")
+
+    with pytest.raises(ValueError, match="real-error"):
+        await h.parallel([slow_thunk, fast_raiser])
+
+    # No outer entry — fan-out crashed, replay will re-dispatch.
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_cancels_inflight_on_ctx_cancelled(ctx):
+    """Setting ctx.cancelled mid-run cancels in-flight thunks and raises
+    CancelledError; no outer entry is written."""
+    ctx.cancelled = asyncio.Event()
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    started = asyncio.Event()
+    never_finish = asyncio.Event()  # set only on cancellation path
+
+    async def slow_thunk(sub):
+        started.set()
+        # Wait on an event that's never set — only cancellation breaks us out.
+        await never_finish.wait()
+        return "should-not-happen"
+
+    async def driver():
+        await h.parallel([slow_thunk, slow_thunk, slow_thunk])
+
+    task = asyncio.create_task(driver())
+    # Wait for thunks to actually start before signalling cancellation.
+    await started.wait()
+    ctx.cancelled.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # No outer entry — replay can re-dispatch.
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_zero_thunks(ctx):
+    """`parallel([])` returns [] immediately and journals an empty result."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    out = await h.parallel([])
+    assert out == []
+
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "parallel"
+    assert entry.result == []
+    expected_fp = fingerprint("parallel", {"count": 0})
+    assert entry.args_fingerprint == expected_fp
+
+
+@pytest.mark.asyncio
+async def test_parallel_nested_in_parallel(ctx):
+    """Outer parallel with one thunk that runs an inner parallel of one
+    thunk that runs one llm_call. Verify key composition lands at
+    (0, 0, 0, 0, 0) for the deepest journaled call."""
+    j = Journal(workflow_name="t")
+
+    async def fake_llm(ctx, **kw):
+        return {"echo": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    async def innermost(inner_sub):
+        return await inner_sub.llm_call(prompt="deep", schema={"x": 1})
+
+    async def outer_thunk(sub):
+        return await sub.parallel([innermost])
+
+    out = await h.parallel([outer_thunk])
+
+    assert out == [[{"echo": "deep"}]]
+
+    # Deepest llm_call at (0, 0, 0, 0, 0).
+    deep = j.get((0, 0, 0, 0, 0))
+    assert deep is not None
+    assert deep.kind == "llm_call"
+    assert deep.result == {"echo": "deep"}
+
+    # Inner parallel outer at (0, 0, 0).
+    inner_outer = j.get((0, 0, 0))
+    assert inner_outer is not None
+    assert inner_outer.kind == "parallel"
+    assert inner_outer.result == [{"echo": "deep"}]
+
+    # Top parallel outer at (0,).
+    top = j.get((0,))
+    assert top is not None
+    assert top.kind == "parallel"
+    assert top.result == [[{"echo": "deep"}]]

--- a/tests/test_workflow_pipeline.py
+++ b/tests/test_workflow_pipeline.py
@@ -1,0 +1,337 @@
+"""Tests for WorkflowHandle.pipeline (Phase 6).
+
+Per-item run of stage1 → stage2 → … → stageN. No barrier between stages.
+Each item gets its own sub-handle keyed (outer_seq, item_idx); all stages
+for that item share the sub-handle's cursor sequentially.
+"""
+import asyncio
+
+import pytest
+
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+@pytest.mark.asyncio
+async def test_pipeline_live_path_basic(ctx):
+    """Three items, two stages. Stage 1 doubles prev; stage 2 adds 1.
+    Items [1, 2, 3] -> [3, 5, 7]; outer entry caches the result list."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def stage_double(prev, item, idx, sub):
+        return prev * 2
+
+    async def stage_plus_one(prev, item, idx, sub):
+        return prev + 1
+
+    out = await h.pipeline([1, 2, 3], stage_double, stage_plus_one)
+    assert out == [3, 5, 7]
+
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "pipeline"
+    assert entry.result == [3, 5, 7]
+    expected_fp = fingerprint(
+        "pipeline", {"items": [1, 2, 3], "stage_count": 2})
+    assert entry.args_fingerprint == expected_fp
+
+
+@pytest.mark.asyncio
+async def test_pipeline_live_path_with_journaled_calls(ctx):
+    """Two items, two stages, each stage does an llm_call via the sub-handle.
+    Journal lands at (0, item_idx, stage_cursor) plus outer at (0,)."""
+    j = Journal(workflow_name="t")
+
+    async def fake_llm(ctx, **kw):
+        return {"answer": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    async def stage_one(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=f"s1-{item}", schema={"type": "object"})
+
+    async def stage_two(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=f"s2-{item}", schema={"type": "object"})
+
+    out = await h.pipeline(["A", "B"], stage_one, stage_two)
+    assert out == [{"answer": "s2-A"}, {"answer": "s2-B"}]
+
+    # Per-item, per-stage entries.
+    assert j.get((0, 0, 0)) is not None
+    assert j.get((0, 0, 0)).result == {"answer": "s1-A"}
+    assert j.get((0, 0, 1)) is not None
+    assert j.get((0, 0, 1)).result == {"answer": "s2-A"}
+    assert j.get((0, 1, 0)) is not None
+    assert j.get((0, 1, 0)).result == {"answer": "s1-B"}
+    assert j.get((0, 1, 1)) is not None
+    assert j.get((0, 1, 1)).result == {"answer": "s2-B"}
+
+    # Outer pipeline entry.
+    outer = j.get((0,))
+    assert outer is not None
+    assert outer.kind == "pipeline"
+    assert outer.result == [{"answer": "s2-A"}, {"answer": "s2-B"}]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_replay_path_full_cache(ctx):
+    """When the outer entry is already journaled, replay returns it without
+    invoking any stage."""
+    j = Journal(workflow_name="t")
+    fp = fingerprint("pipeline", {"items": [1, 2, 3], "stage_count": 2})
+    j.append((0,), "pipeline", fp, [10, 20, 30])
+
+    h = WorkflowHandle(ctx, j)
+
+    async def boom_stage(prev, item, idx, sub):
+        raise AssertionError("stage MUST NOT run during full-cache replay")
+
+    out = await h.pipeline([1, 2, 3], boom_stage, boom_stage)
+    assert out == [10, 20, 30]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_mid_resume_partial_progress(ctx):
+    """Pre-populate (0, 0, 0) with item-0's stage-1 cached result.
+    On re-dispatch: stage 1 for item 0 hits cache; stage 1 for item 1 runs
+    live; stage 2 for both items runs live."""
+    j = Journal(workflow_name="t")
+
+    # Stage 1 fingerprint for item "A" (the prompt the live stage uses).
+    s1_a_fp = fingerprint(
+        "llm_call",
+        {"prompt": "s1-A", "schema": {"type": "object"}, "system": ""},
+    )
+    j.append((0, 0, 0), "llm_call", s1_a_fp, {"cached": "s1-A"})
+
+    live_calls: list[str] = []
+
+    async def fake_llm(ctx, **kw):
+        live_calls.append(kw["user_msg"])
+        return {"live": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    async def stage_one(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=f"s1-{item}", schema={"type": "object"})
+
+    async def stage_two(prev, item, idx, sub):
+        return await sub.llm_call(
+            prompt=f"s2-{item}", schema={"type": "object"})
+
+    out = await h.pipeline(["A", "B"], stage_one, stage_two)
+
+    # item 0's stage 1 was cached; everything else ran live.
+    # Order of live_calls isn't strictly deterministic (concurrent), so
+    # check membership instead.
+    assert set(live_calls) == {"s1-B", "s2-A", "s2-B"}
+    assert out == [{"live": "s2-A"}, {"live": "s2-B"}]
+
+    # Outer entry now written.
+    outer = j.get((0,))
+    assert outer is not None
+    assert outer.kind == "pipeline"
+    assert outer.result == out
+
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_first_exception(ctx):
+    """If any stage raises, the exception surfaces and the outer entry is
+    NOT written (so replay re-dispatches)."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def stage_one(prev, item, idx, sub):
+        return prev
+
+    async def stage_two(prev, item, idx, sub):
+        if idx == 1:
+            raise ValueError("nope")
+        return prev
+
+    with pytest.raises(ValueError, match="nope"):
+        await h.pipeline([1, 2, 3], stage_one, stage_two)
+
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_propagates_real_exception_over_cleanup_cancel(ctx):
+    """A faster item's stage raising while a slower item is still in flight
+    must surface the REAL exception, not the cleanup CancelledError."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    started = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def slow_stage(prev, item, idx, sub):
+        if idx == 0:
+            started.set()
+            await never_finish.wait()
+            return "unreachable"
+        await started.wait()
+        raise ValueError("real-error")
+
+    async def passthrough(prev, item, idx, sub):
+        return prev
+
+    with pytest.raises(ValueError, match="real-error"):
+        await h.pipeline(["A", "B"], slow_stage, passthrough)
+
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_cancels_inflight_on_ctx_cancelled(ctx):
+    """Setting ctx.cancelled mid-run cancels in-flight items and raises
+    CancelledError; no outer entry is written."""
+    ctx.cancelled = asyncio.Event()
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    started = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def slow_stage(prev, item, idx, sub):
+        started.set()
+        await never_finish.wait()
+        return "should-not-happen"
+
+    async def driver():
+        await h.pipeline([1, 2, 3], slow_stage)
+
+    task = asyncio.create_task(driver())
+    await started.wait()
+    ctx.cancelled.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert j.get((0,)) is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_zero_items(ctx):
+    """`pipeline([])` returns [] immediately and journals an empty result."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def some_stage(prev, item, idx, sub):
+        raise AssertionError("must not run on empty items")
+
+    out = await h.pipeline([], some_stage)
+    assert out == []
+
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "pipeline"
+    assert entry.result == []
+    expected_fp = fingerprint(
+        "pipeline", {"items": [], "stage_count": 1})
+    assert entry.args_fingerprint == expected_fp
+
+
+@pytest.mark.asyncio
+async def test_pipeline_zero_stages(ctx):
+    """`pipeline([1, 2])` with no stages returns items unchanged."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    out = await h.pipeline([1, 2])
+    assert out == [1, 2]
+
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "pipeline"
+    assert entry.result == [1, 2]
+    expected_fp = fingerprint(
+        "pipeline", {"items": [1, 2], "stage_count": 0})
+    assert entry.args_fingerprint == expected_fp
+
+
+@pytest.mark.asyncio
+async def test_pipeline_stage_signature_includes_sub(ctx):
+    """Stage receives (prev, item, idx, sub) — verify sub is a WorkflowHandle
+    keyed at (outer_seq, idx)."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    seen: list[tuple[int, tuple[int, ...]]] = []
+
+    async def stage(prev, item, idx, sub):
+        assert isinstance(sub, WorkflowHandle)
+        seen.append((idx, sub._key_prefix))
+        return prev
+
+    await h.pipeline(["x", "y", "z"], stage)
+
+    assert seen == [(0, (0, 0)), (1, (0, 1)), (2, (0, 2))]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_fingerprint_includes_items(ctx):
+    """Two runs with different item lists produce different fingerprints,
+    so a cached entry from run A doesn't match run B."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    async def stage(prev, item, idx, sub):
+        return prev
+
+    fp_a = fingerprint("pipeline", {"items": [1, 2], "stage_count": 1})
+    fp_b = fingerprint("pipeline", {"items": [1, 3], "stage_count": 1})
+    assert fp_a != fp_b
+
+    # Pre-populate journal entry under fp_a; running with different items
+    # would raise WorkflowNonDeterministic (fingerprint mismatch).
+    j.append((0,), "pipeline", fp_a, [1, 2])
+
+    from decafclaw.workflow.errors import WorkflowNonDeterministic
+    with pytest.raises(WorkflowNonDeterministic):
+        await h.pipeline([1, 3], stage)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_nested_with_parallel(ctx):
+    """A pipeline stage uses sub.parallel internally. Verify nested journal
+    keys: stage-level parallel outer at (0, 0, 0); inner thunk's llm_call
+    at (0, 0, 0, 0, 0)."""
+    j = Journal(workflow_name="t")
+
+    async def fake_llm(ctx, **kw):
+        return {"echo": kw["user_msg"]}
+
+    h = WorkflowHandle(ctx, j, llm_caller=fake_llm)
+
+    async def inner_thunk(inner_sub):
+        return await inner_sub.llm_call(prompt="deep", schema={"x": 1})
+
+    async def stage_uses_parallel(prev, item, idx, sub):
+        return await sub.parallel([inner_thunk])
+
+    out = await h.pipeline(["only"], stage_uses_parallel)
+    assert out == [[{"echo": "deep"}]]
+
+    # Innermost llm_call at (0, 0, 0, 0, 0).
+    deep = j.get((0, 0, 0, 0, 0))
+    assert deep is not None
+    assert deep.kind == "llm_call"
+    assert deep.result == {"echo": "deep"}
+
+    # Stage-internal parallel outer at (0, 0, 0).
+    inner_outer = j.get((0, 0, 0))
+    assert inner_outer is not None
+    assert inner_outer.kind == "parallel"
+    assert inner_outer.result == [{"echo": "deep"}]
+
+    # Top pipeline outer at (0,).
+    top = j.get((0,))
+    assert top is not None
+    assert top.kind == "pipeline"
+    assert top.result == [[{"echo": "deep"}]]

--- a/tests/test_workflow_research.py
+++ b/tests/test_workflow_research.py
@@ -1,0 +1,324 @@
+"""Tests for the /research hero workflow (Phase 7).
+
+The orchestrator exercises all four new primitives end-to-end:
+  * wf.user_input (twice — topic, scope)
+  * wf.llm_call    (the plan stage)
+  * wf.parallel    (fan-out search queries via wf.tool_call inside thunks)
+  * wf.pipeline    (per-result extract → summarize via sub.llm_call)
+  * wf.subagent    (final synthesis)
+
+These tests mock the engine boundaries (LLM caller, tool execution,
+delegate.run_child_turn) so we can walk the orchestrator deterministically
+without touching real model/search providers. Phase 8's live smoke covers
+the real wiring.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import decafclaw.workflow.workflows  # noqa: F401 — registers research
+from decafclaw.media import ToolResult
+from decafclaw.workflow.engine import run_workflow
+from decafclaw.workflow.journal import Journal, fingerprint
+from decafclaw.workflow.registry import get_workflow
+
+# --- Helpers ---------------------------------------------------------------
+
+def _fp_user(prompt):
+    return fingerprint("user_input", {"prompt": prompt, "choices": None})
+
+
+def _fp_llm(prompt, schema, system):
+    return fingerprint(
+        "llm_call", {"prompt": prompt, "schema": schema, "system": system})
+
+
+def _fp_tool(name, args):
+    return fingerprint("tool_call", {"name": name, "args": args})
+
+
+def _fp_parallel(count):
+    return fingerprint("parallel", {"count": count})
+
+
+def _fp_pipeline(items, stage_count):
+    return fingerprint(
+        "pipeline", {"items": items, "stage_count": stage_count})
+
+
+# --- Tests -----------------------------------------------------------------
+
+def test_research_registers_as_workflow():
+    """The @workflow('research') decorator side-effects the registry on
+    import; this is the contract the slash-command dispatcher depends on."""
+    spec = get_workflow("research")
+    assert spec is not None
+    assert spec.name == "research"
+
+
+@pytest.mark.asyncio
+async def test_research_orchestrator_walks_to_completion(ctx):
+    """Walk the whole orchestrator with mocked primitives. Verify it
+    invokes each primitive in the right order, threads results through,
+    and returns the synthesized report dict."""
+    from decafclaw.workflow.workflows.research import (
+        _PLAN_SCHEMA,
+        _REPORT_SCHEMA,
+        _SEARCH_TOOL,
+        _SUMMARY_SCHEMA,
+        _SYS_PLAN,
+        _SYS_SUMMARIZE,
+    )
+
+    spec = get_workflow("research")
+    assert spec is not None
+
+    # Seed the journal with the two user_input answers so the orchestrator
+    # walks past the suspend points. Everything downstream runs "live"
+    # against mocked primitives.
+    j = Journal(workflow_name="research")
+    j.append((0,), "user_input",
+             _fp_user("What topic should I research?"),
+             "tide pool ecology")
+    j.append((1,), "user_input",
+             _fp_user("Any specific angle, audience, or constraint? "
+                      "(Press enter for none.)"),
+             "for a general audience")
+
+    # Mock the LLM caller (plan stage + per-source summarize stages).
+    plan_result = {"queries": ["q1: anemones", "q2: hermit crabs",
+                                "q3: ochre stars"]}
+    summarize_returns = [
+        {"title": "Anemones", "key_points": ["sting", "symbiosis"]},
+        {"title": "Hermit crabs", "key_points": ["shells", "moult"]},
+        {"title": "Ochre stars", "key_points": ["keystone", "wasting"]},
+    ]
+
+    llm_calls: list[dict] = []
+    summarize_idx = {"n": 0}
+
+    async def fake_llm(ctx, **kw):
+        llm_calls.append(kw)
+        if kw["system"] == _SYS_PLAN:
+            return plan_result
+        if kw["system"] == _SYS_SUMMARIZE:
+            r = summarize_returns[summarize_idx["n"]]
+            summarize_idx["n"] += 1
+            return r
+        raise AssertionError(f"unexpected llm_call: system={kw['system']!r}")
+
+    # Mock the tool dispatcher. Each call returns a fake search result.
+    tool_calls: list[tuple[str, dict]] = []
+
+    async def fake_tool(ctx, name, args):
+        tool_calls.append((name, args))
+        return ToolResult(text=f"Results for {args.get('query', '?')}",
+                          data=None)
+
+    # Mock the subagent (delegate.run_child_turn).
+    final_report = {"title": "Tide pools",
+                    "body": "# Tide pools\n\nSynthesized."}
+
+    # ctx needs a workspace_path the journal can persist to.
+    # The research orchestrator gates tool_call by ctx.tools.allowed; allow
+    # the chosen search tool through.
+    ctx.tools.allowed = {_SEARCH_TOOL}
+
+    with patch("decafclaw.workflow.handle.execute_tool", new=fake_tool), \
+         patch(
+             "decafclaw.tools.delegate.run_child_turn",
+             new_callable=AsyncMock,
+             return_value=("ignored text", final_report),
+         ) as mock_child:
+        outcome = await run_workflow(
+            ctx, spec.fn, j, llm_caller=fake_llm)
+
+    # The orchestrator returns the structured report (subagent with schema
+    # returns the dict, not the text).
+    assert outcome.status == "done", f"got {outcome.status}: {outcome.error}"
+    assert outcome.result == final_report
+
+    # Primitives invoked in expected order:
+    #   1 plan llm_call + 3 summarize llm_calls = 4 total.
+    assert len(llm_calls) == 4
+    assert llm_calls[0]["schema"] == _PLAN_SCHEMA
+    assert llm_calls[0]["system"] == _SYS_PLAN
+    for i in range(1, 4):
+        assert llm_calls[i]["schema"] == _SUMMARY_SCHEMA
+        assert llm_calls[i]["system"] == _SYS_SUMMARIZE
+
+    # One tool_call per query.
+    assert len(tool_calls) == 3
+    for (name, args), q in zip(tool_calls, plan_result["queries"]):
+        assert name == _SEARCH_TOOL
+        assert args.get("query") == q
+
+    # Subagent called once with the report schema.
+    mock_child.assert_called_once()
+    _args, kwargs = mock_child.call_args
+    assert kwargs["return_schema"] == _REPORT_SCHEMA
+
+
+@pytest.mark.asyncio
+async def test_research_fails_fast_when_search_tool_returns_all_errors(ctx):
+    """When every search-tool call returns an `[error: ...]`-shaped result
+    (e.g., skill-bundled tool unavailable in workflow context — smoke
+    Finding 1), the orchestrator must raise BEFORE the pipeline wastes
+    tokens summarizing error text and the subagent runs on garbage."""
+    from decafclaw.workflow.workflows.research import _SEARCH_TOOL
+
+    spec = get_workflow("research")
+    assert spec is not None
+
+    j = Journal(workflow_name="research")
+    j.append((0,), "user_input",
+             _fp_user("What topic should I research?"), "topic")
+    j.append((1,), "user_input",
+             _fp_user("Any specific angle, audience, or constraint? "
+                      "(Press enter for none.)"), "scope")
+
+    plan_result = {"queries": ["q1", "q2"]}
+
+    async def fake_llm(ctx, **kw):
+        if kw["schema"]["properties"].get("queries"):
+            return plan_result
+        # Summarize must NOT run.
+        raise AssertionError("summarize llm_call must not run after fail-fast")
+
+    async def error_tool(ctx, name, args):
+        return ToolResult(
+            text=f"[error: unknown tool {name!r}]", data=None)
+
+    ctx.tools.allowed = {_SEARCH_TOOL}
+
+    with patch("decafclaw.workflow.handle.execute_tool", new=error_tool), \
+         patch(
+             "decafclaw.tools.delegate.run_child_turn",
+             new_callable=AsyncMock,
+         ) as mock_child:
+        outcome = await run_workflow(ctx, spec.fn, j, llm_caller=fake_llm)
+
+    assert outcome.status == "error"
+    assert "tool likely unavailable" in outcome.error.lower() or \
+           "all" in outcome.error.lower()
+    mock_child.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_research_orchestrator_resumes_from_journal(ctx):
+    """Pre-populate the journal through the pipeline stage. The subagent
+    call is the first live boundary. user_input / llm_call / tool_call /
+    parallel / pipeline should all replay from the journal — if any of
+    them runs live, the sabotage mocks blow up."""
+    from decafclaw.workflow.workflows.research import (
+        _PLAN_SCHEMA,
+        _REPORT_SCHEMA,
+        _SEARCH_TOOL,
+        _SUMMARY_SCHEMA,
+        _SYS_PLAN,
+        _SYS_SUMMARIZE,
+        _research_plan_prompt,
+        _summarize_prompt,
+        _synth_prompt,
+    )
+
+    ctx.tools.allowed = {_SEARCH_TOOL}
+
+    topic = "kelp forests"
+    scope = "for a marine biology newsletter"
+    queries = ["q1: bull kelp", "q2: sea urchins"]
+    search_text_template = "Results for {q}"
+    summaries = [
+        {"title": "Bull kelp", "key_points": ["fast growth", "habitat"]},
+        {"title": "Sea urchins", "key_points": ["barrens", "grazing"]},
+    ]
+    report = {"title": "Kelp forests", "body": "# Kelp..."}
+
+    j = Journal(workflow_name="research")
+    # (0,) user_input — topic
+    j.append((0,), "user_input",
+             _fp_user("What topic should I research?"), topic)
+    # (1,) user_input — scope
+    j.append((1,), "user_input",
+             _fp_user("Any specific angle, audience, or constraint? "
+                      "(Press enter for none.)"), scope)
+    # (2,) llm_call — plan
+    plan_prompt = _research_plan_prompt(topic, scope)
+    j.append((2,), "llm_call",
+             _fp_llm(plan_prompt, _PLAN_SCHEMA, _SYS_PLAN),
+             {"queries": queries})
+
+    # (3,) parallel — search fan-out. Per-thunk child entries:
+    #   (3, i, 0) tool_call — search for queries[i]
+    search_results = []
+    for i, q in enumerate(queries):
+        text = search_text_template.format(q=q)
+        result_dict = {"text": text, "data": None}
+        j.append((3, i, 0), "tool_call",
+                 _fp_tool(_SEARCH_TOOL, {"query": q}), result_dict)
+        search_results.append(result_dict)
+    j.append((3,), "parallel", _fp_parallel(len(queries)), search_results)
+
+    # (4,) pipeline — per-result extract → summarize. Per-item child entries:
+    #   stage 1 (extract) has no journaled side-effect (it's a pure dict ->
+    #   str), so only the summarize llm_call is journaled at (4, i, 0).
+    for i, q in enumerate(queries):
+        extracted = search_text_template.format(q=q)
+        prompt = _summarize_prompt(extracted)
+        j.append((4, i, 0), "llm_call",
+                 _fp_llm(prompt, _SUMMARY_SCHEMA, _SYS_SUMMARIZE),
+                 summaries[i])
+    j.append((4,), "pipeline",
+             _fp_pipeline(search_results, 2), summaries)
+
+    # (5,) subagent — the first live boundary. NOT pre-populated.
+
+    # Sabotage mocks: user_input never gets called (raises automatically
+    # via WorkflowSuspended if the cache misses), llm_call / tool_call
+    # would blow up if invoked live.
+    async def boom_llm(ctx, **kw):
+        raise AssertionError(
+            f"llm_call MUST NOT run during journal-driven replay: {kw}")
+
+    async def boom_tool(ctx, name, args):
+        raise AssertionError(
+            f"tool_call MUST NOT run during journal-driven replay: "
+            f"{name} {args}")
+
+    # The subagent IS live: that's what we're verifying gets reached.
+    with patch("decafclaw.workflow.handle.execute_tool", new=boom_tool), \
+         patch(
+             "decafclaw.tools.delegate.run_child_turn",
+             new_callable=AsyncMock,
+             return_value=("ignored", report),
+         ) as mock_child:
+        spec = get_workflow("research")
+        assert spec is not None
+        outcome = await run_workflow(
+            ctx, spec.fn, j, llm_caller=boom_llm)
+
+    assert outcome.status == "done", f"got {outcome.status}: {outcome.error}"
+    assert outcome.result == report
+
+    # Subagent saw the assembled prompt with topic + scope + rendered
+    # summaries.
+    mock_child.assert_called_once()
+    _args, kwargs = mock_child.call_args
+    expected_prompt = _synth_prompt(topic, scope, summaries)
+    assert kwargs["task"] == expected_prompt
+    assert kwargs["return_schema"] == _REPORT_SCHEMA
+
+
+@pytest.mark.asyncio
+async def test_research_first_suspend_is_topic_question(ctx):
+    """A fresh journal suspends immediately on the topic user_input — the
+    same shape as /interview's first-suspend smoke. Confirms the
+    orchestrator is reachable through run_workflow and the registry."""
+    spec = get_workflow("research")
+    assert spec is not None
+
+    outcome = await run_workflow(
+        ctx, spec.fn, Journal(workflow_name="research"))
+    assert outcome.status == "suspended"
+    assert outcome.suspend is not None
+    assert "topic" in outcome.suspend.prompt.lower()

--- a/tests/test_workflow_resume.py
+++ b/tests/test_workflow_resume.py
@@ -43,7 +43,7 @@ async def test_handler_journals_answer_and_enqueues_resume(tmp_path):
     request = ConfirmationRequest(
         action_type=ConfirmationAction.WORKFLOW_USER_INPUT,
         message="What should this interview be about?",
-        action_data={"workflow_name": "interview", "seq": 0,
+        action_data={"workflow_name": "interview", "seq": "0",
                      "args_fingerprint": fp, "prompt": "...", "choices": None},
         timeout=None,
     )
@@ -61,8 +61,8 @@ async def test_handler_journals_answer_and_enqueues_resume(tmp_path):
     out = await handler.on_approve(_ctx(tmp_path), request, response)
 
     reloaded = load_journal(cfg, "convR")
-    assert reloaded.get(0).kind == "user_input"
-    assert reloaded.get(0).result == "tide pools"
+    assert reloaded.get((0,)).kind == "user_input"
+    assert reloaded.get((0,)).result == "tide pools"
     assert reloaded.status == "running"
     assert enqueued and enqueued[0][1]["metadata"]["resume"] is True
     assert enqueued[0][1]["metadata"]["workflow_name"] == "interview"
@@ -87,7 +87,8 @@ async def test_run_workflow_turn_fresh_start_suspends_and_posts(tmp_path):
         workflow_name="interview", resume=False)
     assert posted, "a confirmation should be posted on suspend"
     assert posted[0].action_type == ConfirmationAction.WORKFLOW_USER_INPUT
-    assert posted[0].action_data["seq"] == 0
+    # action_data carries the tuple-path seq as a dotted string for JSON safety.
+    assert posted[0].action_data["seq"] == "0"
     assert posted[0].action_data["workflow_name"] == "interview"
     from decafclaw.media import ToolResult
     assert isinstance(result, ToolResult)

--- a/tests/test_workflow_subagent.py
+++ b/tests/test_workflow_subagent.py
@@ -1,0 +1,202 @@
+"""Tests for WorkflowHandle.subagent (Phase 4).
+
+These tests mock `run_child_turn` rather than dispatching a real child
+agent loop — that's integration territory and is covered by the Phase 8
+live smoke. Here we exercise the journaling and fingerprint behavior.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+@pytest.mark.asyncio
+async def test_subagent_live_path_text_only(ctx):
+    """Without `schema`, `wf.subagent` returns the child's text and journals
+    that text under kind='subagent'."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("the child said hi", None),
+    ) as mock:
+        out = await h.subagent("ask the child")
+
+    assert out == "the child said hi"
+    mock.assert_called_once()
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "subagent"
+    assert entry.result == "the child said hi"
+
+
+@pytest.mark.asyncio
+async def test_subagent_live_path_with_schema(ctx):
+    """With `schema`, `wf.subagent` returns the structured dict (not text)
+    and journals the dict."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    structured = {"title": "X", "body": "Y"}
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ignored text", structured),
+    ):
+        out = await h.subagent("ask", schema={"type": "object"})
+
+    assert out == structured
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "subagent"
+    assert entry.result == structured
+
+
+@pytest.mark.asyncio
+async def test_subagent_defaults_to_handle_model(ctx):
+    """Without an explicit `model=`, wf.subagent passes the handle's
+    configured model to run_child_turn — parallel to wf.llm_call. A bare
+    "" would let run_child_turn fall through to ctx.active_model, which
+    can differ from the workflow's intent."""
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j, model="workflow-default-model")
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ok", None),
+    ) as mock:
+        await h.subagent("ask")
+    assert mock.call_args.kwargs["model"] == "workflow-default-model"
+
+
+@pytest.mark.asyncio
+async def test_subagent_replay_path(ctx):
+    """A pre-populated subagent entry is returned verbatim; the live
+    `run_child_turn` MUST NOT be called during replay."""
+    j = Journal(workflow_name="t")
+    fp = fingerprint("subagent", {
+        "prompt": "ask",
+        "schema": None,
+        "allowed_tools": None,
+        "allow_vault_retrieval": False,
+        "allow_vault_read": False,
+    })
+    j.append((0,), "subagent", fp, "cached answer")
+
+    h = WorkflowHandle(ctx, j)
+
+    def boom(*a, **kw):
+        raise AssertionError("live run_child_turn MUST NOT run during replay")
+
+    with patch("decafclaw.tools.delegate.run_child_turn", side_effect=boom):
+        out = await h.subagent("ask")
+
+    assert out == "cached answer"
+
+
+@pytest.mark.asyncio
+async def test_subagent_fingerprint_excludes_model(ctx):
+    """`model=` is an execution detail — different per-call model values
+    must NOT bust the cache. Run 1 journals with model=A; replay with model=B
+    hits the cache without raising WorkflowNonDeterministic."""
+    j = Journal(workflow_name="t")
+    h1 = WorkflowHandle(ctx, j, model="modelA")
+
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("first run text", None),
+    ) as mock_run:
+        out1 = await h1.subagent("foo", model="modelA")
+    assert out1 == "first run text"
+    assert mock_run.call_count == 1
+
+    # Fresh handle with a different default model; replay against the
+    # same journal. Should hit the cache, NOT call run_child_turn.
+    h2 = WorkflowHandle(ctx, j, model="modelB")
+
+    def boom(*a, **kw):
+        raise AssertionError("run_child_turn must not be re-invoked")
+
+    with patch("decafclaw.tools.delegate.run_child_turn", side_effect=boom):
+        out2 = await h2.subagent("foo", model="modelB")
+
+    assert out2 == "first run text"
+
+
+@pytest.mark.asyncio
+async def test_subagent_fingerprint_includes_allowed_tools_sorted(ctx):
+    """`allowed_tools` ordering shouldn't affect the fingerprint — replay
+    determinism must survive a caller reshuffling the list."""
+    j1 = Journal(workflow_name="t")
+    h1 = WorkflowHandle(ctx, j1)
+
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ok", None),
+    ):
+        await h1.subagent("foo", allowed_tools=["a", "b"])
+    fp_ab = j1.get((0,)).args_fingerprint
+
+    j2 = Journal(workflow_name="t")
+    h2 = WorkflowHandle(ctx, j2)
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ok", None),
+    ):
+        await h2.subagent("foo", allowed_tools=["b", "a"])
+    fp_ba = j2.get((0,)).args_fingerprint
+
+    assert fp_ab == fp_ba
+
+
+@pytest.mark.asyncio
+async def test_subagent_fingerprint_differs_with_schema(ctx):
+    """Same prompt but different schema → different fingerprint, so the
+    cache doesn't return the no-schema result when a schema is requested."""
+    j1 = Journal(workflow_name="t")
+    h1 = WorkflowHandle(ctx, j1)
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ok", None),
+    ):
+        await h1.subagent("foo")
+    fp_no_schema = j1.get((0,)).args_fingerprint
+
+    j2 = Journal(workflow_name="t")
+    h2 = WorkflowHandle(ctx, j2)
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("ok", {"x": 1}),
+    ):
+        await h2.subagent("foo", schema={"x": 1})
+    fp_with_schema = j2.get((0,)).args_fingerprint
+
+    assert fp_no_schema != fp_with_schema
+
+
+@pytest.mark.asyncio
+async def test_subagent_uses_sub_handle_key_prefix(ctx):
+    """A sub-handle at prefix (3,) journals its subagent call at seq (3, 0)."""
+    j = Journal(workflow_name="t")
+    sub = WorkflowHandle(ctx, j, _key_prefix=(3,))
+
+    with patch(
+        "decafclaw.tools.delegate.run_child_turn",
+        new_callable=AsyncMock,
+        return_value=("child text", None),
+    ):
+        out = await sub.subagent("go")
+
+    assert out == "child text"
+    entry = j.get((3, 0))
+    assert entry is not None
+    assert entry.kind == "subagent"

--- a/tests/test_workflow_tool_call.py
+++ b/tests/test_workflow_tool_call.py
@@ -1,0 +1,187 @@
+"""Tests for WorkflowHandle.tool_call (Phase 3)."""
+import pytest
+
+from decafclaw.media import ToolResult
+from decafclaw.workflow.errors import WorkflowToolNotAllowed
+from decafclaw.workflow.handle import WorkflowHandle
+from decafclaw.workflow.journal import Journal, fingerprint
+
+
+@pytest.mark.asyncio
+async def test_tool_call_live_path(ctx):
+    """A live tool_call invokes the tool, journals the serialized result, and
+    a second handle replays from the journal without re-invoking."""
+    calls: list[dict] = []
+
+    def echo_tool(ctx, **kwargs):
+        calls.append(kwargs)
+        return ToolResult(text=f"echoed: {kwargs.get('message', '')}",
+                          data={"received": kwargs})
+
+    ctx.tools.extra = {"echo": echo_tool}
+    ctx.tools.allowed = {"echo"}
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+    out = await h.tool_call("echo", message="hi")
+    assert out == {"text": "echoed: hi", "data": {"received": {"message": "hi"}}}
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "tool_call"
+    expected_fp = fingerprint("tool_call",
+                              {"name": "echo", "args": {"message": "hi"}})
+    assert entry.args_fingerprint == expected_fp
+    assert len(calls) == 1
+
+    # Fresh handle, same journal → replays without invoking the tool again.
+    h2 = WorkflowHandle(ctx, j)
+    out2 = await h2.tool_call("echo", message="hi")
+    assert out2 == out
+    assert len(calls) == 1  # tool NOT re-invoked
+
+
+@pytest.mark.asyncio
+async def test_tool_call_replay_path(ctx):
+    """A pre-populated journal entry is returned verbatim; the live tool
+    function MUST NOT be called during replay."""
+    def boom_tool(ctx, **kwargs):
+        raise AssertionError("live tool MUST NOT run during replay")
+
+    ctx.tools.extra = {"boom": boom_tool}
+    ctx.tools.allowed = {"boom"}
+
+    j = Journal(workflow_name="t")
+    fp = fingerprint("tool_call", {"name": "boom", "args": {"x": 1}})
+    cached = {"text": "cached-text", "data": {"k": "v"}}
+    j.append((0,), "tool_call", fp, cached)
+
+    h = WorkflowHandle(ctx, j)
+    out = await h.tool_call("boom", x=1)
+    assert out == cached
+
+
+@pytest.mark.asyncio
+async def test_tool_call_rejects_disallowed_tool(ctx):
+    """A tool not in ctx.tools.allowed raises WorkflowToolNotAllowed, and
+    nothing is written to the journal."""
+    ctx.tools.allowed = {"some_other_tool"}
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+    with pytest.raises(WorkflowToolNotAllowed):
+        await h.tool_call("shell_exec", cmd="ls")
+    # Nothing journaled.
+    assert j.get((0,)) is None
+    assert j.entries == {}
+
+
+@pytest.mark.asyncio
+async def test_tool_call_disallowed_does_not_advance_cursor(ctx):
+    """The allowlist gate fires BEFORE the cursor is consumed. If an
+    orchestrator catches WorkflowToolNotAllowed and continues, the next
+    journaled call must land at (0,), not (1,)."""
+    ctx.tools.allowed = {"some_other_tool"}
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+
+    with pytest.raises(WorkflowToolNotAllowed):
+        await h.tool_call("disallowed", x=1)
+    # Cursor must still be at 0 — no journal slot was burned.
+    assert h._cursor == 0
+    assert j.entries == {}
+
+
+@pytest.mark.asyncio
+async def test_tool_call_with_no_allowlist_allows_any_registered_tool(ctx):
+    """`ctx.tools.allowed is None` means "no restriction" — mirrors
+    `execute_tool`'s semantics. Any registered tool is invocable.
+    Guards against a regression to "None collapses to empty set =
+    nothing allowed."
+    """
+    def fake_tool(ctx, **kwargs):
+        return ToolResult(text="fake-ok", data={"args": kwargs})
+
+    ctx.tools.extra = {"the_fake_tool": fake_tool}
+    ctx.tools.allowed = None  # explicit: no restriction
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+    out = await h.tool_call("the_fake_tool", x=1)
+    assert out == {"text": "fake-ok", "data": {"args": {"x": 1}}}
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.kind == "tool_call"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_strips_media_from_journal(ctx):
+    """Media attachments on the ToolResult are not stored in the journal —
+    only text + data make the trip."""
+    def media_tool(ctx, **kwargs):
+        return ToolResult(
+            text="ok",
+            data={"k": 1},
+            media=[{"type": "image", "bytes": b"xxxx"}],
+        )
+
+    ctx.tools.extra = {"with_media": media_tool}
+    ctx.tools.allowed = {"with_media"}
+
+    j = Journal(workflow_name="t")
+    h = WorkflowHandle(ctx, j)
+    out = await h.tool_call("with_media")
+    assert out == {"text": "ok", "data": {"k": 1}}
+    entry = j.get((0,))
+    assert entry is not None
+    assert entry.result == {"text": "ok", "data": {"k": 1}}
+    # No `media` key smuggled into the journal-stored result.
+    assert "media" not in entry.result
+
+
+@pytest.mark.asyncio
+async def test_tool_call_fingerprint_includes_name_and_args(ctx):
+    """Different name OR different args yield different fingerprints."""
+    def t(ctx, **kwargs):
+        return ToolResult(text="ok")
+
+    ctx.tools.extra = {"foo": t, "bar": t}
+    ctx.tools.allowed = {"foo", "bar"}
+
+    # Two args values for same name.
+    j1 = Journal(workflow_name="t")
+    h1 = WorkflowHandle(ctx, j1)
+    await h1.tool_call("foo", x=1)
+    fp_foo_1 = j1.get((0,)).args_fingerprint
+
+    j2 = Journal(workflow_name="t")
+    h2 = WorkflowHandle(ctx, j2)
+    await h2.tool_call("foo", x=2)
+    fp_foo_2 = j2.get((0,)).args_fingerprint
+
+    assert fp_foo_1 != fp_foo_2
+
+    # Two names with same args.
+    j3 = Journal(workflow_name="t")
+    h3 = WorkflowHandle(ctx, j3)
+    await h3.tool_call("bar", x=1)
+    fp_bar_1 = j3.get((0,)).args_fingerprint
+
+    assert fp_foo_1 != fp_bar_1
+
+
+@pytest.mark.asyncio
+async def test_tool_call_uses_sub_handle_key_prefix(ctx):
+    """A sub-handle at prefix (7,) journals its tool_call at seq (7, 0)."""
+    def t(ctx, **kwargs):
+        return ToolResult(text="ok", data=None)
+
+    ctx.tools.extra = {"echo": t}
+    ctx.tools.allowed = {"echo"}
+
+    j = Journal(workflow_name="t")
+    sub = WorkflowHandle(ctx, j, _key_prefix=(7,))
+    out = await sub.tool_call("echo", q="x")
+    assert out == {"text": "ok", "data": None}
+    entry = j.get((7, 0))
+    assert entry is not None
+    assert entry.kind == "tool_call"

--- a/tests/test_workflow_turn_integration.py
+++ b/tests/test_workflow_turn_integration.py
@@ -101,7 +101,7 @@ async def test_workflow_turn_runs_and_suspends_end_to_end(make_manager):
     from decafclaw.confirmations import ConfirmationAction
     assert state.pending_confirmation.action_type is ConfirmationAction.WORKFLOW_USER_INPUT
     assert state.pending_confirmation.action_data["workflow_name"] == "interview"
-    assert state.pending_confirmation.action_data["seq"] == 0
+    assert state.pending_confirmation.action_data["seq"] == "0"
 
 
 @pytest.mark.asyncio
@@ -129,7 +129,7 @@ async def test_durable_resume_after_simulated_restart(tmp_path):
     # --- Process 1: start; suspends at the topic question; journal hits disk ---
     out1 = await run_workflow(fresh_ctx(), spec.fn, Journal(workflow_name="interview"))
     assert out1.status == "suspended"
-    assert out1.suspend.seq == 0
+    assert out1.suspend.seq == (0,)
 
     # --- "Restart": reconstruct ONLY from the on-disk journal ---
     reloaded = load_journal(cfg, conv_id)
@@ -162,8 +162,8 @@ async def test_durable_resume_after_simulated_restart(tmp_path):
     # The recovered answer was REPLAYED from the journal (user_input at seq 0 was
     # NOT re-raised as a suspension), and only llm_calls ran live:
     final = load_journal(cfg, conv_id)
-    assert final.get(0).kind == "user_input"
-    assert final.get(0).result == "tide pools"
+    assert final.get((0,)).kind == "user_input"
+    assert final.get((0,)).result == "tide pools"
     # Live calls were the decision + synth llm_calls only (2), never a user_input.
     # Trace: seq0 user_input → cached (no live call); seq1 llm_call decision →
     # live (done=True, break); seq2 llm_call synth → live (artifact). Total: 2.


### PR DESCRIPTION
## Summary

Extends the workflow replay engine that landed in PR #573 with four new journaled primitives that unlock fan-out workflows: `wf.tool_call`, `wf.subagent`, `wf.parallel`, `wf.pipeline`. Ships a second hero workflow (`/research`) that exercises all four end-to-end, plus a foundation refactor (tuple-path journal keys + sub-handle factory) so primitives compose cleanly.

The fan-out shape was deferred from #573 — see `docs/workflows.md` "What is not in v1" — because it had no concrete use case yet. This PR delivers the use case (research sweeps) and the primitives together.

## Design Decisions

(See `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/spec.md` for full context.)

- **Hierarchical sub-handles with tuple-path journal keys.** `Journal.entries` becomes `dict[tuple[int, ...], JournalEntry]`; on-disk seqs serialize as dotted strings (`"3.0.0"`). Each `parallel` thunk / `pipeline` item gets a sub-handle keyed `(outer_seq, idx)` with its own cursor — composes naturally with nested fan-out. Existing flat-int journals upgrade transparently.
- **`wf.subagent` wraps `delegate.run_child_turn` directly** (promoted from `_run_child_turn`). Inherits the mature child-dispatch path (restricted tools, no vault writes, child conv_id, timeout). Optional `schema=` for forced structured output, symmetric with `wf.llm_call`.
- **Errors propagate by default** in `wf.parallel`/`wf.pipeline`. Callers wrap individual thunks in try/except for tolerant collection — matches decafclaw's "fail loud" posture.
- **`wf.tool_call` gated by `ctx.tools.allowed`**, mirroring `execute_tool`'s "None means no restriction" semantics. Media stripped from journal entries (large, rebuildable); journal stores only `{text, data}`.
- **Pipeline stage signature is `(prev, item, idx, sub)`** — `sub` is the per-item sub-handle stages MUST use for journaled calls. Departs from Claude Code's Workflow signature deliberately: their workflows aren't durable; ours are, so explicit sub-handle access is required.

## Changes

**`src/decafclaw/workflow/`** — the engine surface:
- `journal.py` (+75): tuple-path keys, dict storage, dotted-string serialization, legacy upgrade.
- `handle.py` (+432): `_next_seq`/`_make_subhandle_at`/`tool_call`/`subagent`/`parallel`/`pipeline`.
- `errors.py` (+23): tuple seq, `WorkflowToolNotAllowed`.
- `resume.py` (+10): tuple seq through confirmation payloads.
- `workflows/research.py` (+167): the second hero workflow.

**`src/decafclaw/tools/delegate.py`** (+129): promoted `_run_child_turn` → `run_child_turn` with unified `(text, data | None)` return; structured-output parsing moved into `run_child_turn`; `ERROR_TEXT_PREFIX` constant.

**Tests** (+50 net, 2820 → 2870): one new test file per primitive plus the orchestrator test, regression test for the parallel exception-unmasking fix, nested key-composition coverage.

**Docs**: `docs/workflows.md` "What is not in v1" replaced with four primitive contract sections + multi-primitive example pointing at `/research`. CLAUDE.md key-files entry updated.

## Test Plan

- [x] `make check` clean (ruff + pyright + tsc).
- [x] `make test` → 2870 passed.
- [x] No new tests in top-25 slowest (`pytest --durations=25`).
- [x] Live walk on `vertex-gemini-flash` with mid-run SIGINT — see `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md` for the full transcript. Journal preserved correctly through the crash; tuple-path keys + sub-handle composition verified on disk.

## Smoke findings (file as follow-up issues)

The live smoke proved the primitives work end-to-end and surfaced three real gaps worth tracking as separate issues (none blocking this PR):

1. **Skill-bundled tools (e.g., `tabstack_research`) aren't reachable from workflow contexts.** Workflow turns don't go through `activate_skill`, so skill tools aren't in the registry; `wf.tool_call` correctly surfaces this as an error-shaped result. Real fix is upstream — pre-activate a configurable skill set when a workflow turn starts, or let `@workflow(...)` declare `requires_skills=[...]`.
2. **No auto-resume on server restart for `status=running` workflows.** Replay machinery is correct (Phase 5/6 unit tests cover full-cache + mid-fan-out resume); the wiring gap is "scan for in-flight journals at startup and re-enqueue."
3. **Unexplained 3-minute hang during pipeline summarize against error-text input.** Could be Vertex throttling on degenerate prompts, could be a primitive issue we missed — needs instrumentation to diagnose.

## References

- Spec: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/spec.md`
- Plan: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/plan.md`
- Notes (incl. execution-phase decisions and bug-finds): `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/notes.md`
- Smoke transcript: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md`
- Related: #421 (shared DAG substrate brainstorm), #564 (workflow subagent-skill escape hatch test), #474 (mixture-of-agents — adjacent concept), #575 (WORKFLOW Context-kind ADR — deliberately deferred).

Closes #574