### PR TITLE
fix(tests): stop the accepted forkpty warning dirtying the suite

### DIFF
--- a/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/checks.md
+++ b/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/checks.md
@@ -1,0 +1,101 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/638
+**Frozen at:** 728cd7f (re-anchored after rebase onto origin/main; was c4028de pre-rebase — same tree, rewritten sha)
+**Check files — see "Scoped tamper check" below (this issue edits its own oracle):**
+- `tests/test_terminals.py`
+- `tests/web/test_terminal_ws.py`
+
+## C1
+CRITERION: WHEN the two real-spawn tests run, the suite SHALL report no warnings.
+CHECK: `uv run pytest tests/test_terminals.py tests/web/test_terminal_ws.py -q` emits no
+`warnings summary` section.
+AT FREEZE: **fails** — `13 passed, 2 warnings in 2.16s`, with a `warnings summary` listing two
+`pty.py:95: DeprecationWarning ... forkpty()` entries (one per file). Correct reason: the
+warnings are genuinely present, not a collection error.
+
+## C2
+CRITERION: WHEN the full suite runs, it SHALL report no warnings — this is the clean-suite
+signal the issue is about, and `make test` is the invocation that erodes it.
+CHECK: `make test` emits no `warnings summary` section.
+AT FREEZE: **fails** — `3234 passed, 2 skipped, 2 warnings in 59.56s`, `warnings summary`
+present. Correct reason: same two forkpty warnings.
+
+## Guards
+(Pass today; must keep passing. Not criteria — they cannot fail at freeze.)
+
+- **G1:** `make test` exits 0 with **no test lost, newly skipped, or newly failing** relative to
+  the freeze commit. Stated as an invariant, not a pinned count — upstream legitimately moves
+  the totals (see Clarifications). **Passed at freeze** (`3234 passed, 2 skipped`, exit 0);
+  **passes post-rebase** (`3265 passed, 2 skipped`, exit 0 — the +31 is upstream's, and this
+  branch's diff vs freeze adds no tests, so nothing was lost).
+- **G2:** both exempted tests still RUN and PASS — `uv run pytest
+  tests/test_terminals.py::test_real_pty_echo_and_cleanup
+  tests/web/test_terminal_ws.py::test_ws_handler_serves_real_spawned_session -q` → `2 passed`,
+  zero skipped. Guards the degenerate "fix" of deleting or skipping the real-spawn coverage to
+  make C1/C2 go green. **Passed at freeze.**
+- **G3:** `make check` (ruff + pyright + tsc) green. **Passed at freeze** (exit 0).
+
+## Scoped tamper check (this issue edits its own oracle)
+
+The oracle here *is* the two test files, and the implementation must edit exactly those files to
+add the marks. A whole-file tamper diff would flag the legitimate change, so the protection is
+scoped instead:
+
+```
+git diff <freeze-sha> -- tests/test_terminals.py tests/web/test_terminal_ws.py
+```
+
+**The invariant:** no line in that diff may change what any frozen check asserts. Concretely,
+any change to a test body, an assertion, a `skip`/`xfail` marker, or a function signature is
+tampering and blocks the gate. Adding the `@pytest.mark.filterwarnings` marks and explanatory
+comments is the sanctioned change. G2 is the behavioural backstop: the tests must still run and
+pass.
+
+Stated as an invariant deliberately, not as a whitelist of permitted line forms — see the
+clarification below.
+
+## Corrections made at freeze (pre-freeze, so not amendments)
+
+The intake pass filed a malformed guard. Recorded here because the issue body still carries it:
+
+- **Filed G1** was "`make test` → 3234 passed, 2 skipped **with no `warnings summary`**". Its
+  second half fails today, so it was half guard, half criterion — a guard that cannot pass at
+  freeze isn't a guard. Split into **C2** (no warnings summary — discriminates, fails now) and
+  **G1** (counts unchanged — passes now).
+
+## Clarifications
+(Post-freeze wording fixes that change no criterion or guard. Human-adjudicated.)
+
+- **Scoped tamper check, restated as an invariant.** As frozen it read "every added line MUST be
+  a `@pytest.mark.filterwarnings(...)` decorator" — a whitelist of line *forms*, which the
+  explanatory comments the plan required do not match. The independent verifier flagged the
+  mismatch (correctly, reading it literally); the implementer's own mechanical check had used a
+  looser regex allowing comments, i.e. had silently applied the intent rather than the letter.
+  Restated as the invariant it was always meant to express: nothing may change what a check
+  asserts. Comments are inert to pytest and cannot weaken an assertion.
+  - **Not an amendment, and no tier change:** no criterion or guard was altered, and the
+    substantive protection held throughout — the verifier confirmed on the record that no test
+    body, assertion, marker, or signature was touched. Human-adjudicated before the PR.
+  - The reason this matters beyond wording: a tamper rule that fires on inert changes produces
+    false positives, and false positives train the operator to wave the mechanism through.
+
+- **G1 restated as an invariant.** As frozen it pinned `3234 passed, 2 skipped`. The rebase onto
+  `origin/main` brought in two upstream commits (~31 new tests), so the literal count no longer
+  holds while the property it was protecting — nothing lost, newly skipped, or newly failing —
+  does. Restated accordingly. Second instance of the same defect in one run: **a brittle
+  absolute encoding a relative invariant.** No criterion or guard changed meaning; no tier
+  change.
+  - Evidence nothing was lost: this branch's diff vs the freeze commit adds only decorators and
+    comments to two files (no test added or removed), so the collected set is unchanged relative
+    to freeze; the delta is entirely upstream's.
+
+- **Freeze sha re-anchored after rebase.** `c4028de` → `728cd7f`. The rebase rewrote the freeze
+  commit, so the recorded sha pointed at an object outside the branch's history; a tamper diff
+  against it would have conflated upstream changes with this branch's. Same tree, new sha.
+  Verified upstream did not touch either frozen file (`git diff c4028de 728cd7f -- <files>` is
+  empty), so the two baselines are equivalent here.
+
+## Amendments
+(Append-only. Empty unless an amendment was made post-freeze — i.e. a change to what a criterion
+or guard asserts, which downgrades the run to `needs-review`.)

--- a/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/plan.md
+++ b/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/plan.md
@@ -1,0 +1,84 @@
+# forkpty test warnings — Implementation Plan
+
+**Goal:** exempt the two audited real-spawn tests from the accepted `forkpty` DeprecationWarning
+so the suite is warning-clean, without reversing the deliberate do-not-suppress decision in
+production code.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/638 — **Tier:** `auto-ok`
+(both criteria reduce to concrete commands; touched paths are test files only — no auth,
+secrets, data, deploy/CI config, or dependency changes).
+
+**Approach:** per-test `@pytest.mark.filterwarnings` on the two spawn tests. The warning is
+acceptable *because that fork is written safely* (`chdir` + `execvpe` only between fork and
+exec) — a per-site property, so the exemption is per-site. `terminals.py` is untouched.
+
+**Criteria:** C1 the two spawn test files emit no warnings · C2 `make test` emits no warnings.
+Full text, guards, and the scoped tamper rule live in `checks.md`.
+
+---
+
+## Phase 0: Freeze the acceptance checks — DONE (`c4028de`)
+
+`checks.md` written; C1/C2 observed failing for the right reason; G1/G2/G3 observed passing.
+
+**Verification — automated:**
+- [x] C1 fails at freeze: `13 passed, 2 warnings`
+- [x] C2 fails at freeze: `3234 passed, 2 skipped, 2 warnings in 59.56s`
+- [x] G1 passes: `make test` exit 0, counts as stated
+- [x] G2 passes: both exempted tests run and pass (`2 passed`)
+- [x] G3 passes: `make check` exit 0
+- [x] Freeze commit made; sha recorded (follow-up commit `c1c157b`)
+
+---
+
+## Phase 1: Exempt the two audited spawn tests
+
+Add a message-matched `filterwarnings` mark to each real-spawn test so the accepted warning
+stops dirtying the suite, while any *other* forkpty warning still surfaces.
+
+**Advances:** C1, C2 (both fully — there are only two warning sources).
+
+**Files:**
+- Modify: `tests/test_terminals.py` — mark on `test_real_pty_echo_and_cleanup` (line ~62,
+  already stacked under `@pytest.mark.asyncio`); `import pytest` present at line 4.
+- Modify: `tests/web/test_terminal_ws.py` — mark on
+  `test_ws_handler_serves_real_spawned_session` (line ~84, same stacking); `import pytest`
+  present at line 7.
+
+**Key changes:** on each of the two tests, above the existing `@pytest.mark.asyncio`:
+
+```python
+# The spawn path deliberately keeps Python 3.13's forkpty DeprecationWarning
+# visible in production (terminals.py:71-73); this fork is safe (chdir+execvpe
+# only between fork and exec). Exempt per-site so an unaudited forkpty elsewhere
+# still dirties the suite. #638
+@pytest.mark.filterwarnings(
+    "ignore:.*use of forkpty.*:DeprecationWarning"
+)
+```
+
+Mirror the comment style of the existing `#605` filter (`pyproject.toml:66-69`): say *why* the
+warning is accepted, not just that it is.
+
+**Verification — automated:**
+- [ ] C1's check passes: `uv run pytest tests/test_terminals.py tests/web/test_terminal_ws.py -q`
+      emits no `warnings summary`
+- [ ] C2's check passes: `make test` emits no `warnings summary`
+- [ ] G1 still passes: `make test` → `3234 passed, 2 skipped`, exit 0
+- [ ] G2 still passes: both exempted tests run and pass, zero skipped
+- [ ] G3 still passes: `make check` green
+- [ ] Scoped tamper check: `git diff c4028de -- tests/test_terminals.py
+      tests/web/test_terminal_ws.py` contains only added `@pytest.mark.filterwarnings`
+      decorators and their comments — no test body, assertion, signature, or skip/xfail changes
+
+**Verification — manual:**
+- [ ] The mark's message pattern matches only the forkpty warning, not DeprecationWarning
+      broadly — a reviewer should be able to see the exemption is narrow.
+
+---
+
+## Scope discipline
+
+Not in this plan: any `pyproject.toml` change, any `terminals.py` change, a suite-wide
+warnings-as-errors gate, a blanket `DeprecationWarning` ignore. Each is recorded as out of scope
+in the issue.

--- a/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/spec.md
+++ b/docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/spec.md
@@ -1,0 +1,79 @@
+
+## Observation
+Since the web-terminal PTY work landed (#627 / #635), `make test` ends with `2 warnings`:
+
+```
+.../python3.13/pty.py:95: DeprecationWarning: This process (pid=…) is multi-threaded,
+use of forkpty() may lead to deadlocks in the child.
+```
+
+Source: `src/decafclaw/terminals.py:77` calls `pty.fork()` to spawn the shell in its own session (needed for `login_tty` / job control / `killpg` teardown). Python 3.13 warns when forking a multi-threaded interpreter. `tests/test_terminals.py` exercises the real spawn twice → 2 warnings.
+
+## This is a deliberate decision, not a bug
+The spawn code documents the choice (`terminals.py:71-73`):
+
+> *"Forking a multi-threaded interpreter emits a DeprecationWarning; per project decision we do NOT suppress it (it is ignored by Python's default warning filter in normal runs)."*
+
+The fork itself is written safely — the child only `chdir` + `execvpe` between fork and exec (no async-signal-unsafe work), which is the correct mitigation for the deadlock the warning describes. `posix_spawn(setsid=True)` isn't portable (NotImplementedError on Linux/CI), so `pty.fork()` stands.
+
+**Visibility is test-only.** In a normal server run Python's default filter ignores `DeprecationWarning`, so production terminal spawns don't surface it. Only pytest (which surfaces warnings) shows it.
+
+## Why file it anyway
+It's a standing tension with the project's **zero-tolerance-for-warnings** policy — `make test` is now non-clean (`2 warnings`), which erodes the "clean suite" signal. And it's a latent trap for the `PytestUnraisableExceptionWarning`-as-error gate added in #605/#631: if a future gate promotes `DeprecationWarning` (or all warnings) to errors suite-wide, these 2 would fail CI.
+
+## Options (don't touch the deliberate spawn decision)
+- **Test-scoped `filterwarnings` ignore** — a targeted `ignore::DeprecationWarning` matched to `pty` / this message in `pyproject.toml` (or a `@pytest.mark.filterwarnings` on the spawn tests), so the accepted warning doesn't dirty the suite. Cheapest; keeps the spawn decision intact.
+- **Localized `warnings.catch_warnings()`** around the `pty.fork()` call site in `terminals.py`, suppressing just this message — but that reverses the "we do NOT suppress it" decision, so only if that decision is being revisited.
+
+Leaning test-scoped ignore.
+
+## Related
+- Terminal work: #627 (#442), #635 (#626)
+- Zero-tolerance-for-warnings gate precedent: #605 / #631
+- Surfaced during #604 (PR #636), where a rebase onto the terminal work made the 2 warnings visible.
+
+---
+
+## Acceptance criteria (agent-session intake)
+
+**AC1 — the sanctioned forkpty warning no longer dirties the suite (the only discriminating criterion).**
+WHEN the real-spawn tests run, the suite SHALL report no warnings.
+- CHECK: `uv run pytest tests/test_terminals.py tests/web/test_terminal_ws.py -q` emits no `warnings summary` section.
+- Verified discriminating at intake: today this prints 2 `forkpty` DeprecationWarnings (`13 passed, 2 warnings in 4.61s`).
+
+### Regression guards (pass today; must keep passing — deliberately not criteria)
+
+- **G1:** `make test` → `3234 passed, 2 skipped` with no `warnings summary`.
+- **G2:** both exempted tests still **run and pass** — not skipped, not deleted. Guards against the degenerate "fix" of removing real-spawn coverage.
+- **G3:** `make check` (ruff + pyright + tsc) green.
+
+These pass before any change, so they cannot distinguish done from untouched — they are guards, not acceptance criteria.
+
+## Tier: `auto-ok`
+
+AC1 reduces to a concrete command; touched paths are test files only (no auth/secrets/data/deploy/CI config/dependency changes). Note the interaction: the **per-test-mark mechanism is what keeps this `auto-ok`** — a `pyproject.toml` edit would touch build/CI config and pull the tier toward `needs-review`.
+
+## Design decisions
+
+- **Per-test `@pytest.mark.filterwarnings` on the two audited spawn tests.** The warning is acceptable *because that fork is written safely* (`chdir` + `execvpe` only between fork and exec) — a per-site property, not a global one. A blanket ignore would also hide a future, less careful spawn site.
+  - *Rejected:* a single message-matched ignore in `pyproject.toml` — simpler and one place, but suite-wide, silences unaudited sites, and touches build config.
+- **`terminals.py` untouched.** `terminals.py:71-73` records a deliberate decision to leave the warning visible; Python's default filter ignores it in normal runs anyway.
+  - *Rejected:* `warnings.catch_warnings()` at the call site — reverses that decision.
+- **No warnings-as-errors gate in this issue.** Promoting all warnings to errors is a project-wide posture change with dependency-upgrade blast radius.
+
+Mirror the comment style of the existing `#605` filter (`pyproject.toml:66-69`) on the marks.
+
+## Corrections to the observation above
+
+- The two warnings come from **two different files**, one spawn each — `tests/test_terminals.py::test_real_pty_echo_and_cleanup` and `tests/web/test_terminal_ws.py::test_ws_handler_serves_real_spawned_session` — not from `test_terminals.py` spawning twice.
+- **`-W error::DeprecationWarning` does not catch these**: the warning is emitted in the forked child, so the intuitive "promote to error" check passes today and would be a vacuous oracle. The check must assert on the `warnings summary` section instead.
+
+## Scope
+
+- **In:** exempt the two audited spawn tests so the suite is warning-clean.
+- **Out (own follow-ups):** suite-wide warnings-as-errors gate; any change to the `terminals.py` do-not-suppress decision; a blanket `DeprecationWarning` ignore.
+- **Not a criterion:** "a future unsanctioned forkpty still surfaces." It holds today, so it cannot discriminate; the per-site mechanism is the design-level protection.
+
+---
+*Acceptance criteria + tier added via `agent-session intake`. Original issue text preserved verbatim above.*
+

--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -82,8 +82,17 @@ forkpty() may lead to deadlocks in the child`). But `posix_spawn`'s `setsid`
 is not available on all platforms — it raises `NotImplementedError` on Linux
 (CI and the deploy target), which would break `/terminal` entirely there. So
 we fork. Per project decision the fork's `DeprecationWarning` is **not
-suppressed**; it is ignored by Python's default warning filter in normal runs
-and only shows in pytest's warnings summary (it does not fail tests).
+suppressed** in the spawn path; it is ignored by Python's default warning
+filter in normal runs, so production terminal spawns never surface it.
+
+The two tests that exercise a real spawn — `test_real_pty_echo_and_cleanup`
+and `test_ws_handler_serves_real_spawned_session` — carry a message-matched
+`@pytest.mark.filterwarnings` so the accepted warning does not dirty the
+suite (#638). The exemption is deliberately **per-site, not suite-wide**: the
+warning is acceptable only because *this* fork is written safely, so a
+`forkpty` from an unaudited call site still shows up in pytest's warnings
+summary. A new test that spawns a real PTY needs the mark added explicitly —
+that is the point, not an oversight.
 
 ### Output and replay
 

--- a/tests/test_terminals.py
+++ b/tests/test_terminals.py
@@ -59,6 +59,11 @@ def test_count_for_conv():
     assert reg.count_for_conv("c2") == 1
 
 
+# The spawn path deliberately keeps Python 3.13's forkpty DeprecationWarning
+# visible in production (terminals.py:71-73) — this fork is safe (chdir+execvpe
+# only between fork and exec). Exempt it per-site rather than suite-wide so an
+# unaudited forkpty elsewhere still dirties the suite. #638
+@pytest.mark.filterwarnings("ignore:.*use of forkpty.*:DeprecationWarning")
 @pytest.mark.asyncio
 async def test_real_pty_echo_and_cleanup():
     reg = TerminalRegistry(load_config())

--- a/tests/web/test_terminal_ws.py
+++ b/tests/web/test_terminal_ws.py
@@ -81,6 +81,11 @@ def test_terminal_ws_tolerates_malformed_control_frames(authed_client_with_sessi
         assert msg == {"type": "size_changed", "cols": 80, "rows": 24}
 
 
+# The spawn path deliberately keeps Python 3.13's forkpty DeprecationWarning
+# visible in production (terminals.py:71-73) — this fork is safe (chdir+execvpe
+# only between fork and exec). Exempt it per-site rather than suite-wide so an
+# unaudited forkpty elsewhere still dirties the suite. #638
+@pytest.mark.filterwarnings("ignore:.*use of forkpty.*:DeprecationWarning")
 @pytest.mark.asyncio
 async def test_ws_handler_serves_real_spawned_session(http_config):
     """End-to-end seam the other tests stub around: a REAL spawned PTY session


### PR DESCRIPTION
## Summary
- `make test` has ended with `2 warnings` since the web-terminal PTY work landed, eroding the clean-suite signal the project's zero-tolerance policy depends on — and leaving a latent trap for any future gate that promotes warnings to errors.
- Exempts the two audited real-spawn tests from the accepted `forkpty` DeprecationWarning, per-site. `terminals.py` is untouched, so the deliberate do-not-suppress decision stands.

## Design Decisions
- **Per-test `@pytest.mark.filterwarnings`, not a suite-wide ignore in `pyproject.toml`.** The warning is acceptable only because *this* fork is written safely (`chdir` + `execvpe` only between fork and exec) — a per-site property. A blanket ignore would also hide a `forkpty` from an unaudited call site. A new real-spawn test needs the mark added explicitly; that's the point, not an oversight.
- **`terminals.py` untouched.** `terminals.py:71-73` records the decision to leave the warning visible in production, where Python's default filter ignores it anyway.
- **No warnings-as-errors gate here.** Promoting all warnings to errors is a project-wide posture change with dependency-upgrade blast radius — worth its own issue.

Worth recording: **`-W error::DeprecationWarning` does not catch these** — the warning is emitted in the forked child. The intuitive "promote to error" check passes today, so it would have been a vacuous gate.

## Changes
- `tests/test_terminals.py`, `tests/web/test_terminal_ws.py` — message-matched `filterwarnings` mark on the two real-spawn tests, each with a comment explaining why the exemption is acceptable and why it's per-site.
- `docs/web-terminal.md` — the doc said the warning "only shows in pytest's warnings summary"; that's no longer true.
- `docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/` — session artifacts (spec, frozen checks, plan).

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | the two spawn test files emit no warnings | `uv run pytest tests/test_terminals.py tests/web/test_terminal_ws.py -q` | pass — `13 passed`, no warnings summary |
| C2 | the full suite emits no warnings | `make test` | pass — `3265 passed, 2 skipped`, no warnings summary |

| id | guard | result |
|---|---|---|
| G1 | no test lost, newly skipped, or newly failing vs freeze | pass — exit 0; the +31 vs freeze is upstream's, this branch adds no tests |
| G2 | both exempted tests still run and pass (not skipped/deleted) | pass — `2 passed`, 0 skipped |
| G3 | `make check` (ruff + pyright + tsc) green | pass — exit 0 |

Verified by an independent verifier (fresh context, `checks.md` only, no edit tools). Checks were frozen before implementation at `728cd7f`; tamper diff against that baseline contains only the marks and their comments — no test body, assertion, marker, or signature touched.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass · C2 pass
guards: G1 pass · G2 pass · G3 pass
tamper: clean
freeze: 728cd7f
project-gates: make check green
threads: 4 unresolved (agent-disputed, not fixed)
risk-paths: none
amendments: none
verdict: human-merge-required
reason: 4 review threads the agent disputed rather than fixed — a human decides
```

## References
- Spec / frozen checks / plan: `docs/dev-sessions/2026-07-24-1323-638-forkpty-warnings/`
- Closes #638
