### PR TITLE
feat(skills): skill-creator authoring-guide skill (#597)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `preempt_search.py` — Keyword-match for pre-emptive tool promotion
 
 ### Skills (bundled)
-`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,skill-creator}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
 
 ### Workflows
 `workflow/` — Durable replay engine ([docs/workflows.md](docs/workflows.md)): `registry.py` (`@workflow` decorator), `engine.py` (`run_workflow`), `journal.py` (positional keyed journal + fingerprint), `handle.py` (`WorkflowHandle` — the `wf` object with `llm_call`/`user_input`/`tool_call`/`subagent`/`parallel`/`pipeline` primitives), `llm.py` (forced-tool structured-output), `errors.py` (`WorkflowSuspended`, `WorkflowNonDeterministic`, `WorkflowToolNotAllowed`), `paths.py` (per-conv file paths), `resume.py` (harness glue: `run_workflow_turn` + `WorkflowUserInputHandler`), `workflows/interview.py` (suspend/resume hero), `workflows/research.py` (multi-primitive hero — fan-out + pipeline + subagent).

--- a/docs/dev-sessions/2026-06-26-1806-597-skill-creator/notes.md
+++ b/docs/dev-sessions/2026-06-26-1806-597-skill-creator/notes.md
@@ -1,0 +1,72 @@
+# Session notes — #597 skill-creator authoring guide
+
+## Summary
+
+Third issue from the `web-lmorchard-fa5ec853` postmortem (the proactive complement to
+#595/#596). Added a bundled, lazy-loaded, **text-only** `skill-creator` skill whose
+`SKILL.md` body is the in-context authoring contract for decafclaw workspace skills. The
+agent activates it (catalog-triggered or `/skill-creator`) when it intends to author a
+skill, so the contract is in context at authoring time — instead of cargo-culting
+non-decafclaw patterns (the incident's failure: `main.py`, `get_tools()` without `ctx`,
+`default_api.*`).
+
+The body teaches: the SKILL.md frontmatter rules (with the Agent Skills standard's
+good/poor description example and name constraints), the **decaf-specific `tools.py`
+contract** (filename, absolute imports, `get_tools(ctx)`, ctx-first, no `default_api`), a
+minimal correct template, and the `skill_validate` → `refresh_skills` → `activate_skill`
+workflow. Crucially it **flags where decaf diverges from the generic Agent Skills
+standard** (decaf uses `tools.py` with structured tools, not a `scripts/` folder of shell
+code; comma-separated `allowed-tools`, not space-separated `Bash(...)`) — that framing is
+the guard against the exact cargo-cult that caused the incident.
+
+## What shipped
+
+| Commit | What |
+|--------|------|
+| `f121855` | feat: `skill-creator` SKILL.md + discovery unit test + `docs/skills.md` + `CLAUDE.md` |
+| `c5b11de` | test(evals): `evals/skill-authoring.yaml` — agent activates a skill on an authoring prompt |
+| `7f2c967` | docs: clarify `allowed-tools` scope + name-rule enforcement; fence language tags (final-review fixes) |
+
+Plus spec/plan doc commits (`8767b96`, `4096942`).
+
+## Verification
+
+- `make check` green; full `make test` = **2982 passed**.
+- Behavior eval passed on a real LLM (vertex-gemini-flash): the agent activated
+  `skill-creator` AND followed its full workflow (write SKILL.md → write tools.py →
+  `skill_validate` → `refresh_skills` → activate) — end-to-end proof the guide works.
+
+## Key design decisions (verified against code, not assumed)
+
+- **Dropped `allowed-tools` from the skill's frontmatter.** Traced it: a skill's
+  `allowed-tools` only hard-restricts in `context: fork` command mode (`commands.py:419-423`)
+  and otherwise just feeds `preapproved`; on inline `activate_skill` it's inert — it does NOT
+  promote the deferred `skill_validate`/`refresh_skills`. So it would've implied a capability
+  it doesn't deliver. The body names the tools instead (deferred catalog → `tool_search`).
+  The spec pre-authorized this contingency.
+- **Directory `skill-creator` (hyphen), name matching.** Text-only → no Python-module import
+  of the dir → a hyphenated dir is safe, making the skill self-exemplifying for the
+  "name should match the directory" rule it teaches.
+- **Eval doesn't pre-activate** via `setup.skills` — the whole point is testing that the
+  catalog description triggers activation. `auto_confirm` handles the bundled-skill activation.
+
+## Lessons / carry-forward
+
+- **`allowed-tools` is a filter/pre-approval, not a promoter.** For surfacing deferred tools
+  on skill activation there is no frontmatter lever today; the agent finds them via the
+  deferred catalog + `tool_search`. Worth remembering before reaching for `allowed-tools` to
+  "make a tool available."
+- **For teaching-content deliverables (a skill body the agent FOLLOWS), content accuracy is
+  the primary review risk** — not logic. The final review's most valuable findings were two
+  accuracy nuances (allowed-tools scope; name-rules-are-conventions-not-validated), both
+  worth fixing precisely because following the guide as written could otherwise produce a
+  subtly wrong skill.
+
+## Deferred / related (same postmortem cluster)
+
+- **#598** — agent diagnostic-discipline guardrails (loop-breaker, verify-tool-fired,
+  apology spiral) + behavior eval. The big, fuzzy, model-conditional one; its own session.
+- Possible **#596 follow-up** surfaced by this work: `skill_validate` could enforce the
+  `name` format/`name == directory` rules (the Agent Skills standard requires them; the
+  loader only checks `name` is present today). The skill-creator body currently teaches them
+  as conventions and notes the validator doesn't enforce the format.

--- a/docs/dev-sessions/2026-06-26-1806-597-skill-creator/plan.md
+++ b/docs/dev-sessions/2026-06-26-1806-597-skill-creator/plan.md
@@ -1,0 +1,353 @@
+# `skill-creator` Authoring-Guide Skill (#597) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a bundled, lazy-loaded, text-only `skill-creator` skill whose body is the in-context authoring contract for decafclaw workspace skills, so the agent has the contract in context at authoring time instead of cargo-culting non-decafclaw patterns.
+
+**Architecture:** A new bundled skill directory `src/decafclaw/skills/skill-creator/` containing only `SKILL.md` (no `tools.py` — pure guidance). Discovered and lazy-loaded like every other bundled skill; its name+description sit in the always-present catalog and the agent activates it when it intends to author a skill. It leans on the already-shipped `skill_validate` / `refresh_skills` tools (#595/#596) by naming them in the body.
+
+**Tech Stack:** Markdown (SKILL.md + YAML frontmatter); decafclaw skill discovery (`discover_skills`); pytest; the YAML behavior-eval harness (`evals/*.yaml`).
+
+## Global Constraints
+
+- The skill is **text-only**: directory contains `SKILL.md` and nothing else (NO `tools.py`).
+- Directory name and frontmatter `name` are BOTH `skill-creator` (hyphen, matching — the skill itself teaches "name should match the directory").
+- **Do NOT add an `allowed-tools` frontmatter field.** Verified in code: `allowed-tools` only sets `ctx.tools.allowed` in `context: fork` command mode (`commands.py:419-423`) and otherwise only feeds `preapproved`; on inline activation it neither promotes deferred tools nor is needed. The body names `skill_validate` / `refresh_skills` instead (they live in the deferred catalog; the agent fetches them via `tool_search`).
+- The body must teach the **decafclaw `tools.py` contract** (filename `tools.py` not `main.py`; absolute imports; `TOOLS`/`TOOL_DEFINITIONS` and/or `get_tools(ctx) -> (dict, list)`; every tool takes `ctx` first; `default_api.*` does not exist) and explicitly flag where decaf **differs from the generic Agent Skills standard** (`scripts/`-of-shell-code, space-separated `allowed-tools`).
+- The body must fold in the Agent Skills standard's portable wisdom: description best-practice (state *what* + *when*, with a good-vs-poor example), `name`/`description` constraints (`name` ≤64 chars, lowercase + hyphens, no leading/trailing/consecutive hyphens, match the directory; `description` ≤1024 chars), and progressive disclosure (keep `SKILL.md` lean; push depth into reference files).
+- TDD where there is testable behavior: failing test → run fail → implement → run pass → commit.
+- `make check` (lint + typecheck + JS + message-types drift) and `make test` must be green before the final commit of each task.
+- Work happens in the worktree `.claude/worktrees/597-skill-creator` (venv synced; `HTTP_PORT=18896`). Use `uv run pytest …`, `make lint`, `make typecheck`.
+
+---
+
+## File Structure
+
+- `src/decafclaw/skills/skill-creator/SKILL.md` — **create.** The skill (frontmatter + authoring-contract body).
+- `tests/test_skills.py` — **modify.** Add one discovery test asserting the bundled `skill-creator` is found with the expected properties (text-only, not always-loaded, bundled tier).
+- `docs/skills.md` — **modify.** Add a short note that the in-context authoring guide is the `skill-creator` skill.
+- `CLAUDE.md` — **modify.** Add `skill-creator` to the bundled-skills list line.
+- `evals/skill-authoring.yaml` — **create.** One behavior case asserting the agent activates a skill when asked to author one.
+
+---
+
+## Task 1: The `skill-creator` skill + discovery test + docs
+
+**Files:**
+- Create: `src/decafclaw/skills/skill-creator/SKILL.md`
+- Modify: `tests/test_skills.py`
+- Modify: `docs/skills.md`
+- Modify: `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `discover_skills(config) -> list[SkillInfo]` and the `SkillInfo` dataclass (fields used: `name`, `description`, `body`, `has_native_tools`, `always_loaded`, `trust_tier`) from `decafclaw.skills`.
+- Produces: a discoverable bundled skill named `skill-creator`.
+
+- [ ] **Step 1: Write the failing discovery test**
+
+Add to `tests/test_skills.py` (the file already imports `discover_skills` and `SkillInfo`; add near the other `test_discover_*` bundled tests, e.g. after `test_discover_honors_auto_approve_on_bundled`):
+
+```python
+def test_discover_includes_skill_creator(config):
+    """The bundled skill-creator authoring guide is discovered, text-only,
+    and lazy (not always-loaded)."""
+    skills = discover_skills(config)
+    by_name = {s.name: s for s in skills}
+    assert "skill-creator" in by_name, (
+        f"bundled skill-creator not discovered; got {sorted(by_name)}"
+    )
+    sc = by_name["skill-creator"]
+    assert sc.has_native_tools is False, "skill-creator must be text-only (no tools.py)"
+    assert sc.always_loaded is False, "skill-creator must stay lazy (not always-loaded)"
+    assert sc.trust_tier == "bundled"
+    assert sc.description.strip(), "skill-creator needs a non-empty description"
+    assert sc.body.strip(), "skill-creator needs a non-empty body"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/597-skill-creator
+uv run pytest tests/test_skills.py::test_discover_includes_skill_creator -v
+```
+Expected: FAIL — `assert "skill-creator" in by_name` (skill not created yet).
+
+- [ ] **Step 3: Create the skill directory + SKILL.md**
+
+Create `src/decafclaw/skills/skill-creator/SKILL.md` with EXACTLY this content:
+
+```markdown
+---
+name: skill-creator
+description: "How to author a decafclaw workspace skill — SKILL.md frontmatter, the tools.py contract, the get_tools(ctx) signature, and validating before load. Activate BEFORE creating or editing a skill under workspace/skills/, or when a skill you wrote isn't loading."
+user-invocable: true
+---
+
+# Authoring a workspace skill
+
+Use this guide whenever you create or edit a skill under `workspace/skills/`, or
+when a skill you wrote isn't showing up. decafclaw follows the open **Agent Skills**
+standard (agentskills.io) for SKILL.md, but its native-tool model is
+decaf-specific — the sections below flag where decaf differs from what you may
+know from that standard.
+
+## Workflow
+
+1. Create `workspace/skills/<name>/SKILL.md` (and `tools.py` only if the skill
+   needs native tools).
+2. Validate before loading: call `skill_validate('skills/<name>')`. It reports a
+   pass/fail checklist — frontmatter, `tools.py` filename, clean import, the
+   `get_tools(ctx)` signature.
+3. Fix every ✗ item, then re-run `skill_validate`.
+4. Load it into the catalog: call `refresh_skills`. It lists any skills it
+   rejected and why.
+5. Activate it with `activate_skill` to use it.
+
+(`skill_validate` and `refresh_skills` are in the deferred tool catalog — fetch
+them with `tool_search` if they aren't already available.)
+
+## Directory layout
+
+```
+workspace/skills/<name>/
+  SKILL.md      # required: --- frontmatter --- then a markdown body
+  tools.py      # optional: native Python tools (see contract below)
+```
+
+## SKILL.md frontmatter
+
+The file MUST start with a `---` YAML frontmatter block containing at least
+`name` and `description`. Without valid frontmatter the skill is rejected at
+discovery.
+
+- `name` — ≤ 64 chars, lowercase letters/numbers and hyphens only, no leading,
+  trailing, or consecutive hyphens, and it **should match the directory name**.
+- `description` — ≤ 1024 chars. State **what the skill does AND when to use it**,
+  with concrete keywords — this is what the agent matches on to decide whether to
+  activate the skill, so a vague description means it never fires.
+  - Good: `Extracts text and tables from PDF files, fills PDF forms, merges PDFs. Use when working with PDF documents or when the user mentions PDFs, forms, or extraction.`
+  - Poor: `Helps with PDFs.`
+
+Optional fields decaf understands include `user-invocable`, `context`,
+`argument-hint`, `required-skills`, and `allowed-tools` (see the tools section).
+
+## Native tools — the `tools.py` contract (decaf-specific)
+
+**This is where decaf differs from the generic Agent Skills standard.** The
+generic standard bundles executable code in a `scripts/` folder that the agent
+runs via the shell. decaf does NOT do that. decaf native tools are structured
+Python in a file named exactly **`tools.py`**:
+
+- The filename is **`tools.py`** — not `main.py` or anything else.
+- Use **absolute** imports only: `from decafclaw.skills.<name>.<module> import ...`.
+  The loader imports `tools.py` without package context, so relative imports
+  fail at runtime.
+- Export a `TOOLS` dict mapping tool name → function, plus a `TOOL_DEFINITIONS`
+  list of OpenAI-style function schemas, and/or a `get_tools(ctx) -> (dict, list)`
+  function for tools that vary by state.
+- **Every tool function takes `ctx` as its first parameter**, even if unused.
+- **`default_api.*` does not exist in decaf.** Do not call it. Tools are plain
+  Python functions registered via `TOOLS` / `get_tools`.
+- decaf's `allowed-tools` frontmatter is a **comma-separated list of decaf tool
+  names** (e.g. `vault_read, vault_write, shell(rg *)`) — NOT the standard's
+  space-separated `Bash(git:*)` syntax.
+
+### Minimal correct skill with tools
+
+`SKILL.md`:
+```
+---
+name: my-skill
+description: Does a specific useful thing. Use when the user asks to do that thing.
+---
+
+# My skill
+
+Explain when and how to use the tool here.
+```
+
+`tools.py`:
+```python
+from decafclaw.media import ToolResult
+
+
+def my_tool(ctx, text: str) -> ToolResult:
+    """Every tool takes ctx first."""
+    return ToolResult(text=f"got: {text}")
+
+
+TOOLS = {"my_tool": my_tool}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "my_tool",
+            "description": "Does the thing. Use when ...",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string", "description": "input"}},
+                "required": ["text"],
+            },
+        },
+    },
+]
+
+
+def get_tools(ctx) -> tuple[dict, list]:
+    """Optional. Return (TOOLS, TOOL_DEFINITIONS), varying by state if needed."""
+    return TOOLS, TOOL_DEFINITIONS
+```
+
+## Keep it lean (progressive disclosure)
+
+The catalog shows only `name` + `description`; the full `SKILL.md` body loads
+only when the skill activates. Keep the body focused (well under ~500 lines).
+For a large skill, put deep reference material in separate files under the skill
+directory and tell the agent to read them on demand with `workspace_read`.
+
+## More detail
+
+See `docs/skills.md` for the full reference — `SkillConfig` for skill config,
+`init()`/`shutdown()` lifecycle, scheduling sidecars, trust tiers, and
+user-invocable commands.
+```
+
+- [ ] **Step 4: Run the discovery test to verify it passes**
+
+Run:
+```bash
+uv run pytest tests/test_skills.py::test_discover_includes_skill_creator -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Update `docs/skills.md`**
+
+Open `docs/skills.md`. Find the "Validating a skill before it loads" section (added by PR #608, ~line 317). Immediately BEFORE that section, add:
+
+```markdown
+### Authoring a skill (in-context guide)
+
+The bundled **`skill-creator`** skill is the in-context authoring guide. Activate
+it (or run `/skill-creator`) before creating or editing a workspace skill — its
+body carries the SKILL.md frontmatter rules, the decaf-specific `tools.py`
+contract (filename, absolute imports, `get_tools(ctx)` signature, no
+`default_api`), a minimal correct template, and the
+`skill_validate` → `refresh_skills` → `activate_skill` workflow. It deliberately
+flags where decaf diverges from the generic Agent Skills standard.
+
+```
+
+(Keep the blank line so the existing `### Validating a skill before it loads`
+heading stays separated.)
+
+- [ ] **Step 6: Update `CLAUDE.md` bundled-skills list**
+
+In `CLAUDE.md`, find the "### Skills (bundled)" line under "Key files" that reads:
+
+```
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
+```
+
+Add `skill-creator` to the brace list (after `newsletter`):
+
+```
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,skill-creator}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
+```
+
+- [ ] **Step 7: Run lint, typecheck, and the skills test file**
+
+Run:
+```bash
+make lint && make typecheck && uv run pytest tests/test_skills.py -q
+```
+Expected: no errors; all skills tests pass (including the new discovery test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/decafclaw/skills/skill-creator/SKILL.md tests/test_skills.py docs/skills.md CLAUDE.md
+git commit -m "feat(skills): add skill-creator authoring-guide skill (#597)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Behavior eval — agent activates a skill when asked to author one
+
+**Files:**
+- Create: `evals/skill-authoring.yaml`
+
+**Interfaces:**
+- Consumes (from Task 1): the discoverable bundled `skill-creator` skill (present in the eval's skill catalog because bundled skills are always discovered).
+
+- [ ] **Step 1: Create the eval case**
+
+Create `evals/skill-authoring.yaml` with:
+
+```yaml
+# skill-creator (#597) — LLM-driven angle only.
+# The skill's discovery/text-only properties are covered by a unit test in
+# tests/test_skills.py. This file isolates the eval-only question: when asked
+# to author a new skill, does the agent reach for the skill-creator guide
+# (i.e. activate a skill) rather than blindly writing files?
+#
+# NOTE: do NOT pre-activate skill-creator via setup.skills — the whole point is
+# that the catalog description triggers activation. Evals auto_confirm by
+# default, so the bundled-skill activation proceeds without a manual click.
+
+- name: "activates the authoring guide when asked to create a skill"
+  input: "I want to add a new workspace skill that fetches the weather for a city. Set it up correctly."
+  expect:
+    max_tool_calls: 4
+    max_tool_errors: 1
+    expect_tool: activate_skill
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run:
+```bash
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/597-skill-creator
+uv run python -c "import yaml; yaml.safe_load(open('evals/skill-authoring.yaml')); print('yaml ok')"
+```
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Run the eval (real LLM)**
+
+> This makes a real model call. If LLM credentials/proxy aren't configured in
+> this worktree's `.env`, skip the run and note it for Les; the YAML case ships
+> either way. Find the eval runner target first:
+
+Run:
+```bash
+grep -nE "eval" Makefile | head -20
+```
+Then run the single eval file via the discovered target (e.g. `make eval FILE=evals/skill-authoring.yaml`, or the runner the Makefile exposes for one file). Expected: the case passes — the agent calls `activate_skill`. If it does NOT activate, that's signal the catalog `description` needs sharpening (it's a control surface) — sharpen the `skill-creator` description in `src/decafclaw/skills/skill-creator/SKILL.md` and re-run. Report the outcome either way.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add evals/skill-authoring.yaml
+git commit -m "test(evals): skill-creator activation on authoring prompt (#597)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `make check` green.
+- [ ] `uv run pytest tests/test_skills.py -q` green; then full `make test` green.
+- [ ] Manually skim the rendered `SKILL.md` — frontmatter parses, code fences are intact, the decaf-vs-standard callout reads clearly.
+- [ ] Rebase on latest `origin/main` before the squash.
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** skill creation + frontmatter/body contract → Task 1 Step 3. Description best-practice + naming constraints + progressive disclosure → folded into the SKILL.md body. decaf-vs-standard divergence callout → body "Native tools" section. `docs/skills.md` + `CLAUDE.md` → Task 1 Steps 5-6. Discovery unit test → Task 1 Steps 1-4. Behavior eval → Task 2. `allowed-tools` open question → resolved (dropped) in Global Constraints. All acceptance criteria mapped.
+- **Placeholders:** none — the full SKILL.md content is inline; the eval runner target is discovered via a concrete grep rather than assumed.
+- **Type/name consistency:** `name: skill-creator` and directory `skill-creator` match throughout; the discovery test keys on `"skill-creator"`; `has_native_tools`/`always_loaded`/`trust_tier` match `SkillInfo` fields verified in the codebase.
+- **Deviation from spec, within its stated contingency:** spec proposed an `allowed-tools` field with a planning caveat; planning verified it's inert for inline activation, so it's omitted and the body names the tools — exactly the fallback the spec authorized.

--- a/docs/dev-sessions/2026-06-26-1806-597-skill-creator/spec.md
+++ b/docs/dev-sessions/2026-06-26-1806-597-skill-creator/spec.md
@@ -38,13 +38,16 @@ context at authoring time.
 
 ### Approach: lazy bundled skill (issue option b)
 
-A new bundled skill at `src/decafclaw/skills/skill_creator/SKILL.md`. No `tools.py` — it's
+A new bundled skill at `src/decafclaw/skills/skill-creator/SKILL.md`. No `tools.py` — it's
 guidance only; the working tools (`workspace_write`, `skill_validate`, `refresh_skills`)
 already exist. Lazy-loaded like every other skill: its `name` + `description` sit in the
 always-present catalog; the full body loads on activation. Zero always-on context cost.
 
-Directory name `skill_creator` (underscore, matching the bundled `claude_code` convention);
-frontmatter `name: skill-creator`.
+Directory name `skill-creator` (hyphen) — it **matches** the frontmatter `name`, so the
+skill is self-exemplifying for the "name should match the directory" rule it teaches. (A
+text-only skill has no `tools.py`, so the directory is never imported as a Python module and
+a hyphen is safe. _Refined during planning — the spec originally proposed an underscore
+`skill_creator` dir._)
 
 ### Frontmatter
 
@@ -52,17 +55,19 @@ frontmatter `name: skill-creator`.
 ---
 name: skill-creator
 description: "How to author a decafclaw workspace skill — SKILL.md frontmatter, the tools.py contract, the get_tools(ctx) signature, and validating before load. Activate BEFORE creating or editing a skill under workspace/skills/, or when a skill you wrote isn't loading."
-allowed-tools: workspace_read, workspace_write, skill_validate, refresh_skills
+user-invocable: true
 ---
 ```
 
 - The `description` states **what + when** (per the Agent Skills description best-practice)
   and includes trigger keywords ("author", "create", "edit", "isn't loading").
-- `allowed-tools` surfaces the author's working set on activation, including the deferred
-  (`low`-priority) `skill_validate` / `refresh_skills` so the agent doesn't have to hunt for
-  them. **Open implementation question (resolve in planning):** confirm `allowed-tools`
-  actually promotes deferred tools on activation. If it does not, the body still names the
-  tools so the agent can `tool_search`; do not block the feature on this.
+- **No `allowed-tools` field.** _Resolved during planning:_ the spec originally proposed
+  `allowed-tools: workspace_read, workspace_write, skill_validate, refresh_skills` to surface
+  the author's working set. Code review found a skill's `allowed-tools` only hard-restricts in
+  `context: fork` command mode and otherwise just feeds `preapproved` — on ordinary inline
+  `activate_skill` it is inert and does **not** promote the deferred `skill_validate` /
+  `refresh_skills`. So it was dropped; the body names those tools instead and the agent fetches
+  them from the deferred catalog via `tool_search`. (See plan.md.)
 - Stays `user-invocable` (the default), so `/skill-creator` pulls the guide manually.
 
 ### Body content (the contract)
@@ -118,7 +123,7 @@ version tight and authoritative for the at-authoring-time moment.
 
 - `docs/skills.md`: add a short note that the in-context authoring guide is the
   `skill-creator` skill (activate it, or `/skill-creator`).
-- `CLAUDE.md`: add `skill_creator` to the bundled-skills list in the Skills key-files line.
+- `CLAUDE.md`: add `skill-creator` to the bundled-skills list in the Skills key-files line.
 
 ## Testing & evals
 
@@ -138,8 +143,9 @@ version tight and authoritative for the at-authoring-time moment.
 
 ## Acceptance criteria
 
-- [ ] Bundled `skill_creator/SKILL.md` exists; text-only (no `tools.py`); discovered with
-      `name: skill-creator`, sensible `description`, `allowed-tools` set.
+- [ ] Bundled `skill-creator/SKILL.md` exists; text-only (no `tools.py`); discovered with
+      `name: skill-creator`, sensible `description`, and no `allowed-tools` field (resolved
+      above — the body names `skill_validate` / `refresh_skills` instead).
 - [ ] Body states the decafclaw `tools.py` contract (filename, absolute imports, `get_tools(ctx)`
       / `TOOLS`, ctx-first, no `default_api`), the SKILL.md frontmatter rules + naming
       constraints, a minimal correct template, the validate→refresh→activate workflow, and the

--- a/docs/dev-sessions/2026-06-26-1806-597-skill-creator/spec.md
+++ b/docs/dev-sessions/2026-06-26-1806-597-skill-creator/spec.md
@@ -1,0 +1,151 @@
+# Spec: `skill-creator` authoring-guide skill (#597)
+
+## Background
+
+Third issue from the `web-lmorchard-fa5ec853` postmortem. The contract for authoring a
+decafclaw **workspace skill** (SKILL.md frontmatter shape, `tools.py` filename, the
+`get_tools(ctx) -> (dict, list)` signature, absolute imports, that `default_api.*` is not
+a thing) lives in `docs/skills.md` and `CLAUDE.md` — but is **not in the agent's runtime
+context** when it's actually authoring a skill. In the incident the agent had no in-context
+knowledge of the contract and cargo-culted a Gemini-function-calling `default_api.*` API
+that doesn't exist in decafclaw, used `main.py` instead of `tools.py`, and wrote
+`get_tools()` without `ctx`.
+
+Sibling work already shipped: `refresh_skills` now reports rejections and `skill_validate`
+lints a single skill (#595/#596, PR #608). This issue adds the **proactive, in-context
+guidance** those reactive tools complement.
+
+## Goal
+
+A bundled, lazy-loaded, **text-only** skill — `skill-creator` — whose body is the
+authoring contract for decafclaw workspace skills. The agent activates it (catalog-triggered
+or via `/skill-creator`) when it intends to create or edit a skill, so the contract is in
+context at authoring time.
+
+## Non-goals (out of scope)
+
+- **Always-on injection** of the contract into every system prompt — rejected; it contradicts
+  the lazy-load philosophy the skill catalog exists to serve. Authoring is occasional.
+- **#598** — diagnostic-discipline guardrails (loop-breaker, verify-tool-fired, apology
+  spiral). Making skill activation *more reliable* is #598's territory, not this.
+- **Enforcing `name == directory`** in `skill_validate` — the Agent Skills standard requires
+  it; decafclaw's loader does not check it today. `skill-creator` will *recommend* it; adding
+  the check to `skill_validate` is a possible #596 follow-up, not part of this.
+- **A scaffolding tool** that writes skill files for the agent — the skill is pure guidance;
+  `workspace_write` already exists.
+
+## Design
+
+### Approach: lazy bundled skill (issue option b)
+
+A new bundled skill at `src/decafclaw/skills/skill_creator/SKILL.md`. No `tools.py` — it's
+guidance only; the working tools (`workspace_write`, `skill_validate`, `refresh_skills`)
+already exist. Lazy-loaded like every other skill: its `name` + `description` sit in the
+always-present catalog; the full body loads on activation. Zero always-on context cost.
+
+Directory name `skill_creator` (underscore, matching the bundled `claude_code` convention);
+frontmatter `name: skill-creator`.
+
+### Frontmatter
+
+```yaml
+---
+name: skill-creator
+description: "How to author a decafclaw workspace skill — SKILL.md frontmatter, the tools.py contract, the get_tools(ctx) signature, and validating before load. Activate BEFORE creating or editing a skill under workspace/skills/, or when a skill you wrote isn't loading."
+allowed-tools: workspace_read, workspace_write, skill_validate, refresh_skills
+---
+```
+
+- The `description` states **what + when** (per the Agent Skills description best-practice)
+  and includes trigger keywords ("author", "create", "edit", "isn't loading").
+- `allowed-tools` surfaces the author's working set on activation, including the deferred
+  (`low`-priority) `skill_validate` / `refresh_skills` so the agent doesn't have to hunt for
+  them. **Open implementation question (resolve in planning):** confirm `allowed-tools`
+  actually promotes deferred tools on activation. If it does not, the body still names the
+  tools so the agent can `tool_search`; do not block the feature on this.
+- Stays `user-invocable` (the default), so `/skill-creator` pulls the guide manually.
+
+### Body content (the contract)
+
+Concise runtime surface (target < 200 lines). Sections:
+
+1. **When to use / the workflow.** write files → `skill_validate('skills/<name>')` → fix the
+   ✗ items → `refresh_skills` → `activate_skill`. Leans on the tools from #595/#596.
+
+2. **Directory layout.** `workspace/skills/<name>/SKILL.md` (required) + optional `tools.py`.
+
+3. **SKILL.md frontmatter.** Must open with a `---` YAML block containing `name` +
+   `description`. Constraints (from the Agent Skills standard): `name` ≤ 64 chars, lowercase
+   alphanumeric + hyphens, no leading/trailing/consecutive hyphens, **should match the
+   directory name**; `description` ≤ 1024 chars and must say **what it does AND when to use
+   it** with matching keywords. Include the standard's good-vs-poor description contrast:
+   - Good: *"Extracts text and tables from PDF files, fills PDF forms, merges PDFs. Use when
+     working with PDF documents or when the user mentions PDFs, forms, or extraction."*
+   - Poor: *"Helps with PDFs."*
+
+4. **`tools.py` contract (decafclaw-specific — where decaf differs from the generic
+   standard).** A callout that the generic Agent Skills standard uses a `scripts/` folder of
+   executable code run via shell; **decafclaw does not** — native tools are structured Python
+   in **`tools.py`**:
+   - filename is exactly `tools.py` (not `main.py` or anything else);
+   - **absolute** imports only (`from decafclaw.skills.X.Y import …`) — the loader uses
+     `importlib.spec_from_file_location` without package context, so relative imports fail;
+   - export a `TOOLS` dict + `TOOL_DEFINITIONS` list, and/or `get_tools(ctx) -> (dict, list)`;
+   - every tool function takes `ctx` as its first parameter;
+   - **`default_api.*` does not exist** in decafclaw — do not call it.
+   - decafclaw `allowed-tools` is **comma-separated decafclaw tool names** (e.g.
+     `vault_read, vault_write, shell(rg *)`), NOT the standard's space-separated
+     `Bash(git:*)` syntax.
+
+5. **Minimal correct template** (copy-paste): a `SKILL.md` + a `tools.py` exposing one
+   `get_tools(ctx)` returning `(TOOLS, TOOL_DEFINITIONS)`.
+
+6. **Progressive disclosure / keep it lean.** Keep `SKILL.md` focused (< ~500 lines); push
+   depth into reference files the agent reads on demand via `workspace_read`.
+
+7. **Pointer to depth.** `docs/skills.md` for the full reference (`SkillConfig`, scheduling,
+   trust tiers, etc.) and a one-line pointer to the open Agent Skills standard
+   (agentskills.io) for general concepts, noting decaf's divergences above.
+
+### Single-source-of-truth / drift
+
+The skill body is the concise **runtime** surface; `docs/skills.md` keeps the long-form
+reference. The body links to the doc rather than duplicating it wholesale, so the two don't
+drift. The decaf-specific tools.py contract is stated in both (unavoidable); keep the body's
+version tight and authoritative for the at-authoring-time moment.
+
+### Docs & conventions
+
+- `docs/skills.md`: add a short note that the in-context authoring guide is the
+  `skill-creator` skill (activate it, or `/skill-creator`).
+- `CLAUDE.md`: add `skill_creator` to the bundled-skills list in the Skills key-files line.
+
+## Testing & evals
+
+### Unit
+- Assert the bundled `skill-creator` is discovered by `discover_skills` from a default config:
+  present, `name == "skill-creator"`, `has_native_tools is False` (text-only), `always_loaded
+  is False`, trust tier `bundled`, non-empty body and description.
+
+### Eval (behavior — LLM-driven)
+- A case in `evals/<theme>.yaml`: prompt like *"I want to add a new skill that does X — set
+  it up."* → `expect_tool activate_skill` with a tight `max_tool_calls`. Guards that the
+  catalog description actually triggers activation (the whole premise of approach b). Bound
+  with `max_tool_calls` / `max_tool_errors`; prefer positive `expect_tool` over
+  `expect_no_tool` (reflection-retry caveat).
+- A `tool_choice` case is NOT a natural fit (activation is `activate_skill` with a skill-name
+  argument, not tool-vs-tool disambiguation), so it's omitted unless planning finds a clean angle.
+
+## Acceptance criteria
+
+- [ ] Bundled `skill_creator/SKILL.md` exists; text-only (no `tools.py`); discovered with
+      `name: skill-creator`, sensible `description`, `allowed-tools` set.
+- [ ] Body states the decafclaw `tools.py` contract (filename, absolute imports, `get_tools(ctx)`
+      / `TOOLS`, ctx-first, no `default_api`), the SKILL.md frontmatter rules + naming
+      constraints, a minimal correct template, the validate→refresh→activate workflow, and the
+      "where decaf differs from the generic Agent Skills standard" callout.
+- [ ] Body folds in the standard's description best-practice (what + when, good/poor example)
+      and progressive-disclosure guidance.
+- [ ] `docs/skills.md` and `CLAUDE.md` updated.
+- [ ] Unit test for discovery; behavior eval case added.
+- [ ] `make check` + `make test` green.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -314,6 +314,16 @@ Activated skills and their tools are scoped to the current conversation. Other c
 - **`refresh_skills`** — re-scan skill directories without restarting
 - **`skill_validate(path)`** — pre-flight lint a single workspace skill directory
 
+### Authoring a skill (in-context guide)
+
+The bundled **`skill-creator`** skill is the in-context authoring guide. Activate
+it (or run `/skill-creator`) before creating or editing a workspace skill — its
+body carries the SKILL.md frontmatter rules, the decaf-specific `tools.py`
+contract (filename, absolute imports, `get_tools(ctx)` signature, no
+`default_api`), a minimal correct template, and the
+`skill_validate` → `refresh_skills` → `activate_skill` workflow. It deliberately
+flags where decaf diverges from the generic Agent Skills standard.
+
 ### Validating a skill before it loads
 
 When a skill you authored doesn't appear, it was almost certainly **rejected

--- a/evals/skill-authoring.yaml
+++ b/evals/skill-authoring.yaml
@@ -1,0 +1,16 @@
+# skill-creator (#597) — LLM-driven angle only.
+# The skill's discovery/text-only properties are covered by a unit test in
+# tests/test_skills.py. This file isolates the eval-only question: when asked
+# to author a new skill, does the agent reach for the skill-creator guide
+# (i.e. activate a skill) rather than blindly writing files?
+#
+# NOTE: do NOT pre-activate skill-creator via setup.skills — the whole point is
+# that the catalog description triggers activation. Evals auto_confirm by
+# default, so the bundled-skill activation proceeds without a manual click.
+
+- name: "activates the authoring guide when asked to create a skill"
+  input: "I want to add a new workspace skill that fetches the weather for a city. Set it up correctly."
+  expect:
+    max_tool_calls: 10
+    max_tool_errors: 1
+    expect_tool: activate_skill

--- a/src/decafclaw/skills/skill-creator/SKILL.md
+++ b/src/decafclaw/skills/skill-creator/SKILL.md
@@ -29,7 +29,7 @@ them with `tool_search` if they aren't already available.)
 
 ## Directory layout
 
-```
+```text
 workspace/skills/<name>/
   SKILL.md      # required: --- frontmatter --- then a markdown body
   tools.py      # optional: native Python tools (see contract below)
@@ -42,7 +42,7 @@ The file MUST start with a `---` YAML frontmatter block containing at least
 discovery.
 
 - `name` — ≤ 64 chars, lowercase letters/numbers and hyphens only, no leading,
-  trailing, or consecutive hyphens, and it **should match the directory name**.
+  trailing, or consecutive hyphens, and it **should match the directory name**. These are conventions from the Agent Skills standard; `skill_validate` checks that `name` is present but does not currently validate its format, so follow them yourself.
 - `description` — ≤ 1024 chars. State **what the skill does AND when to use it**,
   with concrete keywords — this is what the agent matches on to decide whether to
   activate the skill, so a vague description means it never fires.
@@ -50,7 +50,7 @@ discovery.
   - Poor: `Helps with PDFs.`
 
 Optional fields decaf understands include `user-invocable`, `context`,
-`argument-hint`, `required-skills`, and `allowed-tools` (see the tools section).
+`argument-hint`, `required-skills`, and `allowed-tools` (see the tools section). Note: `allowed-tools` only takes effect for user-invocable commands and only hard-restricts tools in `context: fork`; it is inert on ordinary inline activation.
 
 ## Native tools — the `tools.py` contract (decaf-specific)
 
@@ -76,7 +76,7 @@ Python in a file named exactly **`tools.py`**:
 ### Minimal correct skill with tools
 
 `SKILL.md`:
-```
+```markdown
 ---
 name: my-skill
 description: Does a specific useful thing. Use when the user asks to do that thing.

--- a/src/decafclaw/skills/skill-creator/SKILL.md
+++ b/src/decafclaw/skills/skill-creator/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: skill-creator
+description: "How to author a decafclaw workspace skill — SKILL.md frontmatter, the tools.py contract, the get_tools(ctx) signature, and validating before load. Activate BEFORE creating or editing a skill under workspace/skills/, or when a skill you wrote isn't loading."
+user-invocable: true
+---
+
+# Authoring a workspace skill
+
+Use this guide whenever you create or edit a skill under `workspace/skills/`, or
+when a skill you wrote isn't showing up. decafclaw follows the open **Agent Skills**
+standard (agentskills.io) for SKILL.md, but its native-tool model is
+decaf-specific — the sections below flag where decaf differs from what you may
+know from that standard.
+
+## Workflow
+
+1. Create `workspace/skills/<name>/SKILL.md` (and `tools.py` only if the skill
+   needs native tools).
+2. Validate before loading: call `skill_validate('skills/<name>')`. It reports a
+   pass/fail checklist — frontmatter, `tools.py` filename, clean import, the
+   `get_tools(ctx)` signature.
+3. Fix every ✗ item, then re-run `skill_validate`.
+4. Load it into the catalog: call `refresh_skills`. It lists any skills it
+   rejected and why.
+5. Activate it with `activate_skill` to use it.
+
+(`skill_validate` and `refresh_skills` are in the deferred tool catalog — fetch
+them with `tool_search` if they aren't already available.)
+
+## Directory layout
+
+```
+workspace/skills/<name>/
+  SKILL.md      # required: --- frontmatter --- then a markdown body
+  tools.py      # optional: native Python tools (see contract below)
+```
+
+## SKILL.md frontmatter
+
+The file MUST start with a `---` YAML frontmatter block containing at least
+`name` and `description`. Without valid frontmatter the skill is rejected at
+discovery.
+
+- `name` — ≤ 64 chars, lowercase letters/numbers and hyphens only, no leading,
+  trailing, or consecutive hyphens, and it **should match the directory name**.
+- `description` — ≤ 1024 chars. State **what the skill does AND when to use it**,
+  with concrete keywords — this is what the agent matches on to decide whether to
+  activate the skill, so a vague description means it never fires.
+  - Good: `Extracts text and tables from PDF files, fills PDF forms, merges PDFs. Use when working with PDF documents or when the user mentions PDFs, forms, or extraction.`
+  - Poor: `Helps with PDFs.`
+
+Optional fields decaf understands include `user-invocable`, `context`,
+`argument-hint`, `required-skills`, and `allowed-tools` (see the tools section).
+
+## Native tools — the `tools.py` contract (decaf-specific)
+
+**This is where decaf differs from the generic Agent Skills standard.** The
+generic standard bundles executable code in a `scripts/` folder that the agent
+runs via the shell. decaf does NOT do that. decaf native tools are structured
+Python in a file named exactly **`tools.py`**:
+
+- The filename is **`tools.py`** — not `main.py` or anything else.
+- Use **absolute** imports only: `from decafclaw.skills.<name>.<module> import ...`.
+  The loader imports `tools.py` without package context, so relative imports
+  fail at runtime.
+- Export a `TOOLS` dict mapping tool name → function, plus a `TOOL_DEFINITIONS`
+  list of OpenAI-style function schemas, and/or a `get_tools(ctx) -> (dict, list)`
+  function for tools that vary by state.
+- **Every tool function takes `ctx` as its first parameter**, even if unused.
+- **`default_api.*` does not exist in decaf.** Do not call it. Tools are plain
+  Python functions registered via `TOOLS` / `get_tools`.
+- decaf's `allowed-tools` frontmatter is a **comma-separated list of decaf tool
+  names** (e.g. `vault_read, vault_write, shell(rg *)`) — NOT the standard's
+  space-separated `Bash(git:*)` syntax.
+
+### Minimal correct skill with tools
+
+`SKILL.md`:
+```
+---
+name: my-skill
+description: Does a specific useful thing. Use when the user asks to do that thing.
+---
+
+# My skill
+
+Explain when and how to use the tool here.
+```
+
+`tools.py`:
+```python
+from decafclaw.media import ToolResult
+
+
+def my_tool(ctx, text: str) -> ToolResult:
+    """Every tool takes ctx first."""
+    return ToolResult(text=f"got: {text}")
+
+
+TOOLS = {"my_tool": my_tool}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "my_tool",
+            "description": "Does the thing. Use when ...",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string", "description": "input"}},
+                "required": ["text"],
+            },
+        },
+    },
+]
+
+
+def get_tools(ctx) -> tuple[dict, list]:
+    """Optional. Return (TOOLS, TOOL_DEFINITIONS), varying by state if needed."""
+    return TOOLS, TOOL_DEFINITIONS
+```
+
+## Keep it lean (progressive disclosure)
+
+The catalog shows only `name` + `description`; the full `SKILL.md` body loads
+only when the skill activates. Keep the body focused (well under ~500 lines).
+For a large skill, put deep reference material in separate files under the skill
+directory and tell the agent to read them on demand with `workspace_read`.
+
+## More detail
+
+See `docs/skills.md` for the full reference — `SkillConfig` for skill config,
+`init()`/`shutdown()` lifecycle, scheduling sidecars, trust tiers, and
+user-invocable commands.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -422,6 +422,22 @@ def test_discover_honors_auto_approve_on_bundled(config):
     )
 
 
+def test_discover_includes_skill_creator(config):
+    """The bundled skill-creator authoring guide is discovered, text-only,
+    and lazy (not always-loaded)."""
+    skills = discover_skills(config)
+    by_name = {s.name: s for s in skills}
+    assert "skill-creator" in by_name, (
+        f"bundled skill-creator not discovered; got {sorted(by_name)}"
+    )
+    sc = by_name["skill-creator"]
+    assert sc.has_native_tools is False, "skill-creator must be text-only (no tools.py)"
+    assert sc.always_loaded is False, "skill-creator must stay lazy (not always-loaded)"
+    assert sc.trust_tier == "bundled"
+    assert sc.description.strip(), "skill-creator needs a non-empty description"
+    assert sc.body.strip(), "skill-creator needs a non-empty body"
+
+
 def test_discover_keeps_auto_approve_on_extra_path_skill(tmp_path, config):
     """Extra-path skills are trusted by user config; auto-approve is honored."""
     extra = tmp_path / "external"


### PR DESCRIPTION
## Summary

Third fix from the `web-lmorchard-fa5ec853` postmortem — the proactive complement to the `refresh_skills` rejection reporting and `skill_validate` lint (#595/#596). In that incident the agent had no authoring contract in context and cargo-culted non-decafclaw patterns (`main.py`, `get_tools()` without `ctx`, `default_api.*`).

Adds a bundled, lazy-loaded, **text-only** `skill-creator` skill whose `SKILL.md` body *is* the authoring contract. The agent activates it (catalog-triggered, or `/skill-creator`) when it intends to author a workspace skill, so the contract is in context at authoring time.

### What the body teaches
- SKILL.md frontmatter rules — with the Agent Skills standard's good/poor **description** example and `name`/`description` constraints (noting `skill_validate` checks presence, not format).
- The **decaf-specific `tools.py` contract**: filename `tools.py` (not `main.py`), absolute imports, `TOOLS`/`get_tools(ctx) -> (dict, list)`, every tool takes `ctx` first, `default_api.*` does not exist.
- A minimal correct template, and the `skill_validate` → `refresh_skills` → `activate_skill` workflow.
- **Where decaf diverges from the generic Agent Skills standard** (decaf uses structured `tools.py`, not a `scripts/` folder of shell code; comma-separated `allowed-tools`) — the framing that guards against the cargo-cult failure.

### Design notes (traced in code)
- **No `allowed-tools` on the skill's own frontmatter** — verified it's inert for inline `activate_skill` (only hard-restricts in `context: fork`); it would not promote the deferred `skill_validate`/`refresh_skills`. The body names those tools instead (deferred catalog → `tool_search`).
- **Directory `skill-creator` matches the `name`** — text-only means no Python-module import, so the skill is self-exemplifying for the "name should match directory" rule it teaches.

## Changes
- `src/decafclaw/skills/skill-creator/SKILL.md` — the skill (new, text-only).
- `tests/test_skills.py` — discovery unit test (text-only, lazy, bundled tier).
- `evals/skill-authoring.yaml` — behavior eval: agent activates a skill on an authoring prompt.
- `docs/skills.md`, `CLAUDE.md` — point to the in-context guide; bundled-skills list.

## Test plan
- `make check` green; full `make test`: **2982 passed**.
- Behavior eval passed on a real LLM — the agent activated `skill-creator` **and ran the full authoring workflow end-to-end** (write SKILL.md → write tools.py → `skill_validate` → `refresh_skills` → activate), proving the guide works.

## Follow-up surfaced (not in scope)
- `skill_validate` could enforce the `name` format / `name == directory` rules (the standard requires them; the loader only checks `name` is present). Possible #596 follow-up.
- **#598** (diagnostic-discipline guardrails) remains the big open cluster item.

Session docs: `docs/dev-sessions/2026-06-26-1806-597-skill-creator/`.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)