### PR TITLE
fix(meta-ingest): state delegate_tasks `tasks` is a string array

### DIFF
--- a/contrib/skills/meta-ingest/SKILL.md
+++ b/contrib/skills/meta-ingest/SKILL.md
@@ -65,7 +65,22 @@ One `delegate_tasks` call, one task per source file. The children run **in paral
 
 - `allow_vault_read: true` — children must browse the vault for context.
 - `return_schema`: the shape shown below.
-- `tasks`: one entry per delegated source (from Step 1), built from the per-source template. At most 6 sources — well under the 10-task cap — so a single call covers them all.
+- `tasks`: a flat JSON **array of plain strings** — one string per delegated source, each being the fully-substituted per-source prompt from the template below. It is **NOT** a list of objects: pass `["<prompt for github>", "<prompt for linkding>", …]`, never `[{"prompt": "…"}]`. At most 6 sources — well under the 10-task cap — so a single call covers them all.
+
+The call looks like this (only `tasks` varies per source; the other three params are shared across the whole batch):
+
+```
+delegate_tasks(
+    allow_vault_read=true,
+    return_schema={ …the shape shown below… },
+    tasks=[
+        "<github prompt, fully substituted>",
+        "<linkding prompt, fully substituted>",
+        "<mastodon prompt, fully substituted>",
+        …one string per remaining source…
+    ],
+)
+```
 
 Each child reads its own source file with `workspace_read(<path from the manifest>)`; you never load the source content into this turn.
 


### PR DESCRIPTION
## Problem

A scheduled `meta-ingest` cycle failed at Step 2 with:

```
[error: tasks[0] must be a non-empty string]
```

The agent built `tasks: [{"prompt": "..."}]` — a list of **objects** — where `delegate_tasks` requires a list of **plain strings** (`delegate.py:426`, schema `items: {type: string}`; validation rejects non-strings at `:459`).

## Root cause

Not a code bug — the tool is correct. The skill *prose* misled the model. Step 2 described `tasks` as *"one **entry** per delegated source, built from the per-source template"* — shape-neutral wording sitting directly below a nested `return_schema` object, which primed the LLM to over-structure each task as `{"prompt": ...}`.

The working predecessor `linkding-ingest` avoids this by saying *"an **array** of … task **descriptions**"*, and `docs/delegation.md` shows `tasks=["...", "..."]`.

## Fix

`contrib/skills/meta-ingest/SKILL.md` Step 2 now states the shape explicitly — *"a flat JSON **array of plain strings** … **NOT** a list of objects: pass `["<prompt>", …]`, never `[{"prompt": "…"}]`"* — and adds a concrete `delegate_tasks(...)` call skeleton showing the string array.

## Testing

Prose-only control-surface change to a contrib skill — no deterministic unit-test surface, and a real eval is impractical (requires `me-to-markdown` installed + a live fetch; meta-ingest is opt-in contrib). Verified `mastodon-ingest` does not use `delegate_tasks`, so the ambiguity was isolated to `meta-ingest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)