### PR TITLE
feat(vault): self-improving vault — frontmatter generation + deterministic importance tuning (#197)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `context_cleanup.py` — Lightweight clear tier: stubs old large tool messages before compaction
 - `canvas.py` — per-conversation canvas state sidecar + state operations
 - `sticky.py` — per-conversation sticky-slot sidecar (`sticky.json`) + `set_sticky`/`clear_sticky`
+- `backlinks.py` — persistent inbound-link index (`{workspace}/backlinks.json`); `rebuild_index`/`load_index`/`inbound_count`/`update_for_page`; incremental update wired to the `vault_changed` event in `runner.py`
 - `persistence.py`, `attachments.py`, `embeddings.py`, `frontmatter.py`, `memory_context.py`, `checklist.py`, `notes.py`
 
 ### Tools

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ tool-usage-report:
 reflection-stats:
 	uv run python -m decafclaw.reflection_metrics
 
+# Retrieval telemetry report from workspace/telemetry/retrieval.jsonl (#197)
+retrieval-report:
+	uv run python -m decafclaw.retrieval_telemetry
+
 # Dry-run sidecar migration (show what would change)
 migrate-sidecars-dry:
 	uv run python scripts/migrate_sidecars_to_dirs.py --dry-run

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,12 @@ reindex:
 prune-embeddings:
 	uv run decafclaw-prune-embeddings
 
+# One-time backfill of frontmatter (summary/keywords/tags/importance) on
+# existing vault pages that predate frontmatter generation. Safe to re-run
+# (already-complete pages are skipped). Follow with `make reindex`. #197
+backfill-frontmatter:
+	uv run decafclaw-backfill-frontmatter
+
 # Migrate wiki/memories to unified vault structure
 migrate-vault:
 	uv run python scripts/migrate_to_vault.py

--- a/docs/config.md
+++ b/docs/config.md
@@ -166,6 +166,18 @@ Vault location and write-gate settings. See [vault.md](vault.md).
 
 `user_writable_paths` lists vault-relative folder paths that bypass the user-page write confirmation. Prefix match (no globs); leading `/` is stripped and a trailing `/` is enforced, so `creative` and `creative/` are equivalent. Entries containing `..` are skipped with a warning. Empty by default — opt-in. Example: `["creative/", "notes/"]`.
 
+### `importance`
+
+Weights for garden's deterministic weekly importance recompute (#197 Phase 5). See [Importance recompute](vault.md#importance-recompute-197).
+
+| Field | Type | Default | Env Var |
+|-------|------|---------|---------|
+| `w_retrieval` | float | `0.6` | `IMPORTANCE_W_RETRIEVAL` |
+| `w_inbound` | float | `0.4` | `IMPORTANCE_W_INBOUND` |
+| `w_reference` | float | `0.0` | `IMPORTANCE_W_REFERENCE` |
+
+`w_reference` is reserved for a future explicit-reference signal (not yet implemented) and contributes nothing to the score while it's 0.
+
 ### `vault_retrieval`
 
 Controls auto-retrieval injection at turn start. See [context-composer.md#memory-retrieval-modes](context-composer.md#memory-retrieval-modes) and #301.

--- a/docs/config.md
+++ b/docs/config.md
@@ -438,7 +438,7 @@ Config CLI shows skill values as raw JSON (`config show skills`). Use `--reveal`
 
 ### `telemetry`
 
-Instrumentation sidecars — append-only JSONL under `workspace/`, metadata only (never tool args/returns, reflection bodies, or prompt contents). Producers are fail-open EventBus subscribers. See [tools.md#tool-usage-telemetry-310](tools.md#tool-usage-telemetry-310) (#310) and [reflection.md#metrics-409](reflection.md#metrics-409) (#409).
+Instrumentation sidecars — append-only JSONL under `workspace/`, metadata only (never tool args/returns, reflection bodies, or prompt contents). Producers are fail-open EventBus subscribers. See [tools.md#tool-usage-telemetry-310](tools.md#tool-usage-telemetry-310) (#310), [reflection.md#metrics-409](reflection.md#metrics-409) (#409), and [context-composer.md#retrieval-telemetry-197](context-composer.md#retrieval-telemetry-197) (#197).
 
 | Field | Type | Default | Env Var |
 |-------|------|---------|---------|
@@ -446,8 +446,10 @@ Instrumentation sidecars — append-only JSONL under `workspace/`, metadata only
 | `tool_usage_path` | str | `tool_usage.jsonl` | `TELEMETRY_TOOL_USAGE_PATH` |
 | `reflection_metrics_enabled` | bool | `true` | `TELEMETRY_REFLECTION_METRICS_ENABLED` |
 | `reflection_metrics_path` | str | `reflection/metrics.jsonl` | `TELEMETRY_REFLECTION_METRICS_PATH` |
+| `retrieval_enabled` | bool | `true` | `TELEMETRY_RETRIEVAL_ENABLED` |
+| `retrieval_path` | str | `telemetry/retrieval.jsonl` | `TELEMETRY_RETRIEVAL_PATH` |
 
-Paths are workspace-relative. Enabled by default so a deployed agent starts collecting without a config edit — the intent is a week of real data. No rotation yet (append-only); retention is a follow-up. Reports: `make tool-usage-report`, `make reflection-stats`.
+Paths are workspace-relative. Enabled by default so a deployed agent starts collecting without a config edit — the intent is a week of real data. No rotation yet (append-only); retention is a follow-up. Reports: `make tool-usage-report`, `make reflection-stats`, `make retrieval-report`.
 
 ### `env`
 

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -316,6 +316,49 @@ importance: 0.5
 
 The embedding index stores a composite document (summary + keywords + tags + body) for richer semantic search. Pages without frontmatter embed as body-only. Frontmatter fields are parsed and used for scoring today; the dream/garden processes don't yet auto-generate them (they use `> tl;dr:` blockquote summaries instead).
 
+## Retrieval telemetry (#197)
+
+Phase 0 of the self-improving vault arc: a fail-open EventBus subscriber
+records which retrieval candidates were considered and which survived to
+injection — the measurement foundation later phases (notably an
+importance-formula rework) build on.
+
+Once per interactive turn, after `_score_candidates` produces the full
+scored candidate list and before the `min_composite_score` threshold and
+token-budget trim are applied, `_compose_vault_retrieval` publishes a
+`retrieval_event` on the event bus:
+
+```python
+{
+    "type": "retrieval_event",
+    "conv_id": str,
+    "candidates": [
+        {
+            "file_path": str,
+            "source_type": str,          # "page" | "user" | "journal" | "graph_expansion"
+            "similarity": float,
+            "recency": float,
+            "importance": float,
+            "composite_score": float,
+            "included": bool,            # survived score threshold AND budget trim
+            "drop_reason": str | None,   # None | "score" | "budget"
+        },
+        ...
+    ],
+}
+```
+
+`retrieval_telemetry.py` mirrors `tool_telemetry.py`'s shape: a fail-open
+subscriber (`make_retrieval_telemetry_subscriber`, guarded by
+`config.telemetry.retrieval_enabled`, default on) appends one JSONL record
+per event to `{workspace}/telemetry/retrieval.jsonl`. The emit itself is
+wrapped in try/except so a telemetry failure never breaks retrieval.
+
+**Report:** `make retrieval-report` (`python -m decafclaw.retrieval_telemetry`)
+aggregates per-page retrieval/include/drop-by-reason counts, plus a
+point-in-time vault-health snapshot (how many pages carry an `importance`
+frontmatter field).
+
 ## Relationship to agent loop
 
 The agent loop (`run_agent_turn`) creates a `ContextComposer` at the start of each turn and calls `compose()` once. The iteration loop still uses `_build_tool_list()` per-iteration because fetched tools change mid-turn as the model calls `tool_search`. After each LLM response, `record_actuals()` stores the real token counts for future calibration.

--- a/docs/context-composer.md
+++ b/docs/context-composer.md
@@ -256,7 +256,7 @@ All factors are normalized to [0, 1].
 |--------|---------|-----------|
 | `w_similarity` | 0.5 | Similarity dominates — relevance to the query matters most |
 | `w_recency` | 0.3 | Recent content is more likely to be useful |
-| `w_importance` | 0.2 | Lower weight until dream/garden actively tune importance |
+| `w_importance` | 0.2 | Kept modest even now that garden actively tunes importance weekly (#197 Phase 5, see [Importance recompute](vault.md#importance-recompute-197)) — retrieval and links move gradually, so this stays a secondary signal alongside similarity and recency |
 
 ### Source boosts
 
@@ -356,8 +356,10 @@ wrapped in try/except so a telemetry failure never breaks retrieval.
 
 **Report:** `make retrieval-report` (`python -m decafclaw.retrieval_telemetry`)
 aggregates per-page retrieval/include/drop-by-reason counts, plus a
-point-in-time vault-health snapshot (how many pages carry an `importance`
-frontmatter field).
+point-in-time vault-health snapshot: `missing_importance` (pages with no
+`importance` frontmatter field) and `graph_orphans` (pages with zero
+inbound `[[wiki-links]]`, per the backlink index) — two distinct metrics,
+not to be conflated (#197 P0-M2).
 
 ## Relationship to agent loop
 

--- a/docs/dev-sessions/2026-07-23-1615-vault-evolution/notes.md
+++ b/docs/dev-sessions/2026-07-23-1615-vault-evolution/notes.md
@@ -1,0 +1,22 @@
+# Notes: self-improving vault (#197)
+
+Session working log. Final summary goes here before the PR.
+
+## Baselines (fill during Measurement phase)
+
+- `make retrieval-report` before Phase 2: _TBD_
+- `evals/retrieval-quality.yaml` judge score before Phase 2: _TBD_
+
+## Deltas (fill after Phase 5)
+
+- `make retrieval-report` after Phase 5: _TBD_
+- `evals/retrieval-quality.yaml` after Phase 5: _TBD_
+
+## Phase log
+
+- Phase 0 — retrieval telemetry: _pending_
+- Phase 1 — vault_update_frontmatter: _pending_
+- Phase 2 — dream generation: _pending_
+- Phase 3 — backfill CLI: _pending_
+- Phase 4 — backlink index: _pending_
+- Phase 5 — importance recompute: _pending_

--- a/docs/dev-sessions/2026-07-23-1615-vault-evolution/notes.md
+++ b/docs/dev-sessions/2026-07-23-1615-vault-evolution/notes.md
@@ -2,21 +2,159 @@
 
 Session working log. Final summary goes here before the PR.
 
-## Baselines (fill during Measurement phase)
+## Measurement (2026-07-23, post-Phase-5, HEAD abe4ff1)
 
-- `make retrieval-report` before Phase 2: _TBD_
-- `evals/retrieval-quality.yaml` judge score before Phase 2: _TBD_
+Because all five phases ran back-to-back in one continuous session, we never
+captured a true pre-arc baseline snapshot of `make retrieval-report` or a
+"before" eval run — there was no stable checkpoint between phases where
+telemetry had accrued real traffic. What follows is the best HONEST
+measurement achievable now, done as a dedicated Measurement step rather than
+faked as a before/after comparison that never actually happened.
 
-## Deltas (fill after Phase 5)
+### Eval-framework assessment (can we seed vault pages with frontmatter?)
 
-- `make retrieval-report` after Phase 5: _TBD_
-- `evals/retrieval-quality.yaml` after Phase 5: _TBD_
+Read `src/decafclaw/eval/runner.py` (`_setup_workspace`) and
+`docs/eval-loop.md`. Findings:
+
+- `setup.workspace_files` **can** seed literal vault page files, frontmatter
+  and all (already used this way by `evals/vault.yaml` and
+  `evals/vault-frontmatter.yaml`). The file lands on disk with real
+  `---\nsummary: ...\n---` YAML — genuinely frontmatter-rich.
+- `setup.memories` seeds **journal** entries only, and auto-indexes them into
+  `embeddings.db` when `search_strategy: semantic` — this is the *only*
+  setup path that pre-populates the embedding index. It has no equivalent
+  for vault pages.
+- Consequence: a vault **page** seeded via `workspace_files` exists on disk
+  with real frontmatter, but is **not** automatically embedded —
+  `_setup_workspace` never calls `index_entry`/`build_composite_text` for
+  pages the way it does for journal `memories`. It's invisible to
+  *proactive* (embedding-based) retrieval until something indexes it.
+- What DOES consume frontmatter during retrieval, confirmed by reading the
+  code (not assumed): `memory_context._enrich_results` re-reads
+  `importance`/`summary` **live from the page file on disk** at
+  retrieval-composition time (not baked into the embedding), so importance
+  really does feed the composite `w_importance` scoring term whenever a
+  page is a retrieval candidate at all. `frontmatter.build_composite_text`
+  prepends summary/keywords/tags to the body before embedding, so
+  frontmatter genuinely shapes the embedding text too, at *index* time.
+  Both mechanisms are real, not aspirational — they're just not reachable
+  from a `workspace_files`-only seed.
+- One real lever that closes the gap without any framework change:
+  `tool_vault_search`'s lazy auto-reindex (`embeddings.search_similar`) —
+  the first semantic search against an empty index runs a real
+  `reindex_vault()` pass over **whatever's on disk**, including
+  `workspace_files`-seeded pages, using the real composite-text builder.
+  So a `vault_search` call in turn 1 gives us genuine embeddings for a
+  frontmatter-rich seeded page, and a later turn can then exercise real
+  proactive (embedding-based) retrieval against them.
+
+**Verdict:** seeding *files* with frontmatter is fully supported today.
+Seeding *pre-built embeddings for those files* (needed for a controlled,
+LLM-write-independent A/B of frontmatter-rich vs. bare content under equal
+distractor load) is **not** supported without a framework extension — see
+follow-up below.
+
+### `evals/retrieval-quality.yaml` — built, run, real output
+
+Two-turn eval (see file comments for full reasoning): seeds one vault page
+with rich frontmatter (`summary`/`keywords`/`tags`/`importance: 0.9`) via
+`workspace_files`. Turn 1 asks the agent to search the vault for the topic
+(forces `vault_search` → real lazy auto-reindex → composite-text embedding
+of the seeded page, frontmatter included). Turn 2 asks about a *different*
+detail from the same page, not restated in turn 1's response (so the model
+can't just recall it from conversation history) and asserts **no** vault
+tool call — i.e. the answer must come from real proactive/composite-scored
+retrieval, not an explicit search.
+
+Real run (`uv run python -m decafclaw.eval evals/retrieval-quality.yaml
+--verbose`, model `vertex-gemini-flash` via the LiteLLM proxy), 3 consecutive
+runs, all PASS, no wording changes needed:
+
+```
+[1/1] vault page frontmatter is embedded and proactively retrieved later . PASS  (8.2s, 6413 tokens, 1 tools)
+         Response: The shift lead has 15 minutes to acknowledge the alert before it auto-escalates to the VP of Engineering.
+1 tests, 1 passed, 0 failed
+```
+
+(Repeated: 9.3s/6416 tokens and 9.4s/6596 tokens, both PASS, 1 tool call —
+`vault_search` in turn 1, zero tool calls in turn 2 as asserted.)
+
+**Honest limitation:** this proves the real production pipeline (frontmatter
+→ composite embedding → proactive retrieval) works end-to-end for a page
+that does get indexed. It is **not** a controlled A/B proving frontmatter
+*improves* retrieval over bare content — with only one page in the vault and
+no distractor crowding, we can't isolate whether `importance: 0.9` was
+load-bearing for the pass, or whether a bare page would have passed too.
+See follow-up below.
+
+**Follow-up (not built here, filed per task scope):** a rigorous
+frontmatter/importance A/B needs a framework extension — a
+`setup.vault_pages` (or similar) fixture path in `eval/runner.py` that seeds
+page files **and** deterministically computes/writes their composite
+embeddings at setup time (mirroring what `tool_vault_write` does on a real
+write), the way `setup.memories` already does for journal entries. That
+would let a test seed two otherwise-identical pages (one frontmatter-rich,
+one bare) plus a shared distractor pool, and assert the frontmatter-rich one
+wins under budget pressure while the bare one doesn't.
+
+### Tool-choice: `vault_recompute_importance` vs. `vault_update_frontmatter`
+
+Added two cases to `evals/tool_choice/core_overlaps.yaml`:
+`recompute-importance-vs-frontmatter-whole-vault` (deterministic, vault-wide
+recompute from measured signals → `vault_recompute_importance`, near-miss
+`vault_update_frontmatter`/`vault_write`) and
+`frontmatter-vs-recompute-single-page-importance` (an explicit value on one
+named page → `vault_update_frontmatter`, near-miss
+`vault_recompute_importance`).
+
+`uv run python -m decafclaw.eval.tool_choice evals/tool_choice/` — both new
+cases **PASS**, 0% swap rate in both directions
+(`vault_recompute_importance ↔ vault_update_frontmatter`,
+`vault_recompute_importance ↔ vault_write`). Overall: 25/30 (83%) — the 5
+failures (`workspace-write-vs-canvas-save-blog-post`,
+`tabstack-automate-vs-research-form-fill`,
+`tabstack-research-vs-automate-multi-source`,
+`ask-choice-vs-text-deploy-target`, `delegate-vs-activate-research`) are
+pre-existing and unrelated to #197 — confirmed by running the suite against
+the pre-change tree (`git stash`), which shows the identical 5 failures at
+23/28 (82%) before these two cases were added.
+
+### Proxy snapshot: `make retrieval-report`
+
+```
+# Retrieval telemetry report
+
+Total candidate appearances: 0 across 0 pages
+
+file_path                                retrieved  included   inc% drop-score drop-budget
+------------------------------------------------------------------------------------------
+
+## Vault health
+  Pages: 247
+  With importance frontmatter: 1 (0%)
+  Missing importance frontmatter: 246
+  Graph orphans (zero inbound links): 136
+```
+
+As expected and noted up front: `Total candidate appearances: 0` because the
+`retrieval_telemetry.jsonl` stream (Phase 0) only accrues from real
+conversation traffic, and this worktree's `.env` points at the main clone's
+`data/` directory, which hasn't had real interactive traffic hit the new
+telemetry path yet. The **production before/after delta on this report is a
+deploy-and-wait item** — it needs roughly a week of real Mattermost/web-UI
+traffic post-deploy before `retrieval_telemetry.aggregate()` has anything to
+show, and only then will `vault_recompute_importance`'s weekly garden sweep
+have real retrieval-frequency + inbound-link signal to compute against
+(right now 246 of 247 pages have no `importance` frontmatter at all — the
+backfill CLI from Phase 3 hasn't been run against production data yet
+either).
 
 ## Phase log
 
-- Phase 0 — retrieval telemetry: _pending_
-- Phase 1 — vault_update_frontmatter: _pending_
-- Phase 2 — dream generation: _pending_
-- Phase 3 — backfill CLI: _pending_
-- Phase 4 — backlink index: _pending_
-- Phase 5 — importance recompute: _pending_
+- Phase 0 — retrieval telemetry: done (`2b42907`) — `retrieval_telemetry.jsonl` stream + `make retrieval-report`
+- Phase 1 — vault_update_frontmatter: done (`f1140ae`, gated `742efa4`) — merge tool for single-page frontmatter fields
+- Phase 2 — dream generation: done (`6f9d55a`) — dream consolidation now calls `vault_update_frontmatter` after writing/revising a page
+- Phase 3 — backfill CLI: done (`5ba079a`) — one-shot CLI to backfill frontmatter across existing pages (not yet run against production vault — see proxy snapshot above)
+- Phase 4 — backlink index: done (`ef4a2ed`, fix `4ba7334`) — persistent inbound-link index (`backlinks.json`)
+- Phase 5 — importance recompute: done (`f010ca6`) — deterministic `vault_recompute_importance` (garden skill) driven by retrieval frequency + inbound links
+- Measurement — this step: `evals/retrieval-quality.yaml` (pipeline-validation eval, 3/3 real runs PASS), `evals/tool_choice/core_overlaps.yaml` (+2 cases, both PASS, pre-existing 5 failures unaffected), `make retrieval-report` snapshot captured (sparse — deploy-and-wait for the real before/after)

--- a/docs/dev-sessions/2026-07-23-1615-vault-evolution/plan.md
+++ b/docs/dev-sessions/2026-07-23-1615-vault-evolution/plan.md
@@ -1,0 +1,359 @@
+# Self-improving Vault Implementation Plan (#197)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the vault self-improving — dream generates page frontmatter, garden tunes `importance` from real signals — and make retrieval quality measurable.
+
+**Architecture:** Six phases on branch `197-vault-evolution`, one commit each. A structured `vault_update_frontmatter` tool is the shared write primitive (enforces respect-manual-values in code); a deterministic `vault_recompute_importance` computes importance from retrieval-frequency telemetry + a persistent backlink index. Measurement is a fail-open retrieval-event telemetry stream plus an LLM-judge eval.
+
+**Tech Stack:** Python 3.13, `uv`, pytest (xdist), EventBus pub/sub, sqlite-vec embeddings, YAML frontmatter, prompt-driven skills (dream/garden).
+
+## Global Constraints
+
+- Python deps via `uv` / `uv run` inside the worktree; never bare `python` (resolves to the main clone's editable install).
+- New runtime state goes on dataclasses; never `setattr`/`getattr` undeclared fields. Config additions: dataclass default → `config.json` → env, wired in `config.py` via `load_sub_config`.
+- Telemetry and all new event subscribers are **fail-open** — never propagate an exception into a turn (`except Exception as exc: log.debug(...)`). No bare `except: pass`.
+- Files on disk, human-readable, crash-recoverable (JSONL / JSON / markdown).
+- Tools receive `ctx` first, even if unused. Tool errors return `ToolResult(text="[error: ...]")`.
+- `make check` + `make test` green before every phase commit. Suite currently ends with 2 known forkpty warnings (#638) — not ours; keep `PytestUnraisableExceptionWarning`-class noise at zero.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Rebase on `origin/main` before the final PR squash (main advances often).
+- Update the feature's `docs/` page in the same PR; update `docs/context-composer.md` for context-assembly/tool changes.
+
+## Cross-phase interface: the retrieval event
+
+Phase 0 defines this; Phase 5's importance formula consumes the aggregated form.
+
+```python
+# Published on the EventBus from _compose_vault_retrieval once per interactive turn.
+{
+    "type": "retrieval_event",
+    "conv_id": str,
+    "candidates": [
+        {
+            "file_path": str,
+            "source_type": str,          # "page" | "user" | "journal" | "graph_expansion"
+            "similarity": float,
+            "recency": float,
+            "importance": float,
+            "composite_score": float,
+            "included": bool,            # survived score threshold AND budget trim
+            "drop_reason": str | None,   # None | "score" | "budget"
+        },
+        ...
+    ],
+}
+```
+
+One JSONL record per event at `{workspace}/telemetry/retrieval.jsonl`.
+
+---
+
+## Phase 0 — Retrieval telemetry stream
+
+**Files:**
+- Create: `src/decafclaw/retrieval_telemetry.py`
+- Create: `tests/test_retrieval_telemetry.py`
+- Modify: `src/decafclaw/context_composer.py` (`_compose_vault_retrieval`, emit event)
+- Modify: `src/decafclaw/config_types.py` (`TelemetryConfig` — add `retrieval_path`)
+- Modify: `src/decafclaw/runner.py` (subscribe the telemetry handler on the bus)
+- Modify: `Makefile` (add `retrieval-report`), `pyproject.toml` (console script)
+
+**Interfaces:**
+- Produces: `make_retrieval_telemetry_subscriber(config) -> Callable[[dict], Awaitable[None]]`; `build_report(config) -> str`; `_retrieval_path(config) -> Path`.
+- Consumes: the `retrieval_event` schema above.
+
+- [ ] **Step 1: Write the failing test for the subscriber**
+
+```python
+# tests/test_retrieval_telemetry.py
+import json
+import pytest
+from decafclaw.retrieval_telemetry import (
+    make_retrieval_telemetry_subscriber, _retrieval_path, record_from_event,
+)
+
+def _event():
+    return {
+        "type": "retrieval_event", "conv_id": "c1",
+        "candidates": [
+            {"file_path": "pages/a.md", "source_type": "page", "similarity": 0.9,
+             "recency": 0.8, "importance": 0.5, "composite_score": 0.77,
+             "included": True, "drop_reason": None},
+            {"file_path": "pages/b.md", "source_type": "page", "similarity": 0.2,
+             "recency": 0.5, "importance": 0.5, "composite_score": 0.3,
+             "included": False, "drop_reason": "score"},
+        ],
+    }
+
+@pytest.mark.asyncio
+async def test_subscriber_writes_one_record_per_event(config):
+    handler = make_retrieval_telemetry_subscriber(config)
+    await handler(_event())
+    await handler({"type": "tool_end"})  # ignored
+    lines = _retrieval_path(config).read_text().strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["conv_id"] == "c1"
+    assert len(rec["candidates"]) == 2
+    assert rec["candidates"][0]["included"] is True
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open_on_bad_event(config):
+    handler = make_retrieval_telemetry_subscriber(config)
+    await handler({"type": "retrieval_event"})  # no candidates key — must not raise
+```
+
+- [ ] **Step 2: Run it, verify import/attribute failure**
+
+Run: `cd .claude/worktrees/197-vault-evolution && uv run pytest tests/test_retrieval_telemetry.py -q`
+Expected: FAIL (module/attr missing).
+
+- [ ] **Step 3: Implement `retrieval_telemetry.py`** — mirror `tool_telemetry.py`.
+
+Model exactly on `tool_telemetry.py`: `_now_iso`, `_retrieval_path(config)` → `config.workspace_path / config.telemetry.retrieval_path`, `record_from_event(event)` (timestamp + conv_id + candidates), `append_record`, `make_retrieval_telemetry_subscriber` (ignore non-`retrieval_event`, fail-open), and the reporting half (`load_records`, `aggregate`, `format_report`, `build_report`, `main`). `aggregate` computes per-page: retrieval_count (appeared as candidate), include_count, drop-by-reason; plus vault-health: frontmatter coverage %, orphan count (needs the vault — read pages, count those with/without `importance` frontmatter). Keep the report format table-shaped like `format_report` in tool_telemetry.
+
+- [ ] **Step 4: Add `retrieval_path` to `TelemetryConfig`**
+
+In `config_types.py`, add `retrieval_path: str = "telemetry/retrieval.jsonl"` next to `tool_usage_path`. (No env wiring change needed beyond the existing `TELEMETRY_` prefix.)
+
+- [ ] **Step 5: Run subscriber tests to green**
+
+Run: `uv run pytest tests/test_retrieval_telemetry.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Write the failing composer-emit test**
+
+```python
+# tests/test_context_composer.py — new async test
+@pytest.mark.asyncio
+async def test_retrieval_event_published_with_drop_verdicts(self, ctx, config):
+    events = []
+    async def cap(e):
+        if e.get("type") == "retrieval_event":
+            events.append(e)
+    ctx.event_bus.subscribe(cap)  # match existing subscribe API in tests
+    mock_results = [
+        {"file_path": "pages/hit.md", "source_type": "page", "entry_text": "x",
+         "similarity": 0.9, "modified_at": "", "importance": 0.9},
+        {"file_path": "pages/miss.md", "source_type": "page", "entry_text": "y",
+         "similarity": 0.01, "modified_at": "", "importance": 0.1},
+    ]
+    with patch("decafclaw.context_composer.retrieve_memory_context",
+               new_callable=AsyncMock, return_value=mock_results):
+        composer = ContextComposer()
+        await composer._compose_vault_retrieval(
+            ctx, config, "q", ComposerMode.INTERACTIVE)
+    assert len(events) == 1
+    paths = {c["file_path"]: c for c in events[0]["candidates"]}
+    assert paths["pages/hit.md"]["included"] is True
+    assert paths["pages/miss.md"]["included"] is False
+    assert paths["pages/miss.md"]["drop_reason"] in ("score", "budget")
+```
+
+(Confirm the exact EventBus subscribe API from an existing composer test before finalizing — reuse whatever pattern `test_background_event_expanded_in_compose` uses.)
+
+- [ ] **Step 7: Emit the event in `_compose_vault_retrieval`**
+
+After `_score_candidates` returns the full scored list, capture it before the threshold/budget filters. Compute the surviving `file_path` set after trim. Build the candidates array tagging `included` + `drop_reason` (`"score"` if below `min_composite_score`, else `"budget"` if dropped by `_trim_to_token_budget`). Publish via `await ctx.publish("retrieval_event", conv_id=..., candidates=[...])` (match the `ctx.publish` signature used elsewhere — it wraps `{"type": ..., **kwargs}`). Fail-open around the emit so telemetry never breaks retrieval.
+
+- [ ] **Step 8: Run composer test + full suite**
+
+Run: `uv run pytest tests/test_context_composer.py -q && uv run pytest -q`
+Expected: PASS (3116+ ; only the known forkpty warnings).
+
+- [ ] **Step 9: Wire the subscriber + report target**
+
+In `runner.py`, subscribe `make_retrieval_telemetry_subscriber(config)` where `make_tool_telemetry_subscriber` is subscribed (grep it). Add `pyproject.toml` console script `decafclaw-retrieval-report = "decafclaw.retrieval_telemetry:main"` and `Makefile` target `retrieval-report:` mirroring `tool-usage-report`.
+
+- [ ] **Step 10: `make check` + commit**
+
+```bash
+uv run pytest tests/test_retrieval_telemetry.py tests/test_context_composer.py -q
+make check
+git add -A && git commit -m "feat(vault): retrieval-event telemetry stream + report (#197)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 1 — `vault_update_frontmatter` tool
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` (new tool fn + `TOOL_HANDLERS`/`TOOL_DEFINITIONS` registration)
+- Modify: `tests/test_vault_tools.py`
+
+**Interfaces:**
+- Produces: `async tool_vault_update_frontmatter(ctx, page, fields: dict, overwrite: bool=False) -> ToolResult`. Registered as tool name `vault_update_frontmatter`.
+- Consumes: `frontmatter.parse_frontmatter`, `frontmatter.serialize_frontmatter`, existing `_reindex_page(ctx, path)` (already in vault tools), `resolve_page`.
+
+- [ ] **Step 1: Failing tests**
+
+```python
+class TestVaultUpdateFrontmatter:
+    @pytest.mark.asyncio
+    async def test_fills_absent_fields(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"; p.write_text("Body text.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"summary": "s", "importance": 0.8})
+        meta, body = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "s" and meta["importance"] == 0.8
+        assert body.strip() == "Body text."
+
+    @pytest.mark.asyncio
+    async def test_respects_existing_value_when_not_overwrite(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"
+        p.write_text("---\nsummary: manual\n---\nBody.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"summary": "auto"}, overwrite=False)
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "manual"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_replaces(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"
+        p.write_text("---\nimportance: 0.5\n---\nBody.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"importance": 0.9}, overwrite=True)
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["importance"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_clamps_importance_and_coerces_lists(self, ctx, agent_pages):
+        p = agent_pages / "t.md"; p.write_text("Body.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/t.md",
+            fields={"importance": 5.0, "tags": "a"})
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["importance"] == 1.0 and meta["tags"] == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_reindexes_after_write(self, ctx, agent_pages):
+        p = agent_pages / "t.md"; p.write_text("Body.\n")
+        with patch("decafclaw.skills.vault.tools._reindex_page",
+                   new_callable=AsyncMock) as rx:
+            await tool_vault_update_frontmatter(
+                ctx, page="agent/pages/t.md", fields={"summary": "s"})
+        rx.assert_awaited_once()
+```
+
+- [ ] **Step 2: Run → fail.** `uv run pytest tests/test_vault_tools.py::TestVaultUpdateFrontmatter -q`
+
+- [ ] **Step 3: Implement the tool.** Read the page via `resolve_page`; `parse_frontmatter`; for each field in `fields`, coerce (importance→clamped float, tags/keywords→list[str], summary→str); merge respecting `overwrite`; `serialize_frontmatter`; write; `await _reindex_page(ctx, path)`; return `ToolResult(text=..., data={"changed": [...]})`. Guard unknown page → `ToolResult(text="[error: ...]")`.
+
+- [ ] **Step 4: Register** in `TOOL_HANDLERS` + `TOOL_DEFINITIONS` (copy the shape of a neighboring vault tool; description states "merge frontmatter fields; only fills absent fields unless overwrite; reindexes"). Confirm registration names via a `tool_choice` eval later.
+
+- [ ] **Step 5: Run → green.** Then `make check`.
+
+- [ ] **Step 6: Commit** `feat(vault): vault_update_frontmatter merge tool (#197)`.
+
+---
+
+## Phase 2 — Dream frontmatter generation
+
+**Files:**
+- Modify: `src/decafclaw/skills/dream/SKILL.md`
+- Create: `evals/vault-frontmatter.yaml` (behavior eval)
+- Modify: `docs/skills.md` / `docs/vault.md` as needed
+
+**Interfaces:** consumes `vault_update_frontmatter` (Phase 1). No code — prose + eval.
+
+- [ ] **Step 1: Edit `dream/SKILL.md` Consolidate phase.** Add: after writing/revising a page body, call `vault_update_frontmatter` (overwrite=False) to fill `summary` (1 sentence), `keywords`, `tags`, and an initial `importance` (0–1; guidance: pages consolidating many journal entries or central to the graph score higher; a passing note scores lower). Do not overwrite fields the user set manually.
+
+- [ ] **Step 2: Add `evals/vault-frontmatter.yaml`.** A case where dream-style consolidation of a seeded journal produces a page, asserting `expect_tool: vault_update_frontmatter`. Bound with `max_tool_calls` / `max_tool_errors`. Add a `tool_choice` case disambiguating `vault_update_frontmatter` from `vault_write`.
+
+- [ ] **Step 3: Run the eval.** `uv run python -m decafclaw.eval evals/vault-frontmatter.yaml` (needs the LiteLLM proxy). Iterate SKILL.md wording until it reliably calls the tool.
+
+- [ ] **Step 4: Commit** `feat(dream): generate page frontmatter on consolidate (#197)`.
+
+---
+
+## Phase 3 — Backfill CLI
+
+**Files:**
+- Create: `src/decafclaw/backfill_frontmatter.py` (CLI)
+- Create: `tests/test_backfill_frontmatter.py`
+- Modify: `pyproject.toml` (console script), `Makefile` (`backfill-frontmatter`)
+
+**Interfaces:**
+- Produces: `generate_fields_for_page(config, path) -> dict` (forced-tool structured-output LLM call, Sophie-style — one schema, "you MUST call this"); `run_backfill(config, *, dry_run=False, limit=None) -> list[dict]`.
+- Consumes: `vault_update_frontmatter` logic (reuse the merge helper — extract a pure `merge_frontmatter(existing, fields, overwrite)` function during Phase 1 so both the tool and the CLI call it without a `ctx`).
+
+> **Note for Phase 1 executor:** extract `merge_frontmatter(existing: dict, fields: dict, overwrite: bool) -> dict` as a pure function in `skills/vault/tools.py`; the tool wraps it. Phase 3 reuses it.
+
+- [ ] **Step 1: Failing test** for `run_backfill` over a tmp vault with 2 pages (one already has frontmatter → skipped, one bare → filled). Patch the LLM call to return fixed fields.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — iterate frontmatter-less pages (via existing vault-page iteration; reuse `embeddings._iter_vault_pages`-style walk or `collect_recent_pages`), call `generate_fields_for_page`, `merge_frontmatter(overwrite=False)`, write. `--dry-run` prints planned changes; `--limit N`; log progress; resumable (skip pages that already have all four fields).
+- [ ] **Step 4: Run → green;** add console script + `make backfill-frontmatter`; note in help that a `make reindex` should follow.
+- [ ] **Step 5: `make check` + commit** `feat(vault): backfill-frontmatter CLI (#197)`.
+
+---
+
+## Phase 4 — Persistent backlink index
+
+**Files:**
+- Create: `src/decafclaw/backlinks.py`
+- Create: `tests/test_backlinks.py`
+- Modify: `src/decafclaw/skills/vault/tools.py` (`tool_vault_backlinks` reads the index; incremental update on write)
+- Modify: `docs/vault.md`
+
+**Interfaces:**
+- Produces: `rebuild_index(config) -> dict[str, list[str]]` (page → inbound linkers); `load_index(config) -> dict[str,list[str]]`; `inbound_count(config, page) -> int`; `update_for_page(config, page)` (incremental). Stored JSON at `{workspace}/backlinks.json`.
+- Consumes: existing `_WIKI_LINK_RE` / `resolve_page`.
+
+- [ ] **Step 1: Failing tests** — build over a tmp vault of 3 pages with `[[links]]`; assert inbound map; assert incremental `update_for_page` after adding a link; assert `inbound_count`.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** `backlinks.py` — full rebuild via one `rglob` pass (reuse the scan logic currently inside `tool_vault_backlinks`), persist JSON, incremental update on a single page's links. Fail-open on IO.
+- [ ] **Step 4: Rewire `tool_vault_backlinks`** to read the index (rebuild lazily if missing). Subscribe an incremental-update handler to `vault_changed` in `runner.py` (fail-open).
+- [ ] **Step 5: Run → green; `make check`; commit** `feat(vault): persistent backlink index (#197)`.
+
+---
+
+## Phase 5 — Deterministic importance tuning (garden)
+
+**Files:**
+- Create: `src/decafclaw/skills/garden/tools.py` (`vault_recompute_importance`) + register
+- Create: `tests/test_recompute_importance.py`
+- Modify: `src/decafclaw/skills/garden/SKILL.md`
+- Modify: `src/decafclaw/config_types.py` (`ImportanceConfig`: `w_retrieval`, `w_inbound`, `w_reference=0.0`), wire in `config.py`
+- Modify: `docs/vault.md`, `docs/config.md`
+
+**Interfaces:**
+- Produces: `compute_importance_scores(config) -> dict[str, float]` (pure, testable); `async tool_vault_recompute_importance(ctx, dry_run: bool=False) -> ToolResult`.
+- Consumes: `retrieval_telemetry.aggregate` (retrieval frequency per page), `backlinks.inbound_count`, `merge_frontmatter` / `vault_update_frontmatter(overwrite=True)`.
+
+Formula (v1, `w_reference=0`): `importance = clamp01(w_retrieval·norm(retrieval_freq) + w_inbound·norm(inbound_links))`, where `norm(x)=x/max(x across pages)` (0 when max is 0). Defaults `w_retrieval=0.6`, `w_inbound=0.4`.
+
+- [ ] **Step 1: Failing test** for `compute_importance_scores` — patch telemetry aggregate + backlink index with fixtures; assert a frequently-retrieved, heavily-linked page scores near 1.0 and an orphan near 0.0; assert clamp + normalization; assert empty-data → all 0.0 (no divide-by-zero).
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** the pure scorer + the tool (tool writes via `overwrite=True`, `--dry-run` returns planned deltas without writing). Add `ImportanceConfig`.
+- [ ] **Step 4: Edit `garden/SKILL.md`** weekly steps: call `vault_recompute_importance`, review outliers, validate frontmatter consistency, flag orphans (inbound_count 0 + low retrieval) and weak-links.
+- [ ] **Step 5: Run → green; `make check`; commit** `feat(garden): deterministic importance recompute (#197)`.
+
+---
+
+## Measurement — retrieval-quality eval
+
+**Files:**
+- Create: `evals/retrieval-quality.yaml`
+- Possibly: extend `make build-eval-fixtures` for a frontmatter-rich fixture vault.
+
+- [ ] LLM-judge cases: seed a fixture vault (with generated frontmatter), pose representative queries, judge whether the injected memory context is relevant/sufficient. Run once as a **baseline before Phase 2's dream generation is active**, and again **after Phase 5**. Record both in `notes.md`. Pair with `make retrieval-report` before/after for the proxy delta.
+
+---
+
+## Self-review (done at write time)
+
+- **Spec coverage:** dream generation (P2), garden importance tuning (P5), backfill+reindex (P3), backlink index (P4), telemetry proxy (P0), LLM-judge eval (Measurement), `vault_update_frontmatter` D1 (P1), deterministic formula D2 (P5). Micro-evolution + reference-frequency correctly excluded. ✓
+- **Type consistency:** `merge_frontmatter(existing, fields, overwrite)` defined in P1, reused P3/P5; `retrieval_event` schema fixed in the cross-phase section, consumed by P0 subscriber + P5 scorer; `inbound_count` P4 → P5. ✓
+- **Ordering:** P1 before P2/P3/P5 (they call the tool/merge); P0 before P5 (retrieval freq); P4 before P5 (inbound count). ✓
+
+## Execution notes
+
+- Subagent-driven: dispatch a fresh subagent per phase; each must `cd` into the worktree, use `uv run`, read the real target files before editing, TDD, and stop at its phase commit for review.
+- After all phases: rebase on `origin/main`, self-review the full diff, update `docs/context-composer.md` (telemetry) + `docs/vault.md` + `CLAUDE.md` key-files/conventions, squash to per-phase commits (keep them) or one — decide at PR time, open PR `Closes #197`, request Copilot.
+- Deploy-and-wait: importance formula weights are guesses until `retrieval.jsonl` accrues real data on the deployed agent (~a week), same posture as the instrumentation-first direction.

--- a/docs/dev-sessions/2026-07-23-1615-vault-evolution/spec.md
+++ b/docs/dev-sessions/2026-07-23-1615-vault-evolution/spec.md
@@ -1,0 +1,176 @@
+# Spec: Self-improving vault — frontmatter generation & importance tuning (#197)
+
+## Problem
+
+Vault pages carry optional YAML frontmatter (`summary`, `keywords`, `tags`,
+`importance`) that feeds two retrieval mechanisms:
+
+- **Composite scoring** — `composite = 0.5·similarity + 0.3·recency + 0.2·importance`
+  (`RelevanceConfig`, consumed in `context_composer._score_candidates`).
+- **Composite embeddings** — `frontmatter.build_composite_text` prepends
+  `summary`/`keywords`/`tags` to the body before embedding.
+
+Both are fully wired. The problem: **nothing ever populates the frontmatter.**
+Dream and garden write bare markdown bodies, so:
+
+- Every page scores a constant `importance = 0.5` (the default). The 0.2
+  importance weight contributes a flat 0.1 to every candidate and does nothing
+  to ranking — it is dead weight.
+- The composite embedding is almost always just the bare body; the metadata
+  channel is unused.
+
+This issue makes the vault self-improving: dream generates frontmatter on
+create/revise, garden tunes `importance` from real signals, and we measure
+whether retrieval actually gets better.
+
+## Current-state map (verified against the tree)
+
+**Already implemented — do not rebuild:**
+
+- `frontmatter.py` — `parse_frontmatter`, `serialize_frontmatter` (round-trip
+  writer exists), `get_frontmatter_field` (typed coercion; `importance`
+  clamped `[0,1]`, default `0.5`), `build_composite_text`.
+- Importance in scoring — `context_composer._score_candidates`; enrichment in
+  `memory_context._enrich_results` (only for `source_type in {page, user}`,
+  not journal). Default `0.5` in three places.
+- Composite embeddings — `embeddings._iter_vault_pages` already calls
+  `build_composite_text`. Reindex path: `reindex_vault` / `make reindex`.
+- One-hop outbound wiki-link graph expansion — `memory_context._expand_graph_links`.
+- Per-turn `memory_candidates` diagnostics (injected candidates only) in the
+  `context.json` sidecar — `context_composer.build_diagnostics`.
+- On-demand `vault_backlinks` tool — brute-force `rglob` scan, no index.
+
+**Genuinely missing — the #197 work:**
+
+- Generation of `summary`/`keywords`/`tags`/`importance` (dream/garden write
+  bare bodies).
+- Tuning of `importance` (nothing sets it; term is effectively constant).
+- Per-page retrieval-frequency telemetry and any record of *dropped*
+  candidates — the blockers for measuring improvement.
+- A persistent inbound-link/backlink index (only brute-force scanning exists).
+
+## Goals
+
+1. Dream generates frontmatter on page create/revise, respecting manual values.
+2. Garden recomputes `importance` from real signals on a defined, testable formula.
+3. One-time backfill of existing pages + reindex.
+4. Persistent backlink index (feeds garden; replaces brute-force scan).
+5. We can **measure** whether retrieval quality improved — proxy telemetry +
+   an LLM-judge eval.
+
+**Non-goals (this arc):**
+
+- Micro-evolution on journal append (deferred → follow-up issue).
+- Retrieval-time backlink boosting (stretch; not required for the arc).
+- Changing the composite-score weights themselves.
+
+## Design decisions (approved)
+
+- **D1 — `vault_update_frontmatter` tool, not pure-prompt YAML.** A structured
+  write primitive in `skills/vault/tools.py` (always-loaded) guarantees valid
+  YAML and enforces the respect-manual-values invariant in code. Reused by
+  dream, garden, and the backfill CLI. Chosen over having dream write raw YAML
+  into page content (fragile; would re-implement the merge rule in prose).
+- **D2 — deterministic `importance` formula, not LLM judgment.** Garden's
+  importance tuning is a testable computation over telemetry + backlinks +
+  reference frequency, so results are reproducible and measurable. The LLM only
+  reviews outliers. Dream's *initial* importance is necessarily LLM judgment
+  (no telemetry exists for a brand-new page); garden's formula corrects it over
+  time.
+
+## Measurement approach (approved: telemetry proxy + LLM-judge eval)
+
+- **Proxy telemetry** (Phase 0): a retrieval-event stream records, per turn,
+  every scored candidate + its include/drop verdict. `make retrieval-report`
+  aggregates per-page retrieval frequency, include/drop ratio, importance
+  distribution/variance, frontmatter coverage %, and orphan count. This is both
+  the proxy metric and the retrieval-frequency *input* garden's formula needs —
+  so the measurement infra is a feature prerequisite, not overhead.
+- **LLM-judge eval** (`evals/retrieval-quality.yaml`): over a fixture vault with
+  frontmatter, a judge rates whether the retrieved context is relevant and
+  sufficient for representative queries. Run before Phase 2 and after Phase 5
+  for a quality delta.
+
+## Architecture — components & boundaries
+
+### `vault_update_frontmatter(ctx, page, fields, overwrite=False)` (Phase 1)
+
+- Home: `skills/vault/tools.py`.
+- Reads the page, `parse_frontmatter`, merges `fields`:
+  - `overwrite=False` → only set keys currently absent/empty (dream).
+  - `overwrite=True` → set/replace given keys (garden importance).
+- `serialize_frontmatter` back, write, reindex the page (composite embedding
+  refresh). Returns a summary of what changed.
+- Field-aware validation: `importance` clamped `[0,1]`; `keywords`/`tags`
+  coerced to lists; `summary` to string.
+
+### Retrieval telemetry (Phase 0)
+
+- Composer emits a `retrieval_event` over the EventBus from the scoring path,
+  carrying **all** scored candidates (pre-trim) each tagged included/dropped
+  with its similarity/recency/importance/composite. Requires exposing the
+  pre-trim candidate list (today only the injected set is recorded).
+- Subscriber (`retrieval_telemetry.py`, mirroring `tool_telemetry.py`) appends
+  to `workspace/telemetry/retrieval.jsonl`. Fail-open.
+- `make retrieval-report` reads the JSONL + the vault to print the aggregates.
+
+### Backlink index (Phase 4)
+
+- `backlinks.py` — persistent inbound-link map on disk (JSON, human-readable,
+  rebuildable), updated on `vault_changed` events + full rebuild path.
+- `vault_backlinks` reads the index instead of `rglob`-scanning.
+
+### Garden importance formula (Phase 5)
+
+- `vault_recompute_importance` (deterministic): for each page,
+  `importance = wf·norm(retrieval_freq) + wl·norm(inbound_links) [+ wr·norm(reference_freq)]`,
+  clamped `[0,1]`, weights in config. Writes via `vault_update_frontmatter(overwrite=True)`.
+  - **Core v1 signals: retrieval frequency (Phase 0) + inbound-link count
+    (Phase 4)** — both have clean, cheap sources.
+  - **Reference frequency is optional/stretch.** There is no clean per-page
+    conversation-reference signal today; the closest is `@[[Page]]` mention
+    injections (`vault_references`), which aren't logged per page. Ship v1 with
+    the two core signals (`wr = 0`); add reference-frequency only if a cheap
+    signal materializes (e.g. logging `vault_references` into the Phase 0
+    stream). Do not build conversation-scanning for it in this arc.
+- Garden SKILL.md orchestrates: recompute → review outliers → validate
+  frontmatter consistency → flag orphans / weak-links.
+
+## Phases (one commit each; commit-per-phase on `197-vault-evolution`)
+
+- **Phase 0** — retrieval telemetry stream + `make retrieval-report`.
+- **Phase 1** — `vault_update_frontmatter` tool (+ tests).
+- **Phase 2** — dream frontmatter generation (SKILL.md) + eval.
+- **Phase 3** — `make backfill-frontmatter` CLI + reindex.
+- **Phase 4** — persistent backlink index; rewire `vault_backlinks`.
+- **Phase 5** — deterministic `vault_recompute_importance` + garden SKILL.md.
+- **Measurement** — `evals/retrieval-quality.yaml`; capture before/after delta.
+
+## Testing
+
+- Unit: `vault_update_frontmatter` (merge, respect-manual, overwrite, clamp,
+  reindex-called); telemetry subscriber (include/drop capture, fail-open);
+  backlink index (build, incremental update, rebuild); importance formula
+  (normalization, weights, clamp).
+- Eval: dream generation produces valid frontmatter (tool_choice / behavior
+  case); `retrieval-quality.yaml` judge before/after.
+- `make check` + `make test` green before each phase commit.
+
+## Success criteria
+
+- Dream-created pages carry generated frontmatter; manual values preserved.
+- `importance` varies across pages (no longer constant 0.5); the 0.2 weight
+  measurably affects ranking.
+- `make retrieval-report` shows a baseline and a post-arc delta.
+- `retrieval-quality.yaml` judge score improves (or holds while the proxy shows
+  healthier distribution) after Phase 5 vs before Phase 2.
+
+## Risks / open items
+
+- Long-lived branch drift — mitigated by commit-per-phase + frequent rebase.
+- Backfill LLM cost/time over a large vault — batch, log progress, resumable.
+- Importance formula weights are a guess until telemetry accrues — ship with
+  defaults, tune once real `retrieval.jsonl` data exists (a deploy-and-wait
+  step, like the instrumentation-first direction already in flight).
+- Deployed agent runs over plain HTTP; telemetry is server-side only, no
+  secure-context concerns.

--- a/docs/dream-consolidation.md
+++ b/docs/dream-consolidation.md
@@ -19,7 +19,7 @@ Runs through four phases:
 
 1. **Orient** — survey existing vault pages and their summaries
 2. **Gather** — scan recent journal entries and search conversations for new insights, corrections, preferences, and overlooked themes
-3. **Consolidate** — update existing vault pages or create new ones, add `[[wiki-links]]`, convert relative dates to absolute
+3. **Consolidate** — update existing vault pages or create new ones, add `[[wiki-links]]`, convert relative dates to absolute, then call [`vault_update_frontmatter`](vault.md#page-frontmatter) (`overwrite=False`) to fill `summary`, `keywords`, `tags`, and an initial `importance` score — never clobbering fields a human set manually
 4. **Prune** — resolve contradictions, note corrections in Sources sections
 
 Always ends with a short narrative summary — what was consolidated and any new pages created. When the cycle was quiet, the summary is prefixed with `HEARTBEAT_OK` so the scheduler's log-line stays tidy; the narrative still reaches the newsletter via the archive. Scheduled runs are logged only, not posted to any channel.
@@ -81,4 +81,4 @@ Save as `data/{agent_id}/schedules/dream.md` — it will override the bundled sk
 
 The dream process maintains `> tl;dr:` summary blockquotes on longer vault pages. Pages shorter than ~20 lines don't need summaries. The dream and garden processes add/update these automatically.
 
-Vault pages also support YAML frontmatter with a `summary` field (see [Context Composer](context-composer.md#vault-page-frontmatter)) — both conventions coexist.
+Vault pages also support YAML frontmatter with a `summary` field (see [Context Composer](context-composer.md#vault-page-frontmatter)) — both conventions coexist. Since #197, dream generates that frontmatter (`summary`, `keywords`, `tags`, `importance`) itself after writing a page, via `vault_update_frontmatter` with `overwrite=False` so it never overrides values a human set by hand.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -174,6 +174,15 @@ Vault content is indexed in the embeddings database with per-type source types a
 - `--concurrency N` controls parallel embedding API calls (default 4)
 - Reindex includes 429 retry with exponential backoff
 
+## Retrieval telemetry (#197)
+
+A fail-open EventBus subscriber records which retrieval candidates were
+considered each interactive turn and which survived to injection —
+measurement foundation for the self-improving vault arc (importance
+formula, dream/garden tuning, and so on down the line). See
+[Retrieval telemetry](context-composer.md#retrieval-telemetry-197) in the
+context-composer docs for the event shape and `make retrieval-report`.
+
 ## Migration
 
 For existing installations with `workspace/wiki/` and `workspace/memories/`:

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -125,8 +125,9 @@ tool or a running agent context.
 
 `make backfill-frontmatter` (`decafclaw-backfill-frontmatter`,
 `src/decafclaw/backfill_frontmatter.py`) is a one-time CLI for vault pages
-written before frontmatter generation existed. It walks all non-journal
-vault pages, and for each one missing `summary`/`keywords`/`tags`/
+written before frontmatter generation existed. It walks the agent's own
+pages (`config.vault_agent_pages_dir`) — not the user's own vault pages
+elsewhere — and for each one missing `summary`/`keywords`/`tags`/
 `importance` makes a single forced-tool structured-output LLM call
 (`generate_fields_for_page`) to generate the missing fields, then merges
 them in via `merge_frontmatter(overwrite=False)` — a manually-set field is
@@ -183,6 +184,17 @@ replaces that guess weekly with a deterministic score, so importance
 tracks measured usage instead of drifting further from it with every LLM
 re-guess.
 
+This sweep is scoped to `agent/` pages only (`config.vault_agent_pages_dir`)
+— it runs weekly and non-interactively, with no human in the loop, so it
+never writes into the user's own hand-written vault pages elsewhere. This
+is narrower than the `vault_update_frontmatter` *tool*, which keeps its
+vault-wide reach for interactive, user-directed edits; only the automated
+sweep (and the `backfill_frontmatter` CLI, below) is scoped down. Pages
+with no measured signal at all yet (zero retrieval, zero inbound links —
+e.g. a page dream just wrote) are left untouched rather than zeroed, so a
+brand-new page's initial importance guess survives until real usage
+signal accumulates.
+
 `compute_importance_scores(config)` in `skills/garden/tools.py` is pure
 and config-driven (no `ctx`, no writes):
 
@@ -204,15 +216,15 @@ resolve `w_retrieval=0.6`, `w_inbound=0.4`, `w_reference=0.0` via the same
 dataclass-default → `config.json` → `IMPORTANCE_*` env resolution as every
 other sub-config.
 
-`tool_vault_recompute_importance(ctx, dry_run=False)` scores every
-non-journal vault page, writes changed scores via
-`vault_update_frontmatter(overwrite=True)`, and skips pages whose rounded
-score is unchanged so a re-run only touches what actually moved.
-`dry_run=true` reports the planned deltas without writing. It's the
-weekly step in the `garden` skill's sweep (`skills/garden/SKILL.md`) —
-review the reported deltas for outliers, and use `vault_backlinks` + the
-recomputed score together to flag orphaned, rarely-retrieved pages as
-split/merge/delete candidates.
+`tool_vault_recompute_importance(ctx, dry_run=False)` scores every agent
+page, writes changed scores via `vault_update_frontmatter(overwrite=True)`,
+and skips pages whose rounded score is unchanged or that have no measured
+signal at all yet, so a re-run only touches pages that both moved and have
+real data behind the move. `dry_run=true` reports the planned deltas
+without writing. It's the weekly step in the `garden` skill's sweep
+(`skills/garden/SKILL.md`) — review the reported deltas for outliers, and
+use `vault_backlinks` + the recomputed score together to flag orphaned,
+rarely-retrieved pages as split/merge/delete candidates.
 
 ### Ownership
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -108,7 +108,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |
 | `vault_section(page, action, section?, title?, level?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. |
-| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; the `backfill-frontmatter` CLI and garden importance tuning build on the same primitive. |
+| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; the `backfill-frontmatter` CLI and garden importance tuning build on the same primitive. Interactive callers writing outside `agent/` go through the same confirmation gate as `vault_write`; non-interactive callers (scheduled dream/garden) proceed without confirmation by design — the one mutating vault tool that doesn't error in non-interactive contexts. |
 
 ### Frontmatter merge (#197)
 
@@ -132,10 +132,12 @@ vault pages, and for each one missing `summary`/`keywords`/`tags`/
 them in via `merge_frontmatter(overwrite=False)` — a manually-set field is
 never clobbered. Pages where all four fields are already present are
 skipped for free, so the CLI is resumable and safe to re-run. `--dry-run`
-prints planned changes without writing; `--limit N` caps how many pages get
-an LLM call in one run (skips don't count against it). It does not reindex
-itself — follow with `make reindex` so composite embeddings pick up the new
-frontmatter.
+prints planned changes without writing; it still makes a real LLM call per
+page and costs the same tokens as a normal run — only the file write is
+skipped. `--limit N` caps how many pages get an LLM call in one run (skips
+don't count against it), which is the way to bound spend on `--dry-run`
+too. It does not reindex itself — follow with `make reindex` so composite
+embeddings pick up the new frontmatter.
 
 ### Backlink index (#197)
 
@@ -188,17 +190,17 @@ and config-driven (no `ctx`, no writes):
 importance = clamp01(
     w_retrieval * norm(retrieval_freq)
     + w_inbound * norm(inbound_links)
-    + w_reference * norm(reference_signal)
 )
 ```
 
 `norm(x) = x / max(x across all vault pages)`, defined as 0 when that max
 is 0 (no divide-by-zero on an empty or brand-new vault). `retrieval_freq`
 comes from `retrieval_telemetry.aggregate`; `inbound_links` from
-`backlinks.inbound_count`. `w_reference` defaults to 0 — no explicit-
-reference signal exists yet, so that term is reserved for a future phase
-and contributes nothing to the score today. Weights are `ImportanceConfig`
-(`w_retrieval=0.6`, `w_inbound=0.4`, `w_reference=0.0`), same
+`backlinks.inbound_count`. `ImportanceConfig` also carries a `w_reference`
+weight (default 0.0) that is **reserved / not yet computed** — no
+explicit-reference signal exists yet, so it's omitted from the formula
+above entirely rather than multiplied against an all-zero signal. Weights
+resolve `w_retrieval=0.6`, `w_inbound=0.4`, `w_reference=0.0` via the same
 dataclass-default → `config.json` → `IMPORTANCE_*` env resolution as every
 other sub-config.
 
@@ -231,7 +233,7 @@ Writes/deletes/renames under the agent folder (`agent/`) execute directly. Opera
 2. **Per-conversation grants.** The agent can call `vault_grant_folder(folder, reason)` to request trust for a folder. After user approval, all writes/deletes/renames under that folder skip confirmation for the rest of the conversation. Grants persist as a sidecar at `{workspace}/conversations/{conv_id}/vault_grants.json` and reset between conversations.
 3. **Per-call confirmation.** Anything else triggers a confirmation request showing the operation and a content preview. Approve to proceed; deny returns an error and no change is made.
 
-Heartbeat / scheduled / child-agent contexts can't display confirmations, so writes outside the agent folder fail with an error in those contexts.
+Heartbeat / scheduled / child-agent contexts can't display confirmations, so writes outside the agent folder fail with an error in those contexts — with one exception: `vault_update_frontmatter` skips this gate entirely for non-interactive callers (scheduled `dream`/`garden`), proceeding ungated by design so weekly maintenance can touch frontmatter vault-wide without a human present. Interactive callers of `vault_update_frontmatter` are still gated exactly like `vault_write`.
 
 ## Vault Gardening
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -108,7 +108,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |
 | `vault_section(page, action, section?, title?, level?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. |
-| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; a future backfill CLI and garden importance tuning build on the same primitive. |
+| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; the `backfill-frontmatter` CLI and garden importance tuning build on the same primitive. |
 
 ### Frontmatter merge (#197)
 
@@ -116,10 +116,26 @@ The vault skill is **always loaded** — its tools are available in every conver
 `merge_frontmatter(existing: dict, fields: dict, overwrite: bool) -> dict` in
 `skills/vault/tools.py`. The pure function does the field coercion (reusing
 `get_frontmatter_field`'s rules so the merge and the parser agree on shape)
-and the fill-vs-replace merge logic, with no ctx or I/O — later phases
-(dream generation, a backfill CLI, garden importance tuning) import and call
-it directly to compute merged frontmatter without going through the tool or
-a running agent context.
+and the fill-vs-replace merge logic, with no ctx or I/O — other callers
+(dream generation, the backfill CLI, garden importance tuning) import and
+call it directly to compute merged frontmatter without going through the
+tool or a running agent context.
+
+### Backfill CLI (#197)
+
+`make backfill-frontmatter` (`decafclaw-backfill-frontmatter`,
+`src/decafclaw/backfill_frontmatter.py`) is a one-time CLI for vault pages
+written before frontmatter generation existed. It walks all non-journal
+vault pages, and for each one missing `summary`/`keywords`/`tags`/
+`importance` makes a single forced-tool structured-output LLM call
+(`generate_fields_for_page`) to generate the missing fields, then merges
+them in via `merge_frontmatter(overwrite=False)` — a manually-set field is
+never clobbered. Pages where all four fields are already present are
+skipped for free, so the CLI is resumable and safe to re-run. `--dry-run`
+prints planned changes without writing; `--limit N` caps how many pages get
+an LLM call in one run (skips don't count against it). It does not reindex
+itself — follow with `make reindex` so composite embeddings pick up the new
+frontmatter.
 
 ### Ownership
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -172,6 +172,46 @@ level and never propagate into a tool call or event subscriber.
 inbound linkers in the index, and re-reads only those specific linking
 pages (not the whole vault) to pull a one-line quote for display context.
 
+### Importance recompute (#197)
+
+`importance` frontmatter starts as an LLM's subjective guess (backfill,
+dream generation). `vault_recompute_importance` — a native tool from the
+`garden` skill's `tools.py` (`src/decafclaw/skills/garden/tools.py`) —
+replaces that guess weekly with a deterministic score, so importance
+tracks measured usage instead of drifting further from it with every LLM
+re-guess.
+
+`compute_importance_scores(config)` in `skills/garden/tools.py` is pure
+and config-driven (no `ctx`, no writes):
+
+```
+importance = clamp01(
+    w_retrieval * norm(retrieval_freq)
+    + w_inbound * norm(inbound_links)
+    + w_reference * norm(reference_signal)
+)
+```
+
+`norm(x) = x / max(x across all vault pages)`, defined as 0 when that max
+is 0 (no divide-by-zero on an empty or brand-new vault). `retrieval_freq`
+comes from `retrieval_telemetry.aggregate`; `inbound_links` from
+`backlinks.inbound_count`. `w_reference` defaults to 0 — no explicit-
+reference signal exists yet, so that term is reserved for a future phase
+and contributes nothing to the score today. Weights are `ImportanceConfig`
+(`w_retrieval=0.6`, `w_inbound=0.4`, `w_reference=0.0`), same
+dataclass-default → `config.json` → `IMPORTANCE_*` env resolution as every
+other sub-config.
+
+`tool_vault_recompute_importance(ctx, dry_run=False)` scores every
+non-journal vault page, writes changed scores via
+`vault_update_frontmatter(overwrite=True)`, and skips pages whose rounded
+score is unchanged so a re-run only touches what actually moved.
+`dry_run=true` reports the planned deltas without writing. It's the
+weekly step in the `garden` skill's sweep (`skills/garden/SKILL.md`) —
+review the reported deltas for outliers, and use `vault_backlinks` + the
+recomputed score together to flag orphaned, rarely-retrieved pages as
+split/merge/delete candidates.
+
 ### Ownership
 
 - Agent writes to `agent/` by default

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -159,10 +159,14 @@ it]` (sorted, human-readable, crash-recoverable via tmp-file-then-rename).
   other page's content.
 
 A `vault_changed`-event subscriber (`make_backlinks_subscriber`, wired in
-`runner.py`) calls `update_for_page` after every vault mutation, so the
-index tracks disk state without an explicit rebuild step. Fail-open
-throughout — I/O or parse errors are logged at debug level and never
-propagate into a tool call or event subscriber.
+`runner.py`) keeps the index current without an explicit rebuild step: for
+create/update (and other same-identity events) it calls `update_for_page`
+for the changed page only; for delete/rename — which change a page's own
+identity in the index and can't be corrected incrementally (a rename event
+only carries the new path) — it runs a full `rebuild_index` instead.
+Delete/rename are rare relative to writes, so the full-scan cost is a
+non-issue. Fail-open throughout — I/O or parse errors are logged at debug
+level and never propagate into a tool call or event subscriber.
 
 `vault_backlinks(page)` itself now just resolves `page`, looks up its
 inbound linkers in the index, and re-reads only those specific linking

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -108,7 +108,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |
 | `vault_section(page, action, section?, title?, level?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. |
-| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — dream generation, a future backfill CLI, and garden importance tuning all build on this. |
+| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; a future backfill CLI and garden importance tuning build on the same primitive. |
 
 ### Frontmatter merge (#197)
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -108,6 +108,18 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |
 | `vault_section(page, action, section?, title?, level?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. |
+| `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — dream generation, a future backfill CLI, and garden importance tuning all build on this. |
+
+### Frontmatter merge (#197)
+
+`vault_update_frontmatter` is a thin async wrapper around a pure helper,
+`merge_frontmatter(existing: dict, fields: dict, overwrite: bool) -> dict` in
+`skills/vault/tools.py`. The pure function does the field coercion (reusing
+`get_frontmatter_field`'s rules so the merge and the parser agree on shape)
+and the fill-vs-replace merge logic, with no ctx or I/O — later phases
+(dream generation, a backfill CLI, garden importance tuning) import and call
+it directly to compute merged frontmatter without going through the tool or
+a running agent context.
 
 ### Ownership
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -137,6 +137,37 @@ an LLM call in one run (skips don't count against it). It does not reindex
 itself — follow with `make reindex` so composite embeddings pick up the new
 frontmatter.
 
+### Backlink index (#197)
+
+`vault_backlinks` no longer brute-force `rglob`s and regex-scans every page
+on each call. `src/decafclaw/backlinks.py` maintains a persistent JSON
+index at `{workspace}/backlinks.json` mapping `page -> [pages linking to
+it]` (sorted, human-readable, crash-recoverable via tmp-file-then-rename).
+
+- `rebuild_index(config)` — full scan: resolves every `[[link]]` (or
+  `[[link|display]]`) in every page to an existing page, case-insensitively
+  by full relative path or falling back to bare filename (stem). Dangling
+  links (no matching page) and self-links are dropped — the index only
+  tracks edges between real pages.
+- `load_index(config)` — reads the persisted JSON, rebuilding lazily if
+  missing or corrupt.
+- `inbound_count(config, page)` — number of distinct pages linking to
+  `page`. This is the raw signal Phase 5's importance formula folds in.
+- `update_for_page(config, page)` — incremental update: re-scans only the
+  changed page's current outbound links and adjusts the index's inbound
+  entries (add new targets, drop stale ones) without re-reading every
+  other page's content.
+
+A `vault_changed`-event subscriber (`make_backlinks_subscriber`, wired in
+`runner.py`) calls `update_for_page` after every vault mutation, so the
+index tracks disk state without an explicit rebuild step. Fail-open
+throughout — I/O or parse errors are logged at debug level and never
+propagate into a tool call or event subscriber.
+
+`vault_backlinks(page)` itself now just resolves `page`, looks up its
+inbound linkers in the index, and re-reads only those specific linking
+pages (not the whole vault) to pull a one-line quote for display context.
+
 ### Ownership
 
 - Agent writes to `agent/` by default

--- a/evals/retrieval-quality.yaml
+++ b/evals/retrieval-quality.yaml
@@ -1,0 +1,67 @@
+# Retrieval-quality eval (#197 Measurement step).
+#
+# What this DOES exercise: the real production retrieval pipeline for a
+# VAULT PAGE carrying rich frontmatter (summary/keywords/tags/importance) —
+# no shortcuts, no pre-baked embeddings fixture. The eval harness only
+# supports seeding raw page files (`setup.workspace_files`) and journal
+# entries (`setup.memories`, auto-indexed if `search_strategy: semantic`);
+# it does NOT auto-index workspace-seeded vault *pages* into embeddings.db.
+# So this test relies on two pieces of *real* production machinery instead:
+#
+#   1. `vault_search`'s lazy auto-reindex (`embeddings.search_similar`):
+#      the very first semantic search against an empty index triggers a
+#      real `reindex_vault()` / `reindex_journal()` pass, which embeds
+#      every vault page using `build_composite_text(frontmatter, body)` —
+#      i.e. the seeded page's frontmatter genuinely flows into its
+#      embedding, exactly as it would in production after a `vault_write`.
+#   2. Proactive memory retrieval (`memory_context.retrieve_memory_context`,
+#      mode "always" by default): once indexed, a *later* turn's own query
+#      can surface the page's content automatically, with NO explicit
+#      tool call — this is the composite-scored (similarity + recency +
+#      importance) auto-injection path that Phase 5's importance recompute
+#      feeds into.
+#
+# Turn 2 asks about a detail that is NOT restated in turn 1's response
+# (so the model can't just recall it from conversation history) and is
+# reachable only via the vault page — forcing genuine retrieval, not
+# memorized dialogue.
+#
+# LIMITATION (see #197 measurement report / notes.md): this is an honest
+# END-TO-END PIPELINE VALIDATION, not a controlled frontmatter-vs-bare-content
+# A/B. A rigorous A/B (frontmatter-rich page vs. an otherwise-identical bare
+# page, both pre-embedded and scored under equal distractor load) needs a
+# framework extension — a `setup.vault_pages` (or similar) fixture path that
+# seeds page files AND computes their composite embeddings deterministically
+# at setup time (mirroring what `tool_vault_write` does on a real write),
+# the way `setup.memories` already does for journal entries. Not built here
+# per the #197 measurement task scope — filed as a follow-up.
+
+- name: "vault page frontmatter is embedded and proactively retrieved later"
+  setup:
+    workspace_files:
+      "vault/agent/pages/escalation-runbook.md": |
+        ---
+        summary: On-call paging escalation chain — who gets notified when the primary responder doesn't acknowledge a page in time.
+        keywords: [escalation, paging, on-call, alerting, incident-response]
+        tags: [ops, runbook]
+        importance: 0.9
+        ---
+        # Escalation Runbook
+
+        If Priya doesn't acknowledge a page within 4 minutes, the alert
+        escalates to Marcus. If Marcus doesn't acknowledge within 8 minutes,
+        it escalates to the shift lead. If the shift lead doesn't acknowledge
+        within 15 minutes, PagerDuty auto-escalates to the VP of Engineering.
+  turns:
+    - input: "Search the vault for our on-call escalation policy — who gets paged first, and who's next if they don't respond?"
+      expect:
+        response_contains_all: ["Priya", "Marcus"]
+        expect_tool: vault_search
+        max_tool_calls: 4
+        max_tool_errors: 0
+    - input: "One more thing on that topic — how long does the shift lead have before it escalates further, and to whom?"
+      expect:
+        response_contains_all: ["15", "re:vp|vice president"]
+        expect_no_tool: [vault_search, vault_read, vault_recent]
+        max_tool_calls: 0
+        max_tool_errors: 0

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -276,8 +276,9 @@
   near_miss: [vault_update_frontmatter, vault_write]
   notes: |
     "Across my whole vault" + "based on how often pages get retrieved and
-    linked to" (not a guess) is the deterministic, vault-wide recompute —
-    exactly what vault_recompute_importance does from measured signals.
+    linked to" (not a guess) is the deterministic, bulk recompute over the
+    agent's managed pages — exactly what vault_recompute_importance does from
+    measured signals.
     vault_update_frontmatter only ever touches ONE named page's fields;
     it has no vault-wide sweep. vault_write would need the caller to
     read/edit/resubmit every page's body just to bump one field.

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -223,6 +223,29 @@
     everything and mutates the live catalog; it reports rejections too, but
     it's the broad/commit path, not the focused "did I author this right" check.
 
+# -- vault_update_frontmatter vs vault_write ---------------------------------
+
+- name: frontmatter-vs-write-metadata-only
+  scenario: "Set the importance to 0.8 and add the tags 'architecture' and 'decision' on my 'context-composer' vault page — don't touch the body."
+  expected: vault_update_frontmatter
+  near_miss: [vault_write]
+  notes: |
+    Metadata-only update (importance/tags) with an explicit "don't touch
+    the body" — the canonical vault_update_frontmatter case. vault_write
+    would need the caller to read, edit, and resubmit the whole body just
+    to change two frontmatter fields, and risks clobbering content the
+    request explicitly says to leave alone.
+
+- name: write-vs-frontmatter-rewrite-body
+  scenario: "Replace the entire body of my 'onboarding' vault page with this corrected text: '# Onboarding\n\n1. Clone the repo.\n2. Run make install.\n3. Copy .env.example to .env.'"
+  expected: vault_write
+  near_miss: [vault_update_frontmatter]
+  notes: |
+    Body content is what's changing here (out-of-date steps replaced with
+    concrete corrected text), not metadata. vault_update_frontmatter never
+    touches the body — it's the wrong tool whenever the actual page content
+    needs to change.
+
 # -- vault_recent vs vault_search / vault_list ---------------------------------
 
 - name: vault-recent-vs-search-whats-new

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -266,3 +266,29 @@
     Time-bounded ("past few days") + my own content points at vault_recent
     (source_type=user). vault_list would dump the whole journal folder with no
     date filter; vault_search needs a query string.
+
+# -- vault_recompute_importance vs vault_update_frontmatter / vault_write ----
+# (#197 Phase 5)
+
+- name: recompute-importance-vs-frontmatter-whole-vault
+  scenario: "Recalculate the importance scores across my whole vault based on how often pages actually get retrieved and linked to — not my guesses."
+  expected: vault_recompute_importance
+  near_miss: [vault_update_frontmatter, vault_write]
+  notes: |
+    "Across my whole vault" + "based on how often pages get retrieved and
+    linked to" (not a guess) is the deterministic, vault-wide recompute —
+    exactly what vault_recompute_importance does from measured signals.
+    vault_update_frontmatter only ever touches ONE named page's fields;
+    it has no vault-wide sweep. vault_write would need the caller to
+    read/edit/resubmit every page's body just to bump one field.
+
+- name: frontmatter-vs-recompute-single-page-importance
+  scenario: "Bump the importance to 0.9 on just my 'roadmap' vault page — I want that one to stand out, don't touch anything else."
+  expected: vault_update_frontmatter
+  near_miss: [vault_recompute_importance]
+  notes: |
+    A specific value on a specific named page is a targeted metadata edit —
+    vault_update_frontmatter. vault_recompute_importance ignores any
+    caller-supplied number; it derives every page's score from retrieval/
+    inbound-link telemetry and would silently overwrite the requested 0.9
+    with whatever the formula computes, which isn't what was asked.

--- a/evals/vault-frontmatter.yaml
+++ b/evals/vault-frontmatter.yaml
@@ -1,0 +1,32 @@
+# Evals for dream-generated page frontmatter (#197 Phase 2).
+#
+# Exercises the real dream consolidation flow end-to-end: seed a handful of
+# related journal entries, run the actual `/dream` skill, and assert it
+# calls `vault_update_frontmatter` after writing/revising the page — not
+# just `vault_write`. This is the behavior eval for Phase 2's SKILL.md
+# addition (dream/SKILL.md Consolidate phase, step 6).
+
+- name: "dream consolidation fills page frontmatter after writing"
+  setup:
+    skills: [dream]
+    memories:
+      - tags: [workflow, worktrees, tooling]
+        content: >-
+          Worktrees for decafclaw live under .claude/worktrees/{branch}/.
+          Each one needs its own venv, created by running `uv sync` inside
+          the worktree.
+      - tags: [workflow, worktrees, tooling]
+        content: >-
+          Copy .env into a new worktree from the main clone before starting
+          work — it points at the main clone's data/ directory so
+          conversations, vault, and config are shared instead of duplicated.
+      - tags: [workflow, worktrees, tooling]
+        content: >-
+          After creating a worktree, add an HTTP_PORT setting to its .env
+          to avoid port collisions with other worktrees that are already
+          running.
+  input: "/dream"
+  expect:
+    max_tool_calls: 30
+    max_tool_errors: 0
+    expect_tool: vault_update_frontmatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ decafclaw-prune-embeddings = "decafclaw.embeddings:prune_embeddings_cli"
 decafclaw-search = "decafclaw.embeddings:search_cli"
 decafclaw-token = "decafclaw.web.auth:token_cli"
 decafclaw-client = "decafclaw.client:main"
+decafclaw-retrieval-report = "decafclaw.retrieval_telemetry:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ decafclaw-search = "decafclaw.embeddings:search_cli"
 decafclaw-token = "decafclaw.web.auth:token_cli"
 decafclaw-client = "decafclaw.client:main"
 decafclaw-retrieval-report = "decafclaw.retrieval_telemetry:main"
+decafclaw-backfill-frontmatter = "decafclaw.backfill_frontmatter:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/decafclaw/backfill_frontmatter.py
+++ b/src/decafclaw/backfill_frontmatter.py
@@ -1,0 +1,232 @@
+"""One-time CLI to backfill YAML frontmatter on existing vault pages (#197).
+
+Pages written before frontmatter generation (dream consolidation, #197 Phase
+2) have no `summary` / `keywords` / `tags` / `importance`. This walks the
+vault, generates the missing fields via a forced-tool LLM call, and merges
+them in without clobbering anything a human already set by hand. Resumable:
+a page whose frontmatter already has all four fields is skipped, so a
+partial or interrupted run can be re-run safely.
+
+Does not reindex embeddings itself — run `make reindex` afterward so
+composite embeddings (frontmatter.build_composite_text) pick up the new
+frontmatter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from decafclaw.frontmatter import parse_frontmatter, serialize_frontmatter
+from decafclaw.llm import call_llm
+from decafclaw.skills.vault.tools import merge_frontmatter
+
+log = logging.getLogger(__name__)
+
+FRONTMATTER_FIELDS = ("summary", "keywords", "tags", "importance")
+
+_TOOL_NAME = "submit_frontmatter"
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "summary": {
+            "type": "string",
+            "description": "One or two sentence summary of the page's content.",
+        },
+        "keywords": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "5-10 keywords or short phrases capturing the page's topics.",
+        },
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "2-5 short topical tags (single words or short hyphenated phrases).",
+        },
+        "importance": {
+            "type": "number",
+            "description": "How important this page is to remember, from 0.0 (trivial) to 1.0 (critical).",
+        },
+    },
+    "required": list(FRONTMATTER_FIELDS),
+}
+
+
+def _iter_frontmatter_candidates(config):
+    """Yield vault page paths eligible for frontmatter backfill.
+
+    Mirrors the walk in `embeddings._iter_vault_pages` (all vault `.md`
+    files except journal entries) but yields `Path` objects instead of
+    embedding text, since backfill needs to read and rewrite each page's
+    frontmatter in place.
+    """
+    vault = config.vault_root
+    if not vault.is_dir():
+        return
+    journal_dir = config.vault_agent_journal_dir
+    for path in sorted(vault.rglob("*.md")):
+        try:
+            if path.resolve().is_relative_to(journal_dir.resolve()):
+                continue
+        except (ValueError, OSError):
+            pass
+        yield path
+
+
+def _has_all_fields(metadata: dict) -> bool:
+    """True if every field backfill would populate is already set and non-empty."""
+    return all(metadata.get(field) not in (None, "", []) for field in FRONTMATTER_FIELDS)
+
+
+async def generate_fields_for_page(config, path: Path) -> dict:
+    """Forced-tool structured-output LLM call generating frontmatter fields.
+
+    Sophie-style: a single tool the model must call, with "you MUST call
+    this" framing and one retry on narrate-stall. Mirrors the pattern in
+    `workflow/llm.py::call_structured`, which needs a `ctx`; this is
+    config-only so the CLI can run outside an agent turn.
+    """
+    _, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+    system = (
+        "You generate vault-page frontmatter metadata — a short summary, "
+        "keywords, tags, and an importance score — from a page's content."
+    )
+    base_user = f"Page content:\n\n{body}"
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": _TOOL_NAME,
+            "description": (
+                "Submit frontmatter metadata for this page. "
+                "You MUST call this — do not respond with prose."
+            ),
+            "parameters": _SCHEMA,
+        },
+    }]
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": base_user},
+    ]
+    last_error: str | None = None
+    for attempt in range(2):
+        response = await call_llm(
+            config, messages, tools=tools, model_name=config.default_model,
+        )
+        tool_calls = response.get("tool_calls") or []
+        if tool_calls:
+            args_raw = tool_calls[0].get("function", {}).get("arguments") or "{}"
+            try:
+                return json.loads(args_raw)
+            except json.JSONDecodeError as e:
+                last_error = f"invalid JSON in tool args: {e}; raw={args_raw[:200]!r}"
+        else:
+            last_error = (
+                f"model emitted text instead of calling {_TOOL_NAME!r}: "
+                f"{(response.get('content') or '')[:200]!r}"
+            )
+        log.debug(
+            "generate_fields_for_page(%s) attempt %d failed: %s",
+            path, attempt, last_error,
+        )
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": (
+                base_user + f"\n\nIMPORTANT: You MUST call the tool "
+                f"`{_TOOL_NAME}` now. Do not narrate. Emit only the call."
+            )},
+        ]
+    raise RuntimeError(f"structured frontmatter call failed for {path}: {last_error}")
+
+
+async def run_backfill(config, *, dry_run: bool = False, limit: int | None = None) -> list[dict]:
+    """Backfill frontmatter on vault pages missing summary/keywords/tags/importance.
+
+    Returns one result dict per page examined: `{path, action, fields}`
+    where `action` is `"filled"`, `"planned"` (dry_run), or `"skipped"`
+    (already complete). `limit`, if given, caps how many pages get an LLM
+    call in this run — already-complete pages are skipped for free and
+    don't count against it, so a capped run stays resumable.
+    """
+    results: list[dict] = []
+    processed = 0
+    for path in _iter_frontmatter_candidates(config):
+        content = path.read_text(encoding="utf-8")
+        metadata, body = parse_frontmatter(content)
+        rel = path.relative_to(config.vault_root)
+
+        if _has_all_fields(metadata):
+            log.info("Skipping %s (frontmatter already complete)", rel)
+            results.append({"path": str(rel), "action": "skipped", "fields": {}})
+            continue
+
+        if limit is not None and processed >= limit:
+            break
+
+        log.info("Generating frontmatter for %s", rel)
+        fields = await generate_fields_for_page(config, path)
+        merged = merge_frontmatter(metadata, fields, overwrite=False)
+        changed = {
+            field: merged[field] for field in FRONTMATTER_FIELDS
+            if merged.get(field) != metadata.get(field)
+        }
+        processed += 1
+
+        if dry_run:
+            log.info("Would update %s: %s", rel, ", ".join(changed) or "(no changes)")
+            results.append({"path": str(rel), "action": "planned", "fields": changed})
+            continue
+
+        path.write_text(serialize_frontmatter(merged, body), encoding="utf-8")
+        log.info("Updated %s: %s", rel, ", ".join(changed) or "(no changes)")
+        results.append({"path": str(rel), "action": "filled", "fields": changed})
+
+    return results
+
+
+def main() -> None:
+    """CLI entry point: backfill frontmatter on existing vault pages that lack it."""
+    from .config import load_config
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "One-time backfill of vault-page frontmatter (summary/keywords/"
+            "tags/importance) for pages written before frontmatter "
+            "generation existed. Safe to re-run — pages already fully "
+            "populated are skipped. Run `make reindex` afterward so "
+            "composite embeddings pick up the new frontmatter."
+        )
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Show planned changes without writing",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Generate frontmatter for at most N pages this run",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+    )
+
+    config = load_config()
+    results = asyncio.run(run_backfill(config, dry_run=args.dry_run, limit=args.limit))
+
+    filled = sum(1 for r in results if r["action"] == "filled")
+    planned = sum(1 for r in results if r["action"] == "planned")
+    skipped = sum(1 for r in results if r["action"] == "skipped")
+    print(
+        f"{len(results)} page(s) examined: "
+        f"{filled} filled, {planned} planned, {skipped} skipped"
+    )
+    if not args.dry_run and filled:
+        print("Run `make reindex` to refresh composite embeddings.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decafclaw/backfill_frontmatter.py
+++ b/src/decafclaw/backfill_frontmatter.py
@@ -2,10 +2,11 @@
 
 Pages written before frontmatter generation (dream consolidation, #197 Phase
 2) have no `summary` / `keywords` / `tags` / `importance`. This walks the
-vault, generates the missing fields via a forced-tool LLM call, and merges
-them in without clobbering anything a human already set by hand. Resumable:
-a page whose frontmatter already has all four fields is skipped, so a
-partial or interrupted run can be re-run safely.
+agent's own pages (`config.vault_agent_pages_dir`) — not the user's own
+vault pages elsewhere — generates the missing fields via a forced-tool LLM
+call, and merges them in without clobbering anything a human already set
+by hand. Resumable: a page whose frontmatter already has all four fields
+is skipped, so a partial or interrupted run can be re-run safely.
 
 Does not reindex embeddings itself — run `make reindex` afterward so
 composite embeddings (frontmatter.build_composite_text) pick up the new
@@ -60,24 +61,19 @@ _SCHEMA = {
 
 
 def _iter_frontmatter_candidates(config):
-    """Yield vault page paths eligible for frontmatter backfill.
+    """Yield agent page paths eligible for frontmatter backfill.
 
-    Mirrors the walk in `embeddings._iter_vault_pages` (all vault `.md`
-    files except journal entries) but yields `Path` objects instead of
-    embedding text, since backfill needs to read and rewrite each page's
-    frontmatter in place.
+    Scoped to `config.vault_agent_pages_dir` only — this walk writes
+    LLM-generated frontmatter unattended, so it stays within the agent's
+    own folder rather than touching the user's own hand-written vault
+    pages elsewhere (#197 whole-branch review; mirrors the same scoping
+    in `garden.tools._iter_importance_candidates`). `agent/journal` is a
+    sibling of `agent/pages`, so it's naturally excluded.
     """
-    vault = config.vault_root
-    if not vault.is_dir():
+    pages_dir = config.vault_agent_pages_dir
+    if not pages_dir.is_dir():
         return
-    journal_dir = config.vault_agent_journal_dir
-    for path in sorted(vault.rglob("*.md")):
-        try:
-            if path.resolve().is_relative_to(journal_dir.resolve()):
-                continue
-        except (ValueError, OSError):
-            pass
-        yield path
+    yield from sorted(pages_dir.rglob("*.md"))
 
 
 def _has_all_fields(metadata: dict) -> bool:

--- a/src/decafclaw/backfill_frontmatter.py
+++ b/src/decafclaw/backfill_frontmatter.py
@@ -10,6 +10,10 @@ partial or interrupted run can be re-run safely.
 Does not reindex embeddings itself — run `make reindex` afterward so
 composite embeddings (frontmatter.build_composite_text) pick up the new
 frontmatter.
+
+`--dry-run` still makes a real LLM call per page to generate the fields —
+it only skips writing them to disk. It costs the same tokens as a normal
+run; use `--limit` to bound the spend.
 """
 
 from __future__ import annotations
@@ -201,7 +205,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--dry-run", action="store_true",
-        help="Show planned changes without writing",
+        help=(
+            "Show planned changes without writing. Still makes a real LLM "
+            "call per page (same token spend as a normal run) — only the "
+            "file write is skipped."
+        ),
     )
     parser.add_argument(
         "--limit", type=int, default=None,

--- a/src/decafclaw/backlinks.py
+++ b/src/decafclaw/backlinks.py
@@ -3,8 +3,8 @@
 Replaces the brute-force ``rglob``-and-regex-scan that used to live inline
 in ``tool_vault_backlinks``: a JSON index at ``{workspace}/backlinks.json``
 mapping ``page -> [pages that link to it]``. Rebuilt lazily on first read,
-kept current incrementally via ``update_for_page`` (wired to the
-``vault_changed`` EventBus event in ``runner.py``), and consumed directly
+kept current via the ``vault_changed`` EventBus subscriber wired in
+``runner.py`` (see ``make_backlinks_subscriber``), and consumed directly
 by ``inbound_count`` — the raw signal Phase 5's importance formula folds
 into its score.
 
@@ -14,6 +14,20 @@ insensitively, first by full relative path and falling back to bare
 filename (stem). Links that don't resolve to any existing page (dangling
 links) and self-links are not recorded — a backlink index only makes
 sense for edges between real pages.
+
+Incremental vs. full rebuild: ``update_for_page`` only rescans the
+*changed page's own outbound links* and reconciles other pages' inbound
+lists accordingly. That's correct for CREATE/UPDATE (and other events that
+don't change a page's identity, e.g. SECTION/JOURNAL/MOVE-between-
+sections) — the page's own rel-path key never moves. It's NOT sufficient
+for DELETE or RENAME: those change (or remove) the page's own key in the
+index, which nothing in ``update_for_page`` ever scrubs or creates, and a
+rename event only carries the new path (no old path to diff against). So
+``make_backlinks_subscriber`` runs a full ``rebuild_index`` on DELETE/
+RENAME and only takes the incremental path otherwise. DELETE/RENAME are
+rare compared to writes, so the full-scan cost is a non-issue — a
+correct-but-occasionally-full-rebuild index beats a fast-but-wrong one.
+There is no separate periodic self-heal; DELETE/RENAME rebuilds are it.
 
 Fail-open throughout: any I/O or parse error is logged at debug level and
 falls back to an empty/rebuilt result rather than propagating into a tool
@@ -26,6 +40,8 @@ import json
 import logging
 from pathlib import Path
 from typing import Awaitable, Callable
+
+from decafclaw.skills.vault._events import KIND_DELETE, KIND_RENAME
 
 log = logging.getLogger(__name__)
 
@@ -177,7 +193,12 @@ def inbound_count(config, page: str) -> int:
         resolved = resolve_page(config, page)
         if resolved is None:
             return 0
-        rel = resolved.relative_to(config.vault_root).as_posix()
+        # resolve_page() returns a fully-resolved path (symlinks collapsed),
+        # so the vault root side of relative_to() must be resolved too, or
+        # a symlinked vault_root component (e.g. /tmp -> /private/tmp on
+        # macOS) makes relative_to() raise and this silently returns 0.
+        vault_resolved = config.vault_root.resolve()
+        rel = resolved.relative_to(vault_resolved).as_posix()
         return len(load_index(config).get(rel, []))
     except Exception as exc:  # fail-open
         log.debug("backlinks: inbound_count failed for %r: %s", page, exc)
@@ -195,7 +216,9 @@ def _resolve_source_rel(config, page: str) -> tuple[str, str]:
 
     resolved = resolve_page(config, page)
     if resolved is not None and resolved.exists():
-        rel = resolved.relative_to(config.vault_root).as_posix()
+        # Same resolved/unresolved consistency requirement as inbound_count.
+        vault_resolved = config.vault_root.resolve()
+        rel = resolved.relative_to(vault_resolved).as_posix()
         return rel, resolved.read_text(encoding="utf-8")
 
     norm = page[:-3] if page.endswith(".md") else page
@@ -210,6 +233,11 @@ def update_for_page(config, page: str) -> None:
     file contents — the per-page lookup maps only need filenames) and
     updates the index's inbound entries: drops this page from targets it
     no longer links to, adds it to new ones. Fail-open — never raises.
+
+    Only correct for events that don't change `page`'s own identity (its
+    own rel-path key in the index). Callers must NOT use this for
+    delete/rename — see the module docstring and `make_backlinks_subscriber`,
+    which routes those to a full `rebuild_index` instead.
     """
     try:
         vault = config.vault_root
@@ -237,13 +265,25 @@ def update_for_page(config, page: str) -> None:
 
 
 def make_backlinks_subscriber(config) -> Callable[[dict], Awaitable[None]]:
-    """EventBus subscriber: incrementally updates the index on `vault_changed`.
+    """EventBus subscriber: keeps the index current on `vault_changed`.
+
+    CREATE/UPDATE (and other same-identity events like SECTION/JOURNAL/MOVE)
+    take the fast incremental path (`update_for_page`) since only the
+    changed page's outbound links can have moved. DELETE/RENAME change a
+    page's identity (its own rel-path key disappears, appears, or both),
+    which `update_for_page` cannot correct — see module docstring — so
+    those trigger a full `rebuild_index` instead. Rare enough in practice
+    that the cost is a non-issue, and correctness beats speed here.
 
     Fail-open — never propagates into the publishing turn.
     """
     async def handle(event: dict) -> None:
         try:
             if event.get("type") != "vault_changed":
+                return
+            kind = event.get("kind") or ""
+            if kind in (KIND_DELETE, KIND_RENAME):
+                rebuild_index(config)
                 return
             path = event.get("path") or ""
             if not path:

--- a/src/decafclaw/backlinks.py
+++ b/src/decafclaw/backlinks.py
@@ -1,0 +1,255 @@
+"""Persistent backlink index (#197 Phase 4 — self-improving vault arc).
+
+Replaces the brute-force ``rglob``-and-regex-scan that used to live inline
+in ``tool_vault_backlinks``: a JSON index at ``{workspace}/backlinks.json``
+mapping ``page -> [pages that link to it]``. Rebuilt lazily on first read,
+kept current incrementally via ``update_for_page`` (wired to the
+``vault_changed`` EventBus event in ``runner.py``), and consumed directly
+by ``inbound_count`` — the raw signal Phase 5's importance formula folds
+into its score.
+
+Link resolution matches the pre-Phase-4 semantics: a raw ``[[link]]`` (or
+``[[link|display]]``) is resolved to an existing vault page case-
+insensitively, first by full relative path and falling back to bare
+filename (stem). Links that don't resolve to any existing page (dangling
+links) and self-links are not recorded — a backlink index only makes
+sense for edges between real pages.
+
+Fail-open throughout: any I/O or parse error is logged at debug level and
+falls back to an empty/rebuilt result rather than propagating into a tool
+call or event subscriber.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Awaitable, Callable
+
+log = logging.getLogger(__name__)
+
+
+def _index_path(config) -> Path:
+    return config.workspace_path / "backlinks.json"
+
+
+def _save_index(config, index: dict[str, list[str]]) -> None:
+    """Persist the index as human-readable JSON via tmp-file-then-rename.
+
+    Fail-open: I/O errors are logged at debug level and swallowed.
+    """
+    path = _index_path(config)
+    tmp = path.with_suffix(".json.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n",
+                        encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        log.debug("backlinks: failed to persist index: %s", exc)
+        try:
+            if tmp.exists():
+                tmp.unlink()
+        except OSError as cleanup_exc:
+            log.debug("backlinks: tmp cleanup failed: %s", cleanup_exc)
+
+
+def _build_page_lookup(
+    pages: list[Path], vault: Path
+) -> tuple[dict[str, str], dict[str, list[str]]]:
+    """Build case-insensitive lookup maps for resolving raw link text.
+
+    Returns (full_lower -> rel_path, stem_lower -> [rel_path, ...]). Both
+    keys are derived from each existing page's vault-relative path (POSIX,
+    ``.md`` stripped for the "full" form).
+    """
+    full_lower_map: dict[str, str] = {}
+    stem_lower_map: dict[str, list[str]] = {}
+    for p in pages:
+        rel = p.relative_to(vault).as_posix()
+        rel_no_ext = rel[:-3] if rel.endswith(".md") else rel
+        full_lower_map.setdefault(rel_no_ext.lower(), rel)
+        stem_lower_map.setdefault(p.stem.lower(), []).append(rel)
+    return full_lower_map, stem_lower_map
+
+
+def _resolve_link_target(
+    raw_link: str,
+    full_lower_map: dict[str, str],
+    stem_lower_map: dict[str, list[str]],
+) -> str | None:
+    """Resolve raw [[link]] text to an existing page's rel path, or None."""
+    target = raw_link.split("|")[0].strip()
+    if target.endswith(".md"):
+        target = target[:-3]
+    if not target:
+        return None
+    hit = full_lower_map.get(target.lower())
+    if hit is not None:
+        return hit
+    candidates = stem_lower_map.get(Path(target).stem.lower())
+    if candidates:
+        return sorted(candidates)[0]
+    return None
+
+
+def _extract_outbound_targets(
+    text: str,
+    source_rel: str,
+    full_lower_map: dict[str, str],
+    stem_lower_map: dict[str, list[str]],
+) -> set[str]:
+    """Distinct existing pages that `text` (the body of `source_rel`) links to."""
+    from decafclaw.skills.vault.tools import _WIKI_LINK_RE
+
+    targets: set[str] = set()
+    for match in _WIKI_LINK_RE.finditer(text):
+        target_rel = _resolve_link_target(
+            match.group(1), full_lower_map, stem_lower_map)
+        if target_rel is not None and target_rel != source_rel:
+            targets.add(target_rel)
+    return targets
+
+
+def rebuild_index(config) -> dict[str, list[str]]:
+    """Full rebuild: scan every vault page's outbound links.
+
+    Returns (and persists) ``{page_path: [pages linking to it]}``, sorted
+    for determinism. Fail-open — any error yields (and persists, best
+    effort) an empty index rather than raising.
+    """
+    try:
+        vault = config.vault_root
+        if not vault.is_dir():
+            _save_index(config, {})
+            return {}
+
+        pages = sorted(vault.rglob("*.md"))
+        full_lower_map, stem_lower_map = _build_page_lookup(pages, vault)
+
+        inbound: dict[str, set[str]] = {}
+        for p in pages:
+            source_rel = p.relative_to(vault).as_posix()
+            try:
+                text = p.read_text(encoding="utf-8")
+            except OSError as exc:
+                log.debug("backlinks: failed reading %s: %s", p, exc)
+                continue
+            for target_rel in _extract_outbound_targets(
+                text, source_rel, full_lower_map, stem_lower_map
+            ):
+                inbound.setdefault(target_rel, set()).add(source_rel)
+
+        result = {k: sorted(v) for k, v in sorted(inbound.items())}
+        _save_index(config, result)
+        return result
+    except Exception as exc:  # fail-open
+        log.debug("backlinks: rebuild_index failed: %s", exc)
+        return {}
+
+
+def load_index(config) -> dict[str, list[str]]:
+    """Read the persisted index, rebuilding lazily if missing or corrupt.
+
+    Fail-open: any error falls back to a fresh rebuild, and if that also
+    fails, an empty index.
+    """
+    path = _index_path(config)
+    try:
+        if not path.exists():
+            return rebuild_index(config)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            log.debug("backlinks: index at %s was not a dict, rebuilding", path)
+            return rebuild_index(config)
+        return data
+    except (json.JSONDecodeError, OSError) as exc:
+        log.debug("backlinks: load_index failed (%s), rebuilding", exc)
+        return rebuild_index(config)
+
+
+def inbound_count(config, page: str) -> int:
+    """Number of distinct pages linking to `page`. Fail-open (returns 0)."""
+    try:
+        from decafclaw.skills.vault.tools import resolve_page
+
+        resolved = resolve_page(config, page)
+        if resolved is None:
+            return 0
+        rel = resolved.relative_to(config.vault_root).as_posix()
+        return len(load_index(config).get(rel, []))
+    except Exception as exc:  # fail-open
+        log.debug("backlinks: inbound_count failed for %r: %s", page, exc)
+        return 0
+
+
+def _resolve_source_rel(config, page: str) -> tuple[str, str]:
+    """Resolve `page` to (canonical rel path, current body text).
+
+    If the page no longer exists on disk (e.g. just deleted), the rel path
+    is best-effort normalized from the raw `page` string and the body is
+    treated as empty (no outbound links) so stale entries get purged.
+    """
+    from decafclaw.skills.vault.tools import resolve_page
+
+    resolved = resolve_page(config, page)
+    if resolved is not None and resolved.exists():
+        rel = resolved.relative_to(config.vault_root).as_posix()
+        return rel, resolved.read_text(encoding="utf-8")
+
+    norm = page[:-3] if page.endswith(".md") else page
+    norm = norm.strip("/")
+    return f"{norm}.md", ""
+
+
+def update_for_page(config, page: str) -> None:
+    """Incrementally update the index after a single page's content changed.
+
+    Re-scans only `page`'s current outbound links (not the whole vault's
+    file contents — the per-page lookup maps only need filenames) and
+    updates the index's inbound entries: drops this page from targets it
+    no longer links to, adds it to new ones. Fail-open — never raises.
+    """
+    try:
+        vault = config.vault_root
+        if not vault.is_dir():
+            return
+        source_rel, text = _resolve_source_rel(config, page)
+
+        pages = sorted(vault.rglob("*.md"))
+        full_lower_map, stem_lower_map = _build_page_lookup(pages, vault)
+        new_targets = _extract_outbound_targets(
+            text, source_rel, full_lower_map, stem_lower_map)
+
+        index = {k: set(v) for k, v in load_index(config).items()}
+        for target_rel, linkers in list(index.items()):
+            if source_rel in linkers and target_rel not in new_targets:
+                linkers.discard(source_rel)
+            if not linkers:
+                del index[target_rel]
+        for target_rel in new_targets:
+            index.setdefault(target_rel, set()).add(source_rel)
+
+        _save_index(config, {k: sorted(v) for k, v in sorted(index.items())})
+    except Exception as exc:  # fail-open
+        log.debug("backlinks: update_for_page failed for %r: %s", page, exc)
+
+
+def make_backlinks_subscriber(config) -> Callable[[dict], Awaitable[None]]:
+    """EventBus subscriber: incrementally updates the index on `vault_changed`.
+
+    Fail-open — never propagates into the publishing turn.
+    """
+    async def handle(event: dict) -> None:
+        try:
+            if event.get("type") != "vault_changed":
+                return
+            path = event.get("path") or ""
+            if not path:
+                return
+            update_for_page(config, path)
+        except Exception as exc:  # fail-open
+            log.debug("backlinks subscriber error: %s", exc)
+
+    return handle

--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -26,6 +26,7 @@ from .config_types import (
     EmbeddingConfig,
     HeartbeatConfig,
     HttpConfig,
+    ImportanceConfig,
     LlmConfig,
     LoopBreakerConfig,
     MapWidgetConfig,
@@ -184,6 +185,7 @@ class Config:
     skills_always_loaded: list[str] = field(default_factory=list)
     vault_retrieval: VaultRetrievalConfig = field(default_factory=VaultRetrievalConfig)
     relevance: RelevanceConfig = field(default_factory=RelevanceConfig)
+    importance: ImportanceConfig = field(default_factory=ImportanceConfig)
     vault: VaultConfig = field(default_factory=VaultConfig)
     vault_guide: VaultGuideConfig = field(default_factory=VaultGuideConfig)
     notifications: NotificationsConfig = field(default_factory=NotificationsConfig)
@@ -463,6 +465,9 @@ def load_config() -> Config:
     relevance = load_sub_config(
         RelevanceConfig, file_data.get("relevance", {}), "RELEVANCE")
 
+    importance = load_sub_config(
+        ImportanceConfig, file_data.get("importance", {}), "IMPORTANCE")
+
     vault = load_sub_config(
         VaultConfig, file_data.get("vault", {}), "VAULT")
 
@@ -570,6 +575,7 @@ def load_config() -> Config:
         skills_always_loaded=skills_always_loaded,
         vault_retrieval=vault_retrieval,
         relevance=relevance,
+        importance=importance,
         vault=vault,
         vault_guide=vault_guide,
         notifications=notifications,

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -310,6 +310,23 @@ class RelevanceConfig:
 
 
 @dataclass
+class ImportanceConfig:
+    """Weights for garden's deterministic weekly importance recompute (#197
+    Phase 5).
+
+    v1 formula: ``importance = clamp01(w_retrieval * norm(retrieval_freq) +
+    w_inbound * norm(inbound_links) + w_reference * norm(reference_signal))``,
+    where ``norm(x) = x / max(x across all pages)`` (0 when the max is 0).
+    ``w_reference`` is reserved for a future explicit-reference signal (not
+    yet implemented) and defaults to 0 — it contributes nothing to the score
+    today. See ``skills/garden/tools.py::compute_importance_scores``.
+    """
+    w_retrieval: float = 0.6
+    w_inbound: float = 0.4
+    w_reference: float = 0.0
+
+
+@dataclass
 class ProviderConfig:
     """Connection config for an LLM provider."""
     type: str = ""  # "vertex", "openai", "openai-compat" (also accepts "litellm")

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -315,11 +315,12 @@ class ImportanceConfig:
     Phase 5).
 
     v1 formula: ``importance = clamp01(w_retrieval * norm(retrieval_freq) +
-    w_inbound * norm(inbound_links) + w_reference * norm(reference_signal))``,
-    where ``norm(x) = x / max(x across all pages)`` (0 when the max is 0).
-    ``w_reference`` is reserved for a future explicit-reference signal (not
-    yet implemented) and defaults to 0 — it contributes nothing to the score
-    today. See ``skills/garden/tools.py::compute_importance_scores``.
+    w_inbound * norm(inbound_links))``, where ``norm(x) = x / max(x across
+    all pages)`` (0 when the max is 0). ``w_reference`` is reserved /
+    not yet computed — no explicit-reference signal exists yet, so it
+    defaults to 0 and is omitted from the formula entirely rather than
+    multiplied against an all-zero signal. See
+    ``skills/garden/tools.py::compute_importance_scores``.
     """
     w_retrieval: float = 0.6
     w_inbound: float = 0.4

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -456,7 +456,8 @@ class LoopBreakerConfig:
 
 @dataclass
 class TelemetryConfig:
-    """Instrumentation sidecars (#310 tool usage, #409 reflection metrics).
+    """Instrumentation sidecars (#310 tool usage, #409 reflection metrics,
+    #197 retrieval telemetry).
 
     Append-only JSONL under ``workspace/``, metadata only — never tool
     args/returns, reflection response bodies, or prompt contents; only
@@ -465,12 +466,14 @@ class TelemetryConfig:
     never break a turn. Paths are workspace-relative. Enabled by default
     so a deployed agent starts collecting without a config edit — the
     point is a week of real data. No rotation yet (append-only); retention
-    is a follow-up. See docs/tools.md and docs/reflection.md.
+    is a follow-up. See docs/tools.md, docs/reflection.md, and docs/vault.md.
     """
     tool_usage_enabled: bool = True
     tool_usage_path: str = "tool_usage.jsonl"
     reflection_metrics_enabled: bool = True
     reflection_metrics_path: str = "reflection/metrics.jsonl"
+    retrieval_enabled: bool = True
+    retrieval_path: str = "telemetry/retrieval.jsonl"
 
 
 def is_secret(dc_class: type, field_name: str) -> bool:

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -709,6 +709,7 @@ class ContextComposer:
             # Score and rank candidates
             total_candidates = len(results)
             results = self._score_candidates(results, config)
+            all_scored = list(results)  # full scored list, before threshold/budget drops
 
             # Drop candidates below minimum score threshold
             score_threshold = config.relevance.min_composite_score
@@ -726,6 +727,38 @@ class ContextComposer:
                           len(results), total_candidates,
                           results[0].get("composite_score", 0),
                           results[-1].get("composite_score", 0))
+
+            # Retrieval-event telemetry (#197 Phase 0): publish the full
+            # scored candidate list — not just what got injected — tagged
+            # with include/drop verdicts. Fail-open: telemetry must never
+            # break retrieval.
+            try:
+                survived_paths = {r.get("file_path", "") for r in results}
+                candidates_payload = []
+                for c in all_scored:
+                    path = c.get("file_path", "")
+                    included = path in survived_paths
+                    if included:
+                        drop_reason = None
+                    elif c.get("composite_score", 0) < score_threshold:
+                        drop_reason = "score"
+                    else:
+                        drop_reason = "budget"
+                    candidates_payload.append({
+                        "file_path": path,
+                        "source_type": c.get("source_type", ""),
+                        "similarity": c.get("similarity", 0.0),
+                        "recency": c.get("recency", 0.0),
+                        "importance": c.get("importance", 0.0),
+                        "composite_score": c.get("composite_score", 0.0),
+                        "included": included,
+                        "drop_reason": drop_reason,
+                    })
+                await ctx.publish(
+                    "retrieval_event", conv_id=ctx.conv_id, candidates=candidates_payload,
+                )
+            except Exception as exc:
+                log.debug("Retrieval telemetry emit failed: %s", exc)
 
             # Compute per-candidate token estimates for diagnostics
             for r in results:

--- a/src/decafclaw/retrieval_telemetry.py
+++ b/src/decafclaw/retrieval_telemetry.py
@@ -1,0 +1,225 @@
+"""Retrieval-event telemetry (#197 Phase 0 — measurement foundation for the
+self-improving vault arc).
+
+A fail-open EventBus subscriber that appends one JSONL record per
+``retrieval_event`` to ``{workspace}/telemetry/retrieval.jsonl`` (path/enable
+via ``config.telemetry``). Each event carries the *full* scored candidate
+list considered during a turn's memory retrieval — not just what got
+injected — tagged with an ``included`` verdict and, for dropped candidates,
+a ``drop_reason`` (``"score"`` for below the composite-score threshold,
+``"budget"`` for trimmed by the token budget). Published once per
+interactive turn from ``ContextComposer._compose_vault_retrieval``.
+
+This is Phase 0 of #197: later phases (notably Phase 5's importance
+formula) consume the aggregated form of this stream to learn which vault
+pages are actually useful versus dead weight.
+
+``make retrieval-report`` (``python -m decafclaw.retrieval_telemetry``)
+aggregates per-page retrieval/include/drop counts alongside a point-in-time
+vault-health snapshot (frontmatter coverage).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _retrieval_path(config) -> Path:
+    return config.workspace_path / config.telemetry.retrieval_path
+
+
+def record_from_event(event: dict) -> dict:
+    """Build a telemetry record from a ``retrieval_event`` event."""
+    return {
+        "timestamp": _now_iso(),
+        "conv_id": event.get("conv_id", ""),
+        "candidates": event.get("candidates", []),
+    }
+
+
+def append_record(config, record: dict) -> None:
+    """Append one record as JSONL. Fail-open — never propagates."""
+    try:
+        path = _retrieval_path(config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:  # fail-open: telemetry must never break a turn
+        log.debug("retrieval telemetry write failed: %s", exc)
+
+
+def make_retrieval_telemetry_subscriber(config) -> Callable[[dict], Awaitable[None]]:
+    """EventBus subscriber: records each ``retrieval_event`` event. Fail-open."""
+    async def handle(event: dict) -> None:
+        try:
+            if event.get("type") != "retrieval_event":
+                return
+            append_record(config, record_from_event(event))
+        except Exception as exc:  # fail-open
+            log.debug("retrieval telemetry subscriber error: %s", exc)
+
+    return handle
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def load_records(config) -> list[dict]:
+    path = _retrieval_path(config)
+    if not path.exists():
+        return []
+    records = []
+    # Stream line-by-line — the log is append-only and unrotated, so avoid
+    # materializing the whole file as one string + a splitlines list.
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def aggregate(records: list[dict]) -> dict[str, dict]:
+    """Aggregate per-page stats: retrieval_count, include_count, drop-by-reason.
+
+    ``retrieval_count`` is how many times a page appeared as a scored
+    candidate (whether or not it survived); ``include_count`` is how many
+    of those it actually survived the score threshold and budget trim.
+    """
+    retrieval_count: dict[str, int] = defaultdict(int)
+    include_count: dict[str, int] = defaultdict(int)
+    drop_score: dict[str, int] = defaultdict(int)
+    drop_budget: dict[str, int] = defaultdict(int)
+    source_type: dict[str, str] = {}
+    for r in records:
+        for c in r.get("candidates", []):
+            path = c.get("file_path", "")
+            if not path:
+                continue
+            retrieval_count[path] += 1
+            source_type.setdefault(path, c.get("source_type", ""))
+            if c.get("included"):
+                include_count[path] += 1
+            else:
+                reason = c.get("drop_reason")
+                if reason == "score":
+                    drop_score[path] += 1
+                elif reason == "budget":
+                    drop_budget[path] += 1
+    stats = {}
+    for path in retrieval_count:
+        n = retrieval_count[path]
+        stats[path] = {
+            "retrieval_count": n,
+            "include_count": include_count[path],
+            "include_rate": include_count[path] / n if n else 0.0,
+            "drop_score": drop_score[path],
+            "drop_budget": drop_budget[path],
+            "source_type": source_type.get(path, ""),
+        }
+    return stats
+
+
+def vault_health(config) -> dict:
+    """Point-in-time vault-health snapshot: frontmatter coverage.
+
+    Reads pages directly from the vault (not the telemetry log) and
+    counts how many carry an ``importance`` frontmatter field versus not.
+    ``orphans`` here means "pages with no importance frontmatter" —
+    disconnected from the importance-driven scoring the later phases of
+    #197 build on top of this stream — not graph-link orphans.
+    Fail-open: a missing/unreadable vault returns zeros.
+    """
+    from .frontmatter import parse_frontmatter
+
+    try:
+        vault = config.vault_root
+        if not vault.is_dir():
+            return {"total_pages": 0, "with_importance": 0, "coverage_pct": 0.0, "orphans": 0}
+
+        journal_dir = config.vault_agent_journal_dir
+        total = 0
+        with_importance = 0
+        for filepath in vault.rglob("*.md"):
+            try:
+                if filepath.resolve().is_relative_to(journal_dir.resolve()):
+                    continue
+            except (ValueError, OSError):
+                pass
+            try:
+                text = filepath.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            metadata, _ = parse_frontmatter(text)
+            total += 1
+            if metadata.get("importance") is not None:
+                with_importance += 1
+
+        coverage_pct = (with_importance / total * 100) if total else 0.0
+        return {
+            "total_pages": total,
+            "with_importance": with_importance,
+            "coverage_pct": coverage_pct,
+            "orphans": total - with_importance,
+        }
+    except Exception as exc:  # fail-open
+        log.debug("vault health snapshot failed: %s", exc)
+        return {"total_pages": 0, "with_importance": 0, "coverage_pct": 0.0, "orphans": 0}
+
+
+def format_report(stats: dict[str, dict], health: dict) -> str:
+    lines = ["# Retrieval telemetry report", ""]
+    total = sum(s["retrieval_count"] for s in stats.values())
+    lines.append(f"Total candidate appearances: {total} across {len(stats)} pages")
+    lines.append("")
+    lines.append(
+        f"{'file_path':<40} {'retrieved':>9} {'included':>9} {'inc%':>6} "
+        f"{'drop-score':>10} {'drop-budget':>11}"
+    )
+    lines.append("-" * 90)
+    for path, s in sorted(stats.items(), key=lambda kv: kv[1]["retrieval_count"], reverse=True):
+        lines.append(
+            f"{path:<40} {s['retrieval_count']:>9} {s['include_count']:>9} "
+            f"{s['include_rate'] * 100:>5.0f}% {s['drop_score']:>10} {s['drop_budget']:>11}"
+        )
+    lines.append("")
+    lines.append("## Vault health")
+    lines.append(f"  Pages: {health['total_pages']}")
+    lines.append(
+        f"  With importance frontmatter: {health['with_importance']} "
+        f"({health['coverage_pct']:.0f}%)"
+    )
+    lines.append(f"  Orphans (no importance frontmatter): {health['orphans']}")
+    return "\n".join(lines)
+
+
+def build_report(config) -> str:
+    records = load_records(config)
+    stats = aggregate(records)
+    health = vault_health(config)
+    return format_report(stats, health)
+
+
+def main() -> None:
+    from .config import load_config
+    config = load_config()
+    print(build_report(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decafclaw/retrieval_telemetry.py
+++ b/src/decafclaw/retrieval_telemetry.py
@@ -135,26 +135,45 @@ def aggregate(records: list[dict]) -> dict[str, dict]:
     return stats
 
 
-def vault_health(config) -> dict:
-    """Point-in-time vault-health snapshot: frontmatter coverage.
+def _empty_vault_health() -> dict:
+    return {
+        "total_pages": 0,
+        "with_importance": 0,
+        "coverage_pct": 0.0,
+        "missing_importance": 0,
+        "graph_orphans": 0,
+    }
 
-    Reads pages directly from the vault (not the telemetry log) and
-    counts how many carry an ``importance`` frontmatter field versus not.
-    ``orphans`` here means "pages with no importance frontmatter" —
-    disconnected from the importance-driven scoring the later phases of
-    #197 build on top of this stream — not graph-link orphans.
+
+def vault_health(config) -> dict:
+    """Point-in-time vault-health snapshot: frontmatter coverage + graph orphans.
+
+    Reads pages directly from the vault (not the telemetry log). Two
+    distinct metrics, easy to conflate (#197 P0-M2 — the original
+    ``orphans`` name below was misleading):
+
+    - ``missing_importance``: pages with no ``importance`` frontmatter
+      field. Feeds importance-coverage tracking, not the link graph.
+    - ``graph_orphans``: pages with zero inbound ``[[wiki-links]]``, per
+      the persistent backlink index (``backlinks.load_index``). This is
+      the genuine graph-orphan count that Phase 5's importance formula
+      also treats as a low-importance signal.
+
     Fail-open: a missing/unreadable vault returns zeros.
     """
+    from .backlinks import load_index
     from .frontmatter import parse_frontmatter
 
     try:
         vault = config.vault_root
         if not vault.is_dir():
-            return {"total_pages": 0, "with_importance": 0, "coverage_pct": 0.0, "orphans": 0}
+            return _empty_vault_health()
 
         journal_dir = config.vault_agent_journal_dir
+        backlink_index = load_index(config)
         total = 0
         with_importance = 0
+        graph_orphans = 0
         for filepath in vault.rglob("*.md"):
             try:
                 if filepath.resolve().is_relative_to(journal_dir.resolve()):
@@ -169,17 +188,21 @@ def vault_health(config) -> dict:
             total += 1
             if metadata.get("importance") is not None:
                 with_importance += 1
+            rel = filepath.relative_to(vault).as_posix()
+            if not backlink_index.get(rel):
+                graph_orphans += 1
 
         coverage_pct = (with_importance / total * 100) if total else 0.0
         return {
             "total_pages": total,
             "with_importance": with_importance,
             "coverage_pct": coverage_pct,
-            "orphans": total - with_importance,
+            "missing_importance": total - with_importance,
+            "graph_orphans": graph_orphans,
         }
     except Exception as exc:  # fail-open
         log.debug("vault health snapshot failed: %s", exc)
-        return {"total_pages": 0, "with_importance": 0, "coverage_pct": 0.0, "orphans": 0}
+        return _empty_vault_health()
 
 
 def format_report(stats: dict[str, dict], health: dict) -> str:
@@ -204,7 +227,8 @@ def format_report(stats: dict[str, dict], health: dict) -> str:
         f"  With importance frontmatter: {health['with_importance']} "
         f"({health['coverage_pct']:.0f}%)"
     )
-    lines.append(f"  Orphans (no importance frontmatter): {health['orphans']}")
+    lines.append(f"  Missing importance frontmatter: {health['missing_importance']}")
+    lines.append(f"  Graph orphans (zero inbound links): {health['graph_orphans']}")
     return "\n".join(lines)
 
 

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -106,6 +106,11 @@ async def run_all(app_ctx):
             app_ctx.event_bus.subscribe(make_reflection_metrics_subscriber(config))
             log.info("Telemetry: reflection-metrics subscriber active (%s)",
                      config.telemetry.reflection_metrics_path)
+        if config.telemetry.retrieval_enabled:
+            from .retrieval_telemetry import make_retrieval_telemetry_subscriber
+            app_ctx.event_bus.subscribe(make_retrieval_telemetry_subscriber(config))
+            log.info("Telemetry: retrieval subscriber active (%s)",
+                     config.telemetry.retrieval_path)
 
         # Start heartbeat timer
         if parse_interval(config.heartbeat.interval) is not None:

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -94,6 +94,13 @@ async def run_all(app_ctx):
             mm_client=mm_client,
         )
 
+        # Wire the persistent backlink index (#197 Phase 4): incrementally
+        # updates {workspace}/backlinks.json on every vault_changed event
+        # instead of brute-force rescanning the vault on each query.
+        # Fail-open — never propagates into the publishing turn.
+        from .backlinks import make_backlinks_subscriber
+        app_ctx.event_bus.subscribe(make_backlinks_subscriber(config))
+
         # Wire telemetry subscribers (measurement only, fail-open). Each
         # records to an append-only JSONL sidecar under workspace/.
         if config.telemetry.tool_usage_enabled:

--- a/src/decafclaw/skills/dream/SKILL.md
+++ b/src/decafclaw/skills/dream/SKILL.md
@@ -49,6 +49,12 @@ For each finding from the gather phase:
    - `vault_write` the new page
 4. Convert any relative dates ("yesterday", "last week") to absolute dates.
 5. For pages that have grown longer than ~20 lines, add or update a `> tl;dr:` summary blockquote after the title.
+6. After `vault_write`, call `vault_update_frontmatter(page, fields, overwrite=False)` on the same page to fill in metadata:
+   - `summary` — one sentence describing what the page covers.
+   - `keywords` — a short list of terms someone would search for.
+   - `tags` — a short list of topical tags.
+   - `importance` — a float 0–1. Score higher for pages that consolidate many journal entries or sit central to the wiki-link graph; score lower for a page capturing a single passing note.
+   - `overwrite=False` respects fields a human already set by hand — never clobber manually-curated frontmatter, even though the tool already enforces this.
 
 ## Phase 4: Prune
 

--- a/src/decafclaw/skills/garden/SKILL.md
+++ b/src/decafclaw/skills/garden/SKILL.md
@@ -54,6 +54,14 @@ Perform a holistic maintenance pass over your agent pages in the vault. This is 
 - For each orphan, find related pages and add links to it.
 - If a page is truly disconnected and has little value, note it for review.
 
+## Step 8: Recompute Importance Scores
+
+- Call `vault_recompute_importance` to deterministically refresh every vault page's `importance` frontmatter from measured signals (retrieval frequency, inbound-link count) — not a fresh guess.
+- Review the reported deltas for outliers: a page that jumped or dropped sharply is worth a second look, since it usually means the retrieval or link graph shifted, not that the page itself changed.
+- Spot-check frontmatter consistency on a few pages while you're in there — `summary`/`keywords`/`tags` that no longer match the body content.
+- Flag pages that are both orphaned (zero inbound links via `vault_backlinks`) and rarely retrieved (low importance after recompute) — these are strong split/merge/delete candidates for a future pass, not something to act on unilaterally.
+- Also flag weakly-linked pages (one or two thin connections) as candidates for Step 4's "add missing connections" work next time around.
+
 ## Finishing Up
 
 End with a short narrative summary of what you tidied: pages merged, links fixed, summaries added, etc. If the vault was already in good shape and nothing needed attention, begin your summary with `HEARTBEAT_OK` on its own line followed by a brief quiet-cycle note — the leading marker lets the scheduler log a tidy line, and the narrative keeps the archive readable for the newsletter.

--- a/src/decafclaw/skills/garden/SKILL.md
+++ b/src/decafclaw/skills/garden/SKILL.md
@@ -56,7 +56,8 @@ Perform a holistic maintenance pass over your agent pages in the vault. This is 
 
 ## Step 8: Recompute Importance Scores
 
-- Call `vault_recompute_importance` to deterministically refresh every vault page's `importance` frontmatter from measured signals (retrieval frequency, inbound-link count) — not a fresh guess.
+- Call `vault_recompute_importance` to deterministically refresh every agent page's `importance` frontmatter from measured signals (retrieval frequency, inbound-link count) — not a fresh guess. Scoped to `agent/` pages only, in keeping with this skill's charter — it never touches the user's own vault pages.
+- Pages with no measured signal yet (new pages, or pages nobody has retrieved or linked to) are left untouched rather than zeroed — any existing importance (e.g. dream's initial guess) stays put until real signal accumulates.
 - Review the reported deltas for outliers: a page that jumped or dropped sharply is worth a second look, since it usually means the retrieval or link graph shifted, not that the page itself changed.
 - Spot-check frontmatter consistency on a few pages while you're in there — `summary`/`keywords`/`tags` that no longer match the body content.
 - Flag pages that are both orphaned (zero inbound links via `vault_backlinks`) and rarely retrieved (low importance after recompute) — these are strong split/merge/delete candidates for a future pass, not something to act on unilaterally.

--- a/src/decafclaw/skills/garden/tools.py
+++ b/src/decafclaw/skills/garden/tools.py
@@ -9,9 +9,12 @@ produce the same score, so `compute_importance_scores` is pure and unit
 testable without a running agent.
 
 `tool_vault_recompute_importance` is the thin async wrapper garden calls
-during its weekly sweep: it scores every non-journal vault page, writes
-changed scores via `vault_update_frontmatter(overwrite=True)`, and skips
-pages whose rounded score didn't change.
+during its weekly sweep: it scores every `agent/` page (this automated
+sweep is scoped to the agent's own folder — never the user's own vault
+pages elsewhere, per garden's charter), writes changed scores via
+`vault_update_frontmatter(overwrite=True)`, and skips pages whose rounded
+score didn't change or that have no measured signal at all yet (leaving
+any existing importance, e.g. dream's initial guess, untouched).
 """
 
 from __future__ import annotations
@@ -34,26 +37,25 @@ _SCORE_PRECISION = 3
 
 
 def _iter_importance_candidates(config) -> list[tuple[str, Path]]:
-    """List (vault-relative POSIX path, Path) for every scoreable vault page.
+    """List (vault-relative POSIX path, Path) for every scoreable agent page.
 
-    Mirrors the walk in `embeddings._iter_vault_pages` /
-    `backfill_frontmatter._iter_frontmatter_candidates`: every vault `.md`
-    file except journal entries (journal is episodic, not curated
-    knowledge — it never carries an `importance` field).
+    Scoped to `config.vault_agent_pages_dir` only — garden's charter is
+    "only read and write within `agent/`", and this sweep runs weekly,
+    non-interactively, with no human in the loop. Writing `importance`
+    frontmatter into the user's own hand-written pages elsewhere in the
+    vault would be unattended and ungated (#197 whole-branch review). The
+    `vault_update_frontmatter` tool itself keeps its vault-wide reach —
+    only this automated sweep is scoped down. `agent/journal` is a sibling
+    of `agent/pages`, so it's naturally excluded without extra filtering.
     """
-    vault = config.vault_root
-    if not vault.is_dir():
+    pages_dir = config.vault_agent_pages_dir
+    if not pages_dir.is_dir():
         return []
-    journal_dir = config.vault_agent_journal_dir
-    candidates: list[tuple[str, Path]] = []
-    for path in sorted(vault.rglob("*.md")):
-        try:
-            if path.resolve().is_relative_to(journal_dir.resolve()):
-                continue
-        except (ValueError, OSError):
-            pass
-        candidates.append((path.relative_to(vault).as_posix(), path))
-    return candidates
+    vault = config.vault_root
+    return [
+        (path.relative_to(vault).as_posix(), path)
+        for path in sorted(pages_dir.rglob("*.md"))
+    ]
 
 
 def _clamp01(value: float) -> float:
@@ -65,13 +67,31 @@ def _norm(value: float, max_value: float) -> float:
     return value / max_value if max_value > 0 else 0.0
 
 
+def compute_importance_signals(config) -> dict[str, tuple[int, int]]:
+    """Raw (retrieval_count, inbound_count) per scoreable agent page.
+
+    Exposed separately from `compute_importance_scores` so the recompute
+    write path can tell "genuinely low importance" apart from "no
+    measured signal at all yet" — a page with zero on both counts hasn't
+    been observed by the system, so its computed score is an artifact of
+    absence, not a judgment, and shouldn't overwrite an existing
+    importance value (#197 whole-branch review).
+    """
+    pages = [rel for rel, _ in _iter_importance_candidates(config)]
+    stats = retrieval_telemetry.aggregate(retrieval_telemetry.load_records(config))
+    return {
+        p: (stats.get(p, {}).get("retrieval_count", 0), backlinks.inbound_count(config, p))
+        for p in pages
+    }
+
+
 def compute_importance_scores(config) -> dict[str, float]:
     """Deterministic per-page importance score (#197 Phase 5, formula v1).
 
     ``importance = clamp01(w_retrieval * norm(retrieval_freq) +
     w_inbound * norm(inbound_links))``
 
-    ``norm(x) = x / max(x across all vault pages)``, defined as 0 when
+    ``norm(x) = x / max(x across all agent pages)``, defined as 0 when
     that max is 0. Weights come from ``config.importance``
     (``ImportanceConfig``). ``w_reference`` is reserved / not yet
     computed — no explicit-reference signal exists yet, so it defaults
@@ -80,15 +100,12 @@ def compute_importance_scores(config) -> dict[str, float]:
 
     Pure and config-driven: no ``ctx``, no I/O beyond reading the
     telemetry log, the backlink index, and vault page paths (never page
-    contents). Returns ``{}`` if the vault has no non-journal pages.
+    contents). Returns ``{}`` if the agent has no pages.
     """
     weights = config.importance
-    candidates = _iter_importance_candidates(config)
-    pages = [rel for rel, _ in candidates]
-
-    stats = retrieval_telemetry.aggregate(retrieval_telemetry.load_records(config))
-    retrieval_freq = {p: stats.get(p, {}).get("retrieval_count", 0) for p in pages}
-    inbound_links = {p: backlinks.inbound_count(config, p) for p in pages}
+    signals = compute_importance_signals(config)
+    retrieval_freq = {p: rc for p, (rc, _ic) in signals.items()}
+    inbound_links = {p: ic for p, (_rc, ic) in signals.items()}
 
     max_retrieval = max(retrieval_freq.values(), default=0)
     max_inbound = max(inbound_links.values(), default=0)
@@ -98,25 +115,35 @@ def compute_importance_scores(config) -> dict[str, float]:
             weights.w_retrieval * _norm(retrieval_freq[p], max_retrieval)
             + weights.w_inbound * _norm(inbound_links[p], max_inbound)
         )
-        for p in pages
+        for p in signals
     }
 
 
 async def tool_vault_recompute_importance(ctx, dry_run: bool = False) -> ToolResult:
-    """Recompute every vault page's importance score deterministically.
+    """Recompute every agent page's importance score deterministically.
 
     Scores come from `compute_importance_scores` (retrieval frequency +
-    inbound-link count — not an LLM's subjective judgment). Pages whose
-    rounded score is unchanged are skipped, so a re-run only touches
-    pages that actually moved. `dry_run=True` reports the planned deltas
-    without writing anything.
+    inbound-link count — not an LLM's subjective judgment), scoped to
+    `agent/` pages only. Pages whose rounded score is unchanged are
+    skipped, so a re-run only touches pages that actually moved. Pages
+    with zero measured signal (no retrieval, no inbound links) are also
+    skipped — that's absence of data, not a computed low score, so any
+    existing importance (e.g. dream's initial guess) is left intact
+    rather than zeroed. `dry_run=True` reports the planned deltas without
+    writing anything.
     """
     log.info(f"[tool:vault_recompute_importance] dry_run={dry_run}")
     scores = compute_importance_scores(ctx.config)
+    signals = compute_importance_signals(ctx.config)
 
     deltas: list[dict] = []
     written = 0
     for rel, new_score in sorted(scores.items()):
+        retrieval_count, inbound_count = signals.get(rel, (0, 0))
+        if retrieval_count == 0 and inbound_count == 0:
+            # No measured signal at all — leave existing importance alone.
+            continue
+
         path = ctx.config.vault_root / rel
         try:
             text = path.read_text(encoding="utf-8")
@@ -172,11 +199,12 @@ TOOL_DEFINITIONS = [
         "function": {
             "name": "vault_recompute_importance",
             "description": (
-                "Deterministically recompute every vault page's `importance` "
+                "Deterministically recompute every agent page's `importance` "
                 "frontmatter score from measured signals (retrieval frequency, "
-                "inbound-link count) — not an LLM judgment call. Weekly garden "
-                "maintenance step. Set dry_run=true to preview planned changes "
-                "without writing."
+                "inbound-link count) — not an LLM judgment call. Scoped to "
+                "agent/ pages only; never touches the user's own vault pages. "
+                "Weekly garden maintenance step. Set dry_run=true to preview "
+                "planned changes without writing."
             ),
             "parameters": {
                 "type": "object",

--- a/src/decafclaw/skills/garden/tools.py
+++ b/src/decafclaw/skills/garden/tools.py
@@ -69,13 +69,14 @@ def compute_importance_scores(config) -> dict[str, float]:
     """Deterministic per-page importance score (#197 Phase 5, formula v1).
 
     ``importance = clamp01(w_retrieval * norm(retrieval_freq) +
-    w_inbound * norm(inbound_links) + w_reference * norm(reference_signal))``
+    w_inbound * norm(inbound_links))``
 
     ``norm(x) = x / max(x across all vault pages)``, defined as 0 when
     that max is 0. Weights come from ``config.importance``
-    (``ImportanceConfig``). ``w_reference`` defaults to 0 — no explicit-
-    reference signal exists yet, so that term is omitted from the sum
-    entirely rather than computed against an all-zero signal.
+    (``ImportanceConfig``). ``w_reference`` is reserved / not yet
+    computed — no explicit-reference signal exists yet, so it defaults
+    to 0 and that term is omitted from the sum entirely rather than
+    computed against an all-zero signal.
 
     Pure and config-driven: no ``ctx``, no I/O beyond reading the
     telemetry log, the backlink index, and vault page paths (never page

--- a/src/decafclaw/skills/garden/tools.py
+++ b/src/decafclaw/skills/garden/tools.py
@@ -1,0 +1,195 @@
+"""Garden skill tools — deterministic importance recompute (#197 Phase 5).
+
+Vault-page `importance` frontmatter starts out as an LLM's subjective guess
+(backfill, dream generation). This module replaces that guess on a weekly
+cadence with a deterministic score driven by two measured signals:
+retrieval frequency (`retrieval_telemetry`, Phase 0) and inbound-link count
+(`backlinks`, Phase 4). No LLM call, no randomness — same inputs always
+produce the same score, so `compute_importance_scores` is pure and unit
+testable without a running agent.
+
+`tool_vault_recompute_importance` is the thin async wrapper garden calls
+during its weekly sweep: it scores every non-journal vault page, writes
+changed scores via `vault_update_frontmatter(overwrite=True)`, and skips
+pages whose rounded score didn't change.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import cast
+
+from decafclaw import backlinks, retrieval_telemetry
+from decafclaw.frontmatter import get_frontmatter_field, parse_frontmatter
+from decafclaw.media import ToolResult
+from decafclaw.skills.vault.tools import tool_vault_update_frontmatter
+
+log = logging.getLogger(__name__)
+
+# Rounding precision for written scores and the unchanged-skip comparison.
+# Three decimal places is plenty of resolution for a 0..1 importance score
+# and avoids rewriting a page for float noise between runs.
+_SCORE_PRECISION = 3
+
+
+def _iter_importance_candidates(config) -> list[tuple[str, Path]]:
+    """List (vault-relative POSIX path, Path) for every scoreable vault page.
+
+    Mirrors the walk in `embeddings._iter_vault_pages` /
+    `backfill_frontmatter._iter_frontmatter_candidates`: every vault `.md`
+    file except journal entries (journal is episodic, not curated
+    knowledge — it never carries an `importance` field).
+    """
+    vault = config.vault_root
+    if not vault.is_dir():
+        return []
+    journal_dir = config.vault_agent_journal_dir
+    candidates: list[tuple[str, Path]] = []
+    for path in sorted(vault.rglob("*.md")):
+        try:
+            if path.resolve().is_relative_to(journal_dir.resolve()):
+                continue
+        except (ValueError, OSError):
+            pass
+        candidates.append((path.relative_to(vault).as_posix(), path))
+    return candidates
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _norm(value: float, max_value: float) -> float:
+    """value / max_value, or 0.0 when max_value is 0 (no divide-by-zero)."""
+    return value / max_value if max_value > 0 else 0.0
+
+
+def compute_importance_scores(config) -> dict[str, float]:
+    """Deterministic per-page importance score (#197 Phase 5, formula v1).
+
+    ``importance = clamp01(w_retrieval * norm(retrieval_freq) +
+    w_inbound * norm(inbound_links) + w_reference * norm(reference_signal))``
+
+    ``norm(x) = x / max(x across all vault pages)``, defined as 0 when
+    that max is 0. Weights come from ``config.importance``
+    (``ImportanceConfig``). ``w_reference`` defaults to 0 — no explicit-
+    reference signal exists yet, so that term is omitted from the sum
+    entirely rather than computed against an all-zero signal.
+
+    Pure and config-driven: no ``ctx``, no I/O beyond reading the
+    telemetry log, the backlink index, and vault page paths (never page
+    contents). Returns ``{}`` if the vault has no non-journal pages.
+    """
+    weights = config.importance
+    candidates = _iter_importance_candidates(config)
+    pages = [rel for rel, _ in candidates]
+
+    stats = retrieval_telemetry.aggregate(retrieval_telemetry.load_records(config))
+    retrieval_freq = {p: stats.get(p, {}).get("retrieval_count", 0) for p in pages}
+    inbound_links = {p: backlinks.inbound_count(config, p) for p in pages}
+
+    max_retrieval = max(retrieval_freq.values(), default=0)
+    max_inbound = max(inbound_links.values(), default=0)
+
+    return {
+        p: _clamp01(
+            weights.w_retrieval * _norm(retrieval_freq[p], max_retrieval)
+            + weights.w_inbound * _norm(inbound_links[p], max_inbound)
+        )
+        for p in pages
+    }
+
+
+async def tool_vault_recompute_importance(ctx, dry_run: bool = False) -> ToolResult:
+    """Recompute every vault page's importance score deterministically.
+
+    Scores come from `compute_importance_scores` (retrieval frequency +
+    inbound-link count — not an LLM's subjective judgment). Pages whose
+    rounded score is unchanged are skipped, so a re-run only touches
+    pages that actually moved. `dry_run=True` reports the planned deltas
+    without writing anything.
+    """
+    log.info(f"[tool:vault_recompute_importance] dry_run={dry_run}")
+    scores = compute_importance_scores(ctx.config)
+
+    deltas: list[dict] = []
+    written = 0
+    for rel, new_score in sorted(scores.items()):
+        path = ctx.config.vault_root / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            log.debug(f"vault_recompute_importance: could not read {rel}: {exc}")
+            continue
+
+        metadata, _ = parse_frontmatter(text)
+        # get_frontmatter_field's declared return type is a broad union
+        # across all frontmatter fields; for "importance" it's always
+        # float|None at runtime (get_frontmatter_field clamps it).
+        old_score = cast("float | None", get_frontmatter_field(metadata, "importance"))
+        new_rounded = round(new_score, _SCORE_PRECISION)
+        if old_score is not None and round(old_score, _SCORE_PRECISION) == new_rounded:
+            continue
+
+        deltas.append({"path": rel, "old": old_score, "new": new_rounded})
+        if dry_run:
+            continue
+
+        result = await tool_vault_update_frontmatter(
+            ctx, rel, {"importance": new_rounded}, overwrite=True,
+        )
+        if result.text.startswith("[error:"):
+            log.warning(
+                f"vault_recompute_importance: failed to write {rel}: {result.text}"
+            )
+            continue
+        written += 1
+
+    if dry_run:
+        text = (
+            f"Dry run: {len(deltas)} of {len(scores)} scored page(s) "
+            f"would change importance."
+        )
+    else:
+        text = (
+            f"Recomputed importance for {len(scores)} page(s): "
+            f"{written} updated, {len(scores) - written} unchanged."
+        )
+    return ToolResult(text=text, data={"deltas": deltas, "dry_run": dry_run})
+
+
+# -- Registry ---------------------------------------------------------------
+
+TOOLS = {
+    "vault_recompute_importance": tool_vault_recompute_importance,
+}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_recompute_importance",
+            "description": (
+                "Deterministically recompute every vault page's `importance` "
+                "frontmatter score from measured signals (retrieval frequency, "
+                "inbound-link count) — not an LLM judgment call. Weekly garden "
+                "maintenance step. Set dry_run=true to preview planned changes "
+                "without writing."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, report planned importance changes without "
+                            "writing them. Default false."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+]

--- a/src/decafclaw/skills/vault/SKILL.md
+++ b/src/decafclaw/skills/vault/SKILL.md
@@ -49,7 +49,8 @@ Your files live under `agent/` in the vault:
 - Use `vault_read` before `vault_write` when updating existing pages — `vault_write` overwrites the entire page.
 - `vault_rename` renames or moves an existing page (updates the embedding index). Prefer it over delete + rewrite when the content stays the same.
 - `vault_delete` permanently removes a page. Only for pages that are definitively wrong, duplicate, or no longer reachable — prefer editing over deleting when the page can be salvaged. Pages outside `agent/` will trigger a user confirmation.
-- User pages outside `agent/` are writable on explicit user request. Each `vault_write` / `vault_delete` / `vault_rename` triggers a user confirmation. For batch operations (3+ pages in the same folder), call `vault_grant_folder` first to trust the folder for the rest of the conversation and skip per-page confirmations.
+- `vault_update_frontmatter` merges metadata fields (summary, keywords, tags, importance) into a page without touching the body. Pages outside `agent/` will trigger a user confirmation in interactive conversations; scheduled maintenance (dream/garden) can update frontmatter vault-wide without confirmation since it can't prompt.
+- User pages outside `agent/` are writable on explicit user request. Each `vault_write` / `vault_delete` / `vault_rename` / `vault_update_frontmatter` triggers a user confirmation. For batch operations (3+ pages in the same folder), call `vault_grant_folder` first to trust the folder for the rest of the conversation and skip per-page confirmations.
 
 ## Editing Sections
 

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -249,6 +249,17 @@ def _format_vault_delete_preview(config, path: Path) -> str:
     )
 
 
+def _format_vault_update_frontmatter_preview(
+    config, path: Path, fields: dict,
+) -> str:
+    """Confirmation preview for vault_update_frontmatter."""
+    try:
+        rel = str(path.resolve().relative_to(config.vault_root.resolve()))
+    except ValueError:
+        rel = path.name
+    return f"Vault frontmatter update to: {rel}\nFields: {', '.join(sorted(fields))}"
+
+
 def _format_vault_rename_preview(config, old_path: Path, new_path: Path) -> str:
     """Confirmation preview for vault_rename. Shows both paths."""
     def _rel(p: Path) -> str:
@@ -1169,11 +1180,37 @@ async def tool_vault_update_frontmatter(
     ctx, page: str, fields: dict, overwrite: bool = False,
 ) -> ToolResult:
     """Merge frontmatter fields into a vault page (thin wrapper over
-    `merge_frontmatter`)."""
+    `merge_frontmatter`).
+
+    Interactive callers updating a user-owned page outside agent/ go through
+    the same confirmation gate as `vault_write`. Non-interactive callers
+    (scheduled dream/garden) can't prompt, so they proceed ungated — vault-
+    wide reach for scheduled maintenance is this tool's intended purpose.
+    """
     log.info(f"[tool:vault_update_frontmatter] page={page!r} overwrite={overwrite}")
     path = resolve_page(ctx.config, page)
     if path is None:
         return ToolResult(text=f"[error: vault page '{page}' not found]")
+
+    if ctx.request_confirmation is not None:
+        outcome = _check_user_write_allowed(ctx, path)
+        gate_result = await _run_gate_or_confirm(
+            ctx,
+            [outcome],
+            tool_name="vault_update_frontmatter",
+            command=f"vault_update_frontmatter on '{page}'",
+            preview=_format_vault_update_frontmatter_preview(ctx.config, path, fields),
+            non_interactive_error=(
+                f"[error: vault_update_frontmatter on '{page}' outside agent "
+                f"folder requires interactive confirmation; not available "
+                f"from this context]"
+            ),
+            denied_error=(
+                f"[error: vault_update_frontmatter on '{page}' was denied by user]"
+            ),
+        )
+        if gate_result is not None:
+            return gate_result
 
     from decafclaw.frontmatter import parse_frontmatter, serialize_frontmatter
 

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -1231,6 +1231,12 @@ async def tool_vault_update_frontmatter(
     merged = merge_frontmatter(metadata, fields, overwrite)
     changed = sorted(field for field in fields if merged.get(field) != metadata.get(field))
 
+    if not changed:
+        return ToolResult(
+            text=f"No frontmatter changes for '{page}'",
+            data={"path": page, "changed": []},
+        )
+
     path.write_text(serialize_frontmatter(merged, body), encoding="utf-8")
     await _reindex_page(ctx, path)
     await publish_vault_changed(
@@ -1238,10 +1244,7 @@ async def tool_vault_update_frontmatter(
     )
 
     return ToolResult(
-        text=(
-            f"Updated frontmatter for '{page}': {', '.join(changed)}"
-            if changed else f"No frontmatter changes for '{page}'"
-        ),
+        text=f"Updated frontmatter for '{page}': {', '.join(changed)}",
         data={"path": page, "changed": changed},
     )
 

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -1141,6 +1141,62 @@ async def _reindex_page(ctx, path: Path) -> None:
         log.warning(f"Failed to reindex vault page '{path}': {e}")
 
 
+def merge_frontmatter(existing: dict, fields: dict, overwrite: bool) -> dict:
+    """Merge coerced field values into existing frontmatter metadata.
+
+    Pure function — no ctx, no I/O — so later callers (dream generation,
+    backfill CLI, garden importance tuning) can reuse the merge logic without
+    a running agent context. Coercion mirrors `get_frontmatter_field`
+    (importance clamped to [0, 1]; tags/keywords to list[str]; summary to
+    str) so the merged result and the parser agree on shape.
+
+    When `overwrite` is False, only fields that are absent or empty in
+    `existing` are filled. When True, every field in `fields` is set,
+    replacing any existing value.
+    """
+    from decafclaw.frontmatter import get_frontmatter_field
+
+    merged = dict(existing)
+    for field, raw_value in fields.items():
+        coerced = get_frontmatter_field({field: raw_value}, field)
+        if not overwrite and merged.get(field) not in (None, "", []):
+            continue
+        merged[field] = coerced
+    return merged
+
+
+async def tool_vault_update_frontmatter(
+    ctx, page: str, fields: dict, overwrite: bool = False,
+) -> ToolResult:
+    """Merge frontmatter fields into a vault page (thin wrapper over
+    `merge_frontmatter`)."""
+    log.info(f"[tool:vault_update_frontmatter] page={page!r} overwrite={overwrite}")
+    path = resolve_page(ctx.config, page)
+    if path is None:
+        return ToolResult(text=f"[error: vault page '{page}' not found]")
+
+    from decafclaw.frontmatter import parse_frontmatter, serialize_frontmatter
+
+    content = path.read_text(encoding="utf-8")
+    metadata, body = parse_frontmatter(content)
+    merged = merge_frontmatter(metadata, fields, overwrite)
+    changed = sorted(field for field in fields if merged.get(field) != metadata.get(field))
+
+    path.write_text(serialize_frontmatter(merged, body), encoding="utf-8")
+    await _reindex_page(ctx, path)
+    await publish_vault_changed(
+        ctx.event_bus, ctx.config, kind=KIND_UPDATE, path=path,
+    )
+
+    return ToolResult(
+        text=(
+            f"Updated frontmatter for '{page}': {', '.join(changed)}"
+            if changed else f"No frontmatter changes for '{page}'"
+        ),
+        data={"path": page, "changed": changed},
+    )
+
+
 async def tool_vault_section(
     ctx,
     page: str,
@@ -1327,6 +1383,7 @@ TOOLS = {
     "vault_show_sections": tool_vault_show_sections,
     "vault_move_lines": tool_vault_move_lines,
     "vault_section": tool_vault_section,
+    "vault_update_frontmatter": tool_vault_update_frontmatter,
 }
 
 TOOL_DEFINITIONS = [
@@ -1829,6 +1886,45 @@ TOOL_DEFINITIONS = [
                     },
                 },
                 "required": ["page", "action"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_update_frontmatter",
+            "description": (
+                "Merge frontmatter fields (summary, importance, tags, keywords, "
+                "etc.) into an existing vault page. By default only fills fields "
+                "that are absent or empty — set overwrite=true to replace existing "
+                "values. Reindexes the page afterward. Does not touch the page body."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "string",
+                        "description": (
+                            "Page path relative to vault root or bare name "
+                            "(e.g. 'agent/pages/note', 'My Page')."
+                        ),
+                    },
+                    "fields": {
+                        "type": "object",
+                        "description": (
+                            "Frontmatter fields to merge, e.g. "
+                            '{"summary": "...", "importance": 0.7, "tags": ["a", "b"]}.'
+                        ),
+                    },
+                    "overwrite": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, replace existing field values. "
+                            "If false (default), only fill absent or empty fields."
+                        ),
+                    },
+                },
+                "required": ["page", "fields"],
             },
         },
     },

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -1071,37 +1071,45 @@ _WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 async def tool_vault_backlinks(ctx, page: str) -> str:
     """Find all vault pages that link to the given page via [[wiki-links]]."""
     log.info(f"[tool:vault_backlinks] page={page}")
+    from decafclaw.backlinks import _build_page_lookup, _resolve_link_target, load_index
+
     vault = _vault_root(ctx.config)
     if not vault.is_dir():
         return f"No backlinks to '{page}' (vault directory does not exist)."
 
-    page_lower = page.lower()
-    # Also match by stem for paths like "agent/pages/Foo"
-    page_stem_lower = Path(page).stem.lower()
-    results = []
+    resolved = resolve_page(ctx.config, page)
+    if resolved is None:
+        return f"No pages link to '{page}'."
+    target_rel = resolved.relative_to(vault).as_posix()
 
-    for path in sorted(vault.rglob("*.md")):
-        stem_lower = path.stem.lower()
-        if stem_lower == page_lower or stem_lower == page_stem_lower:
-            continue  # skip the page itself
-        text = path.read_text()
+    linkers = load_index(ctx.config).get(target_rel, [])
+    if not linkers:
+        return f"No pages link to '{page}'."
+
+    # Persisted index tells us WHICH pages link here; re-read just those
+    # pages (not the whole vault) to pull a one-line quote for context.
+    full_lower_map, stem_lower_map = _build_page_lookup(
+        sorted(vault.rglob("*.md")), vault)
+
+    results = []
+    for linker_rel in linkers:
+        try:
+            text = (vault / linker_rel).read_text(encoding="utf-8")
+        except OSError as exc:
+            log.debug("vault_backlinks: failed reading %s: %s", linker_rel, exc)
+            continue
+        context_line = ""
         for match in _WIKI_LINK_RE.finditer(text):
-            raw_link = match.group(1)
-            # Handle [[target|display]] — extract target before pipe
-            link = raw_link.split("|")[0].strip().lower()
-            link_stem = Path(link).stem.lower()
-            if link == page_lower or link_stem == page_stem_lower:
+            if _resolve_link_target(
+                match.group(1), full_lower_map, stem_lower_map
+            ) == target_rel:
                 line_no = text[:match.start()].count("\n")
                 lines = text.splitlines()
                 context_line = (lines[line_no].strip()[:200]
                                 if line_no < len(lines) else "")
-                rel = path.relative_to(vault)
-                results.append(
-                    f"- **{rel.with_suffix('')}**: {context_line}")
-                break  # one backlink per page
-
-    if not results:
-        return f"No pages link to '{page}'."
+                break
+        rel_display = Path(linker_rel).with_suffix("")
+        results.append(f"- **{rel_display}**: {context_line}")
 
     return f"{len(results)} page(s) link to '{page}':\n\n" + "\n".join(results)
 

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -1076,6 +1076,10 @@ async def tool_vault_backlinks(ctx, page: str) -> str:
     vault = _vault_root(ctx.config)
     if not vault.is_dir():
         return f"No backlinks to '{page}' (vault directory does not exist)."
+    # resolve_page() returns a fully-resolved path, so `vault` must be
+    # resolved too before relative_to() — otherwise a symlinked vault_root
+    # component makes relative_to() raise (fail-open swallows it silently).
+    vault = vault.resolve()
 
     resolved = resolve_page(ctx.config, page)
     if resolved is None:

--- a/tests/test_backfill_frontmatter.py
+++ b/tests/test_backfill_frontmatter.py
@@ -1,0 +1,138 @@
+"""Tests for the one-time vault-frontmatter backfill CLI (#197 Phase 3)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.backfill_frontmatter import run_backfill
+from decafclaw.frontmatter import parse_frontmatter
+
+FIXED_FIELDS = {
+    "summary": "A page about testing.",
+    "keywords": ["testing", "backfill"],
+    "tags": ["test"],
+    "importance": 0.6,
+}
+
+
+@pytest.fixture
+def agent_pages(config):
+    """Create the agent pages directory."""
+    d = config.vault_agent_pages_dir
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def patched_generate():
+    """Patch the LLM call with fixed fields — no real LLM calls in this test."""
+    with patch(
+        "decafclaw.backfill_frontmatter.generate_fields_for_page",
+        AsyncMock(return_value=dict(FIXED_FIELDS)),
+    ) as mock:
+        yield mock
+
+
+class TestRunBackfill:
+    @pytest.mark.asyncio
+    async def test_fills_bare_page_and_skips_complete_page(
+        self, config, agent_pages, patched_generate,
+    ):
+        bare = agent_pages / "bare.md"
+        bare.write_text("Body of the bare page.\n", encoding="utf-8")
+
+        complete = agent_pages / "complete.md"
+        complete.write_text(
+            "---\n"
+            "summary: Already has one.\n"
+            "keywords: [existing]\n"
+            "tags: [done]\n"
+            "importance: 0.9\n"
+            "---\n"
+            "Body of the complete page.\n",
+            encoding="utf-8",
+        )
+
+        results = await run_backfill(config)
+
+        by_path = {r["path"]: r for r in results}
+        assert by_path["agent/pages/bare.md"]["action"] == "filled"
+        assert by_path["agent/pages/complete.md"]["action"] == "skipped"
+
+        # Only the bare page triggered an LLM call.
+        patched_generate.assert_awaited_once()
+
+        meta, body = parse_frontmatter(bare.read_text(encoding="utf-8"))
+        assert meta["summary"] == FIXED_FIELDS["summary"]
+        assert meta["keywords"] == FIXED_FIELDS["keywords"]
+        assert meta["tags"] == FIXED_FIELDS["tags"]
+        assert meta["importance"] == FIXED_FIELDS["importance"]
+        assert body.strip() == "Body of the bare page."
+
+        # The already-complete page is untouched.
+        meta2, _ = parse_frontmatter(complete.read_text(encoding="utf-8"))
+        assert meta2["summary"] == "Already has one."
+
+    @pytest.mark.asyncio
+    async def test_does_not_clobber_partial_manual_frontmatter(
+        self, config, agent_pages, patched_generate,
+    ):
+        p = agent_pages / "partial.md"
+        p.write_text(
+            "---\nsummary: Hand-written summary.\n---\nBody.\n",
+            encoding="utf-8",
+        )
+
+        results = await run_backfill(config)
+
+        assert results[0]["action"] == "filled"
+        meta, _ = parse_frontmatter(p.read_text(encoding="utf-8"))
+        # Manual summary preserved; missing fields filled in.
+        assert meta["summary"] == "Hand-written summary."
+        assert meta["tags"] == FIXED_FIELDS["tags"]
+        assert meta["importance"] == FIXED_FIELDS["importance"]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self, config, agent_pages, patched_generate):
+        p = agent_pages / "bare.md"
+        original = "Body of the bare page.\n"
+        p.write_text(original, encoding="utf-8")
+
+        results = await run_backfill(config, dry_run=True)
+
+        assert results[0]["action"] == "planned"
+        assert results[0]["fields"]["summary"] == FIXED_FIELDS["summary"]
+        assert p.read_text(encoding="utf-8") == original
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_llm_calls_but_not_free_skips(
+        self, config, agent_pages, patched_generate,
+    ):
+        # Named to sort before the bare pages, so it's visited (and skipped
+        # for free) before the limit is reached.
+        (agent_pages / "aaa-complete.md").write_text(
+            "---\n"
+            "summary: s\nkeywords: [a]\ntags: [b]\nimportance: 0.5\n"
+            "---\nBody.\n",
+            encoding="utf-8",
+        )
+        (agent_pages / "bare-a.md").write_text("Body A.\n", encoding="utf-8")
+        (agent_pages / "bare-b.md").write_text("Body B.\n", encoding="utf-8")
+
+        results = await run_backfill(config, limit=1)
+
+        actions = [r["action"] for r in results]
+        assert actions.count("filled") == 1
+        assert actions.count("skipped") == 1
+        patched_generate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_journal_entries(self, config, agent_pages, patched_generate):
+        journal_dir = config.vault_agent_journal_dir
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        (journal_dir / "2026-07-23.md").write_text("## Entry\nSome text.\n", encoding="utf-8")
+
+        results = await run_backfill(config)
+
+        assert results == []
+        patched_generate.assert_not_awaited()

--- a/tests/test_backfill_frontmatter.py
+++ b/tests/test_backfill_frontmatter.py
@@ -136,3 +136,17 @@ class TestRunBackfill:
 
         assert results == []
         patched_generate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_user_pages_outside_agent(self, config, agent_pages, patched_generate):
+        # #197 whole-branch-review fix: backfill's default scope is agent/
+        # pages only — the user's own hand-written pages elsewhere in the
+        # vault must not be touched by this unattended-by-default walk.
+        user_page = config.vault_root / "user-notes.md"
+        user_page.write_text("Les's own hand-written notes.\n", encoding="utf-8")
+
+        results = await run_backfill(config)
+
+        assert results == []
+        patched_generate.assert_not_awaited()
+        assert user_page.read_text(encoding="utf-8") == "Les's own hand-written notes.\n"

--- a/tests/test_backlinks.py
+++ b/tests/test_backlinks.py
@@ -1,0 +1,235 @@
+"""Tests for the persistent backlink index (#197 Phase 4).
+
+Replaces the brute-force rglob scan in ``tool_vault_backlinks`` with a
+persistent JSON index at ``{workspace}/backlinks.json``: ``page -> [inbound
+linker pages]``. Provides ``inbound_count`` for Phase 5's importance
+formula, and an incremental ``update_for_page`` so a single edit doesn't
+require rescanning the whole vault.
+"""
+
+import json
+
+import pytest
+
+from decafclaw.backlinks import (
+    _index_path,
+    inbound_count,
+    load_index,
+    make_backlinks_subscriber,
+    rebuild_index,
+    update_for_page,
+)
+
+
+@pytest.fixture
+def vault_dir(config):
+    """Create the vault directory."""
+    d = config.vault_root
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+class TestRebuildIndex:
+    def test_builds_inbound_map(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("# A\n\nLinks to [[PageB]] and [[PageC]].")
+        (vault_dir / "PageB.md").write_text("# B\n\nLinks to [[PageC]].")
+        (vault_dir / "PageC.md").write_text("# C\n\nNo outbound links.")
+
+        index = rebuild_index(config)
+
+        assert index["PageB.md"] == ["PageA.md"]
+        assert index["PageC.md"] == ["PageA.md", "PageB.md"]
+        assert "PageA.md" not in index  # nothing links to A
+
+    def test_persists_human_readable_json(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("# A\n\nLinks to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+
+        rebuild_index(config)
+
+        path = _index_path(config)
+        assert path.exists()
+        raw = path.read_text(encoding="utf-8")
+        assert "\n" in raw  # indented, not a single-line blob
+        data = json.loads(raw)
+        assert data["PageB.md"] == ["PageA.md"]
+
+    def test_case_insensitive_link_resolution(self, config, vault_dir):
+        """A lowercase [[target]] link should still resolve to Target.md."""
+        (vault_dir / "Target.md").write_text("# Target")
+        (vault_dir / "Linker.md").write_text("See [[target]] for details.")
+
+        index = rebuild_index(config)
+
+        assert index["Target.md"] == ["Linker.md"]
+
+    def test_skips_self_links(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageA]] itself.")
+
+        index = rebuild_index(config)
+
+        assert index == {}
+
+    def test_ignores_dangling_links(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[NoSuchPage]].")
+
+        index = rebuild_index(config)
+
+        assert index == {}
+
+    def test_missing_vault_dir_returns_empty(self, config):
+        # config.vault_root deliberately not created
+        assert rebuild_index(config) == {}
+
+
+class TestLoadIndex:
+    def test_rebuilds_lazily_when_missing(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        assert not _index_path(config).exists()
+
+        index = load_index(config)
+
+        assert index["PageB.md"] == ["PageA.md"]
+        assert _index_path(config).exists()
+
+    def test_reads_persisted_index_without_rescanning(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+
+        # Mutate the page on disk without calling rebuild_index/update_for_page.
+        # load_index must return the stale persisted data, not re-scan.
+        (vault_dir / "PageA.md").write_text("No links now.")
+
+        index = load_index(config)
+
+        assert index["PageB.md"] == ["PageA.md"]
+
+    def test_corrupt_json_rebuilds(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        path = _index_path(config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not valid json", encoding="utf-8")
+
+        index = load_index(config)
+
+        assert index["PageB.md"] == ["PageA.md"]
+
+
+class TestInboundCount:
+    def test_counts_distinct_linkers(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageC]].")
+        (vault_dir / "PageB.md").write_text("Links to [[PageC]].")
+        (vault_dir / "PageC.md").write_text("# C")
+        rebuild_index(config)
+
+        assert inbound_count(config, "PageC") == 2
+        assert inbound_count(config, "PageA") == 0
+
+    def test_unknown_page_returns_zero(self, config, vault_dir):
+        assert inbound_count(config, "DoesNotExist") == 0
+
+    def test_missing_index_rebuilds_lazily(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        assert not _index_path(config).exists()
+
+        assert inbound_count(config, "PageB") == 1
+
+
+class TestUpdateForPage:
+    def test_incremental_add_link(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("# A\n\nNo links yet.")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        assert inbound_count(config, "PageB") == 0
+
+        (vault_dir / "PageA.md").write_text("# A\n\nNow linking to [[PageB]].")
+        update_for_page(config, "PageA")
+
+        index = load_index(config)
+        assert index["PageB.md"] == ["PageA.md"]
+        assert inbound_count(config, "PageB") == 1
+
+    def test_incremental_remove_link(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        assert inbound_count(config, "PageB") == 1
+
+        (vault_dir / "PageA.md").write_text("No more links.")
+        update_for_page(config, "PageA")
+
+        index = load_index(config)
+        assert "PageB.md" not in index
+
+    def test_incremental_does_not_touch_unrelated_pages(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageC]].")
+        (vault_dir / "PageB.md").write_text("Links to [[PageC]].")
+        (vault_dir / "PageC.md").write_text("# C")
+        rebuild_index(config)
+
+        (vault_dir / "PageA.md").write_text("No more links.")
+        update_for_page(config, "PageA")
+
+        index = load_index(config)
+        assert index["PageC.md"] == ["PageB.md"]
+
+    def test_builds_index_if_missing(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        assert not _index_path(config).exists()
+
+        update_for_page(config, "PageA")
+
+        index = load_index(config)
+        assert index["PageB.md"] == ["PageA.md"]
+
+    def test_handles_deleted_page(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        assert inbound_count(config, "PageB") == 1
+
+        (vault_dir / "PageA.md").unlink()
+        update_for_page(config, "PageA.md")
+
+        index = load_index(config)
+        assert "PageB.md" not in index
+
+    def test_unresolvable_page_is_fail_open(self, config, vault_dir):
+        # Should not raise even though the page never existed.
+        update_for_page(config, "NeverExisted")
+        assert load_index(config) == {}
+
+
+class TestBacklinksSubscriber:
+    @pytest.mark.asyncio
+    async def test_updates_index_on_vault_changed(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("# A")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        (vault_dir / "PageA.md").write_text("Now links to [[PageB]].")
+
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "vault_changed", "kind": "update", "path": "PageA.md"})
+
+        assert inbound_count(config, "PageB") == 1
+
+    @pytest.mark.asyncio
+    async def test_ignores_other_event_types(self, config, vault_dir):
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "tool_end"})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_ignores_empty_path(self, config, vault_dir):
+        handler = make_backlinks_subscriber(config)
+        # Must not raise on multi-file ops with no single path.
+        await handler({"type": "vault_changed", "kind": "delete", "path": ""})
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_bad_event(self, config, vault_dir):
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "vault_changed"})  # missing "path" key entirely

--- a/tests/test_backlinks.py
+++ b/tests/test_backlinks.py
@@ -19,6 +19,8 @@ from decafclaw.backlinks import (
     rebuild_index,
     update_for_page,
 )
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig, ReflectionConfig
 
 
 @pytest.fixture
@@ -27,6 +29,28 @@ def vault_dir(config):
     d = config.vault_root
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+@pytest.fixture
+def symlinked_config(tmp_path):
+    """Config whose vault_root path runs through a symlink component, so
+    ``Path.resolve()`` differs from the raw path — regression fixture for
+    the resolved/unresolved ``relative_to()`` mismatch (Bug 1). Mirrors
+    real-world setups where the data dir lives under a symlinked prefix
+    (e.g. macOS ``/tmp`` -> ``/private/tmp``).
+    """
+    real_dir = tmp_path / "real_data"
+    real_dir.mkdir()
+    link_dir = tmp_path / "link_data"
+    link_dir.symlink_to(real_dir, target_is_directory=True)
+    cfg = Config(
+        agent=AgentConfig(data_home=str(link_dir), id="test-agent", user_id="testuser"),
+        reflection=ReflectionConfig(enabled=False),
+    )
+    assert cfg.vault_root != cfg.vault_root.resolve(), (
+        "fixture setup failed to produce a resolve()-diverging vault_root"
+    )
+    return cfg
 
 
 class TestRebuildIndex:
@@ -233,3 +257,113 @@ class TestBacklinksSubscriber:
     async def test_fail_open_on_bad_event(self, config, vault_dir):
         handler = make_backlinks_subscriber(config)
         await handler({"type": "vault_changed"})  # missing "path" key entirely
+
+
+class TestSymlinkedVaultRoot:
+    """Bug 1 regression: resolve_page() returns a resolved path, but three
+    call sites used to combine it with the unresolved config.vault_root,
+    making relative_to() raise (silently swallowed by fail-open) whenever
+    vault_root runs through a symlink."""
+
+    def test_inbound_count_with_symlinked_vault_root(self, symlinked_config):
+        vault = symlinked_config.vault_root
+        vault.mkdir(parents=True, exist_ok=True)
+        (vault / "PageA.md").write_text("Links to [[PageB]].")
+        (vault / "PageB.md").write_text("# B")
+        rebuild_index(symlinked_config)
+
+        assert inbound_count(symlinked_config, "PageB") == 1
+
+    def test_update_for_page_with_symlinked_vault_root(self, symlinked_config):
+        vault = symlinked_config.vault_root
+        vault.mkdir(parents=True, exist_ok=True)
+        (vault / "PageA.md").write_text("# A\n\nNo links yet.")
+        (vault / "PageB.md").write_text("# B")
+        rebuild_index(symlinked_config)
+        assert inbound_count(symlinked_config, "PageB") == 0
+
+        (vault / "PageA.md").write_text("# A\n\nNow linking to [[PageB]].")
+        update_for_page(symlinked_config, "PageA")
+
+        assert inbound_count(symlinked_config, "PageB") == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_vault_backlinks_with_symlinked_vault_root(self, symlinked_config):
+        from decafclaw.context import Context
+        from decafclaw.events import EventBus
+        from decafclaw.skills.vault.tools import tool_vault_backlinks
+
+        vault = symlinked_config.vault_root
+        vault.mkdir(parents=True, exist_ok=True)
+        (vault / "PageA.md").write_text("Links to [[PageB]].")
+        (vault / "PageB.md").write_text("# B")
+        rebuild_index(symlinked_config)
+
+        ctx = Context(config=symlinked_config, event_bus=EventBus())
+        result = await tool_vault_backlinks(ctx, "PageB")
+
+        assert "1 page(s) link to 'PageB'" in result
+        assert "PageA" in result
+
+
+class TestSubscriberIndexSync:
+    """Bug 2 regression: update_for_page never scrubs the changed page's
+    OWN dead/renamed key in the index, so delete/rename desynced the
+    persisted index from what a full rebuild_index would produce. The
+    invariant under test: after any single create/update/delete/rename
+    event, the persisted index EQUALS rebuild_index(config)."""
+
+    @pytest.mark.asyncio
+    async def test_delete_of_linked_to_page_purges_dead_key(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        assert load_index(config)["PageB.md"] == ["PageA.md"]
+
+        (vault_dir / "PageB.md").unlink()
+
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "vault_changed", "kind": "delete", "path": "PageB.md"})
+
+        persisted = load_index(config)
+        assert persisted == rebuild_index(config)
+        assert "PageB.md" not in persisted
+
+    @pytest.mark.asyncio
+    async def test_rename_of_linked_to_page_syncs_key(self, config, vault_dir):
+        # PageC pre-emptively links to the post-rename name; before the
+        # rename that's a dangling link (PageB2 doesn't exist yet).
+        (vault_dir / "PageA.md").write_text("Links to [[PageB]].")
+        (vault_dir / "PageC.md").write_text("Links to [[PageB2]].")
+        (vault_dir / "PageB.md").write_text("# B")
+        rebuild_index(config)
+        assert load_index(config) == {"PageB.md": ["PageA.md"]}
+
+        (vault_dir / "PageB.md").rename(vault_dir / "PageB2.md")
+
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "vault_changed", "kind": "rename", "path": "PageB2.md"})
+
+        persisted = load_index(config)
+        assert persisted == rebuild_index(config)
+        assert "PageB.md" not in persisted
+        # PageA's [[PageB]] is now dangling (target renamed away); PageC's
+        # [[PageB2]] now resolves — the new key reflects the real linkers.
+        assert persisted["PageB2.md"] == ["PageC.md"]
+
+    @pytest.mark.asyncio
+    async def test_rename_of_linker_updates_target_inbound_list(self, config, vault_dir):
+        (vault_dir / "PageA.md").write_text("Links to [[PageTarget]].")
+        (vault_dir / "PageTarget.md").write_text("# Target")
+        rebuild_index(config)
+        assert load_index(config)["PageTarget.md"] == ["PageA.md"]
+
+        (vault_dir / "PageA.md").rename(vault_dir / "PageANew.md")
+
+        handler = make_backlinks_subscriber(config)
+        await handler({"type": "vault_changed", "kind": "rename", "path": "PageANew.md"})
+
+        persisted = load_index(config)
+        assert persisted == rebuild_index(config)
+        assert persisted["PageTarget.md"] == ["PageANew.md"]
+        assert "PageA.md" not in persisted["PageTarget.md"]

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -271,6 +271,36 @@ class TestComposeMemoryContext:
             assert entry2.items_included == 0
             assert entry2.details.get("injection_skipped") is True
 
+    @pytest.mark.asyncio
+    async def test_retrieval_event_published_with_drop_verdicts(self, ctx, config):
+        """A ``retrieval_event`` carries the *full* scored candidate list
+        (not just what got injected), tagged with include/drop verdicts —
+        the measurement foundation for #197."""
+        events = []
+
+        async def cap(e):
+            if e.get("type") == "retrieval_event":
+                events.append(e)
+        ctx.event_bus.subscribe(cap)
+        mock_results = [
+            {"file_path": "pages/hit.md", "source_type": "page", "entry_text": "x",
+             "similarity": 0.9, "modified_at": "", "importance": 0.9},
+            {"file_path": "pages/miss.md", "source_type": "page", "entry_text": "y",
+             "similarity": 0.01, "modified_at": "", "importance": 0.1},
+        ]
+        with patch("decafclaw.context_composer.retrieve_memory_context",
+                   new_callable=AsyncMock, return_value=mock_results):
+            composer = ContextComposer()
+            await composer._compose_vault_retrieval(
+                ctx, config, "q", ComposerMode.INTERACTIVE)
+        assert len(events) == 1
+        assert events[0]["conv_id"] == ctx.conv_id
+        paths = {c["file_path"]: c for c in events[0]["candidates"]}
+        assert paths["pages/hit.md"]["included"] is True
+        assert paths["pages/hit.md"]["drop_reason"] is None
+        assert paths["pages/miss.md"]["included"] is False
+        assert paths["pages/miss.md"]["drop_reason"] in ("score", "budget")
+
 
 # -- Retrieval modes (#301) ----------------------------------------------------
 

--- a/tests/test_recompute_importance.py
+++ b/tests/test_recompute_importance.py
@@ -1,0 +1,150 @@
+"""Tests for garden's deterministic importance recompute (#197 Phase 5).
+
+`compute_importance_scores` is pure and config-driven: retrieval frequency
+(`retrieval_telemetry.aggregate`) and inbound-link count
+(`backlinks.inbound_count`) are patched directly at their source modules so
+the formula's math is exercised without any real telemetry log or backlink
+index on disk.
+"""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+
+from decafclaw.frontmatter import parse_frontmatter
+from decafclaw.skills.garden.tools import (
+    compute_importance_scores,
+    tool_vault_recompute_importance,
+)
+
+STAR = "agent/pages/star.md"
+ORPHAN = "agent/pages/orphan.md"
+
+
+@pytest.fixture
+def vault_pages(config):
+    """A small vault: a heavily-retrieved/linked "star" page and an orphan."""
+    pages_dir = config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    (pages_dir / "star.md").write_text("The star page.\n", encoding="utf-8")
+    (pages_dir / "orphan.md").write_text("Nobody cares about this.\n", encoding="utf-8")
+    return pages_dir
+
+
+def _patch_signals(retrieval_counts: dict[str, int], inbound_counts: dict[str, int]):
+    return (
+        patch(
+            "decafclaw.retrieval_telemetry.aggregate",
+            return_value={
+                path: {"retrieval_count": n} for path, n in retrieval_counts.items()
+            },
+        ),
+        patch(
+            "decafclaw.backlinks.inbound_count",
+            side_effect=lambda cfg, page: inbound_counts.get(page, 0),
+        ),
+    )
+
+
+class TestComputeImportanceScores:
+    def test_frequently_retrieved_and_linked_page_scores_near_one(
+        self, config, vault_pages,
+    ):
+        p1, p2 = _patch_signals({STAR: 10}, {STAR: 5})
+        with p1, p2:
+            scores = compute_importance_scores(config)
+
+        assert scores[STAR] == pytest.approx(1.0)
+        assert scores[ORPHAN] == pytest.approx(0.0)
+
+    def test_clamps_to_one_even_when_weights_sum_above_one(self, config, vault_pages):
+        # Deliberately push weights above 1.0 combined to exercise the clamp,
+        # not just the normalization-to-1.0 case above.
+        config = replace(
+            config,
+            importance=replace(config.importance, w_retrieval=0.9, w_inbound=0.9),
+        )
+        p1, p2 = _patch_signals({STAR: 1}, {STAR: 1})
+        with p1, p2:
+            scores = compute_importance_scores(config)
+
+        assert scores[STAR] == pytest.approx(1.0)
+        assert scores[STAR] <= 1.0
+
+    def test_empty_data_scores_all_zero_no_divide_by_zero(self, config, vault_pages):
+        p1, p2 = _patch_signals({}, {})
+        with p1, p2:
+            scores = compute_importance_scores(config)
+
+        assert scores == {STAR: 0.0, ORPHAN: 0.0}
+
+    def test_excludes_journal_entries(self, config, vault_pages):
+        journal_dir = config.vault_agent_journal_dir
+        journal_dir.mkdir(parents=True, exist_ok=True)
+        (journal_dir / "2026-07-23.md").write_text("## Entry\n", encoding="utf-8")
+
+        p1, p2 = _patch_signals({}, {})
+        with p1, p2:
+            scores = compute_importance_scores(config)
+
+        assert all("journal" not in p for p in scores)
+
+    def test_no_vault_returns_empty(self, config):
+        # vault_root doesn't exist in a fresh tmp config.
+        p1, p2 = _patch_signals({}, {})
+        with p1, p2:
+            scores = compute_importance_scores(config)
+
+        assert scores == {}
+
+
+class TestToolVaultRecomputeImportance:
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_deltas_without_writing(self, ctx, vault_pages):
+        with patch(
+            "decafclaw.skills.garden.tools.compute_importance_scores",
+            return_value={STAR: 0.9, ORPHAN: 0.0},
+        ):
+            result = await tool_vault_recompute_importance(ctx, dry_run=True)
+
+        assert result.data["dry_run"] is True
+        by_path = {d["path"]: d for d in result.data["deltas"]}
+        assert by_path[STAR]["new"] == 0.9
+        # orphan.md's score (0.0) matches its unset importance (None != 0.0
+        # rounds differently) — still counts as a planned change since
+        # there's no existing frontmatter to compare against.
+        assert ORPHAN in by_path
+
+        # Nothing written to disk in dry-run mode.
+        text = (ctx.config.vault_agent_pages_dir / "star.md").read_text(encoding="utf-8")
+        assert "importance" not in text
+
+    @pytest.mark.asyncio
+    async def test_writes_changed_scores_and_skips_unchanged(self, ctx, vault_pages):
+        # orphan.md already carries the score it would be recomputed to —
+        # this page must be skipped as unchanged.
+        (ctx.config.vault_agent_pages_dir / "orphan.md").write_text(
+            "---\nimportance: 0.0\n---\nNobody cares about this.\n", encoding="utf-8",
+        )
+
+        with patch(
+            "decafclaw.skills.garden.tools.compute_importance_scores",
+            return_value={STAR: 0.9, ORPHAN: 0.0},
+        ):
+            result = await tool_vault_recompute_importance(ctx)
+
+        assert result.data["dry_run"] is False
+        changed_paths = {d["path"] for d in result.data["deltas"]}
+        assert changed_paths == {STAR}
+
+        star_meta, _ = parse_frontmatter(
+            (ctx.config.vault_agent_pages_dir / "star.md").read_text(encoding="utf-8")
+        )
+        assert star_meta["importance"] == 0.9
+
+        orphan_meta, orphan_body = parse_frontmatter(
+            (ctx.config.vault_agent_pages_dir / "orphan.md").read_text(encoding="utf-8")
+        )
+        assert orphan_meta["importance"] == 0.0
+        assert orphan_body.strip() == "Nobody cares about this."

--- a/tests/test_recompute_importance.py
+++ b/tests/test_recompute_importance.py
@@ -102,7 +102,12 @@ class TestComputeImportanceScores:
 class TestToolVaultRecomputeImportance:
     @pytest.mark.asyncio
     async def test_dry_run_returns_deltas_without_writing(self, ctx, vault_pages):
-        with patch(
+        # STAR has real signal (retrieval); ORPHAN has none — its mocked
+        # score of 0.0 should NOT show up as a planned change, since a page
+        # with zero raw signal is left alone rather than zeroed (#197 cold
+        # start).
+        p1, p2 = _patch_signals({STAR: 10}, {})
+        with p1, p2, patch(
             "decafclaw.skills.garden.tools.compute_importance_scores",
             return_value={STAR: 0.9, ORPHAN: 0.0},
         ):
@@ -111,10 +116,7 @@ class TestToolVaultRecomputeImportance:
         assert result.data["dry_run"] is True
         by_path = {d["path"]: d for d in result.data["deltas"]}
         assert by_path[STAR]["new"] == 0.9
-        # orphan.md's score (0.0) matches its unset importance (None != 0.0
-        # rounds differently) — still counts as a planned change since
-        # there's no existing frontmatter to compare against.
-        assert ORPHAN in by_path
+        assert ORPHAN not in by_path
 
         # Nothing written to disk in dry-run mode.
         text = (ctx.config.vault_agent_pages_dir / "star.md").read_text(encoding="utf-8")
@@ -123,12 +125,14 @@ class TestToolVaultRecomputeImportance:
     @pytest.mark.asyncio
     async def test_writes_changed_scores_and_skips_unchanged(self, ctx, vault_pages):
         # orphan.md already carries the score it would be recomputed to —
-        # this page must be skipped as unchanged.
+        # this page must be skipped as unchanged (it also has zero raw
+        # signal, so it would be skipped for that reason too).
         (ctx.config.vault_agent_pages_dir / "orphan.md").write_text(
             "---\nimportance: 0.0\n---\nNobody cares about this.\n", encoding="utf-8",
         )
 
-        with patch(
+        p1, p2 = _patch_signals({STAR: 10}, {})
+        with p1, p2, patch(
             "decafclaw.skills.garden.tools.compute_importance_scores",
             return_value={STAR: 0.9, ORPHAN: 0.0},
         ):
@@ -148,3 +152,99 @@ class TestToolVaultRecomputeImportance:
         )
         assert orphan_meta["importance"] == 0.0
         assert orphan_body.strip() == "Nobody cares about this."
+
+
+class TestRecomputeScopedToAgentPages:
+    """#197 whole-branch-review fix: automated importance writes must stay
+    within `agent/` — the tool `vault_update_frontmatter` keeps its
+    vault-wide reach, but the unattended weekly sweep must not touch the
+    user's own hand-written pages living elsewhere in the vault."""
+
+    @pytest.mark.asyncio
+    async def test_user_page_outside_agent_is_never_written(self, ctx, vault_pages):
+        # A user page living directly under vault_root, outside agent/.
+        user_page = ctx.config.vault_root / "user-notes.md"
+        user_page.write_text("Les's own hand-written notes.\n", encoding="utf-8")
+
+        p1, p2 = _patch_signals({STAR: 10, "user-notes.md": 10}, {})
+        with p1, p2:
+            result = await tool_vault_recompute_importance(ctx)
+
+        touched_paths = {d["path"] for d in result.data["deltas"]}
+        assert "user-notes.md" not in touched_paths
+
+        assert user_page.read_text(encoding="utf-8") == "Les's own hand-written notes.\n"
+
+    @pytest.mark.asyncio
+    async def test_nested_user_folder_outside_agent_is_never_written(self, ctx, vault_pages):
+        # A user-owned subfolder outside agent/ (not just a top-level file).
+        other_dir = ctx.config.vault_root / "reference"
+        other_dir.mkdir(parents=True, exist_ok=True)
+        other_page = other_dir / "notes.md"
+        other_page.write_text("Reference material.\n", encoding="utf-8")
+
+        p1, p2 = _patch_signals({STAR: 10}, {"reference/notes.md": 10})
+        with p1, p2:
+            result = await tool_vault_recompute_importance(ctx)
+
+        touched_paths = {d["path"] for d in result.data["deltas"]}
+        assert "reference/notes.md" not in touched_paths
+        assert other_page.read_text(encoding="utf-8") == "Reference material.\n"
+
+
+class TestRecomputeColdStart:
+    """#197 whole-branch-review fix: pages with zero measured signal keep
+    their existing importance (or lack of one) instead of being zeroed."""
+
+    @pytest.mark.asyncio
+    async def test_agent_page_with_real_signal_gets_written(self, ctx, vault_pages):
+        p1, p2 = _patch_signals({STAR: 10}, {})
+        with p1, p2:
+            result = await tool_vault_recompute_importance(ctx)
+
+        touched_paths = {d["path"] for d in result.data["deltas"]}
+        assert STAR in touched_paths
+
+        star_meta, _ = parse_frontmatter(
+            (ctx.config.vault_agent_pages_dir / "star.md").read_text(encoding="utf-8")
+        )
+        # Only retrieval signal is present (default w_retrieval=0.6).
+        assert star_meta["importance"] == pytest.approx(0.6)
+
+    @pytest.mark.asyncio
+    async def test_zero_signal_page_with_existing_importance_is_untouched(
+        self, ctx, vault_pages,
+    ):
+        # A page with dream's initial importance guess but no measured
+        # signal yet — recompute must not overwrite it, even though the
+        # formula would compute 0.0 for it (no retrieval, no inbound links,
+        # and its neighbor STAR absorbs all the normalized signal).
+        (ctx.config.vault_agent_pages_dir / "orphan.md").write_text(
+            "---\nimportance: 0.7\n---\nNobody cares about this.\n", encoding="utf-8",
+        )
+
+        p1, p2 = _patch_signals({STAR: 10}, {})
+        with p1, p2:
+            result = await tool_vault_recompute_importance(ctx)
+
+        touched_paths = {d["path"] for d in result.data["deltas"]}
+        assert ORPHAN not in touched_paths
+
+        orphan_meta, _ = parse_frontmatter(
+            (ctx.config.vault_agent_pages_dir / "orphan.md").read_text(encoding="utf-8")
+        )
+        assert orphan_meta["importance"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_zero_signal_page_with_no_importance_stays_unset(self, ctx, vault_pages):
+        p1, p2 = _patch_signals({STAR: 10}, {})
+        with p1, p2:
+            result = await tool_vault_recompute_importance(ctx)
+
+        touched_paths = {d["path"] for d in result.data["deltas"]}
+        assert ORPHAN not in touched_paths
+
+        orphan_meta, _ = parse_frontmatter(
+            (ctx.config.vault_agent_pages_dir / "orphan.md").read_text(encoding="utf-8")
+        )
+        assert "importance" not in orphan_meta

--- a/tests/test_retrieval_telemetry.py
+++ b/tests/test_retrieval_telemetry.py
@@ -19,6 +19,7 @@ from decafclaw.retrieval_telemetry import (
     format_report,
     make_retrieval_telemetry_subscriber,
     record_from_event,
+    vault_health,
 )
 
 
@@ -121,11 +122,67 @@ def test_format_report_lists_pages_and_health():
             "drop_score": 0, "drop_budget": 1, "source_type": "page",
         },
     }
-    health = {"total_pages": 4, "with_importance": 2, "coverage_pct": 50.0, "orphans": 2}
+    health = {
+        "total_pages": 4, "with_importance": 2, "coverage_pct": 50.0,
+        "missing_importance": 2, "graph_orphans": 1,
+    }
     report = format_report(stats, health)
     assert "pages/a.md" in report
     assert "Vault health" in report
     assert "50" in report
+    assert "Graph orphans" in report
+
+
+# -- vault_health -----------------------------------------------------------
+
+
+def test_vault_health_not_a_dir_returns_zeros(config):
+    # vault_root doesn't exist in a fresh tmp config — short-circuit path.
+    health = vault_health(config)
+    assert health == {
+        "total_pages": 0, "with_importance": 0, "coverage_pct": 0.0,
+        "missing_importance": 0, "graph_orphans": 0,
+    }
+
+
+def test_vault_health_counts_pages_with_and_without_importance(config):
+    pages_dir = config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    (pages_dir / "with_importance.md").write_text(
+        "---\nimportance: 0.5\n---\nBody.\n", encoding="utf-8",
+    )
+    (pages_dir / "without_importance.md").write_text("Body only.\n", encoding="utf-8")
+
+    journal_dir = config.vault_agent_journal_dir
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    (journal_dir / "2026-07-23.md").write_text("## Entry\nSome text.\n", encoding="utf-8")
+
+    health = vault_health(config)
+
+    # Journal entry excluded from the count entirely.
+    assert health["total_pages"] == 2
+    assert health["with_importance"] == 1
+    assert health["missing_importance"] == 1
+    assert health["coverage_pct"] == 50.0
+    # Neither page links to the other — both are graph orphans (#197 P0-M2:
+    # this is the genuine zero-inbound-links metric, distinct from
+    # missing_importance).
+    assert health["graph_orphans"] == 2
+
+
+def test_vault_health_graph_orphans_excludes_linked_pages(config):
+    pages_dir = config.vault_agent_pages_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    (pages_dir / "linker.md").write_text("Links to [[target]].\n", encoding="utf-8")
+    (pages_dir / "target.md").write_text("Linked-to page.\n", encoding="utf-8")
+    (pages_dir / "lonely.md").write_text("Nobody links here.\n", encoding="utf-8")
+
+    health = vault_health(config)
+
+    assert health["total_pages"] == 3
+    # target.md has one inbound link (from linker.md); linker.md and
+    # lonely.md have zero.
+    assert health["graph_orphans"] == 2
 
 
 def test_build_report_end_to_end(config):

--- a/tests/test_retrieval_telemetry.py
+++ b/tests/test_retrieval_telemetry.py
@@ -1,0 +1,143 @@
+"""Retrieval-event telemetry (#197 Phase 0).
+
+Subscriber consumes ``retrieval_event`` events (published once per
+interactive turn from ``ContextComposer._compose_vault_retrieval``) and
+appends one JSONL record per event, capturing the full scored candidate
+list plus each candidate's include/drop verdict. Fail-open. A report
+aggregates per-page retrieval/include/drop counts and a vault-health
+snapshot (frontmatter coverage).
+"""
+
+import json
+
+import pytest
+
+from decafclaw.retrieval_telemetry import (
+    _retrieval_path,
+    aggregate,
+    build_report,
+    format_report,
+    make_retrieval_telemetry_subscriber,
+    record_from_event,
+)
+
+
+def _event():
+    return {
+        "type": "retrieval_event", "conv_id": "c1",
+        "candidates": [
+            {"file_path": "pages/a.md", "source_type": "page", "similarity": 0.9,
+             "recency": 0.8, "importance": 0.5, "composite_score": 0.77,
+             "included": True, "drop_reason": None},
+            {"file_path": "pages/b.md", "source_type": "page", "similarity": 0.2,
+             "recency": 0.5, "importance": 0.5, "composite_score": 0.3,
+             "included": False, "drop_reason": "score"},
+        ],
+    }
+
+
+# -- subscriber ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_subscriber_writes_one_record_per_event(config):
+    handler = make_retrieval_telemetry_subscriber(config)
+    await handler(_event())
+    await handler({"type": "tool_end"})  # ignored
+    lines = _retrieval_path(config).read_text().strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["conv_id"] == "c1"
+    assert len(rec["candidates"]) == 2
+    assert rec["candidates"][0]["included"] is True
+    assert "timestamp" in rec
+
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open_on_bad_event(config):
+    handler = make_retrieval_telemetry_subscriber(config)
+    await handler({"type": "retrieval_event"})  # no candidates key — must not raise
+
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open_on_bad_path(config, tmp_path):
+    # Point the workspace at a location that can't be created (a file as a
+    # dir parent), same fail-open shape as tool_telemetry's coverage.
+    blocker = config.workspace_path
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    blocker.write_text("i am a file, not a dir")
+    handler = make_retrieval_telemetry_subscriber(config)
+    await handler(_event())  # must not raise
+
+
+def test_record_from_event_shape():
+    rec = record_from_event(_event())
+    assert rec["conv_id"] == "c1"
+    assert rec["candidates"] == _event()["candidates"]
+    assert "timestamp" in rec
+
+
+# -- aggregation -----------------------------------------------------------
+
+
+def test_aggregate_counts_retrieval_include_and_drop():
+    records = [
+        {
+            "conv_id": "c1",
+            "candidates": [
+                {"file_path": "pages/a.md", "source_type": "page",
+                 "included": True, "drop_reason": None},
+                {"file_path": "pages/b.md", "source_type": "page",
+                 "included": False, "drop_reason": "score"},
+            ],
+        },
+        {
+            "conv_id": "c2",
+            "candidates": [
+                {"file_path": "pages/a.md", "source_type": "page",
+                 "included": False, "drop_reason": "budget"},
+            ],
+        },
+    ]
+    stats = aggregate(records)
+    a = stats["pages/a.md"]
+    assert a["retrieval_count"] == 2
+    assert a["include_count"] == 1
+    assert a["drop_score"] == 0
+    assert a["drop_budget"] == 1
+    assert a["source_type"] == "page"
+
+    b = stats["pages/b.md"]
+    assert b["retrieval_count"] == 1
+    assert b["include_count"] == 0
+    assert b["drop_score"] == 1
+    assert b["drop_budget"] == 0
+
+
+def test_format_report_lists_pages_and_health():
+    stats = {
+        "pages/a.md": {
+            "retrieval_count": 2, "include_count": 1, "include_rate": 0.5,
+            "drop_score": 0, "drop_budget": 1, "source_type": "page",
+        },
+    }
+    health = {"total_pages": 4, "with_importance": 2, "coverage_pct": 50.0, "orphans": 2}
+    report = format_report(stats, health)
+    assert "pages/a.md" in report
+    assert "Vault health" in report
+    assert "50" in report
+
+
+def test_build_report_end_to_end(config):
+    path = _retrieval_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "conv_id": "c1",
+        "candidates": [
+            {"file_path": "pages/a.md", "source_type": "page",
+             "included": True, "drop_reason": None},
+        ],
+    }) + "\n")
+    report = build_report(config)
+    assert "pages/a.md" in report
+    assert "Vault health" in report

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1323,3 +1323,59 @@ class TestVaultUpdateFrontmatter:
             await tool_vault_update_frontmatter(
                 ctx, page="agent/pages/t.md", fields={"summary": "s"})
         rx.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_interactive_user_page_confirms_then_updates(self, ctx, vault_dir):
+        """Interactive caller updating a user-owned page outside agent/ must
+        hit the same gate as vault_write: confirmation requested, then the
+        write proceeds on approval."""
+        p = vault_dir / "creative" / "foo.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("Body.\n")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with (
+            patch("decafclaw.skills.vault.tools.request_confirmation",
+                  AsyncMock(return_value={"approved": True})) as mock_conf,
+            patch("decafclaw.skills.vault.tools._reindex_page",
+                  new_callable=AsyncMock),
+        ):
+            await tool_vault_update_frontmatter(
+                ctx, page="creative/foo", fields={"summary": "s"})
+        assert mock_conf.called
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "s"
+
+    @pytest.mark.asyncio
+    async def test_interactive_user_page_denied_returns_error_no_update(
+        self, ctx, vault_dir,
+    ):
+        p = vault_dir / "creative" / "foo.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("Body.\n")
+        ctx.request_confirmation = _dummy_request_confirmation
+        with patch("decafclaw.skills.vault.tools.request_confirmation",
+                   AsyncMock(return_value={"approved": False})):
+            result = await tool_vault_update_frontmatter(
+                ctx, page="creative/foo", fields={"summary": "s"})
+        assert "denied by user" in result.text
+        meta, _ = parse_frontmatter(p.read_text())
+        assert "summary" not in meta
+
+    @pytest.mark.asyncio
+    async def test_non_interactive_user_page_updates_without_gate(
+        self, ctx, vault_dir,
+    ):
+        """Non-interactive callers (scheduled dream/garden) can't prompt, so
+        vault-wide reach proceeds ungated — this is the tool's intended
+        maintenance purpose."""
+        p = vault_dir / "creative" / "foo.md"
+        p.parent.mkdir(parents=True)
+        p.write_text("Body.\n")
+        ctx.request_confirmation = None
+        with patch("decafclaw.skills.vault.tools._reindex_page",
+                   new_callable=AsyncMock):
+            result = await tool_vault_update_frontmatter(
+                ctx, page="creative/foo", fields={"summary": "s"})
+        assert "updated" in result.text.lower()
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "s"

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from decafclaw.frontmatter import parse_frontmatter
 from decafclaw.skills.vault._grants import add_grant
 from decafclaw.skills.vault.tools import (
     GateOutcome,
@@ -23,6 +24,7 @@ from decafclaw.skills.vault.tools import (
     tool_vault_recent,
     tool_vault_rename,
     tool_vault_search,
+    tool_vault_update_frontmatter,
     tool_vault_write,
 )
 
@@ -1268,3 +1270,56 @@ class TestVaultRecent:
     async def test_missing_folder_errors(self, ctx, vault_dir):
         result = await tool_vault_recent(ctx, days=7, folder="nope/missing")
         assert "does not exist" in str(result).lower()
+
+
+class TestVaultUpdateFrontmatter:
+    @pytest.mark.asyncio
+    async def test_fills_absent_fields(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"
+        p.write_text("Body text.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"summary": "s", "importance": 0.8})
+        meta, body = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "s" and meta["importance"] == 0.8
+        assert body.strip() == "Body text."
+
+    @pytest.mark.asyncio
+    async def test_respects_existing_value_when_not_overwrite(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"
+        p.write_text("---\nsummary: manual\n---\nBody.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"summary": "auto"}, overwrite=False)
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["summary"] == "manual"
+
+    @pytest.mark.asyncio
+    async def test_overwrite_replaces(self, ctx, agent_pages):
+        p = agent_pages / "topic.md"
+        p.write_text("---\nimportance: 0.5\n---\nBody.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/topic.md",
+            fields={"importance": 0.9}, overwrite=True)
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["importance"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_clamps_importance_and_coerces_lists(self, ctx, agent_pages):
+        p = agent_pages / "t.md"
+        p.write_text("Body.\n")
+        await tool_vault_update_frontmatter(
+            ctx, page="agent/pages/t.md",
+            fields={"importance": 5.0, "tags": "a"})
+        meta, _ = parse_frontmatter(p.read_text())
+        assert meta["importance"] == 1.0 and meta["tags"] == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_reindexes_after_write(self, ctx, agent_pages):
+        p = agent_pages / "t.md"
+        p.write_text("Body.\n")
+        with patch("decafclaw.skills.vault.tools._reindex_page",
+                   new_callable=AsyncMock) as rx:
+            await tool_vault_update_frontmatter(
+                ctx, page="agent/pages/t.md", fields={"summary": "s"})
+        rx.assert_awaited_once()

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1362,6 +1362,28 @@ class TestVaultUpdateFrontmatter:
         assert "summary" not in meta
 
     @pytest.mark.asyncio
+    async def test_noop_merge_skips_write_reindex_publish(self, ctx, agent_pages):
+        """When the merge produces no change (e.g. overwrite=False on an
+        already-populated field), the tool must not rewrite the file, reindex,
+        or publish vault_changed."""
+        p = agent_pages / "topic.md"
+        original = "---\nsummary: existing\n---\nBody.\n"
+        p.write_text(original)
+        with (
+            patch("decafclaw.skills.vault.tools._reindex_page",
+                  new_callable=AsyncMock) as rx,
+            patch("decafclaw.skills.vault.tools.publish_vault_changed",
+                  new_callable=AsyncMock) as pub,
+        ):
+            result = await tool_vault_update_frontmatter(
+                ctx, page="agent/pages/topic.md",
+                fields={"summary": "different"}, overwrite=False)
+        assert p.read_text() == original
+        rx.assert_not_awaited()
+        pub.assert_not_awaited()
+        assert result.data["changed"] == []
+
+    @pytest.mark.asyncio
     async def test_non_interactive_user_page_updates_without_gate(
         self, ctx, vault_dir,
     ):


### PR DESCRIPTION
## What

Makes the vault **self-improving** and makes retrieval quality **measurable**. Vault frontmatter (`summary`/`keywords`/`tags`/`importance`) feeds composite scoring and composite embeddings, but nothing ever populated it — so `importance` was dead weight (constant 0.5 on every page) and the metadata embedding channel was unused. This arc fills that in and adds the telemetry to tell whether it helped.

Real-world confirmation of the premise: `make retrieval-report` on the live vault shows **246 of 247 pages with no importance frontmatter** and 136 graph orphans.

Closes #197.

## Phases (each individually TDD'd + reviewed)

- **Retrieval telemetry** — `retrieval_telemetry.py`: a fail-open EventBus subscriber recording every scored candidate + its include/drop verdict to `workspace/telemetry/retrieval.jsonl`; `make retrieval-report` aggregates per-page retrieval frequency, include/drop, and vault health (frontmatter coverage, graph orphans). Doubles as garden's importance input.
- **`vault_update_frontmatter`** — shared merge tool + pure `merge_frontmatter(existing, fields, overwrite)`. Interactive callers are confirmation-gated like `vault_write`; scheduled dream/garden proceed ungated (by design).
- **Dream frontmatter generation** — dream generates `summary`/`keywords`/`tags`/`importance` on consolidate (respecting manual values); eval verifies it.
- **`make backfill-frontmatter`** — one-time CLI (forced-tool structured output) to populate existing agent pages; run `make reindex` after.
- **Persistent backlink index** — `backlinks.py` (`rebuild_index`/`load_index`/`inbound_count`/`update_for_page`); `vault_backlinks` reads it; incremental on `vault_changed`, full-rebuild on delete/rename.
- **Deterministic importance recompute** — garden's `vault_recompute_importance`: `clamp01(w_retrieval·norm(retrieval_freq) + w_inbound·norm(inbound_links))` from real telemetry + backlinks; scoped to **agent pages only**, preserves cold-start importance (no-signal pages keep dream's estimate).

## Design decisions (approved by Les)

- **Structured merge tool** over prose YAML (enforces respect-manual-values + valid YAML in code; reused by dream/backfill/garden).
- **Deterministic importance formula** (reproducible/testable) over LLM judgment; dream supplies the cold-start estimate, garden's formula tunes over time.
- **Automated importance writes scoped to `agent/` pages** — the tool keeps vault-wide capability, but the unattended weekly sweep + backfill never silently rewrite the user's hand-written notes.
- `w_reference` reserved (0.0) — no clean per-page reference signal yet.

## Measurement

- `evals/retrieval-quality.yaml` — LLM-judge pipeline eval (frontmatter → composite embedding → proactive retrieval), passes 3/3.
- Two `tool_choice` disambiguation cases for the new tools.
- **Honest limitation:** a controlled frontmatter-A/B needs an eval-framework extension (`setup.vault_pages` fixture), filed as follow-up; the production before/after telemetry delta is deploy-and-wait (~a week of real traffic).

## Testing

~46 new unit tests (telemetry, merge tool + gating, backlinks incl. symlinked-root + rename/delete sync, importance formula + agent-scoping + cold-start, backfill). Full suite **3232 passed**, `make check` clean (only the pre-existing #638 forkpty warnings). Docs updated in-PR (`context-composer.md`, `vault.md`, `config.md`, `CLAUDE.md`). Session docs at `docs/dev-sessions/2026-07-24-...`.

## Follow-ups (filed, not in scope)

- Micro-evolution on journal append (#197 "Additional ideas", deferred).
- `setup.vault_pages` eval fixture for a controlled frontmatter A/B.
- Telemetry log rotation (#624) — importance uses lifetime retrieval count, no decay yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
