### PR TITLE
fix(conversation-search): stemmed token matching + relevance ranking (#535)

### DIFF
--- a/docs/conversations.md
+++ b/docs/conversations.md
@@ -99,7 +99,7 @@ Place a `COMPACTION.md` file at `data/{agent_id}/COMPACTION.md` to customize the
 ### Tools
 
 - **`conversation_compact`** — manually trigger compaction without waiting for the token budget to be exceeded
-- **`conversation_search`** — search past conversations using semantic search (across all archived conversations, not just the current one)
+- **`conversation_search`** — search past conversations by stemmed word overlap plus substring, ranked by relevance (across all archived conversations, not just the current one). Stemming means plural/inflected queries match — `"embedding providers"` finds `"embedding provider"`.
 
 ## Web UI conversations
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -51,7 +51,7 @@ Always-activated skill for the unified knowledge base. See [Vault](vault.md).
 
 | Tool | What it does |
 |------|--------------|
-| `conversation_search` | Search past conversation archives (semantic) |
+| `conversation_search` | Search past conversation archives (stemmed word overlap + substring) |
 | `conversation_compact` | Manually trigger conversation compaction |
 
 ## Checklist (`tools/checklist_tools.py`)

--- a/evals/conversation.yaml
+++ b/evals/conversation.yaml
@@ -10,10 +10,9 @@
 
 - name: "reaches for conversation_search on explicit history query"
   setup:
-    # `conversation_search` does case-insensitive *substring* match, so seed
-    # phrasing must contain whichever exact tokens the agent's query is
-    # likely to use. Using plural "embedding providers" + naming all three
-    # provider tokens verbatim makes the search deterministic.
+    # `conversation_search` matches by stemmed word overlap plus substring
+    # (see #535), so exact-token phrasing is no longer required — but naming
+    # the distinctive provider tokens verbatim keeps this case deterministic.
     conversation_history:
       - role: user
         content: "I'm planning to switch our embedding providers from OpenAI to Vertex."
@@ -30,6 +29,28 @@
     # because the agent often paraphrases "switching to Vertex" without
     # naming the "from" side.
     response_contains_all: ["Vertex", "Cohere"]
+    max_tool_calls: 5
+    max_tool_errors: 0
+    expect_tool: conversation_search
+
+# -- Inflection-tolerant recall (#535) ---------------------------------------
+#
+# The seed is SINGULAR ("embedding provider") but the query is PLURAL
+# ("embedding providers"). Under the old substring-only match this returned
+# zero hits and the agent would deny ever discussing it. Stemmed matching
+# now bridges the plural/singular gap. Naming Vertex in the seed lets the
+# assertion prove real retrieval rather than fabrication.
+
+- name: "recalls history across singular/plural query mismatch (#535)"
+  setup:
+    conversation_history:
+      - role: user
+        content: "I'm planning to switch our embedding provider from OpenAI to Vertex."
+      - role: assistant
+        content: "Got it. Vertex it is unless you want me to run a comparison."
+  input: "Search our past chat history for what I said about embedding providers."
+  expect:
+    response_contains: "Vertex"
     max_tool_calls: 5
     max_tool_errors: 0
     expect_tool: conversation_search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tabstack>=2.6.1",
     "uvicorn>=0.41.0",
     "websockets>=16.0",
+    "snowballstemmer>=2.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/decafclaw/tools/conversation_tools.py
+++ b/src/decafclaw/tools/conversation_tools.py
@@ -1,5 +1,6 @@
 """Conversation tools — search and compact conversations."""
 
+import heapq
 import json
 import logging
 
@@ -41,10 +42,14 @@ def tool_conversation_search(ctx, query: str) -> str:
     query_lower = query.lower()
     query_stems = _stemmed_tokens(query)
 
-    # Collect every match with a relevance score, then rank — a message that
-    # overlaps more query tokens should outrank one that overlaps fewer.
-    scored: list[tuple[int, int, str]] = []
-    order = 0  # preserves archive iteration order for deterministic ties
+    # Relevance ranking requires scoring every message (a top match can sit
+    # anywhere in the archive), but we only ever return _MAX_RESULTS. Keep a
+    # bounded min-heap of the best entries so memory stays O(_MAX_RESULTS)
+    # regardless of how many messages match. Heap key is (score, -order):
+    # larger is better — higher score wins, and among equal scores the
+    # earlier (smaller order) message wins. heap[0] is thus the weakest kept.
+    heap: list[tuple[int, int, str]] = []
+    order = 0  # archive iteration order — deterministic tie-break
 
     for conv_id, filepath in archives:
         with filepath.open("r", encoding="utf-8") as f:
@@ -72,15 +77,19 @@ def tool_conversation_search(ctx, query: str) -> str:
 
                 role = msg.get("role", "unknown")
                 excerpt = content[:500] + ("..." if len(content) > 500 else "")
-                scored.append((score, order, f"--- [{conv_id}] {role} ---\n{excerpt}"))
+                item = (score, -order, f"--- [{conv_id}] {role} ---\n{excerpt}")
+                if len(heap) < _MAX_RESULTS:
+                    heapq.heappush(heap, item)
+                elif item > heap[0]:
+                    heapq.heapreplace(heap, item)
                 order += 1
 
-    if not scored:
+    if not heap:
         return f"No conversation history found matching '{query}'"
 
-    # Highest score first; ties keep archive order (order asc).
-    scored.sort(key=lambda t: (-t[0], t[1]))
-    results = [entry for _score, _order, entry in scored[:_MAX_RESULTS]]
+    # Best first: highest score, then earliest (smallest order).
+    ranked = sorted(heap, key=lambda t: (-t[0], -t[1]))
+    results = [entry for _score, _negorder, entry in ranked]
 
     return f"Found {len(results)} matching conversation entries:\n\n" + "\n\n".join(results)
 

--- a/src/decafclaw/tools/conversation_tools.py
+++ b/src/decafclaw/tools/conversation_tools.py
@@ -3,14 +3,34 @@
 import json
 import logging
 
+import snowballstemmer
+
 from ..conversation_paths import iter_conversation_archives
 from ..media import ToolResult
+from ..preempt_search import tokenize
 
 log = logging.getLogger(__name__)
 
+# Ranking: a raw-substring hit is a much stronger signal than incidental
+# token overlap (it's the caller's exact phrase, mid-word matches included),
+# so it dominates the score. Token overlap then orders the rest and breaks
+# ties among substring hits.
+_SUBSTRING_BOOST = 1000
+_MAX_RESULTS = 10
+
+# One shared English stemmer (Porter2). Stemming both query and content
+# tokens lets plural/inflected queries match singular text and vice versa
+# ("colors" ~ "color", "providers" ~ "provider") — the failure mode in #535.
+_STEMMER = snowballstemmer.stemmer("english")
+
+
+def _stemmed_tokens(text: str) -> set[str]:
+    """Tokenize (stopword-filtered, >=3 chars) then stem to word roots."""
+    return {_STEMMER.stemWord(t) for t in tokenize(text)}
+
 
 def tool_conversation_search(ctx, query: str) -> str:
-    """Search across conversation archives using substring matching."""
+    """Search conversation archives by stemmed-token overlap plus substring."""
     log.info(f"[tool:conversation_search] query={query}")
 
     archives = sorted(
@@ -19,8 +39,12 @@ def tool_conversation_search(ctx, query: str) -> str:
         return f"No conversation history found matching '{query}'"
 
     query_lower = query.lower()
-    results: list[str] = []
-    max_results = 10
+    query_stems = _stemmed_tokens(query)
+
+    # Collect every match with a relevance score, then rank — a message that
+    # overlaps more query tokens should outrank one that overlaps fewer.
+    scored: list[tuple[int, int, str]] = []
+    order = 0  # preserves archive iteration order for deterministic ties
 
     for conv_id, filepath in archives:
         with filepath.open("r", encoding="utf-8") as f:
@@ -35,18 +59,28 @@ def tool_conversation_search(ctx, query: str) -> str:
                 if msg.get("role") not in ("user", "assistant"):
                     continue
                 content = msg.get("content", "")
-                if not content or query_lower not in content.lower():
+                if not content:
                     continue
+
+                score = 0
+                if query_lower in content.lower():
+                    score += _SUBSTRING_BOOST
+                if query_stems:
+                    score += len(query_stems & _stemmed_tokens(content))
+                if score == 0:
+                    continue
+
                 role = msg.get("role", "unknown")
                 excerpt = content[:500] + ("..." if len(content) > 500 else "")
-                results.append(f"--- [{conv_id}] {role} ---\n{excerpt}")
-                if len(results) >= max_results:
-                    break
-        if len(results) >= max_results:
-            break
+                scored.append((score, order, f"--- [{conv_id}] {role} ---\n{excerpt}"))
+                order += 1
 
-    if not results:
+    if not scored:
         return f"No conversation history found matching '{query}'"
+
+    # Highest score first; ties keep archive order (order asc).
+    scored.sort(key=lambda t: (-t[0], t[1]))
+    results = [entry for _score, _order, entry in scored[:_MAX_RESULTS]]
 
     return f"Found {len(results)} matching conversation entries:\n\n" + "\n\n".join(results)
 
@@ -77,13 +111,15 @@ CONVERSATION_TOOL_DEFINITIONS = [
         "function": {
             "name": "conversation_search",
             "description": (
-                "Search the **raw chat history** of past conversations using "
-                "substring matching. Use this when the user is asking for a "
-                "verbatim reference — the literal exchange — and only when the "
-                "answer is not better-suited to the vault. **Resolved decisions, "
-                "design choices, and curated knowledge live in the vault — for "
-                "those, prefer vault_search even when the user phrases it as "
-                "'what did we decide' or 'we talked about'.** "
+                "Search the **raw chat history** of past conversations. "
+                "Matches by word overlap (stemmed, so plural/inflected words "
+                "match: 'providers' finds 'provider') and by substring, with "
+                "results ranked by relevance. Use this when the user is asking "
+                "for a verbatim reference — the literal exchange — and only when "
+                "the answer is not better-suited to the vault. **Resolved "
+                "decisions, design choices, and curated knowledge live in the "
+                "vault — for those, prefer vault_search even when the user "
+                "phrases it as 'what did we decide' or 'we talked about'.** "
                 "Searches the full uncompacted JSONL archives. "
                 "Useful for: pinning down the exact wording of a prior exchange."
             ),

--- a/tests/test_conversation_search_tool.py
+++ b/tests/test_conversation_search_tool.py
@@ -89,6 +89,21 @@ def test_search_ranks_higher_overlap_first(ctx):
     assert out.index("conv-strong") < out.index("conv-weak")
 
 
+def test_search_caps_results_at_ten_keeping_earliest_on_ties(ctx):
+    """More than _MAX_RESULTS matches with equal score: exactly 10 come back,
+    and equal-score ties keep the earliest messages (bounded top-k heap)."""
+    _write_dir(ctx.config, "conv-many", [
+        {"role": "user", "content": f"osprey note {i}"} for i in range(12)
+    ])
+    out = tool_conversation_search(ctx, "osprey")
+    assert "Found 10 matching" in out
+    for i in range(10):
+        assert f"osprey note {i}" in out
+    # The last two (highest order) lose the tie and are dropped.
+    assert "osprey note 10" not in out
+    assert "osprey note 11" not in out
+
+
 def test_search_no_match_when_no_tokens_overlap(ctx):
     _write_dir(ctx.config, "conv-x", [
         {"role": "user", "content": "the weather is sunny today"},

--- a/tests/test_conversation_search_tool.py
+++ b/tests/test_conversation_search_tool.py
@@ -38,3 +38,60 @@ def test_search_finds_across_multiple_conversations(ctx):
     out = tool_conversation_search(ctx, "osprey")
     assert "conv-one" in out
     assert "conv-two" in out
+
+
+# --- #535: token-aware matching (plurality / inflection) ---
+
+def test_search_matches_across_plural_inflection(ctx):
+    """The issue's headline repro: singular seed, plural query."""
+    _write_dir(ctx.config, "conv-embed", [
+        {"role": "user",
+         "content": "I'm planning to switch our embedding provider "
+                    "from OpenAI to Vertex"},
+    ])
+    out = tool_conversation_search(ctx, "embedding providers")
+    assert "conv-embed" in out
+
+
+def test_search_matches_ignoring_stopwords_and_plurals(ctx):
+    """The acceptance-criteria repro: 'colors I like' -> 'color ... blue'."""
+    _write_dir(ctx.config, "conv-color", [
+        {"role": "user", "content": "My favorite color is blue"},
+    ])
+    out = tool_conversation_search(ctx, "colors I like")
+    assert "conv-color" in out
+    assert "favorite color is blue" in out
+
+
+def test_search_preserves_midword_substring_match(ctx):
+    """Zero regression: a mid-word substring query still matches. Token
+    stemming alone would miss 'config' -> 'configuration'; the substring
+    branch must keep it working."""
+    _write_dir(ctx.config, "conv-cfg", [
+        {"role": "user", "content": "the configuration was wrong"},
+    ])
+    out = tool_conversation_search(ctx, "config")
+    assert "conv-cfg" in out
+
+
+def test_search_ranks_higher_overlap_first(ctx):
+    """A message overlapping more query tokens should surface before one
+    overlapping fewer."""
+    _write_dir(ctx.config, "conv-weak", [
+        {"role": "user", "content": "we discussed the embedding format"},
+    ])
+    _write_dir(ctx.config, "conv-strong", [
+        {"role": "user", "content": "we should switch embedding providers soon"},
+    ])
+    out = tool_conversation_search(ctx, "switch embedding providers")
+    assert "conv-strong" in out
+    assert "conv-weak" in out
+    assert out.index("conv-strong") < out.index("conv-weak")
+
+
+def test_search_no_match_when_no_tokens_overlap(ctx):
+    _write_dir(ctx.config, "conv-x", [
+        {"role": "user", "content": "the weather is sunny today"},
+    ])
+    out = tool_conversation_search(ctx, "quantum chromodynamics")
+    assert "No conversation history found" in out

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -337,6 +337,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "snowballstemmer" },
     { name = "sqlite-vec" },
     { name = "starlette" },
     { name = "tabstack" },
@@ -375,6 +376,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.0.0" },
+    { name = "snowballstemmer", specifier = ">=2.2.0" },
     { name = "sqlite-vec", specifier = ">=0.1.7" },
     { name = "starlette", specifier = ">=0.52.1" },
     { name = "tabstack", specifier = ">=2.6.1" },
@@ -1068,6 +1070,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`conversation_search` used case-insensitive **substring** matching (`query_lower in content.lower()`). A query whose wording differed from the archived text by inflection returned zero hits — the issue's headline case: `"embedding providers"` (plural) missed a message that said `"embedding provider"` (singular), and the agent would deny ever discussing it. This tool is the agent's only recall path for history outside the active window / post-compaction, so failures read as "the agent forgot."

## Fix (issue's Option B + zero-regression substring)

A message matches if **either** branch fires, and the score ranks results:

- **Substring branch** (dominant score `1000`): preserves 100% of prior behavior, including mid-word matches like `config` → `configuration`.
- **Stemmed token-overlap branch** (score = overlap count): tokenize via the existing `preempt_search.tokenize` (stopwords, ≥3 chars), then stem with snowballstemmer (Porter2). Bridges plural/inflected queries (`colors`~`color`, `providers`~`provider`).
- Results ranked by score, so higher-overlap entries surface first; ties keep archive order.

Stemming is applied **only** in `conversation_search` — preempt-search tool-promotion behavior is untouched (it has its own evals).

## Verification

- **Test-first**: added the two issue repros (`"colors I like"` → `"My favorite color is blue"`; plural query → singular seed) plus regression guards (mid-word substring, whole-word `pelican`/`osprey`, relevance ranking, no-overlap → no match). All green.
- Full suite: **3066 passed**. `make lint typecheck` clean.
- Added an inflection-tolerance case to `evals/conversation.yaml` and corrected the case comment + `docs/` that mislabeled this tool as "semantic" (it never was).

Dependency: `snowballstemmer>=2.2.0` (pure-Python, MIT, no transitive deps).

Note: the eval case is added but not run here (needs live model calls); happy to run `make eval FILE=conversation` on request.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)