### PR TITLE
feat(blog-develop): scout→interview→research→draft idea-development skill

### DIFF
--- a/contrib/skills/README.md
+++ b/contrib/skills/README.md
@@ -80,6 +80,12 @@ A daily brainstorm pass: reviews the week-so-far across your ingested activity (
 
 **Schedule:** ships a `SCHEDULE.md` for a daily 06:00 UTC run, but as a contrib skill it's force-disabled — opt in by creating an overlay at `data/{agent_id}/schedules/blog-ideas.md` (copy the skill's `SCHEDULE.md` and set `enabled: true`). Also runs on demand via the `/blog-ideas` command.
 
+### blog-develop
+
+Develop any blog-post idea into a take-or-leave first draft via scout → interview → deep research → draft.
+
+**Requires:** `tabstack` skill configured (web research) and a vault. No extra binaries or API keys beyond what `tabstack` needs.
+
 ### kindle
 
 Syncs highlights and notes from your Kindle library (`read.amazon.com/notebook`) into per-book vault pages under `agent/pages/kindle/`. Each book gets one page with frontmatter tracking the ASIN, title, author, and highlight count. Deleted highlights are moved to an `## Archived` section with a date stamp.

--- a/contrib/skills/blog-develop/README.md
+++ b/contrib/skills/blog-develop/README.md
@@ -1,0 +1,26 @@
+# blog-develop
+
+On-demand workflow that develops **any** blog-post idea into a take-or-leave
+first draft: **scout → interview → deep research → draft**. Sibling to
+`blog-ideas`, but decoupled — the idea can come from your weekly ideas page or
+from anywhere.
+
+Run it with `/blog-develop <your idea>` (web UI) or `!blog-develop <your idea>`
+(Mattermost). With no argument it asks what you want to write about. The scout,
+research, and draft phases run as child agents; the finished draft lands in
+`blog/drafts/<slug>.md` in your vault for you to take or leave.
+
+## Install
+
+Add to your agent's `extra_skill_paths` in `data/{agent_id}/config.json`:
+
+```json
+{
+  "extra_skill_paths": [
+    "$CONTRIB/skills/blog-develop"
+  ]
+}
+```
+
+Requires the `tabstack` skill configured (web research) and a vault. No extra
+binaries or API keys beyond what `tabstack` needs.

--- a/contrib/skills/blog-develop/SKILL.md
+++ b/contrib/skills/blog-develop/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: blog-develop
+description: On-demand workflow (/blog-develop <idea>) that develops any blog-post idea into a take-or-leave first draft — scout → interview → deep research → draft, with research and drafting run as child agents.
+effort: strong
+required-skills:
+  - vault
+  - tabstack
+user-invocable: true
+context: fork
+allowed-tools: delegate_task, vault_read, vault_write, vault_list, vault_search, current_time, tabstack_research, tabstack_extract_markdown, web_fetch
+---
+
+# Develop a blog idea
+
+Stub. Phases: scout, interview, research, draft. Workers run via
+delegate_task and CANNOT write to the vault — you write the draft to
+blog/drafts yourself. Interview asks one question per turn.

--- a/contrib/skills/blog-develop/SKILL.md
+++ b/contrib/skills/blog-develop/SKILL.md
@@ -6,7 +6,7 @@ required-skills:
   - vault
   - tabstack
 user-invocable: true
-context: fork
+context: inline
 allowed-tools: delegate_task, vault_read, vault_write, vault_list, vault_search, current_time, tabstack_research, tabstack_extract_markdown, web_fetch
 ---
 
@@ -17,14 +17,17 @@ Take **any** blog-post idea and develop it into a *take-or-leave first draft*:
 `blog-ideas` weekly page or from nowhere in particular — this skill does not
 depend on it.
 
-The heavy phases (scout, deep research, draft) run as **child agents** via
-`delegate_task`, so web-search noise and long source text never clog this
-context. **Children CANNOT write to the vault** — they return structured
-results and *you* (this orchestrator) write the final draft.
+You (the orchestrator) run in this conversation and drive the phases. The heavy
+phases (scout, deep research, draft) run as **child agents** via `delegate_task`,
+so web-search noise and long source text stay in the children and never clog
+this conversation. **Children CANNOT write to the vault** — they return
+structured results and *you* write the final draft. (Best run in a fresh
+conversation so the interview starts from a clean slate.)
 
 You MUST run the scout, research, and draft work through `delegate_task`. Do
-**NOT** do the web research or write the draft inline in this turn — keeping
-this context clean is what makes the workflow reliable.
+**NOT** do the web research or write the draft yourself in this conversation —
+delegating the heavy work is what keeps this context clean and the workflow
+reliable.
 
 ## The idea
 

--- a/contrib/skills/blog-develop/SKILL.md
+++ b/contrib/skills/blog-develop/SKILL.md
@@ -12,6 +12,184 @@ allowed-tools: delegate_task, vault_read, vault_write, vault_list, vault_search,
 
 # Develop a blog idea
 
