### PR TITLE
feat(evals): setup.reflection_enabled flag to suppress reflection retries (#534)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ See [docs/eval-loop.md](docs/eval-loop.md). Evals exercise LLM-driven behavior w
 - **New or sharpened tool description → add a `tool_choice` case.** `evals/tool_choice/` covers tool-description disambiguation; `make eval-tools` is fast (~30s). PR #429's smoke test bit-rotted in three weeks because `notes_append` arrived later with no `tool_choice` case guarding the disambiguation — that's the rot vector this convention catches.
 - **Behavior-affecting feature → add a case in `evals/<theme>.yaml`.** New skill, new always-loaded tool, system-prompt change affecting routing, new command. Use `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` for rigorous assertions. Bound every test with `max_tool_calls` and `max_tool_errors`.
 - **Skip evals for non-LLM-visible work.** Pure refactors, storage changes, tool implementation tweaks. Each eval costs tokens and ~6-10 min of wall time.
-- **Avoid `expect_no_tool` where self-reflection might retry.** Reflection's judge can invoke unexpected tools on retries; positive `expect_tool` + tight `max_tool_calls` is more reliable. ([#534](https://github.com/lmorchard/decafclaw/issues/534) tracks a `setup.reflection_enabled: false` harness gate.)
+- **`expect_no_tool` + tight `max_tool_calls` needs `setup.reflection_enabled: false`.** Reflection's judge can invoke unexpected tools on retries and break those assertions. Set `reflection_enabled: false` on tests that assert tool selection (see [docs/eval-loop.md](docs/eval-loop.md) setup-fields table). Positive `expect_tool` alone is fine to run with reflection on.
 - **Check `make eval-history` after running the suite.** Trend deltas catch regressions that single-file smoke tests miss.
 
 ## Key files

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -51,6 +51,7 @@ Tests are YAML files with a list of test cases. Single-turn form:
 | `setup.embeddings_fixture` | Path to a pre-built embeddings.db to copy into the workspace |
 | `setup.auto_confirm` | Default `true`. Auto-approve (or deny) all tool confirmation requests (shell, email, `EndTurnConfirm`, etc.) |
 | `setup.max_tool_iterations` | Override `config.agent.max_tool_iterations` for this test only. Use for tests that need to exercise budget-exhaustion behavior (e.g., the grace turn) without changing the global default |
+| `setup.reflection_enabled` | Override `config.reflection.enabled` for this test only. Default: inherit from config. Set to `false` for tests that assert tool selection with `expect_no_tool` / tight `max_tool_calls` — reflection's judge can trigger retries that invoke unexpected tools and break those assertions. See [#534](https://github.com/lmorchard/decafclaw/issues/534) |
 
 ### Expect assertions
 

--- a/evals/conversation.yaml
+++ b/evals/conversation.yaml
@@ -37,13 +37,13 @@
 # -- Recall from seeded history ----------------------------------------------
 #
 # Validates that setup.conversation_history is reachable by the agent end-to-
-# end. We don't assert tool-selection here — the self-reflection layer may
-# trigger an additional conversation_search retry even when the initial
-# response is correct, and that's an orthogonal behavior (reflection working
-# eagerly, not a bug in seeding).
+# end AND that the agent answers directly from history without reaching for
+# conversation_search. Reflection is disabled per #534 so the judge's retry
+# path can't invoke a spurious conversation_search and break the assertion.
 
 - name: "answers from seeded conversation history"
   setup:
+    reflection_enabled: false
     conversation_history:
       - role: user
         content: "I just got back from a trip to Reykjavik — first time in Iceland."
@@ -56,5 +56,6 @@
   input: "What city did I just visit?"
   expect:
     response_contains: "Reykjavik"
-    max_tool_calls: 5
+    expect_no_tool: conversation_search
+    max_tool_calls: 1
     max_tool_errors: 1

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 
@@ -394,6 +395,32 @@ def _check_assertions(test_case: dict, response: str, tool_calls: int,
     return True, ""
 
 
+def _build_test_config(config: Config, test_case: dict, tmp: str) -> Config:
+    """Apply per-test ``setup`` overrides on top of the base ``config``.
+
+    Keep the list of accepted overrides small — anything that genuinely
+    varies per test opts in here explicitly. Currently:
+
+    - ``setup.max_tool_iterations`` — override ``config.agent.max_tool_iterations``
+      (#448: grace-turn eval needs a small budget to force exhaustion).
+    - ``setup.reflection_enabled`` — override ``config.reflection.enabled``
+      (#534: reflection retries can invoke unexpected tools and break
+      ``expect_no_tool`` / tight ``max_tool_calls`` assertions).
+    """
+    agent_overrides = {"data_home": tmp, "id": "eval"}
+    reflection_overrides: dict = {}
+    setup = test_case.get("setup", {})
+    if "max_tool_iterations" in setup:
+        agent_overrides["max_tool_iterations"] = setup["max_tool_iterations"]
+    if "reflection_enabled" in setup:
+        reflection_overrides["enabled"] = setup["reflection_enabled"]
+    return replace(
+        config,
+        agent=replace(config.agent, **agent_overrides),
+        reflection=replace(config.reflection, **reflection_overrides),
+    )
+
+
 async def run_test(config: Config, test_case: dict) -> dict:
     """Run a single eval test case. Returns a result dict.
 
@@ -594,7 +621,6 @@ async def run_eval(yaml_data: list[dict], config: Config,
     """
     import asyncio
     import tempfile
-    from dataclasses import replace
 
     if model:
         # If model matches a model config, set it as the default
@@ -615,17 +641,7 @@ async def run_eval(yaml_data: list[dict], config: Config,
         nonlocal completed
         async with semaphore:
             with tempfile.TemporaryDirectory() as tmp:
-                # Per-test AgentConfig overrides from `setup`. Keep this list
-                # small — anything that genuinely varies per test should opt
-                # in here. Currently only `max_tool_iterations` (#448 grace
-                # turn eval needs a small budget to force exhaustion).
-                agent_overrides = {"data_home": tmp, "id": "eval"}
-                setup = test_case.get("setup", {})
-                if "max_tool_iterations" in setup:
-                    agent_overrides["max_tool_iterations"] = setup["max_tool_iterations"]
-                test_config = replace(config,
-                    agent=replace(config.agent, **agent_overrides),
-                )
+                test_config = _build_test_config(config, test_case, tmp)
                 result = await run_test(test_config, test_case)
                 completed += 1
                 status = "✓" if result["status"] == "pass" else "✗"

--- a/tests/test_eval_setup_overrides.py
+++ b/tests/test_eval_setup_overrides.py
@@ -1,0 +1,85 @@
+"""Unit coverage for the eval runner's per-test ``setup`` overrides.
+
+These are the fields that let a single eval case tweak a slice of the
+resolved ``Config`` (agent budget, reflection gate, …) without affecting
+the rest of the suite. See ``docs/eval-loop.md`` setup-fields table for
+the accepted keys.
+"""
+
+from decafclaw.config import Config
+from decafclaw.eval.runner import _build_test_config
+
+
+def _tmp(tmp_path):
+    return str(tmp_path)
+
+
+def test_agent_data_home_and_id_are_always_set(tmp_path):
+    """Every test gets an isolated data_home + the sentinel 'eval' agent id
+    regardless of what ``setup`` overrides are present."""
+    cfg = Config()
+    out = _build_test_config(cfg, {"setup": {}}, _tmp(tmp_path))
+    assert out.agent.data_home == _tmp(tmp_path)
+    assert out.agent.id == "eval"
+
+
+def test_reflection_enabled_default_inherits_from_config(tmp_path):
+    """Without an explicit override, config.reflection.enabled is preserved."""
+    cfg = Config()
+    # Ambient default is True; flip both ways and confirm each is preserved.
+    cfg.reflection.enabled = True
+    assert _build_test_config(cfg, {}, _tmp(tmp_path)).reflection.enabled is True
+    cfg.reflection.enabled = False
+    assert _build_test_config(cfg, {}, _tmp(tmp_path)).reflection.enabled is False
+
+
+def test_reflection_enabled_false_overrides_config(tmp_path):
+    """``setup.reflection_enabled: false`` forces reflection off even when
+    the base config has it enabled (the typical case)."""
+    cfg = Config()
+    cfg.reflection.enabled = True
+    out = _build_test_config(
+        cfg, {"setup": {"reflection_enabled": False}}, _tmp(tmp_path),
+    )
+    assert out.reflection.enabled is False
+    # Base config is untouched — we returned a modified copy, not a mutation.
+    assert cfg.reflection.enabled is True
+
+
+def test_reflection_enabled_true_overrides_disabled_config(tmp_path):
+    """The override works both ways — a suite-wide reflection.enabled=False
+    can be opted back into for a specific test."""
+    cfg = Config()
+    cfg.reflection.enabled = False
+    out = _build_test_config(
+        cfg, {"setup": {"reflection_enabled": True}}, _tmp(tmp_path),
+    )
+    assert out.reflection.enabled is True
+
+
+def test_max_tool_iterations_override(tmp_path):
+    """Regression: the existing max_tool_iterations override still applies
+    through the extracted helper (this shape shipped in #448)."""
+    cfg = Config()
+    baseline = cfg.agent.max_tool_iterations
+    out = _build_test_config(
+        cfg, {"setup": {"max_tool_iterations": 3}}, _tmp(tmp_path),
+    )
+    assert out.agent.max_tool_iterations == 3
+    # Absent override → the config default flows through unchanged.
+    unset = _build_test_config(cfg, {}, _tmp(tmp_path))
+    assert unset.agent.max_tool_iterations == baseline
+
+
+def test_overrides_compose_independently(tmp_path):
+    """Setting one override doesn't clobber the other — both nested replaces
+    happen in a single pass on top of the base config."""
+    cfg = Config()
+    cfg.reflection.enabled = True
+    out = _build_test_config(
+        cfg,
+        {"setup": {"reflection_enabled": False, "max_tool_iterations": 2}},
+        _tmp(tmp_path),
+    )
+    assert out.reflection.enabled is False
+    assert out.agent.max_tool_iterations == 2


### PR DESCRIPTION
## Summary

Adds `setup.reflection_enabled` to the per-test eval schema. When set to `false`, the runner forces `config.reflection.enabled = False` for that test only via `dataclasses.replace` on `config.reflection`, so reflection's judge can't invoke unexpected tools on retries and break assertions like `expect_no_tool` / tight `max_tool_calls`. Default: inherit from config, so existing tests are unchanged.

Extracted `_build_test_config(config, test_case, tmp) -> Config` from the inline `_run_one` scope so the override composition is directly testable without spinning up a real LLM. The existing `max_tool_iterations` override moves in with it — same shape, same testable helper.

Converts `evals/conversation.yaml::answers from seeded conversation history` to use the new flag: re-adds `expect_no_tool: conversation_search` and tightens `max_tool_calls` from 5 to 1 (agent should answer directly from seeded history without any tool calls). Removes the "reflection may retry" caveat from the comment above the test.

## Test plan

- [x] `make check` — Python lint + pyright + JS tsc all green
- [x] `make test` — 3007 passed (3001 baseline + 6 new setup-override tests; sole warning is the pre-existing #605 flake)
- [x] New unit tests cover: absent-override inheritance both directions, false override on default-true config, true override on default-false config, `max_tool_iterations` regression, and both overrides composing in a single pass
- [ ] LLM smoke — `make eval` on `conversation.yaml` (deferred; not run in this autonomous session since it costs tokens + wall time. The unit tests fully cover the config-plumbing path; the yaml change is a data-only assertion tightening that becomes signal when Les next runs the suite)

## Docs

- `docs/eval-loop.md` — new row in the setup-fields table
- `CLAUDE.md` — evals convention updated (the caveat used to point at this issue as a future todo; now points at the setup field)

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)