### PR TITLE
fix(context): count background_event tokens + hoist non-cycle imports (#435, #599)

### DIFF
--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -12,11 +12,37 @@ import html
 import json
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from decafclaw.skills.background.tools import format_status_text
 
+from .archive import LLM_ROLES
+from .attachments import resolve_attachments
 from .conversation_paths import sidecar_path
+from .memory_context import (
+    _trim_to_token_budget,
+    format_memory_context,
+    format_memory_headlines,
+    get_already_injected_pages,
+    parse_wiki_references,
+    read_wiki_page,
+    retrieve_memory_context,
+)
+from .notes import format_notes_for_context, read_notes
+from .preempt_search import extract_last_assistant_text, match_tools, tokenize
+from .prompts import wrap_xml
+from .tool_definitions import collect_all_tool_defs
+from .tools import TOOL_DEFINITIONS
+from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
+from .tools.tool_registry import (
+    build_deferred_list_text,
+    classify_tools,
+    estimate_tool_tokens,
+    get_critical_names,
+    get_fetched_tools,
+)
+from .util import estimate_tokens
 
 log = logging.getLogger(__name__)
 
@@ -262,10 +288,6 @@ class ContextComposer:
         Does NOT archive — the caller is responsible for persisting messages
         via the messages_to_archive list.
         """
-        from .archive import LLM_ROLES
-        from .attachments import resolve_attachments
-        from .util import estimate_tokens
-
         config = ctx.config
         sources: list[SourceEntry] = []
         to_archive: list[dict] = []
@@ -507,8 +529,6 @@ class ContextComposer:
         always-loaded skill bodies). Per-conversation activated skill bodies
         are delivered as tool results, not injected into the system prompt.
         """
-        from .util import estimate_tokens
-
         text = config.system_prompt
         tokens = estimate_tokens(text)
         entry = SourceEntry(
@@ -523,8 +543,6 @@ class ContextComposer:
 
         Each candidate gets a composite_score field. Returns sorted descending.
         """
-        from datetime import datetime
-
         relevance = config.relevance
         now = datetime.now()
 
@@ -582,8 +600,6 @@ class ContextComposer:
         ``@[[Page]]`` mentions inject regardless of mode (handled
         separately by ``_compose_vault_references``).
         """
-        from .util import estimate_tokens
-
         skip_modes = {ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT}
         if ctx.skip_vault_retrieval or mode in skip_modes:
             return [], "", [], None
@@ -603,12 +619,6 @@ class ContextComposer:
             return [], "", [], entry
 
         try:
-            from .memory_context import (
-                format_memory_context,
-                format_memory_headlines,
-                retrieve_memory_context,
-            )
-
             results = await retrieve_memory_context(config, user_message)
             if not results:
                 entry = SourceEntry(
@@ -653,7 +663,6 @@ class ContextComposer:
                       total_candidates, budget,
                       "dynamic" if token_budget is not None else "fixed",
                       retrieval_mode)
-            from .memory_context import _trim_to_token_budget
             results = _trim_to_token_budget(results, budget)
             if results:
                 log.debug("Memory context: selected %d/%d candidates (scores %.3f–%.3f)",
@@ -729,17 +738,9 @@ class ContextComposer:
 
         Returns (messages_to_inject, source_entry).
         """
-        from .util import estimate_tokens
-
         skip_modes = {ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT}
         if mode in skip_modes:
             return [], None
-
-        from .memory_context import (
-            get_already_injected_pages,
-            parse_wiki_references,
-            read_wiki_page,
-        )
 
         vault_dir = config.vault_root
         if not vault_dir.exists():
@@ -799,9 +800,6 @@ class ContextComposer:
         Skipped for heartbeat / scheduled / child-agent modes and when
         ``config.vault_guide.enabled`` is False. Returns (wrapped_text, entry).
         """
-        from .prompts import wrap_xml
-        from .util import estimate_tokens
-
         skip_modes = {
             ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT,
         }
@@ -872,15 +870,12 @@ class ContextComposer:
         (heartbeat / scheduled / child agent) and when notes are
         disabled.
         """
-        from .util import estimate_tokens
-
         if not config.notes.enabled:
             return [], None
         skip_modes = {ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT}
         if mode in skip_modes:
             return [], None
 
-        from .notes import format_notes_for_context, read_notes
         conv_id = ctx.conv_id or ctx.channel_id or "default"
         items = read_notes(
             config, conv_id,
@@ -919,14 +914,6 @@ class ContextComposer:
         gating. Currently all composer-driven modes apply matching
         (reflection and compaction bypass the composer entirely).
         """
-        from .preempt_search import (
-            extract_last_assistant_text,
-            match_tools,
-            tokenize,
-        )
-        from .tool_definitions import collect_all_tool_defs
-        from .tools.tool_registry import get_critical_names, get_fetched_tools
-
         _ = mode  # reserved for future per-mode gating
 
         # Reset for this turn. The field lives on ctx.tools (a shared
@@ -992,7 +979,6 @@ class ContextComposer:
         # the promoted tool defs (not a true delta vs. the no-match
         # baseline — a true delta would require a second classification
         # pass, and this approximation is fine for the inspector).
-        from .tools.tool_registry import estimate_tool_tokens
         promoted_defs = [td for td in all_defs
                          if td.get("function", {}).get("name", "") in matched_names]
         tokens_added = estimate_tool_tokens(promoted_defs)
@@ -1024,12 +1010,6 @@ class ContextComposer:
         Returns ``(source_entry, hint_text)``. Both ``None`` if matching
         is disabled, the message tokenizes to nothing, or no skills match.
         """
-        from .preempt_search import (
-            extract_last_assistant_text,
-            tokenize,
-        )
-        from .util import estimate_tokens
-
         _ = mode  # reserved for future per-mode gating
 
         ctx.skills.preempt_matches = set()
@@ -1109,17 +1089,6 @@ class ContextComposer:
         Returns (active_tools, deferred_tools, deferred_text, source_entry).
         Replicates the logic in tool_definitions.build_tool_list() with diagnostics.
         """
-        from .tool_definitions import collect_all_tool_defs
-        from .tools import TOOL_DEFINITIONS
-        from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
-        from .tools.tool_registry import (
-            build_deferred_list_text,
-            classify_tools,
-            estimate_tool_tokens,
-            get_fetched_tools,
-        )
-        from .util import estimate_tokens
-
         all_defs = collect_all_tool_defs(ctx)
         fetched = get_fetched_tools(ctx)
         # Skill tools (from activated skills) should never be deferred
@@ -1197,8 +1166,6 @@ class ContextComposer:
 
     def build_diagnostics(self, config, composed: ComposedContext) -> dict:
         """Build the full diagnostics dict for the context sidecar file."""
-        from datetime import datetime, timezone
-
         candidates = []
         for r in composed.memory_results:
             entry = {

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -373,13 +373,19 @@ class ContextComposer:
         for m in history:
             role = m.get("role")
             if role == "background_event":
-                # Count the expanded content the LLM actually sees, not
-                # the raw archive record (which has no ``content`` field).
+                # Count the expanded content the LLM actually sees (an
+                # assistant tool_call + tool result pair), not the raw
+                # archive record (which has no ``content`` field and is
+                # not the shape sent to the LLM). ``history_msg_count``
+                # feeds the "N messages" status line and must match the
+                # LLM-visible count, so use ``len(expanded)`` — one
+                # archive record contributes two LLM messages here.
+                expanded = _expand_background_event(m)
                 history_tokens += sum(
                     estimate_tokens(str(em.get("content", "")))
-                    for em in _expand_background_event(m)
+                    for em in expanded
                 )
-                history_msg_count += 1
+                history_msg_count += len(expanded)
             elif role in countable_roles:
                 history_tokens += estimate_tokens(str(m.get("content", "")))
                 history_msg_count += 1

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -340,15 +340,27 @@ class ContextComposer:
         # History contains only archived prior-turn content at this point —
         # fresh wiki / notes / memory / user injections are appended after
         # all token accounting, at the end of compose(). Count messages whose
-        # role is sent to the LLM either directly (LLM_ROLES) or after remap
-        # (ROLE_REMAP keys). Other roles (e.g. confirmation_request, archive-only
-        # bookkeeping) are not sent and don't count.
+        # role is sent to the LLM either directly (LLM_ROLES), after remap
+        # (ROLE_REMAP keys), or after expansion (``background_event``, which
+        # ``_expand_background_event`` turns into a synthetic tool-call pair).
+        # Other roles (e.g. confirmation_request, archive-only bookkeeping)
+        # are not sent and don't count.
         countable_roles = LLM_ROLES | ROLE_REMAP.keys()
-        history_tokens = sum(
-            estimate_tokens(str(m.get("content", "")))
-            for m in history
-            if m.get("role") in countable_roles
-        )
+        history_tokens = 0
+        history_msg_count = 0
+        for m in history:
+            role = m.get("role")
+            if role == "background_event":
+                # Count the expanded content the LLM actually sees, not
+                # the raw archive record (which has no ``content`` field).
+                history_tokens += sum(
+                    estimate_tokens(str(em.get("content", "")))
+                    for em in _expand_background_event(m)
+                )
+                history_msg_count += 1
+            elif role in countable_roles:
+                history_tokens += estimate_tokens(str(m.get("content", "")))
+                history_msg_count += 1
         fixed_tokens += history_tokens
         # User message — has its own SourceEntry so the diagnostics
         # waffle chart and [Context: ...] status line account for the
@@ -427,11 +439,8 @@ class ContextComposer:
         llm_history = [resolve_attachments(config, m) for m in llm_history]
 
         # -- History source entry --
-        # history_tokens was computed above (budget side); reuse the same value
-        # so budget and diagnostics are a single source of truth.
-        history_msg_count = sum(
-            1 for m in history if m.get("role") in countable_roles
-        )
+        # history_tokens / history_msg_count were computed above (budget side);
+        # reuse them so budget and diagnostics are a single source of truth.
         history_entry = SourceEntry(
             source="history",
             tokens_estimated=history_tokens,  # computed earlier, single source of truth

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -1214,6 +1214,62 @@ class TestHistoryArchivedRemap:
             f"accounting is drifting."
         )
 
+    @pytest.mark.asyncio
+    async def test_archived_background_event_counted_in_history_entry(
+        self, ctx, config,
+    ):
+        """Regression coverage for #435 — an archived background_event
+        record is expanded into a synthetic assistant tool_call + tool
+        result pair the LLM sees, so history_entry.tokens_estimated
+        must include the expanded content."""
+        composer = ContextComposer()
+        # Use large tails so the expansion has measurable token weight
+        # and the assertion isn't lost in rounding noise.
+        stdout_tail = "expanded stdout " * 50
+        stderr_tail = "expanded stderr " * 50
+        bg_event = {
+            "role": "background_event",
+            "job_id": "job-435",
+            "command": "run something",
+            "status": "completed",
+            "exit_code": 0,
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+            "elapsed_ms": 1234,
+            "completion_tail_lines": 50,
+        }
+        history = [
+            {"role": "user", "content": "start it"},
+            {"role": "assistant", "content": "ok"},
+            bg_event,
+        ]
+
+        with (
+            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.memory_context.retrieve_memory_context",
+                  new_callable=AsyncMock, return_value=[]),
+        ):
+            composed = await composer.compose(
+                ctx, "current user message", history,
+                mode=ComposerMode.INTERACTIVE,
+            )
+
+        history_entries = [s for s in composed.sources if s.source == "history"]
+        assert len(history_entries) == 1
+        history_entry = history_entries[0]
+
+        expanded_msgs = _expand_background_event(bg_event)
+        expanded_tokens = sum(
+            estimate_tokens(str(m.get("content", ""))) for m in expanded_msgs
+        )
+        # The plain user + assistant messages together are much smaller
+        # than the expanded background_event, so any correct accounting
+        # of the expansion has to exceed this floor.
+        assert history_entry.tokens_estimated >= expanded_tokens, (
+            f"history_entry.tokens_estimated={history_entry.tokens_estimated} "
+            f"expected >= expanded background_event tokens {expanded_tokens}"
+        )
+
 
 class TestCancelMarker:
     """The cancel_marker role is archived when a user cancels a turn;

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -186,9 +186,9 @@ class TestComposeMemoryContext:
             {"entry_text": "some memory", "source_type": "page", "similarity": 0.8},
         ]
         with (
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=mock_results),
-            patch("decafclaw.memory_context.format_memory_context",
+            patch("decafclaw.context_composer.format_memory_context",
                   return_value="formatted memory"),
         ):
             composer = ContextComposer()
@@ -205,7 +205,7 @@ class TestComposeMemoryContext:
 
     @pytest.mark.asyncio
     async def test_fail_open_on_error(self, ctx, config):
-        with patch("decafclaw.memory_context.retrieve_memory_context",
+        with patch("decafclaw.context_composer.retrieve_memory_context",
                    new_callable=AsyncMock, side_effect=RuntimeError("boom")):
             composer = ContextComposer()
             msgs, text, raw, entry = await composer._compose_vault_retrieval(
@@ -225,9 +225,9 @@ class TestComposeMemoryContext:
              "file_path": "journal/second.md", "modified_at": "", "importance": 0.5},
         ]
         with (
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=mock_results),
-            patch("decafclaw.memory_context.format_memory_context",
+            patch("decafclaw.context_composer.format_memory_context",
                   return_value="formatted"),
         ):
             composer = ContextComposer()
@@ -244,9 +244,9 @@ class TestComposeMemoryContext:
              "file_path": "pages/first.md", "modified_at": "", "importance": 0.5},
         ]
         with (
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=mock_results),
-            patch("decafclaw.memory_context.format_memory_context",
+            patch("decafclaw.context_composer.format_memory_context",
                   return_value="formatted"),
         ):
             composer = ContextComposer()
@@ -285,7 +285,7 @@ class TestRetrievalModes:
             {"entry_text": "FULL BODY HERE", "source_type": "page",
              "similarity": 0.9, "file_path": "p.md", "modified_at": "", "importance": 0.5},
         ]
-        with patch("decafclaw.memory_context.retrieve_memory_context",
+        with patch("decafclaw.context_composer.retrieve_memory_context",
                    new_callable=AsyncMock, return_value=mock):
             composer = ContextComposer()
             msgs, _, _, entry = await composer._compose_vault_retrieval(
@@ -306,7 +306,7 @@ class TestRetrievalModes:
              "similarity": 0.9, "file_path": "p.md", "modified_at": "",
              "importance": 0.5, "summary": "Concise summary"},
         ]
-        with patch("decafclaw.memory_context.retrieve_memory_context",
+        with patch("decafclaw.context_composer.retrieve_memory_context",
                    new_callable=AsyncMock, return_value=mock):
             composer = ContextComposer()
             msgs, _, _, entry = await composer._compose_vault_retrieval(
@@ -332,7 +332,7 @@ class TestRetrievalModes:
             return []
 
         monkeypatch.setattr(
-            "decafclaw.memory_context.retrieve_memory_context",
+            "decafclaw.context_composer.retrieve_memory_context",
             should_not_be_called,
         )
 
@@ -356,7 +356,7 @@ class TestRetrievalModes:
              "similarity": 0.9, "file_path": "p.md", "modified_at": "",
              "importance": 0.5},
         ]
-        with patch("decafclaw.memory_context.retrieve_memory_context",
+        with patch("decafclaw.context_composer.retrieve_memory_context",
                    new_callable=AsyncMock, return_value=mock):
             composer = ContextComposer()
             msgs, _, _, entry = await composer._compose_vault_retrieval(
@@ -393,9 +393,9 @@ class TestComposeWikiContext:
         vault_dir = tmp_path / "vault"
         vault_dir.mkdir()
         config.vault.vault_path = str(vault_dir)
-        with patch("decafclaw.memory_context.parse_wiki_references",
+        with patch("decafclaw.context_composer.parse_wiki_references",
                    return_value=[{"page": "TestPage", "source": "mention"}]):
-            with patch("decafclaw.memory_context.read_wiki_page",
+            with patch("decafclaw.context_composer.read_wiki_page",
                        return_value="Page content here"):
                 composer = ContextComposer()
                 msgs, entry = composer._compose_vault_references(
@@ -413,7 +413,7 @@ class TestComposeWikiContext:
         vault_dir.mkdir()
         config.vault.vault_path = str(vault_dir)
         history = [{"role": "vault_references", "content": "old", "wiki_page": "TestPage"}]
-        with patch("decafclaw.memory_context.parse_wiki_references",
+        with patch("decafclaw.context_composer.parse_wiki_references",
                    return_value=[{"page": "TestPage", "source": "mention"}]):
             composer = ContextComposer()
             msgs, entry = composer._compose_vault_references(
@@ -564,7 +564,7 @@ class TestComposeTools:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         small_tools = [_make_tool_def("tool_a"), _make_tool_def("tool_b")]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=small_tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=small_tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             assert len(active) == 2
@@ -582,7 +582,7 @@ class TestComposeTools:
         critical_def = _make_tool_def("current_time", "Get current time")
         critical_def["priority"] = "critical"
         many_tools.append(critical_def)
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=many_tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=many_tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             assert len(deferred) > 0
@@ -598,7 +598,7 @@ class TestComposeTools:
         config.compaction.max_tokens = 1000000
         tools = [_make_tool_def("allowed_tool"), _make_tool_def("blocked_tool")]
         ctx.tools.allowed = {"allowed_tool"}
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             active_names = {t["function"]["name"] for t in active}
@@ -613,7 +613,7 @@ class TestComposeTools:
         tools = [_make_tool_def(f"tool_{i}", "x" * 200) for i in range(20)]
         # Simulate a pre-emptive match — tool_7 should survive deferral.
         ctx.tools.preempt_matches = {"tool_7"}
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             active, deferred, text, entry = composer._compose_tools(ctx, config)
             active_names = {t["function"]["name"] for t in active}
@@ -628,7 +628,7 @@ class TestComposePreemptMatches:
         """When pre-emptive search is disabled, no matching happens and no entry is returned."""
         config.agent.preemptive_search.enabled = False
         tools = [_make_tool_def("vault_read", "Read a vault page")]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "read my vault", [], ComposerMode.INTERACTIVE,
@@ -639,7 +639,7 @@ class TestComposePreemptMatches:
     def test_empty_user_message_no_match(self, ctx, config):
         """Empty user message with no prior history yields no matches."""
         tools = [_make_tool_def("vault_read", "vault page")]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "", [], ComposerMode.INTERACTIVE,
@@ -653,7 +653,7 @@ class TestComposePreemptMatches:
             _make_tool_def("vault_backlinks", "List pages linking to a vault page"),
             _make_tool_def("unrelated_tool", "Totally unrelated"),
         ]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show my vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -674,7 +674,7 @@ class TestComposePreemptMatches:
             {"role": "user", "content": "what are the backlinks?"},
             {"role": "assistant", "content": "Here are the vault backlinks for foo."},
         ]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             # User message alone is stopword-only; prior assistant carries the topic.
             entry = composer._compose_preempt_matches(
@@ -687,7 +687,7 @@ class TestComposePreemptMatches:
         """Tools already declared critical don't get re-promoted — they're in already."""
         crit = _make_tool_def("shell", "Run a shell command")
         crit["priority"] = "critical"
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[crit]):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[crit]):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "run a shell command", [], ComposerMode.INTERACTIVE,
@@ -700,7 +700,7 @@ class TestComposePreemptMatches:
         """Already-fetched tools don't get re-promoted."""
         ctx.skills.data = {"fetched_tools": ["vault_backlinks"]}
         tools = [_make_tool_def("vault_backlinks", "vault backlinks")]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show me vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -712,7 +712,7 @@ class TestComposePreemptMatches:
         """max_matches caps the number of promoted tools."""
         config.agent.preemptive_search.max_matches = 3
         tools = [_make_tool_def(f"vault_tool_{i}", "vault operation") for i in range(10)]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "vault operation", [], ComposerMode.INTERACTIVE,
@@ -729,7 +729,7 @@ class TestComposePreemptMatches:
             _make_tool_def("blocked_tool", "Also vault backlinks description"),
         ]
         ctx.tools.allowed = {"vault_backlinks"}
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             entry = composer._compose_preempt_matches(
                 ctx, config, "show vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -742,7 +742,7 @@ class TestComposePreemptMatches:
         """Calling _compose_preempt_matches resets ctx.tools.preempt_matches."""
         ctx.tools.preempt_matches = {"stale_tool"}
         tools = [_make_tool_def("vault_backlinks", "vault backlinks")]
-        with patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=tools):
+        with patch("decafclaw.context_composer.collect_all_tool_defs", return_value=tools):
             composer = ContextComposer()
             composer._compose_preempt_matches(
                 ctx, config, "show vault backlinks", [], ComposerMode.INTERACTIVE,
@@ -961,8 +961,8 @@ class TestCompose:
         config.compaction.max_tokens = 1000000
         small_tools = [_make_tool_def("tool_a")]
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=small_tools),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=small_tools),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -981,8 +981,8 @@ class TestCompose:
         many_tools = [_make_tool_def(f"t_{i}", "x" * 200) for i in range(20)]
         many_tools.append(_make_tool_def("think", "Think"))
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=many_tools),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=many_tools),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1004,8 +1004,8 @@ class TestCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1020,8 +1020,8 @@ class TestCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1038,10 +1038,10 @@ class TestCompose:
             {"entry_text": "memory entry", "source_type": "page", "similarity": 0.8},
         ]
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=mock_results),
-            patch("decafclaw.memory_context.format_memory_context",
+            patch("decafclaw.context_composer.format_memory_context",
                   return_value="formatted memory"),
         ):
             composer = ContextComposer()
