### PR TITLE
fix(tools): never suggest the unknown tool name back in did-you-mean hint (#355)

### DIFF
--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -174,8 +174,11 @@ def _suggest_tool_names(name: str, candidates: set[str], max_results: int = 5) -
     # present in the candidate pool (e.g. a deferred/unactivated tool),
     # difflib would return it as an exact ratio-1.0 match. Case-insensitive
     # so a candidate differing only in case is treated as the same name.
+    # `isinstance(c, str)` guards against a malformed tool def leaving a
+    # None in the pool (deferred_names uses `.get("name")` with no default)
+    # — a suggestion hint must never crash the unknown-tool error path.
     name_lower = name.lower()
-    candidates = {c for c in candidates if c.lower() != name_lower}
+    candidates = {c for c in candidates if isinstance(c, str) and c.lower() != name_lower}
     if not candidates:
         return []
     suggestions: list[str] = []

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -170,13 +170,21 @@ def _suggest_tool_names(name: str, candidates: set[str], max_results: int = 5) -
     """
     if not candidates:
         return []
+    # Never suggest the unknown name back to the caller (#355): if it's
+    # present in the candidate pool (e.g. a deferred/unactivated tool),
+    # difflib would return it as an exact ratio-1.0 match. Case-insensitive
+    # so a candidate differing only in case is treated as the same name.
+    name_lower = name.lower()
+    candidates = {c for c in candidates if c.lower() != name_lower}
+    if not candidates:
+        return []
     suggestions: list[str] = []
     # Suffix match catches the common "dropped prefix" case (e.g. Gemini
     # truncating `mcp__oblique-strategies__get_strategy` to
     # `strategies__get_strategy`).
     for cand in candidates:
         if cand.endswith(f"__{name}") or cand.endswith(name):
-            if cand != name and cand not in suggestions:
+            if cand not in suggestions:
                 suggestions.append(cand)
     # difflib fuzzy match for general typos
     for cand in difflib.get_close_matches(name, list(candidates), n=max_results, cutoff=0.6):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -167,6 +167,19 @@ def test_suggest_tool_names_excludes_case_insensitive_input():
     assert "Project_Advance" not in suggestions
 
 
+def test_suggest_tool_names_tolerates_none_candidate():
+    """A malformed tool def can leave a None in the candidate pool
+    (deferred_names uses `.get("name")` with no default); the suggestion
+    helper must not crash the unknown-tool error path (#355)."""
+    from decafclaw.tools import _suggest_tool_names
+
+    candidates = {None, "workspace_read"}
+    # "workspce_read" is an intentional typo of the real tool name.
+    suggestions = _suggest_tool_names("workspce_read", candidates)
+    assert "workspace_read" in suggestions
+    assert None not in suggestions
+
+
 @pytest.mark.asyncio
 async def test_execute_tool_unknown_suffix_match_suggests_mcp(ctx, monkeypatch):
     """Dropped mcp__ prefix should surface the full MCP name as a suggestion."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -143,6 +143,30 @@ async def test_execute_tool_unknown_suggests_close_match(ctx):
     assert "workspace_read" in result.text
 
 
+def test_suggest_tool_names_excludes_exact_input():
+    """The unknown name must never be suggested back to the caller (#355).
+
+    Regression: when the unknown name is also present in the candidate pool
+    (e.g. a deferred/unactivated tool), difflib returned it as the top
+    (ratio 1.0) match, so the hint read "Did you mean: project_advance"
+    for a call to project_advance.
+    """
+    from decafclaw.tools import _suggest_tool_names
+
+    candidates = {"project_advance", "project_task_done", "project_note"}
+    suggestions = _suggest_tool_names("project_advance", candidates)
+    assert "project_advance" not in suggestions
+
+
+def test_suggest_tool_names_excludes_case_insensitive_input():
+    """A candidate differing only in case is the same name — not a suggestion (#355)."""
+    from decafclaw.tools import _suggest_tool_names
+
+    candidates = {"Project_Advance", "project_note"}
+    suggestions = _suggest_tool_names("project_advance", candidates)
+    assert "Project_Advance" not in suggestions
+
+
 @pytest.mark.asyncio
 async def test_execute_tool_unknown_suffix_match_suggests_mcp(ctx, monkeypatch):
     """Dropped mcp__ prefix should surface the full MCP name as a suggestion."""


### PR DESCRIPTION
## Summary

When the agent calls an unknown tool whose name is also present in the candidate pool (a deferred/unactivated tool or MCP name), `_suggest_tool_names` returned that exact name as the top suggestion — because `difflib.get_close_matches` treats an exact string as a ratio-1.0 match. The error then read:

```
[error: unknown tool 'project_advance'. Did you mean: project_advance, project_task_done, ...]
```

i.e. it suggested the exact name the agent just tried. The suffix-match loop already guarded with `cand != name` (case-sensitive), but the difflib loop had no self-exclusion.

## Fix

Filter the candidate set to drop any entry case-insensitively equal to the unknown input before matching, in `src/decafclaw/tools/__init__.py::_suggest_tool_names`. The suffix loop's now-redundant `cand != name` guard is removed in favor of the single filter.

## Testing

- `test_suggest_tool_names_excludes_exact_input` — name present in candidate pool is never suggested back (test-first: red before fix, green after).
- `test_suggest_tool_names_excludes_case_insensitive_input` — a candidate differing only in case is treated as the same name.
- Existing suggestion tests (typo close-match, MCP suffix-match) still pass.
- `make lint` ✓, `make typecheck` ✓ (0 errors), `make test` ✓ (3052 passed).

Deterministic error-message path → unit tests, no eval needed.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)