### PR TITLE
feat(vault): vault_recent tool + blog-ideas gather/parking-lot rewrite

### DIFF
--- a/contrib/skills/blog-ideas/SKILL.md
+++ b/contrib/skills/blog-ideas/SKILL.md
@@ -13,46 +13,64 @@ context: inline
 Once a day, review the week so far across everything I've been reading, writing,
 and thinking, and maintain a single living page of blog-post ideas for the week.
 The page accumulates and sharpens across the week; you rewrite it in place each
-run. Read and write only within `agent/`.
+run. **Write** only within `agent/` (the living page is the only thing you
+write); **read broadly** across the vault as Phase 2 enumerates — `journals/`,
+`blog/`, and `agent/pages/` are all in scope for reading.
 
 ## Phase 1: Orient
 
 1. Call `blog_ideas_week` to get this week's `week` key, `days_so_far`, and the
    `page_path`. NEVER compute the ISO week yourself.
 2. `vault_read` the `page_path`. If it exists, this is the living page you'll
-   refine — it's also your within-week dedup memory. If it doesn't exist yet,
-   you'll create it this run.
+   refine — it's also your within-week dedup memory; note its `updated:` date
+   (the watermark for incremental reads in Phase 2). If it doesn't exist yet,
+   this is the week's first run and you'll create it.
 3. Call `blog_ideas_week` with `offset_weeks=-1` and `offset_weeks=-2` and
    `vault_read` those pages if present — just enough to notice themes I keep
    circling week to week.
+4. `vault_read agent/pages/blog-ideas/parking-lot.md` if it exists — the rolling
+   set of seeds from the last ~month that haven't ripened. Consider these
+   alongside this week's material: a parked seed that connects to something new
+   can finally graduate into a headliner.
 
-## Phase 2: Gather (read at snippet level — do NOT bulk-read article bodies)
+## Phase 2: Gather
 
-`vault_search`'s `days=N` is a **rolling** lookback (`now − N days`), NOT a
-calendar-week boundary. Use `days=days_so_far` to be sure you cover the whole
-week so far — but that window reaches a little into last week, so when you read
-results, **disregard anything dated before `monday`** (the Monday returned by
-`blog_ideas_week`). That keeps the brainstorm to this week's material and avoids
-re-surfacing last week's items.
+The goal is to read **everything from this week**, not to search for the words
+"blog ideas." `vault_recent` is the right tool — it lists what changed by date.
+Do **NOT** use `vault_search` to enumerate: it requires a content query and only
+returns pages containing that exact text, so it misses almost everything (it's
+for the dedup check in step 4 only).
 
