### PR TITLE
fix(web-terminal): debounce resizes to stop the prompt-reprint storm

### DIFF
--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -165,6 +165,19 @@ broadcasts `size_changed` so every client can letterbox if its own viewport
 is larger. This means a small popped-out window can force the in-canvas
 view (and any program relying on terminal size) down to its dimensions.
 
+The widget **debounces** resizes (`_scheduleResize`, 150 ms) and only sends a
+`resize` frame when the fitted `(cols, rows)` actually changed. This matters
+because the canvas panel animates its width (`transition: width 0.25s` in
+`canvas.css`) whenever a conversation is switched, so the widget's
+`ResizeObserver` fires roughly once per animation frame. Without coalescing,
+the terminal would walk the PTY through every intermediate width — and each
+genuine `TIOCSWINSZ` makes the shell reprint its prompt, so a single switch
+produced a cascade of prompt lines at ramping widths in the scrollback. The
+initial post-replay size (sent after `buffer_replay_done`) goes through the
+same debounce, not an immediate fit: a (re)connect lands mid-animation, and an
+immediate fit would grab a garbage intermediate width (e.g. 2 columns) and
+ship it to the PTY.
+
 The canvas host keeps every open tab's widget mounted (not just the active
 one) and toggles visibility instead of tearing widgets down on tab switch —
 this is what lets the terminal's WebSocket survive switching to another tab

--- a/src/decafclaw/web/static/widgets/terminal/widget.js
+++ b/src/decafclaw/web/static/widgets/terminal/widget.js
@@ -232,16 +232,23 @@ export class TerminalWidget extends LitElement {
     // A hidden panel fits to 0 (no-op) and sub-pixel jitter re-fires the
     // observer without changing cols/rows — neither should hit the PTY.
     if (cols === this._lastCols && rows === this._lastRows) return;
-    this._lastCols = cols;
-    this._lastRows = rows;
-    this._send({ type: 'resize', cols, rows });
+    // Advance the dedup baseline ONLY when the frame actually goes out. A
+    // debounced resize can fire mid-replay (`_send` is gated on !_replaying);
+    // updating the baseline there would let the dedup swallow the required
+    // post-`buffer_replay_done` resize, leaving the socket with no size.
+    if (this._send({ type: 'resize', cols, rows })) {
+      this._lastCols = cols;
+      this._lastRows = rows;
+    }
   }
 
