### PR TITLE
feat(blog-ideas): daily blog-idea brainstorm contrib skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 *.egg-info/
 data/
 evals/results/
+evals/history.jsonl
 node_modules/
 .playwright-mcp/
 .claude/

--- a/contrib/skills/README.md
+++ b/contrib/skills/README.md
@@ -72,6 +72,14 @@ A skill at `data/{agent_id}/skills/<name>/` shadows any same-named entry in `ext
 
 ## Available Skills
 
+### blog-ideas
+
+A daily brainstorm pass: reviews the week-so-far across your ingested activity (`agent/pages/{bookmarks,mastodon,youtube,github,podcasts,music,kindle}`), your Obsidian daily journal (`journals/`), and your blog archive (`blog/drafts`, `blog/daily`, `blog/weeknotes`), then maintains a living tiered "blog ideas this week" page at `agent/pages/blog-ideas/{ISO-week}.md`. Exposes one tool, `blog_ideas_week`, that returns the deterministic ISO-week identity + page path so the agent never hand-computes weeks. Delivery rides the existing newsletter's scheduled-activity aggregation (no newsletter changes).
+
+**Requires:** Nothing — but it's only useful if the vault already holds ingested activity (e.g. via `meta-ingest`) and a synced Obsidian vault with journal + blog folders.
+
+**Schedule:** ships a `SCHEDULE.md` for a daily 06:00 UTC run, but as a contrib skill it's force-disabled — opt in by creating an overlay at `data/{agent_id}/schedules/blog-ideas.md` (copy the skill's `SCHEDULE.md` and set `enabled: true`). Also runs on demand via the `/blog-ideas` command.
+
 ### kindle
 
 Syncs highlights and notes from your Kindle library (`read.amazon.com/notebook`) into per-book vault pages under `agent/pages/kindle/`. Each book gets one page with frontmatter tracking the ASIN, title, author, and highlight count. Deleted highlights are moved to an `## Archived` section with a date stamp.

--- a/contrib/skills/blog-ideas/SCHEDULE.md
+++ b/contrib/skills/blog-ideas/SCHEDULE.md
@@ -1,0 +1,9 @@
+---
+schedule: "0 6 * * *"
+model: strong
+required-skills:
+  - blog-ideas
+  - vault
+---
+
+Time for the daily blog-idea brainstorm. Follow the blog-ideas skill instructions to completion.

--- a/contrib/skills/blog-ideas/SKILL.md
+++ b/contrib/skills/blog-ideas/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: blog-ideas
+description: Daily scheduled brainstorm (also runnable on demand via /blog-ideas) that reviews the week-so-far across ingested activity, the daily journal, and the blog archive, and maintains a living weekly page of blog-post ideas.
+effort: strong
+required-skills:
+  - vault
+user-invocable: true
+context: fork
+---
+
+# Blog-idea brainstorm
+
+Once a day, review the week so far across everything I've been reading, writing,
+and thinking, and maintain a single living page of blog-post ideas for the week.
+The page accumulates and sharpens across the week; you rewrite it in place each
+run. Read and write only within `agent/`.
+
+## Phase 1: Orient
+
+1. Call `blog_ideas_week` to get this week's `week` key, `days_so_far`, and the
+   `page_path`. NEVER compute the ISO week yourself.
+2. `vault_read` the `page_path`. If it exists, this is the living page you'll
+   refine — it's also your within-week dedup memory. If it doesn't exist yet,
+   you'll create it this run.
+3. Call `blog_ideas_week` with `offset_weeks=-1` and `offset_weeks=-2` and
+   `vault_read` those pages if present — just enough to notice themes I keep
+   circling week to week.
+
+## Phase 2: Gather (read at snippet level — do NOT bulk-read article bodies)
+
+`vault_search`'s `days=N` is a **rolling** lookback (`now − N days`), NOT a
+calendar-week boundary. Use `days=days_so_far` to be sure you cover the whole
+week so far — but that window reaches a little into last week, so when you read
+results, **disregard anything dated before `monday`** (the Monday returned by
+`blog_ideas_week`). That keeps the brainstorm to this week's material and avoids
+re-surfacing last week's items.
+
+1. **Ingested activity** — `vault_search` across the ingest folders with
+   `days=<days_so_far>`: `agent/pages/bookmarks`, `agent/pages/mastodon`,
+   `agent/pages/youtube`, `agent/pages/github`, `agent/pages/podcasts`,
+   `agent/pages/music`, `agent/pages/kindle`. These are things I consumed.
+2. **Journal** — `vault_search` with `source_type=user` over my daily journal
+   (`journals/…`) for the same window. ALL of it is fair game — TIL bullets,
+   session notes, offhand musings. Notes tagged `*(blog candidate)*` are a
+   stronger signal but are not the only material.
+3. **Stalled drafts** — `vault_list` `blog/drafts` and `vault_search` it against
+   this week's themes. When fresh material supplies the missing piece for an
+   abandoned draft, that's a high-value idea.
+4. **Published archive** (on demand) — `vault_search` `blog/daily` and
+   `blog/weeknotes` only to check a candidate: skip near-duplicates of things
+   I've already written; frame genuine extensions as follow-ups; keep angles in
+   my actual voice.
+
+Read full bodies (`vault_read`) only for the handful of drafts/posts tied to an
+idea you're actively developing.
+
+## Phase 3: Synthesize
+
+- Treat journal notes and ingested activity as EQUAL peers — an idea may spring
+  from a striking bookmark with no journal note behind it, or from a half-thought
+  in the journal.
+- Connect across sources: a journal note + a bookmark + a stalled draft can be
+  one idea.
+- Hold a high bar for headliners; everything else is a seed.
+
+## Phase 4: Write the living page
+
+`vault_write` the `page_path` with this structure (rewrite in place — refine and
+merge existing entries, add new ones only if they clear the bar, demote faded
+ones; do NOT just append):
+
+    ---
+    tags: [blog-ideas, brainstorm]
+    summary: Blog post ideas for the week of <monday> (<week>)
+    week: <week>
+    updated: <today's date>
+    ---
+
+    # Blog ideas — week of <monday>
+
+    ## Headliners
+    ### <hook title>
+    - **angle:** why this, why now
+    - **sources:** [[page]], journal <date>, connects to draft "<name>"
+    - **shape:** outline bullets / the missing piece
+    - **status:** new | sharpened <date> | follow-up to <published post>
+
+    ## Seeds
+    - <one-liner> — source hint
+
+    ## Recurring
+    - <theme> — circled ~N weeks running; maybe it's ripe
+
+Keep 3–5 headliners. Surface cross-week repeats under **Recurring** as signal —
+do NOT re-pitch them cold in Headliners.
+
+## Finishing up
+
+End with a short narrative summary that doubles as the newsletter's raw material:
+the headliner titles, a one-line hook each, and a link to the full
+`[[<page_path without the .md>]]`. If there was nothing new worth surfacing this
+run, begin your summary with `HEARTBEAT_OK` on its own line followed by a brief
+quiet-cycle note.