@@ -1060,8 +1060,8 @@ class TestComposeVaultGuideIntegration:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1083,8 +1083,8 @@ class TestComposeVaultGuideIntegration:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 1000000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1129,8 +1129,8 @@ class TestHistoryArchivedRemap:
         ]
 
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composed = await composer.compose(
@@ -1175,8 +1175,8 @@ class TestHistoryArchivedRemap:
         ]
 
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composed = await composer.compose(
@@ -1245,8 +1245,8 @@ class TestHistoryArchivedRemap:
         ]
 
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composed = await composer.compose(
@@ -1291,9 +1291,9 @@ class TestCancelMarker:
             },
         ]
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs",
+            patch("decafclaw.context_composer.collect_all_tool_defs",
                   return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1343,9 +1343,9 @@ class TestTurnAbortedMarker:
             },
         ]
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs",
+            patch("decafclaw.context_composer.collect_all_tool_defs",
                   return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1564,8 +1564,8 @@ class TestContextStatusInCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 100000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1584,8 +1584,8 @@ class TestContextStatusInCompose:
         config.agent.tool_context_budget_pct = 1.0
         config.compaction.max_tokens = 100000
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1751,8 +1751,8 @@ class TestComposeExpandsBackgroundEvent:
         ]
 
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()
@@ -1804,8 +1804,8 @@ class TestComposeExpandsBackgroundEvent:
         ]
 
         with (
-            patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-            patch("decafclaw.memory_context.retrieve_memory_context",
+            patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+            patch("decafclaw.context_composer.retrieve_memory_context",
                   new_callable=AsyncMock, return_value=[]),
         ):
             composer = ContextComposer()

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -1269,6 +1269,13 @@ class TestHistoryArchivedRemap:
             f"history_entry.tokens_estimated={history_entry.tokens_estimated} "
             f"expected >= expanded background_event tokens {expanded_tokens}"
         )
