### PR TITLE
fix(blog-ideas): make it work end-to-end (+ vault_recent core tool, dream/garden command context)

### DIFF
--- a/contrib/skills/blog-ideas/SKILL.md
+++ b/contrib/skills/blog-ideas/SKILL.md
@@ -5,7 +5,7 @@ effort: strong
 required-skills:
   - vault
 user-invocable: true
-context: fork
+context: inline
 ---
 
 # Blog-idea brainstorm

--- a/contrib/skills/blog-ideas/test_blog_ideas.py
+++ b/contrib/skills/blog-ideas/test_blog_ideas.py
@@ -69,3 +69,22 @@ def test_tool_registered():
     tool_names = {td["function"]["name"] for td in blog_ideas_tools.TOOL_DEFINITIONS}
     assert "blog_ideas_week" in tool_names, f"got {sorted(tool_names)}"
     assert "blog_ideas_week" in blog_ideas_tools.TOOLS
+
+
+def test_command_runs_inline_not_forked():
+    # `/blog-ideas` MUST run inline, not forked. A forked command runs as a
+    # child agent, which by the #396 vault-access policy gets no vault read
+    # access and cannot write to the vault — but this skill must read AND write
+    # the weekly page. (The scheduled path is unaffected by `context`.)
+    # Parse the YAML frontmatter so the check is on the `context` key, not a
+    # raw substring that body prose could trip.
+    import yaml
+
+    text = (_THIS_DIR / "SKILL.md").read_text()
+    _, frontmatter, _ = text.split("---", 2)
+    meta = yaml.safe_load(frontmatter)
+    assert meta.get("context") == "inline", (
+        f"blog-ideas /command must declare `context: inline` — fork runs it as "
+        f"a child agent with no vault read + blocked vault writes (#396); got "
+        f"{meta.get('context')!r}"
+    )

