### PR TITLE
refactor(conversations): remove flat-layout sidecar fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 
 ### Data and persistence
 - `archive.py` — JSONL conversation archive
-- `conversation_paths.py` — per-conversation sidecar path chokepoint: `conversations/{conv_id}/{file}` dir layout, in-place legacy flat-file fallback, archive iteration + delete helpers (migration: `make migrate-sidecars`)
+- `conversation_paths.py` — per-conversation sidecar path chokepoint: `conversations/{conv_id}/{file}` dir layout, archive iteration + delete helpers (one-time migration from the pre-#576 flat layout: `make migrate-sidecars`)
 - `compaction.py` — Summarization + pre-compaction memory sweep
 - `compaction_decisions.py` — Structured decision slice threaded through compaction (decisions / open questions / artifacts; persisted to per-conv sidecar)
 - `context_cleanup.py` — Lightweight clear tier: stubs old large tool messages before compaction

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -68,28 +68,26 @@ call) removes it.
 
 `src/decafclaw/conversation_paths.py` is the single chokepoint for these
 paths: `conversation_dir(config, conv_id, *, create=False)`,
-`sidecar_path(config, conv_id, filename, legacy_suffix)`,
+`sidecar_path(config, conv_id, filename)`,
 `iter_conversation_archives(config)`, and `delete_conversation_files(config,
-conv_id)`, plus the `SIDECAR_FILENAMES` / `SIDECAR_LEGACY_SUFFIXES`
-constants. `workflow/paths.py` delegates to it. New sidecars get a filename
-in this module rather than a new flat-suffix convention.
+conv_id)`, plus the `SIDECAR_FILENAMES` constant (the migration mapping).
+`workflow/paths.py` delegates to it. New sidecars get a filename in this
+module rather than a new flat-suffix convention.
 
-### Legacy flat layout and the deprecation-window fallback
+### Migrating from the legacy flat layout
 
-The previous layout was flat — each sidecar was a sibling file named
+Before #576 the layout was flat — each sidecar was a sibling file named
 `conversations/{conv_id}.SUFFIX` (e.g. `{conv_id}.jsonl`,
-`{conv_id}.notes.md`, `{conv_id}.context.json`). For one deprecation cycle,
-`sidecar_path` keeps reading **and** writing an existing flat legacy file in
-place when the new-layout file is absent, so a conversation's data never
-splits across the two layouts. No code path moves files; only the migration
-script does. (A future change removes this fallback.)
-
-### Migration
+`{conv_id}.notes.md`, `{conv_id}.context.json`). The code no longer reads
+that layout; an instance upgrading from it must relocate its existing
+sidecars once:
 
 `make migrate-sidecars` runs `scripts/migrate_sidecars_to_dirs.py`, which
-moves existing flat sidecars into their per-conversation directories. It is
-idempotent. Preview the moves first with `make migrate-sidecars-dry`. Run it
-once after upgrading to relocate existing conversations.
+moves flat sidecars into their per-conversation directories. It is
+idempotent and never deletes data (only moves). Preview the moves first with
+`make migrate-sidecars-dry`, then run `make migrate-sidecars` once after
+upgrading. (There is no runtime fallback — run the migration before relying
+on pre-#576 conversations.)
 
 ## Trust boundary
 

--- a/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/notes.md
+++ b/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/notes.md
@@ -1,0 +1,47 @@
+# Notes: remove conversation-sidecar flat fallback (#584)
+
+Follow-up to #576/#578. Branch `584-remove-flat-fallback`.
+
+## Outcome
+
+Removed the deprecation-window flat-layout fallback now that the dir layout is the only
+layout and migration has run everywhere. Net −158 lines. 2 phases, subagent-driven
+(Phase 1 spec + quality reviewed; Phase 2 docs done inline). 2905 tests pass, `make check` clean.
+
+## Precondition handled first (the important part)
+
+Removing the fallback makes any remaining flat sidecar invisible. Before touching code I
+checked the **local** `data/` (shared by worktrees via `.env`) — it was NOT migrated (6465
+flat files, only 18 dirs), even though the deployed agent was. Backed up
+(`data/decafclaw/conversations-backup-pre-sidecar-migration.tar.gz`, 21M), ran
+`make migrate-sidecars` locally (6465 moved → 0 flat remain), verified idempotent re-run = 0
+and archives read back via the dir layout. Only then proceeded.
+
+Lesson: "migration ran" on one instance ≠ ran everywhere. The worktree's shared `data/`
+is a distinct instance from the deployed agent — verify each.
+
+## What changed
+
+- `sidecar_path(config, conv_id, filename)` — dropped `legacy_suffix` + fallback; now just
+  `conversation_dir(...) / filename`. Removed `_legacy_flat_path`.
+- `iter_conversation_archives` — dir-only (dropped the flat-`*.jsonl` branch + `seen` dedup);
+  still excludes compacted (keys on `archive.jsonl`) + fails open on `OSError`.
+- `delete_conversation_files` — dir rmtree; **kept** a best-effort delete-only flat-sidecar
+  cleanup (Copilot review caught that dropping it would leave readable history on disk if an
+  instance was only partially migrated — a privacy footgun, and a regression of #576's
+  comprehensive-delete). Cleanup-only; never makes a flat file authoritative.
+- `SIDECAR_LEGACY_SUFFIXES` deleted (unused after the delete-loop removal).
+- 9 call sites dropped the `legacy_suffix` arg.
+- Removed the fallback / both-layout / no-split-archive tests; rewrote others to dir-only.
+- Docs: data-layout.md fallback section → one-time-migration framing; CLAUDE.md key-file note.
+
+## Kept (intentionally)
+
+`scripts/migrate_sidecars_to_dirs.py`, its tests, `make migrate-sidecars(-dry)`, and
+`SIDECAR_FILENAMES` — an instance upgrading from the pre-#576 flat layout still needs the
+one-shot migration; there's no longer a runtime fallback to lean on.
+
+## Closes
+
+#584. Sibling follow-ups still open: #585 (orphaned `delete_conversation_uploads`),
+#586 (redundant startup_scan guard), #587 (`uploads_dir` sanitization).

--- a/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/plan.md
+++ b/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/plan.md
@@ -1,0 +1,85 @@
+# Remove flat fallback — Implementation Plan
+
+**Goal:** Subtract the deprecation-window flat-layout fallback from the conversation-sidecar path helpers and their call sites; keep the migration script.
+
+**Approach:** Simplify `conversation_paths.py` to dir-only, drop the `legacy_suffix` arg at 9 call sites, rewrite tests to the single-layout contract, update docs.
+
+---
+
+## Phase 1: Code + tests (dir-only path helpers)
+
+**Files:**
+- Modify: `src/decafclaw/conversation_paths.py`
+  - `sidecar_path(config, conv_id, filename)` → `return conversation_dir(config, conv_id) / filename`. Drop `legacy_suffix` param; remove `_legacy_flat_path`.
+  - `iter_conversation_archives`: keep the `try/except OSError` fail-open + missing-root guard; iterate dirs only, yield `(child.name, child/"archive.jsonl")` when it exists. Remove the flat-`*.jsonl` loop and the `seen` set.
+  - `delete_conversation_files`: keep the dir `rmtree` (with its `OSError` log); remove the `SIDECAR_LEGACY_SUFFIXES` unlink loop.
+  - If `SIDECAR_LEGACY_SUFFIXES` is now unreferenced (grep), remove the constant. Keep `SIDECAR_FILENAMES` (migration script).
+  - Update the module docstring: drop the "reads/writes an existing flat legacy file in place" paragraph; state the dir layout is canonical and upgrades run the migration script.
+- Modify (drop the `legacy_suffix` arg, 9 sites):
+  - `archive.py` `archive_path` → `sidecar_path(config, conv_id, "archive.jsonl")`; `_compacted_path` → `"compacted.jsonl"`.
+  - `notes.py` `notes_path` → `"notes.md"`.
+  - `compaction_decisions.py` `_slice_path` → `"decisions.json"`.
+  - `context_composer.py` `_context_sidecar_path` → `"context.json"`.
+  - `canvas.py` `_canvas_sidecar_path` → `"canvas.json"`.
+  - `persistence.py` `_skills_path` → `"skills.json"`, `_skill_data_path` → `"skill_data.json"`.
+  - `skills/vault/_grants.py` `_grants_sidecar_path` → `"vault_grants.json"`.
+- Test: `tests/test_conversation_paths.py` — **remove** the fallback/both-layout tests (`test_sidecar_path_legacy_when_only_flat_exists`, `test_sidecar_path_new_wins_when_both_exist`, `test_iter_archives_yields_flat_layout`, `test_iter_archives_dir_wins_when_both_layouts`, `test_delete_removes_flat_legacy_files`, `test_delete_removes_both_dir_and_legacy`). **Keep/adjust:** `test_sidecar_path_new_when_neither_exists` (now the only sidecar_path behavior — rename to reflect it always returns the dir path), the dir-layout iter cases, `test_iter_archives_skips_compacted`, `test_iter_archives_skips_dir_without_archive`, `test_iter_archives_empty_when_root_missing`, `test_iter_archives_fails_open_on_oserror`, the dir-delete test.
+- Test: `tests/test_archive.py` — **remove** `test_append_does_not_split_existing_flat_archive` (the in-place-flat-append behavior is intentionally gone). Keep the new-layout round-trip + compacted round-trip.
+- Test: per-module fallback tests — **remove** `test_notes.py::test_legacy_flat_file_wins_until_migrated` (and any sibling "legacy flat" per-module tests). Keep the dir-layout path + round-trip assertions.
+
+**Key snippet:**
+```python
+def sidecar_path(config, conv_id: str, filename: str) -> Path:
+    """Resolve a per-conversation sidecar at conversations/{conv_id}/{filename}."""
+    return conversation_dir(config, conv_id) / filename
+
+def iter_conversation_archives(config) -> Iterator[tuple[str, Path]]:
+    base = conversations_root(config)
+    if not base.exists():
+        return
+    try:
+        children = sorted(base.iterdir())
+    except OSError as exc:
+        log.warning("Failed to list conversations dir %s: %s", base, exc)
+        return
+    for child in children:
+        if child.is_dir():
+            archive = child / "archive.jsonl"
+            if archive.exists():
+                yield child.name, archive
+```
+
+**Verification — automated:**
+- [x] `grep -rn "legacy_suffix\|_legacy_flat_path" src/ tests/` returns nothing
+- [x] `uv run pytest tests/test_conversation_paths.py tests/test_archive.py tests/test_notes.py -v` passes
+- [x] `make test` passes (2905 passed)
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] None.
+
+_Review fixes: `SIDECAR_LEGACY_SUFFIXES` deleted (unused); `notes.py` docstring de-staled. Code-quality flagged 4 stale doc refs (data-layout.md sidecar_path signature + SIDECAR_LEGACY_SUFFIXES + fallback section; CLAUDE.md key-file line) — all in Phase 2 scope._
+
+---
+
+## Phase 2: Docs
+
+Doc-only (no behavior).
+
+**Files:**
+- Modify: `docs/data-layout.md` — remove the "Legacy flat layout and the deprecation-window fallback" subsection; reword so the dir layout is the only layout and instances upgrading from the old flat layout run `make migrate-sidecars` (script retained). Keep the Migration subsection.
+- Modify: `CLAUDE.md` — the `conversation_paths.py` key-files line: drop "in-place legacy flat-file fallback"; keep "path chokepoint: `conversations/{conv_id}/{file}` dir layout, archive iteration + delete helpers (migration: `make migrate-sidecars`)".
+- Sweep: `grep -rn "fallback\|legacy flat\|deprecation" docs/data-layout.md docs/context-composer.md CLAUDE.md` — fix any remaining prose implying the code still reads flat files.
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `grep -rn "legacy flat\|flat legacy\|deprecation-window fallback" docs/ CLAUDE.md` returns only migration-context references (not "the code reads flat files")
+
+**Verification — manual:**
+- [x] Read the updated `data-layout.md` section — accurate (single layout + migration path).
+
+---
+
+## Notes
+- One commit per phase. Lint + test before each.
+- The migration script, its tests, Makefile targets, and `SIDECAR_FILENAMES` stay.

--- a/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/spec.md
+++ b/docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/spec.md
@@ -1,0 +1,51 @@
+# Remove conversation-sidecar flat read/write fallback Spec
+
+**Goal:** Now that the directory layout (`conversations/{conv_id}/{file}`) has shipped (#578) and existing data is migrated, remove the deprecation-window flat-layout fallback so the code has one path, not two.
+
+**Source:** [#584](https://github.com/lmorchard/decafclaw/issues/584) (follow-up to #576/#578).
+
+## Precondition (satisfied)
+
+The fallback's only job was to keep pre-migration flat sidecars working. Removing it makes any remaining flat sidecar invisible. Verified before starting:
+- Deployed agent: migrated by Les.
+- Local `data/` (shared by worktrees via `.env`): migrated this session — 6465 files moved, 0 flat sidecars remain, idempotent re-run = 0, archives read back via the dir layout. Backup at `data/decafclaw/conversations-backup-pre-sidecar-migration.tar.gz`.
+
+## Current state
+
+`src/decafclaw/conversation_paths.py` carries the fallback:
+- `sidecar_path(config, conv_id, filename, legacy_suffix)` returns an existing flat legacy file when the new path is absent (`_legacy_flat_path`).
+- `iter_conversation_archives` yields dir-layout archives **and** flat `*.jsonl`, dedup via a `seen` set.
+- `delete_conversation_files` rmtrees the dir **and** unlinks flat legacy files for all 9 `SIDECAR_LEGACY_SUFFIXES`.
+- All 9 sidecar helpers pass a `legacy_suffix` arg.
+
+## Desired end state
+
+- `sidecar_path(config, conv_id, filename)` → `conversation_dir(config, conv_id) / filename`. No `legacy_suffix`, no `_legacy_flat_path`.
+- `iter_conversation_archives` yields only dir-layout `{id}/archive.jsonl` (no flat branch, no `seen` dedup; compacted still excluded by keying on `archive.jsonl`; still fails open on `OSError`).
+- `delete_conversation_files` rmtrees the `{id}/` dir. It also keeps a **best-effort, delete-only** flat-sidecar cleanup (iterating `SIDECAR_FILENAMES`) so a delete stays thorough on a partially-migrated / migration-skipped instance — this is cleanup, not a read/write fallback (added in response to Copilot review; preserves #576's comprehensive-delete intent).
+- 9 call sites drop the `legacy_suffix` arg.
+- Tests rewritten to the single-layout contract (no fallback/both-layout/no-split tests).
+- Docs drop the deprecation-window fallback description.
+
+## Design decisions
+
+- **Keep the migration script + `make migrate-sidecars(-dry)` + `SIDECAR_FILENAMES`.** Removing the fallback doesn't remove the need to migrate an instance upgrading from an old version; the one-shot script is the supported path. Drop `SIDECAR_LEGACY_SUFFIXES` only if it's left with no users after the delete-loop removal.
+  - **Rejected:** deleting the script too — would strand any not-yet-upgraded instance with no migration path.
+- **Keep `sidecar_path` as a thin chokepoint** (`conversation_dir(...) / filename`) rather than inlining at 9 sites — clearer, one place to evolve.
+- **Remove the no-split-archive invariant test.** It guarded "append to an existing flat archive in place." That behavior is intentionally gone; post-migration no flat archive exists. (Per CLAUDE.md: rewrite/remove tests to the new path, no compat shims.)
+
+## Patterns to follow
+
+- `conversation_paths.py` helpers as shipped in #578 (this is a subtraction).
+- Test contract: `tests/test_conversation_paths.py` dir-layout cases stay; fallback cases go.
+
+## What we're NOT doing
+
+- NOT deleting `scripts/migrate_sidecars_to_dirs.py`, its tests, the Makefile targets, or `SIDECAR_FILENAMES`.
+- NOT changing the dir layout, filenames, or `conversation_dir`/`_safe_conv_id` sanitization.
+- NOT touching the 3 sibling follow-ups (#585 orphaned `delete_conversation_uploads`, #586 redundant startup_scan guard, #587 `uploads_dir` sanitization) — separate issues.
+- NOT re-running or modifying the migration.
+
+## Open questions
+
+- **Is `SIDECAR_LEGACY_SUFFIXES` still referenced after the delete-loop removal?** *Default:* grep; if only the removed loop used it, delete the constant (keep `SIDECAR_FILENAMES`). No blocker.

--- a/src/decafclaw/archive.py
+++ b/src/decafclaw/archive.py
@@ -17,7 +17,7 @@ LLM_ROLES = {"system", "user", "assistant", "tool"}
 
 def archive_path(config, conv_id: str) -> Path:
     """Compute the archive file path for a conversation."""
-    return sidecar_path(config, conv_id, "archive.jsonl", ".jsonl")
+    return sidecar_path(config, conv_id, "archive.jsonl")
 
 
 def append_message(config, conv_id: str, message: dict):
@@ -32,7 +32,7 @@ def append_message(config, conv_id: str, message: dict):
 
 
 def _compacted_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "compacted.jsonl", ".compacted.jsonl")
+    return sidecar_path(config, conv_id, "compacted.jsonl")
 
 
 def write_compacted_history(config, conv_id: str, messages: list[dict]):

--- a/src/decafclaw/canvas.py
+++ b/src/decafclaw/canvas.py
@@ -40,7 +40,7 @@ def empty_canvas_state() -> dict:
 
 
 def _canvas_sidecar_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "canvas.json", ".canvas.json")
+    return sidecar_path(config, conv_id, "canvas.json")
 
 
 def _derive_next_tab_id(tabs: list) -> int:

--- a/src/decafclaw/compaction_decisions.py
+++ b/src/decafclaw/compaction_decisions.py
@@ -81,7 +81,7 @@ class DecisionSlice:
 
 
 def _slice_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "decisions.json", ".decisions.json")
+    return sidecar_path(config, conv_id, "decisions.json")
 
 
 def load_slice(config, conv_id: str) -> DecisionSlice:

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -109,7 +109,7 @@ class ComposerState:
 
 
 def _context_sidecar_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "context.json", ".context.json")
+    return sidecar_path(config, conv_id, "context.json")
 
 
 def write_context_sidecar(config, conv_id: str, diagnostics: dict) -> None:

--- a/src/decafclaw/conversation_paths.py
+++ b/src/decafclaw/conversation_paths.py
@@ -2,10 +2,11 @@
 
 Convention (#576): every per-conversation sidecar lives in a directory
 named for the conversation id — conversations/{conv_id}/{file} — e.g.
-archive.jsonl, notes.md, decisions.json. Supersedes the legacy flat
-conversations/{conv_id}.SUFFIX layout. During the deprecation window
-code keeps reading AND writing an existing flat legacy file in place
-(no split data); only scripts/migrate_sidecars_to_dirs.py moves files.
+archive.jsonl, notes.md, decisions.json. This is the only layout.
+
+Instances upgrading from the old flat conversations/{conv_id}.SUFFIX
+layout run scripts/migrate_sidecars_to_dirs.py (`make migrate-sidecars`)
+once to move existing files into per-conversation directories.
 """
 from __future__ import annotations
 
@@ -29,7 +30,6 @@ SIDECAR_FILENAMES: tuple[tuple[str, str], ...] = (
     (".skill_data.json", "skill_data.json"),
     (".vault_grants.json", "vault_grants.json"),
 )
-SIDECAR_LEGACY_SUFFIXES: tuple[str, ...] = tuple(s for s, _ in SIDECAR_FILENAMES)
 
 
 def _safe_conv_id(conv_id: str) -> str:
@@ -51,36 +51,16 @@ def conversation_dir(config, conv_id: str, *, create: bool = False) -> Path:
     return d
 
 
-def _legacy_flat_path(config, conv_id: str, legacy_suffix: str) -> Path:
-    base = conversations_root(config)
-    p = (base / f"{_safe_conv_id(conv_id)}{legacy_suffix}").resolve()
-    if not p.is_relative_to(base):
-        return base / f"_invalid{legacy_suffix}"
-    return p
-
-
-def sidecar_path(config, conv_id: str, filename: str, legacy_suffix: str) -> Path:
-    """Resolve a per-conversation sidecar path. Prefers the directory
-    layout; while a flat legacy file still exists and the new path does
-    not, returns the legacy path so reads and writes stay on the existing
-    file until the migration script moves it. Callers mkdir the parent
-    before writing (the conversation dir is created lazily that way)."""
-    new = conversation_dir(config, conv_id) / filename
-    if not new.exists():
-        legacy = _legacy_flat_path(config, conv_id, legacy_suffix)
-        if legacy.exists():
-            return legacy
-    return new
+def sidecar_path(config, conv_id: str, filename: str) -> Path:
+    """Resolve a per-conversation sidecar at conversations/{conv_id}/{filename}."""
+    return conversation_dir(config, conv_id) / filename
 
 
 def iter_conversation_archives(config) -> Iterator[tuple[str, Path]]:
-    """Yield (conv_id, archive_path) across both layouts. Directory layout
-    ({id}/archive.jsonl) wins over flat ({id}.jsonl); a conv in both yields
-    once. Compacted sidecars are never yielded."""
+    """Yield (conv_id, archive_path) for every conversation directory."""
     base = conversations_root(config)
     if not base.exists():
         return
-    seen: set[str] = set()
     try:
         children = sorted(base.iterdir())
     except OSError as exc:
@@ -92,20 +72,19 @@ def iter_conversation_archives(config) -> Iterator[tuple[str, Path]]:
         if child.is_dir():
             archive = child / "archive.jsonl"
             if archive.exists():
-                seen.add(child.name)
                 yield child.name, archive
-    for child in children:
-        if (child.is_file() and child.name.endswith(".jsonl")
-                and not child.name.endswith(".compacted.jsonl")):
-            conv_id = child.name.removesuffix(".jsonl")
-            if conv_id not in seen:
-                yield conv_id, child
 
 
 def delete_conversation_files(config, conv_id: str) -> None:
     """Remove all on-disk state for a conversation: the {id}/ directory
-    (archive, sidecars, workflow.json, uploads) and any remaining flat
-    legacy sidecars."""
+    (archive, sidecars, workflow.json, uploads).
+
+    Also best-effort removes any leftover pre-#576 flat sidecars
+    (conversations/{id}.SUFFIX). The runtime no longer *reads* the flat
+    layout, but a delete must still be thorough on a partially-migrated or
+    migration-skipped instance — otherwise a "deleted" conversation could
+    leave readable history on disk. This is cleanup-only; it never makes a
+    flat file authoritative."""
     d = conversation_dir(config, conv_id)
     if d.exists():
         try:
@@ -114,8 +93,8 @@ def delete_conversation_files(config, conv_id: str) -> None:
             log.warning("Failed to remove conversation dir %s: %s", d, exc)
     base = conversations_root(config)
     safe = _safe_conv_id(conv_id)
-    for suffix in SIDECAR_LEGACY_SUFFIXES:
-        p = (base / f"{safe}{suffix}").resolve()
+    for legacy_suffix, _ in SIDECAR_FILENAMES:
+        p = (base / f"{safe}{legacy_suffix}").resolve()
         if p.is_relative_to(base) and p.exists():
             try:
                 p.unlink()

--- a/src/decafclaw/notes.py
+++ b/src/decafclaw/notes.py
@@ -36,9 +36,8 @@ class Note:
 
 def notes_path(config, conv_id: str) -> Path:
     """Resolve the per-conversation notes file at
-    conversations/{conv_id}/notes.md (legacy flat fallback during
-    the migration window)."""
-    return sidecar_path(config, conv_id, "notes.md", ".notes.md")
+    conversations/{conv_id}/notes.md."""
+    return sidecar_path(config, conv_id, "notes.md")
 
 
 def _now_iso() -> str:

--- a/src/decafclaw/persistence.py
+++ b/src/decafclaw/persistence.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def _skills_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "skills.json", ".skills.json")
+    return sidecar_path(config, conv_id, "skills.json")
 
 
 def write_skills_state(config, conv_id: str, skills: set[str]) -> None:
@@ -32,7 +32,7 @@ def read_skills_state(config, conv_id: str) -> set[str]:
 
 
 def _skill_data_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "skill_data.json", ".skill_data.json")
+    return sidecar_path(config, conv_id, "skill_data.json")
 
 
 def write_skill_data(config, conv_id: str, data: dict) -> None:

--- a/src/decafclaw/skills/vault/_grants.py
+++ b/src/decafclaw/skills/vault/_grants.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 def _grants_sidecar_path(config, conv_id: str) -> Path:
-    return sidecar_path(config, conv_id, "vault_grants.json", ".vault_grants.json")
+    return sidecar_path(config, conv_id, "vault_grants.json")
 
 
 def normalize_folder(folder: str, *, warn_on_invalid: bool = False) -> str:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,7 +1,5 @@
 """Tests for conversation archive."""
 
-import json
-
 from decafclaw.archive import (
     append_message,
     archive_path,
@@ -29,24 +27,6 @@ def test_archive_roundtrip_new_layout(config):
     msgs = read_archive(config, conv_id)
     assert len(msgs) == 1
     assert msgs[0]["content"] == "hello"
-
-
-def test_append_does_not_split_existing_flat_archive(config):
-    """If a flat legacy {id}.jsonl exists, appends MUST stay on it — no
-    new {id}/archive.jsonl is created (coherence invariant)."""
-    conv_id = "flat-legacy"
-    root = conversations_root(config)
-    root.mkdir(parents=True, exist_ok=True)
-    flat = root / f"{conv_id}.jsonl"
-    flat.write_text(json.dumps({"role": "user", "content": "first"}) + "\n")
-
-    append_message(config, conv_id, {"role": "assistant", "content": "second"})
-
-    lines = [ln for ln in flat.read_text().splitlines() if ln.strip()]
-    assert len(lines) == 2
-    assert not (root / conv_id / "archive.jsonl").exists()
-    msgs = read_archive(config, conv_id)
-    assert [m["content"] for m in msgs] == ["first", "second"]
 
 
 def test_compacted_roundtrip_new_layout(config):

--- a/tests/test_conversation_paths.py
+++ b/tests/test_conversation_paths.py
@@ -63,44 +63,21 @@ def test_conversation_dir_dotdot_only_resolves_to_invalid(tmp_path):
 # --- sidecar_path -----------------------------------------------------------
 
 
-def test_sidecar_path_new_when_neither_exists(tmp_path):
+def test_sidecar_path_returns_dir_path(tmp_path):
     cfg = _cfg(tmp_path)
     root = conversations_root(cfg)
-    p = sidecar_path(cfg, "abc", "notes.md", ".notes.md")
+    p = sidecar_path(cfg, "abc", "notes.md")
     assert p == root / "abc" / "notes.md"
 
 
-def test_sidecar_path_legacy_when_only_flat_exists(tmp_path):
-    cfg = _cfg(tmp_path)
-    root = conversations_root(cfg)
-    root.mkdir(parents=True)
-    legacy = root / "abc.notes.md"
-    legacy.write_text("hi")
-    p = sidecar_path(cfg, "abc", "notes.md", ".notes.md")
-    assert p == legacy
-
-
-def test_sidecar_path_new_when_only_new_exists(tmp_path):
+def test_sidecar_path_returns_dir_path_when_file_exists(tmp_path):
     cfg = _cfg(tmp_path)
     root = conversations_root(cfg)
     convdir = root / "abc"
     convdir.mkdir(parents=True)
     new = convdir / "notes.md"
     new.write_text("hi")
-    p = sidecar_path(cfg, "abc", "notes.md", ".notes.md")
-    assert p == new
-
-
-def test_sidecar_path_new_wins_when_both_exist(tmp_path):
-    cfg = _cfg(tmp_path)
-    root = conversations_root(cfg)
-    convdir = root / "abc"
-    convdir.mkdir(parents=True)
-    new = convdir / "notes.md"
-    new.write_text("new")
-    legacy = root / "abc.notes.md"
-    legacy.write_text("legacy")
-    p = sidecar_path(cfg, "abc", "notes.md", ".notes.md")
+    p = sidecar_path(cfg, "abc", "notes.md")
     assert p == new
 
 
@@ -135,33 +112,12 @@ def test_iter_archives_yields_dir_layout(tmp_path):
     assert list(iter_conversation_archives(cfg)) == [("abc", archive)]
 
 
-def test_iter_archives_yields_flat_layout(tmp_path):
-    cfg = _cfg(tmp_path)
-    root = conversations_root(cfg)
-    root.mkdir(parents=True)
-    flat = root / "abc.jsonl"
-    flat.write_text("{}")
-    assert list(iter_conversation_archives(cfg)) == [("abc", flat)]
-
-
-def test_iter_archives_dir_wins_when_both_layouts(tmp_path):
+def test_iter_archives_skips_compacted(tmp_path):
     cfg = _cfg(tmp_path)
     root = conversations_root(cfg)
     convdir = root / "abc"
     convdir.mkdir(parents=True)
-    dir_archive = convdir / "archive.jsonl"
-    dir_archive.write_text("{}")
-    flat = root / "abc.jsonl"
-    flat.write_text("{}")
-    results = list(iter_conversation_archives(cfg))
-    assert results == [("abc", dir_archive)]
-
-
-def test_iter_archives_skips_compacted(tmp_path):
-    cfg = _cfg(tmp_path)
-    root = conversations_root(cfg)
-    root.mkdir(parents=True)
-    (root / "abc.compacted.jsonl").write_text("{}")
+    (convdir / "compacted.jsonl").write_text("{}")
     assert list(iter_conversation_archives(cfg)) == []
 
 
@@ -190,30 +146,20 @@ def test_delete_removes_dir_with_nested_files(tmp_path):
     assert not convdir.exists()
 
 
-def test_delete_removes_flat_legacy_files(tmp_path):
+def test_delete_also_removes_leftover_flat_sidecars(tmp_path):
+    # Defense for a partially-migrated / migration-skipped instance: delete
+    # must still purge pre-#576 flat sidecars so "deleted" history doesn't
+    # linger on disk, even though the runtime no longer reads them.
     cfg = _cfg(tmp_path)
     root = conversations_root(cfg)
     root.mkdir(parents=True)
-    notes = root / "abc.notes.md"
-    notes.write_text("hi")
-    archive = root / "abc.jsonl"
-    archive.write_text("{}")
+    flat_archive = root / "abc.jsonl"
+    flat_notes = root / "abc.notes.md"
+    flat_archive.write_text("{}")
+    flat_notes.write_text("- note")
     delete_conversation_files(cfg, "abc")
-    assert not notes.exists()
-    assert not archive.exists()
-
-
-def test_delete_removes_both_dir_and_legacy(tmp_path):
-    cfg = _cfg(tmp_path)
-    root = conversations_root(cfg)
-    convdir = root / "abc"
-    convdir.mkdir(parents=True)
-    (convdir / "archive.jsonl").write_text("{}")
-    legacy = root / "abc.notes.md"
-    legacy.write_text("hi")
-    delete_conversation_files(cfg, "abc")
-    assert not convdir.exists()
-    assert not legacy.exists()
+    assert not flat_archive.exists()
+    assert not flat_notes.exists()
 
 
 def test_delete_is_noop_when_nothing_exists(tmp_path):

--- a/tests/test_conversation_search_tool.py
+++ b/tests/test_conversation_search_tool.py
@@ -1,17 +1,9 @@
-"""Tests for tool_conversation_search across both sidecar layouts."""
+"""Tests for tool_conversation_search over the dir sidecar layout."""
 
 import json
 
 from decafclaw.conversation_paths import conversations_root
 from decafclaw.tools.conversation_tools import tool_conversation_search
-
-
-def _write_flat(config, conv_id: str, messages: list[dict]) -> None:
-    root = conversations_root(config)
-    root.mkdir(parents=True, exist_ok=True)
-    with (root / f"{conv_id}.jsonl").open("w") as fh:
-        for m in messages:
-            fh.write(json.dumps(m) + "\n")
 
 
 def _write_dir(config, conv_id: str, messages: list[dict]) -> None:
@@ -36,22 +28,13 @@ def test_search_finds_match_in_dir_layout(ctx):
     assert "pelican migration" in out
 
 
-def test_search_finds_match_in_flat_layout(ctx):
-    _write_flat(ctx.config, "conv-flat", [
-        {"role": "assistant", "content": "the heron stood in the shallows"},
-    ])
-    out = tool_conversation_search(ctx, "heron")
-    assert "conv-flat" in out
-    assert "heron" in out
-
-
-def test_search_finds_across_both_layouts(ctx):
-    _write_dir(ctx.config, "conv-dir", [
+def test_search_finds_across_multiple_conversations(ctx):
+    _write_dir(ctx.config, "conv-one", [
         {"role": "user", "content": "osprey sighting"},
     ])
-    _write_flat(ctx.config, "conv-flat", [
+    _write_dir(ctx.config, "conv-two", [
         {"role": "user", "content": "osprey nesting"},
     ])
     out = tool_conversation_search(ctx, "osprey")
-    assert "conv-dir" in out
-    assert "conv-flat" in out
+    assert "conv-one" in out
+    assert "conv-two" in out

--- a/tests/test_newsletter_skill.py
+++ b/tests/test_newsletter_skill.py
@@ -67,9 +67,9 @@ def test_skill_config_defaults():
 def _write_sched_conv(ws: Path, skill: str, ts: datetime, records: list[dict]) -> str:
     """Helper: write a synthetic scheduled-task conversation archive."""
     conv_id = f"schedule-{skill}-{ts.strftime('%Y%m%d-%H%M%S')}"
-    conv_dir = ws / "conversations"
+    conv_dir = ws / "conversations" / conv_id
     conv_dir.mkdir(parents=True, exist_ok=True)
-    path = conv_dir / f"{conv_id}.jsonl"
+    path = conv_dir / "archive.jsonl"
     with path.open("w") as fh:
         for rec in records:
             fh.write(json.dumps(rec) + "\n")

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -62,22 +62,6 @@ class TestNotesPath:
         assert p.parent.name == "_invalid"
         assert p.name == "notes.md"
 
-    def test_legacy_flat_file_wins_until_migrated(self, config):
-        """While a flat ``{id}.notes.md`` exists and the dir layout
-        does not, reads/writes stay on the legacy file. Once the dir
-        file exists too, the dir layout wins."""
-        root = (config.workspace_path / "conversations").resolve()
-        root.mkdir(parents=True, exist_ok=True)
-        legacy = root / "leg.notes.md"
-        legacy.write_text("- 2026-01-01T00:00:00Z — old\n")
-        # legacy present, new absent → legacy path
-        assert notes_path(config, "leg") == legacy
-        # create the dir-layout file → dir layout wins
-        new_dir = root / "leg"
-        new_dir.mkdir(parents=True, exist_ok=True)
-        (new_dir / "notes.md").write_text("- 2026-01-02T00:00:00Z — new\n")
-        assert notes_path(config, "leg") == new_dir / "notes.md"
-
 
 # -- Append + read -------------------------------------------------------------
 

--- a/tests/test_restore_history.py
+++ b/tests/test_restore_history.py
@@ -31,7 +31,7 @@ def test_restore_history_archive_only(config):
         {"role": "user", "content": "hello", "timestamp": "2026-01-01T00:00:00"},
         {"role": "assistant", "content": "hi", "timestamp": "2026-01-01T00:00:01"},
     ]
-    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", messages)
+    _write_jsonl(_conv_dir(config) / CONV_ID / "archive.jsonl", messages)
 
     result = restore_history(config, CONV_ID)
     assert result == messages
@@ -46,8 +46,8 @@ def test_restore_history_compacted_only(config):
     compacted_msgs = [
         {"role": "assistant", "content": "summary of conversation", "timestamp": "2026-01-01T00:00:01"},
     ]
-    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", archive_msgs)
-    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.compacted.jsonl", compacted_msgs)
+    _write_jsonl(_conv_dir(config) / CONV_ID / "archive.jsonl", archive_msgs)
+    _write_jsonl(_conv_dir(config) / CONV_ID / "compacted.jsonl", compacted_msgs)
 
     result = restore_history(config, CONV_ID)
     # Should return only the compacted messages (no newer archive entries)
@@ -65,8 +65,8 @@ def test_restore_history_compacted_plus_newer(config):
         {"role": "user", "content": "new msg", "timestamp": "2026-01-01T00:00:06"},
         {"role": "assistant", "content": "new reply", "timestamp": "2026-01-01T00:00:07"},
     ]
-    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.jsonl", archive_msgs)
-    _write_jsonl(_conv_dir(config) / f"{CONV_ID}.compacted.jsonl", compacted_msgs)
+    _write_jsonl(_conv_dir(config) / CONV_ID / "archive.jsonl", archive_msgs)
+    _write_jsonl(_conv_dir(config) / CONV_ID / "compacted.jsonl", compacted_msgs)
 
     result = restore_history(config, CONV_ID)
     assert result == [
@@ -78,7 +78,7 @@ def test_restore_history_compacted_plus_newer(config):
 
 def test_restore_history_empty_archive(config):
     """Returns None when archive file exists but is empty."""
-    path = _conv_dir(config) / f"{CONV_ID}.jsonl"
+    path = _conv_dir(config) / CONV_ID / "archive.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("")
 

--- a/tests/test_system_conversations.py
+++ b/tests/test_system_conversations.py
@@ -18,6 +18,13 @@ from decafclaw.web.websocket import (
 )
 
 
+def _write_archive(conv_dir, conv_id: str, body: str) -> None:
+    """Write a dir-layout archive at conversations/{conv_id}/archive.jsonl."""
+    d = conv_dir / conv_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "archive.jsonl").write_text(body)
+
+
 class TestClassifyConvId:
     def test_schedule(self):
         conv_type, title = _classify_conv_id("schedule-dream-20260324-125204")
@@ -52,13 +59,11 @@ class TestListSystemConversations:
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
         # Create a schedule archive
-        (conv_dir / "schedule-dream-20260324-125204.jsonl").write_text(
-            json.dumps({"role": "user", "content": "test"}) + "\n"
-        )
+        _write_archive(conv_dir, "schedule-dream-20260324-125204",
+                       json.dumps({"role": "user", "content": "test"}) + "\n")
         # Create a web archive (should be excluded)
-        (conv_dir / "web-user-abc123.jsonl").write_text(
-            json.dumps({"role": "user", "content": "test"}) + "\n"
-        )
+        _write_archive(conv_dir, "web-user-abc123",
+                       json.dumps({"role": "user", "content": "test"}) + "\n")
 
         results = list_system_conversations(config)
         conv_ids = [r["conv_id"] for r in results]
@@ -87,8 +92,10 @@ class TestListSystemConversations:
     def test_excludes_compacted_sidecars(self, config):
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        (conv_dir / "schedule-foo-20260324-120000.jsonl").write_text("{}\n")
-        (conv_dir / "schedule-foo-20260324-120000.compacted.jsonl").write_text("{}\n")
+        d = conv_dir / "schedule-foo-20260324-120000"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "archive.jsonl").write_text("{}\n")
+        (d / "compacted.jsonl").write_text("{}\n")
 
         results = list_system_conversations(config)
         assert len(results) == 1
@@ -96,7 +103,7 @@ class TestListSystemConversations:
     def test_includes_delegated_children(self, config):
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        (conv_dir / "web-user-abc123--child-def456.jsonl").write_text("{}\n")
+        _write_archive(conv_dir, "web-user-abc123--child-def456", "{}\n")
 
         results = list_system_conversations(config)
         assert len(results) == 1
@@ -106,10 +113,10 @@ class TestListSystemConversations:
         import os
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        old = conv_dir / "schedule-old-20260101-120000.jsonl"
-        new = conv_dir / "schedule-new-20260324-120000.jsonl"
-        old.write_text("{}\n")
-        new.write_text("{}\n")
+        _write_archive(conv_dir, "schedule-old-20260101-120000", "{}\n")
+        _write_archive(conv_dir, "schedule-new-20260324-120000", "{}\n")
+        old = conv_dir / "schedule-old-20260101-120000" / "archive.jsonl"
+        new = conv_dir / "schedule-new-20260324-120000" / "archive.jsonl"
         # Force deterministic mtimes
         os.utime(old, (1000000, 1000000))
         os.utime(new, (2000000, 2000000))
@@ -144,8 +151,8 @@ class TestDelegatedFiltering:
     def test_filters_delegated_by_username(self, config):
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        (conv_dir / "web-alice-abc123--child-def456.jsonl").write_text("{}\n")
-        (conv_dir / "web-bob-abc123--child-ghi789.jsonl").write_text("{}\n")
+        _write_archive(conv_dir, "web-alice-abc123--child-def456", "{}\n")
+        _write_archive(conv_dir, "web-bob-abc123--child-ghi789", "{}\n")
 
         results = list_system_conversations(config, username="alice")
         conv_ids = [r["conv_id"] for r in results]
@@ -155,8 +162,8 @@ class TestDelegatedFiltering:
     def test_no_filter_without_username(self, config):
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        (conv_dir / "web-alice-abc123--child-def456.jsonl").write_text("{}\n")
-        (conv_dir / "web-bob-abc123--child-ghi789.jsonl").write_text("{}\n")
+        _write_archive(conv_dir, "web-alice-abc123--child-def456", "{}\n")
+        _write_archive(conv_dir, "web-bob-abc123--child-ghi789", "{}\n")
 
         results = list_system_conversations(config, username="")
         assert len(results) == 2
@@ -169,9 +176,8 @@ class TestSystemConvAccess:
         config = ws_state["config"]
         conv_dir = config.workspace_path / "conversations"
         conv_dir.mkdir(parents=True, exist_ok=True)
-        (conv_dir / "schedule-test-20260324-120000.jsonl").write_text(
-            json.dumps({"role": "user", "content": "hello"}) + "\n"
-        )
+        _write_archive(conv_dir, "schedule-test-20260324-120000",
+                       json.dumps({"role": "user", "content": "hello"}) + "\n")
 
         ws_send = AsyncMock()
         await _handle_select_conv(ws_send, index, "testuser",

--- a/tests/test_web_conversations.py
+++ b/tests/test_web_conversations.py
@@ -385,9 +385,9 @@ async def test_export_system_conv_with_archive(authed_client, http_config):
     granted by archive-on-disk for non-`web-` conv IDs, mirroring the
     behavior of the WS load_history handler."""
     conv_dir = http_config.workspace_path / "conversations"
-    conv_dir.mkdir(parents=True, exist_ok=True)
     conv_id = "schedule-mastodon-ingest-20260520-053002"
-    archive = conv_dir / f"{conv_id}.jsonl"
+    (conv_dir / conv_id).mkdir(parents=True, exist_ok=True)
+    archive = conv_dir / conv_id / "archive.jsonl"
     archive.write_text(
         '{"role":"user","content":"run the ingest","timestamp":"2026-05-20T05:30:02Z"}\n'
         '{"role":"assistant","content":"done","timestamp":"2026-05-20T05:30:10Z"}\n'
@@ -412,9 +412,9 @@ async def test_history_system_conv_with_archive(authed_client, http_config):
     """REST /history should also serve system conversations (same access
     model as WS load_history and /export)."""
     conv_dir = http_config.workspace_path / "conversations"
-    conv_dir.mkdir(parents=True, exist_ok=True)
     conv_id = "heartbeat-20260520-053000-0"
-    (conv_dir / f"{conv_id}.jsonl").write_text(
+    (conv_dir / conv_id).mkdir(parents=True, exist_ok=True)
+    (conv_dir / conv_id / "archive.jsonl").write_text(
         '{"role":"user","content":"tick"}\n'
     )
 
@@ -427,12 +427,12 @@ async def test_history_system_conv_with_archive(authed_client, http_config):
 async def test_context_diagnostics_system_conv(authed_client, http_config):
     """REST /context should also serve system conversations."""
     conv_dir = http_config.workspace_path / "conversations"
-    conv_dir.mkdir(parents=True, exist_ok=True)
     conv_id = "schedule-newsletter-20260520-080000"
-    (conv_dir / f"{conv_id}.jsonl").write_text("{}\n")
+    (conv_dir / conv_id).mkdir(parents=True, exist_ok=True)
+    (conv_dir / conv_id / "archive.jsonl").write_text("{}\n")
     # /context reads a sidecar; write a minimal one so the endpoint returns 200.
     import json
-    (conv_dir / f"{conv_id}.context.json").write_text(
+    (conv_dir / conv_id / "context.json").write_text(
         json.dumps({"messages": [], "tools": [], "diagnostics": {}})
     )
 
@@ -586,9 +586,10 @@ async def test_list_system_convs(authed_client, http_config):
     """System conversations appear in /system endpoint with type sub-folders."""
     # Create some system conversation archive files
     conv_dir = http_config.workspace_path / "conversations"
-    conv_dir.mkdir(parents=True, exist_ok=True)
-    (conv_dir / "heartbeat-20260401-100000-0.jsonl").write_text("{}\n")
-    (conv_dir / "schedule-daily-20260401-090000.jsonl").write_text("{}\n")
+    (conv_dir / "heartbeat-20260401-100000-0").mkdir(parents=True, exist_ok=True)
+    (conv_dir / "heartbeat-20260401-100000-0" / "archive.jsonl").write_text("{}\n")
+    (conv_dir / "schedule-daily-20260401-090000").mkdir(parents=True, exist_ok=True)
+    (conv_dir / "schedule-daily-20260401-090000" / "archive.jsonl").write_text("{}\n")
 
     # Top level should show sub-folder types, no conversations
     resp = await authed_client.get("/api/conversations/system")
@@ -834,8 +835,8 @@ async def test_delete_conv_route(authed_client, http_config):
     # Add some archive content so we can verify file cleanup
     append_message(http_config, conv_id, {"role": "user", "content": "hello"})
     conv_dir = http_config.workspace_path / "conversations"
-    (conv_dir / f"{conv_id}.compacted.jsonl").write_text("{}\n")
-    (conv_dir / f"{conv_id}.context.json").write_text("{}\n")
+    (conv_dir / conv_id / "compacted.jsonl").write_text("{}\n")
+    (conv_dir / conv_id / "context.json").write_text("{}\n")
 
     resp = await authed_client.delete(f"/api/conversations/{conv_id}")
     assert resp.status_code == 200
@@ -847,9 +848,7 @@ async def test_delete_conv_route(authed_client, http_config):
     assert conv_id not in ids
 
     # Files should be gone
-    assert not (conv_dir / f"{conv_id}.jsonl").exists()
-    assert not (conv_dir / f"{conv_id}.compacted.jsonl").exists()
-    assert not (conv_dir / f"{conv_id}.context.json").exists()
+    assert not (conv_dir / conv_id).exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Removes the deprecation-window fallback that let the code read/write the old flat `conversations/{conv_id}.SUFFIX` sidecars in place.
- Now that the per-conversation directory layout (#576/#578) is the only layout and existing data is migrated, the code can have one path instead of two.

## Design Decisions
- **Keep the migration script + `make migrate-sidecars(-dry)` + `SIDECAR_FILENAMES`.** Removing the *runtime* fallback doesn't remove the need to migrate an instance upgrading from the pre-#576 flat layout — the one-shot script is the supported path. Without the fallback, that migration is now a hard prerequisite (no silent in-place reads).
- **Keep `sidecar_path` as a thin chokepoint** (`conversation_dir(...) / filename`) rather than inlining at 9 sites — one documented seam for the convention.
- **Remove the no-split-archive invariant test.** It guarded "append to an existing flat archive in place" — behavior that's intentionally gone.

## Changes
- `conversation_paths.py`: `sidecar_path` drops `legacy_suffix` + fallback; `_legacy_flat_path` removed; `iter_conversation_archives` is dir-only (still excludes compacted, still fails open on `OSError`); `delete_conversation_files` rmtrees the `{id}/` dir, plus a best-effort *delete-only* cleanup of any leftover flat `{id}.SUFFIX` files (defense for a partially-migrated instance — not a read/write fallback); `SIDECAR_LEGACY_SUFFIXES` deleted (unused).
- 9 sidecar call sites drop the `legacy_suffix` arg.
- Tests: fallback / both-layout / no-split tests removed; the rest rewritten to the single-layout contract.
- Docs: `data-layout.md` reframes the flat layout as a one-time migration (no runtime fallback); `CLAUDE.md` key-file note updated.

Net **−158 lines** (a subtraction).

## Migration prerequisite (done for the known instances)
Removing the fallback makes any remaining flat sidecar invisible, so every instance must be migrated first.
- **Deployed agent:** migrated (you ran `make migrate-sidecars`).
- **Local `data/`** (shared by worktrees via `.env`): was *not* migrated — found 6,465 flat files. Backed up + migrated this session (6,465 moved → 0 flat remain; idempotent re-run = 0; archives read back via the dir layout). See `notes.md`.

Any *other* instance must run `make migrate-sidecars` (after `make migrate-sidecars-dry` + a backup) before deploying this.

## Test Plan
- [x] `make test` — 2905 passed (fallback tests removed; single-layout tests kept/rewritten)
- [x] `make check` — clean
- [x] `grep legacy_suffix|_legacy_flat_path|SIDECAR_LEGACY_SUFFIXES` over src/tests/scripts → empty
- [x] Migration script + `SIDECAR_FILENAMES` intact (`--help` runs; tests pass)

## References
- Spec: `docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/spec.md`
- Plan: `docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/plan.md`
- Notes: `docs/dev-sessions/2026-06-12-1649-584-remove-flat-fallback/notes.md`
- Follow-up to #576 / #578. Sibling follow-ups still open: #585, #586, #587.

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)