### PR TITLE
feat(widgets): progress_tracker widget + checklist/project auto-emit (#414)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ See [docs/tools.md](docs/tools.md), [docs/tool-priority.md](docs/tool-priority.m
 - **Shell approval via shared `check_shell_approval()`** in `shell_tools.py`. Don't duplicate the approval checks.
 - **Per-tool timeout** wraps every non-MCP tool call (default 180s, env `TOOL_TIMEOUT_SEC`). Override via `timeout` key in `TOOL_DEFINITIONS`; `None` opts out. Current opt-outs: `delegate_task`, `conversation_compact`, `claude_code_send`. MCP tools use their own per-server timeout.
 - **`end_turn=True` on `ToolResult`** mechanically ends the turn (one final no-tools LLM call, then return). For review gates use `end_turn=EndTurnConfirm(message=..., on_approve=..., on_deny=...)`. For input widgets (`accepts_input=true`), pair with `end_turn=True` and the loop auto-promotes to a `WidgetInputPause` that pauses via the confirmation infra and resumes with the user's selection injected as a synthetic user message. Priority in one batch: `WidgetInputPause` > `EndTurnConfirm` > `True`.
-- **Checklist tools (`checklist_create/_step_done/_abort/_status`)** are always-loaded. Iteration happens within a single turn: do step → step_done → next.
+- **Checklist tools (`checklist_create/_step_done/_abort/_status`)** are always-loaded. Iteration happens within a single turn: do step → step_done → next. Create/step_done/abort auto-emit a `progress_tracker` into the sticky slot (fail-open), see [docs/widgets.md](docs/widgets.md#progress_tracker-widget).
 - **Events for progress.** Tools publish `tool_status` via `ctx.publish()`.
 
 ### Web UI styling
@@ -180,7 +180,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `preempt_search.py` — Keyword-match for pre-emptive tool promotion
 
 ### Skills (bundled)
-`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,skill-creator}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`.
+`skills/{vault,tabstack,dream,garden,project,claude_code,health,postmortem,ingest,background,mcp,newsletter,skill-creator}/`. `vault`, `background`, `mcp` are always-loaded. Contrib (opt-in) skills live in `contrib/skills/`. `project` auto-emits a `progress_tracker` into the sticky slot while EXECUTING (fail-open), clearing on DONE or leaving EXECUTING.
 
 ### Workflows
 `workflow/` — Durable replay engine ([docs/workflows.md](docs/workflows.md)): `registry.py` (`@workflow` decorator), `engine.py` (`run_workflow`), `journal.py` (positional keyed journal + fingerprint), `handle.py` (`WorkflowHandle` — the `wf` object with `llm_call`/`user_input`/`tool_call`/`subagent`/`parallel`/`pipeline` primitives), `llm.py` (forced-tool structured-output), `errors.py` (`WorkflowSuspended`, `WorkflowNonDeterministic`, `WorkflowToolNotAllowed`), `paths.py` (per-conv file paths), `resume.py` (harness glue: `run_workflow_turn` + `WorkflowUserInputHandler`), `workflows/interview.py` (suspend/resume hero), `workflows/research.py` (multi-primitive hero — fan-out + pipeline + subagent).
@@ -195,7 +195,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `heartbeat.py`, `schedules.py`, `polling.py`
 - `notifications.py`, `notification_channels/`, `mail.py`
 - `mcp_client.py`
-- `media.py`, `widgets.py`, `widget_input.py`, `web/static/widgets/`, `web/static/components/widgets/widget-host.js`
+- `media.py`, `widgets.py`, `widget_input.py`, `web/static/widgets/` (incl. `web/static/widgets/progress_tracker/`), `web/static/components/widgets/widget-host.js`
 - `web/static/components/canvas-panel.js`, `web/static/lib/canvas-state.js`
 - `web/static/components/sticky-slot.js`, `web/static/lib/sticky-state.js` — sticky slot (pinned display-only widget above chat input)
 - `terminals.py` — human-only PTY session registry backing the web terminal ([docs/web-terminal.md](docs/web-terminal.md))

--- a/docs/dev-sessions/2026-07-24-1133-progress-tracker/notes.md
+++ b/docs/dev-sessions/2026-07-24-1133-progress-tracker/notes.md
@@ -86,4 +86,20 @@ session's changes (no terminal code touched).
 
 ## Manual QA
 
-_(pending — live browser QA driven by controller + human)_
+Verified live in the web UI (local web-only server, `MATTERMOST_ENABLED=false`,
+`HTTP_PORT=18992`, Playwright-driven):
+
+- Asked the agent to `widget_pin_sticky` a `progress_tracker` with all five
+  statuses. Agent made the single tool call → `sticky_set` → the slot rendered
+  above the chat input on the first attempt (vertex-gemini-flash, reflection
+  PASS, no console errors).
+- Rendering confirmed quiet and correct: collapsed summary line `1/5 · Run
+  migrations` with a ▾ toggle; title "Deploy pipeline"; step rows —
+  ● done (green, note "cached"), ◐ in_progress (blue), ○ pending (muted),
+  ✗ failed (red, note "registry 500"), ⊘ skipped (muted, strikethrough).
+  Notes render dim inline.
+- Look approved as-is by Les (no glyph/color/spacing changes requested).
+
+Auto-emit wiring (checklist / project → sticky) is covered by the unit tests
+in Tasks 2–3; the live pin above exercises the identical widget + sticky
+render path.

--- a/docs/dev-sessions/2026-07-24-1133-progress-tracker/notes.md
+++ b/docs/dev-sessions/2026-07-24-1133-progress-tracker/notes.md
@@ -1,0 +1,89 @@
+# Notes — progress-tracker (#414)
+
+## Session summary
+
+Built a display-only `progress_tracker` widget and wired two producers to
+auto-emit it into the sticky slot (#419) without any new agent-facing
+tools:
+
+- **Task 1 — widget.** `src/decafclaw/web/static/widgets/progress_tracker/`
+  (`widget.json` + `widget.js`, Lit element). Snapshot-rendered (each
+  update replaces the full step list). Modes `["inline", "canvas",
+  "sticky"]`, `accepts_input: false`. `data_schema`: `steps[]` (each
+  `{label, status, note?}`, `status ∈ pending | in_progress | done | failed
+  | skipped`), plus optional `title` and `summary` (the summary drives the
+  sticky slot's collapsed header line). Five distinct glyphs (○ ◐ ● ✗ ⊘).
+- **Task 2 — checklist auto-emit.** `checklist_create` / `_step_done` /
+  `_abort` (now async) mirror checklist state into the sticky slot as a
+  `progress_tracker` via `sticky.set_sticky` / `clear_sticky`, fail-open.
+  The slot clears once all steps are done or on abort. `checklist_status`
+  stays sync (read-only, no emit).
+- **Task 3 — project skill auto-emit.** While a project is in the
+  `executing` phase, `project_next_task` / `project_update_step` /
+  `project_add_steps` mirror the plan's leaf steps into the sticky slot.
+  Clears on `project_task_done` finalizing the project (DONE) and on
+  `project_advance` moving the project out of `executing`. No emit outside
+  `executing`. Fail-open.
+- **Task 4 — docs + integration gate** (this task). Documented the widget
+  and both auto-emit producers, fixed stale sticky-slot doc text, updated
+  CLAUDE.md, ran `make check` / `make test` clean.
+
+## Key decisions
+
+- **Five statuses including `skipped`.** Matches the project skill's plan
+  step vocabulary (`- [-] N. Skipped step`) so the project producer can
+  pass plan-step status straight through without a lossy mapping.
+- **Project auto-emit is EXECUTING-only.** Brainstorm/spec/plan-review
+  phases don't have a step list yet; emitting outside `executing` would
+  show a stale or empty tracker. The slot only starts tracking once the
+  agent enters execution and clears the moment it leaves (either by
+  finishing or by replanning).
+- **Fail-open everywhere.** Both producers wrap the sticky mirror in a
+  bare `try/except Exception: log.warning(...)` — a sticky-slot failure
+  must never break the underlying checklist or project tool call. This
+  matches the project's existing "producers fail-open" convention (see
+  notifications, memory retrieval).
+- **No new tools, no eval cases.** The auto-emit is a side effect of
+  existing tools (`checklist_*`, `project_*`); nothing new is exposed to
+  the LLM, so there's no new tool-choice surface to guard with an eval.
+  `widget_pin_sticky` remains the manual path for pinning a
+  `progress_tracker` directly.
+- **Both producers call `sticky.set_sticky`/`clear_sticky` directly**,
+  not the `widget_pin_sticky`/`widget_unpin_sticky` tools — those tools
+  exist for agent-driven pinning; the auto-emit is a mechanical mirror the
+  agent doesn't decide about.
+
+## Commits
+
+Full feature range (Tasks 1–4, docs/spec/plan commits, oldest first):
+
+```
+8015f9f docs(414): spec for progress_tracker widget + checklist/project auto-emit
+1e4822e docs(414): implementation plan for progress_tracker widget + auto-emit
+bc4ceac feat(414): progress_tracker widget (meta + Lit element + styles)
+b345081 feat(414): checklist auto-emits progress_tracker to sticky slot
+e2f52d0 feat(414): project skill auto-emits progress_tracker during executing
+b253774 fix(414): clear sticky when project leaves EXECUTING via project_advance; test planning-phase guard
+```
+
+(`git log --oneline b345081^..HEAD` — the command named in the Task 4
+brief — resolves to `b345081`, `e2f52d0`, `b253774`; it excludes `bc4ceac`,
+the Task 1 widget commit, since `b345081^` *is* `bc4ceac`. Listed the full
+`bc4ceac^..HEAD` range above instead so the widget commit isn't dropped
+from the record.)
+
+## Test results (Step 3 — integration gate)
+
+`make check` — **PASS**. gen-message-types drift check no-op (no wire-type
+changes this session), `ruff check` clean, `pyright` 0 errors/0
+warnings/0 informations, `tsc --noEmit` clean.
+
+`make test` — **PASS**. `3248 passed, 2 skipped` in ~47.5s (8 xdist
+workers). Two `DeprecationWarning: forkpty() may lead to deadlocks`
+warnings from `tests/test_terminals.py` / `tests/web/test_terminal_ws.py`
+— pre-existing, from Python's own `pty` module on macOS, unrelated to this
+session's changes (no terminal code touched).
+
+## Manual QA
+
+_(pending — live browser QA driven by controller + human)_

--- a/docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md
+++ b/docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md
@@ -1,0 +1,871 @@
+# progress_tracker Widget + Auto-Emit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a display-only `progress_tracker` widget (multi-step status list) and auto-emit it into the sticky slot from the checklist tool and the project skill, giving the user a live progress view for free.
+
+**Architecture:** A new bundled widget (`web/static/widgets/progress_tracker/`, auto-registered by directory scan). The checklist tools (`checklist_tools.py`) become async and call `sticky.set_sticky`/`clear_sticky` after each mutation; the project skill (`skills/project/tools.py`, already async) does the same during the EXECUTING phase. Both build a `progress_tracker` data payload from their own task model and emit fail-open — a sticky failure never breaks the underlying tool. No new agent tools; no eval cases (deterministic side-effect wiring).
+
+**Tech Stack:** Python 3.13, Lit (web components), jsonschema (widget validation), pytest / pytest-asyncio.
+
+## Global Constraints
+
+- Widget = `widget.json` (meta) + `widget.js` (Lit `dc-widget-<name>`) in one dir under `web/static/widgets/`; auto-registered by directory scan (no central registry edit). Element tag is `dc-widget-` + name with `_`→`-` (`progress_tracker` → `dc-widget-progress-tracker`).
+- Widget renders into **light DOM** (`createRenderRoot() { return this; }`) so global `styles/widgets.css` applies. Widget CSS lives in `src/decafclaw/web/static/styles/widgets.css` (imported by `style.css`).
+- Widget status enum (5 values): `pending | in_progress | done | failed | skipped`.
+- `ToolResult(text="[error: ...]")` for tool errors, never bare strings/raises.
+- **Auto-emit is fail-open:** wrap every `set_sticky`/`clear_sticky` call in `try/except Exception: log.warning(...)`; the checklist/project tool returns its normal result regardless.
+- Skills use **absolute imports** (`from decafclaw...`). Do not import private helpers across modules — replicate the 3-line `_emit_for_ctx` locally where needed.
+- `execute_tool` auto-detects sync vs async, so making the checklist tools async is runtime-safe.
+- Sticky emit in non-web (terminal/Mattermost) conversations is a harmless no-op (web-only surface; sidecar write is cheap).
+- Commit after each task. Run `make check` + `make test` green before the PR.
+
+---
+
+### Task 1: The `progress_tracker` widget
+
+Create the widget (meta + Lit element + CSS) and prove it registers and validates a 5-status payload. This is the reusable half; it renders in inline/canvas/sticky and can be pinned manually via the existing `widget_pin_sticky` tool.
+
+**Files:**
+- Create: `src/decafclaw/web/static/widgets/progress_tracker/widget.json`
+- Create: `src/decafclaw/web/static/widgets/progress_tracker/widget.js`
+- Modify: `src/decafclaw/web/static/styles/widgets.css` (append)
+- Test: `tests/test_widgets.py` (append)
+
+**Interfaces:**
+- Produces: a bundled widget named `progress_tracker`, modes `["inline","canvas","sticky"]`, `accepts_input:false`, whose `data_schema` requires `steps[]` of `{label, status∈{pending,in_progress,done,failed,skipped}, note?}` and allows `title?`, `summary?`. Custom element `dc-widget-progress-tracker` with a `.data` property.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_widgets.py` (uses the existing `fake_config` fixture + bundled-scan pattern, mirroring `test_bundled_markdown_document_is_registered`):
+```python
+def test_bundled_progress_tracker_is_registered(fake_config):
+    """Fresh registry scan finds the bundled progress_tracker widget."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    desc = reg.get("progress_tracker")
+    assert desc is not None
+    assert desc.tier == "bundled"
+    assert desc.accepts_input is False
+    assert set(desc.modes) == {"inline", "canvas", "sticky"}
+
+
+def test_progress_tracker_validates_all_statuses(fake_config):
+    """The schema accepts every status value and rejects an unknown one."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    ok, err = reg.validate("progress_tracker", {
+        "title": "Work",
+        "summary": "1/5",
+        "steps": [
+            {"label": "a", "status": "done", "note": "n"},
+            {"label": "b", "status": "in_progress"},
+            {"label": "c", "status": "pending"},
+            {"label": "d", "status": "failed"},
+            {"label": "e", "status": "skipped"},
+        ],
+    })
+    assert ok, err
+    bad_ok, _ = reg.validate("progress_tracker", {
+        "steps": [{"label": "x", "status": "bogus"}],
+    })
+    assert bad_ok is False
+    missing_ok, _ = reg.validate("progress_tracker", {"steps": [{"label": "x"}]})
+    assert missing_ok is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_widgets.py::test_bundled_progress_tracker_is_registered tests/test_widgets.py::test_progress_tracker_validates_all_statuses -v`
+Expected: FAIL — `reg.get("progress_tracker")` is `None` (widget dir doesn't exist yet).
+
+- [ ] **Step 3: Create `widget.json`**
+
+Create `src/decafclaw/web/static/widgets/progress_tracker/widget.json`:
+```json
+{
+  "name": "progress_tracker",
+  "description": "A quiet multi-step status list (pending / in_progress / done / failed / skipped). Shows in-flight progress of a task at a glance. Display-only, snapshot-rendered. Auto-emitted by the checklist tool and the project skill; can also be pinned manually.",
+  "modes": ["inline", "canvas", "sticky"],
+  "accepts_input": false,
+  "data_schema": {
+    "type": "object",
+    "required": ["steps"],
+    "properties": {
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["label", "status"],
+          "properties": {
+            "label": { "type": "string" },
+            "status": {
+              "type": "string",
+              "enum": ["pending", "in_progress", "done", "failed", "skipped"]
+            },
+            "note": { "type": "string" }
+          }
+        }
+      },
+      "title": { "type": "string" },
+      "summary": { "type": "string" }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Create `widget.js`**
+
+Create `src/decafclaw/web/static/widgets/progress_tracker/widget.js`:
+```javascript
+import { LitElement, html, nothing } from 'lit';
+
+/**
+ * Progress tracker widget. Props:
+ *   data = { steps: [{label, status, note?}], title?: string, summary?: string }
+ * Display-only, snapshot-rendered — each update replaces the full step list.
+ * Status ∈ pending | in_progress | done | failed | skipped.
+ */
+const _GLYPHS = {
+  pending: '○',
+  in_progress: '◐',
+  done: '●',
+  failed: '✗',
+  skipped: '⊘',
+};
+
+export class ProgressTrackerWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    /** @type {{steps: {label: string, status: string, note?: string}[], title?: string, summary?: string}|null} */
+    this.data = null;
+  }
+
+  render() {
+    const d = this.data;
+    if (!d || !Array.isArray(d.steps)) {
+      return html`<div class="progress-tracker progress-tracker--empty"><em>no steps</em></div>`;
+    }
+    return html`
+      <div class="progress-tracker">
+        ${d.title ? html`<div class="progress-tracker__title">${d.title}</div>` : nothing}
+        <ul class="progress-tracker__list">
+          ${d.steps.map((s) => {
+            const status = s && typeof s.status === 'string' ? s.status : 'pending';
+            const glyph = _GLYPHS[status] || _GLYPHS.pending;
+            return html`
+              <li class="progress-tracker__item progress-tracker__item--${status}">
+                <span class="progress-tracker__glyph" aria-hidden="true">${glyph}</span>
+                <span class="progress-tracker__label"
+                  >${s?.label ?? ''}${s?.note
+                    ? html`<span class="progress-tracker__note"> — ${s.note}</span>`
+                    : nothing}</span>
+              </li>
+            `;
+          })}
+        </ul>
+      </div>
+    `;
+  }
+}
+
+customElements.define('dc-widget-progress-tracker', ProgressTrackerWidget);
+```
+
+- [ ] **Step 5: Append CSS**
+
+Append to `src/decafclaw/web/static/styles/widgets.css`:
+```css
+/* progress_tracker — quiet multi-step status list */
+.progress-tracker { font-size: 0.85rem; }
+.progress-tracker__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin: 0 0 0.35rem;
+}
+.progress-tracker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.progress-tracker__item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+.progress-tracker__glyph { flex: 0 0 1rem; text-align: center; }
+.progress-tracker__label { flex: 1; min-width: 0; }
+.progress-tracker__note { color: var(--pico-muted-color); font-size: 0.8rem; }
+.progress-tracker__item--pending { color: var(--pico-muted-color); }
+.progress-tracker__item--pending .progress-tracker__glyph { color: var(--pico-muted-color); }
+.progress-tracker__item--in_progress .progress-tracker__glyph { color: var(--pico-primary); }
+.progress-tracker__item--done .progress-tracker__glyph { color: var(--pico-ins-color, #2e7d32); }
+.progress-tracker__item--failed .progress-tracker__glyph { color: var(--pico-del-color, #c62828); }
+.progress-tracker__item--skipped { color: var(--pico-muted-color); }
+.progress-tracker__item--skipped .progress-tracker__label { text-decoration: line-through; }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_widgets.py -v -k progress_tracker`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Verify JS typechecks**
+
+Run: `make check-js`
+Expected: PASS (tsc --checkJs clean). No new vendored imports, so no `make vendor` needed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/decafclaw/web/static/widgets/progress_tracker/ src/decafclaw/web/static/styles/widgets.css tests/test_widgets.py
+git commit -m "feat(414): progress_tracker widget (meta + Lit element + styles)"
+```
+
+---
+
+### Task 2: Checklist auto-emit
+
+Make the three checklist tools async and emit a mapped `progress_tracker` into the sticky slot on create/step_done, clearing it when all steps are done or the checklist is aborted. Fail-open throughout.
+
+**Files:**
+- Modify: `src/decafclaw/tools/checklist_tools.py`
+- Test: `tests/test_checklist_tools.py` (rewrite calls to async)
+
+**Interfaces:**
+- Consumes: `decafclaw.sticky.set_sticky(config, conv_id, widget_type, data, emit=None)` / `clear_sticky(config, conv_id, emit=None)`; `checklist.checklist_status(config, conv_id) -> list[{text,done,note}]`.
+- Produces: `tool_checklist_create` / `tool_checklist_step_done` / `tool_checklist_abort` are now **async**; `_progress_data_from_checklist(items: list[dict]) -> dict` (progress_tracker payload).
+
+- [ ] **Step 1: Verify no other caller invokes these tools synchronously**
+
+Run: `grep -rn "tool_checklist_create\|tool_checklist_step_done\|tool_checklist_abort" src/ tests/`
+Expected: only `checklist_tools.py` (definition + registry) and `tests/test_checklist_tools.py`. `test_tool_registry.py` / `test_search_tools.py` reference the string name `"checklist_create"` only (synthetic defs), not the function — confirm they do NOT appear. If any other real caller exists, add it to this task's scope (await it).
+
+- [ ] **Step 2: Write the failing tests**
+
+Rewrite `tests/test_checklist_tools.py`. Add `import pytest` and the mapping/wiring tests; convert every tool call to `await` and mark tests `async`. Full file:
+```python
+"""Tests for checklist tools."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from decafclaw.media import ToolResult
+from decafclaw.tools.checklist_tools import (
+    _progress_data_from_checklist,
+    tool_checklist_abort,
+    tool_checklist_create,
+    tool_checklist_status,
+    tool_checklist_step_done,
+)
+
+
+# --- pure mapping ---------------------------------------------------------
+
+def test_progress_data_maps_first_unchecked_to_in_progress():
+    items = [
+        {"text": "A", "done": True, "note": "did a"},
+        {"text": "B", "done": False, "note": ""},
+        {"text": "C", "done": False, "note": ""},
+    ]
+    data = _progress_data_from_checklist(items)
+    assert [s["status"] for s in data["steps"]] == ["done", "in_progress", "pending"]
+    assert data["steps"][0]["note"] == "did a"
+    assert data["title"] == "Checklist"
+    assert data["summary"] == "1/3 · B"
+
+
+def test_progress_data_all_done_summary_has_no_current():
+    items = [{"text": "A", "done": True, "note": ""}]
+    data = _progress_data_from_checklist(items)
+    assert data["steps"][0]["status"] == "done"
+    assert data["summary"] == "1/1"
+
+
+# --- existing behavior (now async) ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_checklist_create(ctx):
+    result = await tool_checklist_create(ctx, steps=["Step A", "Step B", "Step C"])
+    assert isinstance(result, ToolResult)
+    assert "3 steps" in result.text
+    assert "Step A" in result.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_create_empty(ctx):
+    result = await tool_checklist_create(ctx, steps=[])
+    assert "error" in result.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_step_done_advances(ctx):
+    await tool_checklist_create(ctx, steps=["First", "Second", "Third"])
+    result = await tool_checklist_step_done(ctx, note="done with first")
+    assert result.end_turn is False
+    assert "Second" in result.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_step_done_all_complete(ctx):
+    await tool_checklist_create(ctx, steps=["Only step"])
+    result = await tool_checklist_step_done(ctx)
+    assert result.end_turn is True
+    assert "complete" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_checklist_step_done_no_checklist(ctx):
+    result = await tool_checklist_step_done(ctx)
+    assert "error" in result.text.lower() or "no active" in result.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_checklist_abort(ctx):
+    await tool_checklist_create(ctx, steps=["Step 1", "Step 2"])
+    result = await tool_checklist_abort(ctx, reason="changed my mind")
+    assert "aborted" in result.text.lower()
+    assert "changed my mind" in result.text
+    status = await tool_checklist_status(ctx)
+    assert "No active" in status.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_abort_empty(ctx):
+    result = await tool_checklist_abort(ctx)
+    assert "No active" in result.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_status(ctx):
+    await tool_checklist_create(ctx, steps=["A", "B", "C"])
+    await tool_checklist_step_done(ctx)
+    status = await tool_checklist_status(ctx)
+    assert "[x]" in status.text
+    assert "[ ]" in status.text
+    assert "current" in status.text
+    assert "1/3 complete" in status.text
+
+
+@pytest.mark.asyncio
+async def test_checklist_status_empty(ctx):
+    result = await tool_checklist_status(ctx)
+    assert "No active" in result.text
+
+
+# --- sticky auto-emit wiring (monkeypatch sticky funcs) -------------------
+
+@pytest.mark.asyncio
+async def test_create_emits_set_sticky(ctx, monkeypatch):
+    set_mock = AsyncMock()
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["A", "B"])
+    assert set_mock.await_count == 1
+    args, kwargs = set_mock.await_args
+    # (config, conv_id, widget_type, data)
+    assert args[2] == "progress_tracker"
+    assert args[3]["steps"][0]["status"] == "in_progress"
+    clear_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_final_step_done_clears_sticky(ctx, monkeypatch):
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["only"])
+    await tool_checklist_step_done(ctx)
+    assert clear_mock.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_abort_clears_sticky(ctx, monkeypatch):
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["A", "B"])
+    await tool_checklist_abort(ctx)
+    assert clear_mock.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_sticky_failure_is_fail_open(ctx, monkeypatch):
+    monkeypatch.setattr("decafclaw.sticky.set_sticky",
+                        AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky",
+                        AsyncMock(side_effect=RuntimeError("boom")))
+    # Must not raise; checklist still works.
+    result = await tool_checklist_create(ctx, steps=["A"])
+    assert "1 step" in result.text or "1 steps" in result.text
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_checklist_tools.py -v`
+Expected: FAIL — `_progress_data_from_checklist` import error / tools not awaitable.
+
+- [ ] **Step 4: Implement**
+
+Rewrite `src/decafclaw/tools/checklist_tools.py`:
+```python
+"""Checklist tools — mechanical step-by-step execution loop.
+
+Always-loaded tools that drive the agent through a checklist one step
+at a time. The agent iterates within a single turn: do step → call
+step_done → get next step → do next step. ``end_turn=True`` is only
+set when all steps are complete (agent summarizes and stops).
+
+As a side effect, each mutation mirrors the checklist into the sticky
+slot as a ``progress_tracker`` widget so the user sees live progress.
+The mirror is fail-open — a sticky failure never breaks the checklist.
+"""
+
+import logging
+
+from .. import checklist
+from .. import sticky as sticky_mod
+from ..media import ToolResult
+
+log = logging.getLogger(__name__)
+
+
+def _emit_for_ctx(ctx):
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit
+
+
+def _progress_data_from_checklist(items: list[dict]) -> dict:
+    """Map checklist items {text,done,note} → progress_tracker data.
+
+    Completed items → 'done'; the first not-done item → 'in_progress';
+    remaining not-done items → 'pending'.
+    """
+    steps = []
+    first_pending = True
+    done_count = 0
+    current_label = ""
+    for item in items:
+        if item["done"]:
+            status = "done"
+            done_count += 1
+        elif first_pending:
+            status = "in_progress"
+            first_pending = False
+            current_label = item["text"]
+        else:
+            status = "pending"
+        step = {"label": item["text"], "status": status}
+        if item.get("note"):
+            step["note"] = item["note"]
+        steps.append(step)
+    total = len(items)
+    summary = f"{done_count}/{total} · {current_label}" if current_label \
+        else f"{done_count}/{total}"
+    return {"steps": steps, "title": "Checklist", "summary": summary}
+
+
+async def _mirror_to_sticky(ctx, conv_id: str) -> None:
+    """Sync the sticky slot with current checklist state. Fail-open.
+
+    Clears the slot when there is no active checklist or every step is
+    done; otherwise pins a progress_tracker snapshot.
+    """
+    try:
+        items = checklist.checklist_status(ctx.config, conv_id)
+        if not items or all(i["done"] for i in items):
+            await sticky_mod.clear_sticky(
+                ctx.config, conv_id, emit=_emit_for_ctx(ctx))
+            return
+        data = _progress_data_from_checklist(items)
+        await sticky_mod.set_sticky(
+            ctx.config, conv_id, "progress_tracker", data,
+            emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("checklist sticky mirror failed for %s", conv_id,
+                    exc_info=True)
+
+
+async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
+    """Create a checklist and return the first step."""
+    conv_id = ctx.conv_id or "default"
+    if not steps:
+        return ToolResult(text="[error: steps list is empty]")
+    items = checklist.checklist_create(ctx.config, conv_id, steps)
+    await _mirror_to_sticky(ctx, conv_id)
+    first = items[0]["text"]
+    return ToolResult(
+        text=f"Checklist created ({len(items)} steps). "
+             f"Do step 1 now: {first}\n\n"
+             f"When done, call checklist_step_done.",
+    )
+
+
+async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
+    """Mark current step done and advance. end_turn=True only when all complete."""
+    conv_id = ctx.conv_id or "default"
+    next_item = checklist.checklist_complete_current(ctx.config, conv_id, note)
+    await _mirror_to_sticky(ctx, conv_id)
+    if next_item is None:
+        items = checklist.checklist_status(ctx.config, conv_id)
+        if not items:
+            return ToolResult(text="[error: no active checklist]")
+        done = sum(1 for i in items if i["done"])
+        return ToolResult(
+            text=f"All {done} steps complete! Summarize what was accomplished.",
+            end_turn=True,
+        )
+    return ToolResult(
+        text=f"Step {next_item['index'] - 1}/{next_item['total']} done. "
+             f"Do step {next_item['index']} now: {next_item['text']}\n\n"
+             f"When done, call checklist_step_done.",
+    )
+
+
+async def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
+    """Abandon the current checklist."""
+    conv_id = ctx.conv_id or "default"
+    items = checklist.checklist_status(ctx.config, conv_id)
+    if not items:
+        return ToolResult(text="No active checklist to abort.")
+    done = sum(1 for i in items if i["done"])
+    checklist.checklist_abort(ctx.config, conv_id)
+    await _mirror_to_sticky(ctx, conv_id)
+    msg = f"Checklist aborted ({done}/{len(items)} steps were complete)."
+    if reason:
+        msg += f" Reason: {reason}"
+    return ToolResult(text=msg)
+
+
+def tool_checklist_status(ctx) -> ToolResult:
+    """Show current checklist progress."""
+    conv_id = ctx.conv_id or "default"
+    items = checklist.checklist_status(ctx.config, conv_id)
+    if not items:
+        return ToolResult(text="No active checklist.")
+    lines = []
+    current_found = False
+    for i, item in enumerate(items, 1):
+        if item["done"]:
+            note_suffix = f" — {item['note']}" if item.get("note") else ""
+            lines.append(f"  {i}. [x] {item['text']}{note_suffix}")
+        else:
+            marker = " ← current" if not current_found else ""
+            lines.append(f"  {i}. [ ] {item['text']}{marker}")
+            if not current_found:
+                current_found = True
+    done = sum(1 for i in items if i["done"])
+    lines.append(f"\n{done}/{len(items)} complete")
+    return ToolResult(text="\n".join(lines))
+
+
+CHECKLIST_TOOLS = {
+    "checklist_create": tool_checklist_create,
+    "checklist_step_done": tool_checklist_step_done,
+    "checklist_abort": tool_checklist_abort,
+    "checklist_status": tool_checklist_status,
+}
+```
+(Keep the existing `CHECKLIST_TOOL_DEFINITIONS` list below unchanged — descriptions are not modified.) `tool_checklist_status` stays sync (it doesn't mutate; `execute_tool` handles the mix).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_checklist_tools.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 6: Confirm no wider breakage**
+
+Run: `uv run pytest tests/test_tool_registry.py tests/test_search_tools.py -q`
+Expected: PASS (they reference the tool name only).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/decafclaw/tools/checklist_tools.py tests/test_checklist_tools.py
+git commit -m "feat(414): checklist auto-emits progress_tracker to sticky slot"
+```
+
+---
+
+### Task 3: Project-skill auto-emit (EXECUTING phase)
+
+Emit a `progress_tracker` to the sticky slot while a project is EXECUTING, on `project_next_task` / `project_update_step` / `project_add_steps`, and clear on transition to DONE. Fail-open.
+
+**Files:**
+- Modify: `src/decafclaw/skills/project/tools.py`
+- Test: `tests/test_project_tools.py` (add `conv_id` to fixture; add emit tests)
+
+**Interfaces:**
+- Consumes: `decafclaw.sticky.set_sticky`/`clear_sticky`; `plan_parser.parse_plan`, `plan_progress`, `next_actionable`; `Step` fields `number/description/status/note/children`.
+- Produces: `_progress_data_from_plan(info, steps) -> dict`; internal `_emit_project_progress(ctx, info)` / `_clear_project_progress(ctx)` helpers, wired into the four tools above.
+
+- [ ] **Step 1: Write the failing tests**
+
+First, extend the `ctx` fixture in `tests/test_project_tools.py` to carry `conv_id` and (implicitly) no `manager`:
+```python
+@pytest.fixture
+def ctx(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = SimpleNamespace(workspace_path=workspace)
+    tools = SimpleNamespace(
+        preapproved={"project_next_task", "project_advance"},
+        current_call_id=None,
+    )
+    skills = SimpleNamespace(data={})
+    return SimpleNamespace(config=config, tools=tools, skills=skills,
+                           conv_id="proj-conv", manager=None)
+```
+
+Then append a new test class (uses the existing `_advance_to_executing` helper + `AsyncMock` monkeypatch, so no widget registry / real sidecar needed):
+```python
+class TestProgressTrackerEmit:
+    @pytest.mark.asyncio
+    async def test_update_step_emits_during_executing(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        set_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock())
+        await _advance_to_executing(ctx, slug="pt-step")
+        set_mock.reset_mock()
+        await tool_project_update_step(ctx, step="1.1", status="done", note="ok")
+        assert set_mock.await_count >= 1
+        args, _ = set_mock.await_args
+        assert args[2] == "progress_tracker"
+        labels = [s["label"] for s in args[3]["steps"]]
+        assert any(lbl.startswith("1.1.") for lbl in labels)
+
+    @pytest.mark.asyncio
+    async def test_done_clears_sticky(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        clear_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+        plan = "# Plan\n\n## Steps\n\n- [ ] 1. Only step\n"
+        await _advance_to_executing(ctx, slug="pt-done", plan=plan)
+        await tool_project_update_step(ctx, step="1", status="done")
+        result = await tool_project_task_done(ctx)
+        assert _text(result) == "Project complete!" or "complete" in _text(result).lower()
+        assert clear_mock.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_emit_outside_executing(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        set_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock())
+        await tool_project_create(ctx, description="planning phase", slug="pt-plan")
+        # BRAINSTORMING phase: next_task must not pin a tracker.
+        await tool_project_next_task(ctx)
+        set_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_is_fail_open(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        monkeypatch.setattr("decafclaw.sticky.set_sticky",
+                            AsyncMock(side_effect=RuntimeError("boom")))
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky",
+                            AsyncMock(side_effect=RuntimeError("boom")))
+        await _advance_to_executing(ctx, slug="pt-failopen")
+        # Must not raise.
+        result = await tool_project_update_step(ctx, step="1.1", status="done")
+        assert _text(result)
+```
+(`_advance_to_executing` uses the module `SAMPLE_PLAN`, whose first leaf step is `1.1`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit -v`
+Expected: FAIL — no emit happens (helpers not implemented).
+
+- [ ] **Step 3: Implement**
+
+In `src/decafclaw/skills/project/tools.py`:
+
+Add imports near the top (after the existing imports):
+```python
+import logging
+
+from decafclaw import sticky as sticky_mod
+from decafclaw.skills.project.plan_parser import Step
+
+log = logging.getLogger(__name__)
+```
+(`parse_plan`, `plan_progress`, `next_actionable` are already imported.)
+
+Add helpers in the "Helpers" section:
+```python
+def _emit_for_ctx(ctx):
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit
+
+
+def _flatten_leaf_steps(steps: list[Step]) -> list[Step]:
+    """Depth-first list of leaf steps (those without children)."""
+    out: list[Step] = []
+    for s in steps:
+        if s.children:
+            out.extend(_flatten_leaf_steps(s.children))
+        else:
+            out.append(s)
+    return out
+
+
+def _progress_data_from_plan(info: ProjectInfo, steps: list[Step]) -> dict:
+    """Build a progress_tracker payload from parsed plan steps."""
+    widget_steps = []
+    for s in _flatten_leaf_steps(steps):
+        step = {"label": f"{s.number}. {s.description}", "status": s.status}
+        if s.note:
+            step["note"] = s.note
+        widget_steps.append(step)
+    done, total = plan_progress(steps)
+    nxt = next_actionable(steps)
+    summary = f"{done}/{total} · {nxt.number}. {nxt.description}" if nxt \
+        else f"{done}/{total}"
+    return {"steps": widget_steps, "title": info.description, "summary": summary}
+
+
+async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
+    """Mirror an EXECUTING project's plan into the sticky slot. Fail-open."""
+    if info.status != ProjectState.EXECUTING:
+        return
+    try:
+        content = info.plan_path.read_text() if info.plan_path.exists() else ""
+        if not content.strip():
+            return
+        _, steps, _ = parse_plan(content)
+        if not steps:
+            return
+        data = _progress_data_from_plan(info, steps)
+        await sticky_mod.set_sticky(
+            ctx.config, ctx.conv_id, "progress_tracker", data,
+            emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("project sticky emit failed", exc_info=True)
+
+
+async def _clear_project_progress(ctx) -> None:
+    """Clear the sticky slot for a project. Fail-open."""
+    try:
+        await sticky_mod.clear_sticky(
+            ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("project sticky clear failed", exc_info=True)
+```
+
+Wire the emit calls:
+
+In `tool_project_next_task`, in the `EXECUTING` branch, emit before returning:
+```python
+    elif info.status == ProjectState.EXECUTING:
+        await _emit_project_progress(ctx, info)
+        return _next_execution_step(info)
+```
+
+In `tool_project_update_step`, after `save_project(info)` and before building `msg`:
+```python
+    info.plan_path.write_text(render_plan(overview, steps, tail))
+    save_project(info)
+    await _emit_project_progress(ctx, info)
+```
+
+In `tool_project_add_steps`, after `save_project(info)`:
+```python
+    info.plan_path.write_text(render_plan(overview, plan_steps, tail))
+    save_project(info)
+    await _emit_project_progress(ctx, info)
+```
+
+In `tool_project_task_done`, in the `EXECUTING` branch, after setting DONE:
+```python
+        info.status = ProjectState.DONE
+        save_project(info)
+        await _clear_project_progress(ctx)
+        return ToolResult(text="Project complete!", end_turn=True)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_project_tools.py -v`
+Expected: PASS (existing + new `TestProgressTrackerEmit`). Existing tests are unaffected — with no widget registry the real `set_sticky` would return ok=False, but the emit is fail-open and these tests either monkeypatch it or don't assert on it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/skills/project/tools.py tests/test_project_tools.py
+git commit -m "feat(414): project skill auto-emits progress_tracker during executing"
+```
+
+---
+
+### Task 4: Docs, CLAUDE.md, full check, manual QA
+
+**Files:**
+- Modify: `docs/widgets.md` (progress_tracker entry) and/or the widget-surface doc that documents the sticky slot (grep for the #419 "Sticky slot" section).
+- Modify: `docs/tools.md` / project + checklist docs — note the auto-emit side effect (grep for where checklist/project are documented).
+- Modify: `CLAUDE.md` — add the widget to the widgets list; note the checklist/project auto-emit side effect.
+- Modify: session `notes.md` (final summary + QA results).
+
+- [ ] **Step 1: Locate the docs to update**
+
+Run: `grep -rln "sticky slot\|Sticky slot\|progress_tracker\|checklist" docs/ | sort -u`
+Update: the widget catalog / sticky-surface doc with a `progress_tracker` entry (5 statuses, display-only, snapshot, modes inline/canvas/sticky); the checklist doc and project-skill doc with a one-paragraph "auto-emits a progress_tracker to the sticky slot" note.
+
+- [ ] **Step 2: Update `CLAUDE.md`**
+
+In the bundled-widgets / key-files area, add `web/static/widgets/progress_tracker/`, and add a one-line note under the checklist and project entries that they auto-emit a `progress_tracker` into the sticky slot (fail-open, EXECUTING-only for project).
+
+- [ ] **Step 3: Full check + test**
+
+Run: `make check`
+Expected: PASS (lint + typecheck + check-js + check-message-types — no message-type changes this session, so the drift check is a no-op pass).
+Run: `make test`
+Expected: PASS (full suite).
+
+- [ ] **Step 4: Manual web QA**
+
+Per the `reference_ws_smoke_local_run` memory, start a web-only server on the worktree's `HTTP_PORT` (`MATTERMOST_ENABLED=false`), mint a login token (`uv run decafclaw-token create <user>`), open the UI, and:
+- Pin manually: `widget_pin_sticky(widget_type="progress_tracker", data={"title":"Demo","summary":"1/3 · B","steps":[{"label":"A","status":"done"},{"label":"B","status":"in_progress"},{"label":"C","status":"pending"},{"label":"D","status":"failed"},{"label":"E","status":"skipped"}]})` → quiet list renders with distinct glyphs; collapsed line shows the summary.
+- Run a checklist (`checklist_create` with 3+ steps, then `checklist_step_done` a few times) → the sticky slot tracks live; the last `checklist_step_done` clears it; `checklist_abort` clears it.
+- Reload mid-checklist → slot persists (sticky REST recovery from #419).
+- Drive a project into EXECUTING and `project_update_step` → slot tracks; complete → clears.
+- Tune the widget look live with Les (glyphs, spacing, color). Record results + revoke the token.
+
+- [ ] **Step 5: Write `notes.md` and commit**
+
+```bash
+git add docs/ CLAUDE.md docs/dev-sessions/
+git commit -m "docs(414): document progress_tracker widget + auto-emit; QA notes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — every spec section maps to a task:
+- Widget (`widget.json`+`widget.js`, 5 statuses, 3 modes, display-only, snapshot) → Task 1. Widget CSS → Task 1.
+- Checklist auto-emit (async tools, mapping, set/clear on create/step_done/abort, fail-open) → Task 2.
+- Project auto-emit (EXECUTING-only, `project_next_task`/update_step/add_steps set, DONE clear, skipped passthrough, fail-open) → Task 3.
+- No new tools / no evals → honored (no tool-def edits; no `evals/` changes).
+- Tests (widget registration+validation, checklist mapping+wiring+fail-open, project emit+clear+outside-executing+fail-open) → Tasks 1–3. Docs + CLAUDE.md + `make check`/`make test` + manual QA → Task 4.
+- Out-of-scope (delegate/scheduled occupants, canvas promotion, patching, config toggle) correctly absent.
+
+**Placeholder scan** — no TBD/TODO. The two "grep for the doc/caller" steps (Task 2 Step 1, Task 4 Step 1) are verification/location steps with explicit expected outputs, not code gaps.
+
+**Type consistency** — `_progress_data_from_checklist(items: list[dict]) -> dict` and `_progress_data_from_plan(info, steps) -> dict` both return `{steps:[{label,status,note?}], title, summary}` matching the widget `data_schema` from Task 1. `set_sticky(config, conv_id, "progress_tracker", data, emit=...)` argument order is consistent across Tasks 2–3 and matches the existing `sticky.set_sticky` signature (verified in `sticky_tools.py`). Monkeypatch target `decafclaw.sticky.set_sticky` matches the `from .. import sticky as sticky_mod` / `from decafclaw import sticky as sticky_mod` binding in both callers. `Step` field access (`number`, `description`, `status`, `note`, `children`) matches `plan_parser.Step`.

--- a/docs/dev-sessions/2026-07-24-1133-progress-tracker/spec.md
+++ b/docs/dev-sessions/2026-07-24-1133-progress-tracker/spec.md
@@ -1,0 +1,186 @@
+# Spec — `progress_tracker` widget + checklist/project auto-emit (#414)
+
+## Goal
+
+Add a display-only `progress_tracker` widget — a multi-step status list
+(pending / in_progress / done / failed / skipped) that shows the agent's
+in-flight progress at a glance without the user reading prose. Then wire the
+two existing workflow primitives — the **checklist tool** and the **project
+skill** — to auto-emit it into the sticky slot (#419) as a side effect, so the
+user gets a live progress view *for free*.
+
+Builds directly on the sticky widget slot (#419, merged as PR #642): sticky
+infrastructure (`sticky.py`, `set_sticky`/`clear_sticky`, `sticky_set`/
+`sticky_clear` WS events, `<sticky-slot>` component) already exists.
+
+## Background / current architecture
+
+- **Widgets** are declared by `widget.json` (meta-schema in `widgets.py`) +
+  `widget.js` (a Lit `dc-widget-<name>` custom element), one per directory under
+  `web/static/widgets/`, auto-registered by directory scan (no central registry
+  edit). `<dc-widget-host>` mounts `dc-widget-<type>` by naming convention.
+  `markdown_document` already declares `["inline", "canvas", "sticky"]` — a
+  close template.
+- **Sticky slot** (#419): single-slot, display-only surface above the chat
+  input. `sticky.set_sticky(config, conv_id, widget_type, data, emit=None)` /
+  `clear_sticky(config, conv_id, emit=None)` write a `sticky.json` sidecar and
+  emit `sticky_set`/`sticky_clear`. Collapsed line renders `data.summary`
+  (fallback `title` → humanized type). `set_sticky` validates the widget
+  declares `sticky` mode and passes schema validation; it is fail-open on emit.
+- **Checklist tool** (`tools/checklist_tools.py`): always-loaded, **currently
+  sync**, emits no events. Backed by `checklist.py`, which stores items as
+  markdown checkboxes at `workspace/todos/{conv_id}.md`. Item shape:
+  `{text, done, note}` — no `in_progress`/`failed` concept.
+- **Project skill** (`skills/project/`): tools are **already async**. Its task
+  list lives in `plan.md`, parsed by `plan_parser.py` into steps with status
+  `pending | in_progress | done | skipped`. Meaningful step statuses exist in
+  the EXECUTING phase.
+- Both canvas and sticky tools reach the event emitter via
+  `_emit_for_ctx(ctx)` → `ctx.manager.emit` (None when no manager).
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scope | Widget **+ checklist auto-emit + project-skill auto-emit** | The headline is "live progress for free"; widget-only is near dead-code. |
+| Widget statuses | `pending / in_progress / done / failed / skipped` (5) | `skipped` added so the project skill maps losslessly; widget is display-only so an extra status is cheap. |
+| Project surface / lifecycle | Sticky slot, **EXECUTING phase only**; clear on DONE | Step statuses are only live/meaningful during execution; keeps brainstorm/plan phases uncluttered. |
+| Widget visual | Build a quiet v1, tune live in QA | Matches the feel-tuning preference (human drives live controls). |
+| New agent tools | **None** | Widget is emitted (checklist/project) or pinned via the existing `widget_pin_sticky`; no new invocation surface. |
+| Evals | **None** | No tool description changes; auto-emit is deterministic side-effect wiring (unit-tested), not an LLM decision. |
+| Config toggle for auto-emit | None (YAGNI) | Fail-open covers safety; sticky in non-web surfaces is a harmless no-op. |
+
+## Scope
+
+### In scope
+
+1. **`progress_tracker` widget** — `widget.json` + `widget.js`, modes
+   `["inline", "canvas", "sticky"]`, `accepts_input: false`, snapshot-rendered.
+2. **Checklist auto-emit** — make `checklist_create` / `checklist_step_done` /
+   `checklist_abort` tools async; emit a mapped `progress_tracker` to the sticky
+   slot on each mutation; clear on all-done and on abort.
+3. **Project-skill auto-emit** — emit `progress_tracker` to sticky during
+   EXECUTING (on step/plan mutations and on entry to executing); clear on DONE.
+4. Unit tests for all three; docs; `CLAUDE.md` key-files.
+
+### Out of scope (future)
+
+- `delegate_task` progress, scheduled-task in-flight status, multi-turn
+  approval occupants.
+- Canvas promotion for long-running projects (issue floats it; not now).
+- Patching/incremental updates (v1 is snapshot-only).
+- A config flag to disable auto-emit.
+
+## Data shapes
+
+### Widget `data_schema`
+
+```json
+{
+  "type": "object",
+  "required": ["steps"],
+  "properties": {
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "status"],
+        "properties": {
+          "label":  { "type": "string" },
+          "status": { "type": "string",
+                      "enum": ["pending", "in_progress", "done", "failed", "skipped"] },
+          "note":   { "type": "string" }
+        }
+      }
+    },
+    "title":   { "type": "string" },
+    "summary": { "type": "string" }
+  }
+}
+```
+
+### Checklist → progress_tracker mapping
+
+Given checklist items `{text, done, note}` in file order:
+- every completed item → `status: "done"` (carry `note`);
+- the **first** not-done item → `status: "in_progress"`;
+- remaining not-done items → `status: "pending"`.
+- `label` = item `text`.
+- `title` = `"Checklist"`.
+- `summary` = `"{done}/{total} · {current label}"` (in-progress present), else
+  `"{done}/{total}"`.
+
+Emit points: after `checklist_create` and after `checklist_step_done` (while
+steps remain) → `set_sticky`. On all-steps-done and on `checklist_abort` →
+`clear_sticky`.
+
+### Project → progress_tracker mapping (EXECUTING only)
+
+From `plan_parser` steps (status already `pending|in_progress|done|skipped`):
+- pass status straight through (`failed` never occurs from a plan);
+- `label` = step description (with number prefix, e.g. `"1. Foo"`);
+- `note` = step note if present;
+- `title` = project description;
+- `summary` = `"{done}/{total} · {next actionable step}"`, else `"{done}/{total}"`.
+
+Emit points (all already-async tool calls — avoids the synchronous
+`_on_approve` review closures): `project_next_task` while status == EXECUTING
+(fires right after entering execution, when the agent fetches its first step),
+`project_update_step`, and `project_add_steps` → `set_sticky`. On transition into
+DONE (in `project_task_done`) → `clear_sticky`. Guarded to only emit while
+status == EXECUTING.
+
+## Fail-open contract
+
+Auto-emit MUST NOT break the underlying tool. Every `set_sticky` / `clear_sticky`
+call from checklist/project is guarded: a non-ok result or raised exception is
+logged at warning and swallowed; the checklist/project tool returns its normal
+result. `set_sticky` is already fail-open on the emit callback; the sidecar
+write is cheap and harmless in non-web (terminal/Mattermost) conversations.
+
+## Acceptance criteria
+
+- `progress_tracker` is registered by directory scan; declares modes
+  `["inline", "canvas", "sticky"]` and `accepts_input: false`; its schema
+  validates a payload containing all five statuses.
+- Pinning it to sticky (`widget_pin_sticky` or via checklist/project) renders a
+  quiet step list; the collapsed line shows `summary`.
+- `checklist_create` pins a progress_tracker with the first step `in_progress`
+  and the rest `pending`; each `checklist_step_done` advances the mapping;
+  the last `checklist_step_done` and `checklist_abort` clear the slot.
+- Project auto-emits during EXECUTING on `project_next_task` / step / plan
+  mutations and clears on DONE; no emit outside EXECUTING.
+- A sticky failure never breaks the checklist or project tool (fail-open).
+- `make check` (lint + typecheck + check-js + message-types drift) and
+  `make test` pass.
+
+## Testing
+
+- **Widget** (`tests/test_widgets.py`): progress_tracker registered; 3 modes;
+  schema validates a 5-status payload. `make check-js` for the Lit element.
+- **Checklist** (`tests/test_checklist_tools.py`, rewritten async): create →
+  `set_sticky` called with first-step-in_progress mapping; step_done advances;
+  final step_done → `clear_sticky`; abort → `clear_sticky`; sticky failure is
+  swallowed and the tool still returns its normal text.
+- **Project** (`tests/test_project_*` / skill tests): emit-during-executing on
+  step update; clear-on-done; no-emit outside executing; fail-open.
+- Manual web QA via a local web-only server (`MATTERMOST_ENABLED=false`, unique
+  `HTTP_PORT`): live look, collapse/expand, reload recovery, checklist run
+  driving the slot end-to-end.
+
+## Docs
+
+- Document `progress_tracker` in the widget-surface doc (alongside the sticky
+  section from #419) and note the checklist/project auto-emit behavior in the
+  relevant docs (checklist / project skill docs).
+- `CLAUDE.md`: add the widget dir to the widgets list; note the checklist/
+  project auto-emit side effect.
+
+## References
+
+- Widget catalog epic: #256
+- Sticky widget slot: #419 (PR #642) — spec/plan at
+  `docs/dev-sessions/2026-07-23-1545-sticky-widget-slot/`
+- `src/decafclaw/tools/checklist_tools.py`, `src/decafclaw/checklist.py`
+- `src/decafclaw/skills/project/` (`tools.py`, `state.py`, `plan_parser.py`)
+- `src/decafclaw/sticky.py`, `src/decafclaw/tools/sticky_tools.py`

--- a/docs/project-skill.md
+++ b/docs/project-skill.md
@@ -47,6 +47,8 @@ Steps use a markdown checklist with status markers:
 
 Sub-steps are indented under parents. Steps can be inserted mid-execution.
 
+While a project is in the `executing` phase, `project_next_task`, `project_update_step`, and `project_add_steps` also mirror the plan's steps into the sticky slot above the chat input as a `progress_tracker` widget (fail-open). The slot clears when `project_task_done` finalizes the project (all steps checked off) or when `project_advance` moves the project out of `executing` (e.g. back to planning). See [widgets.md](widgets.md#progress_tracker-widget).
+
 ## Tools
 
 | Tool | Description |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -65,6 +65,8 @@ Per-conversation step-by-step execution loop. Storage is markdown checkboxes at 
 | `checklist_abort` | ✓ | Abort the current checklist |
 | `checklist_status` | ✓ | Show current checklist state |
 
+`checklist_create`/`checklist_step_done`/`checklist_abort` also mirror the checklist into the sticky slot above the chat input as a `progress_tracker` widget (fail-open), so the user sees live progress without the agent calling `widget_pin_sticky` directly. The slot clears once all steps are done or on abort. See [widgets.md](widgets.md#progress_tracker-widget).
+
 ## Shell (`tools/shell_tools.py`)
 
 Requires user confirmation unless pre-approved via `shell_allow_patterns.json`.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -585,6 +585,11 @@ underlying tool call) and use `sticky.py`'s `set_sticky` / `clear_sticky`
 directly rather than a `WidgetRequest`/`ToolResult`. It can also be pinned
 manually via `widget_pin_sticky(widget_type="progress_tracker", data={...})`
 like any other sticky-mode widget — see [Sticky slot](#sticky-slot) below.
+Since the sticky slot holds a single widget, these producers and manual
+pinning are last-writer-wins: a newer pin replaces whatever currently
+occupies the slot, and a producer clearing its own tracker (checklist
+completion/abort, project leaving `executing`) clears the slot regardless of
+who pinned it.
 
 ## Sticky slot
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -67,6 +67,10 @@ Post-Phase 4 (#358 part B):
 - **`iframe_sandbox`** — agent-authored HTML/CSS/JS rendered in a CSP-locked sandboxed iframe; inline + canvas modes. Data shape (input): `{body: string, title?: string}`. See [iframe_sandbox](#iframe_sandbox-widget).
 - **`map`** — interactive geographic map (Leaflet + OSM tiles). Trusted first-party widget: the agent supplies structured data only; the tile source is server config (`config.widgets.map`), injected server-side. Data shape (input): `{markers: [{lat, lng, label?, popup?}], center?: {lat, lng}, zoom?, title?}`. See [map](#map-widget).
 
+Post-#414:
+
+- **`progress_tracker`** — quiet multi-step status list; inline, canvas, and sticky modes. Display-only, snapshot-rendered (each update replaces the full step list). Data shape: `{steps: [{label, status, note?}], title?, summary?}` where `status ∈ pending | in_progress | done | failed | skipped`. Auto-emitted into the sticky slot by the checklist tools and the project skill; can also be pinned manually via `widget_pin_sticky`. See [progress_tracker](#progress_tracker-widget).
+
 ## Adding a new widget
 
 Widgets are extensible by admins without changing DecafClaw's core. Each
@@ -543,6 +547,45 @@ return ToolResult(
 
 Or `canvas_new_tab(widget_type="map", data={"markers": [...]})`.
 
+## `progress_tracker` widget
+
+Bundled at `src/decafclaw/web/static/widgets/progress_tracker/`. A quiet
+multi-step status list — shows in-flight progress of a task at a glance.
+Display-only, snapshot-rendered: every update replaces the full step list
+(no incremental diffing). Supports `inline`, `canvas`, and `sticky` modes,
+so it can appear as a normal tool-result widget, live in the canvas panel,
+or pinned above the chat input.
+
+### Data shape
+
+- `steps` (array, required) — each `{label, status, note?}`. `status` is
+  one of `pending | in_progress | done | failed | skipped`, rendered with a
+  distinct glyph (○ / ◐ / ● / ✗ / ⊘ respectively). `note` renders inline
+  after the label.
+- `title` (optional, string) — header above the step list.
+- `summary` (optional, string) — a compact one-line status (e.g.
+  `"2/5 · Step 3"`); this is what the sticky slot's collapsed header shows.
+
+### Auto-emit
+
+The widget is rarely constructed directly by the agent — it's mirrored
+automatically into the sticky slot by two producers:
+
+- **Checklist tools** (`tools/checklist_tools.py`) — every
+  `checklist_create` / `checklist_step_done` / `checklist_abort` call
+  mirrors the current checklist state as a `progress_tracker` snapshot;
+  the slot clears once every step is done or on abort.
+- **Project skill** (`skills/project/tools.py`) — while a project is in the
+  `executing` phase, plan-mutating tools mirror the plan's steps as a
+  `progress_tracker` snapshot; the slot clears on completion or when the
+  project leaves `executing` (e.g. `project_advance` back to planning).
+
+Both producers are fail-open (a sticky-mirror failure never breaks the
+underlying tool call) and use `sticky.py`'s `set_sticky` / `clear_sticky`
+directly rather than a `WidgetRequest`/`ToolResult`. It can also be pinned
+manually via `widget_pin_sticky(widget_type="progress_tracker", data={...})`
+like any other sticky-mode widget — see [Sticky slot](#sticky-slot) below.
+
 ## Sticky slot
 
 A single-slot, display-only widget surface pinned directly above the chat
@@ -552,15 +595,16 @@ so the user keeps seeing at-a-glance status while a workflow runs. Web UI
 only.
 
 A widget opts in by adding `"sticky"` to its `modes` array in `widget.json`
-(alongside `"inline"` / `"canvas"`). `markdown_document` is the first (and
-currently only) sticky-mode widget.
+(alongside `"inline"` / `"canvas"`). `markdown_document` and
+`progress_tracker` are the two sticky-mode widgets so far.
 
 **Driven by tools**, not `WidgetRequest`/`ToolResult` like other widgets:
 `widget_pin_sticky(widget_type, data)` pins a widget, replacing any previous
 occupant (single slot); `widget_unpin_sticky()` clears it. Both are
 normal-priority tools in the base registry (`src/decafclaw/tools/sticky_tools.py`).
-A forthcoming change (#414) will have the checklist tools auto-emit sticky
-updates as steps complete, without the agent calling these tools directly.
+As of #414, the checklist tools and the project skill also drive the sticky
+slot directly (bypassing these two tools) to auto-emit a `progress_tracker`
+snapshot as steps complete — see [progress_tracker](#progress_tracker-widget).
 
 **Collapse to summary.** The header shows a one-line summary (the widget's
 `summary` or `title` field, falling back to the widget type name) with a
@@ -608,12 +652,13 @@ before any live events arrive. Live updates ride the `sticky_set` /
 - `src/decafclaw/tools/sticky_tools.py` — `widget_pin_sticky`/`widget_unpin_sticky` tools
 - `src/decafclaw/web/static/lib/sticky-state.js` — frontend sticky state (collapse persistence, WS event apply)
 - `src/decafclaw/web/static/components/sticky-slot.js` — `<sticky-slot>` panel component
-- `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice, text_input, markdown_document, code_block, iframe_sandbox, map)
+- `src/decafclaw/web/static/widgets/` — bundled widgets (data_table, multiple_choice, text_input, markdown_document, code_block, iframe_sandbox, map, progress_tracker)
 - `src/decafclaw/web/static/widgets/map/` — map widget descriptor + Lit component (Leaflet)
 - `src/decafclaw/web/static/leaflet-entry.js` — Leaflet vendor entry (ESM/UMD interop → default export)
 - `src/decafclaw/web/static/widgets/markdown_document/` — markdown_document widget descriptor + Lit component
 - `src/decafclaw/web/static/widgets/code_block/` — code_block widget descriptor + Lit component
 - `src/decafclaw/web/static/widgets/iframe_sandbox/` — iframe_sandbox widget descriptor + Lit component
+- `src/decafclaw/web/static/widgets/progress_tracker/` — progress_tracker widget descriptor + Lit component; auto-emit callers in `tools/checklist_tools.py` and `skills/project/tools.py`
 - `vendor/bundle/highlight.js` — bundled hljs core + ~20 languages + dual themes
 - `src/decafclaw/web/static/components/widgets/widget-host.js` — frontend host
 - `src/decafclaw/web/static/lib/widget-catalog.js` — catalog client

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -9,6 +9,7 @@ Control flow is mechanical:
 - Phase-boundary tools return end_turn=True to stop the agent loop
 """
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -128,16 +129,21 @@ async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
     if info.status != ProjectState.EXECUTING:
         return
     try:
-        content = info.plan_path.read_text() if info.plan_path.exists() else ""
+        content = (
+            await asyncio.to_thread(info.plan_path.read_text)
+            if info.plan_path.exists() else ""
+        )
         if not content.strip():
             return
         _, steps, _ = parse_plan(content)
         if not steps:
             return
         data = _progress_data_from_plan(info, steps)
-        await sticky_mod.set_sticky(
+        result = await sticky_mod.set_sticky(
             ctx.config, ctx.conv_id, "progress_tracker", data,
             emit=_emit_for_ctx(ctx))
+        if result is not None and not result.ok:
+            log.warning("project sticky set failed: %s", result.error)
     except Exception:
         log.warning("project sticky emit failed", exc_info=True)
 
@@ -145,8 +151,10 @@ async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
 async def _clear_project_progress(ctx) -> None:
     """Clear the sticky slot for a project. Fail-open."""
     try:
-        await sticky_mod.clear_sticky(
+        result = await sticky_mod.clear_sticky(
             ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx))
+        if result is not None and not result.ok:
+            log.warning("project sticky clear failed: %s", result.error)
     except Exception:
         log.warning("project sticky clear failed", exc_info=True)
 
@@ -218,7 +226,7 @@ async def tool_project_next_task(ctx) -> str | ToolResult:
 
     elif info.status == ProjectState.EXECUTING:
         await _emit_project_progress(ctx, info)
-        return _next_execution_step(info)
+        return await asyncio.to_thread(_next_execution_step, info)
 
     elif info.status == ProjectState.DONE:
         return "Project is complete! No more tasks."
@@ -315,14 +323,15 @@ async def tool_project_task_done(ctx) -> str | ToolResult:
         )
 
     elif info.status == ProjectState.EXECUTING:
-        _, steps, _ = parse_plan(info.plan_path.read_text())
+        content = await asyncio.to_thread(info.plan_path.read_text)
+        _, steps, _ = parse_plan(content)
         if next_actionable(steps) is not None:
             return ToolResult(
                 text="[error: there are still incomplete steps. Finish them "
                 "before calling project_task_done.]"
             )
         info.status = ProjectState.DONE
-        save_project(info)
+        await asyncio.to_thread(save_project, info)
         await _clear_project_progress(ctx)
         return ToolResult(text="Project complete!", end_turn=True)
 
@@ -526,13 +535,14 @@ async def tool_project_update_step(
     if status not in ("pending", "in_progress", "done", "skipped"):
         return ToolResult(text="[error: status must be pending, in_progress, done, or skipped]")
 
-    content = info.plan_path.read_text()
+    content = await asyncio.to_thread(info.plan_path.read_text)
     overview, steps, tail = parse_plan(content)
     if not update_step_status(steps, step, status, note):
         return ToolResult(text=f"[error: step '{step}' not found]")
 
-    info.plan_path.write_text(render_plan(overview, steps, tail))
-    save_project(info)
+    rendered = render_plan(overview, steps, tail)
+    await asyncio.to_thread(info.plan_path.write_text, rendered)
+    await asyncio.to_thread(save_project, info)
     await _emit_project_progress(ctx, info)
 
     done, total = plan_progress(steps)
@@ -555,13 +565,14 @@ async def tool_project_add_steps(
     if info.status not in (ProjectState.EXECUTING, ProjectState.PLANNING, ProjectState.PLAN_REVIEW):
         return ToolResult(text="[error: can only add steps during planning, plan_review, or executing]")
 
-    content = info.plan_path.read_text()
+    content = await asyncio.to_thread(info.plan_path.read_text)
     overview, plan_steps, tail = parse_plan(content)
     if not insert_steps(plan_steps, after_step, steps):
         return ToolResult(text=f"[error: step '{after_step}' not found]")
 
-    info.plan_path.write_text(render_plan(overview, plan_steps, tail))
-    save_project(info)
+    rendered = render_plan(overview, plan_steps, tail)
+    await asyncio.to_thread(info.plan_path.write_text, rendered)
+    await asyncio.to_thread(save_project, info)
     await _emit_project_progress(ctx, info)
 
     _, total = plan_progress(plan_steps)

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -9,11 +9,14 @@ Control flow is mechanical:
 - Phase-boundary tools return end_turn=True to stop the agent loop
 """
 
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from decafclaw import sticky as sticky_mod
 from decafclaw.media import EndTurnConfirm, ToolResult
 from decafclaw.skills.project.plan_parser import (
+    Step,
     insert_steps,
     next_actionable,
     parse_plan,
@@ -30,6 +33,8 @@ from decafclaw.skills.project.state import (
     save_project,
     validate_transition,
 )
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -83,6 +88,67 @@ def _load_current(ctx) -> ProjectInfo | ToolResult:
     except ValueError as e:
         return ToolResult(text=f"[error: {e}]")
     return _load_or_error(ctx.config, project)
+
+
+def _emit_for_ctx(ctx):
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit
+
+
+def _flatten_leaf_steps(steps: list[Step]) -> list[Step]:
+    """Depth-first list of leaf steps (those without children)."""
+    out: list[Step] = []
+    for s in steps:
+        if s.children:
+            out.extend(_flatten_leaf_steps(s.children))
+        else:
+            out.append(s)
+    return out
+
+
+def _progress_data_from_plan(info: ProjectInfo, steps: list[Step]) -> dict:
+    """Build a progress_tracker payload from parsed plan steps."""
+    widget_steps = []
+    for s in _flatten_leaf_steps(steps):
+        step = {"label": f"{s.number}. {s.description}", "status": s.status}
+        if s.note:
+            step["note"] = s.note
+        widget_steps.append(step)
+    done, total = plan_progress(steps)
+    nxt = next_actionable(steps)
+    summary = f"{done}/{total} · {nxt.number}. {nxt.description}" if nxt \
+        else f"{done}/{total}"
+    return {"steps": widget_steps, "title": info.description, "summary": summary}
+
+
+async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
+    """Mirror an EXECUTING project's plan into the sticky slot. Fail-open."""
+    if info.status != ProjectState.EXECUTING:
+        return
+    try:
+        content = info.plan_path.read_text() if info.plan_path.exists() else ""
+        if not content.strip():
+            return
+        _, steps, _ = parse_plan(content)
+        if not steps:
+            return
+        data = _progress_data_from_plan(info, steps)
+        await sticky_mod.set_sticky(
+            ctx.config, ctx.conv_id, "progress_tracker", data,
+            emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("project sticky emit failed", exc_info=True)
+
+
+async def _clear_project_progress(ctx) -> None:
+    """Clear the sticky slot for a project. Fail-open."""
+    try:
+        await sticky_mod.clear_sticky(
+            ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("project sticky clear failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +217,7 @@ async def tool_project_next_task(ctx) -> str | ToolResult:
         )
 
     elif info.status == ProjectState.EXECUTING:
+        await _emit_project_progress(ctx, info)
         return _next_execution_step(info)
 
     elif info.status == ProjectState.DONE:
@@ -256,6 +323,7 @@ async def tool_project_task_done(ctx) -> str | ToolResult:
             )
         info.status = ProjectState.DONE
         save_project(info)
+        await _clear_project_progress(ctx)
         return ToolResult(text="Project complete!", end_turn=True)
 
     elif info.status == ProjectState.DONE:
@@ -465,6 +533,7 @@ async def tool_project_update_step(
 
     info.plan_path.write_text(render_plan(overview, steps, tail))
     save_project(info)
+    await _emit_project_progress(ctx, info)
 
     done, total = plan_progress(steps)
     msg = f"Step {step} → **{status}** ({done}/{total})"
@@ -493,6 +562,7 @@ async def tool_project_add_steps(
 
     info.plan_path.write_text(render_plan(overview, plan_steps, tail))
     save_project(info)
+    await _emit_project_progress(ctx, info)
 
     _, total = plan_progress(plan_steps)
     return f"Added {len(steps)} step(s) after step {after_step}. Plan now has {total} steps."

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -597,8 +597,11 @@ async def tool_project_advance(ctx, target_status: str = "") -> str | ToolResult
             f"Valid: {valid}]"
         )
 
+    was_executing = info.status == ProjectState.EXECUTING
     info.status = target
     save_project(info)
+    if was_executing and target != ProjectState.EXECUTING:
+        await _clear_project_progress(ctx)
     return f"Project reverted to {target.value}. Call project_next_task."
 
 

--- a/src/decafclaw/tools/checklist_tools.py
+++ b/src/decafclaw/tools/checklist_tools.py
@@ -4,22 +4,86 @@ Always-loaded tools that drive the agent through a checklist one step
 at a time. The agent iterates within a single turn: do step → call
 step_done → get next step → do next step. ``end_turn=True`` is only
 set when all steps are complete (agent summarizes and stops).
+
+As a side effect, each mutation mirrors the checklist into the sticky
+slot as a ``progress_tracker`` widget so the user sees live progress.
+The mirror is fail-open — a sticky failure never breaks the checklist.
 """
 
 import logging
 
 from .. import checklist
+from .. import sticky as sticky_mod
 from ..media import ToolResult
 
 log = logging.getLogger(__name__)
 
 
-def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
+def _emit_for_ctx(ctx):
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit
+
+
+def _progress_data_from_checklist(items: list[dict]) -> dict:
+    """Map checklist items {text,done,note} → progress_tracker data.
+
+    Completed items → 'done'; the first not-done item → 'in_progress';
+    remaining not-done items → 'pending'.
+    """
+    steps = []
+    first_pending = True
+    done_count = 0
+    current_label = ""
+    for item in items:
+        if item["done"]:
+            status = "done"
+            done_count += 1
+        elif first_pending:
+            status = "in_progress"
+            first_pending = False
+            current_label = item["text"]
+        else:
+            status = "pending"
+        step = {"label": item["text"], "status": status}
+        if item.get("note"):
+            step["note"] = item["note"]
+        steps.append(step)
+    total = len(items)
+    summary = f"{done_count}/{total} · {current_label}" if current_label \
+        else f"{done_count}/{total}"
+    return {"steps": steps, "title": "Checklist", "summary": summary}
+
+
+async def _mirror_to_sticky(ctx, conv_id: str) -> None:
+    """Sync the sticky slot with current checklist state. Fail-open.
+
+    Clears the slot when there is no active checklist or every step is
+    done; otherwise pins a progress_tracker snapshot.
+    """
+    try:
+        items = checklist.checklist_status(ctx.config, conv_id)
+        if not items or all(i["done"] for i in items):
+            await sticky_mod.clear_sticky(
+                ctx.config, conv_id, emit=_emit_for_ctx(ctx))
+            return
+        data = _progress_data_from_checklist(items)
+        await sticky_mod.set_sticky(
+            ctx.config, conv_id, "progress_tracker", data,
+            emit=_emit_for_ctx(ctx))
+    except Exception:
+        log.warning("checklist sticky mirror failed for %s", conv_id,
+                    exc_info=True)
+
+
+async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
     """Create a checklist and return the first step."""
     conv_id = ctx.conv_id or "default"
     if not steps:
         return ToolResult(text="[error: steps list is empty]")
     items = checklist.checklist_create(ctx.config, conv_id, steps)
+    await _mirror_to_sticky(ctx, conv_id)
     first = items[0]["text"]
     return ToolResult(
         text=f"Checklist created ({len(items)} steps). "
@@ -28,10 +92,11 @@ def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
     )
 
 
-def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
+async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
     """Mark current step done and advance. end_turn=True only when all complete."""
     conv_id = ctx.conv_id or "default"
     next_item = checklist.checklist_complete_current(ctx.config, conv_id, note)
+    await _mirror_to_sticky(ctx, conv_id)
     if next_item is None:
         # Check if there was nothing to complete vs all done
         items = checklist.checklist_status(ctx.config, conv_id)
@@ -49,7 +114,7 @@ def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
     )
 
 
-def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
+async def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
     """Abandon the current checklist."""
     conv_id = ctx.conv_id or "default"
     items = checklist.checklist_status(ctx.config, conv_id)
@@ -57,6 +122,7 @@ def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
         return ToolResult(text="No active checklist to abort.")
     done = sum(1 for i in items if i["done"])
     checklist.checklist_abort(ctx.config, conv_id)
+    await _mirror_to_sticky(ctx, conv_id)
     msg = f"Checklist aborted ({done}/{len(items)} steps were complete)."
     if reason:
         msg += f" Reason: {reason}"

--- a/src/decafclaw/tools/checklist_tools.py
+++ b/src/decafclaw/tools/checklist_tools.py
@@ -96,12 +96,13 @@ async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
     """Mark current step done and advance. end_turn=True only when all complete."""
     conv_id = ctx.conv_id or "default"
     next_item = checklist.checklist_complete_current(ctx.config, conv_id, note)
+    items = checklist.checklist_status(ctx.config, conv_id)
+    if not items:
+        # No active checklist — do not touch the sticky slot (avoid clobbering
+        # a manually-pinned or project-owned widget).
+        return ToolResult(text="[error: no active checklist]")
     await _mirror_to_sticky(ctx, conv_id)
     if next_item is None:
-        # Check if there was nothing to complete vs all done
-        items = checklist.checklist_status(ctx.config, conv_id)
-        if not items:
-            return ToolResult(text="[error: no active checklist]")
         done = sum(1 for i in items if i["done"])
         return ToolResult(
             text=f"All {done} steps complete! Summarize what was accomplished.",

--- a/src/decafclaw/tools/checklist_tools.py
+++ b/src/decafclaw/tools/checklist_tools.py
@@ -10,6 +10,7 @@ slot as a ``progress_tracker`` widget so the user sees live progress.
 The mirror is fail-open — a sticky failure never breaks the checklist.
 """
 
+import asyncio
 import logging
 
 from .. import checklist
@@ -63,15 +64,20 @@ async def _mirror_to_sticky(ctx, conv_id: str) -> None:
     done; otherwise pins a progress_tracker snapshot.
     """
     try:
-        items = checklist.checklist_status(ctx.config, conv_id)
+        items = await asyncio.to_thread(
+            checklist.checklist_status, ctx.config, conv_id)
         if not items or all(i["done"] for i in items):
-            await sticky_mod.clear_sticky(
+            result = await sticky_mod.clear_sticky(
                 ctx.config, conv_id, emit=_emit_for_ctx(ctx))
+            if result is not None and not result.ok:
+                log.warning("checklist sticky clear failed: %s", result.error)
             return
         data = _progress_data_from_checklist(items)
-        await sticky_mod.set_sticky(
+        result = await sticky_mod.set_sticky(
             ctx.config, conv_id, "progress_tracker", data,
             emit=_emit_for_ctx(ctx))
+        if result is not None and not result.ok:
+            log.warning("checklist sticky set failed: %s", result.error)
     except Exception:
         log.warning("checklist sticky mirror failed for %s", conv_id,
                     exc_info=True)
@@ -82,7 +88,8 @@ async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
     conv_id = ctx.conv_id or "default"
     if not steps:
         return ToolResult(text="[error: steps list is empty]")
-    items = checklist.checklist_create(ctx.config, conv_id, steps)
+    items = await asyncio.to_thread(
+        checklist.checklist_create, ctx.config, conv_id, steps)
     await _mirror_to_sticky(ctx, conv_id)
     first = items[0]["text"]
     return ToolResult(
@@ -95,8 +102,10 @@ async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
 async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
     """Mark current step done and advance. end_turn=True only when all complete."""
     conv_id = ctx.conv_id or "default"
-    next_item = checklist.checklist_complete_current(ctx.config, conv_id, note)
-    items = checklist.checklist_status(ctx.config, conv_id)
+    next_item = await asyncio.to_thread(
+        checklist.checklist_complete_current, ctx.config, conv_id, note)
+    items = await asyncio.to_thread(
+        checklist.checklist_status, ctx.config, conv_id)
     if not items:
         # No active checklist — do not touch the sticky slot (avoid clobbering
         # a manually-pinned or project-owned widget).
@@ -118,11 +127,12 @@ async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
 async def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
     """Abandon the current checklist."""
     conv_id = ctx.conv_id or "default"
-    items = checklist.checklist_status(ctx.config, conv_id)
+    items = await asyncio.to_thread(
+        checklist.checklist_status, ctx.config, conv_id)
     if not items:
         return ToolResult(text="No active checklist to abort.")
     done = sum(1 for i in items if i["done"])
-    checklist.checklist_abort(ctx.config, conv_id)
+    await asyncio.to_thread(checklist.checklist_abort, ctx.config, conv_id)
     await _mirror_to_sticky(ctx, conv_id)
     msg = f"Checklist aborted ({done}/{len(items)} steps were complete)."
     if reason:

--- a/src/decafclaw/web/static/styles/widgets.css
+++ b/src/decafclaw/web/static/styles/widgets.css
@@ -365,3 +365,34 @@ chat-message .tool-result-raw pre {
   margin: 0;
   padding: 0.75rem 1rem;
 }
+
+/* progress_tracker — quiet multi-step status list */
+.progress-tracker { font-size: 0.85rem; }
+.progress-tracker__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin: 0 0 0.35rem;
+}
+.progress-tracker__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.progress-tracker__item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+.progress-tracker__glyph { flex: 0 0 1rem; text-align: center; }
+.progress-tracker__label { flex: 1; min-width: 0; }
+.progress-tracker__note { color: var(--pico-muted-color); font-size: 0.8rem; }
+.progress-tracker__item--pending { color: var(--pico-muted-color); }
+.progress-tracker__item--pending .progress-tracker__glyph { color: var(--pico-muted-color); }
+.progress-tracker__item--in_progress .progress-tracker__glyph { color: var(--pico-primary); }
+.progress-tracker__item--done .progress-tracker__glyph { color: var(--pico-ins-color, #2e7d32); }
+.progress-tracker__item--failed .progress-tracker__glyph { color: var(--pico-del-color, #c62828); }
+.progress-tracker__item--skipped { color: var(--pico-muted-color); }
+.progress-tracker__item--skipped .progress-tracker__label { text-decoration: line-through; }

--- a/src/decafclaw/web/static/widgets/progress_tracker/widget.js
+++ b/src/decafclaw/web/static/widgets/progress_tracker/widget.js
@@ -1,0 +1,58 @@
+import { LitElement, html, nothing } from 'lit';
+
+/**
+ * Progress tracker widget. Props:
+ *   data = { steps: [{label, status, note?}], title?: string, summary?: string }
+ * Display-only, snapshot-rendered — each update replaces the full step list.
+ * Status ∈ pending | in_progress | done | failed | skipped.
+ */
+const _GLYPHS = {
+  pending: '○',
+  in_progress: '◐',
+  done: '●',
+  failed: '✗',
+  skipped: '⊘',
+};
+
+export class ProgressTrackerWidget extends LitElement {
+  static properties = {
+    data: { type: Object },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    /** @type {{steps: {label: string, status: string, note?: string}[], title?: string, summary?: string}|null} */
+    this.data = null;
+  }
+
+  render() {
+    const d = this.data;
+    if (!d || !Array.isArray(d.steps)) {
+      return html`<div class="progress-tracker progress-tracker--empty"><em>no steps</em></div>`;
+    }
+    return html`
+      <div class="progress-tracker">
+        ${d.title ? html`<div class="progress-tracker__title">${d.title}</div>` : nothing}
+        <ul class="progress-tracker__list">
+          ${d.steps.map((s) => {
+            const status = s && typeof s.status === 'string' ? s.status : 'pending';
+            const glyph = _GLYPHS[status] || _GLYPHS.pending;
+            return html`
+              <li class="progress-tracker__item progress-tracker__item--${status}">
+                <span class="progress-tracker__glyph" aria-hidden="true">${glyph}</span>
+                <span class="progress-tracker__label"
+                  >${s?.label ?? ''}${s?.note
+                    ? html`<span class="progress-tracker__note"> — ${s.note}</span>`
+                    : nothing}</span>
+              </li>
+            `;
+          })}
+        </ul>
+      </div>
+    `;
+  }
+}
+
+customElements.define('dc-widget-progress-tracker', ProgressTrackerWidget);

--- a/src/decafclaw/web/static/widgets/progress_tracker/widget.json
+++ b/src/decafclaw/web/static/widgets/progress_tracker/widget.json
@@ -1,0 +1,29 @@
+{
+  "name": "progress_tracker",
+  "description": "A quiet multi-step status list (pending / in_progress / done / failed / skipped). Shows in-flight progress of a task at a glance. Display-only, snapshot-rendered. Auto-emitted by the checklist tool and the project skill; can also be pinned manually.",
+  "modes": ["inline", "canvas", "sticky"],
+  "accepts_input": false,
+  "data_schema": {
+    "type": "object",
+    "required": ["steps"],
+    "properties": {
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["label", "status"],
+          "properties": {
+            "label": { "type": "string" },
+            "status": {
+              "type": "string",
+              "enum": ["pending", "in_progress", "done", "failed", "skipped"]
+            },
+            "note": { "type": "string" }
+          }
+        }
+      },
+      "title": { "type": "string" },
+      "summary": { "type": "string" }
+    }
+  }
+}

--- a/tests/test_checklist_tools.py
+++ b/tests/test_checklist_tools.py
@@ -163,3 +163,16 @@ async def test_sticky_failure_is_fail_open(ctx, monkeypatch):
     # Must not raise; checklist still works.
     result = await tool_checklist_create(ctx, steps=["A"])
     assert "1 step" in result.text or "1 steps" in result.text
+
+
+@pytest.mark.asyncio
+async def test_ok_false_result_is_logged(ctx, monkeypatch, caplog):
+    from unittest.mock import AsyncMock
+
+    from decafclaw.sticky import StickyOpResult
+    monkeypatch.setattr("decafclaw.sticky.set_sticky",
+                        AsyncMock(return_value=StickyOpResult(ok=False, error="boom")))
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock(return_value=StickyOpResult(ok=True)))
+    with caplog.at_level("WARNING"):
+        await tool_checklist_create(ctx, steps=["A", "B"])
+    assert any("boom" in r.message or "sticky set failed" in r.message for r in caplog.records)

--- a/tests/test_checklist_tools.py
+++ b/tests/test_checklist_tools.py
@@ -144,6 +144,17 @@ async def test_abort_clears_sticky(ctx, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_step_done_no_checklist_does_not_clear_sticky(ctx, monkeypatch):
+    from unittest.mock import AsyncMock
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    result = await tool_checklist_step_done(ctx)  # no active checklist
+    assert "no active" in result.text.lower() or "[error" in result.text
+    clear_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_sticky_failure_is_fail_open(ctx, monkeypatch):
     monkeypatch.setattr("decafclaw.sticky.set_sticky",
                         AsyncMock(side_effect=RuntimeError("boom")))

--- a/tests/test_checklist_tools.py
+++ b/tests/test_checklist_tools.py
@@ -1,74 +1,98 @@
 """Tests for checklist tools."""
 
+from unittest.mock import AsyncMock
+
+import pytest
+
 from decafclaw.media import ToolResult
 from decafclaw.tools.checklist_tools import (
+    _progress_data_from_checklist,
     tool_checklist_abort,
     tool_checklist_create,
     tool_checklist_status,
     tool_checklist_step_done,
 )
 
+# --- pure mapping ---------------------------------------------------------
 
-def test_checklist_create(ctx):
-    """Creating a checklist returns the first step."""
-    result = tool_checklist_create(ctx, steps=["Step A", "Step B", "Step C"])
+def test_progress_data_maps_first_unchecked_to_in_progress():
+    items = [
+        {"text": "A", "done": True, "note": "did a"},
+        {"text": "B", "done": False, "note": ""},
+        {"text": "C", "done": False, "note": ""},
+    ]
+    data = _progress_data_from_checklist(items)
+    assert [s["status"] for s in data["steps"]] == ["done", "in_progress", "pending"]
+    assert data["steps"][0]["note"] == "did a"
+    assert data["title"] == "Checklist"
+    assert data["summary"] == "1/3 · B"
+
+
+def test_progress_data_all_done_summary_has_no_current():
+    items = [{"text": "A", "done": True, "note": ""}]
+    data = _progress_data_from_checklist(items)
+    assert data["steps"][0]["status"] == "done"
+    assert data["summary"] == "1/1"
+
+
+# --- existing behavior (now async) ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_checklist_create(ctx):
+    result = await tool_checklist_create(ctx, steps=["Step A", "Step B", "Step C"])
     assert isinstance(result, ToolResult)
     assert "3 steps" in result.text
     assert "Step A" in result.text
 
 
-def test_checklist_create_empty(ctx):
-    """Creating with empty steps returns an error."""
-    result = tool_checklist_create(ctx, steps=[])
+@pytest.mark.asyncio
+async def test_checklist_create_empty(ctx):
+    result = await tool_checklist_create(ctx, steps=[])
     assert "error" in result.text
 
 
-def test_checklist_step_done_advances(ctx):
-    """step_done marks current step and returns next (no end_turn mid-loop)."""
-    tool_checklist_create(ctx, steps=["First", "Second", "Third"])
-    result = tool_checklist_step_done(ctx, note="done with first")
-    assert isinstance(result, ToolResult)
-    assert result.end_turn is False  # mid-loop: agent keeps going
+@pytest.mark.asyncio
+async def test_checklist_step_done_advances(ctx):
+    await tool_checklist_create(ctx, steps=["First", "Second", "Third"])
+    result = await tool_checklist_step_done(ctx, note="done with first")
+    assert result.end_turn is False
     assert "Second" in result.text
 
 
-def test_checklist_step_done_all_complete(ctx):
-    """step_done on last step returns completion message with end_turn."""
-    tool_checklist_create(ctx, steps=["Only step"])
-    result = tool_checklist_step_done(ctx)
+@pytest.mark.asyncio
+async def test_checklist_step_done_all_complete(ctx):
+    await tool_checklist_create(ctx, steps=["Only step"])
+    result = await tool_checklist_step_done(ctx)
     assert result.end_turn is True
     assert "complete" in result.text.lower()
 
 
-def test_checklist_step_done_no_checklist(ctx):
-    """step_done with no active checklist returns error."""
-    result = tool_checklist_step_done(ctx)
+@pytest.mark.asyncio
+async def test_checklist_step_done_no_checklist(ctx):
+    result = await tool_checklist_step_done(ctx)
     assert "error" in result.text.lower() or "no active" in result.text.lower()
 
 
-def test_checklist_abort(ctx):
-    """Aborting clears the checklist."""
-    tool_checklist_create(ctx, steps=["Step 1", "Step 2"])
-    result = tool_checklist_abort(ctx, reason="changed my mind")
+@pytest.mark.asyncio
+async def test_checklist_abort(ctx):
+    await tool_checklist_create(ctx, steps=["Step 1", "Step 2"])
+    result = await tool_checklist_abort(ctx, reason="changed my mind")
     assert "aborted" in result.text.lower()
     assert "changed my mind" in result.text
-
-    # Status should be empty after abort
     status = tool_checklist_status(ctx)
     assert "No active" in status.text
 
 
-def test_checklist_abort_empty(ctx):
-    """Aborting with no checklist is safe."""
-    result = tool_checklist_abort(ctx)
+@pytest.mark.asyncio
+async def test_checklist_abort_empty(ctx):
+    result = await tool_checklist_abort(ctx)
     assert "No active" in result.text
 
 
-def test_checklist_status(ctx):
-    """Status shows progress."""
-    tool_checklist_create(ctx, steps=["A", "B", "C"])
-    tool_checklist_step_done(ctx)  # complete A
-
+@pytest.mark.asyncio
+async def test_checklist_status(ctx):
+    await tool_checklist_create(ctx, steps=["A", "B", "C"])
+    await tool_checklist_step_done(ctx)
     status = tool_checklist_status(ctx)
     assert "[x]" in status.text
     assert "[ ]" in status.text
@@ -76,7 +100,55 @@ def test_checklist_status(ctx):
     assert "1/3 complete" in status.text
 
 
-def test_checklist_status_empty(ctx):
-    """Status with no checklist says so."""
+@pytest.mark.asyncio
+async def test_checklist_status_empty(ctx):
     result = tool_checklist_status(ctx)
     assert "No active" in result.text
+
+
+# --- sticky auto-emit wiring (monkeypatch sticky funcs) -------------------
+
+@pytest.mark.asyncio
+async def test_create_emits_set_sticky(ctx, monkeypatch):
+    set_mock = AsyncMock()
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["A", "B"])
+    assert set_mock.await_count == 1
+    args, kwargs = set_mock.await_args
+    # (config, conv_id, widget_type, data)
+    assert args[2] == "progress_tracker"
+    assert args[3]["steps"][0]["status"] == "in_progress"
+    clear_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_final_step_done_clears_sticky(ctx, monkeypatch):
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["only"])
+    await tool_checklist_step_done(ctx)
+    assert clear_mock.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_abort_clears_sticky(ctx, monkeypatch):
+    clear_mock = AsyncMock()
+    monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+    await tool_checklist_create(ctx, steps=["A", "B"])
+    await tool_checklist_abort(ctx)
+    assert clear_mock.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_sticky_failure_is_fail_open(ctx, monkeypatch):
+    monkeypatch.setattr("decafclaw.sticky.set_sticky",
+                        AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr("decafclaw.sticky.clear_sticky",
+                        AsyncMock(side_effect=RuntimeError("boom")))
+    # Must not raise; checklist still works.
+    result = await tool_checklist_create(ctx, steps=["A"])
+    assert "1 step" in result.text or "1 steps" in result.text

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -33,7 +33,8 @@ def ctx(tmp_path):
         current_call_id=None,
     )
     skills = SimpleNamespace(data={})
-    return SimpleNamespace(config=config, tools=tools, skills=skills)
+    return SimpleNamespace(config=config, tools=tools, skills=skills,
+                           conv_id="proj-conv", manager=None)
 
 
 def _approve(result):
@@ -397,3 +398,56 @@ class TestGetTools:
         tools, defs = get_tools(ctx)
         def_names = {d["function"]["name"] for d in defs}
         assert def_names == set(tools.keys())
+
+
+class TestProgressTrackerEmit:
+    @pytest.mark.asyncio
+    async def test_update_step_emits_during_executing(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        set_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock())
+        await _advance_to_executing(ctx, slug="pt-step")
+        set_mock.reset_mock()
+        await tool_project_update_step(ctx, step="1.1", status="done", note="ok")
+        assert set_mock.await_count >= 1
+        args, _ = set_mock.await_args
+        assert args[2] == "progress_tracker"
+        labels = [s["label"] for s in args[3]["steps"]]
+        assert any(lbl.startswith("1.1.") for lbl in labels)
+
+    @pytest.mark.asyncio
+    async def test_done_clears_sticky(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        clear_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+        plan = "# Plan\n\n## Steps\n\n- [ ] 1. Only step\n"
+        await _advance_to_executing(ctx, slug="pt-done", plan=plan)
+        await tool_project_update_step(ctx, step="1", status="done")
+        result = await tool_project_task_done(ctx)
+        assert _text(result) == "Project complete!" or "complete" in _text(result).lower()
+        assert clear_mock.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_emit_outside_executing(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        set_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock())
+        await tool_project_create(ctx, description="planning phase", slug="pt-plan")
+        # BRAINSTORMING phase: next_task must not pin a tracker.
+        await tool_project_next_task(ctx)
+        set_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_emit_failure_is_fail_open(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        monkeypatch.setattr("decafclaw.sticky.set_sticky",
+                            AsyncMock(side_effect=RuntimeError("boom")))
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky",
+                            AsyncMock(side_effect=RuntimeError("boom")))
+        await _advance_to_executing(ctx, slug="pt-failopen")
+        # Must not raise.
+        result = await tool_project_update_step(ctx, step="1.1", status="done")
+        assert _text(result)

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -451,3 +451,28 @@ class TestProgressTrackerEmit:
         # Must not raise.
         result = await tool_project_update_step(ctx, step="1.1", status="done")
         assert _text(result)
+
+    @pytest.mark.asyncio
+    async def test_add_steps_during_planning_does_not_emit(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        set_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", set_mock)
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", AsyncMock())
+        await _advance_to_planning(ctx, slug="pt-add-plan")
+        await tool_project_update_plan(ctx, plan_text=SAMPLE_PLAN)
+        # Now in PLAN_REVIEW, not EXECUTING.
+        result = await tool_project_add_steps(ctx, after_step="1", steps=["Extra step"])
+        assert "Added" in _text(result)
+        set_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_advance_out_of_executing_clears(self, ctx, monkeypatch):
+        from unittest.mock import AsyncMock
+        clear_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+        await _advance_to_executing(ctx, slug="pt-advance")
+        clear_mock.reset_mock()
+        result = await tool_project_advance(ctx, target_status="planning")
+        assert "reverted" in _text(result).lower()
+        assert clear_mock.await_count >= 1

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -613,3 +613,38 @@ def test_sticky_is_a_valid_mode(fake_config):
     desc = reg.get("markdown_document")
     assert desc is not None
     assert "sticky" in desc.modes
+
+
+def test_bundled_progress_tracker_is_registered(fake_config):
+    """Fresh registry scan finds the bundled progress_tracker widget."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    desc = reg.get("progress_tracker")
+    assert desc is not None
+    assert desc.tier == "bundled"
+    assert desc.accepts_input is False
+    assert set(desc.modes) == {"inline", "canvas", "sticky"}
+
+
+def test_progress_tracker_validates_all_statuses(fake_config):
+    """The schema accepts every status value and rejects an unknown one."""
+    reg = load_widget_registry(fake_config,
+                               admin_dir=Path("/nonexistent/admin"))
+    ok, err = reg.validate("progress_tracker", {
+        "title": "Work",
+        "summary": "1/5",
+        "steps": [
+            {"label": "a", "status": "done", "note": "n"},
+            {"label": "b", "status": "in_progress"},
+            {"label": "c", "status": "pending"},
+            {"label": "d", "status": "failed"},
+            {"label": "e", "status": "skipped"},
+        ],
+    })
+    assert ok, err
+    bad_ok, _ = reg.validate("progress_tracker", {
+        "steps": [{"label": "x", "status": "bogus"}],
+    })
+    assert bad_ok is False
+    missing_ok, _ = reg.validate("progress_tracker", {"steps": [{"label": "x"}]})
+    assert missing_ok is False


### PR DESCRIPTION
## Summary

Adds the **`progress_tracker`** widget (#414) — a quiet, display-only multi-step status list — and wires the two existing workflow primitives to auto-emit it into the sticky slot (#419) as a side effect, so the user gets a live progress view for free.

Builds on #419 (sticky slot, PR #642).

## What's included

- **Widget** (`web/static/widgets/progress_tracker/`) — modes `inline`/`canvas`/`sticky`, `accepts_input:false`, snapshot-rendered. Five statuses `pending | in_progress | done | failed | skipped` (glyphs `○ ◐ ● ✗ ⊘`). `data_schema`: `steps[]` of `{label, status, note?}` + optional `title`, `summary` (summary drives the sticky collapsed line). Auto-registered by directory scan — no central registry edit.
- **Checklist auto-emit** — `checklist_create`/`step_done`/`abort` are now async and mirror the checklist into the sticky slot as a `progress_tracker` (first-unchecked → `in_progress`); the slot clears when all steps are done or on abort. `checklist_status` stays sync. Fail-open.
- **Project-skill auto-emit** — mirrors an EXECUTING project's plan into the sticky slot; clears on transition to DONE and on `project_advance` out of EXECUTING. No emit outside EXECUTING. Fail-open.

**Fail-open contract:** a sticky failure can never break the underlying checklist/project tool (verified at all emit sites). No new agent tools; no WS message-type changes; no eval cases (deterministic side-effect wiring, unit-tested).

## Testing

- `make check` clean (ruff, pyright, tsc --checkJs, message-types drift).
- `make test`: 3249 passed, 2 skipped (pre-existing forkpty warnings).
- Manual web QA (local web-only server, Playwright): agent pinned a progress_tracker with all five statuses → rendered correctly in the sticky slot on first try; look approved.

## Follow-ups (out of #414's spec scope — will file as issues)

- `project_switch`/`project_create` while EXECUTING leaves a stale tracker (display-only).
- `_emit_for_ctx` is now duplicated across `canvas_tools`/`sticky_tools`/`checklist_tools` + the project skill — extract to a shared helper.

Session docs: `docs/dev-sessions/2026-07-24-1133-progress-tracker/`.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