-Stub. Phases: scout, interview, research, draft. Workers run via
-delegate_task and CANNOT write to the vault — you write the draft to
-blog/drafts yourself. Interview asks one question per turn.
+Take **any** blog-post idea and develop it into a *take-or-leave first draft*:
+**scout → interview → deep research → draft**. The idea can come from your
+`blog-ideas` weekly page or from nowhere in particular — this skill does not
+depend on it.
+
+The heavy phases (scout, deep research, draft) run as **child agents** via
+`delegate_task`, so web-search noise and long source text never clog this
+context. **Children CANNOT write to the vault** — they return structured
+results and *you* (this orchestrator) write the final draft.
+
+You MUST run the scout, research, and draft work through `delegate_task`. Do
+**NOT** do the web research or write the draft inline in this turn — keeping
+this context clean is what makes the workflow reliable.
+
+## The idea
+
+The seed idea is `$ARGUMENTS`. If it is empty, ask the user **"What do you want
+to write about?"**, end your turn, and wait. (They may paste a headliner from
+their `blog-ideas` page, or anything else.) Once you have an idea, continue.
+
+## Phase 1: Scout (child agent)
+
+Get a quick lay-of-the-land so your interview questions are sharp. Call
+`delegate_task` with `allow_vault_read=true` (so the scout can check whether the
+user has already written about this) and this `return_schema`:
+
+```json
+{
+  "summary": "2-3 sentences on the current lay of the land for this idea",
+  "prior_art": [{"title": "...", "url": "...", "angle": "what it argues"}],
+  "open_angles": ["under-explored angle or gap", "..."],
+  "suggested_questions": ["a sharp interview question this surfaced", "..."],
+  "already_written": "note if the user's own vault/blog already covers this, else null"
+}
+```
+
+Scout task prompt (substitute `{idea}`):
+
+```
+You are a research SCOUT. Do a SHALLOW first pass on this blog-post idea so the
+author can be interviewed well. Idea: "{idea}"
+
+Use tabstack_research (and tabstack_extract_markdown only if one source is
+clearly essential) for a quick survey — do NOT go deep. Also vault_search /
+vault_read to see if the author has already written about this.
+
+Return the structured JSON requested by return_schema: a short lay-of-the-land,
+notable prior art, under-explored angles, a few sharp interview questions, and
+whether the author's own vault already covers it. Keep prose to one line.
+```
+
+## Phase 2: Interview (you + the user)
+
+Using the scout brief, interview the author to shape the piece. **Ask one question per turn**, end your turn, and wait for the answer before the next
+question. Adapt each question to the prior answer. Ask **at most 5–6**; stop
+early if the author says "go" / "draft it."
+
+Cover, roughly in this order, skipping anything already obvious from the idea or
+scout:
+- **Angle / thesis** — what is the core claim or point of view?
+- **Audience** — who is this for?
+- **Prior art** — engage or differentiate from what the scout found?
+- **Scope** — how deep/long; what to include vs. leave out?
+- **Voice / tone** — anything specific for this piece?
+
+Do not start the deep research until the interview is done.
+
+## Phase 3: Deep research (child agent)
+
+Now run the real research, steered by the idea + interview answers. Call
+`delegate_task` with `allow_vault_read=true` and this `return_schema`:
+
+```json
+{
+  "thesis_support": ["key claim or fact, with enough context to use it"],
+  "sources": [{"title": "...", "url": "...", "takeaway": "why it matters here"}],
+  "counterpoints": ["objection or counter-argument the draft should address"],
+  "angles": ["framing / structure suggestion"],
+  "notes": "anything else useful for drafting"
+}
+```
+
+Deep-research task prompt (substitute `{idea}` and `{interview_summary}` — a
+tight digest of the angle, audience, scope, and voice the author chose):
+
+```
+You are a DEEP RESEARCHER for a blog post. Idea: "{idea}"
+Author's direction from the interview: {interview_summary}
+
+Use tabstack_research for targeted searches and tabstack_extract_markdown /
+web_fetch to read the most relevant sources. Gather what's needed to write a
+credible, well-sourced post on the author's chosen angle. vault_read related
+pages the author has written for continuity of voice/claims.
+
+Return the structured JSON requested by return_schema: supporting claims/facts,
+sources with URLs and takeaways, counterpoints to address, and framing
+suggestions. Capture real URLs — do not invent them. Keep prose to one line.
+```
+
+## Phase 4: Draft (child agent)
+
+First, locate the author's voice guide: `vault_search` for their voice/tone
+page (try queries like "voice and tone", "writing voice", "style"). Note its
+path — you'll hand it to the drafter.
+
+Call `delegate_task` with `allow_vault_read=true` and this `return_schema`:
+
+```json
+{
+  "title": "post title",
+  "slug": "kebab-case-slug-from-the-title",
+  "draft_markdown": "the full first-draft body in the author's voice",
+  "sources_used": [{"title": "...", "url": "..."}]
+}
+```
+
+Draft task prompt (substitute `{idea}`, `{interview_summary}`, `{voice_path}`,
+and `{research_brief_json}` — the Phase 3 JSON):
+
+```
+You are a DRAFTER writing a blog post in the AUTHOR'S voice. Idea: "{idea}"
+Author's direction: {interview_summary}
+
+First read the author's voice guide so you match their style:
+  vault_read("{voice_path}")
+(If that path is empty or missing, infer voice from a recent post under blog/.)
+
+Use this research brief — cite its sources, address its counterpoints:
+{research_brief_json}
+
+Write a complete FIRST DRAFT (it's a starting point, not a final post). Use the
+author's voice, a clear structure, and real links from the brief. Do NOT invent
+sources or quotes.
+
+Return the structured JSON requested by return_schema: title, kebab-case slug,
+the full draft_markdown, and the sources you used. Keep prose to one line.
+```
+
+## Phase 5: Write the draft (you)
+
+Children can't write the vault, so you do it. `vault_write` to
+`blog/drafts/<slug>.md` (use the drafter's `slug`; if missing, slugify the
+title) with this structure:
+
+```markdown
+---
+title: <title>
+tags: [blog-draft]
+status: draft
+created: <today's date, YYYY-MM-DD — get it from current_time>
+seed: <the original idea>
+sources:
+  - <url>
+  - <url>
+---
+
+<draft_markdown>
+
+## Research notes
+<a compact digest of the Phase 3 research brief: key claims, sources with URLs,
+counterpoints — so the sources stay with the draft for later development>
+```
+
+## Finishing up
+
+End with a short summary: the title, a one-line hook, and a link to
+`[[blog/drafts/<slug>]]`. State plainly that it's a *take-or-leave first draft*
+and suggest one or two next steps for developing it.
+
+## Rules
+
+- **Children cannot write the vault.** Workers return structured results; you
+  apply the single `vault_write`.
+- **Delegate the heavy work.** Scout, deep research, and drafting MUST go
+  through `delegate_task` — never research the web or write the draft inline in
+  this turn.
+- **One interview question per turn.** Ask, end the turn, wait. Cap ~5–6.
+- **No publishing.** Output is a disposable draft in `blog/drafts/`. Do NOT
+  commit, deploy, or touch the live blog. Do NOT modify the `blog-ideas` page.
+- **Real sources only.** Never invent URLs or quotes. Convert relative dates to
+  absolute (`YYYY-MM-DD`).

--- a/contrib/skills/blog-develop/SKILL.md
+++ b/contrib/skills/blog-develop/SKILL.md
@@ -79,6 +79,11 @@ scout:
 
 Do not start the deep research until the interview is done.
 
+When the interview is done, compose a tight `interview_summary` for yourself — a
+few sentences digesting the angle, audience, scope, and voice the author chose
+(a digest, **not** a transcript dump). You substitute this into the Phase 3 and
+Phase 4 task prompts below.
+
 ## Phase 3: Deep research (child agent)
 
 Now run the real research, steered by the idea + interview answers. Call
