### PR TITLE
fix(attachments): route uploads_dir through conversation_dir for sanitization (#587)

### DIFF
--- a/src/decafclaw/attachments.py
+++ b/src/decafclaw/attachments.py
@@ -6,12 +6,18 @@ import mimetypes
 from datetime import datetime
 from pathlib import Path
 
+from decafclaw.conversation_paths import conversation_dir
+
 log = logging.getLogger(__name__)
 
 
 def uploads_dir(config, conv_id: str) -> Path:
-    """Return the uploads directory for a conversation (does not create it)."""
-    return config.workspace_path / "conversations" / conv_id / "uploads"
+    """Return the uploads directory for a conversation (does not create it).
+
+    Delegates to `conversation_dir` so the user-controlled `conv_id` is
+    sanitized and sandboxed under the conversations root (#587).
+    """
+    return conversation_dir(config, conv_id) / "uploads"
 
 
 def save_attachment(config, conv_id: str, filename: str, data: bytes,

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -9,6 +9,7 @@ from decafclaw.attachments import (
     save_attachment,
     uploads_dir,
 )
+from decafclaw.conversation_paths import conversations_root
 
 
 def test_save_attachment_writes_file(config):
@@ -86,3 +87,20 @@ def test_delete_conversation_uploads(config):
 def test_delete_conversation_uploads_noop_if_missing(config):
     # Should not raise
     delete_conversation_uploads(config, "nonexistent")
+
+
+# --- sandboxing (#587) ------------------------------------------------------
+
+
+def test_uploads_dir_traversal_stays_under_root(config):
+    # conv_id from web routes is user-controlled; a traversal id must not
+    # escape the conversations root.
+    root = conversations_root(config)
+    d = uploads_dir(config, "../../etc")
+    assert d.resolve().is_relative_to(root)
+
+
+def test_uploads_dir_empty_id_resolves_to_invalid(config):
+    root = conversations_root(config)
+    d = uploads_dir(config, "")
+    assert d == root / "_invalid" / "uploads"


### PR DESCRIPTION
## Summary

`attachments.py::uploads_dir` built `config.workspace_path / "conversations" / conv_id / "uploads"` directly, bypassing the `_safe_conv_id` sanitization and `is_relative_to` sandbox that every other per-conversation path goes through via `conversation_paths.conversation_dir`. Since `conv_id` from web routes is user-controlled, a traversal id (e.g. `../../etc`) escaped the conversations root.

Fix delegates to the single chokepoint, exactly as proposed in #587:

```python
def uploads_dir(config, conv_id):
    return conversation_dir(config, conv_id) / "uploads"
```

No import cycle — `conversation_paths` imports only stdlib.

## Testing

- Added `test_uploads_dir_traversal_stays_under_root` and `test_uploads_dir_empty_id_resolves_to_invalid` (test-first: confirmed red against unfixed code, green after fix).
- `make lint` ✓, `make typecheck` ✓ (0 errors), `make test` ✓ (3050 passed).

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)