--- a/contrib/skills/blog-ideas/test_blog_ideas.py
+++ b/contrib/skills/blog-ideas/test_blog_ideas.py
@@ -1,0 +1,71 @@
+"""Unit tests for the blog-ideas contrib skill's ISO-week helper.
+
+Loads tools.py via importlib — mirroring the production skill loader — because
+the skill directory (`blog-ideas`) is not an importable Python package.
+"""
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).parent
+_tools_spec = importlib.util.spec_from_file_location(
+    "decafclaw_contrib_blog_ideas_tools", _THIS_DIR / "tools.py"
+)
+assert _tools_spec is not None and _tools_spec.loader is not None
+blog_ideas_tools = importlib.util.module_from_spec(_tools_spec)
+sys.modules["decafclaw_contrib_blog_ideas_tools"] = blog_ideas_tools
+_tools_spec.loader.exec_module(blog_ideas_tools)
+
+compute_week = blog_ideas_tools.compute_week
+
+
+def test_midweek_thursday():
+    # 2026-06-25 is a Thursday in ISO week 2026-W26 (Monday 2026-06-22).
+    info = compute_week(datetime(2026, 6, 25, 15, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 4
+    assert info["page_path"] == "agent/pages/blog-ideas/2026-W26.md"
+
+
+def test_monday_is_day_one():
+    info = compute_week(datetime(2026, 6, 22, 6, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 1
+
+
+def test_sunday_is_day_seven():
+    info = compute_week(datetime(2026, 6, 28, 23, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 7
+
+
+def test_prior_week_offset():
+    # offset_weeks=-1 from a Thursday → previous ISO week, its Monday and path.
+    info = compute_week(datetime(2026, 6, 25, 15, 0, 0), offset_weeks=-1)
+    assert info["week"] == "2026-W25"
+    assert info["monday"] == "2026-06-15"
+    assert info["page_path"] == "agent/pages/blog-ideas/2026-W25.md"
+    # days_so_far still reflects "now" (Thursday), independent of offset.
+    assert info["days_so_far"] == 4
+
+
+def test_iso_year_boundary():
+    # 2021-01-01 is a Friday belonging to ISO week 2020-W53 (Monday 2020-12-28).
+    # The key must use the ISO year (2020), not the calendar year (2021).
+    info = compute_week(datetime(2021, 1, 1, 9, 0, 0))
+    assert info["week"] == "2020-W53"
+    assert info["monday"] == "2020-12-28"
+    assert info["days_so_far"] == 5
+    assert info["page_path"] == "agent/pages/blog-ideas/2020-W53.md"
+
+
+def test_tool_registered():
+    # The skill exposes blog_ideas_week through both registries.
+    tool_names = {td["function"]["name"] for td in blog_ideas_tools.TOOL_DEFINITIONS}
+    assert "blog_ideas_week" in tool_names, f"got {sorted(tool_names)}"
+    assert "blog_ideas_week" in blog_ideas_tools.TOOLS

--- a/contrib/skills/blog-ideas/tools.py
+++ b/contrib/skills/blog-ideas/tools.py
@@ -1,0 +1,91 @@
+"""blog-ideas contrib skill — deterministic ISO-week helper for the living weekly page.
+
+`current_time` returns a plain timestamp with no ISO-week number, and the
+living-page model needs a correct, stable week key (a wrong key duplicates the
+page instead of refining it). ISO-week math — especially around year boundaries
+and "N weeks ago" — is exactly the deterministic mechanic that belongs in code,
+so the skill exposes one helper and the LLM never computes weeks itself.
+
+The week is computed in UTC to match the scheduler: `schedules.py` evaluates
+cron via croniter on a UTC base, so a UTC `now` keeps the page key aligned with
+when the daily run actually fires, independent of the host's local timezone.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from decafclaw.media import ToolResult
+
+log = logging.getLogger(__name__)
+
+PAGE_FOLDER = "agent/pages/blog-ideas"
+
+
+def compute_week(now: datetime, offset_weeks: int = 0) -> dict:
+    """ISO-week identity for the blog-ideas page, offset by whole weeks.
+
+    Returns a dict with:
+      - ``week``:        ISO week key, e.g. ``"2026-W26"``. Uses the ISO year,
+                         which differs from the calendar year near boundaries.
+      - ``monday``:      the offset week's Monday, ``"YYYY-MM-DD"``.
+      - ``days_so_far``: ISO weekday of ``now`` (1=Mon .. 7=Sun). Always reflects
+                         ``now`` — it measures progress into the current week and
+                         is meaningless for non-zero ``offset_weeks`` (used only
+                         to size the gather window when offset is 0).
+      - ``page_path``:   vault path of the offset week's page.
+    """
+    shifted = now + timedelta(weeks=offset_weeks)
+    iso = shifted.isocalendar()  # (year, week, weekday)
+    week_key = f"{iso.year}-W{iso.week:02d}"
+    monday = shifted - timedelta(days=iso.weekday - 1)
+    return {
+        "week": week_key,
+        "monday": monday.strftime("%Y-%m-%d"),
+        "days_so_far": now.isocalendar().weekday,
+        "page_path": f"{PAGE_FOLDER}/{week_key}.md",
+    }
+
+
+def blog_ideas_week(ctx, offset_weeks: int = 0) -> ToolResult:
+    """Return the ISO-week identity + page path for the living weekly page."""
+    # UTC, not local — the schedule fires on a UTC cron base; see module docstring.
+    info = compute_week(datetime.now(timezone.utc), offset_weeks)
+    return ToolResult(
+        text=(
+            f"{info['week']} (week of {info['monday']}, "
+            f"day {info['days_so_far']}/7) -> {info['page_path']}"
+        ),
+        data=info,
+    )
+
+
+TOOLS = {"blog_ideas_week": blog_ideas_week}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "blog_ideas_week",
+            "description": (
+                "Return the ISO-week identity for the living weekly blog-ideas "
+                "page: the week key (e.g. '2026-W26'), that week's Monday, how "
+                "many days into the week it is now (1=Mon..7=Sun), and the vault "
+                "page_path. Pass offset_weeks=-1 for last week, -2 for two weeks "
+                "ago, etc. ALWAYS call this to get the page path — NEVER "
+                "hand-compute ISO week numbers."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "offset_weeks": {
+                        "type": "integer",
+                        "description": (
+                            "Whole-week offset from the current week. 0 = this "
+                            "week (default), -1 = last week, -2 = two weeks ago."
+                        ),
+                    },
+                },
+            },
+        },
+    },
+]

--- a/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
+++ b/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
@@ -1,0 +1,73 @@
+# Notes — Daily blog-idea brainstorm skill
+
+**Date:** 2026-06-25
+**Branch:** `feat-blog-ideas-skill`
+**Outcome:** Feature complete on the branch; final whole-branch review = ready to merge. One post-merge manual gate remains (deployment smoke).
+
+## What was built
+
+A new bundled, scheduled skill `blog-ideas` (dir `src/decafclaw/skills/blog_ideas/`):
+
+- `tools.py` — one deterministic helper, `blog_ideas_week(offset_weeks=0)`, returning the ISO-week key, that week's Monday, days-so-far, and the page path. Pure `compute_week(now, offset_weeks)` underneath, exhaustively unit-tested (mid-week, Monday, Sunday, prior-week offset, ISO year boundary 2021-01-01 → 2020-W53).
+- `SKILL.md` — daily-run prompt: orient (compute week via the helper, read current + ~2 prior pages) → gather at snippet level (7 ingest folders + journal via `source_type=user` + `blog/drafts` + `blog/daily`/`weeknotes`) → synthesize (journal & ingests as equal peers) → rewrite the living tiered page in place → finish with a digest summary (or `HEARTBEAT_OK`).
+- `SCHEDULE.md` — daily 06:00 UTC, `model: strong`, `required-skills: [blog-ideas, vault]`, ships enabled.
+- `evals/blog-ideas.yaml` — one behavior case: explicit run computes the week and writes `agent/pages/blog-ideas/{week}.md`.
+- Docs: `blog_ideas` added to the CLAUDE.md bundled-skills list and a one-line entry in `docs/schedules.md`.
+
+Output lands at `agent/pages/blog-ideas/{ISO-week}.md` (under `agent/` to avoid the out-of-agent write gate). Delivery rides the **existing** newsletter's scheduled-activity aggregation — no newsletter changes; the run's narrative summary is the newsletter's raw material and the nudge to read the page.
+
+## Key decisions
+
+- **Almost prompt-only, plus one helper.** Mirrors `dream`/`garden`, but `current_time` has no ISO-week number and the living-page model needs a stable week key (wrong key → duplicate page instead of refine). ISO-week math (and year boundaries / "N weeks ago") belongs in code. Spec amended to record this deviation.
+- **Single-turn `dream`-style synthesis**, not fan-out or the workflow engine. The value is cross-source connection, which wants one reasoning context; fan-out would fragment it; the living page is already the durable state.
+- **Descoped to the scheduled path** (+ explicit `/blog-ideas`). Mid-implementation we tried to make natural-language questions ("what should I write about?") route to the skill. Les's call: the skill was trying to serve too many purposes — drop NL routing entirely. This also removed a real risk: a QUESTION/COMMAND split in the prompt could have caused the *scheduled* run to be misclassified as a question and silently no-op (the silent-scheduled-task-failure class CLAUDE.md warns about).
+- **Newsletter: contribute, don't modify.** Confirmed in code that the newsletter already aggregates all scheduled-task activity (`final_message` + `vault_pages_touched`).
+
+## Deviations / churn (squashed at merge)
+
+- A routing experiment briefly added a `context_composer.py` preempt-hint score-gap filter (cross-cutting, all skills) + an aggressive SKILL.md description + a "Routing note." All reverted when NL routing was descoped. The composer idea is filed separately as **issue #604** to be judged on its own merits.
+- The discovery test was narrowed (Task 4) from `build_skill_tool_owners` (which eagerly imports every skill's `tools.py`, including the subprocess-spawning `claude_code`/`background`) to `discover_skills` + the skill's own `TOOL_DEFINITIONS`. **Kept as an independent scoping improvement** (a per-skill test shouldn't import every other skill). It was initially believed to fix a `PytestUnraisableExceptionWarning`, but follow-up measurement disproved that: the warning appears intermittently on the suite **with our test file excluded too** (3/3 runs) — it's a pre-existing, flaky GC artifact (a leaked asyncio subprocess transport finalized late, attributed to whatever test is running at GC time), unrelated to this feature. Filed as **issue #605**, not fixed here.
+
+## Relocation to contrib (post-review)
+
+After the PR was opened, the skill was moved from a core bundled skill
+(`src/decafclaw/skills/blog_ideas/`) to **`contrib/skills/blog-ideas/`** — it's personal
+and vault-layout-specific, not core infrastructure. Adaptations:
+
+- Dir renamed `blog_ideas` → `blog-ideas` (hyphen, contrib convention); no `__init__.py`
+  (matches `writing-clearly` — a hyphen dir can't be a package).
+- Unit test moved to a colocated `contrib/skills/blog-ideas/test_blog_ideas.py` using the
+  `importlib.spec_from_file_location` pattern (the production loader's pattern). The
+  `discover_skills`-by-name assertion was dropped (contrib isn't auto-discovered);
+  replaced with a tool-registration check off the loaded module. `make test` already runs
+  `contrib/skills/`.
+- `evals/blog-ideas.yaml` removed — a contrib skill isn't on the default eval skill path,
+  so the eval couldn't resolve it; contrib convention is colocated tests + manual smoke.
+- Docs: removed from the CLAUDE.md bundled list and the `docs/schedules.md` bundled-schedule
+  count; added a `### blog-ideas` section to `contrib/skills/README.md`.
+
+**Activation now requires explicit opt-in** (the point of contrib): the deployment's
+`extra_skill_paths` must include `$CONTRIB/skills/blog-ideas`, and the daily schedule is
+enabled via an overlay at `data/{agent_id}/schedules/blog-ideas.md` (the skill's
+`SCHEDULE.md` ships force-disabled). `/blog-ideas` works on demand regardless.
+
+## Verification
+
+- `make check` clean (ruff + pyright). `make test`: 2930 passed. (A flaky pre-existing `PytestUnraisableExceptionWarning` may appear intermittently — issue #605 — independent of this branch; not introduced here.)
+- ISO-week helper: 5 unit tests. Behavior eval: 1/1 pass (explicit-run page production).
+- Final whole-branch review (opus): ready to merge; no Critical/Important.
+
+## Follow-ups / open items
+
+- **Post-merge manual gate (do with Les):** trigger `/blog-ideas` once against the live deployment vault (real week of ingests + journal + drafts), read the produced page, judge idea quality (grounded vs. bland restatement), tune SKILL.md wording if needed. *Then* let the 06:00 cron run.
+- **Verify at smoke time:** that `journals/` entries surface as `source_type=user` in `vault_search` on the deployment; if not, add a `folder=journals` filter to the Phase-2 journal step.
+- **Issue #604** — context_composer preempt-hint noise reduction (spun out).
+- **Issue #605** — pre-existing flaky `PytestUnraisableExceptionWarning` (leaked asyncio subprocess transport, likely in `claude_code`/`background`/`mcp_client` tests). Confirmed independent of this branch. Spun out.
+- **Deferred design options (YAGNI):** a dedicated blog-ideas email; output under `blog/ideas/` (needs a write-allowlist entry); skill rename (`muse`).
+
+## Accepted Minors (final review triage — left as-is)
+
+- `blog_ideas_week` uses naive `datetime.now()` (matches `current_time`; 06:00 cron is nowhere near a midnight/weekday rollover).
+- `monday` returned as a string (internal display contract; YAGNI).
+- Eval `response_contains` checks the path prefix, not the week suffix (asserting the suffix would make the eval date-fragile; week-key correctness is in the unit tests).
+- Discovery test's tool-name assert has no failure message (1-element set from a same-file constant; unambiguous on failure).

--- a/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/plan.md
+++ b/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/plan.md
@@ -1,0 +1,557 @@
+# Daily blog-idea brainstorm skill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bundled, scheduled `blog-ideas` skill that reviews the week-so-far across ingested content, the daily journal, and the blog archive, and maintains a living tiered "blog ideas this week" vault page surfaced through the existing newsletter.
+
+**Architecture:** An almost-prompt-only bundled skill (`SKILL.md` + `SCHEDULE.md`) in the `dream`/`garden` mold, plus one small `tools.py` carrying a single deterministic ISO-week helper (`blog_ideas_week`) so page identity never depends on LLM date math. A daily scheduled run gathers vault material as search snippets, reads the current weekly page, synthesizes ideas in one context, and rewrites the page in place. Delivery rides the newsletter's existing scheduled-activity aggregation — no newsletter changes.
+
+**Tech Stack:** Python 3 (stdlib `datetime.isocalendar`), decafclaw skill framework (`TOOLS` / `TOOL_DEFINITIONS` / `init` / `SkillConfig` contract), pytest, the YAML eval harness (`evals/*.yaml`).
+
+**Preflight (once, before Task 1):** the worktree has no venv yet. Run `uv sync` in the worktree root, then `make test` for a clean baseline. Commands below assume `uv run …` resolves to that venv. (`make test` → `uv run pytest tests/ contrib/skills/`; `make lint` → `uv run ruff check src/ tests/`.)
+
+## Global Constraints
+
+- **Skills use absolute imports** — `from decafclaw.X import ...` (the loader imports `tools.py` via `spec_from_file_location` with no package context; relative imports fail at runtime).
+- **Tools receive `ctx` as the first parameter**, always, even if unused.
+- **Tool returns are `ToolResult`** (`from decafclaw.media import ToolResult`); errors as `ToolResult(text="[error: ...]")`.
+- **Agent writes stay under `agent/`** — `vault_write` outside `agent/` hits an interactive-confirmation gate a scheduled run can't satisfy. Output page lives at `agent/pages/blog-ideas/{week}.md`.
+- **Skill directory is `blog_ideas/` (underscore, importable); skill `name` is `blog-ideas` (hyphen).** `name` comes from SKILL.md frontmatter (`skills/__init__.py:87`), independent of the directory name.
+- **Ships enabled.** Bundled `SCHEDULE.md` is honored as-is; the deployment is Les's, he can disable via the admin overlay.
+- **Model/effort `strong`** — heavy synthesis, matching `dream`/`garden`.
+- **Evals bound with `max_tool_calls` and `max_tool_errors`**; prefer positive `expect_tool` over `expect_no_tool` (self-reflection can retry).
+- **No fixed `asyncio.sleep` in tests**; the helper is a pure function tested with injected `datetime` values (no scheduler involved).
+
+---
+
+## File Structure
+
+- **Create `src/decafclaw/skills/blog_ideas/__init__.py`** — empty package marker (mirrors `newsletter/__init__.py`), makes `tools.py` importable for unit tests.
+- **Create `src/decafclaw/skills/blog_ideas/tools.py`** — the single deterministic helper: pure `compute_week(now, offset_weeks)` + the `blog_ideas_week(ctx, offset_weeks=0)` tool wrapper, with `TOOLS` / `TOOL_DEFINITIONS` registration. One responsibility: ISO-week → page identity.
+- **Create `src/decafclaw/skills/blog_ideas/SKILL.md`** — the prompt: frontmatter + the daily-run phases (orient → gather → synthesize → write → finish).
+- **Create `src/decafclaw/skills/blog_ideas/SCHEDULE.md`** — daily 06:00 UTC cron, `model: strong`, `required-skills: [blog-ideas, vault]`.
+- **Create `tests/test_blog_ideas_skill.py`** — unit tests for `compute_week` (mid-week, Monday, Sunday, prior-week offset, ISO year boundary) + a discovery test (skill loads under name `blog-ideas`, owns `blog_ideas_week`).
+- **Create `evals/blog-ideas.yaml`** — behavior evals: natural-language routing → `activate_skill`; explicit run → `blog_ideas_week` + `vault_write` page production.
+- **Modify `CLAUDE.md`** — add `blog-ideas` to the bundled-skills list (Key files → Skills).
+- **Modify `docs/schedules.md`** — add `blog-ideas` to the bundled scheduled-skills list if one is enumerated there.
+
+---
+
+## Task 1: ISO-week helper (`blog_ideas_week`) + unit tests
+
+**Files:**
+- Create: `src/decafclaw/skills/blog_ideas/__init__.py`
+- Create: `src/decafclaw/skills/blog_ideas/tools.py`
+- Test: `tests/test_blog_ideas_skill.py`
+
+**Interfaces:**
+- Produces:
+  - `compute_week(now: datetime, offset_weeks: int = 0) -> dict` with keys `week` (str, e.g. `"2026-W26"`), `monday` (str `"YYYY-MM-DD"`), `days_so_far` (int 1–7, ISO weekday of `now`), `page_path` (str, e.g. `"agent/pages/blog-ideas/2026-W26.md"`).
+  - `blog_ideas_week(ctx, offset_weeks: int = 0) -> ToolResult` — tool wrapper; `.data` is the `compute_week` dict.
+  - Module-level `PAGE_FOLDER = "agent/pages/blog-ideas"`, `TOOLS`, `TOOL_DEFINITIONS`.
+
+- [ ] **Step 1: Create the empty package marker**
+
+Create `src/decafclaw/skills/blog_ideas/__init__.py` with a single line:
+
+```python
+"""blog-ideas bundled skill."""
+```
+
+- [ ] **Step 2: Write the failing unit tests**
+
+Create `tests/test_blog_ideas_skill.py`:
+
+```python
+from datetime import datetime
+
+from decafclaw.skills.blog_ideas.tools import compute_week
+
+
+def test_midweek_thursday():
+    # 2026-06-25 is a Thursday in ISO week 2026-W26 (Monday 2026-06-22).
+    info = compute_week(datetime(2026, 6, 25, 15, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 4
+    assert info["page_path"] == "agent/pages/blog-ideas/2026-W26.md"
+
+
+def test_monday_is_day_one():
+    info = compute_week(datetime(2026, 6, 22, 6, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 1
+
+
+def test_sunday_is_day_seven():
+    info = compute_week(datetime(2026, 6, 28, 23, 0, 0))
+    assert info["week"] == "2026-W26"
+    assert info["monday"] == "2026-06-22"
+    assert info["days_so_far"] == 7
+
+
+def test_prior_week_offset():
+    # offset_weeks=-1 from a Thursday → previous ISO week, its Monday and path.
+    info = compute_week(datetime(2026, 6, 25, 15, 0, 0), offset_weeks=-1)
+    assert info["week"] == "2026-W25"
+    assert info["monday"] == "2026-06-15"
+    assert info["page_path"] == "agent/pages/blog-ideas/2026-W25.md"
+    # days_so_far still reflects "now" (Thursday), independent of offset.
+    assert info["days_so_far"] == 4
+
+
+def test_iso_year_boundary():
+    # 2021-01-01 is a Friday belonging to ISO week 2020-W53 (Monday 2020-12-28).
+    # The key must use the ISO year (2020), not the calendar year (2021).
+    info = compute_week(datetime(2021, 1, 1, 9, 0, 0))
+    assert info["week"] == "2020-W53"
+    assert info["monday"] == "2020-12-28"
+    assert info["days_so_far"] == 5
+    assert info["page_path"] == "agent/pages/blog-ideas/2020-W53.md"
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd /Users/lorchard/devel/decafclaw/.claude/worktrees/feat-blog-ideas-skill && uv run pytest tests/test_blog_ideas_skill.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'decafclaw.skills.blog_ideas.tools'`.
+
+- [ ] **Step 4: Implement the helper**
+
+Create `src/decafclaw/skills/blog_ideas/tools.py`:
+
+```python
+"""blog-ideas bundled skill — deterministic ISO-week helper for the living weekly page.
+
+`current_time` returns a plain timestamp with no ISO-week number, and the
+living-page model needs a correct, stable week key (a wrong key duplicates the
+page instead of refining it). ISO-week math — especially around year boundaries
+and "N weeks ago" — is exactly the deterministic mechanic that belongs in code,
+so the skill exposes one helper and the LLM never computes weeks itself.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from decafclaw.media import ToolResult
+
+log = logging.getLogger(__name__)
+
+PAGE_FOLDER = "agent/pages/blog-ideas"
+
+
+def compute_week(now: datetime, offset_weeks: int = 0) -> dict:
+    """ISO-week identity for the blog-ideas page, offset by whole weeks.
+
+    Returns a dict with:
+      - ``week``:        ISO week key, e.g. ``"2026-W26"``. Uses the ISO year,
+                         which differs from the calendar year near boundaries.
+      - ``monday``:      the offset week's Monday, ``"YYYY-MM-DD"``.
+      - ``days_so_far``: ISO weekday of ``now`` (1=Mon .. 7=Sun). Always reflects
+                         ``now`` — it measures progress into the current week and
+                         is meaningless for non-zero ``offset_weeks`` (used only
+                         to size the gather window when offset is 0).
+      - ``page_path``:   vault path of the offset week's page.
+    """
+    shifted = now + timedelta(weeks=offset_weeks)
+    iso = shifted.isocalendar()  # (year, week, weekday)
+    week_key = f"{iso.year}-W{iso.week:02d}"
+    monday = shifted - timedelta(days=iso.weekday - 1)
+    return {
+        "week": week_key,
+        "monday": monday.strftime("%Y-%m-%d"),
+        "days_so_far": now.isocalendar().weekday,
+        "page_path": f"{PAGE_FOLDER}/{week_key}.md",
+    }
+
+
+def blog_ideas_week(ctx, offset_weeks: int = 0) -> ToolResult:
+    """Return the ISO-week identity + page path for the living weekly page."""
+    info = compute_week(datetime.now(), offset_weeks)
+    return ToolResult(
+        text=(
+            f"{info['week']} (week of {info['monday']}, "
+            f"day {info['days_so_far']}/7) -> {info['page_path']}"
+        ),
+        data=info,
+    )
+
+
+TOOLS = {"blog_ideas_week": blog_ideas_week}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "blog_ideas_week",
+            "description": (
+                "Return the ISO-week identity for the living weekly blog-ideas "
+                "page: the week key (e.g. '2026-W26'), that week's Monday, how "
+                "many days into the week it is now (1=Mon..7=Sun), and the vault "
+                "page_path. Pass offset_weeks=-1 for last week, -2 for two weeks "
+                "ago, etc. ALWAYS call this to get the page path — NEVER "
+                "hand-compute ISO week numbers."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "offset_weeks": {
+                        "type": "integer",
+                        "description": (
+                            "Whole-week offset from the current week. 0 = this "
+                            "week (default), -1 = last week, -2 = two weeks ago."
+                        ),
+                    },
+                },
+            },
+        },
+    },
+]
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_blog_ideas_skill.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decafclaw/skills/blog_ideas/__init__.py src/decafclaw/skills/blog_ideas/tools.py tests/test_blog_ideas_skill.py
+git commit -m "feat(blog-ideas): deterministic ISO-week helper for the weekly page
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Skill definition (`SKILL.md` + `SCHEDULE.md`) + discovery test
+
+**Files:**
+- Create: `src/decafclaw/skills/blog_ideas/SKILL.md`
+- Create: `src/decafclaw/skills/blog_ideas/SCHEDULE.md`
+- Modify: `tests/test_blog_ideas_skill.py` (append discovery test)
+
+**Interfaces:**
+- Consumes: `compute_week` / `blog_ideas_week` / `TOOL_DEFINITIONS` from Task 1.
+- Produces: a discoverable bundled skill named `blog-ideas` that owns the `blog_ideas_week` tool and carries a parseable `SCHEDULE.md`.
+
+- [ ] **Step 1: Write the failing discovery test**
+
+Append to `tests/test_blog_ideas_skill.py`:
+
+```python
+def test_skill_discovered_and_owns_tool():
+    from decafclaw.config import load_config
+    from decafclaw.skills import build_skill_tool_owners, discover_skills
+
+    config = load_config()
+    skills = discover_skills(config)
+    by_name = {s.name for s in skills}
+    assert "blog-ideas" in by_name, f"blog-ideas not discovered; got {sorted(by_name)}"
+
+    owners = build_skill_tool_owners(skills)
+    assert owners.get("blog_ideas_week") == "blog-ideas"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `uv run pytest tests/test_blog_ideas_skill.py::test_skill_discovered_and_owns_tool -v`
+Expected: FAIL — `blog-ideas not discovered` (no SKILL.md yet, so the directory isn't a discoverable skill).
+
+- [ ] **Step 3: Write `SKILL.md`**
+
+Create `src/decafclaw/skills/blog_ideas/SKILL.md`:
+
+```markdown
+---
+name: blog-ideas
+description: Review the week's ingested content, journal notes, and blog archive, then maintain a living weekly page of blog-post ideas. Use when asked what to write/blog about, or to brainstorm post ideas from recent activity.
+effort: strong
+required-skills:
+  - vault
+user-invocable: true
+context: fork
+---
+
+# Blog-idea brainstorm
+
+Once a day, review the week so far across everything I've been reading, writing,
+and thinking, and maintain a single living page of blog-post ideas for the week.
+The page accumulates and sharpens across the week; you rewrite it in place each
+run. Read and write only within `agent/`.
+
+## Phase 1: Orient
+
+1. Call `blog_ideas_week` to get this week's `week` key, `days_so_far`, and the
+   `page_path`. NEVER compute the ISO week yourself.
+2. `vault_read` the `page_path`. If it exists, this is the living page you'll
+   refine — it's also your within-week dedup memory. If it doesn't exist yet,
+   you'll create it this run.
+3. Call `blog_ideas_week` with `offset_weeks=-1` and `offset_weeks=-2` and
+   `vault_read` those pages if present — just enough to notice themes I keep
+   circling week to week.
+
+## Phase 2: Gather (read at snippet level — do NOT bulk-read article bodies)
+
+`days_so_far` is how many days of "this week" exist; use it as the `days` window.
+
+1. **Ingested activity** — `vault_search` across the ingest folders with
+   `days=<days_so_far>`: `agent/pages/bookmarks`, `agent/pages/mastodon`,
+   `agent/pages/youtube`, `agent/pages/github`, `agent/pages/podcasts`,
+   `agent/pages/music`, `agent/pages/kindle`. These are things I consumed.
+2. **Journal** — `vault_search` with `source_type=user` over my daily journal
+   (`journals/…`) for the same window. ALL of it is fair game — TIL bullets,
+   session notes, offhand musings. Notes tagged `*(blog candidate)*` are a
+   stronger signal but are not the only material.
+3. **Stalled drafts** — `vault_list` `blog/drafts` and `vault_search` it against
+   this week's themes. When fresh material supplies the missing piece for an
+   abandoned draft, that's a high-value idea.
+4. **Published archive** (on demand) — `vault_search` `blog/daily` and
+   `blog/weeknotes` only to check a candidate: skip near-duplicates of things
+   I've already written; frame genuine extensions as follow-ups; keep angles in
+   my actual voice.
+
+Read full bodies (`vault_read`) only for the handful of drafts/posts tied to an
+idea you're actively developing.
+
+## Phase 3: Synthesize
+
+- Treat journal notes and ingested activity as EQUAL peers — an idea may spring
+  from a striking bookmark with no journal note behind it, or from a half-thought
+  in the journal.
+- Connect across sources: a journal note + a bookmark + a stalled draft can be
+  one idea.
+- Hold a high bar for headliners; everything else is a seed.
+
+## Phase 4: Write the living page
+
+`vault_write` the `page_path` with this structure (rewrite in place — refine and
+merge existing entries, add new ones only if they clear the bar, demote faded
+ones; do NOT just append):
+
+    ---
+    tags: [blog-ideas, brainstorm]
+    summary: Blog post ideas for the week of <monday> (<week>)
+    week: <week>
+    updated: <today's date>
+    ---
+
+    # Blog ideas — week of <monday>
+
+    ## Headliners
+    ### <hook title>
+    - **angle:** why this, why now
+    - **sources:** [[page]], journal <date>, connects to draft "<name>"
+    - **shape:** outline bullets / the missing piece
+    - **status:** new | sharpened <date> | follow-up to <published post>
+
+    ## Seeds
+    - <one-liner> — source hint
+
+    ## Recurring
+    - <theme> — circled ~N weeks running; maybe it's ripe
+
+Keep 3–5 headliners. Surface cross-week repeats under **Recurring** as signal —
+do NOT re-pitch them cold in Headliners.
+
+## Finishing up
+
+End with a short narrative summary that doubles as the newsletter's raw material:
+the headliner titles, a one-line hook each, and a link to the full
+`[[<page_path without the .md>]]`. If there was nothing new worth surfacing this
+run, begin your summary with `HEARTBEAT_OK` on its own line followed by a brief
+quiet-cycle note.
+```
+
+- [ ] **Step 4: Write `SCHEDULE.md`**
+
+Create `src/decafclaw/skills/blog_ideas/SCHEDULE.md`:
+
+```markdown
+---
+schedule: "0 6 * * *"
+model: strong
+required-skills:
+  - blog-ideas
+  - vault
+---
+
+Time for the daily blog-idea brainstorm. Follow the blog-ideas skill instructions to completion.
+```
+
+- [ ] **Step 5: Run the discovery test to verify it passes**
+
+Run: `uv run pytest tests/test_blog_ideas_skill.py::test_skill_discovered_and_owns_tool -v`
+Expected: PASS.
+
+- [ ] **Step 6: Verify the whole unit-test file and lint pass**
+
+Run: `uv run pytest tests/test_blog_ideas_skill.py -v && make lint`
+Expected: all PASS, no lint errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/decafclaw/skills/blog_ideas/SKILL.md src/decafclaw/skills/blog_ideas/SCHEDULE.md tests/test_blog_ideas_skill.py
+git commit -m "feat(blog-ideas): SKILL.md prompt + daily SCHEDULE.md
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Behavior eval
+
+**Files:**
+- Create: `evals/blog-ideas.yaml`
+
+**Interfaces:**
+- Consumes: the discoverable `blog-ideas` skill (Task 2) and its `blog_ideas_week` tool (Task 1).
+
+- [ ] **Step 1: Write the eval cases**
+
+Create `evals/blog-ideas.yaml`:
+
+```yaml
+# Evals for the blog-ideas skill.
+# Case 1: natural-language ask routes to the skill (catalog disambiguation).
+# Case 2: an explicit run computes the week deterministically and writes the
+#         living weekly page. Output content is non-deterministic, so the
+#         assertions are structural (right tools, page path) — quality is judged
+#         by the manual deployment smoke, not here.
+
+- name: "blog-ideas: 'what should I write about' activates the skill"
+  input: "What should I write about on my blog this week? Brainstorm some ideas from what I've been reading and jotting down lately."
+  expect:
+    expect_tool: activate_skill
+    response_not_contains:
+      - "[error"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "blog-ideas: explicit run computes the week and writes the weekly page"
+  setup:
+    skills: [blog-ideas]
+    memories:
+      - tags: [journal, blog-candidate]
+        content: "Spent the morning wrestling llamafile into doing local topic clustering — the embedding step was the tricky part. *(blog candidate)*"
+      - tags: [bookmark, ai]
+        content: "Bookmarked Anil Dash 'What do coders do after AI?' — resonates with the craft-vs-result tension."
+  input: "Do the weekly blog-ideas brainstorm now and update this week's page."
+  expect:
+    expect_tool: blog_ideas_week
+    response_contains:
+      - "agent/pages/blog-ideas/"
+    response_not_contains:
+      - "[error"
+      - "I'm sorry"
+    max_tool_calls: 18
+    max_tool_errors: 0
+```
+
+- [ ] **Step 2: Run the eval**
+
+Run: `uv run python -m decafclaw.eval evals/blog-ideas.yaml` (the eval runner takes a yaml path or a directory; `make eval` runs the whole `evals/` dir).
+Expected: both cases PASS. If case 2's `max_tool_calls` is too tight for the gather phase, raise it (note the change in the dev-session notes) rather than weakening the tool/page assertions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add evals/blog-ideas.yaml
+git commit -m "test(blog-ideas): routing + page-production behavior evals
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Docs, full verification, and deployment smoke
+
+**Files:**
+- Modify: `CLAUDE.md` (bundled-skills list)
+- Modify: `docs/schedules.md` (if it enumerates bundled scheduled skills)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+
+- [ ] **Step 1: Add `blog-ideas` to the CLAUDE.md bundled-skills list**
+
+In `CLAUDE.md`, under "Key files → Skills (bundled)", add `blog-ideas` to the
+skill list line:
+
+```
+### Skills (bundled)
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,blog_ideas}/`. ...
+```
+
+(Use the directory name `blog_ideas` to match the others, which are directory names.)
+
+- [ ] **Step 2: Note the scheduled skill in docs/schedules.md**
+
+Open `docs/schedules.md`. If it lists bundled scheduled skills (alongside
+`dream`/`garden`/`newsletter`), add a one-line entry:
+
+```
+- **blog-ideas** — daily 06:00 UTC; reviews the week-so-far across ingests, journal, and blog archive and refines a living weekly blog-ideas page (`agent/pages/blog-ideas/{ISO-week}.md`). Surfaced via the newsletter's scheduled-activity aggregation.
+```
+
+If no such list exists, skip this step (don't invent a new section).
+
+- [ ] **Step 3: Run the full check + test suite**
+
+Run: `make check && make test`
+Expected: all PASS, zero warnings (project has zero-tolerance for warning/traceback noise).
+
+- [ ] **Step 4: Check test durations for hidden slow tests**
+
+Run: `uv run pytest tests/test_blog_ideas_skill.py --durations=10`
+Expected: the helper tests are sub-millisecond; the discovery test calls `discover_skills` (imports tools.py) but should not approach the top-25 slow list. If it does, that signals an accidental real scheduler/LLM call — investigate before proceeding.
+
+- [ ] **Step 5: Commit the docs**
+
+```bash
+git add CLAUDE.md docs/schedules.md
+git commit -m "docs(blog-ideas): list the bundled scheduled skill
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Manual deployment smoke (judgment gate — do with Les)**
+
+This is where output *quality* is judged; no unit test covers it.
+
+1. Confirm on the deployment that journal entries surface as `source_type=user`
+   in `vault_search` (the spec's build-time open question). If they don't, adjust
+   the Phase-2 journal step in `SKILL.md` to use a `folder=journals` filter
+   instead, and re-commit.
+2. Trigger the skill once interactively (`/blog-ideas`) against the real vault
+   (a live week of ingests + journal + drafts).
+3. Read the generated `agent/pages/blog-ideas/{week}.md`. Judge: are the ideas
+   grounded and genuinely useful, or bland topic-restatements? Tune the SKILL.md
+   synthesis wording if needed (tool descriptions / prompt wording are the
+   control surface) and re-run.
+4. Only after the manual output looks good, let the 06:00 cron run it (it ships
+   enabled).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Inputs (ingests / journal / drafts / published) → Task 2 SKILL.md Phase 2. ✓ (Kindle included.)
+- Daily cadence, week-so-far window → SKILL.md Phase 2 (`days=days_so_far`) + SCHEDULE.md `0 6 * * *`. ✓
+- Balanced journal+ingest synthesis → SKILL.md Phase 3. ✓
+- Draft resurrection, dedup, continuity, voice → SKILL.md Phase 2 steps 3–4. ✓
+- Living weekly page, tiered, in-place rewrite, recurring themes → SKILL.md Phase 4 + Task 1 page path. ✓
+- Output under `agent/pages/blog-ideas/` (no write gate) → Task 1 `PAGE_FOLDER`. ✓
+- Cross-week memory (look back ~2–3 weeks, signal not re-pitch) → SKILL.md Phase 1 step 3 + Phase 4 Recurring, `blog_ideas_week(offset_weeks=…)`. ✓
+- Newsletter delivery without newsletter changes → SKILL.md "Finishing up" rich summary + `HEARTBEAT_OK`; no newsletter file touched. ✓
+- Deterministic week helper + unit tests → Task 1. ✓
+- Behavior eval → Task 3. ✓
+- Ships enabled, model strong → SCHEDULE.md. ✓
+- Build-time open questions (journal `source_type`, output folder) → Task 4 Step 6. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; eval-entrypoint command flagged to confirm against `make` targets (a real ambiguity, not a placeholder) with a concrete fallback.
+
+**Type consistency:** `compute_week` keys (`week`, `monday`, `days_so_far`, `page_path`) are used identically in tests (Task 1), the tool wrapper (Task 1), and referenced by name in SKILL.md (Task 2). Tool name `blog_ideas_week` consistent across `TOOLS`, `TOOL_DEFINITIONS`, discovery test, and eval. Skill name `blog-ideas` vs directory `blog_ideas` consistent throughout (frontmatter name vs dir, per Global Constraints).

--- a/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/spec.md
+++ b/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/spec.md
@@ -1,0 +1,232 @@
+# Spec — Daily blog-idea brainstorm skill
+
+**Date:** 2026-06-25
+**Branch:** `feat-blog-ideas-skill`
+**Status:** Design approved; pending spec review → implementation plan.
+
+## Problem
+
+Les ingests a lot daily — bookmarks, Mastodon posts, liked YouTube videos, GitHub
+activity, podcasts, Kindle highlights — and also keeps a daily Obsidian journal of rough
+notes, plus a backlog of published posts and stalled drafts. There's no routine that
+steps back across all of it and asks: *given what's been on my mind lately, what's worth
+writing about?* The raw material for blog posts accumulates and goes cold.
+
+## Goal
+
+A scheduled skill that, once a day, reviews the week-so-far across all of Les's
+content sources and maintains a living "blog ideas for this week" page — a small set of
+developed ideas plus a list of lighter seeds — that sharpens as the week fills in. The
+daily newsletter surfaces it so Les gets nudged to go read the page as it shapes up.
+
+## Key insight: zero new ingest plumbing
+
+Everything the skill needs already lives in one indexed vault on the deployment:
+
+- **External activity** is pulled in by the existing `meta-ingest` skill (Mastodon,
+  Linkding bookmarks, YouTube, GitHub, Pocket Casts, Spotify) → `agent/pages/{mastodon,
+  bookmarks,youtube,github,podcasts,music}/`, plus **Kindle highlights** from the separate
+  `kindle` skill → `agent/pages/kindle/`.
+- **The daily journal** is Les's Obsidian vault, synced to the deployment and configured
+  as decafclaw's `vault_path` (`obsidian/main/`). Journal entries live at `journals/`.
+- **The blog archive** is in the same vault: `blog/drafts/` (stalled drafts),
+  `blog/daily/` and `blog/weeknotes/` (published posts).
+
+All are reachable through the normal `vault_search` / `vault_read` / `vault_list` tools.
+The skill is therefore **almost prompt-only** (`SKILL.md` + `SCHEDULE.md`), mirroring
+`dream` / `garden`, with **one small `tools.py`** carrying a single deterministic helper.
+
+### Why the one helper tool
+
+`current_time` returns a plain timestamp (`%Y-%m-%d %H:%M:%S (%A)`) with no ISO-week
+number. The living-page model hinges on a correct, stable ISO-week key: a wrong key means
+the daily run can't find yesterday's page and silently creates a duplicate instead of
+refining it. ISO-week math (and "N weeks ago" for the cross-week lookback) is fiddly and
+year-boundary-prone — exactly the deterministic mechanic that belongs in code, not in the
+LLM. So the skill ships a single helper, `blog_ideas_week(offset_weeks=0)`, returning the
+week key, that week's Monday, days-so-far, and the page path. The LLM never does week math;
+page identity is guaranteed. (This is a deliberate, narrow deviation from the pure-prompt
+`dream`/`garden` shape, approved during planning.)
+
+## Requirements
+
+### Inputs (all via existing vault tools)
+
+| Source | Vault location | Role | Read depth |
+|--------|----------------|------|-----------|
+| External ingests | `agent/pages/{bookmarks,mastodon,youtube,github,podcasts,music,kindle}/` | Idea fuel (peer to journal) | Search snippets; full read only for an idea being developed |
+| Daily journal | `journals/` | Idea source (peer to ingests); **all** sections fair game, `*(blog candidate)*`-flagged notes weighted higher | Snippets + targeted reads |
+| Stalled drafts | `blog/drafts/` | Resurface when this week's material connects to an abandoned draft | Read matched drafts |
+| Published posts | `blog/daily/`, `blog/weeknotes/` | Dedup (skip already-covered), continuity (spot follow-ups), voice grounding | On-demand search; read only to verify a candidate |
+
+### Cadence & window
+
+- Runs **daily**, early morning, **before** the newsletter's 07:00 UTC compose. Target
+  `0 6 * * *` (06:00 UTC).
+- Each run covers the **week so far** — an accumulating window from Monday 00:00 through
+  now. Monday's run sees ~1 day; Sunday's sees the full week.
+- Model: `strong` (heavy synthesis, matches `dream` / `garden`).
+- `required-skills: [vault]`.
+
+### Synthesis behavior
+
+- Journal notes and external ingests are **equal peers** — an idea may originate from a
+  striking bookmark with no journal note behind it, or from a journal half-thought.
+- Connect across sources (a journal note + a bookmark + a stalled draft → one idea).
+- Match this week's material against `blog/drafts/`; surface a stalled draft when fresh
+  material supplies its missing piece.
+- Check a candidate against published posts before promoting it: skip near-duplicates,
+  frame genuine extensions as follow-ups.
+
+### Output: a living weekly page
+
+- Path: `agent/pages/blog-ideas/{ISO-week}.md` (e.g. `agent/pages/blog-ideas/2026-W26.md`).
+  Writes under `agent/` to avoid the `vault_write` out-of-agent confirmation gate (a
+  scheduled run can't satisfy interactive confirmation). One page per ISO week.
+- **Rewritten in place** each day (overwrite, not append) — the page *is* the durable
+  within-week state and dedup memory.
+- Tiered structure:
+  - **Headliners** — 3–5 developed ideas (angle, sources, rough shape, status). High bar.
+  - **Seeds** — lightweight bullets, half-formed; may graduate to headliners or fade.
+  - **Recurring** — themes circled across recent weeks, surfaced as signal ("you've
+    returned to X three weeks running — maybe it's ripe"), not re-pitched cold.
+- Frontmatter: `tags`, `summary`, `week`, `updated`.
+
+Page shape:
+
+```markdown
+---
+tags: [blog-ideas, brainstorm]
+summary: Blog post ideas for the week of 2026-06-22 (W26)
+week: 2026-W26
+updated: 2026-06-25
+---
+
+# Blog ideas — week of 2026-06-22
+
+## Headliners
+### <hook title>
+- **angle:** why this, why now
+- **sources:** [[bookmark-x]], journal 06-23, connects to draft "handwriting recognition"
+- **shape:** outline bullets / the missing piece
+- **status:** new | sharpened 06-25 | follow-up to [published post]
+
+## Seeds
+- <one-liner> — source hint
+
+## Recurring
+- <theme> — surfaced ~3 weeks running; maybe it's ripe
+```
+
+### Cross-week memory
+
+- Glance at the last ~2–3 `agent/pages/blog-ideas/*` pages.
+- Pitch genuinely new ideas; for ideas Les keeps circling, surface them under
+  **Recurring** as signal rather than re-listing them cold. Don't hard-suppress —
+  a ripening idea may finally be ready.
+
+### Newsletter delivery (no newsletter changes)
+
+- The newsletter already aggregates **all** scheduled-task activity generically via
+  `newsletter_list_scheduled_activity` (which exposes each run's `final_message` and
+  `vault_pages_touched`) and `newsletter_list_vault_changes` (mtime). A scheduled skill
+  contributes simply by running and ending with a good summary. **No edits to the
+  newsletter skill.**
+- **Design lever — the final summary message.** On a productive day the run ends with a
+  compact digest: headliner titles + a one-line hook each + a link to the full
+  `[[agent/pages/blog-ideas/{week}]]` page. That rich `final_message` is what the
+  newsletter narrates from, giving a good "blog ideas" presence in the email and the
+  nudge to go read the living page. Quiet days emit `HEARTBEAT_OK` and the newsletter
+  skips them.
+- Timing: brainstorm 06:00 → its conversation is well inside the newsletter's lookback
+  at 07:00.
+- Deferred (YAGNI): a guaranteed fixed-format "Blog ideas this week" section would be a
+  small newsletter-prompt nudge later; not in scope now. Keeps the two skills decoupled.
+
+## Architecture
+
+Single scheduled agent turn (`dream`-style), no fan-out, no workflow engine. The core
+value is **cross-source synthesis**, which wants all material in one reasoning context;
+fan-out (meta-ingest-style) would fragment exactly the connection-making that's the
+point, and the workflow engine's durability/suspend-resume buys nothing for a daily
+idempotent page refresh (the living page already is the durable state).
+
+Context stays bounded because reads default to search **snippets** (meta-ingest already
+did the heavy article fetching upstream); full-body `vault_read` happens only for the
+handful of drafts/posts tied to a candidate being actively developed.
+
+### Daily run algorithm (encoded in the prompt)
+
+1. Establish current ISO week → target page path; compute week-so-far window (days since
+   Monday, min 1).
+2. Gather as snippets: `vault_search` over the ingest folders (bookmarks, mastodon,
+   youtube, github, podcasts, music, kindle; `days=<window>`); journal
+   over `journals/` (all sections, blog-flagged weighted); `vault_list` `blog/drafts/` +
+   targeted search to match stalled drafts; published archive on-demand for dedup/continuity.
+3. Read the current weekly page (running state + within-week dedup memory).
+4. Glance at recent prior-week pages for recurring themes.
+5. Synthesize: peers (journal + ingests), connect across sources, match drafts, dedup vs
+   published.
+6. Rewrite the weekly page in place — refine/merge headliners, graduate/add seeds, demote
+   faded ones, refresh `updated` and the Recurring note.
+7. End with the summary: productive day → digest + page link; quiet day → `HEARTBEAT_OK`.
+
+### Naming
+
+Working name `blog-ideas` (sibling to `dream` / `garden` / `newsletter`). `muse` is an
+alternative that fits the evocative-name family; clarity-first convention favors
+`blog-ideas`. Final name decided at implementation.
+
+### Enablement
+
+> **Relocated to contrib (post-implementation).** The skill lives at
+> `contrib/skills/blog-ideas/`, not as a core bundled skill — it's personal and
+> vault-layout-specific. Consequences: it's discovered only when the deployment's
+> `extra_skill_paths` includes `$CONTRIB/skills/blog-ideas`; its `SCHEDULE.md` is
+> **force-disabled** (contrib skills don't auto-activate cron), so the daily run is
+> opted into via a copy-on-write overlay at `data/{agent_id}/schedules/blog-ideas.md`
+> (copy the SCHEDULE.md, set `enabled: true`). The `/blog-ideas` command works on demand
+> regardless. The behavior eval was dropped (a contrib skill isn't on the default eval
+> skill path); validation is the colocated importlib unit tests + the manual deployment
+> smoke. See `notes.md`.
+
+## Testing & validation
+
+- **Eval (LLM-visible):** one behavior case in `evals/blog-ideas.yaml` — an explicit run
+  (the scheduled/`​/blog-ideas` invocation) computes the week via `blog_ideas_week` and
+  writes the weekly page under `agent/pages/blog-ideas/`. Bound with `max_tool_calls` /
+  `max_tool_errors` (the latter intentionally allows the expected "page not found" reads on
+  a fresh week). *Natural-language routing is explicitly not tested or pursued* — see
+  Non-goals.
+- **Unit (deterministic, no LLM):** the `blog_ideas_week` helper — ISO-week key, Monday
+  date, days-so-far, and page path, including year-boundary and prior-week (`offset_weeks`)
+  cases — is a pure function with cheap, exhaustive tests.
+- **Real-data smoke:** trigger the skill manually (user-invocable) once against the
+  deployment's actual vault (real week of ingests + journal + drafts) and eyeball the
+  page — this is where output *quality* is judged, which no unit test covers. Manual
+  trigger before letting cron run it.
+
+## Non-goals / out of scope
+
+- No new ingest sources or fetch code (meta-ingest + sync already cover everything,
+  including YouTube).
+- No newsletter skill modifications.
+- No dedicated blog-ideas email (deferred).
+- No workflow-engine or fan-out architecture.
+- Writing the posts themselves — this surfaces and shapes ideas; Les writes.
+- **No natural-language-question routing.** The skill serves the daily scheduled run and
+  the explicit `/blog-ideas` command (same workflow); it deliberately does *not* try to
+  catch casual "what should I write about?" phrasings or special-case question-vs-command
+  behavior. Keeping that out avoids over-loading the skill and removes any risk of the
+  scheduled prompt being misclassified and silently skipped. (A routing experiment that
+  touched `context_composer.py`'s preempt-hint scoring was reverted and filed separately.)
+
+## Open questions
+
+- **Output folder:** default `agent/pages/blog-ideas/` (no write gate). If Les prefers it
+  under `blog/ideas/` next to his drafts (more discoverable in his Obsidian blog
+  workflow), that needs a one-line entry in the `vault_write` write-allowlist. Decide at
+  implementation.
+- **Skill name:** `blog-ideas` vs `muse`.
+- **Verify at build time:** that `journals/` entries surface as `source_type=user` in
+  `vault_search` (vs. needing a folder filter) on the live deployment.


### PR DESCRIPTION
## What

A new **opt-in contrib skill** (`contrib/skills/blog-ideas/`) that, once a day, reviews the week-so-far across everything I've been reading, writing, and thinking, and maintains a living tiered "blog ideas this week" vault page.

- **Inputs** (all already in the synced vault — zero new ingest plumbing): the agent's ingest folders (`agent/pages/{bookmarks,mastodon,youtube,github,podcasts,music,kindle}`), the daily Obsidian journal (`journals/`, all sections — `*(blog candidate)*` a stronger-but-not-exclusive signal), and the blog archive (`blog/drafts` to resurface stalled drafts; `blog/daily`/`weeknotes` for dedup, follow-ups, and voice).
- **Output:** a living weekly page at `agent/pages/blog-ideas/{ISO-week}.md`, rewritten in place each day — tiered **Headliners** (3–5) + **Seeds** + **Recurring** (cross-week themes surfaced as signal, not re-pitched). Under `agent/` to avoid the out-of-agent write gate a scheduled run can't satisfy.
- **Delivery:** rides the existing newsletter's scheduled-activity aggregation — **no newsletter changes**. The run's narrative summary is the newsletter's raw material and the nudge to read the page.

## Design notes

- **Almost prompt-only** (`SKILL.md` + `SCHEDULE.md`), mirroring `dream`/`garden`, **plus one small `tools.py`**: a deterministic `blog_ideas_week(offset_weeks=0)` helper. `current_time` has no ISO-week number, and the living-page model needs a stable week key (a wrong key duplicates the page instead of refining it). ISO-week math / year boundaries belong in code, not the LLM.
- **Single-turn `dream`-style synthesis**, not fan-out or the workflow engine — the value is cross-source connection, which wants one reasoning context.
- **Scoped to the scheduled path** (+ the explicit `/blog-ideas` command). A mid-implementation experiment to route casual natural-language questions was **reverted** (it over-loaded the skill and risked the scheduled prompt being misclassified and silently no-op'ing); the cross-cutting `context_composer.py` change it introduced is spun out as #604.

## Contrib (opt-in) — activation

This is a personal, vault-layout-specific skill, so it lives in `contrib/`, not as a core bundled skill. To activate on a deployment:
1. Add `$CONTRIB/skills/blog-ideas` to the agent's `extra_skill_paths`.
2. The daily `SCHEDULE.md` ships **force-disabled** (contrib skills don't auto-activate cron) — opt in via a copy-on-write overlay at `data/{agent_id}/schedules/blog-ideas.md` (set `enabled: true`).
3. `/blog-ideas` works on demand regardless.

## Testing

- ISO-week helper: 6 colocated unit tests (`contrib/skills/blog-ideas/test_blog_ideas.py`, importlib-loaded), incl. ISO year boundary `2021-01-01 → 2020-W53` and tool registration. Run under `make test` (which includes `contrib/skills/`).
- No `evals/` entry — a contrib skill isn't on the default eval skill path; behavior/quality is judged by the manual deployment smoke (below).
- `make check` clean; `make test` 2949 passed.

## Follow-ups (not in this PR)

- **#604** — `context_composer` preempt-hint noise reduction (the reverted experiment).
- **#605** — pre-existing flaky `PytestUnraisableExceptionWarning` (leaked asyncio subprocess transport; confirmed independent of this branch).
- **Post-merge manual gate:** add the path + schedule overlay on the deployment, trigger `/blog-ideas` against the live vault, judge idea quality, and verify `journals/` surfaces as `source_type=user` (add a `folder=journals` filter if not). *Then* enable cron.

## Note for merge

Please **squash-merge** — the branch carries intentional fix/revert churn (the reverted NL-routing experiment + the bundled→contrib move) that should collapse into one clean commit. Dev-session spec/plan/notes are included by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)