-1. **Ingested activity** — `vault_search` across the ingest folders with
-   `days=<days_so_far>`: `agent/pages/bookmarks`, `agent/pages/mastodon`,
-   `agent/pages/youtube`, `agent/pages/github`, `agent/pages/podcasts`,
-   `agent/pages/music`, `agent/pages/kindle`. These are things I consumed.
-2. **Journal** — `vault_search` with `source_type=user` over my daily journal
-   (`journals/…`) for the same window. ALL of it is fair game — TIL bullets,
-   session notes, offhand musings. Notes tagged `*(blog candidate)*` are a
-   stronger signal but are not the only material.
-3. **Stalled drafts** — `vault_list` `blog/drafts` and `vault_search` it against
-   this week's themes. When fresh material supplies the missing piece for an
-   abandoned draft, that's a high-value idea.
-4. **Published archive** (on demand) — `vault_search` `blog/daily` and
-   `blog/weeknotes` only to check a candidate: skip near-duplicates of things
-   I've already written; frame genuine extensions as follow-ups; keep angles in
-   my actual voice.
+1. **Everything that changed this week** — call `vault_recent` with
+   `days=<days_so_far>` (from `blog_ideas_week`). It returns every vault page
+   modified this week, newest first, each with its modified date and
+   `source_type`: across all my ingest + distilled sources (`agent/pages/…`:
+   bookmarks, mastodon, youtube, github, podcasts, music, kindle, plus topical
+   pages) **and** my Obsidian daily journal (`journals/…`, `source_type=user`).
+   Ignore `agent/pages/notifications/…` (system noise) and the
+   `agent/pages/blog-ideas/…` pages themselves.
+2. `vault_read` the entries worth considering. ALL of it is fair game: ingested
+   bookmarks/posts/podcasts/videos/repos, distilled topical pages
+   (`source_type=page`), and my daily-journal notes (`source_type=user` — TIL
+   bullets, session notes, offhand musings; `*(blog candidate)*` is a strong
+   signal but not the only material). These pages are already distilled
+   summaries — read them directly, don't re-fetch source URLs.
+   - **Read incrementally.** On the week's first run (no existing page), read
+     everything dated on/after `monday`. On later runs, only `vault_read`
+     entries modified **after** the page's `updated:` date — the living page
+     already captures everything earlier this week, so trust it and merge the
+     new findings in. This keeps daily runs cheap instead of re-reading the
+     whole week every time.
+3. **Stalled drafts** — `vault_list folder=blog/drafts` and `vault_read` any
+   whose title relates to this week's themes. When fresh material supplies the
+   missing piece for an abandoned draft, that's a high-value idea.
+4. **Published archive** (on demand) — here, and only here, use `vault_search`
+   with a topic query against `blog/daily` and `blog/weeknotes` to check a
+   candidate: skip near-duplicates of things I've already written; frame genuine
+   extensions as follow-ups; keep angles in my actual voice.
 
-Read full bodies (`vault_read`) only for the handful of drafts/posts tied to an
-idea you're actively developing.
+Keep reads focused: enumerate broadly, but only `vault_read` this week's entries
+plus the handful of drafts/posts tied to an idea you're actively developing.
 
 ## Phase 3: Synthesize
 
@@ -91,8 +109,40 @@ ones; do NOT just append):
     ## Recurring
     - <theme> — circled ~N weeks running; maybe it's ripe
 
-Keep 3–5 headliners. Surface cross-week repeats under **Recurring** as signal —
-do NOT re-pitch them cold in Headliners.
+Keep 3–5 headliners, **ordered strongest first** — headliner #1 is the week's
+lead (a downstream consumer like the weeknotes composer treats it that way).
+Surface cross-week repeats under **Recurring** as signal — do NOT re-pitch them
+cold in Headliners.
+
+Keep this page structure **stable and parseable**: the section headings
+(`Headliners` / `Seeds` / `Recurring`) and the headliner field set (hook title,
+`angle`, `sources`, `shape`, `status`) are a contract other skills read — don't
+rename or drop them.
+
+## Phase 5: Tend the parking lot
+
+The parking lot (`agent/pages/blog-ideas/parking-lot.md`, under `agent/` so you
+can write it) is how **slow-burning themes** survive — ideas that develop across
+notes and bookmarks over a week or two before they're clearly worth writing.
+A single week rarely makes a trend obvious; this is where evidence accumulates.
+After updating the weekly page, `vault_write` the parking lot:
+
+- **Reinforce:** if this week's material adds evidence to a parked theme, append
+  the new sources and bump its `reinforced:` date. Accumulating evidence is the
+  signal it's ripening.
+- **Graduate:** when a parked theme has gathered enough to be worth writing,
+  promote it to a Headliner on this week's page and remove it from the lot.
+- **Add:** park this week's genuinely-new seeds that didn't become headliners,
+  each tagged `seen: <today>`.
+- **Prune:** drop entries that haven't gained traction in **~1 month** (≈4 weeks
+  since `seen`/`reinforced`) — if it hasn't ripened in a month, let it go. If
+  one is *still actively accumulating* at the month mark, keep it and flag it as
+  a persistent slow-burn rather than dropping it silently.
+
+Entry shape (keep the page a simple list under a short header):
+
+    - <theme / seed one-liner> — sources: [[a]], [[b]], journal <date>
+      (seen <YYYY-MM-DD>, reinforced <YYYY-MM-DD>)
 
 ## Finishing up
 

