### PR TITLE
Inject vault-root AGENTS.md as always-loaded context (#592)

### DIFF
--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -75,6 +75,7 @@ the slice guidance still lives in the system prompt via the addendum.
 │ - USER.md (user context, if present)    │
 │ - Skill catalog (name + description)    │
 │ - Deferred tools list (if over budget)  │
+│ - Vault guide (AGENTS.md, if present)   │
 ├─────────────────────────────────────────┤
 │ TOOL DEFINITIONS (sent as `tools` param)│
 │ - Always-loaded: shell, workspace_*,    │
@@ -159,12 +160,12 @@ class ComposedContext:
 
 The composer is mode-aware via `ComposerMode`:
 
-| Mode | Memory | Wiki | Tools | Use case |
-|------|--------|------|-------|----------|
-| `INTERACTIVE` | Yes | Yes | Full | Mattermost, web UI, terminal |
-| `HEARTBEAT` | No | No | Full | Periodic heartbeat (set via `ctx.task_mode="heartbeat"`) |
-| `SCHEDULED` | No | No | Full | Scheduled tasks (set via `ctx.task_mode="scheduled"`) |
-| `CHILD_AGENT` | No | No | Full | `delegate_task` sub-agents (set via `ctx.is_child`) |
+| Mode | Memory | Wiki | Vault guide | Tools | Use case |
+|------|--------|------|-------------|-------|----------|
+| `INTERACTIVE` | Yes | Yes | Yes | Full | Mattermost, web UI, terminal |
+| `HEARTBEAT` | No | No | No | Full | Periodic heartbeat (set via `ctx.task_mode="heartbeat"`) |
+| `SCHEDULED` | No | No | No | Full | Scheduled tasks (set via `ctx.task_mode="scheduled"`) |
+| `CHILD_AGENT` | No | No | No | Full | `delegate_task` sub-agents (set via `ctx.is_child`) |
 
 `skip_vault_retrieval` on the context is an independent flag — it skips vault retrieval without affecting vault references or the composer mode.
 
@@ -324,6 +325,44 @@ By default, every interactive turn auto-injects scored full-body candidates from
 **Headlines format** uses each result's `summary` frontmatter field when present, falls back to a truncated body excerpt. Configurable cap via `vault_retrieval.headline_summary_max_chars` (default 120).
 
 **Unknown mode values** in config log a warning and fall back to `always`.
+
+## Vault guide
+
+When a guide file exists at the vault root (default `AGENTS.md`, configurable via `vault_guide.path`), `ContextComposer._compose_vault_guide` reads it fresh each interactive turn and injects it as a `<vault_guide>` system message immediately after the main system prompt — before the deferred-tools list and any preempt-skill content.
+
+### Purpose
+
+The vault guide carries always-applies rules: vault folder layout, which paths are the user's vs the agent's, and any protocols the agent must always follow. These rules must be present before the model makes any tool decision. Similarity-gated memory retrieval can miss a procedural rule when the user's message embeds far from it — the vault guide is not gated at all.
+
+### Role and trust
+
+The guide is injected as a **system** message, unlike retrieved vault content (remapped to `user`). This signals binding instructions, not advisory context. The trust assumption is that `AGENTS.md` is the user's own authored file — treat it the same way as `SOUL.md`/`AGENT.md`.
+
+### Independence from vault retrieval
+
+The vault guide is a plain file read — no embeddings, no semantic scoring. It works even when `vault_retrieval` is disabled or no embedding model is configured.
+
+### Skip conditions
+
+Skipped for HEARTBEAT, SCHEDULED, and CHILD_AGENT modes. Only interactive turns inject the guide.
+
+### Failure modes
+
+Fail-open: a missing file, unreadable path, or empty file produces no section. No error is surfaced to the model.
+
+### Token cap
+
+Oversized guides are truncated (head kept) at `vault_guide.max_tokens` (default 2000) with a logged warning. The cap protects against accidentally pointing the config at a large document.
+
+### Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `vault_guide.enabled` | bool | `true` | Enable/disable the feature |
+| `vault_guide.path` | string | `"AGENTS.md"` | Path relative to the vault root |
+| `vault_guide.max_tokens` | int | `2000` | Token cap; oversized guides are truncated at the head |
+
+Config dataclass: `VaultGuideConfig` in `config_types.py`. Settable in `data/{agent_id}/config.json` under the `vault_guide` key, or via the `VAULT_GUIDE_` env prefix (`VAULT_GUIDE_ENABLED`, `VAULT_GUIDE_PATH`, `VAULT_GUIDE_MAX_TOKENS`), following the standard resolution order (defaults → config.json → env).
 
 ## Tool-result clearing (lightweight tier)
 

--- a/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/notes.md
+++ b/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/notes.md
@@ -1,0 +1,83 @@
+# Notes — Always-loaded vault `AGENTS.md` (#592)
+
+## Origin
+
+Started from a debugging thread: the deployed agent (Caffeina, gemini-2.5-flash)
+re-learned the same lesson — "user journal = `journals/YYYY/…`, my journal =
+`agent/journal/`" — five times in ~6 minutes across three conversations, and
+journaled a near-duplicate each time. Diagnosis: an *always-applies* procedural
+rule was routed through *similarity-gated* memory retrieval. A query about
+"meetings this week" embeds far from a vault-structure rule, so retrieval never
+surfaced it. The rule **was** documented — in `obsidian/main/AGENTS.md` — but
+that's a vault page, not always-loaded prompt content, so it only appeared when
+retrieval happened to match or the agent explicitly read it.
+
+The agent also confabulated that the main agent does no proactive vault
+retrieval (it does; the `allow_vault_retrieval` flag it half-remembered is the
+*child-agent* default-deny). Verified on the deployed box: retrieval is on (mode
+`always`, semantic), journal entries are indexed immediately on append and are
+in the search pool — so the lesson was retrievable, just never query-matched.
+
+## Decision
+
+Fix the storage/timing mismatch: load the vault's own `AGENTS.md` into context
+at **turn assembly** (the only point that precedes the model's first tool
+decision). Tool-triggered injection was rejected — a tool call is the model's
+output, so injecting in response to one is always a step too late to prevent the
+first wrong call.
+
+Key design choices (brainstorm):
+- **`system` role** (authoritative), not the `user`-remap used for *retrieved*
+  vault content — the goal is reliable enforcement; trust assumption is that
+  `AGENTS.md` is the user's own authored file.
+- **Single guide file** (YAGNI) — not a configurable list.
+- **Read fresh from the vault** (single source of truth) rather than copying
+  essentials into `USER.md` — avoids drift. The `USER.md` stopgap was
+  intentionally skipped in favor of this durable fix.
+
+## Implementation
+
+Four tasks, subagent-driven (implementer + spec review + code-quality review
+each):
+
+1. `VaultGuideConfig` (`enabled`/`path="AGENTS.md"`/`max_tokens=2000`) on
+   `Config`, env prefix `VAULT_GUIDE_`.
+2. `ContextComposer._compose_vault_guide(config, mode)` — fresh read, wrap in
+   `<vault_guide>`, fail-open, token cap (head + warning), skip background modes.
+3. Wire into `compose()` — tokens added to `fixed_tokens` *before* the budget
+   math; `system` message inserted between the main system prompt and
+   `deferred_text`; `SourceEntry` for diagnostics.
+4. Docs — `context-composer.md` (new section + layout/modes additions) and
+   `vault.md` (mention + cross-link).
+
+## Review-driven fixes
+
+- **Task 2:** broadened `except OSError` → `except (OSError, ValueError)` so
+  `UnicodeDecodeError` (non-UTF-8 guide file) is caught by the fail-open
+  handler; added a regression test. Also `str()`-wrapped the `details` path.
+- **Task 4:** corrected a doc inaccuracy that claimed no env-var prefix exists
+  (it's `VAULT_GUIDE_`).
+
+## Verification
+
+- `make check` clean (ruff + pyright 0 errors, no message-type drift).
+- Full suite: 2927 passed.
+- Final holistic review: ready to merge.
+
+## Follow-ups (separate issues, out of scope here)
+
+- File-wide function-level-import cleanup in `context_composer.py` (the new code
+  follows the file's de-facto cycle-avoidance pattern; the stated convention is
+  module-level).
+- A `config.json` file-based `vault_guide` loading test (defaults + env are
+  covered; file-based relies on shared `load_sub_config` coverage).
+- The context-window layout diagram shows always-loaded sections (deferred
+  tools, now vault guide) inside the SYSTEM-PROMPT box though each is a separate
+  `system` message — a pre-existing diagram convention worth a holistic fix.
+
+## Deployment note
+
+Once merged and deployed, this only takes effect on the deployed agent once its
+`obsidian/main/AGENTS.md` is present (it is) — no config change needed (defaults
+enable it). The five duplicate journal entries from the origin incident remain;
+`dream` will consolidate them, or they can be pruned manually.

--- a/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/plan.md
+++ b/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/plan.md
@@ -1,0 +1,459 @@
+# Always-loaded vault `AGENTS.md` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Inject the vault's authored guide file (default `AGENTS.md` at the vault root) into every interactive turn's context as an always-loaded `system` section, so vault-layout/protocol rules are present *before* the model makes any tool decisions.
+
+**Architecture:** A new synchronous `ContextComposer._compose_vault_guide(config, mode)` helper reads `<vault_root>/<path>` fresh each turn, wraps it in a `<vault_guide>` XML section, and returns `(text, SourceEntry|None)`. `compose()` adds its tokens to the fixed-token budget and inserts it as a `system` message immediately after the main system prompt, before the deferred-tools/preempt sections. Config lives in a new `VaultGuideConfig` dataclass wired onto `Config` via the standard `load_sub_config` path. Independent of `vault_retrieval` (no embeddings).
+
+**Tech Stack:** Python 3, dataclasses, pytest (xdist). Repo conventions: `wrap_xml` from `decafclaw.prompts`, `estimate_tokens` from `decafclaw.util` (~4 chars/token), `load_sub_config` env resolution.
+
+**Worktree:** `.claude/worktrees/592-vault-guide-always-loaded` (branch `592-vault-guide-always-loaded`, off `origin/main`, venv synced). Run all commands from there.
+
+---
+
+## File Structure
+
+- `src/decafclaw/config_types.py` — add `VaultGuideConfig` dataclass (near `VaultRetrievalConfig`, ~line 237).
+- `src/decafclaw/config.py` — add `vault_guide` field to `Config` (~line 178); add `load_sub_config` call (~line 448) and pass it into the `Config(...)` constructor (~line 540).
+- `src/decafclaw/context_composer.py` — add `_compose_vault_guide` method; call it in `compose()` (add to `fixed_tokens` + `sources`, insert `system` message in the assembly block).
+- `tests/test_config.py` — `VaultGuideConfig` defaults + env override.
+- `tests/test_context_composer.py` — helper unit tests + `compose()` integration tests.
+- `docs/context-composer.md`, `docs/vault.md` — doc updates.
+
+---
+
+## Task 1: `VaultGuideConfig` dataclass + Config wiring
+
+**Files:**
+- Modify: `src/decafclaw/config_types.py` (after `VaultRetrievalConfig`, ~line 254)
+- Modify: `src/decafclaw/config.py` (`Config` field ~line 178; `load_sub_config` ~line 448; constructor ~line 540)
+- Test: `tests/test_config.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config.py` (inside the existing test class alongside `test_default_config`, or as new methods at module test-class level — match the file's style):
+
+```python
+    def test_vault_guide_defaults(self):
+        """VaultGuideConfig defaults: enabled, AGENTS.md, 2000-token cap."""
+        from decafclaw.config_types import VaultGuideConfig
+        c = Config()
+        assert isinstance(c.vault_guide, VaultGuideConfig)
+        assert c.vault_guide.enabled is True
+        assert c.vault_guide.path == "AGENTS.md"
+        assert c.vault_guide.max_tokens == 2000
+
+    def test_vault_guide_env_override(self, tmp_path, monkeypatch):
+        """Env prefix VAULT_GUIDE_* overrides the guide config."""
+        monkeypatch.setenv("VAULT_GUIDE_ENABLED", "false")
+        monkeypatch.setenv("VAULT_GUIDE_PATH", "protocols/GUIDE.md")
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.vault_guide.enabled is False
+        assert c.vault_guide.path == "protocols/GUIDE.md"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_config.py -k vault_guide -v`
+Expected: FAIL — `AttributeError: 'Config' object has no attribute 'vault_guide'` (and import error for `VaultGuideConfig`).
+
+- [ ] **Step 3: Add the dataclass**
+
+In `src/decafclaw/config_types.py`, immediately after the `VaultRetrievalConfig` dataclass (before `class RelevanceConfig`):
+
+```python
+@dataclass
+class VaultGuideConfig:
+    """Always-loaded vault guide (e.g. AGENTS.md).
+
+    When a guide file is present at ``<vault_root>/<path>``, its contents
+    are injected as an authoritative ``system`` section on every
+    interactive turn (#592). Independent of vault_retrieval — plain file
+    read, no embeddings.
+    """
+    enabled: bool = True
+    path: str = "AGENTS.md"      # relative to vault root
+    max_tokens: int = 2000       # AGENTS.md is ~500 tok; generous cap
+```
+
+- [ ] **Step 4: Wire onto Config**
+
+In `src/decafclaw/config.py`, add the field to the `Config` dataclass next to `vault` (~line 178):
+
+```python
+    vault_guide: VaultGuideConfig = field(default_factory=VaultGuideConfig)
+```
+
+Add the import to the existing `config_types` import block (find where `VaultConfig`, `VaultRetrievalConfig` are imported) so `VaultGuideConfig` is in scope.
+
+In `load_config()`, after the `vault = load_sub_config(...)` block (~line 448):
+
+```python
+    vault_guide = load_sub_config(
+        VaultGuideConfig, file_data.get("vault_guide", {}), "VAULT_GUIDE")
+```
+
+In the `Config(...)` constructor call, next to `vault=vault,` (~line 540):
+
+```python
+        vault_guide=vault_guide,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_config.py -k vault_guide -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decafclaw/config_types.py src/decafclaw/config.py tests/test_config.py
+git commit -m "feat(592): add VaultGuideConfig"
+```
+
+---
+
+## Task 2: `_compose_vault_guide` helper
+
+**Files:**
+- Modify: `src/decafclaw/context_composer.py` (new method on `ContextComposer`, place near `_compose_vault_references`)
+- Test: `tests/test_context_composer.py` (new `TestComposeVaultGuide` class)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new test class to `tests/test_context_composer.py` (model on the existing `TestComposeWikiContext`). The `config`, `ctx`, and `tmp_path` fixtures come from `tests/conftest.py`:
+
+```python
+class TestComposeVaultGuide:
+    def _write_guide(self, config, tmp_path, text):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir(exist_ok=True)
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / config.vault_guide.path).write_text(text, encoding="utf-8")
+        return vault_dir
+
+    def test_returns_section_when_present(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "# Vault Guide\nUser journals live in journals/.")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text.startswith("<vault_guide>")
+        assert "journals/" in text
+        assert entry is not None
+        assert entry.source == "vault_guide"
+        assert entry.items_included == 1
+        assert entry.tokens_estimated > 0
+
+    def test_skips_when_disabled(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "# Guide")
+        config.vault_guide.enabled = False
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_file_absent(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)  # no AGENTS.md written
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_file_empty(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "   \n  ")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    @pytest.mark.parametrize("mode", [
+        ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT,
+    ])
+    def test_skips_background_modes(self, config, tmp_path, mode):
+        self._write_guide(config, tmp_path, "# Guide")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, mode)
+        assert text == ""
+        assert entry is None
+
+    def test_truncates_oversized_guide(self, config, tmp_path):
+        config.vault_guide.max_tokens = 10  # ~40 char budget
+        self._write_guide(config, tmp_path, "WORD " * 200)  # ~1000 chars
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert "[vault guide truncated]" in text
+        assert entry.items_truncated == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_context_composer.py::TestComposeVaultGuide -v`
+Expected: FAIL — `AttributeError: 'ContextComposer' object has no attribute '_compose_vault_guide'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/decafclaw/context_composer.py`, add this method to the `ContextComposer` class, immediately after `_compose_vault_references` (keep the vault-related helpers together):
+
+```python
+    def _compose_vault_guide(
+        self, config, mode: ComposerMode,
+    ) -> tuple[str, SourceEntry | None]:
+        """Inject the vault's authored guide (default ``AGENTS.md``) as an
+        always-loaded ``system`` section.
+
+        Read fresh each interactive turn from ``<vault_root>/<path>`` so the
+        single source of truth is the vault file itself (no duplication into
+        SOUL.md/AGENT.md/USER.md, no drift). Authoritative ``system`` role by
+        design (#592): unlike *retrieved* vault content — which the composer
+        remaps to ``user`` for prompt-injection posture — this is the user's
+        own protocol doc and the goal is reliable enforcement.
+
+        Fail-open: missing file / no vault / read error → ("", None).
+        Skipped for heartbeat / scheduled / child-agent modes and when
+        ``config.vault_guide.enabled`` is False. Returns (wrapped_text, entry).
+        """
+        from .prompts import wrap_xml
+        from .util import estimate_tokens
+
+        skip_modes = {
+            ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT,
+        }
+        if not config.vault_guide.enabled or mode in skip_modes:
+            return "", None
+
+        try:
+            guide_path = config.vault_root / config.vault_guide.path
+            if not guide_path.is_file():
+                return "", None
+            content = guide_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            log.debug("vault guide read failed: %s", exc)
+            return "", None
+
+        if not content:
+            return "", None
+
+        truncated = 0
+        max_tokens = config.vault_guide.max_tokens
+        if estimate_tokens(content) > max_tokens:
+            full_len = len(content)
+            content = content[: max_tokens * 4].rstrip() + "\n\n[vault guide truncated]"
+            truncated = 1
+            log.warning(
+                "vault guide %s exceeds max_tokens=%d; truncated from %d chars",
+                config.vault_guide.path, max_tokens, full_len,
+            )
+
+        text = wrap_xml("vault_guide", content)
+        entry = SourceEntry(
+            source="vault_guide",
+            tokens_estimated=estimate_tokens(text),
+            items_included=1,
+            items_truncated=truncated,
+            details={"path": config.vault_guide.path},
+        )
+        return text, entry
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_context_composer.py::TestComposeVaultGuide -v`
+Expected: PASS (all 6 cases incl. the 3 parametrized background modes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/context_composer.py tests/test_context_composer.py
+git commit -m "feat(592): _compose_vault_guide helper"
+```
+
+---
+
+## Task 3: Wire the guide into `compose()`
+
+**Files:**
+- Modify: `src/decafclaw/context_composer.py` (`compose()` — budget math + assembly block)
+- Test: `tests/test_context_composer.py` (add to `TestCompose`)
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add to `tests/test_context_composer.py`. Model the setup on the existing `TestCompose` class (it already builds `composer`/`ctx` and calls `composer.compose(...)`). These tests write a guide into the vault dir, run `compose()`, and assert the `<vault_guide>` system message is present for `INTERACTIVE` and absent for `HEARTBEAT`:
+
+```python
+class TestComposeVaultGuideIntegration:
+    async def test_guide_injected_for_interactive(self, ctx, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / "AGENTS.md").write_text(
+            "# Vault Guide\nUser journals: journals/YYYY/.", encoding="utf-8")
+        composer = ContextComposer()
+        result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+        system_msgs = [m["content"] for m in result.messages if m["role"] == "system"]
+        assert any("<vault_guide>" in c and "journals/YYYY/" in c for c in system_msgs)
+        # Appears right after the main system prompt, before any other content.
+        guide_idx = next(i for i, m in enumerate(result.messages)
+                         if m["role"] == "system" and "<vault_guide>" in m["content"])
+        assert guide_idx == 1
+        assert any(s.source == "vault_guide" for s in result.sources)
+
+    async def test_guide_skipped_for_heartbeat(self, ctx, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / "AGENTS.md").write_text("# Vault Guide", encoding="utf-8")
+        composer = ContextComposer()
+        result = await composer.compose(ctx, "hello", [], mode=ComposerMode.HEARTBEAT)
+        system_msgs = [m["content"] for m in result.messages if m["role"] == "system"]
+        assert not any("<vault_guide>" in c for c in system_msgs)
+```
+
+> Note: `TestCompose` methods in this file are already `async` and rely on the project's asyncio test config — match the existing decorator/style in that class (e.g. `@pytest.mark.asyncio` if present there; otherwise none).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_context_composer.py::TestComposeVaultGuideIntegration -v`
+Expected: FAIL — no `<vault_guide>` system message present (assertion error), because `compose()` doesn't call the helper yet.
+
+- [ ] **Step 3: Wire into `compose()` — budget + sources**
+
+In `src/decafclaw/context_composer.py`, in `compose()`, find the budget block that ends just before `# Response reserve (leave room for the model's response)`. Immediately after the `preempt_skill_entry` token accounting:
+
+```python
+        if preempt_skill_entry is not None:
+            fixed_tokens += preempt_skill_entry.tokens_estimated
+```
+
+add:
+
+```python
+        # -- Vault guide (always-loaded authored vault doc, e.g. AGENTS.md) --
+        vault_guide_text, vault_guide_entry = self._compose_vault_guide(config, mode)
+        if vault_guide_entry is not None:
+            sources.append(vault_guide_entry)
+            fixed_tokens += vault_guide_entry.tokens_estimated
+```
+
+(Placing it here ensures its tokens are subtracted from the memory-retrieval budget computed on the next lines.)
+
+- [ ] **Step 4: Wire into `compose()` — message assembly**
+
+Find the assembly block under the `# -- Assemble final messages --` comment:
+
+```python
+        messages = [{"role": "system", "content": system_text}]
+        if deferred_text:
+            messages.append({"role": "system", "content": deferred_text})
+```
+
+Insert the guide message between the system prompt and `deferred_text`:
+
+```python
+        messages = [{"role": "system", "content": system_text}]
+        if vault_guide_text:
+            messages.append({"role": "system", "content": vault_guide_text})
+        if deferred_text:
+            messages.append({"role": "system", "content": deferred_text})
+```
+
+- [ ] **Step 5: Run the integration tests + full composer suite**
+
+Run: `uv run pytest tests/test_context_composer.py -v`
+Expected: PASS (new integration tests pass; no regressions in existing tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decafclaw/context_composer.py tests/test_context_composer.py
+git commit -m "feat(592): inject vault guide as always-loaded system section in compose()"
+```
+
+---
+
+## Task 4: Docs
+
+**Files:**
+- Modify: `docs/context-composer.md`
+- Modify: `docs/vault.md`
+
+- [ ] **Step 1: Update `docs/context-composer.md`**
+
+Add a subsection documenting the always-loaded vault guide. Place it near the memory-retrieval / always-loaded context discussion. Content to include:
+
+```markdown
+### Vault guide (always-loaded)
+
+When a guide file exists at the vault root (default `AGENTS.md`, configurable
+via `vault_guide.path`), `ContextComposer._compose_vault_guide` reads it fresh
+each interactive turn and injects it as an authoritative `<vault_guide>`
+**system** section, immediately after the main system prompt and before the
+deferred-tools/preempt sections.
+
+This is for *always-applies* vault rules (folder layout, which paths are the
+user's vs the agent's, protocols) that must be present before the model makes
+any tool decision — unlike memory retrieval, which is similarity-gated and can
+miss a procedural rule when the query embeds far from it.
+
+- **Authoritative `system` role** — unlike retrieved vault content (remapped to
+  `user`), the guide is treated as binding instructions. Trust assumption: it is
+  the user's own authored file.
+- **Independent of `vault_retrieval`** — plain file read, no embeddings; works
+  even when semantic search is disabled.
+- **Skipped** for heartbeat / scheduled / child-agent modes.
+- **Fail-open** — missing file / read error → no section.
+- **Token cap** (`vault_guide.max_tokens`, default 2000) — oversized guides are
+  truncated (head kept) with a logged warning.
+
+Config: `vault_guide.{enabled,path,max_tokens}` (`VaultGuideConfig`).
+```
+
+- [ ] **Step 2: Update `docs/vault.md`**
+
+Add one line where vault structure / AGENTS.md is relevant:
+
+```markdown
+A guide file at the vault root (default `AGENTS.md`) is auto-injected into every
+interactive turn as an always-loaded `system` section — see
+[context-composer.md](context-composer.md#vault-guide-always-loaded). Use it for
+vault-layout and protocol rules the agent must always follow.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/context-composer.md docs/vault.md
+git commit -m "docs(592): document always-loaded vault guide"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run lint + typecheck + full test suite**
+
+```bash
+uv run make check && uv run make test
+```
+
+Expected: clean (no warnings), all tests pass. (If `make` targets don't take `uv run`, run `make check` / `make test` directly inside the worktree venv.)
+
+- [ ] **Manual smoke (optional, ask Les before touching a running server)**
+
+Confirm via a CLI compose smoke or local web-only run that the `<vault_guide>` section appears for an interactive turn when an `AGENTS.md` exists at the vault root. Do **not** start a server that collides with Les's running `make dev`.
+
+---
+
+## Spec coverage check
+
+- ✅ `_compose_vault_guide`, fresh read, `<vault_guide>` system section — Task 2.
+- ✅ Placement after `system_text`, before deferred/preempt — Task 3 Step 4.
+- ✅ Mode skip (heartbeat/scheduled/child) — Task 2 (parametrized) + Task 3 integration.
+- ✅ Fail-open (missing/empty/unreadable) — Task 2.
+- ✅ Token cap + logged truncation — Task 2.
+- ✅ `SourceEntry(source="vault_guide")` diagnostics — Task 2 + budget wiring Task 3 Step 3.
+- ✅ `VaultGuideConfig` (enabled/path/max_tokens), independent of retrieval — Task 1.
+- ✅ Unit-only, no eval — all tasks.
+- ✅ Docs (`context-composer.md`, `vault.md`) — Task 4.

--- a/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/spec.md
+++ b/docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/spec.md
@@ -1,0 +1,116 @@
+# Spec — Inject vault-root `AGENTS.md` as always-loaded context
+
+**Issue:** [#592](https://github.com/lmorchard/decafclaw/issues/592) — enhancement, core · Ready / P1 / S
+**Branch:** `592-vault-guide-always-loaded`
+
+## Problem
+
+The vault can contain a user-authored guide to vault structure and agent protocols
+(`obsidian/main/AGENTS.md` on the deployed agent) — folder layout, which paths are the
+user's vs the agent's, append-only rules. Today that file is just another vault page:
+the agent only sees it when (a) semantic retrieval happens to surface it for the current
+query, or (b) the agent explicitly reads it.
+
+That fails for procedural rules that must *always* apply regardless of query. Observed on
+the deployed agent: asked to "summarize my meetings this week," it confused
+`agent/journal/` (its own journal) with `journals/YYYY/…` (the user's journal). The
+distinction **is** documented in the vault's `AGENTS.md`, but a meeting-summary query
+embeds nowhere near a vault-structure guide, so retrieval never surfaced it. The agent
+guessed wrong, was corrected, journaled the lesson — then repeated the identical mistake
+(and re-journaled it) across three conversations in ~6 minutes, because the journaled
+lesson is *also* similarity-gated and never feeds back proactively.
+
+Root cause: an *always-applies* rule is routed through an *occasionally-matched* episodic
+store. A tool-triggered injection ("inject before vault tools run") can't fix it either —
+a tool call is the model's output, so by the time the call exists the wrong decision is
+already made; tool-triggered injection is always one step late and can't prevent the
+*first* wrong call. The only injection point that prevents the first mistake is **turn
+assembly**.
+
+## Solution
+
+Add a `ContextComposer` step that, when a vault-guide file is present, injects its
+contents as an **always-loaded** section every interactive turn — read fresh from the
+vault's own `AGENTS.md` (single source of truth, no duplication into `USER.md`/`AGENT.md`,
+no drift).
+
+### Behavior
+
+1. **New step `_compose_vault_guide`**, called from `ContextComposer.compose()`.
+2. Resolves `<vault_root>/<guide path>` (default `AGENTS.md`) using the same
+   `_vault_root(config)` logic the vault tools use (`skills/vault/tools.py:39`).
+3. If the file exists and is non-empty, reads it **fresh** (plain file read — no
+   embeddings, so it works even when semantic search is off), wraps it in a
+   `<vault_guide>` XML section per the system-prompt section convention, and injects it
+   as a **`system`** message.
+   - **Role rationale:** authoritative, like `SOUL.md`/`AGENT.md`, because the goal is
+     reliable enforcement of vault-layout rules. This intentionally departs from the
+     composer's convention of remapping *retrieved* vault content to the `user` role
+     (prompt-injection posture). Trust assumption: `AGENTS.md` is the user's own authored
+     file in a single-user agent. Documented as such.
+4. **Placement:** immediately after the main `system_text` message, *before*
+   `deferred_text` / `preempt_skill_text` (`context_composer.py:438`). It is stable,
+   authoritative content, so it belongs adjacent to the system prompt and early in the
+   prefix for prompt-cache stability (deferred/preempt churn more).
+5. **Mode skip:** skip for `HEARTBEAT` / `SCHEDULED` / `CHILD_AGENT` — mirror the
+   `skip_modes` set in `_compose_vault_retrieval` (`context_composer.py:~571`).
+6. **Fail-open:** missing file, no vault, or read error → no section, no error
+   (log at debug).
+7. **Token cap:** if the guide exceeds `max_tokens`, truncate to the cap (keep the head)
+   and log a warning — never silent.
+8. **Diagnostics:** add a `SourceEntry(source="vault_guide", …)` so it appears in the
+   diagnostics waffle chart and the `[Context: …]` status line.
+
+Independent of `vault_retrieval`: separate enable flag, no embedding dependency, not
+affected by retrieval `mode`.
+
+### Config
+
+New `VaultGuideConfig` dataclass in `config_types.py` (mirrors `VaultRetrievalConfig`'s
+shape rather than crowding `VaultConfig`), resolved via the standard defaults →
+`config.json` → env order:
+
+```python
+@dataclass
+class VaultGuideConfig:
+    enabled: bool = True
+    path: str = "AGENTS.md"      # relative to vault root
+    max_tokens: int = 2000       # AGENTS.md is ~500 tok; generous cap
+```
+
+Wired onto `Config` alongside `vault` / `vault_retrieval`.
+
+## Testing
+
+Unit-only (deterministic context-assembly, not LLM routing/tool-choice — **no eval**):
+
+- Present file → `<vault_guide>` `system` message appears in composed output for
+  `INTERACTIVE`.
+- Absent file / empty file / unreadable → no section, no error (fail-open).
+- Oversized file → truncated to cap + warning logged.
+- Per-mode skip → iterate `ComposerMode` values (don't hand-list), assert skipped for the
+  three background modes, present for `INTERACTIVE`.
+- `enabled = False` → no section.
+
+## Docs
+
+Same-PR doc updates:
+
+- `docs/context-composer.md` — new always-loaded section in context assembly.
+- `docs/vault.md` — one line on the vault guide.
+
+## Out of scope (YAGNI)
+
+- A configurable *list* of always-loaded vault docs — single guide file only; generalize
+  later if a real need appears.
+- `USER.md` stopgap — intentionally skipped in favor of this durable fix.
+- Lazy inject-on-first-vault-tool-use — rejected (reactive; can't prevent the first wrong
+  call).
+
+## Files (anticipated)
+
+- `src/decafclaw/config_types.py` — `VaultGuideConfig`, wired onto `Config`.
+- `src/decafclaw/config.py` — defaults/env resolution if needed.
+- `src/decafclaw/context_composer.py` — `_compose_vault_guide`, call site, `SourceEntry`.
+- `tests/…` — unit coverage above.
+- `docs/context-composer.md`, `docs/vault.md`.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -155,6 +155,7 @@ Users can share vault pages directly into conversation context:
 
 - **Open page in UI**: When a page is open in the web UI side panel, its content is automatically injected as context.
 - **@[[PageName]] mentions**: Reference pages in message text using `@[[PageName]]` or `@[[folder/PageName]]` syntax. Works across all channels.
+- **Vault guide (`AGENTS.md`)**: A guide file at the vault root (default `AGENTS.md`) is auto-injected into every interactive turn as an always-loaded `system` section — before any tool decisions. Use it for vault-layout and protocol rules the agent must always follow. See [Vault guide](context-composer.md#vault-guide) in the context-composer docs for configuration and skip conditions.
 
 Each page is injected **once per conversation**. If a referenced page doesn't exist, the agent sees an error note.
 

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -35,6 +35,7 @@ from .config_types import (
     ReflectionConfig,
     RelevanceConfig,
     VaultConfig,
+    VaultGuideConfig,
     VaultRetrievalConfig,
     WidgetsConfig,
 )
@@ -176,6 +177,7 @@ class Config:
     vault_retrieval: VaultRetrievalConfig = field(default_factory=VaultRetrievalConfig)
     relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
+    vault_guide: VaultGuideConfig = field(default_factory=VaultGuideConfig)
     notifications: NotificationsConfig = field(default_factory=NotificationsConfig)
     email: EmailConfig = field(default_factory=EmailConfig)
     background: BackgroundConfig = field(default_factory=BackgroundConfig)
@@ -447,6 +449,9 @@ def load_config() -> Config:
     vault = load_sub_config(
         VaultConfig, file_data.get("vault", {}), "VAULT")
 
+    vault_guide = load_sub_config(
+        VaultGuideConfig, file_data.get("vault_guide", {}), "VAULT_GUIDE")
+
     notifications = load_sub_config(
         NotificationsConfig, file_data.get("notifications", {}), "NOTIFICATIONS")
 
@@ -538,6 +543,7 @@ def load_config() -> Config:
         vault_retrieval=vault_retrieval,
         relevance=relevance,
         vault=vault,
+        vault_guide=vault_guide,
         notifications=notifications,
         email=email,
         background=background,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -253,6 +253,20 @@ class VaultRetrievalConfig:
 
 
 @dataclass
+class VaultGuideConfig:
+    """Always-loaded vault guide (e.g. AGENTS.md).
+
+    When a guide file is present at ``<vault_root>/<path>``, its contents
+    are injected as an authoritative ``system`` section on every
+    interactive turn (#592). Independent of vault_retrieval — plain file
+    read, no embeddings.
+    """
+    enabled: bool = True
+    path: str = "AGENTS.md"      # relative to vault root
+    max_tokens: int = 2000       # AGENTS.md is ~500 tok; generous cap
+
+
+@dataclass
 class RelevanceConfig:
     w_similarity: float = 0.5
     w_recency: float = 0.3

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -366,6 +366,12 @@ class ContextComposer:
         if preempt_skill_entry is not None:
             fixed_tokens += preempt_skill_entry.tokens_estimated
 
+        # -- Vault guide (always-loaded authored vault doc, e.g. AGENTS.md) --
+        vault_guide_text, vault_guide_entry = self._compose_vault_guide(config, mode)
+        if vault_guide_entry is not None:
+            sources.append(vault_guide_entry)
+            fixed_tokens += vault_guide_entry.tokens_estimated
+
         # Response reserve (leave room for the model's response)
         response_reserve = 4096
 
@@ -436,6 +442,8 @@ class ContextComposer:
 
         # -- Assemble final messages --
         messages = [{"role": "system", "content": system_text}]
+        if vault_guide_text:
+            messages.append({"role": "system", "content": vault_guide_text})
         if deferred_text:
             messages.append({"role": "system", "content": deferred_text})
         if preempt_skill_text:
@@ -764,6 +772,85 @@ class ContextComposer:
             items_truncated=skipped,
         )
         return messages, entry
+
+    def _compose_vault_guide(
+        self, config, mode: ComposerMode,
+    ) -> tuple[str, SourceEntry | None]:
+        """Inject the vault's authored guide (default ``AGENTS.md``) as an
+        always-loaded ``system`` section.
+
+        Read fresh each interactive turn from ``<vault_root>/<path>`` so the
+        single source of truth is the vault file itself (no duplication into
+        SOUL.md/AGENT.md/USER.md, no drift). Authoritative ``system`` role by
+        design (#592): unlike *retrieved* vault content — which the composer
+        remaps to ``user`` for prompt-injection posture — this is the user's
+        own protocol doc and the goal is reliable enforcement.
+
+        Fail-open: missing file / no vault / read error → ("", None).
+        Skipped for heartbeat / scheduled / child-agent modes and when
+        ``config.vault_guide.enabled`` is False. Returns (wrapped_text, entry).
+        """
+        from .prompts import wrap_xml
+        from .util import estimate_tokens
+
+        skip_modes = {
+            ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT,
+        }
+        if not config.vault_guide.enabled or mode in skip_modes:
+            return "", None
+
+        rel_path = config.vault_guide.path
+        if ".." in rel_path or rel_path.startswith("/") or Path(rel_path).is_absolute():
+            log.debug(
+                "vault guide path %r is not vault-relative; skipping", rel_path)
+            return "", None
+
+        try:
+            vault_root = config.vault_root.resolve()
+            guide_path = (vault_root / rel_path).resolve()
+            if not guide_path.is_relative_to(vault_root):
+                log.debug(
+                    "vault guide path %r escapes vault root; skipping", rel_path)
+                return "", None
+            if not guide_path.is_file():
+                return "", None
+            content = guide_path.read_text(encoding="utf-8").strip()
+        except (OSError, ValueError) as exc:
+            log.debug("vault guide read failed: %s", exc)
+            return "", None
+
+        if not content:
+            return "", None
+
+        max_tokens = config.vault_guide.max_tokens
+        if max_tokens <= 0:
+            # A non-positive cap means "do not inject" rather than
+            # "inject only the truncation marker".
+            return "", None
+
+        truncated = 0
+        if estimate_tokens(content) > max_tokens:
+            marker = "\n\n[vault guide truncated]"
+            # Reserve space for the marker so the truncated content stays
+            # within the configured token cap.
+            char_budget = max(0, max_tokens * 4 - len(marker))
+            full_len = len(content)
+            content = content[:char_budget].rstrip() + marker
+            truncated = 1
+            log.warning(
+                "vault guide %s exceeds max_tokens=%d; truncated from %d chars",
+                config.vault_guide.path, max_tokens, full_len,
+            )
+
+        text = wrap_xml("vault_guide", content)
+        entry = SourceEntry(
+            source="vault_guide",
+            tokens_estimated=estimate_tokens(text),
+            items_included=1,
+            items_truncated=truncated,
+            details={"path": str(config.vault_guide.path)},
+        )
+        return text, entry
 
     def _compose_notes(
         self, ctx, config, mode: ComposerMode,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ def _isolate_env(monkeypatch):
             "LLM_", "MATTERMOST_", "COMPACTION_", "EMBEDDING_",
             "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
             "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
-            "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_",
+            "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_", "VAULT_GUIDE_",
         )):
             monkeypatch.delenv(key, raising=False)
 
@@ -95,6 +95,24 @@ class TestDefaults:
     def test_compaction_context_budget_fallback(self):
         c = Config(compaction=CompactionConfig(max_tokens=100000, llm_max_tokens=0))
         assert c.compaction_context_budget == 100000
+
+    def test_vault_guide_defaults(self):
+        """VaultGuideConfig defaults: enabled, AGENTS.md, 2000-token cap."""
+        from decafclaw.config_types import VaultGuideConfig
+        c = Config()
+        assert isinstance(c.vault_guide, VaultGuideConfig)
+        assert c.vault_guide.enabled is True
+        assert c.vault_guide.path == "AGENTS.md"
+        assert c.vault_guide.max_tokens == 2000
+
+    def test_vault_guide_env_override(self, tmp_path, monkeypatch):
+        """Env prefix VAULT_GUIDE_* overrides the guide config."""
+        monkeypatch.setenv("VAULT_GUIDE_ENABLED", "false")
+        monkeypatch.setenv("VAULT_GUIDE_PATH", "protocols/GUIDE.md")
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.vault_guide.enabled is False
+        assert c.vault_guide.path == "protocols/GUIDE.md"
 
 
 class TestJsonFileLoading:

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -425,6 +425,125 @@ class TestComposeWikiContext:
             assert entry.items_truncated == 1
 
 
+class TestComposeVaultGuide:
+    def _write_guide(self, config, tmp_path, text):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir(exist_ok=True)
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / config.vault_guide.path).write_text(text, encoding="utf-8")
+        return vault_dir
+
+    def test_returns_section_when_present(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "# Vault Guide\nUser journals live in journals/.")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text.startswith("<vault_guide>")
+        assert "journals/" in text
+        assert entry is not None
+        assert entry.source == "vault_guide"
+        assert entry.items_included == 1
+        assert entry.tokens_estimated > 0
+
+    def test_skips_when_disabled(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "# Guide")
+        config.vault_guide.enabled = False
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_file_absent(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)  # no AGENTS.md written
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_file_empty(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "   \n  ")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    @pytest.mark.parametrize("mode", [
+        ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT,
+    ])
+    def test_skips_background_modes(self, config, tmp_path, mode):
+        self._write_guide(config, tmp_path, "# Guide")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, mode)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_file_not_utf8(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        # Latin-1 byte 0xff is invalid UTF-8 → read_text raises UnicodeDecodeError
+        (vault_dir / config.vault_guide.path).write_bytes(b"\xff\xfe guide")
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_truncates_oversized_guide(self, config, tmp_path):
+        config.vault_guide.max_tokens = 10  # ~40 char budget
+        self._write_guide(config, tmp_path, "WORD " * 200)  # ~1000 chars
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert "[vault guide truncated]" in text
+        assert entry.items_truncated == 1
+
+    def test_skips_when_path_absolute(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        # Create a file OUTSIDE the vault that an absolute path would read
+        secret = tmp_path / "secret.md"
+        secret.write_text("TOP SECRET", encoding="utf-8")
+        config.vault_guide.path = str(secret)  # absolute
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_path_traverses_parent(self, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        secret = tmp_path / "secret.md"
+        secret.write_text("TOP SECRET", encoding="utf-8")
+        config.vault_guide.path = "../secret.md"
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_skips_when_max_tokens_non_positive(self, config, tmp_path):
+        self._write_guide(config, tmp_path, "# Guide\nlots of content here")
+        config.vault_guide.max_tokens = 0
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert text == ""
+        assert entry is None
+
+    def test_truncation_respects_token_cap(self, config, tmp_path):
+        from decafclaw.util import estimate_tokens
+        config.vault_guide.max_tokens = 20
+        self._write_guide(config, tmp_path, "WORD " * 300)
+        composer = ContextComposer()
+        text, entry = composer._compose_vault_guide(config, ComposerMode.INTERACTIVE)
+        assert entry.items_truncated == 1
+        # The truncated content (incl. marker) stays within the cap.
+        assert "[vault guide truncated]" in text
+        # Strip the XML wrapper lines to estimate the content portion.
+        inner = text[len("<vault_guide>\n"): -len("\n</vault_guide>")]
+        assert estimate_tokens(inner) <= config.vault_guide.max_tokens
+
+
 # -- Tool assembly -------------------------------------------------------------
 
 
@@ -928,6 +1047,50 @@ class TestCompose:
             composer = ContextComposer()
             result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
             assert result.retrieved_context_text == "formatted memory"
+
+
+class TestComposeVaultGuideIntegration:
+    @pytest.mark.asyncio
+    async def test_guide_injected_for_interactive(self, ctx, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / "AGENTS.md").write_text(
+            "# Vault Guide\nUser journals: journals/YYYY/.", encoding="utf-8")
+        config.agent.tool_context_budget_pct = 1.0
+        config.compaction.max_tokens = 1000000
+        with (
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composer = ContextComposer()
+            result = await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+        system_msgs = [m["content"] for m in result.messages if m["role"] == "system"]
+        assert any("<vault_guide>" in c and "journals/YYYY/" in c for c in system_msgs)
+        # Appears right after the main system prompt (index 0), before other sections.
+        guide_idx = next(i for i, m in enumerate(result.messages)
+                         if m["role"] == "system" and "<vault_guide>" in m["content"])
+        assert guide_idx == 1
+        assert any(s.source == "vault_guide" for s in result.sources)
+
+    @pytest.mark.asyncio
+    async def test_guide_skipped_for_heartbeat(self, ctx, config, tmp_path):
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        config.vault.vault_path = str(vault_dir)
+        (vault_dir / "AGENTS.md").write_text("# Vault Guide", encoding="utf-8")
+        config.agent.tool_context_budget_pct = 1.0
+        config.compaction.max_tokens = 1000000
+        with (
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composer = ContextComposer()
+            result = await composer.compose(ctx, "hello", [], mode=ComposerMode.HEARTBEAT)
+        system_msgs = [m["content"] for m in result.messages if m["role"] == "system"]
+        assert not any("<vault_guide>" in c for c in system_msgs)
 
 
 class TestHistoryArchivedRemap:


### PR DESCRIPTION
## Summary

When a guide file is present at the vault root (default `AGENTS.md`), inject its
contents into every interactive turn as an authoritative `<vault_guide>`
**system** section — present *before* the model makes any tool decision, instead
of relying on similarity-gated memory retrieval to surface it.

Closes #592.

### Why

The deployed agent kept re-learning the same rule — "user journal = `journals/YYYY/…`,
my journal = `agent/journal/`" — and re-journaling near-duplicates across multiple
conversations. Root cause: an *always-applies* procedural rule was routed through
*similarity-gated* retrieval. A "meetings this week" query embeds far from a
vault-structure rule, so retrieval never matched it — even though the rule was
documented in the vault's `AGENTS.md` (a vault page, not always-loaded prompt
content). Turn assembly is the only injection point that precedes the model's first
tool decision, so that's where the guide now loads.

### What changed

- **`VaultGuideConfig`** (`enabled=True`, `path="AGENTS.md"`, `max_tokens=2000`) on
  `Config`, env prefix `VAULT_GUIDE_`.
- **`ContextComposer._compose_vault_guide(config, mode)`** — reads `<vault_root>/<path>`
  fresh each turn, wraps in `<vault_guide>`. Fail-open (missing / `OSError` /
  non-UTF-8 `ValueError` / empty → no section). Token cap with head-truncation +
  logged warning. Skips heartbeat / scheduled / child-agent modes. Independent of
  `vault_retrieval` (plain file read, no embeddings).
- **`compose()` wiring** — guide tokens added to `fixed_tokens` before the
  memory-budget math; `system` message inserted between the main system prompt and
  `deferred_text`; `SourceEntry` for diagnostics.
- **Docs** — `docs/context-composer.md` (new section + layout/modes additions) and
  `docs/vault.md` (mention + cross-link).

### Design notes

- **`system` role** (authoritative), not the `user`-remap used for *retrieved*
  vault content — the goal is reliable enforcement; trust assumption is that
  `AGENTS.md` is the user's own authored file.
- Single guide file (YAGNI), read fresh from the vault (single source of truth, no
  `USER.md` duplication/drift). Tool-triggered injection was rejected — it's always
  one step too late to prevent the first wrong call.

Spec / plan / notes: `docs/dev-sessions/2026-06-21-1414-vault-guide-always-loaded/`.

## Test Plan

- [x] `make check` clean (ruff + pyright 0 errors, no message-type drift)
- [x] Full suite: 2927 passed
- [x] Unit: skip conditions (disabled / absent / empty / non-UTF-8 / 3 background modes), truncation, success
- [x] Integration via `compose()`: `<vault_guide>` system message present at index 1 for INTERACTIVE; absent for HEARTBEAT
- [x] Config: defaults + `VAULT_GUIDE_*` env override
- [ ] Post-merge: confirm the `<vault_guide>` 🧠/section appears for an interactive turn on the deployed agent (its `AGENTS.md` already exists; defaults enable the feature)

## Follow-ups (separate issues, not in scope)

- File-wide function-level-import cleanup in `context_composer.py`
- A `config.json` file-based `vault_guide` loading test
- Context-window layout diagram: always-loaded sections shown inside the SYSTEM-PROMPT box are actually separate `system` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)