@@ -127,6 +132,10 @@ Call `delegate_task` with `allow_vault_read=true` and this `return_schema`:
   "sources_used": [{"title": "...", "url": "..."}]
 }
 ```
+
+When you build the draft prompt, paste the Phase 3 research-brief JSON verbatim
+where `{research_brief_json}` appears — embed it as a literal block exactly as
+the worker returned it; do not paraphrase, summarize, or hand-edit it.
 
 Draft task prompt (substitute `{idea}`, `{interview_summary}`, `{voice_path}`,
 and `{research_brief_json}` — the Phase 3 JSON):

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/notes.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/notes.md
@@ -1,44 +1,67 @@
 # Dev Session Notes: blog-develop skill
 
-## Task 4: eval downgraded to manual smoke
+## Task 4: eval status (UPDATED after the fork→inline switch)
 
-### Why the harness cannot guard this
+> **Update (commit 63ca046):** Task 4 was originally downgraded because the skill
+> was `context: fork`, which the eval harness can't drive (see the superseded
+> reasoning below). The skill now ships as **`context: inline`**, which *reverses*
+> that conclusion — the eval is viable again. Read this section first; the
+> fork-era reasoning below is kept only as a record.
 
-`/blog-develop` is a `user-invocable: true`, `context: fork` command.
+### Inline makes the scout-via-delegate eval viable
 
-In the eval runner (`src/decafclaw/eval/runner.py`, lines 479–508), when
-`dispatch_command` returns `cmd.mode == "fork"`, the runner:
+In inline mode the orchestrator runs in the main turn via `run_agent_turn`, so its
+own `delegate_task` tool call (the scout) lands in the outer history the eval
+runner inspects. So `expect_tool: delegate_task` would now pass when the skill
+behaves correctly and fail if it narrates-instead-of-delegates — exactly the
+#557 guard we want.
 
-1. Captures `cmd.text` (the child agent's final response) as the turn response.
-2. Skips `run_agent_turn` entirely — no agent loop runs in the outer context.
-3. Records **zero tool calls** in the outer history, because all tool calls
-   happen inside `run_child_turn`'s isolated child context and are never
-   appended to the main `history` list the runner inspects.
-4. Fires assertions against `tool_names=[]`.
+Two useful properties:
+- **Resilient to missing tabstack creds.** The assertion is on the *parent-level*
+  `delegate_task` call. Even if the scout child can't actually web-search (no
+  creds in the eval env), `delegate_task` still returns (with an error string)
+  and counts as called — so the structural guard holds without a live web
+  dependency. Keep `max_tool_errors` lenient enough that a child-side failure
+  surfaced as a parent tool result doesn't fail the case spuriously.
+- **Cost caveat.** The `delegate_task` call still blocks on a real child turn, so
+  the case is not as cheap as a pure `tool_choice` case. Bound it tightly
+  (`max_tool_calls: 4`).
 
-This means `expect_tool: delegate_task` would unconditionally FAIL: the
-`delegate_task` call happens inside the forked child (which IS the
-blog-develop orchestrator), invisible to the outer harness's
-`_collect_tool_names`. The fork isolation that makes the skill reliable in
-production is exactly what makes it untestable via the current harness's
-structural assertions.
+Still NOT assertable via evals: anything that happens *inside* the child agents
+(e.g. "the deep-research child called tabstack_research") — child-internal tool
+calls are not propagated to the outer history. Only the orchestrator's own calls
+are visible. That's fine; the scout-via-delegate contract is an orchestrator-level
+property.
 
-An eval case added under these conditions would be permanently broken — not
-a false alarm, but structurally unable to pass. Per project convention
-(CLAUDE.md: "Do NOT ship a broken/un-runnable eval"), this case is
-downgraded.
+### Decision
 
-### What guards the scout-via-delegate contract instead
+The eval was **not added in this session** — adding it correctly means running it
+once against a live model to validate the exact schema and behavior, which pairs
+naturally with the Task 5 live-smoke session (running app + model available).
+Recommended follow-up: add `evals/blog_develop.yaml` with a
+`blog_develop_scouts_via_delegate` case (`input: "/blog-develop the sovereignty
+ladder as a mental model"`, `expect_tool: delegate_task`, `max_tool_calls: 4`),
+run it once to confirm green, then commit. Until then, the contract is guarded by
+the live smoke test (Task 5).
 
-The scout-first / delegate-not-narrate contract is instead verified by the
-**Task 5 live smoke test** against a running DecafClaw instance. That smoke
-test drives `/blog-develop <idea>` through the real UI or CLI, observes the
-first tool call the orchestrator makes, and confirms it is `delegate_task`
-(scout), not any inline web-research tool.
+---
 
-### Future path to an automated guard
+## Superseded (fork-era) reasoning — kept for the record
 
