### PR TITLE
feat(web-terminal): move `>_` button to the chat-action cluster; fix attach-btn height

### DIFF
--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -12,10 +12,10 @@ Dev-session artifacts: [`docs/dev-sessions/2026-05-06-2042-web-terminal-canvas/`
 
 Two ways, both human-only:
 
-- Click the **`>_` button** in the chat input row (next to the 📎 attach
-  button). It appears once a conversation is active and sends `/terminal`
-  over the normal chat WebSocket — the same path as typing it, no dedicated
-  endpoint. Opens in the default CWD.
+- Click the **`>_` button** in the chat-action cluster at the top-right of the
+  conversation (next to the 📋 Copy menu). It appears once a conversation is
+  active and sends `/terminal` over the normal chat WebSocket — the same path
+  as typing it, no dedicated endpoint. Opens in the default CWD.
 - Type `/terminal` or `/terminal <cwd>` in the chat input (use the typed form
   to pass a specific CWD).
 

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -839,3 +839,29 @@ function setupCopyConversationMenu() {
 }
 
 setupCopyConversationMenu();
+
+function setupTerminalButton() {
+  // `>_` lives in the chat-action cluster (top-right of #chat-main), next to
+  // the Copy menu. Clicking it sends the `/terminal` side-effect command —
+  // conversation-store special-cases it (no busy state, no user echo; the
+  // canvas tab opens over the separate canvas channel). Hidden until a
+  // conversation is active, mirroring the Copy menu's convId gating.
+  const actions = getChatActions();
+  if (!actions) return;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'terminal-open-btn dc-floating-btn';
+  btn.title = 'Open a terminal';
+  btn.setAttribute('aria-label', 'Open a terminal');
+  btn.textContent = '>_';
+  btn.addEventListener('click', () => {
+    if (!store.currentConvId) return;
+    store.sendMessage('/terminal');
+  });
+  const sync = () => { btn.hidden = !store.currentConvId; };
+  sync();
+  actions.appendChild(btn);
+  store.addEventListener('change', sync);
+}
+
+setupTerminalButton();

--- a/src/decafclaw/web/static/components/chat-input.js
+++ b/src/decafclaw/web/static/components/chat-input.js
@@ -130,17 +130,6 @@ export class ChatInput extends LitElement {
     /** @type {HTMLInputElement|null} */ (this.querySelector('#file-input'))?.click();
   }
 
-  /** Open a terminal by sending the /terminal command over the normal send
-   * path — same server-side handler as typing it, no dedicated endpoint. */
-  #openTerminal() {
-    if (this.disabled) return;
-    this.dispatchEvent(new CustomEvent('send', {
-      detail: { text: '/terminal', attachments: [] },
-      bubbles: true,
-      composed: true,
-    }));
-  }
-
   // -- Drag and drop ----------------------------------------------------------
 
   /** @param {DragEvent} e */
@@ -198,10 +187,6 @@ export class ChatInput extends LitElement {
         ${!this.disabled ? html`
           <button type="button" class="attach-btn" @click=${this.#openFilePicker}
             title="Attach file">&#128206;</button>
-        ` : nothing}
-        ${!this.disabled && this.convId ? html`
-          <button type="button" class="terminal-btn" @click=${this.#openTerminal}
-            title="Open a terminal" aria-label="Open a terminal">&gt;_</button>
         ` : nothing}
         <textarea
           placeholder=${this.placeholder}

--- a/src/decafclaw/web/static/styles/chat-input.css
+++ b/src/decafclaw/web/static/styles/chat-input.css
@@ -34,19 +34,15 @@ chat-input .attach-btn {
   cursor: pointer;
   font-size: 1.2rem;
   opacity: 0.7;
+  /* The button carries `type="button"`, which matches Pico's
+     `[type=button] { margin-bottom: var(--pico-spacing) }` (specificity 0,1,0)
+     — that beats our `chat-input button { margin: 0 }` reset (0,0,2), leaving a
+     1rem bottom margin. With the row's `align-items: stretch`, that margin box
+     fills the row while the border box sits 1rem short. Zero it here (this
+     selector is 0,1,1, so it wins) so the button matches the field/Send. */
+  margin: 0;
 }
 chat-input .attach-btn:hover {
-  opacity: 1;
-}
-
-chat-input .terminal-btn {
-  cursor: pointer;
-  font-family: var(--pico-font-family-monospace, monospace);
-  font-weight: 700;
-  font-size: 1rem;
-  opacity: 0.7;
-}
-chat-input .terminal-btn:hover {
   opacity: 1;
 }
 

--- a/src/decafclaw/web/static/styles/chat.css
+++ b/src/decafclaw/web/static/styles/chat.css
@@ -41,6 +41,16 @@ chat-view {
   padding: 0 0.85rem;
   font-size: 0.85rem;
 }
+
+/* `>_` terminal-open button sits in the cluster next to Copy. Inherits the
+   .dc-floating-btn frame; here we only set the monospace glyph treatment. */
+button.terminal-open-btn {
+  padding: 0 0.85rem;
+  font-family: var(--pico-font-family-monospace, monospace);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+button.terminal-open-btn[hidden] { display: none; }
 .copy-menu-list {
   position: absolute;
   top: calc(100% + 0.3rem);


### PR DESCRIPTION
## What

Two small web-UI changes:

### 1. Relocate the terminal `>_` button
Moves it out of the chat-input row and into the top-right **chat-action cluster** next to the 📋 Copy menu (styled as a `dc-floating-btn`, hidden until a conversation is active). It sends the same `/terminal` side-effect command as before — chat-silent, canvas tab opens over the canvas channel.

### 2. Fix the 📎 attach-button height (surfaced by the move)
Once the terminal button left the row, the attach button was visibly ~1rem shorter than the field and Send.

**Root cause (confirmed via live computed-style inspection):** the attach button carries `type="button"`, which matches Pico's `[type=button] { margin-bottom: var(--pico-spacing) }` (specificity `0,1,0`). That outranks our `chat-input button { margin: 0 }` reset (`0,0,2`), so a 1rem bottom margin survived — and the row's `align-items: stretch` stretched the *margin box* to fill the row while the border box sat 1rem short. (Send has no `type` attribute, so it never matched and stayed at margin 0.) Zeroing the margin at `chat-input .attach-btn` (`0,1,1`) wins the cascade.

## Files
- `app.js` — `setupTerminalButton()` mounts in `.dc-chat-actions`, gated on `currentConvId`.
- `chat-input.js` — drop the in-row terminal button + `#openTerminal`.
- `chat.css` — `button.terminal-open-btn` glyph styling (+ an explicit `[hidden]` rule, since `.dc-floating-btn` sets `display: inline-flex` which would override the `hidden` attribute).
- `chat-input.css` — zero the attach-btn margin; remove the old `.terminal-btn` rule.
- `docs/web-terminal.md` — update the button's documented location.

## Verification
`make check-js` + `make lint` clean. Verified live: terminal button opens correctly from the cluster; attach button now matches the field/Send height (computed `marginBottom` back to 0). No Python surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
