### PR TITLE
fix(web): clipboard copy fails on plain http (non-secure context)

### DIFF
--- a/src/decafclaw/web/static/components/copy-conversation-menu.js
+++ b/src/decafclaw/web/static/components/copy-conversation-menu.js
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { showToast } from '../lib/toast.js';
+import { copyToClipboard } from '../lib/utils.js';
 
 /**
  * Floating "Copy ▾" menu for the active conversation. Fetches the
@@ -58,7 +59,7 @@ export class CopyConversationMenu extends LitElement {
         return;
       }
       const text = await res.text();
-      await navigator.clipboard.writeText(text);
+      await copyToClipboard(text);
       showToast(`Copied as ${format}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/decafclaw/web/static/components/messages/assistant-message.js
+++ b/src/decafclaw/web/static/components/messages/assistant-message.js
@@ -1,7 +1,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { renderMarkdown } from '../../lib/markdown.js';
-import { formatTime } from '../../lib/utils.js';
+import { formatTime, copyToClipboard } from '../../lib/utils.js';
 import hljs from 'hljs';
 
 /** Assistant message — markdown-rendered, with optional streaming indicator and usage info. */
@@ -65,9 +65,15 @@ export class AssistantMessage extends LitElement {
       btn.className = 'copy-btn';
       btn.type = 'button';
       btn.textContent = 'Copy';
+      // Copy from the <code> element, not <pre> — the <pre> also holds the
+      // language label and Copy button, whose text would otherwise leak in.
+      const copySource = /** @type {HTMLElement} */ (anyCode ?? pre);
       btn.addEventListener('click', () => {
-        navigator.clipboard.writeText(/** @type {HTMLElement} */ (pre).innerText).then(() => {
+        copyToClipboard(copySource.innerText).then(() => {
           btn.textContent = 'Copied!';
+          setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+        }).catch(() => {
+          btn.textContent = 'Copy failed';
           setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
         });
       });

--- a/src/decafclaw/web/static/lib/utils.js
+++ b/src/decafclaw/web/static/lib/utils.js
@@ -39,6 +39,49 @@ export function formatRelativeTime(ts) {
 }
 
 /**
+ * Copy text to the clipboard, with a fallback for non-secure contexts.
+ *
+ * `navigator.clipboard` only exists in secure contexts (HTTPS or localhost).
+ * The deployed agent serves over plain http://, where `navigator.clipboard`
+ * is `undefined` — accessing `.writeText` throws. Localhost masks this because
+ * it counts as a secure context. So we fall back to the legacy
+ * `document.execCommand('copy')` path via a hidden textarea.
+ *
+ * @param {string} text
+ * @returns {Promise<void>} resolves on success, rejects on failure
+ */
+export async function copyToClipboard(text) {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch (err) {
+    // Clipboard API present but rejected (e.g. permission / focus) — fall
+    // through to the legacy path rather than failing outright.
+    console.debug('clipboard API writeText failed, using fallback:', err);
+  }
+
+  // Legacy fallback: a hidden textarea + execCommand('copy').
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '-9999px';
+  document.body.appendChild(ta);
+  const prevFocus = /** @type {HTMLElement | null} */ (document.activeElement);
+  ta.select();
+  try {
+    if (!document.execCommand('copy')) {
+      throw new Error('copy command was rejected by the browser');
+    }
+  } finally {
+    document.body.removeChild(ta);
+    if (prevFocus && typeof prevFocus.focus === 'function') prevFocus.focus();
+  }
+}
+
+/**
  * Set up a drag-to-resize handle that adjusts a CSS custom property.
  *
  * Restores the last saved width from localStorage on init, and persists


### PR DESCRIPTION
## Problem

The conversation **Copy** menu fails on the deployed agent with:

> Copy failed: can't access property "writeText", navigator.clipboard is undefined

**Root cause:** `navigator.clipboard` only exists in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) — HTTPS or `localhost`. The deployed agent serves over plain `http://`, so `navigator.clipboard` is `undefined` there and `.writeText` throws. It worked when tested via `make dev` because browsers treat `localhost` as secure, which masks the bug entirely.

Two call sites hit `navigator.clipboard.writeText` directly with no fallback — the conversation Copy ▾ menu (reported) and the per-code-block copy button (same latent bug).

## Fix

Added a shared `copyToClipboard()` helper in `lib/utils.js`:
- Uses the async Clipboard API when available (secure context).
- Falls back to a hidden `<textarea>` + `document.execCommand('copy')` otherwise.

Routed both call sites through it. The code-block button now also surfaces a transient "Copy failed" on rejection.

## Testing

- `make check-js` passes (tsc clean).
- No JS unit-test harness exists in the repo, so there's no failing-test-first artifact here. The fallback path can't be exercised on `localhost` (always a secure context) — **needs verification against the deployed http:// host**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)