-If the harness is extended to propagate child-agent tool calls back into the
-outer result bundle (e.g. a `child_tool_calls` list on `CommandResult`),
-a structural eval assertion becomes possible. Until then, the smoke test is
-the right boundary.
+When the skill was `context: fork`: in the eval runner
+(`src/decafclaw/eval/runner.py`, lines 479–508), when `dispatch_command` returned
+`cmd.mode == "fork"`, the runner captured `cmd.text` as the response, skipped
+`run_agent_turn`, recorded zero outer tool calls (all calls happened inside the
+isolated child context), and fired assertions against `tool_names=[]`. So
+`expect_tool: delegate_task` would have unconditionally failed. That is why Task 4
+was downgraded at the time. The switch to `context: inline` removes this blocker.
+
+---
+
+## Task 5: live smoke test (pending — needs Les + running app)
+
+Not yet run. Checklist in `plan.md` Task 5. Verify: scout-via-`delegate_task`
+first (not inline research); one-question-at-a-time interview that waits;
+deep-research child; draft written to `blog/drafts/<slug>.md` with the frontmatter
+contract + `## Research notes`; take-or-leave summary with a link. Capture results
+and any prompt-tuning here.

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/notes.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/notes.md
@@ -1,0 +1,44 @@
+# Dev Session Notes: blog-develop skill
+
+## Task 4: eval downgraded to manual smoke
+
+### Why the harness cannot guard this
+
+`/blog-develop` is a `user-invocable: true`, `context: fork` command.
+
+In the eval runner (`src/decafclaw/eval/runner.py`, lines 479–508), when
+`dispatch_command` returns `cmd.mode == "fork"`, the runner:
+
+1. Captures `cmd.text` (the child agent's final response) as the turn response.
+2. Skips `run_agent_turn` entirely — no agent loop runs in the outer context.
+3. Records **zero tool calls** in the outer history, because all tool calls
+   happen inside `run_child_turn`'s isolated child context and are never
+   appended to the main `history` list the runner inspects.
+4. Fires assertions against `tool_names=[]`.
+
+This means `expect_tool: delegate_task` would unconditionally FAIL: the
+`delegate_task` call happens inside the forked child (which IS the
+blog-develop orchestrator), invisible to the outer harness's
+`_collect_tool_names`. The fork isolation that makes the skill reliable in
+production is exactly what makes it untestable via the current harness's
+structural assertions.
+
+An eval case added under these conditions would be permanently broken — not
+a false alarm, but structurally unable to pass. Per project convention
+(CLAUDE.md: "Do NOT ship a broken/un-runnable eval"), this case is
+downgraded.
+
+### What guards the scout-via-delegate contract instead
+
+The scout-first / delegate-not-narrate contract is instead verified by the
+**Task 5 live smoke test** against a running DecafClaw instance. That smoke
+test drives `/blog-develop <idea>` through the real UI or CLI, observes the
+first tool call the orchestrator makes, and confirms it is `delegate_task`
+(scout), not any inline web-research tool.
+
+### Future path to an automated guard
+
+If the harness is extended to propagate child-agent tool calls back into the
+outer result bundle (e.g. a `child_tool_calls` list on `CommandResult`),
+a structural eval assertion becomes possible. Until then, the smoke test is
+the right boundary.

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
@@ -461,6 +461,7 @@ Automated tests can't validate prompt quality or the multi-turn interview. Smoke
 ## Deferred to v2 (not in this plan)
 
 - **Reviewer agent** after the draft: a `delegate_task` phase running two quality lenses — a **"humanizer"** (scan/strip "AI tells") and an **"editor"** applying Strunk & White. Note: `contrib/skills/writing-clearly` already exists and is a likely fit for the editor lens — evaluate reusing it. This is the reliable reviewer-persona pattern; deliberately out of v1 scope.
+- **Replace `tabstack_research` with an owned/local research workflow** in the scout + deep-research workers (reduce the hosted-service dependency; make the research loop inspectable/tunable). Needs a local search primitive — only `web_fetch` exists locally today. Worker `return_schema` contracts stay; only the tool changes. Natural home: the #255 replay engine.
 
 ---
 

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
@@ -6,6 +6,14 @@
 
 **Architecture:** A pure prose **SKILL.md** orchestration skill (no `tools.py`) modeled on `contrib/skills/meta-ingest`. The forked command agent owns control flow: it dispatches `delegate_task` workers for the scout, deep-research, and draft phases (each returning structured JSON via `return_schema`), runs a human interview in between as ordinary multi-turn conversation, and — because **children cannot write the vault** — performs the final `vault_write` itself. Reliability rests on the human-driven interview plus bounded persona-workers, not on the LLM cranking a long-horizon state machine.
 
+> **Correction (during implementation):** this plan was written for `context: fork`.
+> Final review found `fork` runs the orchestrator through `run_child_turn`, which
+> strips `delegate_task` + vault tools and is a one-shot child turn that cannot run
+> the multi-turn interview. **The skill ships as `context: inline`** (full tool set,
+> interview works, heavy work still isolated in `delegate_task` children). Wherever
+> a task snippet below says `context: fork` / `assert meta["context"] == "fork"`,
+> read it as `inline`. The implemented files are correct.
+
 **Tech Stack:** DecafClaw skills system (`SKILL.md` frontmatter: `user-invocable`, `context: fork`, `required-skills`, `allowed-tools`), `delegate_task` (`return_schema`, `allow_vault_read`), tabstack web tools (`tabstack_research`, `tabstack_extract_markdown`), `web_fetch`, vault read/write tools. pytest for the structural/loader test; an evals YAML case for the structural guard.
 
 ---

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/plan.md
@@ -1,0 +1,463 @@
+# blog-develop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an on-demand contrib skill `/blog-develop <idea>` that develops any blog-post idea into a take-or-leave first draft via scout → interview → deep research → draft, with research and drafting run as child agents.
+
+**Architecture:** A pure prose **SKILL.md** orchestration skill (no `tools.py`) modeled on `contrib/skills/meta-ingest`. The forked command agent owns control flow: it dispatches `delegate_task` workers for the scout, deep-research, and draft phases (each returning structured JSON via `return_schema`), runs a human interview in between as ordinary multi-turn conversation, and — because **children cannot write the vault** — performs the final `vault_write` itself. Reliability rests on the human-driven interview plus bounded persona-workers, not on the LLM cranking a long-horizon state machine.
+
+**Tech Stack:** DecafClaw skills system (`SKILL.md` frontmatter: `user-invocable`, `context: fork`, `required-skills`, `allowed-tools`), `delegate_task` (`return_schema`, `allow_vault_read`), tabstack web tools (`tabstack_research`, `tabstack_extract_markdown`), `web_fetch`, vault read/write tools. pytest for the structural/loader test; an evals YAML case for the structural guard.
+
+---
+
+## Background the implementer needs
+
+- **Spec:** `docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md`. Read it first.
+- **Template to mirror:** `contrib/skills/meta-ingest/SKILL.md` — orchestrator preps, delegates workers with `allow_vault_read` + `return_schema` + per-worker task templates, then applies vault writes itself, then summarizes. Copy its *shape* and its prominent "**Children CANNOT write to the vault**" framing. We differ in two ways: (1) `delegate_task` singular/sequential, not `delegate_tasks` parallel; (2) a human interview phase sits between scout and deep-research.
+- **`delegate_task` facts** (`src/decafclaw/tools/delegate.py`): `priority: critical` so it's always available; children inherit the parent's activated-skill tools (so tabstack reaches the worker); `allow_vault_read=true` opts a child into vault *read* tools; vault *write* tools are categorically blocked for children; `return_schema` makes the child emit a fenced JSON block parsed onto `ToolResult.data` (a hint, not enforced — parse failure falls back to prose).
+- **`allowed-tools` constrains children too** (`delegate.py` ~line 233: child tools are intersected with `parent_ctx.tools.allowed`). So every tool a worker needs MUST appear in the command's `allowed-tools`.
+- **Contrib skill conventions:** `contrib/skills/README.md`. Each skill is a directory with `SKILL.md` (+ optional `README.md`). Installed by adding `$CONTRIB/skills/<name>` to an agent's `extra_skill_paths`.
+- **Voice docs are not at a known path** (spec open item). Resolve at runtime: the skill instructs the agent to `vault_search` for the user's voice/tone page and pass its path to the drafter with `allow_vault_read=true`. No hardcoded path.
+
+## File structure
+
+- Create: `contrib/skills/blog-develop/SKILL.md` — the entire workflow (orchestration prose + worker task templates + return schemas + output contract).
+- Create: `contrib/skills/blog-develop/README.md` — one-paragraph what-it-is + install snippet (mirror a short contrib README).
+- Create: `tests/test_blog_develop_skill.py` — structural/loader test guarding frontmatter + body contract strings against rot.
+- Modify: `contrib/skills/README.md` — add `blog-develop` to the skill listing (if it enumerates skills).
+- Create/Modify: an evals YAML case — structural guard that invoking the skill delegates the scout rather than researching inline.
+
+---
+
+## Task 1: Scaffold the skill directory + failing structural test
+
+**Files:**
+- Test: `tests/test_blog_develop_skill.py`
+- Create: `contrib/skills/blog-develop/SKILL.md`
+
+- [ ] **Step 1: Write the failing structural test**
+
+```python
+"""Structural guard for the blog-develop contrib skill.
+
+The skill is prose (no tools.py), so this is the automated rot-guard:
+it asserts the frontmatter contract and that the body still documents
+the load-bearing rules (delegate the workers, children can't write the
+vault, one-question-at-a-time interview, blog/drafts output). Prompt
+quality itself is validated by live smoke testing, not here.
+"""
+
+from pathlib import Path
+
+from decafclaw.skills import validate_skill_md
+
+SKILL = (
+    Path(__file__).resolve().parents[1]
+    / "contrib" / "skills" / "blog-develop" / "SKILL.md"
+)
+
+
+def test_blog_develop_frontmatter_contract():
+    result = validate_skill_md(SKILL)
+    assert result.ok is True, result.first_failure
+    meta = result.meta
+    assert meta["name"] == "blog-develop"
+    assert meta["user-invocable"] is True
+    assert meta["context"] == "fork"
+    assert "vault" in meta["required-skills"]
+    assert "tabstack" in meta["required-skills"]
+    # Every tool a worker needs must be in allowed-tools (it constrains
+    # children too). delegate_task + research + vault read/write.
+    allowed = meta["allowed-tools"]
+    for tool in ("delegate_task", "tabstack_research", "vault_write", "vault_read"):
+        assert tool in allowed, f"{tool} missing from allowed-tools"
+
+
+def test_blog_develop_body_documents_contract():
+    body = validate_skill_md(SKILL).body.lower()
+    # The reliability-critical rules must stay in the prose.
+    assert "delegate_task" in body
+    assert "cannot write" in body            # children can't write the vault
+    assert "blog/drafts" in body             # output location
+    assert "one question" in body            # interview discipline
+    for phase in ("scout", "interview", "research", "draft"):
+        assert phase in body
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_blog_develop_skill.py -q`
+Expected: FAIL — `validate_skill_md` errors / file not found (SKILL.md doesn't exist yet).
+
+- [ ] **Step 3: Create a minimal valid SKILL.md so the frontmatter test passes**
+
+Create `contrib/skills/blog-develop/SKILL.md` with the frontmatter and a stub body (full body comes in Task 2):
+
+```markdown
+---
+name: blog-develop
+description: On-demand workflow (/blog-develop <idea>) that develops any blog-post idea into a take-or-leave first draft — scout → interview → deep research → draft, with research and drafting run as child agents.
+effort: strong
+required-skills:
+  - vault
+  - tabstack
+user-invocable: true
+context: fork
+allowed-tools: delegate_task, vault_read, vault_write, vault_list, vault_search, current_time, tabstack_research, tabstack_extract_markdown, web_fetch
+---
+
+# Develop a blog idea
+
+Stub. Phases: scout, interview, research, draft. Workers run via
+delegate_task and CANNOT write to the vault — you write the draft to
+blog/drafts yourself. Interview asks one question per turn.
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_blog_develop_skill.py -q`
+Expected: PASS (both tests — the stub body already contains the required strings).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_blog_develop_skill.py contrib/skills/blog-develop/SKILL.md
+git commit -m "feat(blog-develop): scaffold skill + structural guard test"
+```
+
+---
+
+## Task 2: Author the full SKILL.md orchestration
+
+Replace the stub body (keep the frontmatter from Task 1) with the full workflow below. This is the deliverable; the test from Task 1 keeps guarding it.
+
+- [ ] **Step 1: Write the full body**
+
+Set `contrib/skills/blog-develop/SKILL.md` body (everything after the frontmatter `---`) to:
+
+````markdown
+# Develop a blog idea
+
+Take **any** blog-post idea and develop it into a *take-or-leave first draft*:
+**scout → interview → deep research → draft**. The idea can come from your
+`blog-ideas` weekly page or from nowhere in particular — this skill does not
+depend on it.
+
+The heavy phases (scout, deep research, draft) run as **child agents** via
+`delegate_task`, so web-search noise and long source text never clog this
+context. **Children CANNOT write to the vault** — they return structured
+results and *you* (this orchestrator) write the final draft.
+
+You MUST run the scout, research, and draft work through `delegate_task`. Do
+**NOT** do the web research or write the draft inline in this turn — keeping
+this context clean is what makes the workflow reliable.
+
+## The idea
+
+The seed idea is `$ARGUMENTS`. If it is empty, ask the user **"What do you want
+to write about?"**, end your turn, and wait. (They may paste a headliner from
+their `blog-ideas` page, or anything else.) Once you have an idea, continue.
+
+## Phase 1: Scout (child agent)
+
+Get a quick lay-of-the-land so your interview questions are sharp. Call
+`delegate_task` with `allow_vault_read=true` (so the scout can check whether the
+user has already written about this) and this `return_schema`:
+
+```json
+{
+  "summary": "2-3 sentences on the current lay of the land for this idea",
+  "prior_art": [{"title": "...", "url": "...", "angle": "what it argues"}],
+  "open_angles": ["under-explored angle or gap", "..."],
+  "suggested_questions": ["a sharp interview question this surfaced", "..."],
+  "already_written": "note if the user's own vault/blog already covers this, else null"
+}
+```
+
+Scout task prompt (substitute `{idea}`):
+
+```
+You are a research SCOUT. Do a SHALLOW first pass on this blog-post idea so the
+author can be interviewed well. Idea: "{idea}"
+
+Use tabstack_research (and tabstack_extract_markdown only if one source is
+clearly essential) for a quick survey — do NOT go deep. Also vault_search /
+vault_read to see if the author has already written about this.
+
+Return the structured JSON requested by return_schema: a short lay-of-the-land,
+notable prior art, under-explored angles, a few sharp interview questions, and
+whether the author's own vault already covers it. Keep prose to one line.
+```
+
+## Phase 2: Interview (you + the user)
+
+Using the scout brief, interview the author to shape the piece. **Ask ONE
+question per turn**, end your turn, and wait for the answer before the next
+question. Adapt each question to the prior answer. Ask **at most 5–6**; stop
+early if the author says "go" / "draft it."
+
+Cover, roughly in this order, skipping anything already obvious from the idea or
+scout:
+- **Angle / thesis** — what is the core claim or point of view?
+- **Audience** — who is this for?
+- **Prior art** — engage or differentiate from what the scout found?
+- **Scope** — how deep/long; what to include vs. leave out?
+- **Voice / tone** — anything specific for this piece?
+
+Do not start the deep research until the interview is done.
+
+## Phase 3: Deep research (child agent)
+
+Now run the real research, steered by the idea + interview answers. Call
+`delegate_task` with `allow_vault_read=true` and this `return_schema`:
+
+```json
+{
+  "thesis_support": ["key claim or fact, with enough context to use it"],
+  "sources": [{"title": "...", "url": "...", "takeaway": "why it matters here"}],
+  "counterpoints": ["objection or counter-argument the draft should address"],
+  "angles": ["framing / structure suggestion"],
+  "notes": "anything else useful for drafting"
+}
+```
+
+Deep-research task prompt (substitute `{idea}` and `{interview_summary}` — a
+tight digest of the angle, audience, scope, and voice the author chose):
+
+```
+You are a DEEP RESEARCHER for a blog post. Idea: "{idea}"
+Author's direction from the interview: {interview_summary}
+
+Use tabstack_research for targeted searches and tabstack_extract_markdown /
+web_fetch to read the most relevant sources. Gather what's needed to write a
+credible, well-sourced post on the author's chosen angle. vault_read related
+pages the author has written for continuity of voice/claims.
+
+Return the structured JSON requested by return_schema: supporting claims/facts,
+sources with URLs and takeaways, counterpoints to address, and framing
+suggestions. Capture real URLs — do not invent them. Keep prose to one line.
+```
+
+## Phase 4: Draft (child agent)
+
+First, locate the author's voice guide: `vault_search` for their voice/tone
+page (try queries like "voice and tone", "writing voice", "style"). Note its
+path — you'll hand it to the drafter.
+
+Call `delegate_task` with `allow_vault_read=true` and this `return_schema`:
+
+```json
+{
+  "title": "post title",
+  "slug": "kebab-case-slug-from-the-title",
+  "draft_markdown": "the full first-draft body in the author's voice",
+  "sources_used": [{"title": "...", "url": "..."}]
+}
+```
+
+Draft task prompt (substitute `{idea}`, `{interview_summary}`, `{voice_path}`,
+and `{research_brief_json}` — the Phase 3 JSON):
+
+```
+You are a DRAFTER writing a blog post in the AUTHOR'S voice. Idea: "{idea}"
+Author's direction: {interview_summary}
+
+First read the author's voice guide so you match their style:
+  vault_read("{voice_path}")
+(If that path is empty or missing, infer voice from a recent post under blog/.)
+
+Use this research brief — cite its sources, address its counterpoints:
+{research_brief_json}
+
+Write a complete FIRST DRAFT (it's a starting point, not a final post). Use the
+author's voice, a clear structure, and real links from the brief. Do NOT invent
+sources or quotes.
+
+Return the structured JSON requested by return_schema: title, kebab-case slug,
+the full draft_markdown, and the sources you used. Keep prose to one line.
+```
+
+## Phase 5: Write the draft (you)
+
+Children can't write the vault, so you do it. `vault_write` to
+`blog/drafts/<slug>.md` (use the drafter's `slug`; if missing, slugify the
+title) with this structure:
+
+```markdown
+---
+title: <title>
+tags: [blog-draft]
+status: draft
+created: <today's date, YYYY-MM-DD — get it from current_time>
+seed: <the original idea>
+sources:
+  - <url>
+  - <url>
+---
+
+<draft_markdown>
+
+## Research notes
+<a compact digest of the Phase 3 research brief: key claims, sources with URLs,
+counterpoints — so the sources stay with the draft for later development>
+```
+
+## Finishing up
+
+End with a short summary: the title, a one-line hook, and a link to
+`[[blog/drafts/<slug>]]`. State plainly that it's a *take-or-leave first draft*
+and suggest one or two next steps for developing it.
+
+## Rules
+
+- **Children cannot write the vault.** Workers return structured results; you
+  apply the single `vault_write`.
+- **Delegate the heavy work.** Scout, deep research, and drafting MUST go
+  through `delegate_task` — never research the web or write the draft inline in
+  this turn.
+- **One interview question per turn.** Ask, end the turn, wait. Cap ~5–6.
+- **No publishing.** Output is a disposable draft in `blog/drafts/`. Do NOT
+  commit, deploy, or touch the live blog. Do NOT modify the `blog-ideas` page.
+- **Real sources only.** Never invent URLs or quotes. Convert relative dates to
+  absolute (`YYYY-MM-DD`).
+````
+
+- [ ] **Step 2: Run the structural test to confirm the full body still satisfies the contract**
+
+Run: `uv run pytest tests/test_blog_develop_skill.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Lint**
+
+Run: `make lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add contrib/skills/blog-develop/SKILL.md
+git commit -m "feat(blog-develop): full scout/interview/research/draft orchestration"
+```
+
+---
+
+## Task 3: README + contrib skill listing
+
+**Files:**
+- Create: `contrib/skills/blog-develop/README.md`
+- Modify: `contrib/skills/README.md`
+
+- [ ] **Step 1: Write the skill README**
+
+Create `contrib/skills/blog-develop/README.md`:
+
+```markdown
+# blog-develop
+
+On-demand workflow that develops **any** blog-post idea into a take-or-leave
+first draft: **scout → interview → deep research → draft**. Sibling to
+`blog-ideas`, but decoupled — the idea can come from your weekly ideas page or
+from anywhere.
+
+Run it with `/blog-develop <your idea>` (web UI) or `!blog-develop <your idea>`
+(Mattermost). With no argument it asks what you want to write about. The scout,
+research, and draft phases run as child agents; the finished draft lands in
+`blog/drafts/<slug>.md` in your vault for you to take or leave.
+
+## Install
+
+Add to your agent's `extra_skill_paths` in `data/{agent_id}/config.json`:
+
+```json
+{
+  "extra_skill_paths": [
+    "$CONTRIB/skills/blog-develop"
+  ]
+}
+```
+
+Requires the `tabstack` skill configured (web research) and a vault. No extra
+binaries or API keys beyond what `tabstack` needs.
+```
+
+- [ ] **Step 2: Add blog-develop to the contrib skill listing**
+
+Inspect `contrib/skills/README.md` for a list/table of skills. If one exists, add a `blog-develop` row matching the existing format (name + one-line description). If there is no enumerated list, skip this step (the per-skill README is enough).
+
+Run first to locate the listing: `grep -n "blog-ideas" contrib/skills/README.md`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add contrib/skills/blog-develop/README.md contrib/skills/README.md
+git commit -m "docs(blog-develop): skill README + contrib listing"
+```
+
+---
+
+## Task 4: Structural eval — guard against narrate-instead-of-delegate
+
+The #557 failure mode is the orchestrator *narrating* "I'll research this" and stalling instead of calling a tool. The high-value structural guard is: invoking the skill makes the **first substantive action a `delegate_task` (the scout)**, not an inline `tabstack_research` / `web_fetch`. (Per project rule: evals guard structure; prompt quality comes from live smoke testing.)
+
+**Files:**
+- Modify or create: an `evals/<theme>.yaml` case (pick the existing theme file that covers skills/commands; create `evals/blog_develop.yaml` if none fits).
+
+- [ ] **Step 1: Inspect the evals format and pick a home**
+
+Run: `ls evals/ && sed -n '1,60p' evals/$(ls evals | grep -m1 yaml)`
+Read `docs/eval-loop.md` for the case schema (`expect_tool`, `expect_no_tool`, `max_tool_calls`, `max_tool_errors`). Confirm how a `user-invocable` `/blog-develop` command is invoked in a case (prompt text vs. command field).
+
+- [ ] **Step 2: Add the case**
+
+Add a case asserting the scout-first contract. Shape (adapt field names to the harness verified in Step 1):
+
+```yaml
+- name: blog_develop_scouts_via_delegate
+  description: >
+    /blog-develop must kick off the scout through delegate_task, not by
+    researching inline (guards the narrate-instead-of-delegate stall).
+  prompt: "/blog-develop the sovereignty ladder as a mental model"
+  max_tool_calls: 4
+  max_tool_errors: 0
+  expect_tool: delegate_task
+```
+
+Avoid `expect_no_tool` (self-reflection retries can fire unexpected tools — see CLAUDE.md). The positive `expect_tool: delegate_task` under a tight `max_tool_calls` is the reliable assertion.
+
+- [ ] **Step 3: Run the single case**
+
+Run: `make eval-tools` (if the case lands in the tool_choice set) or the suite command from `docs/eval-loop.md` scoped to this case.
+Expected: PASS — `delegate_task` invoked within the call budget. If it fails because the harness can't drive a `context: fork` command, downgrade this task to a documented manual smoke step (Task 5) and note the limitation in `notes.md` rather than shipping a broken eval.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add evals/
+git commit -m "test(blog-develop): eval guards scout-via-delegate contract"
+```
+
+---
+
+## Task 5: Live smoke test (manual — run with Les)
+
+Automated tests can't validate prompt quality or the multi-turn interview. Smoke-test in the real app (ask Les to run, or run in the web UI per CLAUDE.md — do not start a second bot instance).
+
+- [ ] **Step 1: Install the skill** — add `$CONTRIB/skills/blog-develop` to the dev agent's `extra_skill_paths`; restart so the loader picks it up. Confirm it appears in the skill catalog.
+- [ ] **Step 2: Run with an argument** — `/blog-develop <a real idea>`. Verify: (a) first action is a scout `delegate_task` (not inline research); (b) the interview asks one question at a time and waits; (c) deep research runs as a child; (d) a draft lands at `blog/drafts/<slug>.md` with the frontmatter contract + `## Research notes`; (e) the summary links the draft and calls it take-or-leave.
+- [ ] **Step 3: Run with no argument** — `/blog-develop`. Verify it asks "What do you want to write about?" and waits.
+- [ ] **Step 4: Watch for the stall mode** — if the orchestrator narrates instead of delegating, sharpen the imperative wording in the MUST rules (this is the prompt-tuning loop; structure is already guarded by Tasks 1 & 4). Record any tuning in `notes.md`.
+- [ ] **Step 5: Capture results** in `docs/dev-sessions/2026-06-28-1209-blog-develop/notes.md` (final session summary).
+
+---
+
+## Deferred to v2 (not in this plan)
+
+- **Reviewer agent** after the draft: a `delegate_task` phase running two quality lenses — a **"humanizer"** (scan/strip "AI tells") and an **"editor"** applying Strunk & White. Note: `contrib/skills/writing-clearly` already exists and is a likely fit for the editor lens — evaluate reusing it. This is the reliable reviewer-persona pattern; deliberately out of v1 scope.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** placement/frontmatter (Task 1), scout→interview→deep-research→draft flow + worker contracts (Task 2), output contract incl. `## Research notes` single-file (Task 2 Phase 5), decoupling from blog-ideas + no-arg behavior (Task 2 "The idea"), #255 narrate-vs-delegate risk guard (Task 4), live smoke (Task 5), v2 reviewer deferral (Deferred section). Voice-doc open item resolved via runtime `vault_search` (Task 2 Phase 4).
+- **Placeholder scan:** worker task prompts, return schemas, frontmatter, test code, and draft frontmatter are all concrete. The two genuinely environment-dependent lookups (evals harness invocation syntax; whether `contrib/skills/README.md` enumerates skills) are explicit inspect-first steps, not hidden TODOs.
+- **Naming consistency:** `delegate_task` (singular) throughout; tool names match the codebase (`tabstack_research`, `tabstack_extract_markdown`, `web_fetch`, `vault_write`); slug/title/`draft_markdown` field names are consistent between the Phase 4 schema and the Phase 5 write.

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
@@ -31,7 +31,12 @@ the (not-yet-shipped) replay engine.
   Personal blogging workflow → contrib, like `blog-ideas`.
 - **Frontmatter:**
   - `user-invocable: true` — triggers via `/blog-develop` (web UI) / `!blog-develop` (Mattermost).
-  - `context: fork` — the "fresh session" requirement.
+  - `context: inline` — runs in the conversation with the full tool set. (NOTE:
+    originally specced as `context: fork`; corrected during implementation —
+    `fork` runs the orchestrator through `run_child_turn`, which strips
+    `delegate_task` + vault tools AND is a one-shot child turn that cannot
+    conduct the multi-turn interview. The "fresh session" intent is met by
+    running the command in a new conversation.)
   - `required-skills: [vault, tabstack]` — vault for read/write, tabstack for web research.
   - `effort: strong`.
   - **No** `SCHEDULE.md` — on-demand only.

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
@@ -119,6 +119,18 @@ the #255 replay engine.
   context, fixed return contract) identified across SAW, the agentic-harness
   video, and our own #255 retro. Deliberately deferred from v1, not an oversight.
 
+- **Replace `tabstack_research` with an owned/local research workflow.** v1's
+  scout + deep-research workers call `tabstack_research`, a hosted external
+  service. v2 could swap it for a DecafClaw-owned research loop (e.g. a
+  delegate-orchestrated or #255-replay-engine research workflow over `web_fetch`
+  + a search primitive), reducing the external dependency and making the research
+  loop inspectable and tunable — the "own the rig" theme from this session.
+  Wrinkle: a fully-local loop needs a **search** primitive; DecafClaw currently
+  has only `web_fetch` locally (search comes via tabstack), so this means either
+  adding a local search tool or accepting fetch-only research. The worker
+  contracts (structured `return_schema`) stay the same; only the tool the worker
+  uses changes — so this is a localized swap, not a redesign.
+
 ## Open items
 
 - Identify the actual voice-doc paths in the vault to feed the drafter (the

--- a/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
+++ b/docs/dev-sessions/2026-06-28-1209-blog-develop/spec.md
@@ -1,0 +1,121 @@
+# blog-develop — spec
+
+A new on-demand contrib skill that takes an **arbitrary blog-post idea** and runs
+a fresh session of **scout → interview → deep research → draft**, producing a
+take-or-leave first draft in the vault. Sibling to the existing `blog-ideas`
+skill, but decoupled from it: the idea can come from the blog-ideas living page
+or from nowhere in particular.
+
+## Motivation
+
+`blog-ideas` (`contrib/skills/blog-ideas/SKILL.md`) maintains a living weekly
+page of post ideas. The next step Les wants is to *develop* a single idea: flesh
+it out through a short interview, back it with web research, and draft it. This
+is the natural follow-on, and structurally it is the interview→artifact pipeline
+discussed in the #255 workflow-replay-engine work — built here as a skill, not on
+the (not-yet-shipped) replay engine.
+
+## Non-goals (v1)
+
+- Not a batch/eager developer — does **not** auto-develop headliners on a
+  schedule. On-demand only. (Decided: "selective, on-demand.")
+- Not a publishing pipeline — output is a disposable first draft, not a finished
+  post. No deploy, no commit of the draft, no touching the live blog.
+- Not durable across restart — single on-demand conversation, short-horizon. No
+  replay-engine dependency.
+- No automated reviewer/editor pass in v1 (see Deferred work).
+
+## Surface & configuration
+
+- **Location:** `contrib/skills/blog-develop/` (SKILL.md + optional `tools.py`).
+  Personal blogging workflow → contrib, like `blog-ideas`.
+- **Frontmatter:**
+  - `user-invocable: true` — triggers via `/blog-develop` (web UI) / `!blog-develop` (Mattermost).
+  - `context: fork` — the "fresh session" requirement.
+  - `required-skills: [vault, tabstack]` — vault for read/write, tabstack for web research.
+  - `effort: strong`.
+  - **No** `SCHEDULE.md` — on-demand only.
+- **Idea input:** `$ARGUMENTS` is the seed idea (any free text).
+  - No arg → first turn asks "what do you want to write about?" and offers to
+    list this week's `blog-ideas` headliners as a convenience seed source.
+  - The `blog-ideas` living page is **one optional source** of a seed, not a
+    dependency or entry contract.
+
+## Phase flow
+
+Orchestrated by the SKILL.md body (the main forked agent follows it). Two child
+worker *roles* dispatched via `delegate_task`: **researcher** (invoked twice) and
+**drafter**.
+
+1. **Scout** — `delegate_task` → *researcher* (shallow). Quick lay-of-the-land +
+   prior art on the idea. Returns a short scout brief. Purpose: make the
+   interview questions sharp instead of asked in a vacuum.
+2. **Interview** — back in the main forked session. Conversational, **one
+   question per turn**, adaptive, informed by the scout brief. Shapes angle,
+   audience, core claim, voice, and whether to engage/differentiate from prior
+   art the scout found. Caps ~5–6 questions, or ends early when Les says "go."
+   **Human-driven transitions** (each user answer advances the phase).
+3. **Deep research** — `delegate_task` → *researcher* (deep), steered by the idea
+   + interview answers. Returns a structured **research brief**: key claims,
+   sources/URLs, supporting angles, counterpoints.
+4. **Draft** — `delegate_task` → *drafter*: research brief + interview answers +
+   Les's **voice docs** (voice-and-tone / stop-slop equivalents from the vault) →
+   first draft.
+5. **Write** — `vault_write blog/drafts/<slug>.md`.
+
+### Why this is safe from the #255 "LLM-crank" failure mode
+
+The only place the LLM drives multi-phase flow autonomously is the tail
+(deep-research → draft → write = 2 bounded `delegate_task` calls). Everything
+before it is **human-driven** (the interview). That is the human + persona-as-
+worker combination established as reliable in the #255 retrospective — not a
+long-horizon autonomous state machine the model must crank.
+
+**Known risk:** the orchestrator could narrate-instead-of-delegate (the failure
+seen in #557 live smokes). Mitigations: loud imperative MUST instructions in the
+SKILL.md body around each `delegate_task` boundary; bounded, single-purpose
+worker contracts. Validation is **live smoke testing**, not just evals (per the
+project rule: evals guard structure, prompt tuning comes from live smoke). If it
+proves flaky in practice, this skill is the natural first workload to lift onto
+the #255 replay engine.
+
+## Worker contracts
+
+- **Researcher (scout mode):** input = idea seed. Output = short scout brief
+  (what's already out there, notable prior art, obvious angles/gaps). Shallow:
+  a few searches, light fetching.
+- **Researcher (deep mode):** input = idea + interview answers. Output =
+  structured research brief: claims, sources (with URLs), supporting angles,
+  counterpoints. Heavier: targeted searches + fetches.
+- **Drafter:** input = research brief + interview answers + voice docs.
+  Output = first-draft markdown in Les's voice.
+
+## Output contract
+
+- File: `blog/drafts/<slug>.md` (vault). `<slug>` derived from the title.
+- Frontmatter: `title`, `tags: [blog-draft]`, `status: draft`, `created`,
+  `seed:` (the original idea), `sources:` (from the research brief).
+- The research brief is appended as a collapsed `## Research notes` section at
+  the bottom of the same file — sources stay visible without sibling-file
+  clutter.
+- **Does not mutate** the `blog-ideas` living page (decoupled). Because
+  `blog/drafts` is already a location `blog-ideas` reads ("Stalled drafts —
+  `vault_list folder=blog/drafts`"), developed drafts naturally feed back into
+  future brainstorms with no extra wiring.
+
+## Deferred work (v2)
+
+- **Reviewer agent** as an additional `delegate_task` phase after Draft, running
+  two skills as quality lenses:
+  - a **"humanizer"** skill that scans for "AI tells" and flags/removes them, and
+  - an **"editor"** skill that applies Strunk & White ("The Elements of Style")
+    advice to the prose.
+  This is the reliable reviewer/verifier-persona pattern (independent fresh
+  context, fixed return contract) identified across SAW, the agentic-harness
+  video, and our own #255 retro. Deliberately deferred from v1, not an oversight.
+
+## Open items
+
+- Identify the actual voice-doc paths in the vault to feed the drafter (the
+  blog-ideas skill references "my actual voice" / voice standards — confirm exact
+  page paths during implementation).

--- a/tests/test_blog_develop_skill.py
+++ b/tests/test_blog_develop_skill.py
@@ -1,0 +1,44 @@
+"""Structural guard for the blog-develop contrib skill.
+
+The skill is prose (no tools.py), so this is the automated rot-guard:
+it asserts the frontmatter contract and that the body still documents
+the load-bearing rules (delegate the workers, children can't write the
+vault, one-question-at-a-time interview, blog/drafts output). Prompt
+quality itself is validated by live smoke testing, not here.
+"""
+
+from pathlib import Path
+
+from decafclaw.skills import validate_skill_md
+
+SKILL = (
+    Path(__file__).resolve().parents[1]
+    / "contrib" / "skills" / "blog-develop" / "SKILL.md"
+)
+
+
+def test_blog_develop_frontmatter_contract():
+    result = validate_skill_md(SKILL)
+    assert result.ok is True, result.first_failure
+    meta = result.meta
+    assert meta["name"] == "blog-develop"
+    assert meta["user-invocable"] is True
+    assert meta["context"] == "fork"
+    assert "vault" in meta["required-skills"]
+    assert "tabstack" in meta["required-skills"]
+    # Every tool a worker needs must be in allowed-tools (it constrains
+    # children too). delegate_task + research + vault read/write.
+    allowed = meta["allowed-tools"]
+    for tool in ("delegate_task", "tabstack_research", "vault_write", "vault_read"):
+        assert tool in allowed, f"{tool} missing from allowed-tools"
+
+
+def test_blog_develop_body_documents_contract():
+    body = validate_skill_md(SKILL).body.lower()
+    # The reliability-critical rules must stay in the prose.
+    assert "delegate_task" in body
+    assert "cannot write" in body            # children can't write the vault
+    assert "blog/drafts" in body             # output location
+    assert "one question" in body            # interview discipline
+    for phase in ("scout", "interview", "research", "draft"):
+        assert phase in body

--- a/tests/test_blog_develop_skill.py
+++ b/tests/test_blog_develop_skill.py
@@ -23,7 +23,7 @@ def test_blog_develop_frontmatter_contract():
     meta = result.meta
     assert meta["name"] == "blog-develop"
     assert meta["user-invocable"] is True
-    assert meta["context"] == "fork"
+    assert meta["context"] == "inline"
     assert "vault" in meta["required-skills"]
     assert "tabstack" in meta["required-skills"]
     # Every tool a worker needs must be in allowed-tools (it constrains


### PR DESCRIPTION
## Summary

New on-demand contrib skill **`/blog-develop <idea>`** that develops *any* blog-post idea into a take-or-leave first draft via **scout → interview → deep research → draft**. Sibling to `blog-ideas`, but decoupled — the idea can come from the weekly ideas page or anywhere.

Pure-prose `SKILL.md` (no `tools.py`), modeled on `meta-ingest`. The heavy phases run as `delegate_task` child agents (structured `return_schema`), so web-search noise and long source text stay isolated in the children; the orchestrator does the final `vault_write` to `blog/drafts/<slug>.md` (children can't write the vault). The interview is a human-driven, one-question-per-turn conversation. This is the persona-as-worker pattern from the #255 retro — a natural future workload for the replay engine.

## What's here

- `contrib/skills/blog-develop/SKILL.md` — scout / interview / deep-research / draft orchestration + worker prompts + return schemas + output contract.
- `tests/test_blog_develop_skill.py` — structural rot-guard (frontmatter + body contract).
- `contrib/skills/blog-develop/README.md` + entry in the contrib skill listing.
- `docs/dev-sessions/2026-06-28-1209-blog-develop/` — spec, plan, notes.

## Notable design fix during review

The skill was originally specced `context: fork`. Final review caught (and the code confirmed) that `context: fork` runs the orchestrator *through* `run_child_turn`, which strips `delegate_task` + vault tools, and is a one-shot turn that can't run a multi-turn interview. **Switched to `context: inline`** — full tool set, interview works, heavy work still isolated in the delegate children. The "fresh session" intent is met by running the command in a new conversation.

## Pre-merge TODO (needs a running instance)

- [ ] **Live smoke test** (the real quality gate) — `plan.md` Task 5: verify scout-via-`delegate_task` first (not inline research), the interview waits one question at a time, deep-research child runs, draft lands at `blog/drafts/<slug>.md` with the frontmatter contract + `## Research notes`, take-or-leave summary with a link. Fold any prompt-tuning back in.
- [ ] **Add `evals/blog_develop.yaml`** — scout-via-delegate structural guard. Viable now that the skill is `inline` (the orchestrator's own `delegate_task` call is visible to `expect_tool`); add + run once during the smoke session. Rationale in `notes.md`.

## Deferred to v2

- Reviewer agent: a **"humanizer"** lens (scan/strip AI tells) + an **"editor"** lens applying Strunk & White (`contrib/skills/writing-clearly` is a candidate).
- Replace `tabstack_research` (hosted) with an owned/local research workflow — needs a local search primitive (only `web_fetch` exists locally today); natural home is the #255 replay engine.

## Test plan

- `make lint` — clean.
- `uv run pytest tests/test_blog_develop_skill.py -q` — 2 passed.
- Live smoke + eval: pending (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
