### PR TITLE
fix(workflow): auto-resume interrupted status=running journals on startup

### DIFF
--- a/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/notes.md
+++ b/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/notes.md
@@ -1,0 +1,19 @@
+# Notes — Workflow status=running auto-resume (#581)
+
+## Session start — 2026-07-07 15:48
+
+- Branch: `fix/581-workflow-autoresume` (from `origin/main` @ `293b624`)
+- Worktree: `/Users/lorchard/devel/decafclaw/.claude/worktrees/fix-581-workflow-autoresume`
+- Session dir: `docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/`
+- HTTP_PORT: 18896; `TABSTACK_API_KEY` enabled per prior sessions' learnings
+- Baseline: `make test` — 2983 passing in 19.59s
+
+## Origin
+
+Filed as follow-up to #574's smoke (PR #579 Finding 2). If a server crash interrupts a workflow turn mid-LLM, `workflow.json` persists at `status="running"` but nothing re-enqueues it on server restart. The replay machinery itself is correct (unit tests already cover full-cache + mid-fan-out resume against synthetic journals) — the wiring gap is at the harness layer.
+
+This is the LAST remaining follow-up from #574's smoke trio. After this, the workflow surface should be stable:
+- #580 (skill activation from workflows) — closed
+- #582 (parallel/pipeline hang) — closed
+- #613 (/research timeout) — closed
+- #581 (auto-resume on restart) — this session

--- a/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/plan.md
+++ b/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/plan.md
@@ -1,0 +1,186 @@
+# Plan — Auto-resume `status="running"` workflows (#581)
+
+Spec: `spec.md`. Research: `research.md`.
+
+Execution mode: TDD per phase where practical (test-first for behavior changes, straight edits for pure data-model additions). Each phase is a single logical commit and independently reviewable.
+
+## Phase 1 — Journal `attempts` field
+
+**Files:**
+- `src/decafclaw/workflow/journal.py`
+- `tests/test_workflow_journal.py` (extend if exists; create otherwise)
+
+**Changes:**
+1. Add `attempts: int = 0` to `Journal` dataclass (line ~45).
+2. Add `"attempts": self.attempts` to `to_dict()` output.
+3. In `from_dict()`, read via `d.get("attempts", 0)`.
+
+**Tests (write first):**
+- `test_journal_attempts_defaults_to_zero` — construct a `Journal`, assert `attempts == 0`.
+- `test_journal_attempts_round_trip` — set `attempts=2`, `to_dict` → `from_dict`, assert preserved.
+- `test_journal_backward_compatible_missing_attempts` — dict without `attempts` key → loads with `attempts=0`.
+
+**Acceptance:** All three tests pass. `make test` clean.
+
+## Phase 2 — `WorkflowConfig.max_resume_attempts`
+
+**Files:**
+- `src/decafclaw/config_types.py` — new `WorkflowConfig` dataclass.
+- `src/decafclaw/config.py` — import + wire into top-level `Config`.
+- `tests/test_config.py` (or wherever existing dataclass tests live).
+
+**Changes:**
+1. In `config_types.py`, add:
+   ```python
+   @dataclass
+   class WorkflowConfig:
+       max_resume_attempts: int = 3
+   ```
+2. In `config.py`:
+   - Import `WorkflowConfig`.
+   - Add `workflow: WorkflowConfig = field(default_factory=WorkflowConfig)` on `Config`.
+   - Add `workflow = load_sub_config(WorkflowConfig, file_data.get("workflow", {}), "WORKFLOW")` and pass to `Config(...)`.
+   - Verify env override: `WORKFLOW_MAX_RESUME_ATTEMPTS=5` → `config.workflow.max_resume_attempts == 5`.
+
+**Tests (write first):**
+- `test_workflow_config_defaults` — default is 3.
+- `test_workflow_config_env_override` — set env, load config, verify.
+- `test_workflow_config_json_override` — file `{"workflow": {"max_resume_attempts": 7}}`, verify.
+
+**Acceptance:** All three tests pass. `make config` shows the new section. No regressions in `make test`.
+
+## Phase 3 — `startup_scan_workflows` on `ConversationManager`
+
+**Files:**
+- `src/decafclaw/conversation_manager.py` — new method next to `startup_scan()`.
+- `src/decafclaw/runner.py` — call the new method after existing `startup_scan()`.
+- `tests/test_conversation_manager.py` — unit tests mirroring the existing scan tests.
+
+**Method skeleton:**
+```python
+async def startup_scan_workflows(self) -> int:
+    """Recover workflows in status='running' by re-enqueueing them.
+
+    Returns the number of workflows re-enqueued (not counting cap-exceeded).
+    """
+    from decafclaw.workflow.journal import load_journal, save_journal
+    from decafclaw.workflow.paths import workflow_path
+
+    resumed = 0
+    for conv_id, _archive in iter_conversation_archives(self.config):
+        path = workflow_path(self.config, conv_id)
+        if not path.exists():
+            continue
+        try:
+            journal = load_journal(path)
+        except Exception as exc:
+            log.warning("Failed to load workflow journal at %s: %s", path, exc)
+            continue
+
+        if journal.status != "running":
+            continue
+
+        cap = self.config.workflow.max_resume_attempts
+        if journal.attempts >= cap:
+            log.warning(
+                "Workflow %r in %s exceeded resume attempts (%d), marked as error.",
+                journal.workflow_name, conv_id, cap)
+            journal.status = "error"
+            save_journal(path, journal)
+            continue
+
+        journal.attempts += 1
+        save_journal(path, journal)
+
+        log.info(
+            "Resuming workflow %r in %s (attempt %d/%d)",
+            journal.workflow_name, conv_id, journal.attempts, cap)
+
+        await self.enqueue_turn(
+            conv_id,
+            kind=TurnKind.WORKFLOW,
+            prompt="",
+            metadata={"workflow_name": journal.workflow_name, "resume": True},
+        )
+        resumed += 1
+
+    return resumed
+```
+
+**Wire into runner:**
+```python
+# runner.py line ~59
+await manager.startup_scan()
+await manager.startup_scan_workflows()
+```
+
+**Tests (write first):**
+- `test_startup_scan_workflows_resumes_running` — write journal `status="running"`, `attempts=0`; call scan; assert (a) `attempts=1` persisted on disk, (b) `enqueue_turn` called once with matching metadata.
+- `test_startup_scan_workflows_skips_non_running` — arrange three journals (`done`, `error`, `suspended`); assert zero enqueues.
+- `test_startup_scan_workflows_hits_attempt_cap` — journal at `attempts=3` (cap default); assert `status="error"` on disk, no enqueue.
+- `test_startup_scan_workflows_increments_before_enqueue` — patch `enqueue_turn` to raise; verify persisted `attempts` still reflects increment (so a crash inside enqueue still consumes an attempt).
+- `test_startup_scan_workflows_empty` — no conversations dir; scan returns 0.
+- `test_startup_scan_workflows_missing_journal_file` — conv dir exists but no `workflow.json`; skip silently.
+- `test_startup_scan_workflows_corrupt_journal` — write malformed JSON; scan logs warning, continues to next conv.
+- `test_startup_scan_workflows_multiple_conversations` — mix of resumable + non-resumable across conv dirs; assert only the running ones get enqueued.
+
+**Fixture pattern:** copy the arrangement from `test_startup_scan_finds_pending_confirmation` (`test_conversation_manager.py:869-889`). Use the `manager` fixture; write journal files via `save_journal(workflow_path(config, conv_id), journal)`.
+
+**Enqueue mock:** patch `manager.enqueue_turn` with an `AsyncMock` or a lightweight recorder — asserting the call was made, not that the turn actually ran (that's Phase 4's job).
+
+**Acceptance:** all eight tests pass. `make check` clean. `make test` shows no regressions.
+
+## Phase 4 — E2E integration test
+
+**File:** `tests/test_workflow_turn_integration.py` (extend).
+
+**New test:** `test_startup_scan_resumes_running_workflow_end_to_end`
+- Arrange: use the same setup as `test_durable_resume_after_simulated_restart` (108-173).
+- Suspend a workflow mid-fan-out via existing helpers.
+- Manually flip journal `status` from `"suspended"` back to `"running"` (simulating a crash mid-`_persist`).
+- Discard the old manager, construct a new one against the same config (simulating restart).
+- Call `startup_scan_workflows()` on the fresh manager.
+- Await the returned turn's completion signal (through the existing test infra).
+- Assert: workflow reaches `status="done"`, no double-execution of cached primitives (checked via the same call-count assertions the existing test uses).
+
+**Acceptance:** test passes. Existing `test_durable_resume_after_simulated_restart` still passes.
+
+## Phase 5 — Docs
+
+**Files:**
+- `docs/workflows.md` — new section, e.g. under "Durability".
+
+**Content:**
+- What auto-resume does (one paragraph).
+- The attempt cap and why it exists (one paragraph).
+- Config field: `workflow.max_resume_attempts` (default 3), env `WORKFLOW_MAX_RESUME_ATTEMPTS`.
+- Terminal states: `done` (success), `error` (failed, exceeded cap, or non-determinism).
+
+**Acceptance:** doc renders, links check out. No code changes.
+
+## Verification commands
+
+Between phases:
+- `make lint` — compile-check
+- `make check` — lint + typecheck (Python + JS + message types)
+- `make test` — full pytest run
+
+Before opening PR:
+- `make check && make test` clean
+- Check `pytest --durations=25` for any new slow tests (should not appear — all tests should be fixture-based)
+- Manual smoke: no evals needed (this is a startup-time recovery mechanism, not LLM-visible)
+
+## Not doing (deferred / non-goals)
+
+- Client-side "resume workflow" command — separate issue if we want it.
+- Attempt-counter reset on `suspended` transitions — see spec §"Attempt counter reset".
+- Cross-machine coordination — single-instance deployment.
+- Migration for existing on-disk journals — backward-compatible via `d.get("attempts", 0)`.
+
+## Risk register
+
+- **Replay-storm** — bounded by attempt cap.
+- **Broken journal blocks startup** — mitigated by fail-open (log + continue).
+- **Attempt cap too aggressive** — default 3 is conservative; config field lets users tune.
+- **Attempt cap too permissive** — user can set `max_resume_attempts=0` to effectively disable auto-resume.
+- **Race with a live transport enqueue** — impossible; scan runs before transports connect (verified in research §1).

