### PR TITLE
feat(telemetry): tool-usage, reflection, and prompt-cache instrumentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,8 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `prompts/` — System prompt assembly
 - `commands.py` — User-invokable commands
 - `reflection.py` — Self-reflection (Reflexion pattern)
+- `tool_telemetry.py` — Tool-usage telemetry subscriber + report (#310); `make tool-usage-report`
+- `reflection_metrics.py` — Reflection cost/effectiveness telemetry subscriber + stats (#409); `make reflection-stats`
 - `heartbeat.py`, `schedules.py`, `polling.py`
 - `notifications.py`, `notification_channels/`, `mail.py`
 - `mcp_client.py`

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,14 @@ migrate-vault-dry:
 migrate-sidecars:
 	uv run python scripts/migrate_sidecars_to_dirs.py
 
+# Ranked tool-usage report from workspace/tool_usage.jsonl (#310)
+tool-usage-report:
+	uv run python -m decafclaw.tool_telemetry
+
+# Reflection cost/effectiveness stats from workspace/reflection/metrics.jsonl (#409)
+reflection-stats:
+	uv run python -m decafclaw.reflection_metrics
+
 # Dry-run sidecar migration (show what would change)
 migrate-sidecars-dry:
 	uv run python scripts/migrate_sidecars_to_dirs.py --dry-run

--- a/docs/config.md
+++ b/docs/config.md
@@ -421,6 +421,19 @@ Skill config fields support env var overrides via the skill's `SkillConfig` meta
 
 Config CLI shows skill values as raw JSON (`config show skills`). Use `--reveal` to unmask values.
 
+### `telemetry`
+
+Instrumentation sidecars — append-only JSONL under `workspace/`, metadata only (never tool args/returns, reflection bodies, or prompt contents). Producers are fail-open EventBus subscribers. See [tools.md#tool-usage-telemetry-310](tools.md#tool-usage-telemetry-310) (#310) and [reflection.md#metrics-409](reflection.md#metrics-409) (#409).
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `tool_usage_enabled` | bool | `true` | `TELEMETRY_TOOL_USAGE_ENABLED` |
+| `tool_usage_path` | str | `tool_usage.jsonl` | `TELEMETRY_TOOL_USAGE_PATH` |
+| `reflection_metrics_enabled` | bool | `true` | `TELEMETRY_REFLECTION_METRICS_ENABLED` |
+| `reflection_metrics_path` | str | `reflection/metrics.jsonl` | `TELEMETRY_REFLECTION_METRICS_PATH` |
+
+Paths are workspace-relative. Enabled by default so a deployed agent starts collecting without a config edit — the intent is a week of real data. No rotation yet (append-only); retention is a follow-up. Reports: `make tool-usage-report`, `make reflection-stats`.
+
 ### `env`
 
 Arbitrary environment variables set at startup. Useful for API keys and tool-specific config that doesn't have a dedicated config field.

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -173,6 +173,17 @@ The composer is mode-aware via `ComposerMode`:
 
 Each context source produces a `SourceEntry` with token estimates, item counts, and source-specific details. These are stored on `ComposerState.last_sources` and can be inspected for debugging (not published as events every turn).
 
+### Prompt-cache tokens (#480)
+
+The per-conversation diagnostics sidecar (`workspace/conversations/{conv_id}/context.json`, served by `GET /api/conversations/{id}/context`) also carries the prompt-cache figures providers report:
+
+| Field | Meaning |
+|-------|---------|
+| `cached_prompt_tokens` | Prompt tokens served from the provider's cache on the last turn |
+| `cache_hit_rate` | `cached_prompt_tokens / total_tokens_actual` (0.0 when no prompt tokens) |
+
+Providers normalize their native counter into a common `cached_tokens` usage key — Vertex from `usageMetadata.cachedContentTokenCount`, OpenAI-compatible from `prompt_tokens_details.cached_tokens`. The agent's usage merge point (`agent.py`) accumulates it onto `TokenUsage.total_cached_prompt` / `last_cached_prompt` and feeds `record_actuals`. The context-inspector popover renders a **Cached** row (count + hit-rate %). This is measurement only — no `cache_control` hints are emitted and no behavior changes (issue #480 Phase 1). A `LOG_LEVEL=DEBUG` "Turn token usage: prompt=… cached=… completion=…" line prints per turn.
+
 ## Vault retrieval
 
 Before each interactive turn, the composer automatically surfaces relevant vault content — without the agent needing to explicitly search.

--- a/docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/plan.md
+++ b/docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/plan.md
@@ -1,0 +1,179 @@
+# Instrumentation-first Implementation Plan
+
+**Goal:** Add data-collection instrumentation for three subsystems (prompt-cache tokens, tool usage, reflection cost/effectiveness) that **changes no behavior** — only observes.
+
+**Approach:** Each concern is an append-only JSONL sidecar under `workspace/`, fed by EventBus enrichment/subscribers, fail-open, metadata-only (no args/returns/prompt bodies). A shared `TelemetryConfig` groups enables/paths through the normal defaults→config.json→env chain. Reporting via `make` targets. Cache tokens ride the existing diagnostics sidecar + popover.
+
+**Tech stack:** Python 3, dataclasses, existing `EventBus` (`events.py`), existing provider usage dicts, existing diagnostics sidecar (`context_composer.py`), pytest.
+
+**Confirmed decisions (2026-07-23):**
+- #310: enrich `tool_start`/`tool_end` events with `conv_id` + `duration_ms` (+ `input_bytes`) at the publish site in `tool_execution.py`; subscriber consumes `tool_end` only (no start/end pairing).
+- #409: emit a reflection-metrics row **only for judge-eligible turns** (reflection enabled, non-child, produced a final response). Buckets: `passed_first` / `passed_after_retry` / `loop_exhausted` / `errored` / `skipped_empty`. Child-agent and reflection-disabled turns emit nothing.
+- `end_turn` dropped from #310 outcome set — not cheaply observable on `tool_end`. Outcomes: `success` / `error` / `cancelled`, inferred from the `result_text` prefix.
+- Telemetry defaults **enabled** (this is meant to run ~a week to collect data). No rotation this session — append-only; retention is a follow-up.
+
+---
+
+## Phase 1: #480 Phase 1 — prompt-cache token surfacing
+
+Parse the cached-token counts providers already return but drop, thread them onto `TokenUsage`, surface in the diagnostics sidecar + existing popover, log per turn. Pure enrichment; no control-flow change.
+
+**Files:**
+- Modify: `src/decafclaw/llm/providers/vertex.py` — add `cached_tokens` to both usage-parse sites (streaming `_VertexStreamState.process_chunk` ~262-266; non-streaming `_parse_usage` ~558-567) from `usageMetadata.cachedContentTokenCount`.
+- Modify: `src/decafclaw/llm/providers/openai_compat.py` — add normalized `cached_tokens` from `usage.prompt_tokens_details.cached_tokens` at both sites (non-streaming ~104-123; streaming `process_chunk` ~294-296).
+- Modify: `src/decafclaw/context.py` — `TokenUsage` gains `total_cached_prompt: int = 0`, `last_cached_prompt: int = 0`.
+- Modify: `src/decafclaw/agent.py` — at the usage merge chokepoint (~598-608) read `usage.get("cached_tokens", 0)`, accumulate onto `ctx.tokens`, add a `log.debug` "cached=%s / prompt=%s".
+- Modify: `src/decafclaw/context_composer.py` — `build_diagnostics` (~1201-1213) adds `cached_prompt_tokens` (from `ComposerState`) and a `cache_hit_rate`; `record_actuals` + `ComposerState` carry the cached figure.
+- Modify: `src/decafclaw/web/static/components/context-inspector.js` — one `<dt>Cached</dt><dd>` row next to Actual (~158-163).
+- Test: `tests/test_provider_cache_tokens.py` (new) — usage parsing for vertex (stream + non-stream) and openai_compat (stream + non-stream) with fixture responses carrying/omitting cached counts; `tests/test_token_usage.py` or extend existing agent-usage test — accumulation onto `TokenUsage`.
+- Docs: `docs/context-composer.md` — cache-token fields in diagnostics.
+
+**Key changes:**
+- Providers normalize to a common `cached_tokens` key so the merge point stays provider-agnostic (`usage.get("cached_tokens", 0)`), mirroring the existing `prompt_tokens`/`completion_tokens` contract.
+
+```python
+# vertex.py — both sites
+"cached_tokens": (chunk_usage or meta).get("cachedContentTokenCount", 0),
+
+# openai_compat.py — both sites, after obtaining `usage`
+if usage is not None:
+    details = usage.get("prompt_tokens_details") or {}
+    usage["cached_tokens"] = details.get("cached_tokens", 0)
+
+# context.py
+@dataclass
+class TokenUsage:
+    total_prompt: int = 0
+    total_completion: int = 0
+    last_prompt: int = 0
+    total_cached_prompt: int = 0
+    last_cached_prompt: int = 0
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (new provider-cache + token tests) — 3021 passed
+- [x] `make check` passes (incl. `check-js` for the popover edit)
+
+**Verification — manual:**
+- [x] Fixture-level: fabricated vertex/openai responses with a cached count parse into `usage["cached_tokens"]`; absent → 0, never KeyError. (unit-tested)
+- [ ] Diagnostics sidecar for a real conversation shows `cached_prompt_tokens`; popover renders the Cached row. (deferred to post-merge live test)
+
+---
+
+## Phase 2: #310 — tool usage telemetry + report
+
+Introduce the shared `TelemetryConfig`, enrich tool lifecycle events with the missing fields, add a fail-open subscriber that appends one JSONL record per tool call, and a `make` report that ranks tools and flags unused ones.
+
+**Files:**
+- Modify: `src/decafclaw/config_types.py` — new `TelemetryConfig` dataclass (full, both concerns).
+- Modify: `src/decafclaw/config.py` — import, top-level `Config.telemetry` field (~186), `load_sub_config(TelemetryConfig, file_data.get("telemetry", {}), "TELEMETRY")` (~395), constructor arg (~536).
+- Modify: `src/decafclaw/tool_execution.py` — capture `perf_counter()` before `execute_tool`; in the `finally` `tool_end` publish add `conv_id=call_ctx.conv_id`, `duration_ms`, `input_bytes=len(json-serialized fn_args)`. Also add `conv_id` to the `tool_start` publish for symmetry.
+- Create: `src/decafclaw/tool_telemetry.py` — `classify_source(name, config) -> (source, detail)`; `make_tool_telemetry_subscriber(config)` factory returning `async def handle(event)`; a JSONL append writer (fail-open); a `build_report(config)` aggregator; `main()` for `python -m`.
+- Modify: `src/decafclaw/runner.py` — subscribe the telemetry handler on `app_ctx.event_bus` near `init_notification_channels` (~87-95), guarded by `config.telemetry.tool_usage_enabled`.
+- Modify: `Makefile` — `tool-usage-report` target → `python -m decafclaw.tool_telemetry`.
+- Test: `tests/test_tool_telemetry.py` (new) — subscriber writes correct record from a `tool_end` event; `classify_source` for core/skill/mcp; outcome inference (`success`/`error`/`cancelled` from prefix); report aggregation (calls/tool, unique convs/tool, error rate, last-called); unused-tool detection; fail-open when the path is unwritable.
+- Docs: `docs/tools.md` — new "Tool usage telemetry" section (record shape, report, privacy stance).
+
+**Key changes:**
+
+```python
+# config_types.py
+@dataclass
+class TelemetryConfig:
+    """Instrumentation sidecars (#310 tool usage, #409 reflection metrics).
+    Append-only JSONL under workspace/, metadata only — no tool args/returns,
+    reflection bodies, or prompt contents. Fail-open producers."""
+    tool_usage_enabled: bool = True
+    tool_usage_path: str = "tool_usage.jsonl"            # workspace-relative
+    reflection_metrics_enabled: bool = True
+    reflection_metrics_path: str = "reflection/metrics.jsonl"  # workspace-relative
+
+# tool_telemetry record (one per tool_end)
+{"timestamp", "conv_id", "tool", "source", "source_detail",
+ "outcome", "duration_ms", "input_bytes", "output_bytes"}
+```
+
+- `classify_source`: `mcp__` prefix → `("mcp", server)` via `split("__",2)[1]`; `name in config.skill_tool_owners` → `("skill", owner)`; else `("core", "")`.
+- Outcome: `result_text` startswith `[error` → `error`; `[cancelled` → `cancelled`; else `success`.
+- Report enumerates all known tools (core `TOOL_DEFINITIONS` + discovered skill tools) to flag never-called ones; **MCP unused-detection is best-effort** (MCP tools only enumerable when servers are connected) — report notes this caveat.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (new tool-telemetry tests) — 3030 passed
+- [x] `make check` passes
+- [x] `make tool-usage-report` runs against a fixture/real log and prints a ranked report (smoke: 0 calls, 48 unused core+skill tools listed)
+
+**Verification — manual:**
+- [ ] Exercise several tools in a session; records land in `workspace/tool_usage.jsonl` with sane `duration_ms`/`conv_id`; report ranks them; a never-called tool shows as unused. (deferred to post-merge live test)
+
+---
+
+## Phase 3: #409 — reflection cost/effectiveness telemetry + stats
+
+Capture judge token cost (currently discarded), the first-vs-final response pair, and per-turn outcome bucket; emit one `reflection_turn` event per judge-eligible turn; subscriber appends JSONL; `make reflection-stats` aggregates.
+
+**Files:**
+- Modify: `src/decafclaw/reflection.py` — `ReflectionResult` gains `prompt_tokens: int = 0`, `completion_tokens: int = 0`; `evaluate_response` reads `response.get("usage")` and populates them (fail-open — absent usage → 0).
+- Modify: `src/decafclaw/agent.py` (`TurnRunner`) —
+  - new fields: `reflection_first_response: str | None = None`, `reflection_judge_prompt_tokens: int = 0`, `reflection_judge_completion_tokens: int = 0`, `reflection_exhausted: bool = False`.
+  - `_reflection_evaluate`: on round 0 capture `reflection_first_response = <content being judged>`; after each result accumulate judge tokens.
+  - `_reflection_skip`: when the exhausted branch fires, set `reflection_exhausted = True` **before** `last_reflection` is nulled.
+  - at turn completion in `run()`: for judge-eligible turns compute the bucket + delta + overlap + fingerprint and `await ctx.publish("reflection_turn", ...)` exactly once (covers all finalization exits).
+- Create: `src/decafclaw/reflection_metrics.py` — `make_reflection_metrics_subscriber(config)` factory; JSONL append writer (fail-open); `response_delta(first, final) -> (char_delta, overlap_ratio)`; `build_stats(config, hours=...)` aggregator; `main()` for `python -m`.
+- Modify: `src/decafclaw/runner.py` — subscribe near the tool-telemetry handler, guarded by `config.telemetry.reflection_metrics_enabled`.
+- Modify: `Makefile` — `reflection-stats` target → `python -m decafclaw.reflection_metrics`.
+- Test: `tests/test_reflection_metrics.py` (new) — each outcome bucket (`passed_first`, `passed_after_retry`, `loop_exhausted`, `errored`, `skipped_empty`); `response_delta` char-delta + overlap (identical → overlap 1.0, disjoint → 0.0); judge-token capture from a usage-bearing judge response; fail-open on writer error; disabled/child turns emit no row; stats aggregation.
+- Docs: `docs/reflection.md` — metrics section + how to read the four #409 questions off the stats.
+
+**Key changes:**
+
+```python
+# reflection_metrics.py
+def response_delta(first: str, final: str) -> tuple[int, float]:
+    char_delta = len(final) - len(first)
+    a, b = set(first.split()), set(final.split())
+    overlap = len(a & b) / len(a | b) if (a or b) else 1.0
+    return char_delta, round(overlap, 4)
+
+# reflection_turn event payload
+{"outcome", "retry_count", "judge_prompt_tokens", "judge_completion_tokens",
+ "char_delta", "overlap_ratio", "critique_fingerprint"}  # fingerprint = critique[:120]
+```
+
+- Bucket at emit time: not eligible (disabled/child) or cancelled → no emit. `reflection_first_response is None` → `skipped_empty`. `last_reflection.error` → `errored`. `reflection_exhausted` → `loop_exhausted`. `retry_count == 0 and passed` → `passed_first`. `retry_count > 0 and passed` → `passed_after_retry`.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (new reflection-metrics tests) — 3048 passed
+- [x] `make check` passes
+- [x] `make reflection-stats` runs against a fixture/real log and prints aggregate stats (smoke: 0 turns)
+
+**Verification — manual:**
+- [x] Integration-tested: pass-first, passed-after-retry (real overlap<1.0 delta + summed judge tokens), loop-exhausted (survives last_reflection nulling), and child-agent no-emit — all via real `run_agent_turn`.
+- [ ] Live: run turns in the web UI; confirm buckets + judge tokens land in `workspace/reflection/metrics.jsonl`. (deferred to post-merge live test)
+
+---
+
+## Phase 4: docs + config + key-files sweep
+
+Finalize cross-cutting docs the earlier phases pointed at.
+
+**Files:**
+- Modify: `docs/config.md` — new `TelemetryConfig` group (fields, defaults, env prefix `TELEMETRY_`).
+- Modify: `CLAUDE.md` — key-files list gains `tool_telemetry.py`, `reflection_metrics.py`; note the telemetry sidecars in the data/config section if warranted.
+- Modify: `docs/index.md` — link any new doc/section.
+- Verify `docs/reflection.md`, `docs/tools.md`, `docs/context-composer.md` edits from earlier phases read coherently together.
+
+**Verification — automated:**
+- [x] `make check` passes
+- [x] `make config` shows the telemetry group (nested group → appears, all 4 fields resolve)
+
+**Verification — manual:**
+- [x] Docs cross-reference each other (tools.md ↔ reflection.md ↔ config.md ↔ context-composer.md); privacy stance stated per doc; no new index entry needed (sections added to existing pages).
+
+---
+
+## Sequencing & commits
+
+One commit per phase (`Phase N: <name>`). Phases are independent enough to build in order 1→2→3→4; #310 (Phase 2) establishes `TelemetryConfig` that #409 (Phase 3) reuses. Non-LLM-visible plumbing → **unit tests required, no evals** (per spec + CLAUDE.md).

--- a/docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/spec.md
+++ b/docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/spec.md
@@ -1,0 +1,148 @@
+# Spec — Instrumentation first: measure before building
+
+**Session slug:** `instrumentation-measure-first`
+**Date:** 2026-07-23
+**Issues:** #310 (tool usage telemetry), #409 (reflection cost/effectiveness telemetry), #480 Phase 1 (prompt-cache measurement)
+
+## Thesis
+
+Three of the most-argued subsystems — reflection, the tool registry, and prompt
+handling — are being reasoned about from *impression*, not data. The backlog
+triage (2026-07-23) surfaced this as the single strongest cross-cutting signal:
+speculative follow-ups pile up (the reflection-judge epic #591→#589/#529/#530,
+the tool-scoring framework #274 and its satellites, prompt-prefix churn) while
+the cheap instrumentation that would tell us whether any of it is worth building
+sits unstarted.
+
+This session builds that instrumentation and **changes no behavior**. The
+deliverable is data-collection surfaces plus a way to read them. Decisions about
+what to do with the data are explicitly out of scope and become follow-up issues
+once a week of real numbers exists.
+
+All three are non-LLM-visible plumbing, so per project convention: **unit tests
+required, no evals.**
+
+## Shared design decisions
+
+These three issues independently reach for the same shape (an event-bus
+subscriber → append-only JSONL sidecar → on-demand report). Decide once, apply
+consistently:
+
+- **Storage: append-only JSONL under `workspace/`**, one file per concern
+  (`workspace/tool_usage.jsonl`, `workspace/reflection/metrics.jsonl`). Matches
+  the "files on disk, human-readable, crash-recoverable" convention. No SQLite in
+  this session — add an on-demand index later only if query ergonomics demand it.
+- **Config: a new `TelemetryConfig` dataclass** (in `config_types.py`) grouping
+  the enables/paths, resolved through the normal defaults→config.json→env chain.
+  Fields: `tool_usage_enabled`, `tool_usage_path`, `reflection_metrics_enabled`,
+  `reflection_metrics_path`. (Cache measurement rides existing diagnostics; no new
+  file — see #480 below.)
+- **Producers are EventBus subscribers, fail-open.** A telemetry write that
+  raises must never break a turn — `except Exception as exc: log.debug(...)`,
+  never bare `except: pass`.
+- **No privacy-sensitive payloads.** Tool args/returns, reflection response
+  bodies, and prompt contents are NOT logged — only metadata (names, sizes,
+  counts, token totals, fingerprints).
+- **Reporting: `make` targets** producing ranked markdown/text to stdout, plus
+  (where cheap) a read-only `/api/*` endpoint the web UI can hang a view off
+  later. No new UI in this session beyond what already exists.
+
+## Scope by issue
+
+### #310 — Tool usage telemetry (M)
+
+Subscribe to `tool_start` / `tool_end` (published in `agent.py`) and persist one
+record per call: `timestamp, conversation_id, tool_name, source (core/skill/mcp
+server), outcome (success/error/end_turn), duration_ms, input_bytes,
+output_bytes`. Optionally record failed tool *lookups* (model called a tool we
+don't expose) to catch deferred-catalog gaps.
+
+- New `src/decafclaw/tool_telemetry.py` — subscriber + JSONL writer.
+- `make tool-usage-report` — ranked report: calls/tool, unique convs/tool, error
+  rate, last-called. Flags unused / low-usage tools as consolidation candidates.
+- Feeds the parked tool-audit work (#307) and gives #303/#526 real-world
+  ambiguity ground truth.
+
+### #409 — Reflection telemetry (M)
+
+Record per turn where reflection runs: `outcome bucket
+(passed_first / passed_after_retry / loop_exhausted / errored / skipped+reason)`,
+`retry_count`, `judge token cost` (prompt+completion, summed across rounds),
+`response delta on retry` (char-length change + token-overlap ratio between first
+and final response), `critique fingerprint` (first ~120 chars, to spot repeating
+rejection patterns).
+
+- New `src/decafclaw/reflection_metrics.py` — rolling JSONL writer + simple
+  aggregation.
+- Emit from `reflection.py` (structured result) + `agent.py` (per-turn outcome
+  and token cost from `ctx.tokens`).
+- `make reflection-stats` (and/or `/api/reflection/stats`) — last-N-hours
+  pass-rate, mean retries, mean tokens, loop-exhausted rate.
+- Answers the four questions in #409: pass-first fraction (pure overhead),
+  loop-exhausted fraction (waste + bad UX), whether successful retries meaningfully
+  differ (genuine value), token cost per active hour.
+
+### #480 Phase 1 only — Prompt-cache measurement (S)
+
+Parse and surface cached-token counts already returned by providers but
+currently dropped:
+
+- Vertex: pull `usageMetadata.cachedContentTokenCount` into the usage dict
+  (`vertex.py` `_VertexStreamState.usage`, ~262-266).
+- OpenAI-compat: pull `prompt_tokens_details.cached_tokens`
+  (`openai_compat.py`).
+- Surface on `TokenUsage` and in the per-conversation diagnostics sidecar
+  (`workspace/conversations/{conv_id}/context.json`) so the existing UI popover
+  can show cache hit rate. Debug log line per turn: cached / total prompt tokens.
+
+**Phases 2 (reorder volatile prompt injections) and 3 (Anthropic `cache_control`
+breakpoints) are explicitly out of scope** — they only happen if Phase 1 data
+shows the cache is being shredded by our prefix churn (skill loading, dynamic
+tool sets, `context_cleanup` stubbing, compaction rewrites).
+
+## Out of scope (this session)
+
+- Any behavior change driven by the data (gating/disabling reflection, tool
+  consolidation, prompt reordering, cache-control hints). Each becomes a
+  follow-up issue once data exists.
+- The reflection judge prompt itself (#591 epic territory).
+- SQLite storage / long-window query tooling.
+- New web UI beyond reusing the existing diagnostics popover for cache stats.
+
+## Validation
+
+- **#310:** run a session exercising several tools; confirm records land in
+  `tool_usage.jsonl` and `make tool-usage-report` ranks them; confirm a
+  never-called tool shows as unused. Unit test the subscriber + report aggregation.
+- **#409:** unit-test each outcome bucket (pass-first, passed-after-retry,
+  loop-exhausted, errored, skipped-with-reason) with the delta/overlap
+  computation; confirm fail-open on a writer error.
+- **#480:** open a long conversation, confirm cached-token counts appear in the
+  diagnostics sidecar and rise monotonically as the prefix stabilizes. Unit-test
+  the usage-parsing for both providers with fixture responses.
+
+## Sequencing
+
+Independent enough to parallelize, but a sensible order:
+
+1. **#480 Phase 1** (S) — smallest, touches only provider usage parsing +
+   existing diagnostics; no new subsystem.
+2. **#310** (M) — establishes the `tool_telemetry.py` subscriber + `TelemetryConfig`
+   + report-target pattern that #409 mirrors.
+3. **#409** (M) — reuses the pattern; slightly more logic in the delta/overlap +
+   token accounting.
+
+## Docs to update (same PRs)
+
+- `docs/reflection.md` — reflection metrics + how to read them (#409).
+- New tool-telemetry doc or a section in `docs/tools.md` (#310).
+- `docs/context-composer.md` — cache-token surfacing in diagnostics (#480).
+- `docs/config.md` — new `TelemetryConfig` group.
+- CLAUDE.md key-files list if new modules land.
+
+## Success criterion
+
+After this session ships and runs for ~a week of normal use, we can answer with
+numbers — not impressions — whether reflection earns its keep, which tools are
+load-bearing, and whether prompt-prefix churn is quietly defeating provider
+caches. Those answers drive the next round of issues.

--- a/docs/dev-sessions/2026-07-23-0948-issue-triage/triage.md
+++ b/docs/dev-sessions/2026-07-23-0948-issue-triage/triage.md
@@ -1,0 +1,127 @@
+# Backlog triage & roadmap — 2026-07-23
+
+Full triage of all open GitHub issues via an 11-agent fan-out, each cross-checking
+its cluster against current code. This doc is the durable record of *why* — the
+close/merge rationale, the epic groupings, and the strategic direction — since
+that reasoning decays fastest from scattered issue-close comments.
+
+**Outcome:** open issues pruned **208 → 181**, Ready column reshaped around an
+instrumentation-first arc, one new umbrella (#621) created.
+
+---
+
+## Headline read
+
+The backlog wasn't broken — it was **over-decomposed and under-pruned**. ~1/4 was
+closeable (already shipped, or dead code from the workflow-engine pivot) or
+mergeable (same work filed 2–5 times).
+
+The dominant cross-cutting signal: **the project builds on impression, not
+measurement.** Reflection, tool-scoring, and prompt-caching all have cheap
+instrumentation sitting unbuilt while their speculative follow-ups pile up — and
+those follow-ups are correctly *gated* on data that doesn't exist yet. Hence the
+chosen next direction (below).
+
+---
+
+## Pruned
+
+### Closed — done / superseded
+| # | Why |
+|---|---|
+| #272 | MCP disconnect filtering already implemented (`mcp_client.py` filters on `status=="connected"`) |
+| #402 | Per-conversation sidecar dir shipped (#578 migration, #588 removed fallback); `make migrate-sidecars` exists |
+| #22 | Superseded by the workflow interview engine (`wf.user_input`) |
+| #561–#564 | **Zombie follow-ups** to the LLM phase-state-machine (PR #557) that was *deleted* in the code-driven replay-engine pivot (commit `14b24ec`). Referenced mechanisms no longer exist. |
+
+### Closed — stale / out of direction
+#23 (conversation handoff — multi-user/support-desk shape), #26 (channel mgmt —
+team-ops), #28 (infancy grab-bag), #461 (RL/benchmarking — "different mission"),
+#462 (kanban board — covered by `delegate_task`), #102 (external eval, no action),
+#478 (Spotify history covered by me-to-markdown; only playback remained).
+
+### Merged — duplicates
+#21→#39 · #96→#449 · #99→#472 · #32→#44 · #278→#274 · #243+#541→#364 ·
+#287→#377 · #463→#447
+
+### Consolidated
+Five low-value presentational widgets (#412 link_card, #413 tree_view, #415
+image_gallery, #417 date_picker, #418 rating) folded into new umbrella **#621**.
+
+---
+
+## Epics (parent + carve-outs — don't work the parent directly)
+
+- **Pluggable reflection judges:** #591 (keystone `verifier_model`, do first) →
+  #589 + #529 + #530, all gated on **#528** (eval infra). #532 (ceremony tuning)
+  shares the #528 gate.
+- **Tool-scoring framework:** #274 parent; discrete signals #270/#271 near-term;
+  #275/#276/#277 gated research. #274 itself says "don't start yet."
+- **MCP-overload consolidation:** #310 (telemetry) → #307 (audit) → #308/#309
+  (reductions) → #311 (guidance). #308 + #311 shippable now without telemetry.
+- **Tool-execution resilience (#7):** #325 → #326; #324 parallel sibling.
+- **Time/calendar awareness (#97):** split when picked up (layer 1 = inject
+  current date into prompt, confirmed NOT done today).
+- **Personal-history ingest** is now owned by me-to-markdown + `meta-ingest`
+  (Mastodon/Linkding/GitHub/Spotify/YouTube/Pocket Casts) — which guts the
+  "skill per service" halves of #374/#376/#478/#286. Remaining real gap is
+  *on-demand* transcript ingest, not history pulls.
+
+---
+
+## Strategic direction — where next
+
+### 1. Instrumentation first ("measure before building") — CHOSEN NEXT
+Reflection, tool-scoring, and prompt handling are argued from impression. Three
+cheap items answer "does this earn its keep" before their expensive follow-ups
+start:
+- **#310** tool usage / unused-tool report
+- **#409** reflection cost/effectiveness telemetry
+- **#480 Phase 1** prompt-cache hit-rate measurement
+
+Spec written: `docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/spec.md`.
+Behavior change is explicitly out of scope; each becomes a follow-up issue once a
+week of data exists.
+
+### 2. Vault retrieval quality
+#197 (dream/garden auto-fill frontmatter — upstream of retrieval *and* the vault
+evals) → #306 (recency journal surfacing) → #318 (first-class tags).
+
+### 3. Confirmation unification
+#364 absorbing #243/#541 — retires the brittle `EndTurnConfirm` label hack,
+unifies two human-input mechanisms, closes three issues in one session.
+
+### 4. Event-reactive, not just polling
+#449 routines/webhooks (unlocks #96) with #553 (structured status) as
+prerequisite. **#447 (MCP-serve)** is the single highest-leverage integration
+item — turns Claude Code into a native driver, obsoletes #463.
+
+---
+
+## Ready column (13, priority-ordered)
+
+1. **Quick-win bugs** (cheap, verified against code): #526 (poisons the eval
+   suite), #355, #587 (security — unsanitized `conv_id`), #535, #604
+2. **Instrumentation:** #310, #409, #480
+3. **Validated features:** #414 + #419 (pair), #285, #598, #605
+
+---
+
+## Flagged for Les's call (NOT auto-actioned)
+
+- **#25** (bot/channel allowlists) — left open; genuine keep-or-close judgment.
+- **#460** (multi-platform gateway), **#465** (Termux) — left open as research
+  parking-lot; close if preferred.
+- **#442** (In Progress) — spec-complete in a worktree but **zero code
+  committed**; may belong back in Ready.
+- **#40** (heartbeat media), **#468** (vision — passive multimodal already works)
+  — stale premises; re-verify before picking up.
+- **#598 ↔ #539** overlap on the loop-breaker — pick one mechanism before building.
+
+---
+
+## Other quick-win bugs staged behind Ready
+#566 (skill-discovery env-only check swaps bundled→shadow), #137 (client-MIME
+embedding hole), #146 (JSON arg repair), #431 (config-show skips scalars),
+#600/#601 (vault-guide test + doc), #575 (workflow Context-kind ADR),
+#166+#555 (web-UI a11y pass), #350/#531 (eval-infra additions).

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -119,9 +119,34 @@ Reflection is fail-open. The agent's response is always delivered even if reflec
 - **Unparseable judge output** — treat as pass, log warning.
 - **False positives** (judge incorrectly fails a good response) — the retry budget limits damage. After `max_retries`, deliver whatever the agent has.
 
+## Metrics (#409)
+
+`reflection_metrics.py` records one **metadata-only** JSONL row per judge-eligible turn to `{workspace}/reflection/metrics.jsonl` so we can answer "does reflection earn its keep" with data instead of impression. It's a fail-open EventBus subscriber (guarded by `config.telemetry.reflection_metrics_enabled`, default on); the agent loop publishes one `reflection_turn` event per eligible turn.
+
+**A turn is judge-eligible** when reflection is enabled, the agent is not a child agent, the turn wasn't cancelled, and it reached a no-tool final response (the point the judge actually weighs in). Turns that end via `end_turn`, a grace turn, or max-iteration exhaustion never invoke the judge and emit no row — keeping the pass-rate denominator meaningful.
+
+**Row fields:** `timestamp`, `conv_id`, `outcome`, `retry_count`, `judge_prompt_tokens`, `judge_completion_tokens`, `char_delta`, `overlap_ratio`, `critique_fingerprint`.
+
+**Outcome buckets:**
+
+| Bucket | Meaning |
+|--------|---------|
+| `passed_first` | Judge approved on the first call — pure overhead (a judge call that changed nothing) |
+| `passed_after_retry` | Judge rejected, the agent retried, judge then approved — the genuine-value case |
+| `loop_exhausted` | Judge kept rejecting through `max_retries`; the last (possibly worse) answer ships with an escalation nudge |
+| `errored` | Judge call failed or returned unparseable output (treated as pass, fail-open) |
+| `skipped_empty` | Eligible turn whose final content was empty |
+
+**Effectiveness signals:** the judge's token cost per round is captured (previously discarded); `char_delta` + `overlap_ratio` (Jaccard over whitespace tokens between the first and final response) measure whether a retry *actually rewrote anything* — a `passed_after_retry` with `overlap_ratio ≈ 1.0` is a performative loop, not real self-correction. `critique_fingerprint` (first 120 chars of the rejection) surfaces repeating rejection patterns. Response bodies and prompt contents are never recorded.
+
+**Reading the four questions from #409:** `make reflection-stats` (`python -m decafclaw.reflection_metrics`) prints the pass-first rate (pure overhead), loop-exhausted rate (waste + bad UX), mean retries, and total/per-turn judge tokens. Whether successful retries meaningfully differ is read from the `overlap_ratio` distribution of `passed_after_retry` rows.
+
+This is measurement only — reflection behavior is unchanged (issue #409). See [tools.md](tools.md#tool-usage-telemetry-310) for the parallel tool-usage telemetry and [config.md](config.md) for the `telemetry` config group.
+
 ## Files
 
-- `src/decafclaw/reflection.py` — judge call, prompt assembly, result parsing
-- `src/decafclaw/agent.py` — reflection check after final response, retry integration
-- `src/decafclaw/config_types.py` — `ReflectionConfig` dataclass
+- `src/decafclaw/reflection.py` — judge call, prompt assembly, result parsing (now also carries per-round judge token usage on `ReflectionResult`)
+- `src/decafclaw/agent.py` — reflection check after final response, retry integration, per-turn `reflection_turn` metrics emit (`_emit_reflection_metrics`)
+- `src/decafclaw/reflection_metrics.py` — metrics subscriber, `response_delta` / `classify_outcome`, stats aggregation, `make reflection-stats`
+- `src/decafclaw/config_types.py` — `ReflectionConfig` and `TelemetryConfig` dataclasses
 - `data/{agent_id}/REFLECTION.md` — optional custom judge prompt override

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -171,3 +171,17 @@ These skills ship with DecafClaw and provide tools when activated. Full details 
 ## Priority tiers and deferred loading
 
 Every tool declares a priority: `critical` (✓ above), `normal` (default), or `low`. When the active tool budget is exceeded, the classifier fills tier by tier: critical first, then normal, deferring `low`-priority tools behind `tool_search`. Pre-emptive search can promote tools to critical for a single turn based on user-message keyword matches. See [Tool Priority System](tool-priority.md), [Tool Search](tool-search.md), and [Pre-emptive Tool Search](preemptive-tool-search.md).
+
+## Tool usage telemetry (#310)
+
+`tool_telemetry.py` is a fail-open EventBus subscriber that appends one **metadata-only** JSONL record per tool call to `{workspace}/tool_usage.jsonl`. It answers "which tools are load-bearing and which are decorative" with data instead of intuition — the first step before any [MCP-overload](tool-priority.md) consolidation.
+
+**Record shape** (one per `tool_end` event): `timestamp`, `conv_id`, `tool`, `source` (`core`/`skill`/`mcp`), `source_detail` (owning skill / MCP server), `outcome` (`success`/`error`/`cancelled`), `duration_ms`, `input_bytes`, `output_bytes`.
+
+**Privacy:** tool arguments and return bodies are **never** recorded — only names, sizes, counts, and the inferred outcome. Outcome is derived from the result-text prefix (`[error…]` / `[cancelled…]`), so unknown-tool calls surface as `error` records automatically.
+
+The publish site in `tool_execution.py` enriches `tool_start`/`tool_end` with `conv_id`, `duration_ms`, and `input_bytes`; the subscriber consumes `tool_end` only. Wired in `runner.py`, guarded by `config.telemetry.tool_usage_enabled` (default on).
+
+**Report:** `make tool-usage-report` (`python -m decafclaw.tool_telemetry`) ranks tools by calls with unique-conversation counts, error rate, and last-called time, then lists never-called core + skill tools as consolidation candidates. MCP tools are only enumerable when their servers are connected, so offline unused-detection doesn't cover them.
+
+Config: see [config.md](config.md) `telemetry` group.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -29,6 +29,7 @@ from .iteration_budget import IterationBudget
 from .llm import call_llm
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause, extract_workspace_media
 from .persistence import read_skill_data, read_skills_state, write_skill_data, write_skills_state
+from .reflection_metrics import classify_outcome, response_delta
 from .skills import activate_always_loaded
 from .tool_definitions import build_tool_list, refresh_dynamic_tools
 from .tool_execution import execute_tool_calls
@@ -470,6 +471,14 @@ class TurnRunner:
     empty_retries: int = 0
     reflection_retries: int = 0
     last_reflection: "ReflectionResult | None" = None
+    # Reflection telemetry (#409) — captured across rounds for the per-turn
+    # metrics emit. first_response is the round-0 response the judge saw;
+    # exhausted survives _reflection_skip nulling last_reflection.
+    reflection_first_response: "str | None" = None
+    reflection_judge_prompt_tokens: int = 0
+    reflection_judge_completion_tokens: int = 0
+    reflection_exhausted: bool = False
+    reflection_last_critique: str = ""
     turn_start_index: int = 0
     accumulated_text_parts: list[str] = field(default_factory=list)
     model_override: dict[str, str] = field(default_factory=dict)
@@ -493,6 +502,11 @@ class TurnRunner:
             self.empty_retries = 0
             self.reflection_retries = 0
             self.last_reflection = None  # last ReflectionResult, for archiving after final response
+            self.reflection_first_response = None
+            self.reflection_judge_prompt_tokens = 0
+            self.reflection_judge_completion_tokens = 0
+            self.reflection_exhausted = False
+            self.reflection_last_critique = ""
 
             self.accumulated_text_parts = []  # text from iterations that also had tool calls
             self.budget = IterationBudget(
@@ -599,13 +613,19 @@ class TurnRunner:
         if usage:
             prompt_tokens = usage.get("prompt_tokens", 0)
             completion_tokens = usage.get("completion_tokens", 0)
+            cached_tokens = usage.get("cached_tokens", 0)
             self.ctx.tokens.total_prompt += prompt_tokens
             self.ctx.tokens.total_completion += completion_tokens
             self.ctx.tokens.last_prompt = prompt_tokens
+            self.ctx.tokens.total_cached_prompt += cached_tokens
+            self.ctx.tokens.last_cached_prompt = cached_tokens
             self.prompt_tokens = prompt_tokens
+            log.debug("Turn token usage: prompt=%s, cached=%s, completion=%s",
+                      prompt_tokens, cached_tokens, completion_tokens)
             # composer is set by _compose() before the loop; guard is for the type checker
             if self.composer is not None:
-                self.composer.record_actuals(prompt_tokens, completion_tokens)
+                self.composer.record_actuals(prompt_tokens, completion_tokens,
+                                             cached_tokens)
 
         tool_calls = response.get("tool_calls")
         if tool_calls:
@@ -759,8 +779,44 @@ class TurnRunner:
                 _archive(self.ctx, {"role": "reflection", "tool": label,
                                     "content": detail})
 
+        await self._emit_reflection_metrics(content)
         await _maybe_compact(self.ctx, self.config, self.history, self.prompt_tokens)
         return _Final(result=self._extract_workspace_media(content))
+
+    async def _emit_reflection_metrics(self, final_content: str) -> None:
+        """Publish one reflection_turn telemetry event per judge-eligible turn
+        (#409). Fail-open — measurement only, never affects the turn."""
+        try:
+            config = self.config
+            if not config.reflection.enabled or self.ctx.skip_reflection:
+                return  # disabled or child agent — not a reflection turn
+            if self.ctx.cancelled and self.ctx.cancelled.is_set():
+                return
+            last_error = self.last_reflection.error if self.last_reflection else ""
+            outcome = classify_outcome(
+                first_response=self.reflection_first_response,
+                last_error=last_error,
+                retry_count=self.reflection_retries,
+                exhausted=self.reflection_exhausted,
+                final_content=final_content,
+            )
+            if outcome is None:
+                return
+            first = self.reflection_first_response or final_content
+            char_delta, overlap = response_delta(first, final_content)
+            await self.ctx.publish(
+                "reflection_turn",
+                conv_id=self.ctx.conv_id,
+                outcome=outcome,
+                retry_count=self.reflection_retries,
+                judge_prompt_tokens=self.reflection_judge_prompt_tokens,
+                judge_completion_tokens=self.reflection_judge_completion_tokens,
+                char_delta=char_delta,
+                overlap_ratio=overlap,
+                critique_fingerprint=self.reflection_last_critique[:120],
+            )
+        except Exception as exc:  # fail-open
+            log.debug("reflection metrics emit failed: %s", exc)
 
     async def _handle_reflection(self, content: str) -> ReflectionOutcome:
         """Thin orchestrator. Mutates self.reflection_retries and
@@ -781,6 +837,10 @@ class TurnRunner:
             and self.last_reflection is not None
             and not self.last_reflection.passed
         )
+        # Telemetry (#409): persist the exhausted verdict before nulling
+        # last_reflection, so the per-turn emit can bucket it as loop_exhausted.
+        if reflection_exhausted:
+            self.reflection_exhausted = True
         self.last_reflection = None
         if reflection_exhausted:
             content += (
@@ -818,11 +878,20 @@ class TurnRunner:
             part for part in [*self.accumulated_text_parts, content]
             if part and part.strip()
         ) or content
+        # Telemetry (#409): capture the first response the judge sees and
+        # accumulate judge token cost across rounds.
+        if self.reflection_first_response is None:
+            self.reflection_first_response = content
+
         result = await evaluate_response(
             self.config, judge_user_message, judge_agent_response, tool_summary,
             prior_turn_summary=prior_turn_summary,
             retrieved_context=self.retrieved_context_text,
         )
+        self.reflection_judge_prompt_tokens += result.prompt_tokens
+        self.reflection_judge_completion_tokens += result.completion_tokens
+        if result.critique:
+            self.reflection_last_critique = result.critique
 
         log.info("Reflection result: passed=%s, critique=%s, error=%s",
                  result.passed, result.critique[:200] if result.critique else "",

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -34,6 +34,7 @@ from .config_types import (
     ProviderConfig,
     ReflectionConfig,
     RelevanceConfig,
+    TelemetryConfig,
     VaultConfig,
     VaultGuideConfig,
     VaultRetrievalConfig,
@@ -183,6 +184,7 @@ class Config:
     email: EmailConfig = field(default_factory=EmailConfig)
     background: BackgroundConfig = field(default_factory=BackgroundConfig)
     workflow: WorkflowConfig = field(default_factory=WorkflowConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     widgets: WidgetsConfig = field(default_factory=WidgetsConfig)
 
     # Custom environment variables from config.json "env" section
@@ -466,6 +468,9 @@ def load_config() -> Config:
     workflow = load_sub_config(
         WorkflowConfig, file_data.get("workflow", {}), "WORKFLOW")
 
+    telemetry = load_sub_config(
+        TelemetryConfig, file_data.get("telemetry", {}), "TELEMETRY")
+
     # Build the doubly-nested widgets.map leaf explicitly so its systematic
     # env vars (WIDGETS_MAP_*) resolve. load_sub_config only recurses into a
     # nested dataclass field when that key is present in JSON, so a bare
@@ -553,6 +558,7 @@ def load_config() -> Config:
         email=email,
         background=background,
         workflow=workflow,
+        telemetry=telemetry,
         widgets=widgets,
         env=env_vars,
         system_prompt=system_prompt,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -407,6 +407,25 @@ class WorkflowConfig:
     max_resume_attempts: int = 3
 
 
+@dataclass
+class TelemetryConfig:
+    """Instrumentation sidecars (#310 tool usage, #409 reflection metrics).
+
+    Append-only JSONL under ``workspace/``, metadata only — never tool
+    args/returns, reflection response bodies, or prompt contents; only
+    names, sizes, counts, token totals, and fingerprints. Producers are
+    fail-open EventBus subscribers: a telemetry write that raises must
+    never break a turn. Paths are workspace-relative. Enabled by default
+    so a deployed agent starts collecting without a config edit — the
+    point is a week of real data. No rotation yet (append-only); retention
+    is a follow-up. See docs/tools.md and docs/reflection.md.
+    """
+    tool_usage_enabled: bool = True
+    tool_usage_path: str = "tool_usage.jsonl"
+    reflection_metrics_enabled: bool = True
+    reflection_metrics_path: str = "reflection/metrics.jsonl"
+
+
 def is_secret(dc_class: type, field_name: str) -> bool:
     """Check if a dataclass field is marked as secret."""
     for f in dc_fields(dc_class):

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -17,6 +17,10 @@ class TokenUsage:
     total_prompt: int = 0
     total_completion: int = 0
     last_prompt: int = 0
+    # Prompt tokens served from the provider's cache (#480). Subset of the
+    # prompt totals — measurement only, no billing/behavior implication here.
+    total_cached_prompt: int = 0
+    last_cached_prompt: int = 0
 
 
 @dataclass

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -123,6 +123,7 @@ class ComposerState:
     last_total_tokens_estimated: int = 0
     last_prompt_tokens_actual: int = 0
     last_completion_tokens_actual: int = 0
+    last_cached_prompt_tokens_actual: int = 0  # prompt tokens served from provider cache (#480)
     injected_paths: set[str] = field(default_factory=set)  # file_paths already in context; cleared on compaction
     # Cumulative tool-result clearing stats for this conversation
     # (#298). Reset on compaction since the surviving summary
@@ -1165,10 +1166,12 @@ class ContextComposer:
             f" ({pct:.0f}%), {message_count} messages{hint}]"
         )
 
-    def record_actuals(self, prompt_tokens: int, completion_tokens: int) -> None:
+    def record_actuals(self, prompt_tokens: int, completion_tokens: int,
+                       cached_prompt_tokens: int = 0) -> None:
         """Record actual token usage from the LLM response."""
         self.state.last_prompt_tokens_actual = prompt_tokens
         self.state.last_completion_tokens_actual = completion_tokens
+        self.state.last_cached_prompt_tokens_actual = cached_prompt_tokens
 
     def build_diagnostics(self, config, composed: ComposedContext) -> dict:
         """Build the full diagnostics dict for the context sidecar file."""
@@ -1202,6 +1205,12 @@ class ContextComposer:
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "total_tokens_estimated": composed.total_tokens_estimated,
             "total_tokens_actual": self.state.last_prompt_tokens_actual,
+            "cached_prompt_tokens": self.state.last_cached_prompt_tokens_actual,
+            "cache_hit_rate": (
+                round(self.state.last_cached_prompt_tokens_actual
+                      / self.state.last_prompt_tokens_actual, 4)
+                if self.state.last_prompt_tokens_actual else 0.0
+            ),
             "context_window_size": self._get_context_window_size(config),
             "compaction_threshold": config.compaction.max_tokens,
             "sources": sources,

--- a/src/decafclaw/llm/providers/openai_compat.py
+++ b/src/decafclaw/llm/providers/openai_compat.py
@@ -105,8 +105,10 @@ class OpenAICompatProvider:
         usage = data.get("usage")
 
         if usage:
-            log.debug("LLM usage: prompt=%s, completion=%s",
-                      usage.get("prompt_tokens"), usage.get("completion_tokens"))
+            usage["cached_tokens"] = _cached_tokens(usage)
+            log.debug("LLM usage: prompt=%s, completion=%s, cached=%s",
+                      usage.get("prompt_tokens"), usage.get("completion_tokens"),
+                      usage.get("cached_tokens"))
         log.debug("LLM response: content=%s, tool_calls=%d",
                   bool(message.get("content")), len(message.get("tool_calls", [])))
 
@@ -253,6 +255,17 @@ class OpenAICompatProvider:
 # ---------------------------------------------------------------------------
 
 
+def _cached_tokens(usage: dict | None) -> int:
+    """Prompt cache-hit token count from an OpenAI-compatible usage dict.
+
+    OpenAI reports it under ``prompt_tokens_details.cached_tokens``; providers
+    that don't cache omit it. Returns 0 when absent (#480)."""
+    if not usage:
+        return 0
+    details = usage.get("prompt_tokens_details") or {}
+    return details.get("cached_tokens", 0) or 0
+
+
 class _RetryableError(Exception):
     """Raised on 429/5xx to trigger retry logic."""
     def __init__(self, status: int, body: str, retry_after: str | None = None):
@@ -293,6 +306,7 @@ class _StreamState:
         """Process a single parsed SSE chunk."""
         chunk_usage = chunk.get("usage")
         if chunk_usage:
+            chunk_usage["cached_tokens"] = _cached_tokens(chunk_usage)
             self.usage = chunk_usage
 
         choices = chunk.get("choices", [])

--- a/src/decafclaw/llm/providers/vertex.py
+++ b/src/decafclaw/llm/providers/vertex.py
@@ -263,6 +263,7 @@ class _VertexStreamState:
                 "prompt_tokens": chunk_usage.get("promptTokenCount", 0),
                 "completion_tokens": chunk_usage.get("candidatesTokenCount", 0),
                 "total_tokens": chunk_usage.get("totalTokenCount", 0),
+                "cached_tokens": chunk_usage.get("cachedContentTokenCount", 0),
             }
 
         candidates = chunk.get("candidates", [])
@@ -564,4 +565,5 @@ def _parse_usage(data: dict) -> dict | None:
         "prompt_tokens": meta.get("promptTokenCount", 0),
         "completion_tokens": meta.get("candidatesTokenCount", 0),
         "total_tokens": meta.get("totalTokenCount", 0),
+        "cached_tokens": meta.get("cachedContentTokenCount", 0),
     }

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -31,6 +31,10 @@ class ReflectionResult:
     critique: str = ""
     raw_response: str = ""  # full judge output for debug mode
     error: str = ""         # non-empty if the judge call failed
+    # Judge LLM token cost for this round (#409 telemetry). 0 when the
+    # provider reports no usage or the call errored before completing.
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
 
 
 def load_reflection_prompt(config) -> str:
@@ -298,14 +302,21 @@ async def evaluate_response(
             )
 
         raw = response.get("content", "")
+        usage = response.get("usage") or {}
+        judge_prompt = usage.get("prompt_tokens", 0)
+        judge_completion = usage.get("completion_tokens", 0)
         passed, critique = _parse_verdict(raw)
 
         if passed is None:
             log.warning("Reflection judge returned unparseable output: %s", raw[:200])
             return ReflectionResult(passed=True, raw_response=raw,
-                                    error="unparseable judge output")
+                                    error="unparseable judge output",
+                                    prompt_tokens=judge_prompt,
+                                    completion_tokens=judge_completion)
 
-        return ReflectionResult(passed=passed, critique=critique, raw_response=raw)
+        return ReflectionResult(passed=passed, critique=critique, raw_response=raw,
+                                prompt_tokens=judge_prompt,
+                                completion_tokens=judge_completion)
 
     except Exception as exc:
         log.error("Reflection judge call failed: %s", exc)

--- a/src/decafclaw/reflection_metrics.py
+++ b/src/decafclaw/reflection_metrics.py
@@ -1,0 +1,188 @@
+"""Reflection cost/effectiveness telemetry (#409).
+
+A fail-open EventBus subscriber that appends one **metadata-only** JSONL
+record per judge-eligible turn to ``{workspace}/reflection/metrics.jsonl``
+(path/enable via ``config.telemetry``). It answers "does reflection earn its
+keep" with data: pass-first fraction (pure overhead), loop-exhausted fraction
+(waste), whether retries meaningfully change the answer (genuine value), and
+judge token cost.
+
+Privacy: we record the outcome bucket, retry count, judge token totals, a
+first-vs-final response *delta* (lengths + token-overlap ratio — not the
+bodies), and a short critique *fingerprint* (first ~120 chars, to spot
+repeating rejection patterns). No response bodies or prompt contents.
+
+``make reflection-stats`` (``python -m decafclaw.reflection_metrics``)
+aggregates recent rows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable
+
+log = logging.getLogger(__name__)
+
+FINGERPRINT_MAX = 120
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def response_delta(first: str, final: str) -> tuple[int, float]:
+    """Compare the first and final response cheaply.
+
+    Returns ``(char_delta, overlap_ratio)`` where char_delta is the signed
+    length change and overlap_ratio is the Jaccard overlap of whitespace
+    tokens (1.0 = identical wording, 0.0 = disjoint). Two empty strings count
+    as fully overlapping.
+    """
+    char_delta = len(final) - len(first)
+    a, b = set(first.split()), set(final.split())
+    union = a | b
+    overlap = len(a & b) / len(union) if union else 1.0
+    return char_delta, round(overlap, 4)
+
+
+def classify_outcome(*, first_response: str | None, last_error: str,
+                     retry_count: int, exhausted: bool,
+                     final_content: str) -> str | None:
+    """Decide the outcome bucket for a judge-eligible turn.
+
+    Returns ``None`` when no row should be emitted (eligible turn that never
+    reached the judge and produced a non-empty answer — e.g. an end_turn
+    path). Callers pass state captured on the turn runner.
+    """
+    if first_response is None:
+        # Judge never evaluated. The only reflect-gate decline that reaches a
+        # non-child, non-cancelled final is empty content; anything else isn't
+        # a reflection turn.
+        if not (final_content or "").strip():
+            return "skipped_empty"
+        return None
+    if exhausted:
+        return "loop_exhausted"
+    if last_error:
+        return "errored"
+    if retry_count == 0:
+        return "passed_first"
+    return "passed_after_retry"
+
+
+def _metrics_path(config) -> Path:
+    return config.workspace_path / config.telemetry.reflection_metrics_path
+
+
+def record_from_event(event: dict) -> dict:
+    """Build a record from a ``reflection_turn`` event (drops the type)."""
+    rec = {k: v for k, v in event.items() if k != "type"}
+    rec["timestamp"] = _now_iso()
+    return rec
+
+
+def append_record(config, record: dict) -> None:
+    """Append one record as JSONL. Fail-open — never propagates."""
+    try:
+        path = _metrics_path(config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:  # fail-open: telemetry must never break a turn
+        log.debug("reflection metrics write failed: %s", exc)
+
+
+def make_reflection_metrics_subscriber(config) -> Callable[[dict], Awaitable[None]]:
+    """EventBus subscriber: records each ``reflection_turn`` event. Fail-open."""
+    async def handle(event: dict) -> None:
+        try:
+            if event.get("type") != "reflection_turn":
+                return
+            append_record(config, record_from_event(event))
+        except Exception as exc:  # fail-open
+            log.debug("reflection metrics subscriber error: %s", exc)
+
+    return handle
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def load_records(config) -> list[dict]:
+    path = _metrics_path(config)
+    if not path.exists():
+        return []
+    records = []
+    # Stream line-by-line — the log is append-only and unrotated, so avoid
+    # materializing the whole file as one string + a splitlines list.
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def aggregate(records: list[dict]) -> dict:
+    """Aggregate reflection stats over a list of records."""
+    n = len(records)
+    buckets: dict[str, int] = defaultdict(int)
+    total_retries = 0
+    total_judge_tokens = 0
+    for r in records:
+        buckets[r.get("outcome", "unknown")] += 1
+        total_retries += r.get("retry_count", 0)
+        total_judge_tokens += (r.get("judge_prompt_tokens", 0)
+                               + r.get("judge_completion_tokens", 0))
+    return {
+        "total_turns": n,
+        "buckets": dict(buckets),
+        "pass_first_rate": buckets["passed_first"] / n if n else 0.0,
+        "loop_exhausted_rate": buckets["loop_exhausted"] / n if n else 0.0,
+        "mean_retries": total_retries / n if n else 0.0,
+        "total_judge_tokens": total_judge_tokens,
+        "mean_judge_tokens": total_judge_tokens / n if n else 0.0,
+    }
+
+
+def format_stats(stats: dict) -> str:
+    lines = ["# Reflection metrics", ""]
+    lines.append(f"Turns recorded: {stats['total_turns']}")
+    lines.append("")
+    lines.append("Outcome buckets:")
+    for bucket in ("passed_first", "passed_after_retry", "loop_exhausted",
+                   "errored", "skipped_empty"):
+        lines.append(f"  {bucket:<20} {stats['buckets'].get(bucket, 0)}")
+    for other, count in sorted(stats["buckets"].items()):
+        if other not in ("passed_first", "passed_after_retry", "loop_exhausted",
+                         "errored", "skipped_empty"):
+            lines.append(f"  {other:<20} {count}")
+    lines.append("")
+    lines.append(f"pass-first rate:     {stats['pass_first_rate'] * 100:.1f}%  (pure overhead)")
+    lines.append(f"loop-exhausted rate: {stats['loop_exhausted_rate'] * 100:.1f}%  (waste + bad UX)")
+    lines.append(f"mean retries:        {stats['mean_retries']:.2f}")
+    lines.append(f"judge tokens total:  {stats['total_judge_tokens']:,}")
+    lines.append(f"judge tokens/turn:   {stats['mean_judge_tokens']:.0f}")
+    return "\n".join(lines)
+
+
+def build_stats_report(config) -> str:
+    return format_stats(aggregate(load_records(config)))
+
+
+def main() -> None:
+    from .config import load_config
+    config = load_config()
+    print(build_stats_report(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -94,6 +94,19 @@ async def run_all(app_ctx):
             mm_client=mm_client,
         )
 
+        # Wire telemetry subscribers (measurement only, fail-open). Each
+        # records to an append-only JSONL sidecar under workspace/.
+        if config.telemetry.tool_usage_enabled:
+            from .tool_telemetry import make_tool_telemetry_subscriber
+            app_ctx.event_bus.subscribe(make_tool_telemetry_subscriber(config))
+            log.info("Telemetry: tool-usage subscriber active (%s)",
+                     config.telemetry.tool_usage_path)
+        if config.telemetry.reflection_metrics_enabled:
+            from .reflection_metrics import make_reflection_metrics_subscriber
+            app_ctx.event_bus.subscribe(make_reflection_metrics_subscriber(config))
+            log.info("Telemetry: reflection-metrics subscriber active (%s)",
+                     config.telemetry.reflection_metrics_path)
+
         # Start heartbeat timer
         if parse_interval(config.heartbeat.interval) is not None:
             # Use Mattermost heartbeat cycle if available, otherwise basic

--- a/src/decafclaw/tool_execution.py
+++ b/src/decafclaw/tool_execution.py
@@ -16,6 +16,7 @@ import functools
 import json
 import logging
 import re as _re
+import time
 
 from .archive import append_message
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause
@@ -226,9 +227,11 @@ async def execute_single_tool(call_ctx, tc, semaphore):
 
     result = ToolResult(text=f"[error: {fn_name} did not complete]")
     async with semaphore:
+        started = time.perf_counter()
         try:
             await call_ctx.publish("tool_start", tool=fn_name, args=fn_args,
-                                   tool_call_id=tool_call_id)
+                                   tool_call_id=tool_call_id,
+                                   conv_id=call_ctx.conv_id)
             result = await execute_tool(call_ctx, fn_name, fn_args)
             log.debug(f"Tool result [{fn_name}]: {result.text[:200]}...")
 
@@ -246,6 +249,10 @@ async def execute_single_tool(call_ctx, tc, semaphore):
             result = ToolResult(text=f"[error executing {fn_name}: {e}]")
         finally:
             widget_payload = resolve_widget(fn_name, result, tool_call_id)
+            try:
+                input_bytes = len(json.dumps(fn_args, default=str).encode("utf-8"))
+            except (TypeError, ValueError):
+                input_bytes = 0
             publish_kwargs = {
                 "tool": fn_name,
                 "result_text": result.text,
@@ -254,6 +261,9 @@ async def execute_single_tool(call_ctx, tc, semaphore):
                     result, "display_short_text", None),
                 "media": result.media or [],
                 "tool_call_id": tool_call_id,
+                "conv_id": call_ctx.conv_id,
+                "duration_ms": round((time.perf_counter() - started) * 1000, 1),
+                "input_bytes": input_bytes,
             }
             if widget_payload is not None:
                 publish_kwargs["widget"] = widget_payload

--- a/src/decafclaw/tool_telemetry.py
+++ b/src/decafclaw/tool_telemetry.py
@@ -1,0 +1,211 @@
+"""Tool-usage telemetry (#310).
+
+A fail-open EventBus subscriber that appends one metadata-only JSONL record
+per tool call to ``{workspace}/tool_usage.jsonl`` (path/enable via
+``config.telemetry``). We only record names, sizes, counts, and outcome —
+never tool args or return bodies.
+
+The subscriber consumes ``tool_end`` events, which the publish site in
+``tool_execution.py`` enriches with ``conv_id`` / ``duration_ms`` /
+``input_bytes``. Outcome is inferred from the ``result_text`` prefix
+(``[error…]`` / ``[cancelled…]``) since tool results encode failure as a
+string, not a structured field.
+
+``make tool-usage-report`` (``python -m decafclaw.tool_telemetry``) ranks
+tools by calls and flags never-called ones as consolidation candidates.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def classify_source(name: str, config) -> tuple[str, str]:
+    """Classify a tool by origin → (source, detail).
+
+    ``("mcp", server)`` for ``mcp__<server>__<tool>`` names, ``("skill",
+    owner)`` for names in ``config.skill_tool_owners``, else ``("core", "")``.
+    """
+    if name.startswith("mcp__"):
+        parts = name.split("__", 2)
+        server = parts[1] if len(parts) >= 3 else "unknown"
+        return ("mcp", server)
+    owner = getattr(config, "skill_tool_owners", {}).get(name)
+    if owner:
+        return ("skill", owner)
+    return ("core", "")
+
+
+def infer_outcome(result_text: str) -> str:
+    """Infer call outcome from the result-text prefix."""
+    text = (result_text or "").lstrip()
+    if text.startswith("[cancelled"):
+        return "cancelled"
+    if text.startswith("[error"):
+        return "error"
+    return "success"
+
+
+def _usage_path(config) -> Path:
+    return config.workspace_path / config.telemetry.tool_usage_path
+
+
+def record_from_event(event: dict, config) -> dict:
+    """Build a telemetry record from a ``tool_end`` event (metadata only)."""
+    name = event.get("tool", "")
+    source, detail = classify_source(name, config)
+    result_text = event.get("result_text", "") or ""
+    return {
+        "timestamp": _now_iso(),
+        "conv_id": event.get("conv_id", ""),
+        "tool": name,
+        "source": source,
+        "source_detail": detail,
+        "outcome": infer_outcome(result_text),
+        "duration_ms": event.get("duration_ms", 0),
+        "input_bytes": event.get("input_bytes", 0),
+        "output_bytes": len(result_text.encode("utf-8")),
+    }
+
+
+def append_record(config, record: dict) -> None:
+    """Append one record as JSONL. Fail-open — never propagates."""
+    try:
+        path = _usage_path(config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:  # fail-open: telemetry must never break a turn
+        log.debug("tool telemetry write failed: %s", exc)
+
+
+def make_tool_telemetry_subscriber(config) -> Callable[[dict], Awaitable[None]]:
+    """EventBus subscriber: records each ``tool_end`` event. Fail-open."""
+    async def handle(event: dict) -> None:
+        try:
+            if event.get("type") != "tool_end":
+                return
+            append_record(config, record_from_event(event, config))
+        except Exception as exc:  # fail-open
+            log.debug("tool telemetry subscriber error: %s", exc)
+
+    return handle
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def load_records(config) -> list[dict]:
+    path = _usage_path(config)
+    if not path.exists():
+        return []
+    records = []
+    # Stream line-by-line — the log is append-only and unrotated, so avoid
+    # materializing the whole file as one string + a splitlines list.
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def aggregate(records: list[dict]) -> dict[str, dict]:
+    """Aggregate per-tool stats: calls, unique convs, errors, last-called."""
+    calls: dict[str, int] = defaultdict(int)
+    errors: dict[str, int] = defaultdict(int)
+    convs: dict[str, set] = defaultdict(set)
+    last: dict[str, str] = {}
+    source: dict[str, str] = {}
+    for r in records:
+        tool = r.get("tool", "")
+        calls[tool] += 1
+        if r.get("outcome") == "error":
+            errors[tool] += 1
+        conv = r.get("conv_id")
+        if conv:
+            convs[tool].add(conv)
+        ts = r.get("timestamp", "")
+        if ts and ts > last.get(tool, ""):
+            last[tool] = ts
+        source.setdefault(tool, r.get("source", ""))
+    stats = {}
+    for tool in calls:
+        n = calls[tool]
+        stats[tool] = {
+            "calls": n,
+            "unique_convs": len(convs[tool]),
+            "errors": errors[tool],
+            "error_rate": errors[tool] / n if n else 0.0,
+            "last_called": last.get(tool, ""),
+            "source": source.get(tool, ""),
+        }
+    return stats
+
+
+def known_tool_names(config) -> set[str]:
+    """All tool names we can enumerate offline: core + skill-owned.
+
+    MCP tools are only knowable when their servers are connected, so
+    unused-MCP detection is out of reach for this offline report.
+    """
+    from .tools import TOOL_DEFINITIONS
+    names = {td.get("function", {}).get("name", "") for td in TOOL_DEFINITIONS}
+    names |= set(getattr(config, "skill_tool_owners", {}).keys())
+    names.discard("")
+    return names
+
+
+def format_report(stats: dict[str, dict], unused: set[str]) -> str:
+    lines = ["# Tool usage report", ""]
+    total = sum(s["calls"] for s in stats.values())
+    lines.append(f"Total calls recorded: {total} across {len(stats)} tools")
+    lines.append("")
+    lines.append(f"{'tool':<32} {'calls':>6} {'convs':>6} {'err%':>6}  last-called")
+    lines.append("-" * 72)
+    for tool, s in sorted(stats.items(), key=lambda kv: kv[1]["calls"], reverse=True):
+        lines.append(
+            f"{tool:<32} {s['calls']:>6} {s['unique_convs']:>6} "
+            f"{s['error_rate'] * 100:>5.0f}%  {s['last_called']}"
+        )
+    lines.append("")
+    lines.append(f"## Unused tools ({len(unused)}) — consolidation candidates")
+    lines.append("(core + skill tools never called; MCP tools not covered offline)")
+    if unused:
+        for name in sorted(unused):
+            lines.append(f"  - {name}")
+    else:
+        lines.append("  (none)")
+    return "\n".join(lines)
+
+
+def build_report(config) -> str:
+    records = load_records(config)
+    stats = aggregate(records)
+    unused = known_tool_names(config) - set(stats.keys())
+    return format_report(stats, unused)
+
+
+def main() -> None:
+    from .config import load_config
+    config = load_config()
+    print(build_report(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decafclaw/web/static/components/context-inspector.js
+++ b/src/decafclaw/web/static/components/context-inspector.js
@@ -159,6 +159,12 @@ export class ContextInspector extends LitElement {
         <dd>${data.total_tokens_estimated?.toLocaleString() || '—'}</dd>
         <dt>Actual</dt>
         <dd>${data.total_tokens_actual?.toLocaleString() || '—'}</dd>
+        <dt>Cached</dt>
+        <dd>
+          ${data.cached_prompt_tokens != null
+            ? html`${data.cached_prompt_tokens.toLocaleString()} (${Math.round((data.cache_hit_rate || 0) * 100)}%)`
+            : '—'}
+        </dd>
         <dt>Window</dt>
         <dd>${data.context_window_size?.toLocaleString() || '—'}</dd>
         <dt>Compact at</dt>

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -792,6 +792,24 @@ async def test_run_agent_turn_tracks_token_usage(ctx):
 
 
 @pytest.mark.asyncio
+async def test_run_agent_turn_tracks_cached_prompt_tokens(ctx):
+    """Cached-prompt-token count from provider usage accumulates on context (#480)."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "You are a test bot."
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = _mock_llm_response(
+            "hi", usage={"prompt_tokens": 200, "completion_tokens": 50,
+                         "cached_tokens": 160}
+        )
+        history = []
+        await run_agent_turn(ctx, "hi", history)
+
+    assert ctx.tokens.total_cached_prompt == 160
+    assert ctx.tokens.last_cached_prompt == 160
+
+
+@pytest.mark.asyncio
 async def test_run_agent_turn_archives_messages(ctx):
     """Messages are archived during the turn."""
     ctx.config.llm.streaming = False
@@ -996,6 +1014,122 @@ async def test_reflection_sees_text_emitted_alongside_tool_calls(ctx):
         f"but agent_response was: {agent_response_arg!r}"
     )
     assert trailer_text in agent_response_arg
+
+
+# -- reflection telemetry (#409) ----------------------------------------------
+
+
+def _collect_reflection_turns(ctx):
+    """Subscribe a collector for reflection_turn events. Returns the list."""
+    events: list[dict] = []
+
+    def _on(event):
+        if event.get("type") == "reflection_turn":
+            events.append(event)
+
+    ctx.event_bus.subscribe(_on)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_reflection_turn_emitted_passed_first(ctx):
+    """A first-pass turn emits one passed_first row with judge token cost."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+    events = _collect_reflection_turns(ctx)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("Good answer")
+        mock_eval.return_value = ReflectionResult(
+            passed=True, prompt_tokens=150, completion_tokens=8)
+        await run_agent_turn(ctx, "question", [])
+
+    assert len(events) == 1
+    assert events[0]["outcome"] == "passed_first"
+    assert events[0]["retry_count"] == 0
+    assert events[0]["judge_prompt_tokens"] == 150
+    assert events[0]["judge_completion_tokens"] == 8
+    assert events[0]["overlap_ratio"] == 1.0  # first == final
+    assert events[0]["char_delta"] == 0
+
+
+@pytest.mark.asyncio
+async def test_reflection_turn_emitted_passed_after_retry(ctx):
+    """A retried-then-passed turn emits passed_after_retry with a real delta
+    between the first and final response, and summed judge tokens."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True, max_retries=2)
+    events = _collect_reflection_turns(ctx)
+
+    llm_calls = 0
+
+    async def llm_side(*a, **k):
+        nonlocal llm_calls
+        llm_calls += 1
+        return _mock_llm_response("Bad answer" if llm_calls == 1 else "Better fuller answer")
+
+    eval_calls = 0
+
+    async def eval_side(*a, **k):
+        nonlocal eval_calls
+        eval_calls += 1
+        if eval_calls == 1:
+            return ReflectionResult(passed=False, critique="You missed the point",
+                                    prompt_tokens=200, completion_tokens=15)
+        return ReflectionResult(passed=True, prompt_tokens=210, completion_tokens=5)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock, side_effect=llm_side), \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock,
+               side_effect=eval_side):
+        await run_agent_turn(ctx, "question", [])
+
+    assert len(events) == 1
+    e = events[0]
+    assert e["outcome"] == "passed_after_retry"
+    assert e["retry_count"] == 1
+    assert e["judge_prompt_tokens"] == 410  # summed across rounds
+    assert e["judge_completion_tokens"] == 20
+    assert e["overlap_ratio"] < 1.0  # first differs from final
+    assert e["critique_fingerprint"].startswith("You missed the point")
+
+
+@pytest.mark.asyncio
+async def test_reflection_turn_emitted_loop_exhausted(ctx):
+    """An always-failing judge exhausts retries and emits loop_exhausted even
+    though last_reflection is nulled on the skip path."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True, max_retries=1)
+    events = _collect_reflection_turns(ctx)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.reflection.evaluate_response", new_callable=AsyncMock) as mock_eval:
+        mock_llm.return_value = _mock_llm_response("Mediocre answer")
+        mock_eval.return_value = ReflectionResult(
+            passed=False, critique="Still not great", prompt_tokens=180)
+        await run_agent_turn(ctx, "question", [])
+
+    assert len(events) == 1
+    assert events[0]["outcome"] == "loop_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_reflection_turn_not_emitted_for_child_agent(ctx):
+    """Child agents (skip_reflection) emit no reflection_turn row."""
+    ctx.config.llm.streaming = False
+    ctx.config.system_prompt = "test"
+    ctx.config.reflection = ReflectionConfig(enabled=True)
+    ctx.skip_reflection = True
+    events = _collect_reflection_turns(ctx)
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.return_value = _mock_llm_response("child response")
+        await run_agent_turn(ctx, "question", [])
+
+    assert events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_streaming.py
+++ b/tests/test_llm_streaming.py
@@ -113,7 +113,7 @@ async def test_streaming_text_only():
 
 @pytest.mark.asyncio
 async def test_streaming_with_usage():
-    """Usage from final chunk is captured."""
+    """Usage from final chunk is captured (with normalized cached_tokens, #480)."""
     usage = {"prompt_tokens": 10, "completion_tokens": 5}
     events = _make_text_events(["Hi"], usage=usage)
 
@@ -121,7 +121,8 @@ async def test_streaming_with_usage():
         mock_sse.return_value = FakeEventSource(events)
         result = await call_llm_streaming(_config(), [])
 
-    assert result["usage"] == usage
+    assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5,
+                               "cached_tokens": 0}
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_cache_tokens.py
+++ b/tests/test_provider_cache_tokens.py
@@ -1,0 +1,76 @@
+"""Prompt-cache token surfacing (#480 Phase 1).
+
+Providers already receive cached-prompt-token counts but drop them. These
+tests pin the normalization: every provider usage dict grows a ``cached_tokens``
+key (0 when the provider reports none), so the agent merge point stays
+provider-agnostic.
+"""
+
+import pytest
+
+from decafclaw.llm.providers import openai_compat, vertex
+
+# -- Vertex (Gemini usageMetadata.cachedContentTokenCount) --------------------
+
+
+def test_vertex_parse_usage_extracts_cached_tokens():
+    data = {
+        "usageMetadata": {
+            "promptTokenCount": 1000,
+            "candidatesTokenCount": 50,
+            "totalTokenCount": 1050,
+            "cachedContentTokenCount": 800,
+        }
+    }
+    usage = vertex._parse_usage(data)
+    assert usage["prompt_tokens"] == 1000
+    assert usage["cached_tokens"] == 800
+
+
+def test_vertex_parse_usage_cached_defaults_zero():
+    data = {"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 2,
+                              "totalTokenCount": 12}}
+    usage = vertex._parse_usage(data)
+    assert usage["cached_tokens"] == 0
+
+
+@pytest.mark.asyncio
+async def test_vertex_streaming_usage_carries_cached():
+    state = vertex._VertexStreamState()
+    await state.process_chunk({
+        "usageMetadata": {
+            "promptTokenCount": 500,
+            "candidatesTokenCount": 20,
+            "totalTokenCount": 520,
+            "cachedContentTokenCount": 300,
+        }
+    })
+    assert state.usage["cached_tokens"] == 300
+
+
+# -- OpenAI-compat (prompt_tokens_details.cached_tokens) ----------------------
+
+
+def test_openai_compat_cached_tokens_helper():
+    assert openai_compat._cached_tokens(
+        {"prompt_tokens": 1200, "prompt_tokens_details": {"cached_tokens": 900}}
+    ) == 900
+
+
+def test_openai_compat_cached_tokens_absent_is_zero():
+    assert openai_compat._cached_tokens({"prompt_tokens": 1200}) == 0
+    assert openai_compat._cached_tokens(None) == 0
+
+
+@pytest.mark.asyncio
+async def test_openai_compat_streaming_usage_carries_cached():
+    state = openai_compat._StreamState()
+    await state.process_chunk({
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 1200,
+            "completion_tokens": 40,
+            "prompt_tokens_details": {"cached_tokens": 900},
+        },
+    })
+    assert state.usage["cached_tokens"] == 900

--- a/tests/test_reflection_metrics.py
+++ b/tests/test_reflection_metrics.py
@@ -1,0 +1,161 @@
+"""Reflection cost/effectiveness telemetry (#409).
+
+Records one metadata-only row per judge-eligible turn: outcome bucket, retry
+count, judge token cost, first-vs-final response delta, and a critique
+fingerprint. Fail-open. ``make reflection-stats`` aggregates.
+"""
+
+import json
+
+import pytest
+
+from decafclaw import reflection_metrics
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig
+
+
+def _config(tmp_path):
+    return Config(agent=AgentConfig(data_home=str(tmp_path), id="t"))
+
+
+# -- response delta ------------------------------------------------------------
+
+
+def test_response_delta_identical():
+    char_delta, overlap = reflection_metrics.response_delta("same text", "same text")
+    assert char_delta == 0
+    assert overlap == 1.0
+
+
+def test_response_delta_disjoint():
+    char_delta, overlap = reflection_metrics.response_delta("alpha beta", "gamma delta epsilon")
+    assert overlap == 0.0
+    assert char_delta == len("gamma delta epsilon") - len("alpha beta")
+
+
+def test_response_delta_partial_overlap():
+    _, overlap = reflection_metrics.response_delta("the quick fox", "the quick dog")
+    # {the,quick,fox} vs {the,quick,dog}: intersection 2, union 4 → 0.5
+    assert overlap == 0.5
+
+
+def test_response_delta_empty_both():
+    char_delta, overlap = reflection_metrics.response_delta("", "")
+    assert char_delta == 0
+    assert overlap == 1.0
+
+
+# -- outcome classification ----------------------------------------------------
+
+
+def test_classify_passed_first():
+    assert reflection_metrics.classify_outcome(
+        first_response="hi", last_error="", retry_count=0,
+        exhausted=False, final_content="hi") == "passed_first"
+
+
+def test_classify_passed_after_retry():
+    assert reflection_metrics.classify_outcome(
+        first_response="v0", last_error="", retry_count=1,
+        exhausted=False, final_content="v1") == "passed_after_retry"
+
+
+def test_classify_loop_exhausted():
+    assert reflection_metrics.classify_outcome(
+        first_response="v0", last_error="", retry_count=2,
+        exhausted=True, final_content="v2") == "loop_exhausted"
+
+
+def test_classify_errored():
+    assert reflection_metrics.classify_outcome(
+        first_response="v0", last_error="judge boom", retry_count=0,
+        exhausted=False, final_content="v0") == "errored"
+
+
+def test_classify_skipped_empty():
+    assert reflection_metrics.classify_outcome(
+        first_response=None, last_error="", retry_count=0,
+        exhausted=False, final_content="") == "skipped_empty"
+
+
+def test_classify_none_when_not_evaluated_but_has_content():
+    # Eligible but judge never ran and content is non-empty (e.g. end_turn
+    # path) → no row.
+    assert reflection_metrics.classify_outcome(
+        first_response=None, last_error="", retry_count=0,
+        exhausted=False, final_content="a real answer") is None
+
+
+# -- subscriber writes a record ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscriber_writes_record(tmp_path):
+    cfg = _config(tmp_path)
+    handle = reflection_metrics.make_reflection_metrics_subscriber(cfg)
+    await handle({
+        "type": "reflection_turn",
+        "conv_id": "conv-1",
+        "outcome": "passed_after_retry",
+        "retry_count": 1,
+        "judge_prompt_tokens": 300,
+        "judge_completion_tokens": 20,
+        "char_delta": 45,
+        "overlap_ratio": 0.6,
+        "critique_fingerprint": "the answer omits the error handling",
+    })
+    path = cfg.workspace_path / cfg.telemetry.reflection_metrics_path
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["outcome"] == "passed_after_retry"
+    assert rec["retry_count"] == 1
+    assert rec["judge_prompt_tokens"] == 300
+    assert rec["conv_id"] == "conv-1"
+    assert rec["critique_fingerprint"] == "the answer omits the error handling"
+    assert "timestamp" in rec
+    assert "type" not in rec
+
+
+@pytest.mark.asyncio
+async def test_subscriber_ignores_other_events(tmp_path):
+    cfg = _config(tmp_path)
+    handle = reflection_metrics.make_reflection_metrics_subscriber(cfg)
+    await handle({"type": "reflection_result", "passed": True})
+    path = cfg.workspace_path / cfg.telemetry.reflection_metrics_path
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open(tmp_path):
+    cfg = _config(tmp_path)
+    # Occupy the reflection/ dir path with a plain file so mkdir(parents) fails.
+    workspace = tmp_path / "data" / "t" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "reflection").write_text("file, not a dir")
+    handle = reflection_metrics.make_reflection_metrics_subscriber(cfg)
+    await handle({"type": "reflection_turn", "outcome": "passed_first"})  # must not raise
+
+
+# -- stats aggregation ---------------------------------------------------------
+
+
+def test_aggregate_stats():
+    records = [
+        {"outcome": "passed_first", "retry_count": 0, "judge_prompt_tokens": 100,
+         "judge_completion_tokens": 10},
+        {"outcome": "passed_first", "retry_count": 0, "judge_prompt_tokens": 120,
+         "judge_completion_tokens": 12},
+        {"outcome": "passed_after_retry", "retry_count": 1, "judge_prompt_tokens": 300,
+         "judge_completion_tokens": 30},
+        {"outcome": "loop_exhausted", "retry_count": 2, "judge_prompt_tokens": 500,
+         "judge_completion_tokens": 50},
+    ]
+    stats = reflection_metrics.aggregate(records)
+    assert stats["total_turns"] == 4
+    assert stats["buckets"]["passed_first"] == 2
+    assert stats["buckets"]["loop_exhausted"] == 1
+    assert stats["pass_first_rate"] == pytest.approx(0.5)
+    assert stats["loop_exhausted_rate"] == pytest.approx(0.25)
+    assert stats["mean_retries"] == pytest.approx((0 + 0 + 1 + 2) / 4)
+    assert stats["total_judge_tokens"] == 100 + 10 + 120 + 12 + 300 + 30 + 500 + 50

--- a/tests/test_tool_telemetry.py
+++ b/tests/test_tool_telemetry.py
@@ -1,0 +1,139 @@
+"""Tool-usage telemetry (#310).
+
+Subscriber consumes ``tool_end`` events (enriched with conv_id / duration_ms /
+input_bytes at the publish site) and appends one metadata-only JSONL record per
+tool call. Fail-open. A report ranks tools and flags never-called ones.
+"""
+
+import json
+
+import pytest
+
+from decafclaw import tool_telemetry
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig
+
+
+def _config(tmp_path):
+    cfg = Config(agent=AgentConfig(data_home=str(tmp_path), id="t"))
+    cfg.skill_tool_owners = {"vault_write": "vault", "dream_now": "dream"}
+    return cfg
+
+
+# -- source classification ----------------------------------------------------
+
+
+def test_classify_source_core():
+    cfg = Config()
+    cfg.skill_tool_owners = {}
+    assert tool_telemetry.classify_source("notes_append", cfg) == ("core", "")
+
+
+def test_classify_source_skill():
+    cfg = Config()
+    cfg.skill_tool_owners = {"vault_write": "vault"}
+    assert tool_telemetry.classify_source("vault_write", cfg) == ("skill", "vault")
+
+
+def test_classify_source_mcp():
+    cfg = Config()
+    cfg.skill_tool_owners = {}
+    assert tool_telemetry.classify_source(
+        "mcp__fastmail__send_email", cfg) == ("mcp", "fastmail")
+
+
+# -- outcome inference ---------------------------------------------------------
+
+
+def test_infer_outcome():
+    assert tool_telemetry.infer_outcome("all good") == "success"
+    assert tool_telemetry.infer_outcome("[error executing foo: boom]") == "error"
+    assert tool_telemetry.infer_outcome("[error: unknown tool 'x']") == "error"
+    assert tool_telemetry.infer_outcome("[cancelled: foo]") == "cancelled"
+
+
+# -- subscriber writes a record ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscriber_writes_record(tmp_path):
+    cfg = _config(tmp_path)
+    handle = tool_telemetry.make_tool_telemetry_subscriber(cfg)
+    await handle({
+        "type": "tool_end",
+        "tool": "vault_write",
+        "conv_id": "conv-1",
+        "result_text": "wrote page",
+        "duration_ms": 12.5,
+        "input_bytes": 40,
+    })
+    path = cfg.workspace_path / cfg.telemetry.tool_usage_path
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["tool"] == "vault_write"
+    assert rec["source"] == "skill"
+    assert rec["source_detail"] == "vault"
+    assert rec["outcome"] == "success"
+    assert rec["conv_id"] == "conv-1"
+    assert rec["duration_ms"] == 12.5
+    assert rec["input_bytes"] == 40
+    assert rec["output_bytes"] == len("wrote page".encode("utf-8"))
+    assert "timestamp" in rec
+
+
+@pytest.mark.asyncio
+async def test_subscriber_ignores_other_events(tmp_path):
+    cfg = _config(tmp_path)
+    handle = tool_telemetry.make_tool_telemetry_subscriber(cfg)
+    await handle({"type": "tool_start", "tool": "vault_write"})
+    path = cfg.workspace_path / cfg.telemetry.tool_usage_path
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open_on_bad_path(tmp_path, caplog):
+    cfg = _config(tmp_path)
+    # Point the path at a location that can't be created (a file as a dir parent).
+    blocker = tmp_path / "data" / "t" / "workspace"
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("i am a file, not a dir")
+    handle = tool_telemetry.make_tool_telemetry_subscriber(cfg)
+    # Must not raise.
+    await handle({"type": "tool_end", "tool": "x", "result_text": "ok"})
+
+
+# -- report aggregation --------------------------------------------------------
+
+
+def test_aggregate_counts_and_error_rate():
+    records = [
+        {"tool": "a", "conv_id": "c1", "outcome": "success", "timestamp": "2026-07-23T10:00:00Z"},
+        {"tool": "a", "conv_id": "c1", "outcome": "error", "timestamp": "2026-07-23T11:00:00Z"},
+        {"tool": "a", "conv_id": "c2", "outcome": "success", "timestamp": "2026-07-23T12:00:00Z"},
+        {"tool": "b", "conv_id": "c1", "outcome": "success", "timestamp": "2026-07-23T09:00:00Z"},
+    ]
+    stats = tool_telemetry.aggregate(records)
+    a = stats["a"]
+    assert a["calls"] == 3
+    assert a["unique_convs"] == 2
+    assert a["errors"] == 1
+    assert a["error_rate"] == pytest.approx(1 / 3)
+    assert a["last_called"] == "2026-07-23T12:00:00Z"
+
+
+def test_build_report_flags_unused(tmp_path, monkeypatch):
+    cfg = _config(tmp_path)
+    # One record for a known skill tool; the other known tools are unused.
+    path = cfg.workspace_path / cfg.telemetry.tool_usage_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "tool": "vault_write", "conv_id": "c1", "outcome": "success",
+        "timestamp": "2026-07-23T10:00:00Z"}) + "\n")
+    # Pretend the full known-tool set is exactly these two skill tools.
+    monkeypatch.setattr(tool_telemetry, "known_tool_names",
+                        lambda c: {"vault_write", "dream_now"})
+    report = tool_telemetry.build_report(cfg)
+    assert "vault_write" in report
+    assert "dream_now" in report  # unused → listed
+    assert "unused" in report.lower()

--- a/tests/test_vertex_translation.py
+++ b/tests/test_vertex_translation.py
@@ -449,6 +449,7 @@ def test_parse_usage():
         "prompt_tokens": 100,
         "completion_tokens": 50,
         "total_tokens": 150,
+        "cached_tokens": 0,
     }
 
 


### PR DESCRIPTION
## Summary
- Adds measure-before-building instrumentation for the three most-argued subsystems — the tool registry (#310), reflection (#409), and prompt handling (#480) — surfaced by the 2026-07-23 backlog triage as the strongest cross-cutting signal: these are reasoned about from impression, and their expensive follow-ups are correctly *gated* on data that doesn't exist yet.
- **Changes no behavior.** Pure data-collection surfaces plus a way to read them. Decisions about what to do with the data are out of scope and become follow-up issues once ~a week of real numbers exists.

## Design Decisions
- **Shared shape** across all three: append-only JSONL sidecars under `workspace/`, a new `TelemetryConfig` group (defaults→config.json→env), fail-open EventBus-subscriber producers, reports via `make` targets.
- **Metadata only** — never tool args/returns, reflection response bodies, or prompt contents; only names, sizes, counts, token totals, deltas, and a 120-char critique fingerprint.
- **Enabled by default** so a deployed agent starts collecting immediately (the point is a week of real data). No log rotation yet — append-only; retention is a follow-up.
- **Two forks confirmed with the author during brainstorm:** (1) enrich `tool_end` events with `conv_id`/`duration_ms`/`input_bytes` at the publish site rather than pairing start/end in the subscriber; (2) emit a reflection row only for *judge-eligible* turns (enabled, non-child, reached a no-tool final), keeping pass-rate denominators meaningful.

## Changes
- **#480 Phase 1 — prompt-cache tokens:** providers normalize a common `cached_tokens` usage key (Vertex `cachedContentTokenCount`; OpenAI-compat `prompt_tokens_details.cached_tokens`); `TokenUsage.total/last_cached_prompt`; surfaced in the diagnostics sidecar (`cached_prompt_tokens` + `cache_hit_rate`) and the context-inspector popover. Phases 2/3 (prompt reorder, `cache_control` hints) explicitly out of scope.
- **#310 — tool usage:** `tool_telemetry.py` subscriber → `workspace/tool_usage.jsonl` (source classification core/skill/mcp, outcome from result-text prefix); `make tool-usage-report` ranks tools + flags never-called core/skill tools.
- **#409 — reflection:** `ReflectionResult` now carries per-round judge tokens (were discarded); `reflection_metrics.py` subscriber → `workspace/reflection/metrics.jsonl` with outcome buckets, retry count, judge token cost, first-vs-final response delta (char + Jaccard overlap), critique fingerprint; `make reflection-stats`. An explicit `reflection_exhausted` flag is set before `_reflection_skip` nulls `last_reflection` so `loop_exhausted` survives.
- Docs: `config.md` (telemetry group), `tools.md`, `reflection.md`, `context-composer.md`, CLAUDE.md key-files.

## Test Plan
- [x] `make test` — 3048 passed (34 new: provider parsing, tool telemetry, reflection metrics + through-`run_agent_turn` bucket integration)
- [x] `make check` — clean (ruff + pyright + tsc)
- [x] `make tool-usage-report` / `make reflection-stats` — run against an empty log without error
- [ ] **Live (post-merge):** run turns in the web UI; confirm records land in the two sidecars with sane fields, the report/stats rank them, and the popover shows the Cached row rising as the prefix stabilizes.

## References
- Spec: `docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/spec.md`
- Plan: `docs/dev-sessions/2026-07-23-0917-instrumentation-measure-first/plan.md`
- Triage that motivated this: `docs/dev-sessions/2026-07-23-0948-issue-triage/triage.md` (roadmap #622)
- Closes #310
- Closes #409
- #480 — **Phase 1 only**; issue stays open for Phases 2/3 (gated on this data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)