-  /** @param {Object} obj */
+  /** @param {Object} obj @returns {boolean} whether the frame was transmitted */
   _send(obj) {
     if (this._ws && this._ws.readyState === WebSocket.OPEN && !this._replaying) {
       this._ws.send(JSON.stringify(obj));
+      return true;
     }
+    return false;
   }
 
   _teardownSocket() {

--- a/src/decafclaw/web/static/widgets/terminal/widget.js
+++ b/src/decafclaw/web/static/widgets/terminal/widget.js
@@ -51,6 +51,9 @@ export class TerminalWidget extends LitElement {
     this._ro = null;
     this._surface = null;
     this._reconnectTimer = null;
+    this._resizeTimer = null;    // debounce for ResizeObserver-driven fits
+    this._lastCols = 0;          // last size sent to the server (resize dedup)
+    this._lastRows = 0;
     this._connectedKey = null;   // `${convId}/${tabId}` of the currently-targeted session
   }
 
@@ -108,7 +111,7 @@ export class TerminalWidget extends LitElement {
     this._term.open(host);
     this._fit.fit();
     this._term.onData((d) => this._send({ type: 'input', data: d }));
-    this._ro = new ResizeObserver(() => this._onResize());
+    this._ro = new ResizeObserver(() => this._scheduleResize());
     this._ro.observe(host);
     // No live theme-change event exists in this codebase (theme-toggle.js
     // just sets/removes the data-theme attribute) — the terminal picks up
@@ -145,6 +148,11 @@ export class TerminalWidget extends LitElement {
   _connect() {
     this._state = 'connecting';
     this._connectedKey = `${this.convId}/${this.tabId}`;
+    // Force the post-replay resize to send: each socket registers its viewport
+    // server-side on its first `resize` frame (keyed per-connection), so the
+    // dedup must not swallow the initial size after a (re)connect.
+    this._lastCols = 0;
+    this._lastRows = 0;
     const ws = new WebSocket(this._wsUrl());
     ws.binaryType = 'arraybuffer';
     this._ws = ws;
@@ -174,7 +182,13 @@ export class TerminalWidget extends LitElement {
     if (msg.type === 'buffer_replay_done') {
       this._replaying = false;
       this._state = 'attached';
-      this._onResize();                           // send initial size
+      // Debounced, NOT immediate: a (re)connect lands while the canvas panel
+      // is still animating its width open (canvas.css `width 0.25s`), so an
+      // immediate fit grabs a garbage intermediate width (e.g. 2 cols) and
+      // ships it to the PTY — the shell reprints its prompt catastrophically
+      // wrapped. Debouncing coalesces this with the animation's resize burst
+      // and sends exactly one size, after the layout settles.
+      this._scheduleResize();                     // send initial size once settled
     } else if (msg.type === 'session_ended') {
       this._ended = msg.exit_status;
       this._state = 'ended';
@@ -196,10 +210,31 @@ export class TerminalWidget extends LitElement {
     this._reconnectTimer = setTimeout(() => this._connect(), delay);
   }
 
+  /**
+   * Coalesce ResizeObserver bursts. The canvas panel animates its width
+   * (`transition: width 0.25s` in canvas.css) whenever a conversation is
+   * switched, so the observer fires ~once per animation frame. Fitting +
+   * sending a resize on each frame walks the PTY through every intermediate
+   * width — and each genuine size change makes the shell reprint its prompt
+   * into the scrollback (a cascade of prompt lines at ramping widths). Debounce
+   * so we fit + send exactly once, after the layout settles.
+   */
+  _scheduleResize() {
+    clearTimeout(this._resizeTimer);
+    this._resizeTimer = setTimeout(() => this._onResize(), 150);
+  }
+
   _onResize() {
     if (!this._fit || !this._term) return;
     this._fit.fit();
-    this._send({ type: 'resize', cols: this._term.cols, rows: this._term.rows });
+    const { cols, rows } = this._term;
+    // Dedup: only tell the server when the fitted size actually changed.
+    // A hidden panel fits to 0 (no-op) and sub-pixel jitter re-fires the
+    // observer without changing cols/rows — neither should hit the PTY.
+    if (cols === this._lastCols && rows === this._lastRows) return;
+    this._lastCols = cols;
+    this._lastRows = rows;
+    this._send({ type: 'resize', cols, rows });
   }
 
   /** @param {Object} obj */
@@ -223,6 +258,8 @@ export class TerminalWidget extends LitElement {
 
   _teardown() {
     this._teardownSocket();
+    clearTimeout(this._resizeTimer);
+    this._resizeTimer = null;
     if (this._ro) { this._ro.disconnect(); this._ro = null; }
     if (this._term) { this._term.dispose(); this._term = null; }
     this._fit = null;


### PR DESCRIPTION
## Problem

Switching conversations spewed a cascade of duplicated shell prompt lines — at *ramping* widths — into the terminal scrollback. (Follow-on from #627, discovered while smoke-testing #647.)

## Root cause (confirmed by instrumented live repro, not inference)

The canvas panel animates its width (`transition: width 0.25s` in `canvas.css`) on every conversation switch. The widget's `ResizeObserver` therefore fires ~once per animation frame, and `_onResize` did an xterm `fit()` + sent a `resize` frame on **every** callback with no coalescing — walking the PTY through every intermediate width. Each genuine `TIOCSWINSZ` makes the shell reprint its prompt, and those reprints accumulate in the ring buffer and re-render on every reconnect+replay.

Evidence gathered by temporarily instrumenting the server:
- A macOS kernel test confirmed identical `TIOCSWINSZ` calls **don't** re-signal — so the storm was genuine size *changes*, not repeats.
- Server logs showed each (re)connect firing `resize cols=2` (a garbage mid-animation width) then `cols=63` — the `cols=2` came from an **immediate** `_onResize()` on `buffer_replay_done` firing mid-animation.

## Fix (client-side, `widget.js`)

- **Debounce** ResizeObserver-driven fits (`_scheduleResize`, 150 ms) → fit + send exactly once, after the layout settles.
- **Dedup** — only send `resize` when the fitted `cols`/`rows` actually changed (hidden panel fits to 0; sub-pixel jitter re-fires the observer).
- Route the **initial post-replay** size through the same debounce instead of an immediate fit (that's what was shipping `cols=2`). Reset the dedup baseline on each `_connect` so a fresh socket still registers its settled size server-side.
- Docs: `docs/web-terminal.md` "Multi-attach and resize" section documents the debounce + why.

## Verification

Instrumented the server and reproduced before/after. **Post-fix:** each (re)connect emits a single `resize` at the settled width, which matches the PTY's existing size → kernel dedups → no reprint; ring buffer holds steady (`2377 → 2377`) across round trips. `make check` / `check-js` clean; terminal unit tests pass.

**Note:** switching *conversations* still tears down + reconnects the socket (by design — the canvas panel unmounts per conversation; keep-alive only spans canvas *tab* switches). Benign now that resizes are clean. No JS unit harness exists for the widget — verification is `check-js` + the instrumented live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)