### PR TITLE
fix(config-cli): surface top-level scalar/dict fields in `config show`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -41,6 +41,8 @@ Only include settings you want to override — absent keys use defaults.
 ```bash
 decafclaw config show              # all resolved values (secrets masked)
 decafclaw config show llm          # filter by group
+decafclaw config show providers    # dict groups (providers, model_configs) print per-entry fields
+decafclaw config show default_model  # filter by a top-level scalar field name
 decafclaw config show --reveal     # show secret values
 decafclaw config get llm.model     # single value
 decafclaw config set llm.model gemini-2.5-pro   # write to config.json

--- a/src/decafclaw/config_cli.py
+++ b/src/decafclaw/config_cli.py
@@ -35,6 +35,28 @@ def _format_value(value, field_info, reveal: bool) -> str:
     return str(value)
 
 
+# Top-level Config fields handled by dedicated renderers or that are
+# runtime-only (assembled at startup, never read from config.json) — these
+# are excluded from the generic scalar/list printing in cmd_show.
+_SHOW_SPECIAL_FIELDS = {"skills", "env"}
+_SHOW_RUNTIME_ONLY_FIELDS = {
+    "system_prompt",
+    "discovered_skills",
+    "always_loaded_skill_tools",
+    "skill_tool_owners",
+}
+
+
+def _print_dict_of_dataclasses(prefix: str, mapping: dict, reveal: bool) -> None:
+    """Print each entry of a dict-of-dataclasses (providers, model_configs)."""
+    for key in sorted(mapping):
+        entry = mapping[key]
+        if hasattr(entry, "__dataclass_fields__"):
+            _print_group(f"{prefix}.{key}", entry, reveal)
+        else:
+            print(f"{prefix}.{key} = {entry}")
+
+
 def _resolve_field(config: Config, path: str):
     """Walk dotted path and return (parent_obj, field_info, value)."""
     parts = path.split(".")
@@ -79,14 +101,21 @@ def cmd_show(args) -> None:
 
     valid_groups = set()
     for group_field in fields(config):
-        if group_field.name in ("system_prompt", "discovered_skills", "skills", "env"):
+        name = group_field.name
+        if name in _SHOW_SPECIAL_FIELDS or name in _SHOW_RUNTIME_ONLY_FIELDS:
             continue
-        group = getattr(config, group_field.name)
-        if hasattr(group, "__dataclass_fields__"):
-            valid_groups.add(group_field.name)
-            if args.group and group_field.name != args.group:
-                continue
-            _print_group(group_field.name, group, args.reveal)
+        value = getattr(config, name)
+        valid_groups.add(name)
+        if args.group and args.group != name:
+            continue
+        if hasattr(value, "__dataclass_fields__"):
+            _print_group(name, value, args.reveal)
+        elif name in ("providers", "model_configs"):
+            _print_dict_of_dataclasses(name, value, args.reveal)
+        else:
+            # Top-level scalar/list field — printed with its bare name as the
+            # path so `make config` surfaces it (issue #431).
+            print(f"{name} = {_format_value(value, group_field, args.reveal)}")
 
     # Show skills section (raw dict, schema unknown — mask all values)
     valid_groups.add("skills")

--- a/tests/test_config_cli.py
+++ b/tests/test_config_cli.py
@@ -54,6 +54,88 @@ def test_show_group_filter(capsys, monkeypatch, tmp_path):
     assert "llm." not in out
 
 
+def test_show_top_level_scalar_fields(capsys, monkeypatch, tmp_path):
+    """Top-level scalar/list fields appear in unfiltered output (issue #431)."""
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group=None, reveal=False))
+    out = capsys.readouterr().out
+    # Scalars and lists that are NOT nested dataclasses used to be dropped.
+    assert "default_model = " in out
+    assert "extra_skill_paths = " in out
+    assert "skills_always_loaded = " in out
+
+
+def test_show_excludes_runtime_only_fields(capsys, monkeypatch, tmp_path):
+    """Runtime-only (non-config-file) fields stay out of `show` output."""
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group=None, reveal=False))
+    out = capsys.readouterr().out
+    assert "system_prompt" not in out
+    assert "discovered_skills" not in out
+    assert "always_loaded_skill_tools" not in out
+    assert "skill_tool_owners" not in out
+
+
+def test_show_providers_masks_api_key(capsys, monkeypatch, tmp_path):
+    """providers dict prints per-entry fields, masking api_key by default."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    (agent_dir / "config.json").write_text(json.dumps({
+        "providers": {
+            "openai": {"type": "openai", "api_key": "sk-secret-123"},
+        },
+    }))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_show(_Args(group=None, reveal=False))
+    out = capsys.readouterr().out
+    assert "providers.openai.type = openai" in out
+    assert "providers.openai.api_key = ****" in out
+    assert "sk-secret-123" not in out
+
+
+def test_show_providers_reveal(capsys, monkeypatch, tmp_path):
+    """--reveal unmasks provider secrets."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    (agent_dir / "config.json").write_text(json.dumps({
+        "providers": {
+            "openai": {"type": "openai", "api_key": "sk-secret-123"},
+        },
+    }))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_show(_Args(group="providers", reveal=True))
+    out = capsys.readouterr().out
+    assert "providers.openai.api_key = sk-secret-123" in out
+
+
+def test_show_model_configs(capsys, monkeypatch, tmp_path):
+    """model_configs dict prints per-entry fields."""
+    agent_dir = tmp_path / "decafclaw"
+    agent_dir.mkdir()
+    (agent_dir / "config.json").write_text(json.dumps({
+        "model_configs": {
+            "flash": {"provider": "vertex", "model": "gemini-2.5-flash"},
+        },
+    }))
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    cmd_show(_Args(group="model_configs", reveal=False))
+    out = capsys.readouterr().out
+    assert "model_configs.flash.provider = vertex" in out
+    assert "model_configs.flash.model = gemini-2.5-flash" in out
+
+
+def test_show_top_level_field_filter(capsys, monkeypatch, tmp_path):
+    """A top-level scalar name is a valid `show` filter, not an unknown group."""
+    monkeypatch.setenv("DATA_HOME", str(tmp_path))
+    (tmp_path / "decafclaw").mkdir()
+    cmd_show(_Args(group="default_model", reveal=False))
+    out = capsys.readouterr().out
+    assert "default_model = " in out
+    assert "llm." not in out
+
+
 def test_get(capsys, monkeypatch, tmp_path):
     monkeypatch.setenv("DATA_HOME", str(tmp_path))
     (tmp_path / "decafclaw").mkdir()


### PR DESCRIPTION
## Summary

Fixes #431. `decafclaw config show` (`make config`) iterated `fields(config)` and only printed fields whose value was itself a dataclass, so top-level scalar/list fields and the provider/model dicts were silently dropped.

Now `config show` also prints:

- **Top-level scalar/list fields** — `default_model`, `extra_skill_paths`, `skills_always_loaded` — as `name = value`. Empty values (e.g. `skills_always_loaded = []`) still print so the field is discoverable.
- **`providers` / `model_configs`** — each entry's fields rendered (`providers.openai.type = openai`), reusing the existing secret-masking path so `api_key` stays `****` unless `--reveal`.
- Every printed field name is now a valid `show` filter, so `config show default_model` no longer errors with "Unknown group".

Runtime-only fields (`system_prompt`, `discovered_skills`, `always_loaded_skill_tools`, `skill_tool_owners`) — assembled at startup, never read from config.json — stay excluded.

## Testing

- 6 new tests in `tests/test_config_cli.py` (top-level scalars shown, runtime-only excluded, provider masking + reveal, model_configs, top-level filter). Wrote them failing first, then implemented.
- `make lint`, `make typecheck` clean; `tests/test_config_cli.py` + `tests/test_config.py` green (69 passed).
- Smoke: ran `make config` against the real data dir — provider `api_key`s masked, real `extra_skill_paths` shown, `skills_always_loaded = []` prints, no runtime-only fields leaked.
- `docs/config.md` CLI examples updated in the same PR.

No LLM-visible behavior change (config-inspection CLI only), so no evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)