### PR TITLE
docs: retrospective for the #576 conversation-sidecar-dir session

### DIFF
--- a/docs/dev-sessions/2026-06-10-1728-conversation-sidecar-dirs/notes.md
+++ b/docs/dev-sessions/2026-06-10-1728-conversation-sidecar-dirs/notes.md
@@ -61,3 +61,50 @@ New: `src/decafclaw/conversation_paths.py`, `scripts/migrate_sidecars_to_dirs.py
 `tests/test_conversation_paths.py`, `tests/test_conversation_search_tool.py`,
 `tests/test_migrate_sidecars.py`. Plus 9 sidecar helpers, 4 discovery sites, delete handler,
 `workflow/paths.py`, Makefile, and ~12 doc/docstring files.
+
+## Retrospective
+
+Merged as #578 (squash `11e0691`) on 2026-06-12. Copilot review surfaced 2 fail-open gaps
+in the central helper (`iter_conversation_archives` iterdir, `delete_conversation_files`
+unlink) — both real, both fixed before merge.
+
+**What was built vs. planned:** Tracked the 6-phase plan exactly, no re-planning. Each phase
+landed as one commit, two-stage reviewed; the plan's code snippets were accurate enough that
+implementers mostly transcribed them.
+
+**Scope drift:** The only growth was deliberate and decided up front (9 sidecars vs the
+issue's 4, surfaced in research before brainstorm Q&A). No mid-execution scope creep. The
+docs phase quietly expanded to ~12 files once the sweep grep ran — expected, not drift.
+
+**Surprises:**
+- The issue undercounted sidecars (4 named, 9 real) and discovery sites (2 implied, 4 real)
+  + a delete site that already leaked 4 of 9. The pre-brainstorm documentarian research is
+  what caught this — going straight to plan would have shipped a half-migration.
+- `fnmatch`'s `*` crosses `/`, so `READONLY_PATTERNS = ("conversations/*.jsonl",)` still
+  matches the dir-layout archive. The docs subagent flagged a "regression" assuming glob
+  semantics; verifying the actual fnmatch behavior turned a false alarm into a confirmed
+  non-issue. Lesson: verify path-matching semantics, don't assume glob vs fnmatch.
+- I initially told subagents to leave the session-docs dir untracked; at PR time found 434
+  dev-session files ARE committed in this repo. They belong in the PR.
+
+**Workflow friction:**
+- `SendMessage` to continue a prior subagent isn't available in this harness, so the
+  "implementer fixes its own review findings" loop in subagent-driven-dev couldn't round-trip.
+  For the 1-3 line review fixes (rmtree logging, removesuffix, Copilot's OSError guards) I
+  applied them directly with full context + re-verified, rather than spawning a fresh
+  implementer for a few lines. Reasonable trade; worth knowing the loop isn't available.
+- The per-phase two-stage review was high-value on Phases 1-3 (caught the silent-rmtree and
+  the strip-vs-reject semantic change) and lighter-weight on Phase 4 (trivial delegation) —
+  collapsing 4's review to one combined pass was proportionate.
+
+**Misses:** Research enumerated glob sites but I didn't initially clock `workspace_paths.py`
+READONLY_PATTERNS as a path-coupled site (it's pattern-matching, not globbing). It turned out
+fine (fnmatch crosses `/`), but a "what else is coupled to the flat path *shape*?" question in
+research would have surfaced it deliberately instead of via the docs sweep.
+
+**Memory candidates (acted on):** dev-session docs are committed in this repo;
+`workspace_paths.py` READONLY/SECRET patterns are a path-shape-coupled site + the fnmatch
+`*`-crosses-`/` gotcha.
+
+**Deferred follow-ups:** see the "Deferred" section above — remove flat fallback post-migration,
+orphaned `delete_conversation_uploads`, redundant startup_scan guard, unify `uploads_dir`.


### PR DESCRIPTION
Docs-only. Appends the post-merge retrospective to the #576 session notes (`docs/dev-sessions/2026-06-10-1728-conversation-sidecar-dirs/notes.md`).

The retro happens after the implementation PR merges, so #578 didn't carry it. Captures: recap, scope drift (none beyond the planned 4→9 sidecar growth), surprises (the issue undercounted sidecars/discovery sites; `fnmatch` `*` crosses `/`), workflow friction, misses, and the deferred follow-ups (now filed as issues).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)