--- a/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
+++ b/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
@@ -28,6 +28,12 @@ Output lands at `agent/pages/blog-ideas/{ISO-week}.md` (under `agent/` to avoid 
 - A routing experiment briefly added a `context_composer.py` preempt-hint score-gap filter (cross-cutting, all skills) + an aggressive SKILL.md description + a "Routing note." All reverted when NL routing was descoped. The composer idea is filed separately as **issue #604** to be judged on its own merits.
 - The discovery test was narrowed (Task 4) from `build_skill_tool_owners` (which eagerly imports every skill's `tools.py`, including the subprocess-spawning `claude_code`/`background`) to `discover_skills` + the skill's own `TOOL_DEFINITIONS`. **Kept as an independent scoping improvement** (a per-skill test shouldn't import every other skill). It was initially believed to fix a `PytestUnraisableExceptionWarning`, but follow-up measurement disproved that: the warning appears intermittently on the suite **with our test file excluded too** (3/3 runs) — it's a pre-existing, flaky GC artifact (a leaked asyncio subprocess transport finalized late, attributed to whatever test is running at GC time), unrelated to this feature. Filed as **issue #605**, not fixed here.
 
+## Bugfix: `/blog-ideas` command had no vault access (`context: fork` → `inline`)
+
+First deployment smoke of `/blog-ideas` failed: *"vault_read tool is not available in this context."* Root cause (systematic-debugging): the SKILL.md had `context: fork`, which routes the `/command` through `run_child_turn` (delegate.py). Per the #396 child-agent vault policy, **child agents get no vault read access by default and vault writes are categorically blocked** — but this skill must read and write the weekly page. The `dream`/`garden` skills use `context: fork` too, but only ever run via the *scheduled* path (which ignores `context`); `/dream` as a command would hit the same wall. The working reference is `newsletter`: a user-invocable, vault-writing skill that uses **`context: inline`** (runs in the user's conversation with the full tool set). Fix: `context: fork` → `context: inline`, plus a regression test asserting it. The scheduled path is unaffected by `context`.
+
+> General gotcha: a `user-invocable` skill that needs the vault (especially writes) must use `context: inline`, not `fork`.
+
 ## Relocation to contrib (post-review)
 
 After the PR was opened, the skill was moved from a core bundled skill

--- a/src/decafclaw/skills/dream/SKILL.md
+++ b/src/decafclaw/skills/dream/SKILL.md
@@ -5,7 +5,7 @@ effort: strong
 required-skills:
   - vault
 user-invocable: true
-context: fork
+context: inline
 ---
 
 # Memory Consolidation

--- a/src/decafclaw/skills/garden/SKILL.md
+++ b/src/decafclaw/skills/garden/SKILL.md
@@ -5,7 +5,7 @@ effort: strong
 required-skills:
   - vault
 user-invocable: true
-context: fork
+context: inline
 ---
 
 # Vault Gardening Sweep

--- a/tests/test_skill_command_context.py
+++ b/tests/test_skill_command_context.py
@@ -1,0 +1,28 @@
+"""Guard: a user-invocable skill that requires the vault must run inline.
+
+A `/command` with `context: fork` runs as a child agent, which by the #396
+vault-access policy gets no vault read access and has vault writes categorically
+blocked. So any user-invocable skill that declares `vault` in `required-skills`
+(i.e. needs to read/write the vault) must use `context: inline` — otherwise its
+command invocation silently can't touch the vault. The scheduled path is
+unaffected by `context`.
+"""
+
+from decafclaw.config import load_config
+from decafclaw.skills import discover_skills
+
+
+def test_vault_requiring_commands_run_inline():
+    skills = discover_skills(load_config())
+    offenders = [
+        s.name
+        for s in skills
+        if s.user_invocable
+        and "vault" in (s.requires_skills or [])
+        and s.context == "fork"
+    ]
+    assert not offenders, (
+        "user-invocable skills that require the vault must use `context: inline`, "
+        "not `fork` — a forked command runs as a child agent with no vault read "
+        f"and blocked vault writes (#396): {offenders}"
+    )


### PR DESCRIPTION
Follow-up to #606. What started as a one-line command-context fix grew as deploy smokes surfaced more — captured here as one coherent "make the skill actually work" change.

## 1. Command context: fork → inline (blog-ideas, dream, garden)
`context: fork` runs a `/command` as a child agent, which by the **#396** policy gets no vault read and blocked vault writes. blog-ideas/dream/garden all read+write the vault, so their commands failed (`"vault_read not available"`). Switched all three to `context: inline` (like `newsletter`). Added `tests/test_skill_command_context.py` — a guard that any user-invocable, vault-requiring skill must be `inline`.

## 2. New core tool: `vault_recent` (the gap the skill surfaced)
The gather phase needed "everything changed this week," but the vault had only `vault_search` (needs a content query) and `vault_list` (no date filter) — `newsletter` had even grown a private `_collect_vault_changes`. Added a general **`vault_recent(days=7, folder="", source_type="")`** to the always-loaded vault skill: recency-based, newest-first, optional folder/source_type scoping. Unit tests + a `tool_choice` eval disambiguating it from search/list (both cases pass). *Follow-up (not here): refactor `newsletter` onto it.*

## 3. blog-ideas gather rewrite
First smoke produced generic ideas and never read the Obsidian journal: the prompt told the model to `vault_search` the ingest folders, but that needs a content query (it searched `"blog ideas"`, found ~nothing) and it hit `agent/journal` instead of `journals/`. Phase 2 now calls `vault_recent(days=days_so_far)` to read **everything** changed this week across all ingest + distilled folders **and** the Obsidian daily journal (`source_type=user`), then reads the relevant entries.

## Testing
`make check` clean; `make test` 2976 passed; the two `vault_recent` `tool_choice` cases pass. End-to-end is validated by re-running `/blog-ideas` on the deployment.

> Will re-squash to a clean commit once the deployment smoke confirms the gather produces good, grounded ideas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)