### PR TITLE
feat(agent): diagnostic-discipline guardrails — loop-breaker + prompt sharpening (#598)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ See [docs/context-composer.md](docs/context-composer.md), [docs/semantic-search.
 - **Confirmations are persistent conversation messages** (`role: "confirmation_request"` / `"confirmation_response"`). Pending confirmations survive page reload and server restart (startup scan recovers them). Typed `ConfirmationAction` handlers determine on-approve/on-deny behavior.
 - **Transports subscribe to per-conversation event streams** via `manager.subscribe(conv_id, callback)` — not the global bus. Manager bridges global → per-conversation.
 - **Self-reflection is fail-open** ([docs/reflection.md](docs/reflection.md)). Skipped for child agents, cancelled turns, empty responses. Retries consume `max_tool_iterations` budget.
+- **Per-turn loop breaker** ([docs/loop-breaker.md](docs/loop-breaker.md)) detects autonomous tool-call thrash (repeated identical calls or an error surge) and escalates: first trip injects an ephemeral (never archived) diagnostic nudge, a second trip hard-stops the turn. The related diagnostic/apology/phantom-call guardrail prompt text lives in `AGENT.md`, not in code.
 - **Pre-compaction memory sweep** runs as an isolated background child agent before compaction summarizes old history. Vault-only tools, fail-open, controlled by `compaction.memory_sweep_enabled`. Prompt at `data/{agent_id}/MEMORY_SWEEP.md` (bundled fallback).
 
 ### Mattermost-specific
@@ -186,6 +187,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `prompts/` — System prompt assembly
 - `commands.py` — User-invokable commands
 - `reflection.py` — Self-reflection (Reflexion pattern)
+- `loop_breaker.py` — Per-turn autonomous tool-call thrash detector (nudge → hard-stop escalation, #598)
 - `tool_telemetry.py` — Tool-usage telemetry subscriber + report (#310); `make tool-usage-report`
 - `reflection_metrics.py` — Reflection cost/effectiveness telemetry subscriber + stats (#409); `make reflection-stats`
 - `heartbeat.py`, `schedules.py`, `polling.py`

--- a/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md
+++ b/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md
@@ -1,0 +1,133 @@
+# Diagnostic-discipline guardrails — Session Notes
+
+**Issue:** [#598](https://github.com/lmorchard/decafclaw/issues/598)
+**Status:** shipped
+
+## Trigger
+
+A real session (`web-lmorchard-fa5ec853`, Gemini-Pro) spent ~150 messages
+stuck debugging a skill that wouldn't load, at only 87K/300K token budget —
+not a context problem, a diagnostic-discipline collapse. Three distinct
+failure modes: repeated the same failed edit-and-refresh cycle dozens of
+times (no loop-breaker), wrote out a plan to re-engage Claude Code but never
+emitted the tool call (phantom tool call), and opened nearly every turn with
+"You are absolutely correct, my apologies…" before repeating the same failed
+move (apology spiral).
+
+## Design decisions
+
+- **No model-conditional prompting.** There is no per-model prompt mechanism
+  today and we didn't build one for this. All `AGENT.md` guardrails are
+  universal, even though the triggering session was specifically
+  Gemini-Pro-worst.
+- **Key finding that shaped the whole design:** `AGENT.md` already carried
+  strong, specific anti-apology-spiral guidance (the exact "You're
+  absolutely right, my apologies" anti-example) — and the model sailed past
+  it for ~150 messages anyway. That's the evidence that more prompt text
+  alone isn't a reliable fix for the worst failure mode. So the loop itself
+  (mode 1) got a **mechanical backstop**; the softer modes (2 and 3) stayed
+  **prompt-only** refinements.
+- **Detector trips on either signal**, not just one: same `(tool_name,
+  args_fingerprint)` seen `repeat_threshold` (default 3) or more times this
+  turn, OR `error_threshold` (default 4) or more of the last `error_window`
+  (default 6) tool results were errors. Repeats-with-varying-args-but-all-
+  failing was a real pattern in the original session and neither signal
+  alone would have caught both shapes of thrash.
+- **Escalation: nudge, then stop** — not straight to hard-stop. First trip
+  injects a diagnostic nudge and lets the turn continue (the model gets a
+  chance to self-correct); only a second trip after the nudge ends the turn.
+  This avoids over-triggering on a single legitimate burst of retries while
+  still capping genuine loops.
+- **The nudge is ephemeral — messages-only, deliberately never archived.**
+  It's appended to `self.messages` (the in-memory turn list) but never
+  written to `self.history` or the archive. Reasoning: archiving it would
+  let `restore_history` resurrect it on a page reload or process restart — a
+  `system`-role message is a real LLM role, not UI-only — permanently
+  polluting every later turn's context with a diagnostic aside that only
+  made sense in the moment it fired. The hard-stop's *final summary*, by
+  contrast, is archived normally, because it's a genuine response the user
+  should see and the agent should remember having said. Verified with a
+  dedicated wiring test (end-turn precedence + non-archival of the nudge).
+- **Config is a top-level `config.loop_breaker`, not nested under
+  `config.agent`.** This deliberately dodges a known project gotcha:
+  `load_sub_config` only recurses into a nested dataclass's env vars when
+  the JSON key is present, so a doubly-nested group can silently drop env
+  overrides. Top-level sidesteps it entirely, same pattern as `config.http` /
+  `config.terminal`.
+- **Mode 2 (phantom tool call) is prompt-only for v1**, by design — no
+  mechanical detection was built. Reliably detecting "narrated an action in
+  prose but didn't emit the tool call" needs fuzzy intent-vs-emitted-call
+  analysis that isn't worth the false-positive risk yet. It's a straight
+  `AGENT.md` addition ("Emit the call, don't narrate it").
+- **Mode 3 (apology spiral) got a light-touch connector line, not a
+  rewrite.** Since the existing block already failed to hold the line once,
+  piling on more text seemed unlikely to help by itself; the new line ties
+  it explicitly to the loop concept ("Acknowledgement is not progress...
+  that's the loop wearing a disguise") so it reads as one coherent framework
+  with mode 1's mechanical backstop, rather than a second unrelated rule.
+- **Evals skipped for modes 2 and 3, on purpose** — a conscious, documented
+  departure from the project convention that every behavior-affecting change
+  gets an eval case. The apology spiral is a stochastic, model-specific
+  register (the eval model may not reproduce Gemini-Pro's worst behavior)
+  and the phantom-call guardrail is prompt-only; an assertion on either would
+  be flaky and low-signal. The one eval that exists (mode 1, the mechanical
+  loop-breaker) carries the load for this feature.
+- **Eval bound: `max_tool_calls: 15` / `max_tool_errors: 15`**, both true
+  upper bounds (not counts) per the eval runner's `expect` semantics. Chosen
+  because a real 150-message loop would blow through either bound many times
+  over, so the bound is only satisfiable if the breaker (or a clean
+  first-try fix) actually caps the thrash. `expect_tool` (asserting which
+  tool the model reaches for first) was tried and dropped — which path the
+  model takes (`activate_skill` vs. `tool_search` vs. `skill_validate`)
+  varies run to run and isn't what the eval cares about. Verified live: one
+  run hit the breaker for real (`activate_skill("broken_skill")` 3× with
+  identical args → `"[loop-breaker] Stopped: you called activate_skill 3x
+  with the same args without progress."`); another run had the model give
+  up cleanly after one `tool_search` call. Both are legitimate outcomes
+  within the bound.
+
+## Implementation notes
+
+- `fingerprint()` hashes `tool_name` + sorted-JSON args (`sha1`), so argument
+  order doesn't cause false negatives.
+- `LoopBreaker` tracks `{fingerprint: [tool_name, count]}` (not just a bare
+  count) so `last_signal()` can name the offending tool in both the nudge
+  and the hard-stop summary — an adjustment made during implementation to
+  satisfy the test asserting the tool name appears in the reason string.
+- The loop-breaker check only runs on the normal "keep going" path in
+  `_handle_tool_calls` — a genuine end-turn signal (widget pause,
+  `EndTurnConfirm`, or `end_turn=True`) already returns earlier and takes
+  precedence, confirmed by a dedicated precedence test.
+- `_finalize_loop_break` mirrors the existing `max_tool_iterations`
+  exhaustion path: preserves `accumulated_text_parts`, archives the final
+  assistant message, and runs the same post-turn compaction check.
+
+## Final shipped state
+
+Nine commits on `598-diagnostic-guardrails`, in order: design spec →
+implementation plan → `LoopBreakerConfig` (top-level config) → `LoopBreaker`
+detector/escalation (deterministic core, `loop_breaker.py`) → `TurnRunner`
+wiring (nudge + hard-stop in `agent.py`) → fix keeping the nudge ephemeral +
+end-turn-precedence test → `AGENT.md` guardrail sharpening (three prose
+edits: two-strikes-diagnose, acknowledgement-is-not-progress,
+emit-the-call-don't-narrate-it) → the `diagnostic_discipline.yaml` eval +
+fixture → a follow-up tightening the eval bound to 15/15 and fixing a
+fixture-sync comment → this docs pass.
+
+Shipped surface:
+
+- `src/decafclaw/loop_breaker.py` — `LoopBreaker`, `LoopVerdict`,
+  `fingerprint()`.
+- `src/decafclaw/agent.py` — per-turn `LoopBreaker` instance on `TurnRunner`,
+  `_extract_call_signatures`, verdict handling in `_handle_tool_calls`,
+  `_finalize_loop_break`.
+- `src/decafclaw/config_types.py` / `config.py` — `LoopBreakerConfig`,
+  top-level `config.loop_breaker`, `LOOP_BREAKER_*` env.
+- `src/decafclaw/prompts/AGENT.md` — three sharpened/added guardrails.
+- `tests/test_loop_breaker.py`, `tests/test_agent_loop_breaker.py` —
+  deterministic unit coverage.
+- `evals/diagnostic_discipline.yaml` — one bounded, real-LLM eval.
+- `docs/loop-breaker.md` (new), linked from `docs/index.md`; `CLAUDE.md`
+  key-files + agent-behavior bullet (this pass).
+
+No src/test changes in this docs pass — verified `make check` stays clean.

--- a/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md
+++ b/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md
@@ -42,7 +42,7 @@ move (apology spiral).
   It's appended to `self.messages` (the in-memory turn list) but never
   written to `self.history` or the archive. Reasoning: archiving it would
   let `restore_history` resurrect it on a page reload or process restart — a
-  `system`-role message is a real LLM role, not UI-only — permanently
+  `user`-role message is a real LLM role, not UI-only — permanently
   polluting every later turn's context with a diagnostic aside that only
   made sense in the moment it fired. The hard-stop's *final summary*, by
   contrast, is archived normally, because it's a genuine response the user

--- a/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/plan.md
+++ b/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/plan.md
@@ -1,0 +1,546 @@
+# Diagnostic-Discipline Guardrails Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Break autonomous within-turn thrash loops with a mechanical loop-breaker (nudge → hard-stop), and sharpen `AGENT.md` prompt guardrails against the apology spiral, phantom tool calls, and repeated-edit thrashing.
+
+**Architecture:** A per-turn `LoopBreaker` (new `loop_breaker.py`) records each iteration's tool-call signatures + error flags; its `verdict()` escalates NONE → NUDGE → STOP. `TurnRunner._handle_tool_calls` feeds it after every `execute_tool_calls` and acts on the verdict (inject a diagnostic system message, or finalize the turn). Config lives in a top-level `config.loop_breaker`. Prompt guardrails are universal edits to `AGENT.md`.
+
+**Tech Stack:** Python (stdlib `hashlib`/`json` for fingerprints), existing `TurnRunner` loop in `agent.py`, `load_sub_config` config pattern, the YAML eval framework.
+
+## Global Constraints
+
+- **No model-conditional prompting.** All `AGENT.md` guardrails are universal.
+- **Per-turn state only.** The `LoopBreaker` resets every turn; no cross-turn persistence.
+- **Trip on either signal:** same `(tool_name, args_fingerprint)` ≥ `repeat_threshold`, OR ≥ `error_threshold` of the last `error_window` results are errors.
+- **Escalation:** first trip → inject one diagnostic `system` nudge; next trip after nudging → hard-stop the turn with a summary.
+- **Config defaults (verbatim):** `enabled=True`, `repeat_threshold=3`, `error_threshold=4`, `error_window=6`. Top-level `config.loop_breaker` (NOT nested under `config.agent`).
+- **Config style:** new runtime state on the dataclass; wire via `load_sub_config`; never hand-enumerate fields.
+- **Errors are marked** by tool-result message `content` starting with `"[error"` (see `tool_execution.py:356`, `ToolResult(text="[error: ...]")`).
+- **Mode 2 (phantom call) is prompt-only.** No mechanical detection.
+- Commit after each task; `make lint && make test` before committing; `make check` clean.
+
+---
+
+## File Structure
+
+**New:**
+- `src/decafclaw/loop_breaker.py` — `LoopBreaker` class + `LoopVerdict` enum. Pure, per-turn detector + escalation state machine. No agent/LLM imports.
+- `tests/test_loop_breaker.py` — deterministic unit tests for the detector + escalation.
+- `evals/fixtures/broken_skill/SKILL.md` — a deliberately-unloadable skill fixture (bad frontmatter / missing required field) used by the eval.
+- `evals/diagnostic_discipline.yaml` — one eval case asserting the breaker caps edit-thrashing.
+
+**Modified:**
+- `src/decafclaw/config_types.py` — add `LoopBreakerConfig` dataclass.
+- `src/decafclaw/config.py` — `loop_breaker` field on `Config` + `load_sub_config` wiring.
+- `src/decafclaw/agent.py` — instantiate `LoopBreaker` per turn; in `_handle_tool_calls`, extract signatures + feed the breaker + act on verdict; add `_finalize_loop_break`.
+- `src/decafclaw/prompts/AGENT.md` — sharpen mode-1 diagnosis block, add mode-3 connector line, add mode-2 phantom-call guardrail.
+- `docs/agent-behavior.md` (or nearest existing behavior doc) + `CLAUDE.md` — document the loop-breaker + config.
+- `docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md` — session notes.
+
+---
+
+## Task 1: `LoopBreakerConfig`
+
+**Files:**
+- Modify: `src/decafclaw/config_types.py`
+- Modify: `src/decafclaw/config.py`
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Produces: `config.loop_breaker: LoopBreakerConfig` with `enabled: bool`, `repeat_threshold: int`, `error_threshold: int`, `error_window: int`.
+
+- [ ] **Step 1: Write failing tests** in `tests/test_config.py`:
+
+```python
+def test_loop_breaker_config_defaults():
+    from decafclaw.config import load_config
+    cfg = load_config()
+    assert cfg.loop_breaker.enabled is True
+    assert cfg.loop_breaker.repeat_threshold == 3
+    assert cfg.loop_breaker.error_threshold == 4
+    assert cfg.loop_breaker.error_window == 6
+
+
+def test_loop_breaker_config_env_override(monkeypatch):
+    from decafclaw.config import load_config
+    monkeypatch.setenv("LOOP_BREAKER_ENABLED", "false")
+    monkeypatch.setenv("LOOP_BREAKER_REPEAT_THRESHOLD", "2")
+    cfg = load_config()
+    assert cfg.loop_breaker.enabled is False
+    assert cfg.loop_breaker.repeat_threshold == 2
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_config.py -k loop_breaker -v`
+Expected: FAIL — `AttributeError: 'Config' object has no attribute 'loop_breaker'`.
+
+- [ ] **Step 3: Add the dataclass** in `config_types.py` (near `HttpConfig`):
+
+```python
+@dataclass
+class LoopBreakerConfig:
+    enabled: bool = True
+    repeat_threshold: int = 3      # same (tool, args) N times → trip
+    error_threshold: int = 4       # this many errors...
+    error_window: int = 6          # ...within the last N tool results → trip
+```
+
+- [ ] **Step 4: Wire into `config.py`.** Add `LoopBreakerConfig` to the `from .config_types import (...)` block; add the field to `Config` (near `http`):
+
+```python
+    loop_breaker: "LoopBreakerConfig" = field(default_factory=LoopBreakerConfig)
+```
+
+In `load_config`, next to the other `load_sub_config` calls:
+
+```python
+    loop_breaker = load_sub_config(LoopBreakerConfig, file_data.get("loop_breaker", {}), "LOOP_BREAKER")
+```
+
+Pass `loop_breaker=loop_breaker` into the `Config(...)` constructor.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_config.py -k loop_breaker -v` → PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+make lint
+git add src/decafclaw/config_types.py src/decafclaw/config.py tests/test_config.py
+git commit -m "feat(loop-breaker): LoopBreakerConfig top-level config (#598)"
+```
+
+---
+
+## Task 2: `LoopBreaker` detector + escalation (deterministic core)
+
+**Files:**
+- Create: `src/decafclaw/loop_breaker.py`
+- Test: `tests/test_loop_breaker.py`
+
+**Interfaces:**
+- Produces:
+  - `class LoopVerdict(enum.Enum): NONE; NUDGE; STOP`
+  - `def fingerprint(tool_name: str, args) -> str` — stable hash of `(tool_name, args)`.
+  - `class LoopBreaker`:
+    - `__init__(self, config)` where `config` is a `LoopBreakerConfig`.
+    - `record(self, calls: list[tuple[str, str, bool]]) -> None` — each tuple is `(tool_name, fingerprint, is_error)` for one iteration's calls.
+    - `verdict(self) -> LoopVerdict` — evaluates trip conditions + escalation; returns NONE/NUDGE/STOP and advances internal escalation state.
+    - `last_signal(self) -> str` — human-readable reason for the last non-NONE verdict (for the nudge/summary text), e.g. `"called workspace_edit 3× with the same args"` or `"4 of the last 6 tool results were errors"`.
+
+- [ ] **Step 1: Write failing unit tests** in `tests/test_loop_breaker.py`:
+
+```python
+from decafclaw.config_types import LoopBreakerConfig
+from decafclaw.loop_breaker import LoopBreaker, LoopVerdict, fingerprint
+
+
+def _lb(**kw):
+    cfg = LoopBreakerConfig(**kw)
+    return LoopBreaker(cfg)
+
+
+def test_fingerprint_stable_and_arg_sensitive():
+    assert fingerprint("edit", {"a": 1, "b": 2}) == fingerprint("edit", {"b": 2, "a": 1})
+    assert fingerprint("edit", {"a": 1}) != fingerprint("edit", {"a": 2})
+    assert fingerprint("edit", {"a": 1}) != fingerprint("read", {"a": 1})
+
+
+def test_repeat_threshold_trips_nudge_then_stop():
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE          # 1 occurrence
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE           # 2
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE           # 3 → first trip
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.STOP            # trips again after nudge
+
+
+def test_error_window_trips():
+    lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
+    # 3 distinct erroring calls, then a 4th → 4 errors in window
+    for i in range(3):
+        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("t3", fingerprint("t3", {}), True)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+
+
+def test_errors_outside_window_do_not_trip():
+    lb = _lb(repeat_threshold=99, error_threshold=3, error_window=3)
+    lb.record([("a", "fa", True)])
+    lb.verdict()
+    lb.record([("b", "fb", False)])
+    lb.verdict()
+    lb.record([("c", "fc", False)])
+    lb.verdict()
+    lb.record([("d", "fd", True)])  # window now [b?,c,d] errors=1 (a aged out)
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_disabled_never_trips():
+    lb = _lb(enabled=False, repeat_threshold=1, error_threshold=1, error_window=1)
+    lb.record([("edit", "fp", True)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_last_signal_describes_reason():
+    lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"p": "x"})
+    lb.record([("edit", fp, False)]); lb.verdict()
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    assert "edit" in lb.last_signal()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/test_loop_breaker.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'decafclaw.loop_breaker'`.
+
+- [ ] **Step 3: Implement `loop_breaker.py`**
+
+```python
+"""Per-turn loop-breaker: detects autonomous tool-call thrash and escalates
+a diagnostic nudge, then a hard stop. Pure/deterministic — no agent or LLM
+imports; driven by TurnRunner. See docs/dev-sessions/.../spec.md (#598)."""
+
+import enum
+import hashlib
+import json
+
+
+class LoopVerdict(enum.Enum):
+    NONE = "none"
+    NUDGE = "nudge"
+    STOP = "stop"
+
+
+def fingerprint(tool_name: str, args) -> str:
+    """Stable hash of a tool call's name + arguments (order-insensitive)."""
+    try:
+        arg_repr = json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        arg_repr = repr(args)
+    return hashlib.sha1(f"{tool_name}\x00{arg_repr}".encode()).hexdigest()
+
+
+class LoopBreaker:
+    def __init__(self, config):
+        self._cfg = config
+        self._counts: dict[str, int] = {}          # fingerprint → times seen
+        self._recent_errors: list[bool] = []       # rolling is_error flags
+        self._nudged = False
+        self._last_signal = ""
+
+    def record(self, calls) -> None:
+        """calls: iterable of (tool_name, fingerprint, is_error) for one iteration."""
+        for tool_name, fp, is_error in calls:
+            self._counts[fp] = self._counts.get(fp, 0) + 1
+            self._counts_name = tool_name  # last seen name, for messaging
+            self._last_fp = fp
+            self._recent_errors.append(bool(is_error))
+        # Trim the error window.
+        window = self._cfg.error_window
+        if len(self._recent_errors) > window:
+            self._recent_errors = self._recent_errors[-window:]
+
+    def _tripped_reason(self) -> str | None:
+        # Repeated identical call?
+        top_fp, top_n = None, 0
+        for fp, n in self._counts.items():
+            if n > top_n:
+                top_fp, top_n = fp, n
+        if top_n >= self._cfg.repeat_threshold:
+            return f"called the same tool {top_n}× with identical args"
+        # Repeated errors in the window?
+        errs = sum(self._recent_errors)
+        if errs >= self._cfg.error_threshold:
+            return f"{errs} of the last {len(self._recent_errors)} tool results were errors"
+        return None
+
+    def verdict(self) -> LoopVerdict:
+        if not self._cfg.enabled:
+            return LoopVerdict.NONE
+        reason = self._tripped_reason()
+        if reason is None:
+            return LoopVerdict.NONE
+        self._last_signal = reason
+        if not self._nudged:
+            self._nudged = True
+            return LoopVerdict.NUDGE
+        return LoopVerdict.STOP
+
+    def last_signal(self) -> str:
+        return self._last_signal
+```
+
+Note on `test_last_signal`: the reason string says "the same tool"; the test asserts `"edit" in lb.last_signal()`. Adjust the reason to include the tool name — track the name alongside the fingerprint count (e.g. store `{fp: (name, count)}`) so the message can name the tool. Update the implementation to thread the tool name into `_tripped_reason` so the assertion holds; keep the test as the contract.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/test_loop_breaker.py -v`
+Expected: PASS (all cases). Fix the tool-name threading if `test_last_signal_describes_reason` fails.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+make lint
+git add src/decafclaw/loop_breaker.py tests/test_loop_breaker.py
+git commit -m "feat(loop-breaker): per-turn detector + nudge/stop escalation (#598)"
+```
+
+---
+
+## Task 3: Wire `LoopBreaker` into `TurnRunner`
+
+**Files:**
+- Modify: `src/decafclaw/agent.py` (`TurnRunner.run`, `_handle_tool_calls`, new `_finalize_loop_break`)
+- Test: `tests/test_agent_loop_breaker.py`
+
+**Interfaces:**
+- Consumes: `LoopBreaker`, `LoopVerdict`, `fingerprint` (Task 2); `config.loop_breaker` (Task 1); existing `_Final`, `_Continue`, `_archive`, `execute_tool_calls`.
+- Produces: loop-breaker behavior in the live turn loop.
+
+- [ ] **Step 1: Add a pure signature-extraction helper + its test.**
+
+In `agent.py` (module-level helper):
+
+```python
+def _extract_call_signatures(tool_calls, messages):
+    """Map each tool_call to (tool_name, fingerprint, is_error) using the
+    tool-result messages just appended by execute_tool_calls. Errors are
+    tool-role messages whose content starts with '[error'."""
+    from .loop_breaker import fingerprint
+    results_by_id = {
+        m.get("tool_call_id"): (m.get("content") or "")
+        for m in messages if m.get("role") == "tool"
+    }
+    out = []
+    for tc in tool_calls:
+        fn = tc.get("function", {})
+        name = fn.get("name", "")
+        raw_args = fn.get("arguments", "")
+        try:
+            args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        except (TypeError, ValueError):
+            args = raw_args
+        content = results_by_id.get(tc.get("id"), "")
+        is_error = content.lstrip().startswith("[error")
+        out.append((name, fingerprint(name, args), is_error))
+    return out
+```
+
+In `tests/test_agent_loop_breaker.py`:
+
+```python
+from decafclaw.agent import _extract_call_signatures
+
+
+def test_extract_signatures_flags_errors():
+    tool_calls = [
+        {"id": "1", "function": {"name": "edit", "arguments": '{"path": "x"}'}},
+        {"id": "2", "function": {"name": "read", "arguments": '{"path": "y"}'}},
+    ]
+    messages = [
+        {"role": "tool", "tool_call_id": "1", "content": "[error: bad edit]"},
+        {"role": "tool", "tool_call_id": "2", "content": "ok"},
+    ]
+    sigs = _extract_call_signatures(tool_calls, messages)
+    assert sigs[0][0] == "edit" and sigs[0][2] is True
+    assert sigs[1][0] == "read" and sigs[1][2] is False
+    assert sigs[0][1] != sigs[1][1]
+```
+
+Confirm the `tc` shape (`tc["function"]["name"]`, `tc["function"]["arguments"]`) against `execute_single_tool` / `_handle_single_tool_call` in `tool_execution.py`; adjust the accessors if the shape differs (some paths use `tc["name"]`). Handle both defensively (`fn.get("name") or tc.get("name", "")`).
+
+Run: `.venv/bin/pytest tests/test_agent_loop_breaker.py::test_extract_signatures_flags_errors -v` → PASS.
+
+- [ ] **Step 2: Instantiate the breaker per turn.** In `TurnRunner.run`, alongside `self.budget = IterationBudget(...)` (agent.py:512):
+
+```python
+        from .loop_breaker import LoopBreaker
+        self.loop_breaker = LoopBreaker(self.config.loop_breaker)
+```
+
+- [ ] **Step 3: Feed the breaker + act on the verdict** in `_handle_tool_calls`, AFTER the `execute_tool_calls` call returns and before returning `_Continue` (agent.py ~657). Add:
+
+```python
+        from .loop_breaker import LoopVerdict
+        sigs = _extract_call_signatures(tool_calls, self.messages)
+        self.loop_breaker.record(sigs)
+        verdict = self.loop_breaker.verdict()
+        if verdict is LoopVerdict.NUDGE:
+            nudge = {
+                "role": "system",
+                "content": (
+                    f"[loop-breaker] You {self.loop_breaker.last_signal()} without "
+                    "progress. STOP repeating it. Switch to root-cause diagnosis: "
+                    "read the relevant logs, build a minimal repro, and re-check the "
+                    "contract/interface before any further edits."
+                ),
+            }
+            self.messages.append(nudge)
+            _archive(self.ctx, nudge)
+            await self.ctx.publish("loop_breaker", action="nudge",
+                                   reason=self.loop_breaker.last_signal())
+        elif verdict is LoopVerdict.STOP:
+            await self.ctx.publish("loop_breaker", action="stop",
+                                   reason=self.loop_breaker.last_signal())
+            return _Final(result=await self._finalize_loop_break())
+```
+
+(Place this before the existing end-turn-signal handling returns, but do not let it override a genuine end-turn signal already produced this iteration — if `end_turn_signal` is truthy, honor that first; only run the loop-breaker check on the normal `_Continue` path.)
+
+- [ ] **Step 4: Add `_finalize_loop_break`** (mirrors `_finalize_max_iterations`, agent.py:999):
+
+```python
+    async def _finalize_loop_break(self) -> "ToolResult":
+        """Loop-breaker hard-stop: end the turn with a summary of the thrash
+        and a diagnostic next step, preserving any accumulated text."""
+        note = (
+            f"\n\n[loop-breaker] Stopped: you {self.loop_breaker.last_signal()} "
+            "without progress. Next: read the relevant logs, build a minimal "
+            "repro, and re-check the contract before retrying."
+        )
+        accumulated = "\n\n".join(self.accumulated_text_parts)
+        msg = accumulated + note if accumulated else note.strip()
+        final_msg = {"role": "assistant", "content": msg}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+        from .tool_execution import ToolResult
+        return ToolResult(text=msg)
+```
+
+Match the exact `ToolResult` construction + any `_maybe_compact`/finalize bookkeeping that `_finalize_max_iterations` does; reuse that path rather than reinventing it (read agent.py:999-1020 and mirror it).
+
+- [ ] **Step 5: Integration test** — drive a turn with a scripted LLM that repeats the same failing tool call; assert nudge then stop. In `tests/test_agent_loop_breaker.py`, patch `decafclaw.agent._call_llm_with_events` to return a fixed tool-call response repeatedly and stub `execute_tool_calls` to append an `[error: ...]` tool message. Assert: (a) a `system` message containing `[loop-breaker]` is injected after `repeat_threshold` iterations, and (b) the turn ends via `_finalize_loop_break` (returns a `ToolResult` whose text contains `[loop-breaker] Stopped`) rather than running to `max_tool_iterations`. Follow the existing `TurnRunner`/`run_agent_turn` test setup in `tests/` (grep for `TurnRunner(` or `run_agent_turn(` to find the harness + fixtures to reuse); if no such harness exists, test at the `_handle_tool_calls` level by constructing a `TurnRunner` with minimal stubbed `ctx`/`config`/`messages` and calling it directly. Report DONE_WITH_CONCERNS if the end-to-end harness is heavier than a focused `_handle_tool_calls` test warrants — the pure pieces (Task 2 + Step 1 helper) already carry the deterministic coverage.
+
+- [ ] **Step 6: Run + lint + commit**
+
+Run: `.venv/bin/pytest tests/test_agent_loop_breaker.py -v` → PASS; then `make lint && make test`.
+
+```bash
+git add src/decafclaw/agent.py tests/test_agent_loop_breaker.py
+git commit -m "feat(loop-breaker): wire detector into TurnRunner (nudge + hard-stop) (#598)"
+```
+
+---
+
+## Task 4: Prompt guardrails (`AGENT.md`)
+
+**Files:**
+- Modify: `src/decafclaw/prompts/AGENT.md`
+
+**Verification:** prose edits — no unit test; validated by the eval (Task 5) + `make lint` (no code change). Read the current sections first (lines 50–114) so the edits match the surrounding voice/format.
+
+- [ ] **Step 1: Sharpen the mode-1 diagnosis block.** Replace the "Name the pattern on repeated errors" paragraph (~line 103) so it ends with the explicit rule:
+
+> **Two strikes → diagnose, don't re-edit.** After two failed attempts at the same fix, STOP editing and switch to root-cause diagnosis: read the relevant logs, build a minimal repro, and re-check the contract/interface. Repeating a failed edit a third time is the loop — break it by changing *what you're doing*, not by trying the same thing harder.
+
+- [ ] **Step 2: Add the mode-3 connector** to the "Don't surrender" block (~lines 87–99), as a final line:
+
+> Acknowledgement is not progress. Never open a turn with an apology and then repeat the same failed move — that's the loop wearing a disguise. One clause of acknowledgement at most, then a genuinely different move or a stop.
+
+- [ ] **Step 3: Add the mode-2 phantom-call guardrail** under the tool-use section (near "Only call tools that exist", ~line 51):
+
+> **Emit the call, don't narrate it.** Don't report an action as done until its tool call has actually fired in this turn. If you describe doing something — running a command, sending to Claude Code, editing a file — emit the call in the *same* turn. Never write out a plan to act and then stop or hand back without the call. Before you say "I've done X," confirm X's tool call is present in this turn.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `make lint` (unchanged code; sanity). Manually re-read the three edited sections for voice consistency.
+
+```bash
+git add src/decafclaw/prompts/AGENT.md
+git commit -m "docs(guardrails): sharpen AGENT.md diagnosis/apology/phantom-call guidance (#598)"
+```
+
+---
+
+## Task 5: Eval — deliberately-unloadable skill
+
+**Files:**
+- Create: `evals/fixtures/broken_skill/SKILL.md`
+- Create: `evals/diagnostic_discipline.yaml`
+- (Check: read `docs/eval-loop.md` + an existing `evals/*.yaml` for the exact schema — setup fields, `expect_tool_count_by_name`, `max_tool_calls`, fixture-loading convention.)
+
+**Verification:** `make eval` (or the targeted eval runner) for this file; assert it runs and the assertion holds. This is LLM-driven — expect ~6–10 min + token cost.
+
+- [ ] **Step 1: Create the broken-skill fixture.** `evals/fixtures/broken_skill/SKILL.md` with frontmatter that fails validation (e.g. missing the required `description`, or malformed YAML) so activating/using it reliably errors. Match how other eval fixtures are laid out (grep `evals/` for existing fixture skills; if evals load skills from a configured `extra_skill_paths`/workspace, place it where the eval harness will discover it).
+
+- [ ] **Step 2: Write the eval case** `evals/diagnostic_discipline.yaml`:
+
+```yaml
+- name: loop_breaker_caps_edit_thrash
+  setup:
+    reflection_enabled: false
+    # point the agent at the broken skill fixture per the harness's
+    # skill-path convention (mirror an existing eval that loads a fixture skill)
+  prompt: >
+    Load and use the "broken_skill" skill. If it won't load, get it working.
+  max_tool_calls: 20
+  max_tool_errors: 20
+  expect_tool_count_by_name:
+    # the breaker + prompt must stop the agent from thrashing the editor;
+    # cap well below what a 150-message loop would produce
+    workspace_edit: { max: 5 }
+```
+
+Use the ACTUAL edit tool name(s) the agent would thrash (grep tool definitions — likely `workspace_edit` / `workspace_replace_lines`; cap each, or the most likely one). Keep the assertion on the mechanical outcome (bounded edit count) rather than fuzzy "did it read logs", per the spec's flakiness note.
+
+- [ ] **Step 3: Run the eval**
+
+Run the single eval file via the project's eval runner (see `docs/eval-loop.md` / `make eval-*`). Expected: the case passes — the agent does not exceed the edit-count cap. If it fails because the agent legitimately needs >5 edits, raise the cap to a value still far below loop territory and note the reasoning.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add evals/fixtures/broken_skill/ evals/diagnostic_discipline.yaml
+git commit -m "test(guardrails): eval — loop-breaker caps edit thrash on unloadable skill (#598)"
+```
+
+---
+
+## Task 6: Docs
+
+**Files:**
+- Modify: `CLAUDE.md` (agent-behavior section + `loop_breaker.py` in key files)
+- Modify/Create: the nearest `docs/` behavior page (check `docs/index.md`; likely `docs/reflection.md` sibling or a new `docs/loop-breaker.md`)
+- Create: session `notes.md`
+
+- [ ] **Step 1: Document the mechanism.** Add a short `docs/` section: what the loop-breaker is (per-turn thrash detector), the two trip signals, nudge→stop escalation, and `config.loop_breaker` fields + `LOOP_BREAKER_*` env. Link from `docs/index.md`.
+
+- [ ] **Step 2: Update `CLAUDE.md`.** Add `loop_breaker.py` to the key-files "Other" list with a one-line description; add one bullet under "Agent behavior" describing the per-turn loop-breaker + that guardrail prompt text lives in `AGENT.md`.
+
+- [ ] **Step 3: Write session `notes.md`** summarizing the design decisions (no model-conditional, both signals, escalate, mode-2 prompt-only, evals-skipped-for-modes-2/3) and the final state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/ docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/notes.md
+git commit -m "docs(loop-breaker): document mechanism + config (#598)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Loop-breaker mechanism (detector, both signals, escalation, per-turn, config) — Tasks 1–3. ✓
+- Prompt guardrails modes 1/2/3 (universal, no model-conditional) — Task 4. ✓
+- Config `config.loop_breaker` top-level (dodges nested-env gotcha) — Task 1. ✓
+- Unit tests (deterministic) — Task 2 + Task 3 Step 1. ✓
+- One bounded eval; modes 2/3 evals skipped — Task 5. ✓
+- Docs — Task 6. ✓
+
+**Placeholder scan:** Two deliberate "read the existing pattern and match it" instructions remain (Task 3 `tc` shape + finalize bookkeeping; Task 5 eval schema + fixture-loading convention) — these point at concrete live code to mirror, correct given they must match existing structure exactly. Task 2 Step 3 flags a known adjustment (thread tool name into the reason string) with the test as the contract.
+
+**Type consistency:** `LoopVerdict` (NONE/NUDGE/STOP), `LoopBreaker.record/verdict/last_signal`, `fingerprint`, `_extract_call_signatures`, `_finalize_loop_break`, `config.loop_breaker` used consistently across Tasks 1–3. Error marker `"[error"` matches `tool_execution.py`.
+
+**Known risk:** Task 3 Step 5's end-to-end `TurnRunner` test may be heavier than the harness supports; the plan authorizes falling back to a focused `_handle_tool_calls`-level test since the deterministic coverage lives in Task 2 + the extraction helper.

--- a/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/spec.md
+++ b/docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/spec.md
@@ -1,0 +1,152 @@
+# Agent diagnostic-discipline guardrails — Design Spec
+
+**Issue:** [#598](https://github.com/lmorchard/decafclaw/issues/598)
+**Status:** brainstormed + approved 2026-07-23; ready to plan
+**Owner:** Les
+
+## Problem
+
+A session (`web-lmorchard-fa5ec853`, Gemini-Pro) fell into a ~150-message
+degenerate loop debugging a skill that wouldn't load. Three behavioral failure
+modes, none caused by token budget (87K/300K) — this was diagnostic-discipline
+collapse:
+
+1. **No loop-breaker.** Repeated the same failed edit-and-refresh cycle dozens
+   of times, guessing at causes, never switching to diagnosis.
+2. **Phantom tool call.** Wrote a full plan to re-engage Claude Code but never
+   emitted the `claude_code_send` call; the user had to catch it.
+3. **Apology spiral.** Nearly every turn opened with "You are absolutely
+   correct, my apologies…" then repeated the same failed move.
+
+## Key finding that shapes the design
+
+`AGENT.md` **already** carries strong, specific guidance against the apology
+spiral (lines 80–99, including the exact "You're absolutely right, my apologies"
+anti-example) — and Gemini-Pro sailed past it for ~150 messages. Adding more
+universal prompt text is therefore not, by itself, a reliable fix for the worst
+offender. The most damaging mode (the loop) gets a **mechanical backstop**;
+the softer modes get **prompt refinements**.
+
+## Decisions
+
+- **No model-conditional prompting.** There is no per-model prompt mechanism
+  today and we are not building one now. All prompt guardrails are universal.
+- **Mode 1 (loop) → mechanical loop-breaker + sharpened prompt.**
+- **Modes 2 & 3 → prompt-only refinements.**
+- **Detector trips on either signal** (repeated identical calls OR repeated
+  failures).
+- **Escalation:** nudge first, hard-stop if it keeps looping.
+
+## Component 1 — Loop-breaker mechanism (mode 1)
+
+**Where:** `TurnRunner.run()` in `agent.py`, inside the existing
+`while self.budget.consume()` tool-iteration loop. A small per-turn detector,
+updated after each round of tool results. State is **per-turn** — fresh each
+turn, no cross-turn persistence.
+
+**Detector state:** a rolling list of recent tool calls as
+`(tool_name, args_fingerprint, is_error)`. `args_fingerprint` = a stable hash of
+the call's arguments (e.g. `hash(json.dumps(args, sort_keys=True))`).
+
+**Trip conditions (either):**
+- Same `(tool_name, args_fingerprint)` seen ≥ `repeat_threshold` times this turn, OR
+- ≥ `error_threshold` of the last `error_window` tool results were errors.
+
+**Escalation:**
+1. **First trip →** inject a synthetic `system`-role message into the turn's
+   message list before the next LLM iteration:
+   > "You've called `<tool>` N times with the same result / hit N tool errors
+   > without progress. STOP repeating it. Switch to root-cause diagnosis: read
+   > the relevant logs, build a minimal repro, re-check the contract/interface.
+   > Do not repeat the same call."
+
+   Mark the detector "nudged." Turn continues.
+2. **Trips again after the nudge →** hard-stop: end the turn (one final
+   no-tools LLM response that summarizes what was tried and the suggested
+   diagnostic next step), surfaced to the user. Reuses the existing
+   end-of-turn path (the same mechanism as the `max_tool_iterations` exhaustion
+   response).
+
+**Config:** a `LoopBreakerConfig` **top-level** sub-config —
+`config.loop_breaker`, alongside `config.http` / `config.terminal` (NOT nested
+under `config.agent`, which would trip the doubly-nested env-var gotcha where
+`load_sub_config` only reads a nested dataclass's env vars if its JSON key is
+present). Fields:
+- `enabled: bool = True`
+- `repeat_threshold: int = 3`
+- `error_threshold: int = 4`
+- `error_window: int = 6`
+
+Defaults sit slightly above the issue's "~2" so a single legitimate retry
+doesn't trip the breaker. Tunable via `config.json` (`loop_breaker` key) /
+`LOOP_BREAKER_*` env, resolving through one `load_sub_config` call.
+
+**Injection mechanism:** the nudge is a synthetic message appended to the
+turn's working message list before the next LLM call — the exact insertion
+point (history vs. messages, role) to be confirmed against `TurnRunner` during
+planning. The hard-stop reuses the existing turn-termination path.
+
+## Component 2 — Prompt guardrails (`AGENT.md`, all universal)
+
+**Mode 1 — diagnosis discipline (pairs with the mechanism).** Sharpen the
+existing "Name the pattern on repeated errors" block (~line 103) from generic
+"name it and do something different" into the explicit rule: *two failed
+attempts at the same fix = stop editing, switch to diagnosis — read the
+relevant logs, build a minimal repro, re-check the contract/interface.* The
+prompt carries the intent so the model ideally self-corrects before the
+mechanism fires; the mechanism is the backstop.
+
+**Mode 3 — apology spiral (light touch).** The existing block (lines 80–99) is
+already strong, so rather than pile on more text that already failed, add one
+connecting line tying it to the loop: *"Acknowledgement is not progress. Never
+open with an apology and then repeat the same failed move — that's the loop
+wearing a disguise. One clause of acknowledgement at most, then a genuinely
+different move or a stop."*
+
+**Mode 2 — phantom tool call (new, prompt-only).** Add a guardrail near the
+tool-use section: *"Don't report an action as done until its tool call has
+actually fired in this turn. If you describe doing something (running a command,
+sending to Claude Code), emit the call in the same turn — never narrate a tool
+action in prose and then stop or hand back."* Prompt-only for v1: mechanically
+detecting "narrated an action it didn't emit" needs fuzzy intent-vs-emitted-call
+analysis not worth the false-positive risk yet.
+
+## Testing
+
+**Unit tests (deterministic — the mechanism's real coverage).** Exercise the
+loop-breaker detector + escalation in isolation with sequences of
+`(tool_name, args_fingerprint, is_error)`:
+- same `(tool, args)` reaching `repeat_threshold` → trips
+- `error_threshold`-of-`error_window` errors → trips
+- first trip → nudge emitted; trips again after nudge → hard-stop signal
+- below thresholds → no trip; boundary (threshold−1 vs threshold)
+- `enabled=False` → never trips
+- per-turn reset (fresh state each turn)
+
+**One eval (LLM behavior).** A deliberately-unloadable skill fixture; the user
+asks the agent to use it. Bounded, rigorous assertions per project eval
+conventions: `max_tool_calls` cap + `expect_tool_count_by_name` capping the
+repeated edit tool (the agent *cannot* thrash the editor beyond ~N calls — the
+breaker enforces it), with `setup.reflection_enabled: false` since we assert
+tool-count discipline. Validates the combined prompt + mechanism end-to-end
+against a real model.
+
+**Deliberately skipped:** dedicated evals for modes 2 & 3. The apology spiral is
+a stochastic, model-specific register (Gemini-Pro-worst; the eval model may
+differ) and the phantom-call guardrail is prompt-only — an assertion on either
+would be flaky and low-signal. Conscious, documented departure from "every
+behavior-affecting change gets an eval"; the loop-breaker eval carries the load.
+
+## Out of scope / deferred
+
+- Model-conditional prompting.
+- Mechanical detection of the phantom-tool-call mode (mode 2 stays prompt-only).
+- Cross-turn loop detection (the postmortem loop was autonomous within-turn
+  iteration; per-turn state covers it).
+
+## Docs to update in the implementation PR
+
+- `docs/` page covering agent behavior / guardrails (or `AGENT.md` is the
+  source; note the loop-breaker in the relevant behavior doc).
+- `CLAUDE.md` — one line under agent behavior if a new config block + mechanism
+  warrant it; add `LoopBreakerConfig` to config docs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ These docs are as much for me as they are for agents working on this project. Th
 
 - [Workflow Replay Engine](workflows.md) — Durable, human-in-the-loop workflows with deterministic replay; code owns control flow, LLM is a structured-output worker; primitives include `llm_call`, `user_input`, `tool_call`, `subagent`, `parallel`, `pipeline`
 - [Self-Reflection](reflection.md) — Binary judge + critique + retry before delivering responses (Reflexion pattern)
+- [Loop Breaker](loop-breaker.md) — Per-turn detector for autonomous tool-call thrash; nudge then hard-stop escalation, plus the related `AGENT.md` diagnostic-discipline guardrails
 - [Sub-Agent Delegation](delegation.md) — Fork child agents for concurrent subtasks
 - [Heartbeat](heartbeat.md) — Periodic agent wake-up for monitoring and recurring tasks
 - [Scheduled Tasks](schedules.md) — Cron-style per-task scheduling with model, tool, and skill configuration

--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -33,9 +33,11 @@ sorted-JSON arguments) and asks the breaker for a verdict.
 
 **Escalation is one-way per turn:**
 
-1. **First trip → nudge.** A `system`-role diagnostic message is appended
+1. **First trip → nudge.** A `user`-role diagnostic message is appended
    telling the model to stop repeating the move and switch to root-cause
-   diagnosis (read logs, build a minimal repro, re-check the contract). The
+   diagnosis (read logs, build a minimal repro, re-check the contract). It is
+   `user`-role rather than `system` because models weight user-role directives
+   more heavily for mid-turn corrections (matching `_run_grace_turn`). The
    turn continues normally into the next iteration.
 2. **Any subsequent trip → hard stop.** The turn ends immediately with a
    short summary of what was tried and the same diagnostic next step,
@@ -51,7 +53,7 @@ already ends the turn earlier and takes precedence over the breaker.
 The nudge message is appended to the turn's in-memory `messages` list only
 — it is **never** written to `self.history` and **never** archived. This is
 intentional: archiving it would let it get restored via `restore_history`
-on a page reload or process restart (a `system`-role message is a real LLM
+on a page reload or process restart (a `user`-role message is a real LLM
 role, not UI-only), permanently polluting the context of every later turn
 with a diagnostic aside that only made sense in the moment it fired. The
 hard-stop's final summary, by contrast, *is* archived normally — it's a

--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -1,0 +1,133 @@
+# Loop Breaker
+
+The loop breaker is a per-turn, mechanical backstop against autonomous
+tool-call thrash — the agent repeating the same failed move (or hitting a
+run of errors) inside a single turn's tool-iteration loop, without ever
+switching to diagnosis. It shipped alongside sharpened `AGENT.md`
+guardrails as part of [#598](https://github.com/lmorchard/decafclaw/issues/598),
+after a real session spent ~150 messages stuck editing-and-refreshing a
+skill that wouldn't load.
+
+Prompting alone wasn't a reliable fix — `AGENT.md` already carried strong
+anti-apology-spiral guidance and the model sailed past it. So the worst
+failure mode (the loop itself) gets a mechanical detector; the softer
+failure modes (apology spirals, phantom tool calls — see below) stay
+prompt-only refinements in `AGENT.md`.
+
+## How it works
+
+`TurnRunner` (`agent.py`) creates one `LoopBreaker` per turn — state does
+not persist across turns, only within the current turn's tool-iteration
+loop. After each round of tool calls, `TurnRunner._handle_tool_calls`
+records the round's `(tool_name, args_fingerprint, is_error)` signatures
+(`fingerprint()` in `loop_breaker.py` is a stable hash of the call's name +
+sorted-JSON arguments) and asks the breaker for a verdict.
+
+**Trip conditions (either signal fires it):**
+
+- The same `(tool_name, args_fingerprint)` pair has been seen
+  `repeat_threshold` or more times this turn — a genuine repeat-the-same-call
+  loop, or
+- `error_threshold` or more of the last `error_window` tool results were
+  errors — a run of failures even if the calls themselves vary.
+
+**Escalation is one-way per turn:**
+
+1. **First trip → nudge.** A `system`-role diagnostic message is appended
+   telling the model to stop repeating the move and switch to root-cause
+   diagnosis (read logs, build a minimal repro, re-check the contract). The
+   turn continues normally into the next iteration.
+2. **Any subsequent trip → hard stop.** The turn ends immediately with a
+   short summary of what was tried and the same diagnostic next step,
+   delivered as the turn's final response — the same termination path used
+   when `max_tool_iterations` is exhausted.
+
+The loop breaker only runs on the "keep going" path — a genuine end-turn
+signal (a widget pause, `EndTurnConfirm`, or `end_turn=True` from a tool)
+already ends the turn earlier and takes precedence over the breaker.
+
+### The nudge is ephemeral, deliberately
+
+The nudge message is appended to the turn's in-memory `messages` list only
+— it is **never** written to `self.history` and **never** archived. This is
+intentional: archiving it would let it get restored via `restore_history`
+on a page reload or process restart (a `system`-role message is a real LLM
+role, not UI-only), permanently polluting the context of every later turn
+with a diagnostic aside that only made sense in the moment it fired. The
+hard-stop's final summary, by contrast, *is* archived normally — it's a
+real assistant response the user should see and the agent should remember
+saying.
+
+## Prompt guardrails (`AGENT.md`)
+
+Two related, prompt-only behaviors from the same investigation live as
+plain guidance in `src/decafclaw/prompts/AGENT.md`, not in this mechanism —
+there's no per-model prompt system today, so none of this is
+model-conditional:
+
+- **"Two strikes → diagnose, don't re-edit."** After two failed attempts at
+  the same fix, stop editing and switch to root-cause diagnosis. This is
+  the prompt-side companion to the loop breaker: the model should ideally
+  self-correct before the mechanism ever needs to trip.
+- **"Acknowledgement is not progress."** Opening a turn with an apology and
+  then repeating the same failed move is the loop wearing a disguise — one
+  clause of acknowledgement at most, then a genuinely different move or a
+  stop.
+- **"Emit the call, don't narrate it."** Don't report an action (running a
+  command, sending to Claude Code, editing a file) as done until its tool
+  call has actually fired in this turn — never narrate an action in prose
+  and then stop or hand back without emitting it. This "phantom tool call"
+  mode is prompt-only by design: mechanically detecting "narrated an action
+  it didn't emit" needs fuzzy intent-vs-emitted-call analysis that isn't
+  worth the false-positive risk yet.
+
+There are no evals for these two prompt-only guardrails — see
+[Eval Loop](eval-loop.md) and the design spec for why (stochastic,
+model-specific register for the apology spiral; low-signal for a
+prompt-only phantom-call check). The mechanical loop breaker is covered by
+`evals/diagnostic_discipline.yaml`, which caps a deliberately-unloadable
+skill fixture at `max_tool_calls: 15` / `max_tool_errors: 15` and relies on
+the breaker (or a clean first-try fix) to stay inside that bound.
+
+## Configuration
+
+The `loop_breaker` config group (`data/{agent_id}/config.json`), top-level
+alongside `http` / `terminal` — not nested under `agent`, which would trip
+the doubly-nested env-var gotcha where `load_sub_config` only reads a
+nested dataclass's env vars if its JSON key is present:
+
+```json
+{
+  "loop_breaker": {
+    "enabled": true,
+    "repeat_threshold": 3,
+    "error_threshold": 4,
+    "error_window": 6
+  }
+}
+```
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `enabled` | bool | `true` | `LOOP_BREAKER_ENABLED` |
+| `repeat_threshold` | int | `3` | `LOOP_BREAKER_REPEAT_THRESHOLD` |
+| `error_threshold` | int | `4` | `LOOP_BREAKER_ERROR_THRESHOLD` |
+| `error_window` | int | `6` | `LOOP_BREAKER_ERROR_WINDOW` |
+
+Defaults sit slightly above "a single legitimate retry" so normal retry
+behavior doesn't trip the breaker. Set `enabled: false` to disable the
+mechanism entirely (the `AGENT.md` prompt guardrails still apply either
+way).
+
+## Files
+
+- `src/decafclaw/loop_breaker.py` — `LoopBreaker`, `LoopVerdict`,
+  `fingerprint()` — pure/deterministic, no agent or LLM imports
+- `src/decafclaw/agent.py` — `TurnRunner._handle_tool_calls` wiring
+  (`_extract_call_signatures`, nudge injection, `_finalize_loop_break`)
+- `src/decafclaw/config_types.py` — `LoopBreakerConfig`
+- `src/decafclaw/prompts/AGENT.md` — the diagnosis / acknowledgement /
+  phantom-call prompt guardrails
+- `tests/test_loop_breaker.py`, `tests/test_agent_loop_breaker.py` —
+  detector unit tests + `TurnRunner` wiring tests
+- `evals/diagnostic_discipline.yaml` — the bounded, real-LLM eval

--- a/evals/diagnostic_discipline.yaml
+++ b/evals/diagnostic_discipline.yaml
@@ -14,8 +14,11 @@
 # this case inlines the fixture's content via `setup.workspace_files`
 # (same convention as evals/ingest.yaml) at
 # "skills/broken_skill/SKILL.md" — the workspace tier that
-# `discover_skills` scans (`{workspace_path}/skills/`). Keep this block
-# in sync with evals/fixtures/broken_skill/SKILL.md.
+# `discover_skills` scans (`{workspace_path}/skills/`). Only the
+# frontmatter needs to match evals/fixtures/broken_skill/SKILL.md (same
+# `name: broken_skill`, still missing `description`) — that's what
+# drives the validation failure this eval depends on; the prose bodies
+# need not match.
 #
 # Discovery-timing note: `config.discovered_skills` is populated once,
 # before `setup.workspace_files` are written to disk (see
@@ -70,5 +73,5 @@
   input: >
     Load and use the "broken_skill" skill. If it won't load, get it working.
   expect:
-    max_tool_calls: 20
-    max_tool_errors: 20
+    max_tool_calls: 15
+    max_tool_errors: 15

--- a/evals/diagnostic_discipline.yaml
+++ b/evals/diagnostic_discipline.yaml
@@ -1,0 +1,74 @@
+# Eval for the loop-breaker (#598): a deliberately-unloadable skill
+# fixture where a thrashing agent gets capped. Validates the combined
+# AGENT.md prompt guardrails + LoopBreaker mechanism (src/decafclaw/
+# loop_breaker.py) end-to-end, with real LLM calls.
+#
+# Fixture: evals/fixtures/broken_skill/SKILL.md — frontmatter is missing
+# the required `description` field, so `validate_skill_md` rejects it
+# during skill discovery.
+#
+# Fixture-loading note: the eval harness (src/decafclaw/eval/runner.py)
+# has no path-based skill-fixture loader — `setup.skills` only
+# pre-activates *discovered* skills by name, and discovery only scans
+# real filesystem directories (workspace/admin/bundled/extra tiers). So
+# this case inlines the fixture's content via `setup.workspace_files`
+# (same convention as evals/ingest.yaml) at
+# "skills/broken_skill/SKILL.md" — the workspace tier that
+# `discover_skills` scans (`{workspace_path}/skills/`). Keep this block
+# in sync with evals/fixtures/broken_skill/SKILL.md.
+#
+# Discovery-timing note: `config.discovered_skills` is populated once,
+# before `setup.workspace_files` are written to disk (see
+# `run_test` in runner.py). So the agent's first `activate_skill
+# (name="broken_skill")` reliably errors with "not found" — the broken
+# skill isn't even in the catalog yet. Only `refresh_skills` (which
+# re-scans) or `skill_validate` will resurface it as a validation
+# rejection with the actual reason ("missing required 'description'
+# field"), giving the agent what it needs to fix the file.
+#
+# Assertion note: `expect_tool_count_by_name` in the real runner asserts
+# EXACT equality (`got != want`), not an upper bound — it can't express
+# "at most N edits," and forcing a made-up exact count here would be
+# flaky against a stochastic real-LLM run (the number of fix attempts
+# before the agent gets the frontmatter right is not deterministic).
+# The mechanical, deterministic bound on thrash is `max_tool_calls` /
+# `max_tool_errors` — both genuine upper bounds per the runner's
+# `_check_expect` implementation, and the fields the eval docs already
+# recommend for bounding thrash-prone tests. A true 200-iteration loop
+# would blow through either bound many times over; the loop breaker
+# (repeat_threshold=3 same-call, or error_threshold=4-in-6-window) trips
+# well before that, so this bound is only satisfiable if the breaker
+# (or a clean first-try fix) actually caps things.
+#
+# `expect_tool` was tried and dropped: which tool the model reaches for
+# first (activate_skill vs. tool_search vs. skill_validate) varies run
+# to run and isn't the thing this eval cares about — only the bounded
+# tool-call/error count is. Verified live: one run had the model try
+# `activate_skill("broken_skill")` 3x with identical args (fixing the
+# file in between via a botched-then-corrected workspace_edit) and the
+# loop breaker fired for real — the response ended with
+# "[loop-breaker] Stopped: you called activate_skill 3x with the same
+# args without progress." — inside the max_tool_calls/max_tool_errors
+# bound. Another run had the model call `tool_search` once, conclude
+# the skill wasn't findable, and stop — also well inside the bound.
+# Both are legitimate outcomes for this eval's purpose.
+
+- name: "loop_breaker_caps_edit_thrash"
+  setup:
+    reflection_enabled: false
+    workspace_files:
+      "skills/broken_skill/SKILL.md": |
+        ---
+        name: broken_skill
+        ---
+
+        # Broken Skill (eval fixture)
+
+        This is a deliberately-unloadable skill fixture for the loop-breaker
+        eval (#598). Its frontmatter is missing the required `description`
+        field, so skill discovery rejects it.
+  input: >
+    Load and use the "broken_skill" skill. If it won't load, get it working.
+  expect:
+    max_tool_calls: 20
+    max_tool_errors: 20

--- a/evals/fixtures/broken_skill/SKILL.md
+++ b/evals/fixtures/broken_skill/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: broken_skill
+---
+
+# Broken Skill (eval fixture)
+
+This is a deliberately-unloadable skill fixture for the loop-breaker eval
+(#598). Its frontmatter is missing the required `description` field, so
+`validate_skill_md` rejects it during discovery — `activate_skill` will
+report "not found" until the frontmatter is fixed, and `refresh_skills` /
+`skill_validate` will surface the real rejection reason.
+
+If you're reading this after a fix: there's nothing else to do here. This
+skill has no real capability — it exists purely to trigger a validation
+failure for the eval.
+
+Note: this file is not loaded directly by the eval harness (there's no
+path-based skill-fixture mechanism in `decafclaw.eval.runner`). The eval
+case in `evals/diagnostic_discipline.yaml` inlines this same content via
+`setup.workspace_files` so it lands under the test's ephemeral
+`{workspace}/skills/broken_skill/SKILL.md` where skill discovery scans.
+Keep the two in sync if you change this fixture.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import re as _re
 from dataclasses import dataclass, field
@@ -23,10 +24,12 @@ if TYPE_CHECKING:
 
 from .archive import append_message
 from .compaction import compact_history
+from .config_types import LoopBreakerConfig
 from .context_cleanup import clear_old_tool_results
 from .context_composer import ComposerMode, ContextComposer
 from .iteration_budget import IterationBudget
 from .llm import call_llm
+from .loop_breaker import LoopBreaker, LoopVerdict, fingerprint
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause, extract_workspace_media
 from .persistence import read_skill_data, read_skills_state, write_skill_data, write_skills_state
 from .reflection_metrics import classify_outcome, response_delta
@@ -116,6 +119,31 @@ async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
             ctx.composer.cleanup_cleared_bytes = 0
         except Exception as e:
             log.error(f"Compaction failed: {e}")
+
+
+def _extract_call_signatures(tool_calls, messages):
+    """Map each tool_call to (tool_name, fingerprint, is_error) using the
+    tool-result messages just appended by execute_tool_calls. Errors are
+    tool-role messages whose content starts with '[error' (see
+    tool_execution.py:ToolResult(text="[error: ...]")).
+    """
+    results_by_id = {
+        m.get("tool_call_id"): (m.get("content") or "")
+        for m in messages if m.get("role") == "tool"
+    }
+    out = []
+    for tc in tool_calls:
+        fn = tc.get("function", {})
+        name = fn.get("name") or tc.get("name", "")
+        raw_args = fn.get("arguments", tc.get("arguments", ""))
+        try:
+            args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        except (TypeError, ValueError):
+            args = raw_args
+        content = results_by_id.get(tc.get("id"), "")
+        is_error = content.lstrip().startswith("[error")
+        out.append((name, fingerprint(name, args), is_error))
+    return out
 
 
 # -- Agent turn helpers --------------------------------------------------------
@@ -488,6 +516,9 @@ class TurnRunner:
     budget: IterationBudget = field(
         default_factory=lambda: IterationBudget(remaining=0),
     )
+    loop_breaker: LoopBreaker = field(
+        default_factory=lambda: LoopBreaker(LoopBreakerConfig()),
+    )
 
     async def run(self) -> "ToolResult":
         """Process a single user message through the agent loop."""
@@ -512,6 +543,7 @@ class TurnRunner:
             self.budget = IterationBudget(
                 remaining=self.config.agent.max_tool_iterations,
             )
+            self.loop_breaker = LoopBreaker(self.config.loop_breaker)
 
             iteration = 0
             while self.budget.consume():
@@ -725,6 +757,31 @@ class TurnRunner:
             _archive(self.ctx, final_msg)
 
             return _Final(result=self._extract_workspace_media(content))
+
+        # Loop-breaker: only checked on the normal continue path — a genuine
+        # end-turn signal (widget pause / EndTurnConfirm / end_turn=True)
+        # already returned above and takes precedence over the breaker.
+        sigs = _extract_call_signatures(tool_calls, self.messages)
+        self.loop_breaker.record(sigs)
+        verdict = self.loop_breaker.verdict()
+        if verdict is LoopVerdict.NUDGE:
+            nudge = {
+                "role": "system",
+                "content": (
+                    f"[loop-breaker] You {self.loop_breaker.last_signal()} without "
+                    "progress. STOP repeating it. Switch to root-cause diagnosis: "
+                    "read the relevant logs, build a minimal repro, and re-check the "
+                    "contract/interface before any further edits."
+                ),
+            }
+            self.messages.append(nudge)
+            _archive(self.ctx, nudge)
+            await self.ctx.publish("loop_breaker", action="nudge",
+                                   reason=self.loop_breaker.last_signal())
+        elif verdict is LoopVerdict.STOP:
+            await self.ctx.publish("loop_breaker", action="stop",
+                                   reason=self.loop_breaker.last_signal())
+            return _Final(result=await self._finalize_loop_break())
 
         return _Continue()
 
@@ -1005,6 +1062,24 @@ class TurnRunner:
         )
         accumulated = "\n\n".join(self.accumulated_text_parts)
         msg = accumulated + limit_note if accumulated else limit_note.strip()
+        final_msg = {"role": "assistant", "content": msg}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+        await _maybe_compact(
+            self.ctx, self.config, self.history, self.prompt_tokens,
+        )
+        return ToolResult(text=msg)
+
+    async def _finalize_loop_break(self) -> "ToolResult":
+        """Loop-breaker hard-stop: end the turn with a summary of the thrash
+        and a diagnostic next step, preserving any accumulated text."""
+        note = (
+            f"\n\n[loop-breaker] Stopped: you {self.loop_breaker.last_signal()} "
+            "without progress. Next: read the relevant logs, build a minimal "
+            "repro, and re-check the contract before retrying."
+        )
+        accumulated = "\n\n".join(self.accumulated_text_parts)
+        msg = accumulated + note if accumulated else note.strip()
         final_msg = {"role": "assistant", "content": msg}
         self.history.append(final_msg)
         _archive(self.ctx, final_msg)

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -761,31 +761,39 @@ class TurnRunner:
         # Loop-breaker: only checked on the normal continue path — a genuine
         # end-turn signal (widget pause / EndTurnConfirm / end_turn=True)
         # already returned above and takes precedence over the breaker.
-        sigs = _extract_call_signatures(tool_calls, self.messages)
-        self.loop_breaker.record(sigs)
-        verdict = self.loop_breaker.verdict()
-        if verdict is LoopVerdict.NUDGE:
-            # Ephemeral — appended to self.messages only, never archived or
-            # added to self.history. Archiving would re-surface it via
-            # restore_history on a restart/reload (role "system" is an LLM
-            # role), permanently polluting context on all later turns.
-            # Matches _run_grace_turn's injected note.
-            nudge = {
-                "role": "system",
-                "content": (
-                    f"[loop-breaker] You {self.loop_breaker.last_signal()} without "
-                    "progress. STOP repeating it. Switch to root-cause diagnosis: "
-                    "read the relevant logs, build a minimal repro, and re-check the "
-                    "contract/interface before any further edits."
-                ),
-            }
-            self.messages.append(nudge)
-            await self.ctx.publish("loop_breaker", action="nudge",
-                                   reason=self.loop_breaker.last_signal())
-        elif verdict is LoopVerdict.STOP:
-            await self.ctx.publish("loop_breaker", action="stop",
-                                   reason=self.loop_breaker.last_signal())
-            return _Final(result=await self._finalize_loop_break())
+        # Gated on `enabled` so a disabled breaker is a true no-op — nothing
+        # is extracted or recorded, not just the verdict skipped.
+        if self.loop_breaker.enabled:
+            sigs = _extract_call_signatures(tool_calls, self.messages)
+            self.loop_breaker.record(sigs)
+            verdict = self.loop_breaker.verdict()
+            if verdict is LoopVerdict.NUDGE:
+                # Role "user", not "system": models weight user-role directives
+                # more heavily than system-role for mid-turn corrections, and a
+                # weakly-followed "STOP and diagnose" defeats the point of the
+                # nudge. Matches _run_grace_turn's deliberate user-role choice.
+                #
+                # Ephemeral — appended to self.messages only, never archived or
+                # added to self.history. Archiving would re-surface it via
+                # restore_history on a restart/reload (role "user" is equally an
+                # LLM role that gets resurrected), permanently polluting context
+                # on all later turns.
+                nudge = {
+                    "role": "user",
+                    "content": (
+                        f"[loop-breaker] You {self.loop_breaker.last_signal()} without "
+                        "progress. STOP repeating it. Switch to root-cause diagnosis: "
+                        "read the relevant logs, build a minimal repro, and re-check the "
+                        "contract/interface before any further edits."
+                    ),
+                }
+                self.messages.append(nudge)
+                await self.ctx.publish("loop_breaker", action="nudge",
+                                       reason=self.loop_breaker.last_signal())
+            elif verdict is LoopVerdict.STOP:
+                await self.ctx.publish("loop_breaker", action="stop",
+                                       reason=self.loop_breaker.last_signal())
+                return _Final(result=await self._finalize_loop_break())
 
         return _Continue()
 

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -765,6 +765,11 @@ class TurnRunner:
         self.loop_breaker.record(sigs)
         verdict = self.loop_breaker.verdict()
         if verdict is LoopVerdict.NUDGE:
+            # Ephemeral — appended to self.messages only, never archived or
+            # added to self.history. Archiving would re-surface it via
+            # restore_history on a restart/reload (role "system" is an LLM
+            # role), permanently polluting context on all later turns.
+            # Matches _run_grace_turn's injected note.
             nudge = {
                 "role": "system",
                 "content": (
@@ -775,7 +780,6 @@ class TurnRunner:
                 ),
             }
             self.messages.append(nudge)
-            _archive(self.ctx, nudge)
             await self.ctx.publish("loop_breaker", action="nudge",
                                    reason=self.loop_breaker.last_signal())
         elif verdict is LoopVerdict.STOP:

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -27,6 +27,7 @@ from .config_types import (
     HeartbeatConfig,
     HttpConfig,
     LlmConfig,
+    LoopBreakerConfig,
     MapWidgetConfig,
     MattermostConfig,
     ModelConfig,
@@ -189,6 +190,7 @@ class Config:
     email: EmailConfig = field(default_factory=EmailConfig)
     background: BackgroundConfig = field(default_factory=BackgroundConfig)
     workflow: WorkflowConfig = field(default_factory=WorkflowConfig)
+    loop_breaker: LoopBreakerConfig = field(default_factory=LoopBreakerConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     widgets: WidgetsConfig = field(default_factory=WidgetsConfig)
 
@@ -479,6 +481,9 @@ def load_config() -> Config:
     workflow = load_sub_config(
         WorkflowConfig, file_data.get("workflow", {}), "WORKFLOW")
 
+    loop_breaker = load_sub_config(
+        LoopBreakerConfig, file_data.get("loop_breaker", {}), "LOOP_BREAKER")
+
     telemetry = load_sub_config(
         TelemetryConfig, file_data.get("telemetry", {}), "TELEMETRY")
 
@@ -571,6 +576,7 @@ def load_config() -> Config:
         email=email,
         background=background,
         workflow=workflow,
+        loop_breaker=loop_breaker,
         telemetry=telemetry,
         widgets=widgets,
         env=env_vars,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -440,6 +440,21 @@ class WorkflowConfig:
 
 
 @dataclass
+class LoopBreakerConfig:
+    """Diagnostic guardrails for infinite loop detection (#598).
+
+    The agent loop monitors tool-call patterns to detect infinite loops
+    (same tool with same args N times) and error surges (E errors within
+    W tool results). Tuning these thresholds tunes the sensitivity of
+    the trip signal.
+    """
+    enabled: bool = True
+    repeat_threshold: int = 3      # same (tool, args) N times → trip
+    error_threshold: int = 4       # this many errors...
+    error_window: int = 6          # ...within the last N tool results → trip
+
+
+@dataclass
 class TelemetryConfig:
     """Instrumentation sidecars (#310 tool usage, #409 reflection metrics).
 

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -1,0 +1,89 @@
+"""Per-turn loop-breaker: detects autonomous tool-call thrash and escalates
+a diagnostic nudge, then a hard stop. Pure/deterministic — no agent or LLM
+imports; driven by TurnRunner. See docs/dev-sessions/.../spec.md (#598)."""
+
+import enum
+import hashlib
+import json
+
+
+class LoopVerdict(enum.Enum):
+    NONE = "none"
+    NUDGE = "nudge"
+    STOP = "stop"
+
+
+def fingerprint(tool_name: str, args) -> str:
+    """Stable hash of a tool call's name + arguments (order-insensitive)."""
+    try:
+        arg_repr = json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        arg_repr = repr(args)
+    return hashlib.sha1(f"{tool_name}\x00{arg_repr}".encode()).hexdigest()
+
+
+class LoopBreaker:
+    """Detects tool-call thrash within a single turn and escalates.
+
+    Trips on either signal:
+    - the same (tool_name, args_fingerprint) seen >= repeat_threshold times
+    - >= error_threshold of the last error_window tool results are errors
+
+    Escalation is one-way per instance: the first trip returns NUDGE; any
+    subsequent trip after that returns STOP. `enabled=False` always returns
+    NONE. One LoopBreaker per turn — state is not meant to persist across
+    turns.
+    """
+
+    def __init__(self, config):
+        self._cfg = config
+        # fingerprint -> [tool_name, count]. Tracks the name alongside the
+        # count so last_signal() can name the offending tool.
+        self._counts: dict[str, list] = {}
+        self._recent_errors: list[bool] = []  # rolling is_error flags
+        self._nudged = False
+        self._last_signal = ""
+
+    def record(self, calls) -> None:
+        """Record one iteration's tool calls.
+
+        calls: iterable of (tool_name, fingerprint, is_error).
+        """
+        for tool_name, fp, is_error in calls:
+            entry = self._counts.setdefault(fp, [tool_name, 0])
+            entry[0] = tool_name
+            entry[1] += 1
+            self._recent_errors.append(bool(is_error))
+        # Trim to a rolling window of the last N results.
+        window = self._cfg.error_window
+        if len(self._recent_errors) > window:
+            self._recent_errors = self._recent_errors[-window:]
+
+    def _tripped_reason(self) -> str | None:
+        # Repeated identical call?
+        top_name, top_n = None, 0
+        for name, n in self._counts.values():
+            if n > top_n:
+                top_name, top_n = name, n
+        if top_n >= self._cfg.repeat_threshold:
+            return f"called {top_name} {top_n}× with the same args"
+        # Repeated errors in the window?
+        errs = sum(self._recent_errors)
+        if errs >= self._cfg.error_threshold:
+            return f"{errs} of the last {len(self._recent_errors)} tool results were errors"
+        return None
+
+    def verdict(self) -> LoopVerdict:
+        if not self._cfg.enabled:
+            return LoopVerdict.NONE
+        reason = self._tripped_reason()
+        if reason is None:
+            return LoopVerdict.NONE
+        self._last_signal = reason
+        if not self._nudged:
+            self._nudged = True
+            return LoopVerdict.NUDGE
+        return LoopVerdict.STOP
+
+    def last_signal(self) -> str:
+        return self._last_signal

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -1,6 +1,6 @@
 """Per-turn loop-breaker: detects autonomous tool-call thrash and escalates
 a diagnostic nudge, then a hard stop. Pure/deterministic — no agent or LLM
-imports; driven by TurnRunner. See docs/dev-sessions/.../spec.md (#598)."""
+imports; driven by TurnRunner. See docs/loop-breaker.md (#598)."""
 
 import enum
 import hashlib
@@ -44,6 +44,10 @@ class LoopBreaker:
         self._nudged = False
         self._last_signal = ""
 
+    @property
+    def enabled(self) -> bool:
+        return self._cfg.enabled
+
     def record(self, calls) -> None:
         """Record one iteration's tool calls.
 
@@ -74,6 +78,12 @@ class LoopBreaker:
         return None
 
     def verdict(self) -> LoopVerdict:
+        """Compute the verdict for the most recently recorded round.
+
+        Mutates escalation state: a NUDGE verdict flips the one-way "already
+        nudged" flag, so a second call without an intervening `record()`
+        will escalate NUDGE -> STOP. Call exactly once per recorded round.
+        """
         if not self._cfg.enabled:
             return LoopVerdict.NONE
         reason = self._tripped_reason()

--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -54,6 +54,14 @@ confirm it's at the expected path before calling it. Hallucinating
 tool names or script paths erodes trust — search the catalog or
 ask before guessing.
 
+**Emit the call, don't narrate it.** Don't report an action as
+done until its tool call has actually fired in this turn. If you
+describe doing something — running a command, sending to Claude
+Code, editing a file — emit the call in the *same* turn. Never
+write out a plan to act and then stop or hand back without the
+call. Before you say "I've done X," confirm X's tool call is
+present in this turn.
+
 **Use tools, don't apologize for them.** When a tool returns
 results, use them. If a tool errors, try alternatives or answer
 from your own knowledge. NEVER say "tools are unavailable" —
@@ -97,16 +105,19 @@ for alternatives or the trade-offs genuinely need a side-by-side.
   change course, but don't apologize for having held it. The
   acknowledgement is one short clause; the fix is the rest of
   the response.
+- *Acknowledgement is not progress.* Never open a turn with an
+  apology and then repeat the same failed move — that's the loop
+  wearing a disguise. One clause of acknowledgement at most, then
+  a genuinely different move or a stop.
 
 ### Error handling
 
-**Name the pattern on repeated errors.** If you notice you're
-making the same kind of mistake twice in the same conversation,
-don't just acknowledge it again. In one short sentence, name the
-pattern and what you'll do differently. Example: "I've tried
-workspace_edit twice and hit the same exact-match failure. The
-current content has drifted from what I remember. Switching to
-workspace_read + workspace_replace_lines."
+**Two strikes → diagnose, don't re-edit.** After two failed
+attempts at the same fix, STOP editing and switch to root-cause
+diagnosis: read the relevant logs, build a minimal repro, and
+re-check the contract/interface. Repeating a failed edit a third
+time is the loop — break it by changing *what you're doing*, not
+by trying the same thing harder.
 
 **Don't fix the prompt mid-task.** When something goes wrong, stay
 focused on "what I should do next in this conversation." Don't

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -1,0 +1,110 @@
+"""Tests for LoopBreaker wiring into TurnRunner (#598)."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.agent import _extract_call_signatures, run_agent_turn
+
+
+def _mock_llm_response(content="Hello!", tool_calls=None, usage=None):
+    """Build a mock LLM response dict (mirrors test_agent_turn.py's helper)."""
+    return {
+        "content": content,
+        "tool_calls": tool_calls,
+        "role": "assistant",
+        "usage": usage or {"prompt_tokens": 100, "completion_tokens": 50},
+    }
+
+
+# -- _extract_call_signatures ---------------------------------------------------
+
+
+def test_extract_signatures_flags_errors():
+    tool_calls = [
+        {"id": "1", "function": {"name": "edit", "arguments": '{"path": "x"}'}},
+        {"id": "2", "function": {"name": "read", "arguments": '{"path": "y"}'}},
+    ]
+    messages = [
+        {"role": "tool", "tool_call_id": "1", "content": "[error: bad edit]"},
+        {"role": "tool", "tool_call_id": "2", "content": "ok"},
+    ]
+    sigs = _extract_call_signatures(tool_calls, messages)
+    assert sigs[0][0] == "edit" and sigs[0][2] is True
+    assert sigs[1][0] == "read" and sigs[1][2] is False
+    assert sigs[0][1] != sigs[1][1]
+
+
+def test_extract_signatures_handles_missing_tool_result():
+    """A tool_call with no matching tool-result message (shouldn't happen in
+    practice, but defend against it) is treated as non-error."""
+    tool_calls = [
+        {"id": "missing", "function": {"name": "edit", "arguments": "{}"}},
+    ]
+    sigs = _extract_call_signatures(tool_calls, [])
+    assert sigs[0] == ("edit", sigs[0][1], False)
+
+
+def test_extract_signatures_handles_malformed_json_args():
+    """Malformed JSON args fall back to the raw string rather than raising."""
+    tool_calls = [
+        {"id": "1", "function": {"name": "edit", "arguments": "not json"}},
+    ]
+    messages = [{"role": "tool", "tool_call_id": "1", "content": "ok"}]
+    sigs = _extract_call_signatures(tool_calls, messages)
+    assert sigs[0][0] == "edit"
+    assert sigs[0][2] is False
+
+
+# -- Integration: TurnRunner nudges then hard-stops on repeated tool errors ----
+
+
+@pytest.mark.asyncio
+async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
+    """A repeated failing tool call trips the loop-breaker: a [loop-breaker]
+    system message is injected after repeat_threshold iterations, and the
+    turn ends via _finalize_loop_break rather than running to
+    max_tool_iterations."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99  # isolate the repeat signal
+    ctx.config.loop_breaker.error_window = 50
+
+    # Unknown tool name -> execute_tool naturally returns a "[error: ...]"
+    # ToolResult without any stubbing of execute_tool_calls.
+    repeated_call = _mock_llm_response(
+        content=None,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {
+                "name": "definitely_not_a_real_tool",
+                "arguments": "{}",
+            },
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        # Repeat the same failing tool call indefinitely; the loop-breaker
+        # should stop the turn well before max_tool_iterations (50).
+        mock_llm.side_effect = [repeated_call] * 10
+        history = []
+        result = await run_agent_turn(ctx, "loop forever", history)
+
+    assert "[loop-breaker] Stopped" in result.text
+    assert "max tool iterations" not in result.text
+
+    # The nudge is injected into the LLM-facing message list (not the
+    # canonical turn `history`, mirroring the grace-turn nudge pattern) but
+    # is archived for a durable record — check the archive.
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    system_msgs = [m for m in archived if m.get("role") == "system"]
+    assert any("[loop-breaker]" in m.get("content", "") for m in system_msgs)
+
+    # Tripped at repeat_threshold=3, and the LLM was called once per
+    # iteration up to and including the stop iteration (NUDGE at 3rd call's
+    # iteration, STOP at the 4th) — well short of the 10 stubbed responses
+    # or the 50-iteration budget.
+    assert mock_llm.call_count < 10

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -85,6 +85,9 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
         }],
     )
 
+    published_events = []
+    ctx.event_bus.subscribe(lambda event: published_events.append(event))
+
     with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
         # Repeat the same failing tool call indefinitely; the loop-breaker
         # should stop the turn well before max_tool_iterations (50).
@@ -95,16 +98,118 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     assert "[loop-breaker] Stopped" in result.text
     assert "max tool iterations" not in result.text
 
-    # The nudge is injected into the LLM-facing message list (not the
-    # canonical turn `history`, mirroring the grace-turn nudge pattern) but
-    # is archived for a durable record — check the archive.
+    # The nudge itself is ephemeral: appended to the LLM-facing message list
+    # only (mirroring the grace-turn nudge pattern), never archived — an
+    # archived "system"-role message would get read back into history by
+    # restore_history on a restart/reload, permanently polluting context on
+    # later turns. Confirm it's absent from the archive...
     from decafclaw.archive import read_archive
     archived = read_archive(ctx.config, ctx.conv_id)
     system_msgs = [m for m in archived if m.get("role") == "system"]
-    assert any("[loop-breaker]" in m.get("content", "") for m in system_msgs)
+    assert not any("[loop-breaker]" in (m.get("content") or "") for m in system_msgs)
+
+    # ...while the hard-stop's final assistant message IS archived (it's the
+    # turn's actual output, correctly durable).
+    assistant_msgs = [m for m in archived if m.get("role") == "assistant"]
+    assert any("[loop-breaker] Stopped" in (m.get("content") or "") for m in assistant_msgs)
+
+    # The nudge is still observable via the durable/observable event signal.
+    nudge_events = [e for e in published_events
+                     if e.get("type") == "loop_breaker" and e.get("action") == "nudge"]
+    assert len(nudge_events) == 1
+
+    stop_events = [e for e in published_events
+                   if e.get("type") == "loop_breaker" and e.get("action") == "stop"]
+    assert len(stop_events) == 1
 
     # Tripped at repeat_threshold=3, and the LLM was called once per
     # iteration up to and including the stop iteration (NUDGE at 3rd call's
     # iteration, STOP at the 4th) — well short of the 10 stubbed responses
     # or the 50-iteration budget.
     assert mock_llm.call_count < 10
+
+
+# -- Integration: a genuine end-turn signal always wins over the breaker ------
+
+
+@pytest.mark.asyncio
+async def test_end_turn_signal_preempts_loop_breaker(ctx):
+    """A genuine end-turn signal (e.g. end_turn=True from a tool result) must
+    win over the loop-breaker even when the tool-call history would
+    otherwise trip it on that very iteration.
+
+    _handle_tool_calls checks end_turn_signal (widget pause / EndTurnConfirm
+    / end_turn=True) BEFORE recording the iteration's calls into the
+    LoopBreaker and computing a verdict — so a genuine end-turn returns
+    early and never reaches loop_breaker.record()/verdict() for that
+    iteration. This locks in that ordering: two prior iterations of
+    identical failing tool calls prime the breaker to its NUDGE trip (and it
+    fires), then the third iteration reaches repeat_threshold again but
+    signals end_turn=True instead of a normal tool result — the turn must
+    end via the end-turn path, not _finalize_loop_break."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 2
+    ctx.config.loop_breaker.error_threshold = 99  # isolate the repeat signal
+    ctx.config.loop_breaker.error_window = 50
+
+    repeated_call = _mock_llm_response(
+        content=None,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {
+                "name": "some_tool",
+                "arguments": "{}",
+            },
+        }],
+    )
+    final_response = _mock_llm_response(content="All done here.")
+
+    # end_turn_signal sequence for the three tool-call iterations: the first
+    # two look like normal (non-end-turn) tool completions so the breaker
+    # accumulates the repeat count and fires its one-shot NUDGE; the third
+    # would push the same repeated call past repeat_threshold again (which
+    # would be a STOP if recorded) but instead signals a genuine end_turn.
+    end_turn_signals = iter([False, False, True])
+
+    async def fake_execute_tool_calls(fork_ctx, tool_calls, history, messages):
+        for tc in tool_calls:
+            tool_msg = {
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": "still not done",
+            }
+            history.append(tool_msg)
+            messages.append(tool_msg)
+        return None, next(end_turn_signals)
+
+    published_events = []
+    ctx.event_bus.subscribe(lambda event: published_events.append(event))
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm, \
+         patch("decafclaw.agent.execute_tool_calls",
+               side_effect=fake_execute_tool_calls) as mock_execute:
+        mock_llm.side_effect = [repeated_call, repeated_call, repeated_call, final_response]
+        history = []
+        result = await run_agent_turn(ctx, "keep trying", history)
+
+    # The real end-turn signal wins: the turn ends with the final no-tools
+    # LLM call's content, not the loop-breaker's hard-stop text.
+    assert result.text == "All done here."
+    assert "[loop-breaker] Stopped" not in result.text
+
+    # A NUDGE legitimately fired on the second iteration (breaker still
+    # observes and escalates right up to the end-turn iteration)...
+    nudge_events = [e for e in published_events
+                    if e.get("type") == "loop_breaker" and e.get("action") == "nudge"]
+    assert len(nudge_events) == 1
+
+    # ...but STOP never fires, because the third iteration's end_turn=True
+    # is handled before the breaker ever records/verdicts that iteration.
+    stop_events = [e for e in published_events
+                   if e.get("type") == "loop_breaker" and e.get("action") == "stop"]
+    assert len(stop_events) == 0
+
+    # 3 tool-call iterations + 1 final no-tools call after end_turn=True.
+    assert mock_llm.call_count == 4
+    assert mock_execute.call_count == 3

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -63,7 +63,7 @@ def test_extract_signatures_handles_malformed_json_args():
 @pytest.mark.asyncio
 async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     """A repeated failing tool call trips the loop-breaker: a [loop-breaker]
-    system message is injected after repeat_threshold iterations, and the
+    user-role message is injected after repeat_threshold iterations, and the
     turn ends via _finalize_loop_break rather than running to
     max_tool_iterations."""
     ctx.config.llm.streaming = False
@@ -99,14 +99,25 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     assert "max tool iterations" not in result.text
 
     # The nudge itself is ephemeral: appended to the LLM-facing message list
-    # only (mirroring the grace-turn nudge pattern), never archived — an
-    # archived "system"-role message would get read back into history by
-    # restore_history on a restart/reload, permanently polluting context on
-    # later turns. Confirm it's absent from the archive...
+    # only (mirroring the grace-turn nudge pattern, which is also user-role),
+    # never archived — an archived "user"-role message would get read back
+    # into history by restore_history on a restart/reload, permanently
+    # polluting context on later turns. Confirm it's absent from the archive...
     from decafclaw.archive import read_archive
     archived = read_archive(ctx.config, ctx.conv_id)
-    system_msgs = [m for m in archived if m.get("role") == "system"]
-    assert not any("[loop-breaker]" in (m.get("content") or "") for m in system_msgs)
+    user_msgs = [m for m in archived if m.get("role") == "user"]
+    assert not any("[loop-breaker]" in (m.get("content") or "") for m in user_msgs)
+
+    # ...and confirm the nudge that WAS injected into the live LLM-facing
+    # message list carries role "user", not "system" (models weight
+    # user-role directives more heavily for mid-turn corrections). The same
+    # `messages` list object is mutated in place across LLM calls, so any
+    # recorded call's `messages` arg reflects the final state.
+    sent_messages = mock_llm.call_args_list[-1][0][1]
+    nudge_msgs = [m for m in sent_messages
+                  if "[loop-breaker]" in (m.get("content") or "")]
+    assert len(nudge_msgs) == 1
+    assert nudge_msgs[0]["role"] == "user"
 
     # ...while the hard-stop's final assistant message IS archived (it's the
     # turn's actual output, correctly durable).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ def _isolate_env(monkeypatch):
             "HEARTBEAT_", "HTTP_", "TABSTACK_", "CLAUDE_CODE_",
             "SKILLS_", "MEMORY_SEARCH", "SYSTEM_PROMPT",
             "NOTIFICATIONS_", "EMAIL_", "EXTRA_SKILL_", "VAULT_GUIDE_",
-            "WORKFLOW_",
+            "WORKFLOW_", "LOOP_BREAKER_",
         )):
             monkeypatch.delenv(key, raising=False)
 
@@ -649,3 +649,23 @@ class TestTerminalConfig:
         monkeypatch.setenv("DATA_HOME", str(tmp_path))
         cfg = load_config()  # must not raise
         assert cfg.terminal.allowed_cwd_roots == []
+
+
+class TestLoopBreakerConfig:
+    """LoopBreakerConfig — diagnostic guardrails for infinite loop detection (#598)."""
+
+    def test_loop_breaker_config_defaults(self):
+        from decafclaw.config import load_config
+        cfg = load_config()
+        assert cfg.loop_breaker.enabled is True
+        assert cfg.loop_breaker.repeat_threshold == 3
+        assert cfg.loop_breaker.error_threshold == 4
+        assert cfg.loop_breaker.error_window == 6
+
+    def test_loop_breaker_config_env_override(self, monkeypatch):
+        from decafclaw.config import load_config
+        monkeypatch.setenv("LOOP_BREAKER_ENABLED", "false")
+        monkeypatch.setenv("LOOP_BREAKER_REPEAT_THRESHOLD", "2")
+        cfg = load_config()
+        assert cfg.loop_breaker.enabled is False
+        assert cfg.loop_breaker.repeat_threshold == 2

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -1,0 +1,64 @@
+from decafclaw.config_types import LoopBreakerConfig
+from decafclaw.loop_breaker import LoopBreaker, LoopVerdict, fingerprint
+
+
+def _lb(**kw):
+    cfg = LoopBreakerConfig(**kw)
+    return LoopBreaker(cfg)
+
+
+def test_fingerprint_stable_and_arg_sensitive():
+    assert fingerprint("edit", {"a": 1, "b": 2}) == fingerprint("edit", {"b": 2, "a": 1})
+    assert fingerprint("edit", {"a": 1}) != fingerprint("edit", {"a": 2})
+    assert fingerprint("edit", {"a": 1}) != fingerprint("read", {"a": 1})
+
+
+def test_repeat_threshold_trips_nudge_then_stop():
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE          # 1 occurrence
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE           # 2
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE           # 3 → first trip
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.STOP            # trips again after nudge
+
+
+def test_error_window_trips():
+    lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
+    # 3 distinct erroring calls, then a 4th → 4 errors in window
+    for i in range(3):
+        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("t3", fingerprint("t3", {}), True)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+
+
+def test_errors_outside_window_do_not_trip():
+    lb = _lb(repeat_threshold=99, error_threshold=3, error_window=3)
+    lb.record([("a", "fa", True)])
+    lb.verdict()
+    lb.record([("b", "fb", False)])
+    lb.verdict()
+    lb.record([("c", "fc", False)])
+    lb.verdict()
+    lb.record([("d", "fd", True)])  # window now [b?,c,d] errors=1 (a aged out)
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_disabled_never_trips():
+    lb = _lb(enabled=False, repeat_threshold=1, error_threshold=1, error_window=1)
+    lb.record([("edit", "fp", True)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_last_signal_describes_reason():
+    lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"p": "x"})
+    lb.record([("edit", fp, False)])
+    lb.verdict()
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    assert "edit" in lb.last_signal()


### PR DESCRIPTION
Closes #598.

Addresses the three degenerate behaviors from the postmortem (a ~150-message thrash loop debugging an unloadable skill): no loop-breaker, phantom tool calls, and the apology spiral. A mechanical backstop for the worst mode + sharpened universal prompt guardrails for the rest.

## What's here
- **Loop-breaker** (`loop_breaker.py` + `TurnRunner._handle_tool_calls`) — a **per-turn** detector of autonomous tool-call thrash. Trips on either signal: the same `(tool, args)` called ≥ `repeat_threshold` times, OR ≥ `error_threshold` of the last `error_window` tool results erroring. Escalates: first trip injects an **ephemeral user-role** diagnostic nudge ("stop repeating — read logs / minimal repro / check the contract"); a second trip **hard-stops** the turn with a summary via `_finalize_loop_break`.
- **`config.loop_breaker`** (top-level `LoopBreakerConfig`): `enabled=True`, `repeat_threshold=3`, `error_threshold=4`, `error_window=6`; env `LOOP_BREAKER_*`. `enabled=False` is a true short-circuit.
- **`AGENT.md` guardrails** (universal — no model-conditional): "two strikes → diagnose, don't re-edit" (mode 1), "acknowledgement is not progress" (mode 3, apology→action), "emit the call, don't narrate it" (mode 2, phantom call — prompt-only).
- **Eval** `evals/diagnostic_discipline.yaml` + a deliberately-unloadable skill fixture; bounds edit-thrash (15/15) so the breaker's effect is guarded, not just runaway.
- Docs: `docs/loop-breaker.md` + CLAUDE.md.

## Design notes
- **No model-conditional prompting** (the existing apology guidance was already strong yet Gemini-Pro sailed past it — so the loop got a *mechanism*, not more universal text).
- **Nudge is ephemeral (never archived).** Archiving it with an LLM role would resurrect it into context on a server restart via `restore_history`, permanently polluting later turns. It lives in the turn's `messages` only + fires a `loop_breaker` event.
- **Nudge is user-role**, not system — mid-turn strict directives are weighted more heavily as user-role (matches `_run_grace_turn`).

## Testing
Deterministic unit tests for the detector + escalation + signature extraction; an end-to-end `run_agent_turn` integration test that pins the nudge→hard-stop path **and** end-turn precedence (the breaker never preempts a genuine end-turn). The eval passes at the tightened 15/15 bound. Full suite green (3140 passed, 2 skipped); `make check` clean.

## Process
Subagent-driven (6 tasks, per-task spec+quality reviews, whole-branch review). Dev-session docs under `docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/`.

## Follow-up (non-blocking)
- Loop-breaker **observability**: `ctx.publish("loop_breaker", ...)` fires but nothing subscribes; a telemetry subscriber (à la `tool_telemetry.py`) would answer "how often is the breaker tripping / are false-positives happening" in production. Especially worth having to watch the `≥4-errors-in-6` signal (the more false-positive-prone of the two). I'll file this as an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)