### PR TITLE
fix(background): close subprocess transport in _finalize_job (#632)

### DIFF
--- a/src/decafclaw/skills/background/tools.py
+++ b/src/decafclaw/skills/background/tools.py
@@ -134,6 +134,19 @@ async def _finalize_job(job: BackgroundJob) -> None:
         return
     job.finalized = True
 
+    # Deterministically release the subprocess transport now that the process
+    # has exited, while the event loop is still alive. asyncio otherwise only
+    # closes it when the Process is garbage-collected; if that GC runs after
+    # the loop is gone (e.g. pytest-asyncio's function-scoped loop),
+    # BaseSubprocessTransport.__del__ raises against a dead loop and surfaces
+    # as a PytestUnraisableExceptionWarning (#632). Harmless in production
+    # (single long-lived loop), but we close explicitly so cleanup is
+    # deterministic regardless of loop lifetime. `_transport` is a real
+    # asyncio.subprocess.Process attribute that its type stub omits.
+    transport = job.process._transport  # type: ignore[attr-defined]
+    if transport is not None:
+        transport.close()
+
     if job.config is None:
         return  # no config => nothing we can do
 


### PR DESCRIPTION
## Summary

`tests/test_background_tools.py` emitted 2 `PytestUnraisableExceptionWarning`s from `BaseSubprocessTransport.__del__`, violating the repo's zero-warning standard.

**The issue's original hypothesis (tests don't clean up) was wrong** — every test already calls `cleanup_all()`. The real root cause: asyncio only closes a subprocess transport when its owning `Process` is garbage-collected. Under pytest-asyncio's function-scoped loop, that GC can land *after* the loop is torn down, so `__del__` runs against a dead loop and pytest reports it. The warning is emergent across the module (each test in isolation emits 0; the file emits 2) and **never fires in production**, which runs a single long-lived loop.

## Fix

Close the transport explicitly in `_finalize_job` — the single terminal chokepoint every job passes through exactly once — so cleanup is deterministic regardless of loop lifetime. `_transport` is a real `asyncio.subprocess.Process` attribute that its type stub omits, hence the scoped `# type: ignore[attr-defined]`.

13-line, source-only change.

## Investigation notes (for reviewers)

- Bisected: each test alone → 0 warnings; the full file → 2. Emergent cross-test GC timing.
- Tried a test-side `gc.collect()` teardown first — **flaky** (2/0/2 across runs), so rejected it in favor of the deterministic source fix.
- No unit assertion guards this: the observable transport state (`is_closing()`) converges to True with or without the fix (asyncio schedules the auto-close during `stop()`'s awaits); the warning only manifests at session-teardown GC. A test that passed either way would be false confidence, so it isn't included.

## Verification

```
# warning count, 6 runs each:
with fix:    0 0 0 0 0 0
without fix: 2 2 2 2 2 2
```

- `make lint` ✓, `make typecheck` ✓ (0 errors/warnings), `make test` ✓ (3057 passed, **no warning line**).

Not LLM-visible (internal resource cleanup) → no eval.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)