### PR TITLE
feat(evals): wire ConversationManager for end-to-end delegate_task (#536)

### DIFF
--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -71,6 +71,8 @@ Note that `response_contains` with a list uses OR semantics — to require sever
 
 Tool-name assertions see only parent-agent tool calls; tools invoked inside child agents (via `delegate_task`) are not visible.
 
+The eval harness wires a `ConversationManager` onto the parent context (#536) so `delegate_task` executes end-to-end — the child agent runs a real turn and returns its result to the parent. Confirmations that route through the manager's typed path (child-side tool confirmations) are auto-resolved per `setup.auto_confirm`, mirroring the legacy event-bus shim's behavior for parent-side tools. Tests that only care about the parent's tool-choice angle don't need any special setup — `expect_tool: delegate_task` works as before; the difference is that the delegation no longer surfaces a `[error: requires a ConversationManager]` tool result.
+
 ### Post-turn workspace assertions
 
 `expect_workspace` sits at the test-case top level (parallel to `setup` / `expect`) and runs once at the end of the test, after all turns complete. Useful for tests that need to verify the agent's *side effects* rather than its response text.

--- a/evals/delegate.yaml
+++ b/evals/delegate.yaml
@@ -1,12 +1,19 @@
-# delegate_task — LLM tool-choice angle only. Fork mechanism, context
-# isolation, error propagation, and timeouts are covered by 10 unit tests
-# in tests/test_delegate.py. This file isolates the eval-only question:
-# does the agent decide to delegate at appropriate times?
+# delegate_task — both LLM tool-choice AND end-to-end execution paths.
+# Fork mechanism, context isolation, error propagation, and timeouts are
+# covered by 10 unit tests in tests/test_delegate.py. This file exercises
+# the eval-only question: does the agent decide to delegate, and does the
+# resulting child agent turn actually produce useful output for the
+# parent to narrate?
+#
+# The eval runner wires a ConversationManager onto the parent ctx (#536)
+# so delegate_task can run children end-to-end; the manager auto-resolves
+# any child-side confirmations per setup.auto_confirm.
 
 # -- Good candidate: explicit user framing ----------------------------------
 
 - name: "delegates when user explicitly asks for a sub-agent"
   setup:
+    reflection_enabled: false
     workspace_files:
       "vault/agent/pages/auth-rewrite.md": |
         ---
@@ -27,15 +34,34 @@
 
         Token revocation latency, refresh-token rotation, replay attacks.
   input: "Spin up a separate sub-agent to read the auth-rewrite vault page and produce a one-paragraph summary of its approach and risks."
-  # The eval runner doesn't wire up a ConversationManager, so delegate_task
-  # cannot actually execute in this context — it returns a "requires a
-  # ConversationManager" error. The LLM-decision is what's under test;
-  # execution is covered by tests/test_delegate.py. Allow 1 error and 4
-  # calls so the agent can attempt the delegation and narrate the failure.
+  # Test-under-focus: the LLM decides to delegate. With the manager wired
+  # in the eval runner (#536) the child now actually executes, but that
+  # child's success also depends on the parent choosing to pass
+  # allow_vault_read=true — see the sibling case for end-to-end response
+  # narration coverage. Here we still only assert the tool-choice.
   expect:
-    max_tool_calls: 4
-    max_tool_errors: 1
+    max_tool_calls: 3
+    max_tool_errors: 0
     expect_tool: delegate_task
+
+# -- End-to-end: child response lands in parent's narration ----------------
+
+- name: "child result lands in parent response"
+  setup:
+    reflection_enabled: false
+  # Deliberately picking a task the child can answer from its own
+  # training with no tools — keeps the assertion focused on the
+  # parent-narrates-child-result path rather than the child's tool
+  # selection.
+  input: >-
+    Spin up a separate sub-agent whose only job is to name the largest
+    planet in our solar system (a one-word answer). Then tell me what
+    that sub-agent said.
+  expect:
+    expect_tool: delegate_task
+    response_contains: "Jupiter"
+    max_tool_calls: 2
+    max_tool_errors: 0
 
 # -- Bad candidate: trivial direct question ---------------------------------
 

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -10,10 +10,76 @@ from ..agent import run_agent_turn
 from ..commands import dispatch_command
 from ..config import Config
 from ..context import Context
+from ..conversation_manager import ConversationManager
 from ..events import EventBus
 from ..skills import discover_skills as _discover_skills_fn
 
 log = logging.getLogger(__name__)
+
+
+class _EvalConversationManager(ConversationManager):
+    """Eval-mode manager: auto-resolves confirmations routed through the
+    manager path.
+
+    In production, transports (mattermost, web UI) subscribe to per-conv
+    event streams and dispatch confirmation UIs. Eval mode has no UI, and
+    child conv_ids created by ``delegate_task`` never get a transport
+    subscriber. Without something in the loop, ``manager.request_confirmation``
+    would emit the request and then block on ``confirmation_event.wait()``
+    indefinitely.
+
+    We install an auto-resolver on every new conversation the manager
+    tracks (parent + all children, including nested delegates). The
+    resolver approves or denies per ``setup.auto_confirm``, matching the
+    existing legacy event-bus shim's behavior for parent tools.
+
+    Note the parent conversation ("eval") reaches this manager only if
+    ``run_test`` sets ``ctx.manager = self`` AND some parent tool routes
+    through the manager path. Today ``run_test`` calls ``run_agent_turn``
+    directly with ``ctx.request_confirmation = None``, so parent tools
+    take the event-bus fallback; child tools go through
+    ``manager._start_turn`` which overwrites ``child_ctx.request_confirmation``
+    to a manager-based closure (see ``conversation_manager.py::_start_turn``).
+    """
+
+    def __init__(self, config, event_bus, *, auto_confirm: bool):
+        super().__init__(config, event_bus)
+        self._eval_auto_confirm = auto_confirm
+
+    def _get_or_create(self, conv_id):
+        is_new = conv_id not in self._conversations
+        state = super()._get_or_create(conv_id)
+        if is_new:
+            self._install_auto_confirm(conv_id)
+        return state
+
+    def _install_auto_confirm(self, conv_id: str) -> None:
+        """Subscribe an auto-resolver to ``conv_id``'s event stream.
+
+        Fires on ``confirmation_request`` emits and calls
+        ``respond_to_confirmation`` with the configured verdict. Uses
+        ``asyncio.create_task`` so the resolver doesn't block the emit
+        chain (the manager awaits subscribers sequentially).
+        """
+        approved = self._eval_auto_confirm
+
+        async def _resolver(event):
+            if event.get("type") != "confirmation_request":
+                return
+            cid = event.get("confirmation_id", "")
+            if not cid:
+                return
+            try:
+                await self.respond_to_confirmation(
+                    conv_id, cid, approved=approved,
+                )
+            except Exception:
+                log.exception(
+                    "Eval auto-confirm resolver failed for conv %s / cid %s",
+                    conv_id, cid,
+                )
+
+        self.subscribe(conv_id, _resolver)
 
 
 async def _setup_skills(ctx, test_case: dict):
@@ -437,13 +503,27 @@ async def run_test(config: Config, test_case: dict) -> dict:
         config.discovered_skills = _discover_skills_fn(config)
         config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
 
+    # setup.auto_confirm: true (default) = auto-approve, false = auto-deny.
+    # Resolved early so both the manager (child confirmations via typed
+    # path) and the event-bus shim (parent confirmations via legacy path)
+    # see the same verdict.
+    auto_confirm = test_case.get("setup", {}).get("auto_confirm", True)
+
     bus = EventBus()
+    manager = _EvalConversationManager(config, bus, auto_confirm=auto_confirm)
     ctx = Context(config=config, event_bus=bus)
     ctx.conv_id = "eval"
     ctx.channel_id = "eval"
     ctx.channel_name = "eval"
     ctx.thread_id = ""
     ctx.user_id = config.agent.user_id
+    # Wire the manager onto the parent context so ``delegate_task`` can
+    # ``enqueue_turn`` a child agent (#536). We deliberately leave
+    # ``ctx.request_confirmation`` as None so parent tools take the
+    # event-bus fallback (handled by ``_handle_confirm`` below); the
+    # manager's ``_start_turn`` will set the child's own
+    # ``request_confirmation`` to the manager-based closure.
+    ctx.manager = manager
 
     # Set allowed tools if specified (disallowed tools return an error)
     allowed_tools = test_case.get("allowed_tools")
@@ -460,10 +540,6 @@ async def run_test(config: Config, test_case: dict) -> dict:
 
     # Pre-activate skills
     await _setup_skills(ctx, test_case)
-
-    # Handle confirmation requests in evals.
-    # setup.auto_confirm: true (default) = auto-approve, false = auto-deny
-    auto_confirm = test_case.get("setup", {}).get("auto_confirm", True)
 
     import asyncio
 

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -56,10 +56,15 @@ class _EvalConversationManager(ConversationManager):
     def _install_auto_confirm(self, conv_id: str) -> None:
         """Subscribe an auto-resolver to ``conv_id``'s event stream.
 
-        Fires on ``confirmation_request`` emits and calls
-        ``respond_to_confirmation`` with the configured verdict. Uses
-        ``asyncio.create_task`` so the resolver doesn't block the emit
-        chain (the manager awaits subscribers sequentially).
+        Fires on ``confirmation_request`` emits and awaits
+        ``respond_to_confirmation`` inline. Safe against deadlock because
+        ``ConversationManager.request_confirmation`` releases ``state.lock``
+        before it emits the request, so the resolver's own lock
+        acquisition inside ``respond_to_confirmation`` doesn't contend
+        with the caller. The manager runs subscribers concurrently via
+        ``asyncio.gather`` in ``emit`` — this resolver just needs to be
+        the one that lands ``state.confirmation_response`` before
+        ``request_confirmation`` returns to its ``event.wait()``.
         """
         approved = self._eval_auto_confirm
 

--- a/tests/test_eval_conversation_manager.py
+++ b/tests/test_eval_conversation_manager.py
@@ -1,18 +1,20 @@
 """Unit tests for the eval-mode ConversationManager subclass (#536).
 
-Covers:
-- Every new conversation gets an auto-confirm subscriber installed.
+Covers the deterministic plumbing:
+- Every new conversation the manager tracks gets an auto-confirm
+  subscriber installed on first ``_get_or_create``.
 - The subscriber resolves ``confirmation_request`` emits with the
-  configured verdict.
-- ``ctx.manager`` is wired to the manager after ``run_test`` builds the
-  context.
+  verdict passed to the subclass constructor.
+- The resolver is defensive — errors from
+  ``respond_to_confirmation`` log and don't propagate out of the
+  emit gather.
 
-The full ``run_test`` end-to-end path with a real LLM is exercised by
-``evals/delegate.yaml`` under ``make eval``; here we cover the
-deterministic plumbing without spinning up the agent loop.
+``ctx.manager = manager`` wiring in ``run_test`` and the full LLM
+end-to-end are exercised by ``evals/delegate.yaml`` under
+``make eval`` — not this file.
 """
 
-import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -91,24 +93,39 @@ async def test_resolver_ignores_non_confirmation_events():
 
 @pytest.mark.asyncio
 async def test_resolver_error_is_logged_not_raised(caplog):
-    """The resolver is defensive — errors from ``respond_to_confirmation``
-    log and don't crash the emit chain (which awaits subscribers)."""
+    """The resolver catches exceptions from ``respond_to_confirmation`` and
+    logs them — a raise would propagate out of the manager's emit gather
+    (which uses ``return_exceptions=True``) into stderr noise and mask
+    the real test failure."""
     manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
     state = manager._get_or_create("child-boom")
     resolver = next(iter(state.subscribers.values()))
-    # A request event whose confirmation_id doesn't match anything pending —
-    # ``respond_to_confirmation`` will just log a warning and return, so
-    # the resolver completes cleanly. This proves the defensive shape
-    # without needing to stub the underlying call.
-    await resolver({
-        "type": "confirmation_request",
-        "confirmation_id": "does-not-exist",
-    })
-    # Also cover the drop-events-with-no-cid path.
-    await resolver({"type": "confirmation_request"})
+
+    boom = AsyncMock(side_effect=RuntimeError("simulated failure"))
+    with patch.object(manager, "respond_to_confirmation", boom):
+        # Should not raise. The resolver's try/except catches and logs.
+        await resolver({
+            "type": "confirmation_request",
+            "confirmation_id": "abc123",
+        })
+
+    boom.assert_awaited_once()
+    assert any(
+        "Eval auto-confirm resolver failed" in rec.message
+        for rec in caplog.records
+    ), f"expected resolver failure log; got {[r.message for r in caplog.records]}"
 
 
-def test_asyncio_import_smoke():
-    """Guard against stray asyncio imports being dropped by refactors —
-    the resolver depends on the module being importable."""
-    assert asyncio is not None
+@pytest.mark.asyncio
+async def test_resolver_skips_events_missing_confirmation_id():
+    """A ``confirmation_request`` emit without a confirmation_id is
+    ignored — no exception, no call to ``respond_to_confirmation``."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    state = manager._get_or_create("child-no-cid")
+    resolver = next(iter(state.subscribers.values()))
+
+    spy = AsyncMock()
+    with patch.object(manager, "respond_to_confirmation", spy):
+        await resolver({"type": "confirmation_request"})
+        await resolver({"type": "confirmation_request", "confirmation_id": ""})
+    spy.assert_not_called()

--- a/tests/test_eval_conversation_manager.py
+++ b/tests/test_eval_conversation_manager.py
@@ -1,0 +1,114 @@
+"""Unit tests for the eval-mode ConversationManager subclass (#536).
+
+Covers:
+- Every new conversation gets an auto-confirm subscriber installed.
+- The subscriber resolves ``confirmation_request`` emits with the
+  configured verdict.
+- ``ctx.manager`` is wired to the manager after ``run_test`` builds the
+  context.
+
+The full ``run_test`` end-to-end path with a real LLM is exercised by
+``evals/delegate.yaml`` under ``make eval``; here we cover the
+deterministic plumbing without spinning up the agent loop.
+"""
+
+import asyncio
+
+import pytest
+
+from decafclaw.config import Config
+from decafclaw.confirmations import ConfirmationAction, ConfirmationRequest
+from decafclaw.eval.runner import _EvalConversationManager
+from decafclaw.events import EventBus
+
+
+@pytest.mark.asyncio
+async def test_new_conversation_gets_auto_confirm_subscriber():
+    """``_get_or_create`` installs a subscriber on brand-new conv_ids."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    state = manager._get_or_create("child-1")
+    assert len(state.subscribers) == 1
+
+    # A second access to the same conv_id doesn't stack subscribers.
+    manager._get_or_create("child-1")
+    assert len(state.subscribers) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_resolves_pending_confirmation():
+    """A ``confirmation_request`` on a tracked conv_id gets auto-approved."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        message="run 'echo hi'?",
+        timeout=5.0,
+    )
+    # Fire and await the manager's request_confirmation. The auto-confirm
+    # subscriber will resolve it via respond_to_confirmation before the
+    # timeout.
+    response = await manager.request_confirmation("child-abc", request)
+    assert response.approved is True
+
+
+@pytest.mark.asyncio
+async def test_auto_deny_when_auto_confirm_false():
+    """setup.auto_confirm=false → auto-deny propagates through the manager."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=False)
+    request = ConfirmationRequest(
+        action_type=ConfirmationAction.RUN_SHELL_COMMAND,
+        message="run 'rm -rf /'?",
+        timeout=5.0,
+    )
+    response = await manager.request_confirmation("child-xyz", request)
+    assert response.approved is False
+
+
+@pytest.mark.asyncio
+async def test_nested_child_conv_ids_also_get_subscribed():
+    """A deep delegate chain (grandchild etc.) gets auto-confirm on each
+    level — every ``_get_or_create`` call installs a subscriber."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    for conv_id in ("child-1", "child-2", "grandchild-1"):
+        state = manager._get_or_create(conv_id)
+        assert len(state.subscribers) == 1, (
+            f"expected auto-confirm subscriber on {conv_id}, "
+            f"got {len(state.subscribers)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolver_ignores_non_confirmation_events():
+    """The subscriber only fires for ``confirmation_request`` — other
+    event types (tool_status, stream chunks, etc.) pass through untouched."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    state = manager._get_or_create("child-noise")
+    # Grab the resolver and hand-drive it with a non-confirmation event.
+    resolver = next(iter(state.subscribers.values()))
+    # Should not raise, should not touch pending_confirmation state.
+    await resolver({"type": "tool_status", "message": "working"})
+    assert state.pending_confirmation is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_error_is_logged_not_raised(caplog):
+    """The resolver is defensive — errors from ``respond_to_confirmation``
+    log and don't crash the emit chain (which awaits subscribers)."""
+    manager = _EvalConversationManager(Config(), EventBus(), auto_confirm=True)
+    state = manager._get_or_create("child-boom")
+    resolver = next(iter(state.subscribers.values()))
+    # A request event whose confirmation_id doesn't match anything pending —
+    # ``respond_to_confirmation`` will just log a warning and return, so
+    # the resolver completes cleanly. This proves the defensive shape
+    # without needing to stub the underlying call.
+    await resolver({
+        "type": "confirmation_request",
+        "confirmation_id": "does-not-exist",
+    })
+    # Also cover the drop-events-with-no-cid path.
+    await resolver({"type": "confirmation_request"})
+
+
+def test_asyncio_import_smoke():
+    """Guard against stray asyncio imports being dropped by refactors —
+    the resolver depends on the module being importable."""
+    assert asyncio is not None


### PR DESCRIPTION
## Summary

The eval runner didn't wire a `ConversationManager`, so `delegate_task` returned `[error: delegate_task requires a ConversationManager]` and `evals/delegate.yaml` had to work around with `max_tool_errors: 1` — restricting eval coverage to the LLM's *decision* to delegate and leaving the child's behavior + the parent's narration unreachable.

## What changed

- **`src/decafclaw/eval/runner.py`** — new `_EvalConversationManager(ConversationManager)` subclass. Overrides `_get_or_create` to auto-subscribe an auto-resolver on every new conversation the manager tracks (parent + all children, including nested delegates). The resolver approves or denies per `setup.auto_confirm`, mirroring the legacy event-bus shim's behavior for parent-side tools. `run_test` sets `ctx.manager = manager` on the parent context; parent-side tool confirmations continue to use the event-bus fallback (`ctx.request_confirmation` stays `None`), while child-side confirmations flow through the manager's typed path (delegate.py overwrites `child_ctx.request_confirmation` in `_start_turn` regardless of what the parent's ctx holds, so per-conv subscription is the correct hook).

- **`evals/delegate.yaml`**
  - Dropped `max_tool_errors: 1` on the existing *"delegates when user explicitly asks"* case now that `delegate_task` actually runs.
  - Added *"child result lands in parent response"* — parent delegates a self-contained fact question ("name the largest planet, one word"), child answers from its own knowledge, parent narrates. Both cases opt into `reflection_enabled: false` (#534) so tool-count assertions aren't perturbed by reflection retries.

- **`docs/eval-loop.md`** — brief note under the tool-name assertion section explaining the manager wiring and confirmation semantics.

## Test plan

- [x] `make check` — Python lint + pyright + JS tsc all green
- [x] `make test` — 3014 passed (baseline 3007 from #619 + 7 new subclass tests). No warnings this run.
- [x] New unit tests cover: auto-approve, auto-deny, nested/repeated conv_ids, non-confirmation events ignored, defensive error handling in the resolver
- [ ] LLM smoke — `make eval evals/delegate.yaml` (deferred; costs tokens + wall time. The three cases are self-checking under `make eval` on Les's schedule)

## No production code changes

All logic is in the eval-mode subclass; `conversation_manager.py`, `delegate.py`, and other production modules are untouched.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)