--- a/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/research.md
+++ b/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/research.md
@@ -1,0 +1,56 @@
+# Research — Workflow status=running auto-resume (#581)
+
+Dispatched a documentarian subagent. Findings verbatim, condensed to load-bearing points.
+
+## 1. Existing startup scan (confirmations)
+
+- **Method:** `ConversationManager.startup_scan()` at `conversation_manager.py:1794-1830`.
+- **Iteration:** `iter_conversation_archives(self.config)` from `conversation_paths.py:24` walks per-conversation archive JSONL files.
+- **Per-archive helper:** `_scan_archive_for_pending()` at `conversation_manager.py:1832-1893`. Reads only the last 64 KB of each archive; reverse-scans for a `confirmation_request` without a matching `confirmation_response`; drops stale (>24 h) entries.
+- **Recovery dispatch:** does NOT call `enqueue_turn`. Installs the recovered request directly into `state.pending_confirmation` with `state.confirmation_event = None`. The `None`-event branch routes through `_dispatch_recovery()` when the user later approves.
+- **Startup order:** called from `runner.py:59`, after `ConversationManager` construction, before any transport connects (HTTP line 64, Mattermost line 82).
+
+**Implication:** Sibling scan for `status="running"` journals. Unlike the confirmation scan, this one re-enqueues immediately (no user in the loop) — via `enqueue_turn(kind=TurnKind.WORKFLOW, metadata={"workflow_name": ..., "resume": True})`.
+
+## 2. Journal structure
+
+- **File:** `workflow/journal.py:42-48`. Dataclass fields: `workflow_name: str`, `status: str = "running"`, `entries: dict[tuple[int, ...], JournalEntry]`.
+- **Serialization:** `to_dict()` at 62-76 (hand-rolled), `from_dict()` at 78-89 (`d.get(k, default)` — forgiving of missing keys).
+- **Status write sites** (all four):
+  - `"running"`: `resume.py:45` (new journal), `resume.py:118` (on user-input approve).
+  - `"suspended"`: `engine.py:43`.
+  - `"error"`: `engine.py:46-51`, `resume.py:56` (skill activation failure).
+  - `"done"`: `engine.py:54`.
+- **Adding `attempts: int = 0`:** field on dataclass, one line in `to_dict`, `from_dict` gets it via `d.get("attempts", 0)`. No migration; existing on-disk journals load with default.
+
+## 3. `tool_status` publish flow
+
+- **Existing publish:** `workflow/resume.py:62-63` and `67-68`: `await ctx.publish("tool_status", tool="workflow", message=f"[workflow: {workflow_name}] running")`.
+- **`ctx.publish`:** `context.py:191-201`. Auto-fills `context_id` and `tool_call_id`. Fans out via `EventBus.publish` (`events.py:27-36`), exception-safe.
+- **WebSocket relay:** `web/websocket.py:512-591`. `_subscribe_to_conv` installs an `on_conv_event` callback via `manager.subscribe(conv_id, on_conv_event)` (line 734). Lines 585-591 route `tool_status` → `{"type": WSMessageType.TOOL_STATUS, "conv_id", "tool", "message", "tool_call_id"}`.
+
+**Timing wrinkle:** startup scan runs before transports connect, so a scan-level publish would fan out to zero subscribers. The workflow's own subsequent publishes (once the resumed turn runs) will reach live clients when they subscribe. Cleanest UX: publish `[workflow: X] resuming after restart` from the resumed worker task (via `run_workflow_turn`'s existing path), not from the scan itself.
+
+## 4. `enqueue_turn` API contract
+
+- **Signature:** `conversation_manager.py:412-427`: `enqueue_turn(conv_id, *, kind, prompt, history=None, task_mode=None, context_setup=None, user_id="", archive_text="", attachments=None, command_ctx=None, wiki_page=None, metadata=None) -> asyncio.Future`.
+- **WORKFLOW dispatch:** `conversation_manager.py:1507-1513`: reads `metadata.get("workflow_name", "")` + `metadata.get("resume", False)`, calls `run_workflow_turn(ctx, self, workflow_name=..., resume=...)`.
+- **Busy flag / lock:** `state.lock` at `enqueue_turn:440`. If `state.busy`, queues into `state.pending_messages`. `_start_turn` sets `busy=True` (1366); reset in finally (1597-1612).
+- **Startup timing:** transports not yet connected → `busy` always `False` at scan time. Concurrent turns from different conversations run fine.
+
+## 5. Test patterns to mirror
+
+- `tests/test_conversation_manager.py:866-935` — four confirmation-recovery-scan tests.
+- Fixture pattern: `manager` fixture from conftest + `append_message(manager.config, conv_id, msg_dict)` for arranging state.
+- Sibling tests to model after:
+  - `test_startup_scan_finds_pending_confirmation` (869-889): arrange archive → call scan → assert count + state.
+  - `test_startup_scan_empty_archive` (932-935): baseline zero.
+- E2E to mirror: `test_workflow_turn_integration.py:test_durable_resume_after_simulated_restart` (108-173): suspend workflow → reload journal from disk → simulate recovery → assert completion.
+
+## Key patterns for the new feature
+
+1. Sibling method `startup_scan_workflows()` on `ConversationManager` — called from `runner.py` right after `startup_scan()`, or extend `startup_scan()` with a second pass.
+2. Iterate conversation dirs (per-conv layout post-#576: `conversations/{conv_id}/workflow.json`), load each journal, filter `status="running"` with `attempts < N`, increment `attempts`, persist, `enqueue_turn(kind=WORKFLOW, metadata={workflow_name, resume: True})`.
+3. `Journal` gains `attempts: int = 0` — dataclass + `to_dict`/`from_dict`.
+4. When `attempts >= N`, mark `status="error"` and skip. Emit a log line (no live subscriber to receive `tool_status` at scan time).
+5. Resume "ping" `tool_status` fires from the worker task itself once transports are up (existing publish in `resume.py:62-63` already runs on every resumed turn — probably sufficient without additions).

--- a/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/spec.md
+++ b/docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/spec.md
@@ -1,0 +1,136 @@
+# Spec — Auto-resume `status="running"` workflow journals on server restart (#581)
+
+<!-- dev-session:spec -->
+
+## Context
+
+If a server crash (SIGINT, OOM, deploy) interrupts a workflow turn mid-LLM, the journal persists at `status="running"` — but on server restart, nothing scans for in-flight workflows and re-enqueues them. The workflow stays stuck until a user action triggers it.
+
+Surfaced during the live smoke for #574 ([PR #579](https://github.com/lmorchard/decafclaw/pull/579), Finding 2). The replay machinery itself is correct — unit tests in `tests/test_workflow_parallel.py` and `tests/test_workflow_pipeline.py` cover full-cache + mid-fan-out resume against synthetic journals. The gap is the wiring at the harness layer: **nothing re-enters the engine when the server comes back up**.
+
+Contrast with `status="suspended"` (waiting on a user_input confirmation): those recover via the existing confirmation-recovery scan in `ConversationManager.startup_scan()`. A user-approve-later triggers `WorkflowUserInputHandler.on_approve`, which re-enqueues. `status="running"` has no equivalent trigger.
+
+## Goal
+
+On server startup, scan each conversation for a `workflow.json` at `status="running"` and re-enqueue that conversation's workflow turn. The replay engine short-circuits cached entries, so the resumed turn picks up exactly where the crash left off.
+
+Bound the risk of replay-storms with a per-journal attempt counter — a workflow that crashes deterministically on the same replay position gets marked `status="error"` after N attempts and stops retrying.
+
+## Non-goals
+
+- Client-side "resume workflow" command (nice-to-have; not blocking).
+- Recovering `status="error"` journals (correctly excluded — errors include `WorkflowNonDeterministic` and are terminal).
+- Cross-machine coordination or a shared restart lock (single-instance deployment).
+- Change to how `WorkflowSuspended` is handled (already correct — that's the "waiting on user" path).
+
+## Design
+
+### Startup flow
+
+`ConversationManager` gains a sibling method `startup_scan_workflows()`, called from `runner.py:59` right after the existing `startup_scan()`.
+
+```python
+# runner.py, alongside existing startup_scan
+await manager.startup_scan()          # recovers status="suspended" confirmations
+await manager.startup_scan_workflows()  # recovers status="running" workflows
+```
+
+Splitting to a separate method (rather than folding into `startup_scan`) keeps the two recovery surfaces independently testable and independently observable via log messages.
+
+### Scan behavior
+
+For each conversation directory:
+
+1. `workflow_path(config, conv_id)` — if not exists, skip.
+2. Load journal via `load_journal(path)`. If load fails, log warning and skip (fail-open).
+3. If `journal.status != "running"`, skip.
+4. If `journal.attempts >= config.workflow.max_resume_attempts` (default 3):
+   - Set `journal.status = "error"`.
+   - Persist.
+   - Log warning: "Workflow {name} in {conv_id} exceeded resume attempts, marked as error."
+   - Skip.
+5. Increment `journal.attempts`, persist journal.
+6. `enqueue_turn(conv_id, kind=TurnKind.WORKFLOW, prompt="", metadata={"workflow_name": journal.workflow_name, "resume": True})`.
+
+The attempt increment happens **before** enqueue and is persisted immediately — so a crash inside the resumed turn still consumes an attempt. This is the correct behavior: a workflow that crashes the server every time it replays position `(3, 2, 0)` needs to eventually stop.
+
+### Attempt counter reset
+
+Successful completion (`status="done"`) leaves `attempts` untouched — the field is only relevant while status is "running". If a workflow eventually completes, the field is dead weight but harmless.
+
+If a user-input suspension resets the counter: **no**. A workflow that alternates `running → suspended → running → suspended` and crashes at each `running` phase is still crashing repeatedly and should hit the cap. Only a full `done` should reset (and by then the journal is terminal).
+
+Deferred: complete reset on `done` — not needed for v1 since done journals are terminal.
+
+### Journal changes
+
+- New field on `Journal` dataclass in `workflow/journal.py`: `attempts: int = 0`.
+- `to_dict()` gains `"attempts": self.attempts`.
+- `from_dict()` uses `d.get("attempts", 0)` — existing on-disk journals load with `attempts=0`, no migration.
+
+### Config
+
+- New field on `WorkflowConfig` dataclass in `config_types.py`: `max_resume_attempts: int = 3`.
+- Env override: `WORKFLOW_MAX_RESUME_ATTEMPTS`.
+
+### UX signal
+
+The workflow engine already publishes `[workflow: {name}] running` via `ctx.publish("tool_status", ...)` on every resumed turn (`resume.py:62-63`). Once transports reconnect, that publish reaches the client subscriber and the resumed workflow becomes visible.
+
+No new publish sites needed. The scan itself logs but does not publish (transports not yet up at scan time — no live subscribers).
+
+### Error path (attempt cap reached)
+
+When `attempts >= max_resume_attempts`, the journal is marked `status="error"` at scan time. This is symmetric with how the engine marks `status="error"` on `WorkflowSuspended`/exception (`engine.py:46-51`) — the terminal-state guarantee holds.
+
+The user's next interaction with that conversation will see:
+- No workflow in flight (`status="error"` excludes it from resume).
+- The `/workflow-name` command can start a new one.
+
+## Alternatives considered
+
+- **Retry-in-memory only (no journal field).** Track attempts in a `dict[conv_id, int]` on the manager, reset each restart. Simpler, but doesn't survive successive restarts — a workflow that crashes on the same position every startup would re-attempt forever. Journal-persisted attempt counter is only ~3 lines more code for actual safety.
+- **Time-based cooldown instead of attempt cap.** "Skip if attempted within X seconds." Handles rapid-restart edge cases but doesn't bound total attempts and adds a clock dependency. Attempt cap is cleaner.
+- **Fold into `startup_scan` as a second pass.** Considered; keeping separate makes tests and logs cleaner. Two distinct concerns: confirmations vs workflows.
+
+## Testing
+
+Unit tests in `tests/test_workflow_resume.py` (extending the existing file if it makes sense, otherwise new file):
+
+1. **`test_startup_scan_workflows_resumes_running`** — write a journal with `status="running"`, `attempts=0` to a fresh conv dir; call `startup_scan_workflows()`; assert `attempts=1` persisted and `enqueue_turn` was called with `kind=TurnKind.WORKFLOW`, `metadata={"workflow_name": ..., "resume": True}`.
+
+2. **`test_startup_scan_workflows_skips_non_running`** — write journals with `status="done"`, `"error"`, `"suspended"`; call scan; assert no enqueues.
+
+3. **`test_startup_scan_workflows_hits_attempt_cap`** — write a journal with `attempts >= max_resume_attempts`; call scan; assert journal is marked `status="error"`, persisted, and NO enqueue fires.
+
+4. **`test_startup_scan_workflows_increments_and_persists_before_enqueue`** — verify order: journal on disk has `attempts=N+1` even if enqueue fires (regression guard so a subsequent crash sees the incremented value).
+
+5. **`test_startup_scan_workflows_empty`** — no conversations; scan returns 0.
+
+6. **`test_startup_scan_workflows_missing_journal_file`** — conversation dir exists but no `workflow.json`; scan skips silently.
+
+7. **`test_startup_scan_workflows_corrupt_journal`** — write a malformed `workflow.json`; scan logs warning and skips (fail-open).
+
+8. **`test_journal_backward_compatible`** (in `test_workflow_journal.py`) — load a journal dict without `attempts` field; assert loads with `attempts=0`.
+
+E2E: extend `test_workflow_turn_integration.py:test_durable_resume_after_simulated_restart` (or add a sibling) to exercise the scan path end-to-end: suspend workflow mid-fan-out → simulate restart → call `startup_scan_workflows()` → assert workflow completes.
+
+## Docs to update
+
+- `docs/workflows.md` — new section under "Durability" covering the auto-resume flow, attempt cap, and config field.
+- CLAUDE.md — no changes (convention unchanged).
+
+## Rollout / risk
+
+- Feature is on by default with `max_resume_attempts=3`. Config field lets users tune or effectively disable via `max_resume_attempts=0`.
+- Fail-open behavior throughout: any error in the scan logs and continues — a broken journal in one conversation can't block startup.
+- Existing `status="suspended"` recovery path unchanged.
+
+## References
+
+- Smoke transcript: `docs/dev-sessions/2026-06-10-1732-574-workflow-batch-primitives/smoke.md` (Finding 2)
+- Replay engine: `src/decafclaw/workflow/engine.py`, `src/decafclaw/workflow/resume.py`
+- Existing scan: `src/decafclaw/conversation_manager.py:1794-1830` (`startup_scan`)
+- Journal: `src/decafclaw/workflow/journal.py`
+- Paths: `src/decafclaw/workflow/paths.py`, `src/decafclaw/conversation_paths.py:59` (`iter_conversation_archives`)
+- PR #573 (engine), PR #579 (primitives), PR #603, #610, #616 (smoke follow-ups)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -468,6 +468,35 @@ the agent loop.
 This is what keeps the LLM off the crank. The confirmation round-trip is purely between the
 user and the harness; the LLM only runs when an orchestrator explicitly calls `wf.llm_call`.
 
+## Auto-resume on startup
+
+If the server crashes or is killed while an orchestrator is mid-execution (i.e. the journal
+`status` is still `"running"` — no pending `user_input` question, just interrupted work),
+`ConversationManager.startup_scan_workflows()` walks each conversation directory, finds every
+`workflow.json` still marked `running`, increments a persistent `attempts` counter, saves,
+and re-enqueues a `TurnKind.WORKFLOW` turn. The replay engine then short-circuits every
+cached primitive from the journal; only the un-journaled work re-runs. Per-conversation
+errors (unreadable or corrupt journal) log a warning and continue — fail-open so one bad row
+doesn't stall startup.
+
+To bound replay-storm risk (a workflow that crashes deterministically on the same primitive
+would otherwise loop forever), the scan caps retries at `config.workflow.max_resume_attempts`
+(default `3`, env override `WORKFLOW_MAX_RESUME_ATTEMPTS`). At the cap, the journal is flipped
+to `status="error"` and skipped. The `attempts` bump is persisted **before** the turn is
+enqueued, so a crash inside the resumed turn still consumes an attempt.
+
+**Terminal states:**
+
+- `done` — orchestrator returned; artifact rendered.
+- `error` — engine caught an exception (LLM/schema failure, `WorkflowNonDeterministic`, user
+  denied a confirmation), or the resume cap was exceeded on startup.
+
+**Cross-reference:** `status="suspended"` (waiting on a `wf.user_input` confirmation) is a
+distinct recovery path — the pending question is a persistent `ConfirmationRequest`, so
+`ConversationManager.startup_scan()` picks it up alongside every other pending confirmation.
+The two scans are siblings: `startup_scan()` handles the "waiting on the user" case and
+`startup_scan_workflows()` handles the "was running when we died" case.
+
 ## Invoking a workflow
 
 In the web UI, type `/interview` (or the name of any registered workflow). The WebSocket

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -38,6 +38,7 @@ from .config_types import (
     VaultGuideConfig,
     VaultRetrievalConfig,
     WidgetsConfig,
+    WorkflowConfig,
 )
 from .skills.vault._grants import normalize_folder
 
@@ -181,6 +182,7 @@ class Config:
     notifications: NotificationsConfig = field(default_factory=NotificationsConfig)
     email: EmailConfig = field(default_factory=EmailConfig)
     background: BackgroundConfig = field(default_factory=BackgroundConfig)
+    workflow: WorkflowConfig = field(default_factory=WorkflowConfig)
     widgets: WidgetsConfig = field(default_factory=WidgetsConfig)
 
     # Custom environment variables from config.json "env" section
@@ -461,6 +463,9 @@ def load_config() -> Config:
     background = load_sub_config(
         BackgroundConfig, file_data.get("background", {}), "BACKGROUND")
 
+    workflow = load_sub_config(
+        WorkflowConfig, file_data.get("workflow", {}), "WORKFLOW")
+
     # Build the doubly-nested widgets.map leaf explicitly so its systematic
     # env vars (WIDGETS_MAP_*) resolve. load_sub_config only recurses into a
     # nested dataclass field when that key is present in JSON, so a bare
@@ -547,6 +552,7 @@ def load_config() -> Config:
         notifications=notifications,
         email=email,
         background=background,
+        workflow=workflow,
         widgets=widgets,
         env=env_vars,
         system_prompt=system_prompt,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -394,6 +394,18 @@ class BackgroundConfig:
     default_completion_tail_lines: int = 50
 
 
+@dataclass
+class WorkflowConfig:
+    """Configuration for the durable workflow engine (#581).
+
+    ``max_resume_attempts`` caps how many times auto-resume will retry a
+    suspended workflow before the journal is marked errored. Each attempt
+    increments ``Journal.attempts``; on the (max+1)th failure the journal
+    transitions to an error state instead of being retried again.
+    """
+    max_resume_attempts: int = 3
+
+
 def is_secret(dc_class: type, field_name: str) -> bool:
     """Check if a dataclass field is marked as secret."""
     for f in dc_fields(dc_class):

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -398,10 +398,11 @@ class BackgroundConfig:
 class WorkflowConfig:
     """Configuration for the durable workflow engine (#581).
 
-    ``max_resume_attempts`` caps how many times auto-resume will retry a
-    suspended workflow before the journal is marked errored. Each attempt
-    increments ``Journal.attempts``; on the (max+1)th failure the journal
-    transitions to an error state instead of being retried again.
+    ``max_resume_attempts`` caps how many times the startup scan will
+    auto-resume a workflow left at ``status="running"`` after a server
+    crash. Each resume increments ``Journal.attempts``; once the counter
+    reaches ``max_resume_attempts``, the scan flips ``status="error"``
+    instead of retrying (bounds replay-storm risk).
     """
     max_resume_attempts: int = 3
 

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -1884,15 +1884,24 @@ class ConversationManager:
                 "Resuming workflow %r in %s (attempt %d/%d)",
                 journal.workflow_name, conv_id, journal.attempts, cap)
 
-            await self.enqueue_turn(
-                conv_id,
-                kind=TurnKind.WORKFLOW,
-                prompt="",
-                metadata={
-                    "workflow_name": journal.workflow_name,
-                    "resume": True,
-                },
-            )
+            try:
+                await self.enqueue_turn(
+                    conv_id,
+                    kind=TurnKind.WORKFLOW,
+                    prompt="",
+                    metadata={
+                        "workflow_name": journal.workflow_name,
+                        "resume": True,
+                    },
+                )
+            except Exception as exc:
+                # Fail-open per conversation: attempts already incremented on
+                # disk, so the crash-safety guarantee still holds. Skip to the
+                # next conversation rather than block startup.
+                log.warning(
+                    "Failed to enqueue workflow resume for %s: %s",
+                    conv_id, exc)
+                continue
             resumed += 1
 
         if resumed:

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -23,6 +23,8 @@ from .confirmations import (
 )
 from .conversation_paths import iter_conversation_archives
 from .heartbeat import is_background_wake_ok
+from .workflow.journal import load_journal, save_journal
+from .workflow.paths import workflow_path
 
 log = logging.getLogger(__name__)
 
@@ -1828,6 +1830,74 @@ class ConversationManager:
             log.info("Startup scan: recovered %d pending confirmation(s)",
                      recovered)
         return recovered
+
+    async def startup_scan_workflows(self) -> int:
+        """Recover workflows in status='running' by re-enqueueing them (#581).
+
+        Called on server startup after ``startup_scan()``. Walks each
+        conversation directory; for every ``workflow.json`` still marked
+        ``running``, bumps the persistent ``attempts`` counter and re-enqueues
+        a ``TurnKind.WORKFLOW`` turn so the durable replay engine can pick up
+        where it left off. If a run exceeds ``config.workflow.max_resume_attempts``
+        the journal is flipped to ``status='error'`` and left alone — the cap
+        bounds a crash loop from replaying forever.
+
+        Per-conversation errors (unreadable / corrupt journal) log a warning
+        and continue; fail-open on the loop itself keeps one bad row from
+        stalling startup. The persisted ``attempts`` increment happens before
+        ``enqueue_turn`` so a crash inside the turn still consumes an attempt.
+
+        Returns the number of workflows re-enqueued (not counting those that
+        hit the cap).
+        """
+        resumed = 0
+        cap = self.config.workflow.max_resume_attempts
+        for conv_id, _archive in iter_conversation_archives(self.config):
+            path = workflow_path(self.config, conv_id)
+            if not path.exists():
+                continue
+            try:
+                journal = load_journal(self.config, conv_id)
+            except Exception as exc:
+                log.warning(
+                    "Failed to load workflow journal for %s: %s", conv_id, exc)
+                continue
+            if journal is None:
+                continue
+
+            if journal.status != "running":
+                continue
+
+            if journal.attempts >= cap:
+                log.warning(
+                    "Workflow %r in %s exceeded resume attempts (%d), "
+                    "marked as error.",
+                    journal.workflow_name, conv_id, cap)
+                journal.status = "error"
+                save_journal(self.config, conv_id, journal)
+                continue
+
+            journal.attempts += 1
+            save_journal(self.config, conv_id, journal)
+
+            log.info(
+                "Resuming workflow %r in %s (attempt %d/%d)",
+                journal.workflow_name, conv_id, journal.attempts, cap)
+
+            await self.enqueue_turn(
+                conv_id,
+                kind=TurnKind.WORKFLOW,
+                prompt="",
+                metadata={
+                    "workflow_name": journal.workflow_name,
+                    "resume": True,
+                },
+            )
+            resumed += 1
+
+        if resumed:
+            log.info("Startup scan: resumed %d workflow(s)", resumed)
+        return resumed
 
     def _scan_archive_for_pending(self, archive_path, stale_cutoff: str,
                                   conv_id: str

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -57,6 +57,7 @@ async def run_all(app_ctx):
         manager = ConversationManager(config, app_ctx.event_bus)
         register_widget_handler(manager.confirmation_registry)
         await manager.startup_scan()
+        await manager.startup_scan_workflows()
 
         # Start HTTP server (button callbacks + web gateway)
         if config.http.enabled:

--- a/src/decafclaw/workflow/journal.py
+++ b/src/decafclaw/workflow/journal.py
@@ -43,6 +43,11 @@ class JournalEntry:
 class Journal:
     workflow_name: str
     status: str = "running"  # running | suspended | done | error
+    # Persistent replay-attempt counter. Bumped each time the harness starts
+    # a run; if the workflow keeps crashing at the same replay position, this
+    # bounds the storm — the harness marks status="error" once it exceeds
+    # max_resume_attempts.
+    attempts: int = 0
     entries: dict[tuple[int, ...], JournalEntry] = dataclasses.field(
         default_factory=dict)
 
@@ -68,6 +73,7 @@ class Journal:
         return {
             "workflow_name": self.workflow_name,
             "status": self.status,
+            "attempts": self.attempts,
             "entries": [
                 {"seq": path_to_str(e.seq), "kind": e.kind,
                  "args_fingerprint": e.args_fingerprint, "result": e.result}
@@ -78,7 +84,8 @@ class Journal:
     @classmethod
     def from_dict(cls, d: dict) -> "Journal":
         j = cls(workflow_name=d["workflow_name"],
-                status=d.get("status", "running"))
+                status=d.get("status", "running"),
+                attempts=d.get("attempts", 0))
         for entry_d in d.get("entries", []):
             seq = path_from_any(entry_d["seq"])
             if seq in j.entries:

--- a/src/decafclaw/workflow/journal.py
+++ b/src/decafclaw/workflow/journal.py
@@ -43,10 +43,10 @@ class JournalEntry:
 class Journal:
     workflow_name: str
     status: str = "running"  # running | suspended | done | error
-    # Persistent replay-attempt counter. Bumped each time the harness starts
-    # a run; if the workflow keeps crashing at the same replay position, this
-    # bounds the storm — the harness marks status="error" once it exceeds
-    # max_resume_attempts.
+    # Persistent replay-attempt counter. Bumped by the startup scan each time
+    # it auto-resumes this workflow; if the workflow keeps crashing at the
+    # same replay position, this bounds the storm — the scan flips status to
+    # "error" when attempts reach max_resume_attempts (before the bump).
     attempts: int = 0
     entries: dict[tuple[int, ...], JournalEntry] = dataclasses.field(
         default_factory=dict)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ def _isolate_env(monkeypatch):
             "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
             "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
             "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_", "VAULT_GUIDE_",
+            "WORKFLOW_",
         )):
             monkeypatch.delenv(key, raising=False)
 
@@ -583,3 +584,33 @@ class TestCompatRemoved:
             _ = c.llm_model
         with pytest.raises(AttributeError):
             _ = c.data_home
+
+
+class TestWorkflowConfig:
+    """WorkflowConfig — settings for the durable workflow engine (#581)."""
+
+    def test_workflow_config_defaults(self, tmp_path, monkeypatch):
+        """load_config() with no env / no JSON → default max_resume_attempts."""
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.delenv("WORKFLOW_MAX_RESUME_ATTEMPTS", raising=False)
+        c = load_config()
+        assert c.workflow.max_resume_attempts == 3
+
+    def test_workflow_config_env_override(self, tmp_path, monkeypatch):
+        """WORKFLOW_MAX_RESUME_ATTEMPTS env var overrides the default."""
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.setenv("WORKFLOW_MAX_RESUME_ATTEMPTS", "5")
+        c = load_config()
+        assert c.workflow.max_resume_attempts == 5
+
+    def test_workflow_config_json_override(self, tmp_path, monkeypatch):
+        """config.json workflow.max_resume_attempts overrides the default."""
+        agent_dir = tmp_path / "decafclaw"
+        agent_dir.mkdir()
+        (agent_dir / "config.json").write_text(json.dumps({
+            "workflow": {"max_resume_attempts": 7},
+        }))
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        monkeypatch.delenv("WORKFLOW_MAX_RESUME_ATTEMPTS", raising=False)
+        c = load_config()
+        assert c.workflow.max_resume_attempts == 7

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1012,13 +1012,18 @@ async def test_startup_scan_workflows_hits_attempt_cap(manager):
 
 
 @pytest.mark.asyncio
-async def test_startup_scan_workflows_increments_before_enqueue(manager):
-    """If enqueue_turn raises, the incremented attempts must already be on disk.
+async def test_startup_scan_workflows_increments_before_enqueue(
+        manager, caplog):
+    """If enqueue_turn raises, attempts must already be on disk and the scan
+    must fail-open to the next conversation.
 
-    This is the crash-safety guarantee: an attempt is 'spent' the moment the
-    scan commits to retrying, so a crash inside enqueue_turn cannot leak into
-    an infinite retry loop.
+    This is the crash-safety + fail-open guarantee: an attempt is 'spent' the
+    moment the scan commits to retrying (so a crash inside enqueue_turn cannot
+    leak into an infinite retry loop), and a single conversation's enqueue
+    failure must not block startup for other conversations.
     """
+    import logging
+
     from decafclaw.archive import append_message
     from decafclaw.workflow.journal import Journal, load_journal, save_journal
 
@@ -1031,12 +1036,15 @@ async def test_startup_scan_workflows_increments_before_enqueue(manager):
         raise RuntimeError("enqueue failed")
 
     with patch.object(manager, "enqueue_turn", new=_boom):
-        with pytest.raises(RuntimeError, match="enqueue failed"):
-            await manager.startup_scan_workflows()
+        with caplog.at_level(logging.WARNING):
+            resumed = await manager.startup_scan_workflows()
 
+    assert resumed == 0
     reloaded = load_journal(manager.config, conv_id)
     assert reloaded is not None
     assert reloaded.attempts == 1
+    assert any("Failed to enqueue workflow resume" in rec.message
+               for rec in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -935,6 +935,189 @@ async def test_startup_scan_empty_archive(manager):
     assert recovered == 0
 
 
+# -- Workflow startup recovery -------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_resumes_running(manager):
+    """A workflow in status='running' should be re-enqueued with attempts bumped."""
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import Journal, load_journal, save_journal
+
+    conv_id = "conv-wf-running"
+    # iter_conversation_archives only yields dirs that contain archive.jsonl.
+    append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+    save_journal(manager.config, conv_id,
+                 Journal(workflow_name="interview", status="running"))
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 1
+    mock_eq.assert_awaited_once()
+    _, kwargs = mock_eq.call_args
+    assert kwargs["kind"] is TurnKind.WORKFLOW
+    assert kwargs["metadata"] == {"workflow_name": "interview", "resume": True}
+
+    reloaded = load_journal(manager.config, conv_id)
+    assert reloaded is not None
+    assert reloaded.attempts == 1
+    assert reloaded.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_skips_non_running(manager):
+    """Journals in done/error/suspended are not re-enqueued."""
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import Journal, save_journal
+
+    for conv_id, status in (
+        ("conv-wf-done", "done"),
+        ("conv-wf-error", "error"),
+        ("conv-wf-suspended", "suspended"),
+    ):
+        append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+        save_journal(manager.config, conv_id,
+                     Journal(workflow_name="wf-" + status, status=status))
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 0
+    mock_eq.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_hits_attempt_cap(manager):
+    """A running journal at the cap flips to 'error' and is not re-enqueued."""
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import Journal, load_journal, save_journal
+
+    conv_id = "conv-wf-cap"
+    append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+    # Default cap is 3; attempts=3 means "already tried thrice" → next resume
+    # would exceed the cap.
+    save_journal(manager.config, conv_id,
+                 Journal(workflow_name="stuck", status="running", attempts=3))
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 0
+    mock_eq.assert_not_called()
+
+    reloaded = load_journal(manager.config, conv_id)
+    assert reloaded is not None
+    assert reloaded.status == "error"
+    assert reloaded.attempts == 3
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_increments_before_enqueue(manager):
+    """If enqueue_turn raises, the incremented attempts must already be on disk.
+
+    This is the crash-safety guarantee: an attempt is 'spent' the moment the
+    scan commits to retrying, so a crash inside enqueue_turn cannot leak into
+    an infinite retry loop.
+    """
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import Journal, load_journal, save_journal
+
+    conv_id = "conv-wf-crash"
+    append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+    save_journal(manager.config, conv_id,
+                 Journal(workflow_name="explodes", status="running"))
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("enqueue failed")
+
+    with patch.object(manager, "enqueue_turn", new=_boom):
+        with pytest.raises(RuntimeError, match="enqueue failed"):
+            await manager.startup_scan_workflows()
+
+    reloaded = load_journal(manager.config, conv_id)
+    assert reloaded is not None
+    assert reloaded.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_empty(manager):
+    """No conversations → zero resumes, no enqueues."""
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 0
+    mock_eq.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_missing_journal_file(manager):
+    """A conversation dir without workflow.json is silently skipped."""
+    from decafclaw.archive import append_message
+
+    conv_id = "conv-no-wf"
+    append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 0
+    mock_eq.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_corrupt_journal(manager, caplog):
+    """A malformed workflow.json logs a warning and does not raise."""
+    import logging
+
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.paths import workflow_dir, workflow_path
+
+    conv_id = "conv-wf-corrupt"
+    append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+    workflow_dir(manager.config, conv_id, create=True)
+    workflow_path(manager.config, conv_id).write_text("{not valid json")
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        with caplog.at_level(logging.WARNING, logger="decafclaw.conversation_manager"):
+            resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 0
+    mock_eq.assert_not_called()
+    assert any("workflow" in rec.message.lower() and conv_id in rec.message
+               for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_workflows_multiple_conversations(manager):
+    """Two running + one done → exactly the two running are re-enqueued."""
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import Journal, save_journal
+
+    for conv_id, name, status in (
+        ("conv-a", "flow-a", "running"),
+        ("conv-b", "flow-b", "done"),
+        ("conv-c", "flow-c", "running"),
+    ):
+        append_message(manager.config, conv_id, {"role": "user", "content": "hi"})
+        save_journal(manager.config, conv_id,
+                     Journal(workflow_name=name, status=status))
+
+    with patch.object(manager, "enqueue_turn", new_callable=AsyncMock) as mock_eq:
+        resumed = await manager.startup_scan_workflows()
+
+    assert resumed == 2
+    assert mock_eq.await_count == 2
+
+    seen = {
+        call.kwargs["metadata"]["workflow_name"]
+        for call in mock_eq.await_args_list
+    }
+    assert seen == {"flow-a", "flow-c"}
+    for call in mock_eq.await_args_list:
+        assert call.kwargs["kind"] is TurnKind.WORKFLOW
+        assert call.kwargs["metadata"]["resume"] is True
+
+
 @pytest.mark.asyncio
 async def test_drain_pending_resolves_all_queued_futures(
     manager, config, monkeypatch

--- a/tests/test_workflow_journal.py
+++ b/tests/test_workflow_journal.py
@@ -136,7 +136,7 @@ def test_journal_attempts_defaults_to_zero():
     assert j.attempts == 0
 
 
-def test_journal_attempts_round_trip(tmp_path):
+def test_journal_attempts_round_trip():
     """attempts must survive to_dict / from_dict so the counter persists
     across process restarts (that's the whole point — bounding replay
     storms across crashes)."""

--- a/tests/test_workflow_journal.py
+++ b/tests/test_workflow_journal.py
@@ -129,6 +129,37 @@ def test_load_missing_returns_none(tmp_path):
     assert load_journal(_cfg(tmp_path), "nope") is None
 
 
+def test_journal_attempts_defaults_to_zero():
+    """A freshly-constructed Journal starts with attempts=0 so the
+    auto-resume counter has a well-defined baseline."""
+    j = Journal(workflow_name="t")
+    assert j.attempts == 0
+
+
+def test_journal_attempts_round_trip(tmp_path):
+    """attempts must survive to_dict / from_dict so the counter persists
+    across process restarts (that's the whole point — bounding replay
+    storms across crashes)."""
+    j = Journal(workflow_name="t")
+    j.attempts = 2
+    d = j.to_dict()
+    assert d["attempts"] == 2
+    restored = Journal.from_dict(d)
+    assert restored.attempts == 2
+
+
+def test_journal_backward_compatible_missing_attempts():
+    """Journal files written before this field existed load with
+    attempts=0 rather than raising a KeyError."""
+    d = {
+        "workflow_name": "t",
+        "status": "running",
+        "entries": [],
+    }
+    j = Journal.from_dict(d)
+    assert j.attempts == 0
+
+
 def test_from_dict_rejects_duplicate_seq(tmp_path):
     """A corrupted journal file with two entries that resolve to the same
     tuple-path seq must raise rather than silently overwrite — symmetric

--- a/tests/test_workflow_turn_integration.py
+++ b/tests/test_workflow_turn_integration.py
@@ -1,5 +1,8 @@
 """Integration tests for workflow turn support in ConversationManager."""
 
+import asyncio
+from unittest.mock import patch
+
 import pytest
 
 from decafclaw.confirmations import ConfirmationAction, ConfirmationRequest
@@ -171,3 +174,112 @@ async def test_durable_resume_after_simulated_restart(tmp_path):
     # The replayed topic actually flowed into the LLM prompts (guards against a
     # wrong-replay-value regression that fake_llm would otherwise mask).
     assert any("tide pools" in (c.get("user_msg") or "") for c in live_calls)
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_resumes_running_workflow_end_to_end(make_manager, config):
+    """A workflow left status='running' mid-execution (simulating a crash) is
+    resumed end-to-end by startup_scan_workflows: a fresh manager picks up the
+    journal, replays cached primitives without re-invoking them, runs only the
+    un-journaled primitive live, and drives the workflow to status='done'.
+
+    This is the whole loop that the Phase 3 unit tests stop short of: the
+    unit tests assert the scan enqueued a WORKFLOW turn; this one proves that
+    turn actually replays through the engine and reaches completion.
+    """
+    from decafclaw.archive import append_message
+    from decafclaw.workflow.journal import (
+        Journal,
+        fingerprint,
+        load_journal,
+        save_journal,
+    )
+    from decafclaw.workflow.registry import REGISTRY, workflow
+
+    # Sequential three-stage workflow. Each stage's llm_call has a stable
+    # prompt/system/schema so we can compute the journal fingerprint below.
+    _SCHEMA = {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": ["value"],
+    }
+    _STAGE_PROMPTS = ("stage-1", "stage-2", "stage-3")
+    _STAGE_SYSTEM = "test-e2e-resume"
+    workflow_name = "_test_e2e_resume"
+
+    @workflow(workflow_name)
+    async def _three_stage(wf):
+        r1 = await wf.llm_call(
+            prompt=_STAGE_PROMPTS[0], schema=_SCHEMA, system=_STAGE_SYSTEM)
+        r2 = await wf.llm_call(
+            prompt=_STAGE_PROMPTS[1], schema=_SCHEMA, system=_STAGE_SYSTEM)
+        r3 = await wf.llm_call(
+            prompt=_STAGE_PROMPTS[2], schema=_SCHEMA, system=_STAGE_SYSTEM)
+        return {
+            "title": "combined",
+            "body": f"{r1['value']}|{r2['value']}|{r3['value']}",
+        }
+
+    try:
+        conv_id = "conv-e2e-resume"
+
+        # iter_conversation_archives only yields conv dirs that contain
+        # archive.jsonl — Phase 3 unit tests use the same pattern.
+        append_message(config, conv_id, {"role": "user", "content": "hi"})
+
+        # Arrange a journal that looks like: workflow ran past stages 1 and 2
+        # (both journaled with results), then the process crashed mid-stage-3
+        # before the third llm_call returned. status="running" is the crash
+        # signal that startup_scan_workflows recovers on.
+        def _fp(prompt: str) -> str:
+            return fingerprint("llm_call", {
+                "prompt": prompt, "schema": _SCHEMA, "system": _STAGE_SYSTEM})
+
+        j = Journal(workflow_name=workflow_name, status="running", attempts=0)
+        j.append((0,), "llm_call", _fp(_STAGE_PROMPTS[0]), {"value": "one"})
+        j.append((1,), "llm_call", _fp(_STAGE_PROMPTS[1]), {"value": "two"})
+        save_journal(config, conv_id, j)
+
+        # Fresh manager, simulating a process restart. Patch the default LLM
+        # caller so `wf.llm_call` uses this stub — cached entries hit the
+        # journal and never call it; only the un-journaled stage-3 will.
+        live_calls = []
+
+        async def stub_llm(ctx, **kw):
+            live_calls.append(kw)
+            return {"value": "three"}
+
+        manager = make_manager()
+
+        with patch("decafclaw.workflow.handle._default_llm_call", new=stub_llm):
+            resumed = await manager.startup_scan_workflows()
+            assert resumed == 1
+
+            # startup_scan_workflows internally calls enqueue_turn, which
+            # schedules the WORKFLOW turn as a task on the manager's state.
+            # Grab it and await completion — no sleeps.
+            state = manager._conversations[conv_id]
+            task = state.agent_task
+            assert task is not None
+            await asyncio.wait_for(task, timeout=5.0)
+
+        # (a) Journal reached status="done" on disk.
+        final = load_journal(config, conv_id)
+        assert final is not None
+        assert final.status == "done"
+        # attempts was bumped once by the scan before enqueue.
+        assert final.attempts == 1
+
+        # (b) Cached primitives were NOT re-invoked. Only stage-3 ran live.
+        assert len(live_calls) == 1
+        assert live_calls[0]["user_msg"] == _STAGE_PROMPTS[2]
+
+        # (c) All three stages ended up journaled, with the pre-existing
+        # results preserved verbatim (not overwritten by the resumed run).
+        assert final.get((0,)).result == {"value": "one"}
+        assert final.get((1,)).result == {"value": "two"}
+        assert final.get((2,)).result == {"value": "three"}
+    finally:
+        # Registry is process-global; other tests in the same worker would
+        # trip the "already registered" guard on a re-import.
+        REGISTRY.pop(workflow_name, None)


### PR DESCRIPTION
Closes #581.

## Summary

If a server crash (SIGINT, OOM, deploy) interrupts a workflow turn mid-LLM, the journal persists at `status=\"running\"` — but on restart nothing re-enters the engine. The workflow stays stuck until a user action triggers it. Suspend/resume via user_input already recovered correctly through the confirmation-recovery scan; mid-execution crashes did not.

This adds a sibling scan `ConversationManager.startup_scan_workflows()` that walks each conversation, finds `workflow.json` with `status=\"running\"`, increments a persisted attempt counter, and re-enqueues the workflow turn. The replay engine short-circuits already-cached primitives, so the resumed turn picks up exactly where the crash left off.

- **Attempt cap** — bounded by `config.workflow.max_resume_attempts` (default 3, env `WORKFLOW_MAX_RESUME_ATTEMPTS`). At the cap, the journal is marked `status=\"error\"` and skipped, preventing a deterministically-crashing workflow from replay-storming.
- **Bump-before-enqueue** — the increment is persisted BEFORE `enqueue_turn` runs, so a crash inside the resumed turn still consumes an attempt.
- **Fail-open** — a broken journal in one conversation logs a warning and continues; startup is never blocked by workflow state.

Last of the #574 smoke follow-ups. Companion to #573 (engine), #579 (primitives), #603 / #610 / #616 (other smoke gaps).

## Design (five phases on branch, will squash on merge)

| Commit | Change |
|---|---|
| `e0683a6` + `17959b6` | `Journal.attempts: int = 0` field + round-trip tests |
| `e6227f1` | `WorkflowConfig.max_resume_attempts: int = 3` + env override |
| `2296568` | `startup_scan_workflows()` method + `runner.py` wiring + 8 unit tests |
| `f836775` | E2E integration test proving resume-to-done, no double-execution |
| `06e2ac7` | `docs/workflows.md` — new \"Auto-resume on startup\" section |

Per-phase spec-compliance + code-quality review under subagent-driven-development. Full session notes in `docs/dev-sessions/2026-07-07-1548-581-workflow-autoresume/`.

## Test plan

- [x] `make check` clean (ruff + pyright + tsc + message-types drift)
- [x] `make test` — 2998 passing (+12 vs baseline: 3 journal + 3 config + 8 scan + 1 E2E — minus dedup)
- [x] E2E test in `test_workflow_turn_integration.py` proves resumed workflow reaches `status=\"done\"` without re-invoking cached primitives
- [ ] Manual smoke: start `/research` or `/interview`, `Ctrl-C` mid-turn, `make dev` back up, confirm workflow finishes without user action

## Not doing (deferred)

- Client-side \"resume workflow\" command (nice-to-have; not blocking auto-resume)
- Attempt-counter reset on `suspended → running` transitions (see spec §\"Attempt counter reset\")
- Cross-machine coordination (single-instance deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)