--- a/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
+++ b/docs/dev-sessions/2026-06-25-1554-daily-blog-brainstorm/notes.md
@@ -34,6 +34,74 @@ First deployment smoke of `/blog-ideas` failed: *"vault_read tool is not availab
 
 > General gotcha: a `user-invocable` skill that needs the vault (especially writes) must use `context: inline`, not `fork`.
 
+## Feedback from a weeknotes-composer session (cross-skill consumer)
+
+Another agent flagged issues while wanting to consume the living page. Applied:
+- **Contradiction fixed:** the intro said "read and write only within `agent/`",
+  contradicting Phase 2's reads of `journals/` + `blog/` (and likely contributing
+  to the journal-miss — a literal model avoiding non-`agent/` reads). Reworded to
+  **write** within `agent/`, **read** broadly.
+- **Incremental reads:** Phase 2 re-read all of Mon–Thu on every run (5× by
+  Friday). Now: first run of the week reads everything since `monday`; later runs
+  only `vault_read` entries modified after the page's `updated:` watermark and
+  trust the page for earlier material. Flat daily cost.
+- **Downstream contract:** Headliners now ordered strongest-first (headliner #1 =
+  the week's lead); page structure (Headliners/Seeds/Recurring + the headliner
+  field set) declared a stable contract other skills parse. The weeknotes composer
+  intends to use headliners as the post's lead/spine, recurring as continuity
+  callbacks, seeds as Miscellanea candidates.
+
+**Decided (Les): keep seeds ~1 month as a slow-burn theme tracker** (Phase 5).
+The motivating case: themes that develop across notes/bookmarks over a week or
+two before they're an obvious trend — a single week rarely makes them clear. So
+a standing `agent/pages/blog-ideas/parking-lot.md` (under `agent/`, writable by
+the cron run — `blog/drafts` is NOT, write gate) accumulates un-ripened seeds
+with `seen`/`reinforced` dates. Each run: reinforce parked themes with new
+evidence, graduate ripe ones to Headliners, add new seeds, prune anything that
+hasn't gained traction in ~1 month (≈4 weeks). Prompt-only, approximate
+date-eyeballing (a seed lingering 4 vs 5 weeks is harmless). Complements
+`Recurring` (which catches themes already repeating on weekly pages).
+
+## New core tool: `vault_recent` (the gather fix; skill surfaced a core gap)
+
+Building the gather phase exposed a real gap in the **core** vault toolset: there
+was `vault_search` (needs a content query) and `vault_list` (folder enumeration,
+no date filter) but **nothing for "what changed recently."** `newsletter` had
+even grown its own private `_collect_vault_changes` for exactly this. So instead
+of a blog-ideas-local helper, we added a general **`vault_recent(days=7,
+folder="", source_type="")`** to the always-loaded vault skill (newest-first,
+recency-based, optional folder/source_type scoping) with a unit test and a
+tool_choice eval disambiguating it from search/list. blog-ideas Phase 2 now calls
+`vault_recent(days=days_so_far)` to read *everything* changed this week across all
+ingest + distilled folders AND the Obsidian journal (`source_type=user`), then
+`vault_read`s the relevant entries. The scan logic is a shared, symlink-safe
+`collect_recent_pages(config, cutoff_ts, folder, source_type)` helper; both
+`vault_recent` and `newsletter._collect_vault_changes` use it (DRY — newsletter's
+private rglob is gone). `vault_recent` errors on non-positive `days` rather than
+silently coercing. (Copilot review on #611 prompted the symlink-safety + days
+fixes; the newsletter refactor was done in the same PR at Les's request.)
+
+## Bugfix: gather phase used the wrong tool (`vault_search` → `vault_recent`)
+
+Second deploy smoke: the skill ran but produced shallow, generic ideas and never
+touched the Obsidian daily journal. Root cause was the Phase 2 gather:
+- `vault_search` **requires a content query** and (on the deployment) runs in
+  substring mode — so it returns only pages *containing* the query text, not
+  "everything recent." The model searched `"blog ideas"`/`"entry"`, found almost
+  nothing, then errored on an empty query.
+- The journal step said `journals/…` but the model searched `folder=agent/journal`
+  (the agent's journal → newsletter pages), missing the human's daily notes.
+- Result: ideas synthesized from page *titles* quoted in newsletter recaps, not
+  real content.
+
+Fix (prompt-only): rewrote Phase 2 to **enumerate with `vault_list`** per folder
+(incl. `journals` explicitly = my Obsidian daily notes, NOT `agent/journal`) and
+`vault_read` entries modified on/after `monday`; `vault_search` is reserved for
+the published-archive dedup query only, with an explicit warning that it can't
+enumerate. (`vault_list` is the right tool — the model already used it correctly
+for `blog/drafts` in the smoke.) Helper-tool gather kept as a fallback if a
+re-smoke still struggles.
+
 ## Relocation to contrib (post-review)
 
 After the PR was opened, the skill was moved from a core bundled skill

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -222,3 +222,24 @@
     "check it's set up correctly" before reloading. refresh_skills re-scans
     everything and mutates the live catalog; it reports rejections too, but
     it's the broad/commit path, not the focused "did I author this right" check.
+
+# -- vault_recent vs vault_search / vault_list ---------------------------------
+
+- name: vault-recent-vs-search-whats-new
+  scenario: "What's been added or changed in my vault over the last week?"
+  expected: vault_recent
+  near_miss: [vault_search, vault_list]
+  notes: |
+    "Added or changed ... over the last week" is a pure recency query —
+    vault_recent. vault_search needs a content query (there's no topic here),
+    and vault_list enumerates a folder regardless of date. Recency is the whole
+    ask.
+
+- name: vault-recent-vs-list-recent-journal
+  scenario: "Show me the notes I've written in my journal in the past few days."
+  expected: vault_recent
+  near_miss: [vault_list, vault_search]
+  notes: |
+    Time-bounded ("past few days") + my own content points at vault_recent
+    (source_type=user). vault_list would dump the whole journal folder with no
+    date filter; vault_search needs a query string.

--- a/src/decafclaw/skills/newsletter/tools.py
+++ b/src/decafclaw/skills/newsletter/tools.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from decafclaw.conversation_paths import iter_conversation_archives
 from decafclaw.mail import send_mail
 from decafclaw.media import ToolResult
+from decafclaw.skills.vault.tools import collect_recent_pages
 
 log = logging.getLogger(__name__)
 
@@ -225,30 +226,22 @@ def _collect_vault_changes(ctx, hours: int = 24) -> list[dict]:
     Returns a list of {path (str, relative to vault root), mtime (ISO-8601), size (int)}.
     Excludes files under the newsletter output folder (self-references).
     """
-    vault_root = ctx.config.vault_root
-    if not vault_root.is_dir():
-        return []
-
     cutoff_ts = (datetime.now(timezone.utc) - timedelta(hours=hours)).timestamp()
     newsletter_folder = None
     if _skill_config is not None:
         newsletter_folder = _skill_config.vault_folder
 
     out: list[dict] = []
-    for path in vault_root.rglob("*.md"):
-        try:
-            stat = path.stat()
-        except OSError:
-            continue
-        if stat.st_mtime < cutoff_ts:
-            continue
-        rel = path.relative_to(vault_root).as_posix()
+    # Shared, symlink-safe recency scan (see vault.tools.collect_recent_pages).
+    for row in collect_recent_pages(ctx.config, cutoff_ts):
+        rel = row["path"]
         if newsletter_folder and rel.startswith(newsletter_folder.rstrip("/") + "/"):
             continue
         out.append({
             "path": rel,
-            "mtime": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-            "size": stat.st_size,
+            "mtime": datetime.fromtimestamp(
+                row["mtime"], tz=timezone.utc).isoformat(),
+            "size": row["size"],
         })
     out.sort(key=lambda r: r["mtime"])
     return out

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -6,7 +6,7 @@ that supports curated pages, daily journal entries, and user content.
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 
@@ -881,6 +881,106 @@ async def tool_vault_list(ctx, folder: str = "", pattern: str = "") -> str | Too
     return f"{len(pages)} page(s):\n\n" + "\n".join(pages)
 
 
+def collect_recent_pages(config, cutoff_ts: float, folder: str = "",
+                         source_type: str = "") -> list[dict]:
+    """Vault ``.md`` pages modified at/after ``cutoff_ts`` (epoch seconds).
+
+    Returns ``[{path, mtime (float), source_type, size}]`` (unsorted; callers
+    sort). Symlink-safe: a file whose resolved path escapes the vault root is
+    skipped, so symlinked directories can't leak external files into the
+    listing. Shared by ``vault_recent`` and the newsletter's change scan.
+    """
+    search_root = _safe_folder(config, folder)
+    if search_root is None or not search_root.is_dir():
+        return []
+    vault = _vault_root(config)
+    vault_resolved = vault.resolve()
+
+    out: list[dict] = []
+    for path in search_root.rglob("*.md"):
+        try:
+            resolved = path.resolve()
+            if not resolved.is_relative_to(vault_resolved):
+                continue
+            stat = resolved.stat()
+        except OSError:
+            continue
+        if stat.st_mtime < cutoff_ts:
+            continue
+        st = _source_type_for_path(config, path)
+        if source_type and st != source_type:
+            continue
+        # Use the resolved pair consistently: when vault_root is a symlink and
+        # `folder` is given, search_root (and thus `path`) is resolved while
+        # `vault` is not, so `path.relative_to(vault)` would raise ValueError.
+        out.append({
+            "path": resolved.relative_to(vault_resolved).as_posix(),
+            "mtime": stat.st_mtime,
+            "source_type": st,
+            "size": stat.st_size,
+        })
+    return out
+
+
+async def tool_vault_recent(ctx, days: int = 7, folder: str = "",
+                            source_type: str = "") -> str | ToolResult:
+    """List vault pages modified within the last `days`, newest first."""
+    log.info(f"[tool:vault_recent] days={days} folder={folder} "
+             f"source_type={source_type}")
+    if days <= 0:
+        return ToolResult(text="[error: days must be a positive integer]")
+    safe = _safe_folder(ctx.config, folder)
+    if safe is None:
+        return ToolResult(text=f"[error: invalid folder path '{folder}']")
+    if not safe.is_dir():
+        if folder:
+            return ToolResult(text=f"[error: folder '{folder}' does not exist]")
+        return "Vault directory does not exist."
+    cutoff = (datetime.now(tz=timezone.utc) - timedelta(days=days)).timestamp()
+    rows = collect_recent_pages(ctx.config, cutoff, folder=folder,
+                                source_type=source_type)
+    rows.sort(key=lambda r: r["mtime"], reverse=True)
+
+    scope = f" in '{folder}'" if folder else ""
+    st_note = f" (source_type={source_type})" if source_type else ""
+    if not rows:
+        return f"No pages modified in the last {days} day(s){scope}{st_note}."
+
+    limit = 100
+    shown = rows[:limit]
+
+    def _fmt(ts):
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+
+    lines = [
+        f"- {r['path']} ({r['source_type']}, "
+        f"modified: {_fmt(r['mtime']).strftime('%Y-%m-%d %H:%M')})"
+        for r in shown
+    ]
+    header = (
+        f"{len(rows)} page(s) modified in the last {days} day(s){scope}{st_note}"
+    )
+    if len(rows) > limit:
+        header += f" (showing {limit} most recent)"
+    return ToolResult(
+        text=header + ":\n\n" + "\n".join(lines),
+        data={
+            "days": days,
+            "folder": folder,
+            "source_type": source_type,
+            "count": len(rows),
+            "pages": [
+                {
+                    "path": r["path"],
+                    "source_type": r["source_type"],
+                    "modified": _fmt(r["mtime"]).isoformat(),
+                }
+                for r in shown
+            ],
+        },
+    )
+
+
 _WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
@@ -1149,6 +1249,7 @@ TOOLS = {
     "vault_journal_append": tool_vault_journal_append,
     "vault_search": tool_vault_search,
     "vault_list": tool_vault_list,
+    "vault_recent": tool_vault_recent,
     "vault_backlinks": tool_vault_backlinks,
     "vault_show_sections": tool_vault_show_sections,
     "vault_move_lines": tool_vault_move_lines,
@@ -1424,6 +1525,51 @@ TOOL_DEFINITIONS = [
                         "description": (
                             "Optional filter pattern "
                             "(e.g. 'project' to match pages with 'project' in the name)"
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_recent",
+            "description": (
+                "List vault pages MODIFIED in the last N days (newest first), "
+                "with each page's modified date and source_type. This is the "
+                "'what changed / what's new / recent activity' tool — use it to "
+                "review everything added or updated lately, whether from me or "
+                "from ingestion. Unlike vault_search (which needs a content "
+                "query and only returns matching pages) and vault_list (which "
+                "lists a folder regardless of date), vault_recent is purely "
+                "recency-based. Optionally scope by folder and/or source_type "
+                "(e.g. source_type='user' for my own notes/journal)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "days": {
+                        "type": "integer",
+                        "description": (
+                            "Look back this many days (by modified time). "
+                            "Defaults to 7."
+                        ),
+                    },
+                    "folder": {
+                        "type": "string",
+                        "description": (
+                            "Optional subfolder to scope to (e.g. 'agent/pages', "
+                            "'journals'). Empty = entire vault."
+                        ),
+                    },
+                    "source_type": {
+                        "type": "string",
+                        "description": (
+                            "Optional filter: 'page' (agent pages), 'journal' "
+                            "(agent journal), or 'user' (my own notes/journal "
+                            "outside agent/). Empty = all."
                         ),
                     },
                 },

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1,5 +1,7 @@
 """Tests for vault tools."""
 
+import os
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,6 +17,7 @@ from decafclaw.skills.vault.tools import (
     tool_vault_journal_append,
     tool_vault_list,
     tool_vault_read,
+    tool_vault_recent,
     tool_vault_rename,
     tool_vault_search,
     tool_vault_write,
@@ -1117,3 +1120,72 @@ class TestVaultGrantFolder:
             result = await tool_vault_write(ctx, "creative/foo", "content body")
         assert sentinel.call_count == 0
         assert "saved" in str(result)
+
+
+def _set_mtime(path, days_ago: float):
+    """Backdate a file's atime and mtime by `days_ago` days."""
+    when = time.time() - days_ago * 86400
+    os.utime(path, (when, when))
+
+
+class TestVaultRecent:
+    async def test_lists_only_recent_pages(self, ctx, agent_pages):
+        (agent_pages / "fresh.md").write_text("# Fresh")
+        old = agent_pages / "stale.md"
+        old.write_text("# Stale")
+        _set_mtime(old, 30)
+        result = await tool_vault_recent(ctx, days=7)
+        text = str(result)
+        assert "agent/pages/fresh" in text
+        assert "stale" not in text
+
+    async def test_source_type_filter_user_only(self, ctx, vault_dir, agent_pages):
+        # Human content lives outside agent/ → source_type "user".
+        journals = vault_dir / "journals" / "2026"
+        journals.mkdir(parents=True)
+        (journals / "2026-06-24.md").write_text("# Daily note")
+        (agent_pages / "ingested.md").write_text("# Ingested page")
+        result = await tool_vault_recent(ctx, days=7, source_type="user")
+        text = str(result)
+        assert "journals/2026/2026-06-24" in text
+        assert "agent/pages/ingested" not in text
+
+    async def test_folder_scope(self, ctx, vault_dir, agent_pages):
+        journals = vault_dir / "journals"
+        journals.mkdir(parents=True)
+        (journals / "note.md").write_text("# Note")
+        (agent_pages / "page.md").write_text("# Page")
+        result = await tool_vault_recent(ctx, days=7, folder="journals")
+        text = str(result)
+        assert "journals/note" in text
+        assert "agent/pages/page" not in text
+
+    async def test_no_recent_pages_message(self, ctx, agent_pages):
+        old = agent_pages / "ancient.md"
+        old.write_text("# Ancient")
+        _set_mtime(old, 90)
+        result = await tool_vault_recent(ctx, days=7)
+        assert "No pages modified" in str(result)
+
+    async def test_rejects_non_positive_days(self, ctx, agent_pages):
+        for d in (0, -1):
+            result = await tool_vault_recent(ctx, days=d)
+            assert "error" in str(result).lower()
+
+    async def test_excludes_symlinked_escape(self, ctx, vault_dir, agent_pages,
+                                              tmp_path):
+        # A symlinked dir inside the vault pointing outside must not leak its
+        # files into the listing (resolved path escapes the vault root).
+        (agent_pages / "real.md").write_text("# Real")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "leak.md").write_text("# Leak")
+        os.symlink(outside, vault_dir / "sneaky")
+        result = await tool_vault_recent(ctx, days=7)
+        text = str(result)
+        assert "agent/pages/real" in text
+        assert "leak" not in text
+
+    async def test_missing_folder_errors(self, ctx, vault_dir):
+        result = await tool_vault_recent(ctx, days=7, folder="nope/missing")
+        assert "does not exist" in str(result).lower()


### PR DESCRIPTION
Follow-up to #609 (the command-context fix, now merged). This is the gather-quality work that landed on that branch after it merged — packaged as its own PR.

## 1. New core tool: `vault_recent`
Building the blog-ideas gather surfaced a real gap in the always-loaded vault toolset: `vault_search` needs a content query and `vault_list` has no date filter, so there was no way to ask "what changed recently" (`newsletter` had even grown a private `_collect_vault_changes`). Adds **`vault_recent(days=7, folder="", source_type="")`** — recency-based, newest-first, optional folder/source_type scoping. Unit tests + a `tool_choice` eval disambiguating it from search/list (both cases pass).

*Follow-up (not here): refactor `newsletter` onto `vault_recent` for DRY.*

## 2. blog-ideas gather rewrite (fixes two deploy smokes)
- **Read everything this week, not search terms.** Phase 2 now calls `vault_recent(days=days_so_far)` to read all ingest + distilled pages **and** the Obsidian journal (`source_type=user`), then reads the relevant entries — fixing the smoke where the model mis-used `vault_search("blog ideas")` and never touched the daily notes.
- **Read/write contradiction fixed** (weeknotes-composer feedback): the intro said "read and write only within `agent/`", contradicting Phase 2's cross-folder reads. Now: **write** within `agent/`, **read** broadly.
- **Incremental reads:** later runs only read entries modified after the page's `updated:` watermark; flat daily cost instead of re-reading the whole week.
- **Downstream contract:** headliners ordered strongest-first; stable, parseable page structure (the weeknotes composer consumes this page).

## 3. Parking lot — slow-burn theme tracker (Phase 5)
Themes often develop across notes/bookmarks over a week or two before they're an obvious trend. A standing `agent/pages/blog-ideas/parking-lot.md` (under `agent/`, writable by the cron run) accumulates un-ripened seeds with `seen`/`reinforced` dates: reinforce with new evidence, graduate ripe themes to headliners, prune anything stale past ~1 month.

## Testing
`make check` clean; `make test` 2976 passed; both `vault_recent` `tool_choice` cases pass. Validated end-to-end by re-running `/blog-ideas` on the deployment (reads the journal + all sources, grounded ideas, writes the parking lot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)