+        # ``items_included`` feeds the "N messages" status line and must
+        # count LLM-visible messages after expansion. One user +
+        # one assistant + two expanded (tool_call + tool result) = 4.
+        assert history_entry.items_included == 4, (
+            f"history_entry.items_included={history_entry.items_included} "
+            f"expected 4 (user + assistant + 2 expanded background_event msgs)"
+        )
 
 
 class TestCancelMarker:

--- a/tests/test_orphaned_tool_results.py
+++ b/tests/test_orphaned_tool_results.py
@@ -113,8 +113,8 @@ def _compose(ctx, config, user_message, history):
     config.agent.tool_context_budget_pct = 1.0
     config.compaction.max_tokens = 1000000
     with (
-        patch("decafclaw.tool_definitions.collect_all_tool_defs", return_value=[]),
-        patch("decafclaw.memory_context.retrieve_memory_context",
+        patch("decafclaw.context_composer.collect_all_tool_defs", return_value=[]),
+        patch("decafclaw.context_composer.retrieve_memory_context",
               new_callable=AsyncMock, return_value=[]),
     ):
         composer = ContextComposer()


### PR DESCRIPTION
## Summary

Two independent, focused fixes in `context_composer.py`:

- **#435** — Archived `background_event` records are expanded via `_expand_background_event` into a synthetic assistant tool_call + tool result pair the LLM sees, but the role-allowlist filter behind `history_tokens` / `history_msg_count` (introduced in #434) excluded `background_event` — so diagnostics under-reported by the expansion size on every turn after a background job completed. Fix: consolidate both counters into a single loop over history and, for `background_event`, sum `estimate_tokens` over the same expansion the composer uses when building `llm_history` (option 2 from the issue). Adds a regression test to `TestHistoryArchivedRemap` parallel to the #393 coverage the class already carries.
- **#599** — Removes ~15 function-level imports pervasive across `compose()`, `_compose_system_prompt()`, `_score_candidates()`, `_compose_vault_retrieval()`, `_compose_vault_references()`, `_compose_vault_guide()`, `_compose_notes()`, `_compose_preempt_matches()`, `_compose_preempt_skill_matches()`, `_compose_tools()`, and `build_diagnostics()`. Audited each by hoisting all to module scope and verifying via `python -c "import decafclaw.context_composer"` + full test suite; none are cycle-breakers. Test patches for the affected symbols are retargeted to `decafclaw.context_composer.*` per Python's "patch where used, not where defined" convention.

## Test plan

- [x] `make check` — Python lint + pyright + JS tsc all green
- [x] `make test` — 3001 passed (the sole warning is #605, which is out of scope for this PR)
- [x] New regression test `test_archived_background_event_counted_in_history_entry` fails on `main` and passes with the fix
- [x] Adjacent invariant `test_source_entries_account_for_all_llm_content` still passes after the change

Closes #435
Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)