### PR TITLE
fix(web-terminal): open terminal chat-silently so the spinner doesn't hang (#627)

### DIFF
--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -23,8 +23,18 @@ Two ways, both human-only:
 **server-side side-effect command** — it is intercepted in `_handle_send`
 (`web/websocket.py`) before command dispatch, spawns the PTY, and opens a
 canvas tab, all without an LLM turn and without writing anything to the
-conversation's JSONL archive. The client only sees a `COMMAND_ACK` frame and
-the new canvas tab appearing.
+conversation's JSONL archive.
+
+A successful open is **chat-silent**: the server sends *no* chat frame, and
+the client (`conversation-store.js`) special-cases `/terminal` so it neither
+sets the "busy" progress state nor echoes an optimistic user message. The tab
+appears purely via the separate `canvas_update` channel. This decoupling is
+load-bearing: because the command runs no agent turn, it never emits a
+`MESSAGE_COMPLETE` frame — the signal that would clear the client's busy flag.
+An earlier version emitted a `COMMAND_ACK` on success, which rendered a
+"Running skill: terminal" bubble and left the progress spinner stuck forever
+with nothing to clear it. Only the *error* paths send a chat message (an
+inline `MESSAGE_COMPLETE`, which also clears busy).
 
 - No argument → CWD defaults to `terminal.default_cwd` (falls back to the
   agent's workspace path).

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -447,6 +447,18 @@ export class ConversationStore extends EventTarget {
       this.createConversation('', this.#activeModel, this.#currentFolder);
       return;
     }
+    // `/terminal` is a human-only side-effect command (#442): it opens a
+    // canvas tab via the separate canvas channel and runs NO agent turn, so
+    // it must not engage the conversation's busy/turn machinery. Sending it
+    // like a normal message would set `#busy` with nothing to clear it (the
+    // server sends no MESSAGE_COMPLETE for it) — a perpetual spinner. Fire it
+    // off without the busy flag or an optimistic user echo. Mirrors the
+    // server-side guard in _handle_send.
+    const trimmed = text.trim();
+    if (trimmed === '/terminal' || trimmed.startsWith('/terminal ')) {
+      this.#ws.send({ type: MESSAGE_TYPES.SEND, conv_id: this.#currentConvId, text });
+      return;
+    }
     // Optimistically add user message
     const userMsg = { role: 'user', content: text, timestamp: new Date().toISOString() };
     if (attachments.length) userMsg.attachments = attachments;

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -512,10 +512,12 @@ async def _handle_terminal_command(ws_send: WSSendCallable, conv_id, text, usern
         await _msg(f"Could not start terminal: {exc}")
         return
 
-    await ws_send({
-        "type": WSMessageType.COMMAND_ACK, "conv_id": conv_id,
-        "command": "/terminal", "skill": "terminal",
-    })
+    # Success is chat-silent: the tab opens via the canvas channel (the
+    # `emit` above), and we send NO chat message. A COMMAND_ACK here would
+    # leave the client's optimistic `busy` flag set forever — the terminal
+    # path runs no agent turn, so nothing would ever clear it (perpetual
+    # "Running skill: terminal" spinner). See _handle_send / conversation
+    # store: the client also skips the busy flag + user echo for /terminal.
 
 
 async def _handle_cancel_turn(ws_send: WSSendCallable, index, username, msg, state) -> None:

--- a/tests/web/test_terminal_command.py
+++ b/tests/web/test_terminal_command.py
@@ -140,7 +140,20 @@ async def test_terminal_command_spawns_and_creates_tab(terminal_send_env):
     await env.handle_send({"conv_id": "c1", "text": "/terminal"})
     assert env.registry.count_for_conv("c1") == 1
     assert env.new_tab_calls and env.new_tab_calls[0]["widget_type"] == "terminal"
-    assert any(m["type"] == "command_ack" for m in env.sent)
+
+
+@pytest.mark.asyncio
+async def test_terminal_command_success_is_chat_silent(terminal_send_env):
+    """A successful /terminal must emit NO chat messages — no COMMAND_ACK and
+    no MESSAGE_COMPLETE. The tab opens via the canvas channel; the chat log
+    stays untouched. Regression: COMMAND_ACK left the client's optimistic
+    `busy` flag set with nothing to clear it (perpetual "Running skill"
+    spinner), since the terminal path runs no agent turn."""
+    env = terminal_send_env()
+    await env.handle_send({"conv_id": "c1", "text": "/terminal"})
+    assert env.registry.count_for_conv("c1") == 1  # it really opened
+    assert not any(m["type"] == "command_ack" for m in env.sent)
+    assert not any(m["type"] == "message_complete" for m in env.sent)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Opening a terminal (the `>_` button or typing `/terminal`) left the conversation stuck in a perpetual progress spinner, looking like "a skill that never finishes." Reported against #627.

## Root cause

`/terminal` is a human-only side-effect command that runs **no agent turn** — but it reused the normal chat-send machinery:

- **Client** (`conversation-store.js`): `sendMessage` optimistically set `#busy = true` (the progress spinner) on every send, including `/terminal`. `#busy` is only cleared by a `MESSAGE_COMPLETE {final}` or `ERROR` frame.
- **Server** (`websocket.py`): a successful `/terminal` replied with only a `COMMAND_ACK`, which the client renders as a **"Running skill: terminal"** bubble. Because there's no agent turn, no `MESSAGE_COMPLETE` is ever sent — so nothing clears `#busy`.

Both symptoms (stuck spinner + never-completing "skill" bubble) came from this single coupling. Failures already cleared correctly (the error path sends an inline `MESSAGE_COMPLETE`); only the **success** path hung.

## Fix — decouple from the busy/turn machinery (chat-silent)

The tab already opens through the independent `canvas_update` channel, so the chat frames were never needed for the terminal to appear.

- **`websocket.py`** — drop the success `COMMAND_ACK`. Success is now chat-silent.
- **`conversation-store.js`** — `sendMessage` special-cases `/terminal` (button *and* typed): fires the WS message without setting `#busy` or echoing an optimistic user bubble. Single choke point covers both entry points.
- **`test_terminal_command.py`** — flipped the assertion that expected `COMMAND_ACK`; added `test_terminal_command_success_is_chat_silent` as a regression guard.
- **`docs/web-terminal.md`** — documented the chat-silent contract and why it's load-bearing.

Error paths are unchanged.

## Verification

- `make check` (ruff + pyright + tsc + message-type drift) clean.
- All terminal + web tests pass.

**Not yet done:** a live browser smoke (click `>_`, confirm the tab opens with no spinner / no "Running skill", send a follow-up message afterward) — the one thing unit tests can't cover, same limitation noted on #627. Didn't run it to avoid a competing bot instance against a running `make dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)