### PR TITLE
feat(vault): first-class tags — filter search, listing, journal + inline #tags, Tags tab (#318)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `canvas.py` — per-conversation canvas state sidecar + state operations
 - `sticky.py` — per-conversation sticky-slot sidecar (`sticky.json`) + `set_sticky`/`clear_sticky`
 - `backlinks.py` — persistent inbound-link index (`{workspace}/backlinks.json`); `rebuild_index`/`load_index`/`inbound_count`/`update_for_page`; incremental update wired to the `vault_changed` event in `runner.py`
+- `tags.py` — first-class tag extraction/normalization + on-demand scan (`extract_tags`/`collect_all_tags`/`pages_with_tags`); tags from frontmatter + journal bullet + inline `#tags`, unioned at the query layer (#318)
 - `persistence.py`, `attachments.py`, `embeddings.py`, `frontmatter.py`, `memory_context.py`, `checklist.py`, `notes.py`
 
 ### Tools

--- a/docs/dev-sessions/2026-07-24-1141-vault-tags/notes.md
+++ b/docs/dev-sessions/2026-07-24-1141-vault-tags/notes.md
@@ -1,0 +1,18 @@
+# Notes: first-class vault tags (#318)
+
+Session working log. Final summary goes here before the PR.
+
+## Phase log
+- Phase 1 — tags.py foundation: pending
+- Phase 2 — inline #tags in composite embeddings: pending
+- Phase 3 — journal inline #tags emission: pending
+- Phase 4 — tag-filtered vault_search: pending
+- Phase 5 — vault_tags() tool + /api/vault/tags: pending
+- Phase 6 — Tags tab (web UI): pending
+
+## Decisions (from brainstorm)
+- Unify at index/query layer; journal daily-file format unchanged.
+- Inline #tags = native per-entry mechanism (per-entry frontmatter rejected: Obsidian mid-file --- = <hr>).
+- On-demand scan, no persistent tag index.
+- AND default + any_tag=true; case-insensitive, no -/_ merge.
+- Full feature, Tags tab last.

--- a/docs/dev-sessions/2026-07-24-1141-vault-tags/plan.md
+++ b/docs/dev-sessions/2026-07-24-1141-vault-tags/plan.md
@@ -1,0 +1,258 @@
+# First-class Vault Tags Implementation Plan (#318)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make vault tags first-class — a shared extraction module, inline `#tags`, tag-filtered search, a `vault_tags()` tool + REST endpoint, and a web UI Tags tab.
+
+**Architecture:** A greenfield `tags.py` is the core primitive (normalize / parse inline / extract-per-file / collect-all / filter); everything else consumes it. Unification is at the index/query layer — journal files keep their daily-file `## timestamp` format. On-demand scanning, no persistent tag index.
+
+**Tech Stack:** Python 3.13, `uv`, pytest (xdist), YAML frontmatter, sqlite-vec embeddings, Starlette (http_server.py) REST, Lit web components.
+
+## Global Constraints
+
+- `uv run` inside the worktree; never bare `python`.
+- Fail-open on file IO in scan/extract paths (`except Exception as exc: log.debug(...)`); no bare `except`. Never let a tag scan break a search/turn.
+- New runtime state (if any) on dataclasses; no `setattr`/`getattr` of undeclared fields.
+- Journal daily-file `## YYYY-MM-DD HH:MM` format and `vault_journal_append`'s signature MUST stay compatible with `read_recent_journal_entries` (#306) — guarded by tests.
+- Case-insensitive tags: lowercase canonical key, preserve first-seen display casing; do NOT merge `-`/`_` variants.
+- Tag AND-by-default; `any_tag=true` = OR.
+- Reuse `frontmatter.parse_frontmatter` / `get_frontmatter_field` — don't reimplement frontmatter parsing/coercion.
+- `make check` + `make test` green before each phase commit. Suite baseline ends with 2 known #638 forkpty warnings — introduce no new warnings.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- WebSocket/wire-type changes: none expected. Web UI styling: reach for primitives; tag-qualify custom button rules (Pico gotchas in CLAUDE.md).
+- Rebase on `origin/main` before final squash. Update the feature's `docs/` page in the same PR.
+
+## Cross-phase interface: `tags.py` (Phase 1 defines; all later phases consume)
+
+```python
+def normalize_tag(tag: str) -> str: ...            # strip leading '#', lowercase, trim
+def parse_inline_tags(body: str) -> set[str]: ...  # normalized inline #tags, code excluded
+def extract_tags(content: str, source_type: str) -> set[str]: ...  # union for one file, normalized
+def collect_all_tags(config) -> dict[str, dict]: ...   # {norm_tag: {"count": int, "display": str, "pages": list[str]}}
+def pages_with_tags(config, tags: list[str], any_tag: bool = False) -> list[str]: ...  # vault-rel page paths
+```
+All tag comparisons use `normalize_tag`. `extract_tags` reads frontmatter `tags:` + (journal only) the `- **tags:**` bullet + inline `#tags`.
+
+---
+
+## Phase 1 — `tags.py` foundation
+
+**Files:**
+- Create: `src/decafclaw/tags.py`
+- Create: `tests/test_tags.py`
+
+**Interfaces:** Produces the five functions above.
+
+- [ ] **Step 1: Write failing tests** (`tests/test_tags.py`)
+
+```python
+import pytest
+from decafclaw.tags import (
+    normalize_tag, parse_inline_tags, extract_tags,
+    collect_all_tags, pages_with_tags,
+)
+
+def test_normalize():
+    assert normalize_tag("#Rust") == "rust"
+    assert normalize_tag("  async ") == "async"
+    assert normalize_tag("rust-lang") == "rust-lang"  # hyphen preserved, distinct from "rust"
+
+def test_parse_inline_basic():
+    assert parse_inline_tags("working on #rust and #async-io today") == {"rust", "async-io"}
+
+def test_parse_inline_start_of_line_and_slash():
+    assert parse_inline_tags("#project/alpha notes") == {"project/alpha"}
+
+def test_parse_inline_rejects_digit_start_and_midword():
+    # "#42" (digit start) is not a tag; "a#b" (not preceded by whitespace/SOL) is not
+    assert parse_inline_tags("issue #42 and foo a#b") == set()
+
+def test_parse_inline_ignores_code():
+    body = "text #real\n```\n#fenced-not-tag\n```\ninline `#inline-not-tag` end"
+    assert parse_inline_tags(body) == {"real"}
+
+def test_parse_inline_atx_heading_not_a_tag():
+    # "# Heading" (hash + space at SOL) is a markdown heading, not a tag
+    assert parse_inline_tags("# Heading\n#realtag") == {"realtag"}
+
+def test_extract_page_frontmatter_plus_inline():
+    content = "---\ntags: [Rust, Async]\n---\nbody with #extra tag"
+    assert extract_tags(content, "page") == {"rust", "async", "extra"}
+
+def test_extract_journal_bullet_plus_inline():
+    content = "## 2026-07-24 10:00\n\n- **tags:** rust, async\n\nsome #extra note"
+    assert extract_tags(content, "journal") == {"rust", "async", "extra"}
+```
+
+- [ ] **Step 2: Run → fail.** `cd .claude/worktrees/318-vault-tags && uv run pytest tests/test_tags.py -q` → import error.
+
+- [ ] **Step 3: Implement `tags.py`.**
+
+```python
+"""First-class vault tags (#318): extraction, normalization, on-demand scan.
+
+Tags come from three sources, unioned at the query layer (not stored
+uniformly on disk): page frontmatter `tags:`, the journal `- **tags:**`
+bullet, and Obsidian-style inline `#tags` in body prose. All comparisons
+use the lowercased canonical form; display casing is the first seen.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from decafclaw.frontmatter import get_frontmatter_field, parse_frontmatter
+
+log = logging.getLogger(__name__)
+
+# Inline #tag: preceded by whitespace/SOL, starts with letter/_/ '/', then
+# word chars / - / /. Digit-start excluded so "#42" isn't a tag.
+_INLINE_TAG_RE = re.compile(r"(?:(?<=\s)|^)#([A-Za-z_/][\w\-/]*)", re.MULTILINE)
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_JOURNAL_TAGS_BULLET_RE = re.compile(r"^- \*\*tags:\*\* (.+)$", re.MULTILINE)
+
+
+def normalize_tag(tag: str) -> str:
+    return tag.lstrip("#").strip().lower()
+
+
+def _strip_code(body: str) -> str:
+    body = _FENCED_CODE_RE.sub(" ", body)
+    return _INLINE_CODE_RE.sub(" ", body)
+
+
+def parse_inline_tags(body: str) -> set[str]:
+    stripped = _strip_code(body)
+    return {normalize_tag(m.group(1)) for m in _INLINE_TAG_RE.finditer(stripped)}
+
+
+def extract_tags(content: str, source_type: str) -> set[str]:
+    metadata, body = parse_frontmatter(content)
+    tags: set[str] = set()
+    for t in get_frontmatter_field(metadata, "tags", []) or []:
+        tags.add(normalize_tag(str(t)))
+    if source_type == "journal":
+        for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
+            for part in m.group(1).split(","):
+                if part.strip():
+                    tags.add(normalize_tag(part))
+    tags |= parse_inline_tags(body)
+    tags.discard("")
+    return tags
+```
+Then `collect_all_tags(config)` and `pages_with_tags(config, tags, any_tag=False)`: iterate page dirs + journal dirs (reuse the walk from `embeddings._iter_vault_pages` for pages and `config.vault_agent_journal_dir` for journals — read those to match), call `extract_tags` per file (fail-open per file), aggregate. `collect_all_tags` keys on normalized tag, tracks count (distinct files), first-seen display casing, and vault-relative page paths. `pages_with_tags` returns paths whose extracted tags ⊇ requested (AND) or ∩ (any_tag); normalize the requested tags first.
+
+- [ ] **Step 4: Run → green.** Add tests for `collect_all_tags` counts/display and `pages_with_tags` AND vs `any_tag` over a tmp vault (use the `config` fixture; write page + journal files). Then `make check`.
+
+- [ ] **Step 5: Commit** `feat(vault): tags.py — extraction, normalization, on-demand scan (#318)`.
+
+---
+
+## Phase 2 — inline `#tags` in composite embeddings
+
+**Files:**
+- Modify: `src/decafclaw/frontmatter.py` (`build_composite_text`, line ~88)
+- Modify: `tests/test_frontmatter.py` (or wherever build_composite_text is tested)
+
+**Interfaces:** Consumes `tags.parse_inline_tags`.
+
+- [ ] **Step 1: Failing test** — `build_composite_text` includes inline `#tags` from the body in the composite metadata text (so they shape embeddings), in addition to frontmatter tags.
+
+```python
+def test_composite_includes_inline_tags():
+    from decafclaw.frontmatter import build_composite_text
+    out = build_composite_text({"tags": ["rust"]}, "body mentioning #async")
+    assert "rust" in out and "async" in out
+```
+
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — in `build_composite_text`, union `parse_inline_tags(body)` into the tags line it already builds from frontmatter. Import `parse_inline_tags` from `decafclaw.tags` at module level (watch for an import cycle: `tags.py` imports `frontmatter`, so `frontmatter` importing `tags` would cycle — if so, do a function-level import inside `build_composite_text` and add a comment noting the cycle-break, per the CLAUDE.md exception).
+- [ ] **Step 4: Run → green; `make check`.** Note in the commit body + docs that existing pages need `make reindex` to pick this up.
+- [ ] **Step 5: Commit** `feat(vault): fold inline #tags into composite embeddings (#318)`.
+
+---
+
+## Phase 3 — journal inline `#tags` emission
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` (`tool_vault_journal_append`, ~line 586)
+- Modify: `tests/test_vault_tools.py`
+
+- [ ] **Step 1: Failing tests** — after `vault_journal_append(ctx, tags=["rust","async"], content="hi")`: (a) the entry still contains the `- **tags:** rust, async` bullet (back-compat), (b) the entry body also contains inline `#rust #async`, (c) `read_recent_journal_entries` still parses the file into one entry (import it; assert one `RecentJournalEntry` with the expected timestamp). Assert `extract_tags(file_content, "journal")` returns `{"rust","async"}` with no duplication.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — in `tool_vault_journal_append`, after the existing bullet, append a line of inline tags (e.g. `\n#rust #async`) into the entry body before writing. Keep the bullet. Do not change the `## {now:%Y-%m-%d %H:%M}` header or the append-to-daily-file behavior. Mirror the change in the embedded `entry_text` used for indexing so search sees them.
+- [ ] **Step 4: Run → green** (incl. an existing `read_recent_journal_entries` test still passing); `make check`.
+- [ ] **Step 5: Commit** `feat(vault): journal entries emit inline #tags (#318)`.
+
+---
+
+## Phase 4 — tag-filtered `vault_search`
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` (`tool_vault_search`, line 655; + its `TOOL_DEFINITIONS` entry)
+- Modify: `tests/test_vault_tools.py`
+- Create: `evals/vault-tags.yaml`; Modify: `evals/tool_choice/core_overlaps.yaml`
+
+**Interfaces:** Consumes `tags.extract_tags`, `tags.pages_with_tags`.
+
+- [ ] **Step 1: Failing tests** — read the current `tool_vault_search` signature/body first. Cases: (a) `query="x", tags=["async"]` → only results whose `extract_tags` include `async`; (b) `query="", tags=["rust","async"]` → pure filter, AND semantics (only pages with both); (c) `any_tag=True` → OR; (d) tags filter spans page + journal source types. Build a tmp vault with tagged pages + journal entries.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — add `tags: list[str] = []`, `any_tag: bool = False`. When `query` is empty and `tags` given → return `pages_with_tags(...)` results (formatted like existing search output). When both given → run the existing semantic/substring search, then drop candidates whose `extract_tags` don't satisfy the filter. Normalize requested tags. Update the `TOOL_DEFINITIONS` description to document `tags`/`any_tag` tightly (control surface).
+- [ ] **Step 4: Run → green; `make check`.**
+- [ ] **Step 5: Add evals.** `evals/vault-tags.yaml`: seed tagged pages via `setup.workspace_files`; a case asserting a tag-filtered ask uses `vault_search` with tags and returns the right page (`expect_tool: vault_search`, bounded). Add a `tool_choice` case: "list all the tags I've used" → `vault_tags` (near-miss `vault_search`) — placeholder now, real once Phase 5 lands; if ordering matters, add this case in Phase 5 instead. Run `uv run python -m decafclaw.eval evals/vault-tags.yaml --verbose`.
+- [ ] **Step 6: Commit** `feat(vault): tag-filtered vault_search (#318)`.
+
+---
+
+## Phase 5 — `vault_tags()` tool + `/api/vault/tags`
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` (new `tool_vault_tags` + register in `TOOLS`/`TOOL_DEFINITIONS`)
+- Modify: `src/decafclaw/http_server.py` (new `GET /api/vault/tags` route; read existing vault routes ~`_vault_root`/`_vault_source_type` to match auth + response conventions)
+- Modify: `tests/test_vault_tools.py`, and the http/api test file (find the existing vault/workspace API tests)
+- Modify: `evals/tool_choice/core_overlaps.yaml` (vault_tags vs vault_search)
+
+**Interfaces:** Consumes `tags.collect_all_tags`.
+
+- [ ] **Step 1: Failing tests** — `tool_vault_tags(ctx)` returns tags sorted by count desc with counts (assert shape + order over a seeded vault). API test: `GET /api/vault/tags` returns JSON `{tags: [{tag, count, ...}]}` (mirror an existing vault/workspace API test's client setup).
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** the tool (thin wrapper over `collect_all_tags`, ToolResult with `data`) + the route (mirror an existing `/api/vault/*` or `/api/workspace/*` handler for auth/JSON). Register the tool. Tighten description.
+- [ ] **Step 4: Run → green; `make check`.** Add the `vault_tags` vs `vault_search` `tool_choice` case; run `make eval-tools`.
+- [ ] **Step 5: Commit** `feat(vault): vault_tags tool + /api/vault/tags endpoint (#318)`.
+
+---
+
+## Phase 6 — Tags tab (web UI)
+
+**Files:**
+- Modify: the sidebar component that owns the vault/wiki tab — confirm whether it's `web/static/components/vault-sidebar.js` or `conversation-sidebar.js` (grep `_sidebarTab`, `#switchTab`, the `wiki`/`files`/`schedules` tab buttons ~line 489) — add a `tags` tab button + panel there.
+- Modify: `web/static/service/*` or wherever `/api/*` fetches live (find the existing vault API client call).
+- Reference: `docs/web-ui.md` / `docs/web-ui-design.md` for primitives + row conventions.
+
+- [ ] **Step 1** Add a **Tags** tab button alongside the existing tabs (mirror the `wiki`/`files` button markup + `#switchTab('tags')`). Fetch `/api/vault/tags` on activation; render tags sorted by count as clickable rows (reuse the sidebar row convention — plain `<div @click>` per `reference_sidebar_clickable_row_convention`); clicking a tag lists its pages (from the endpoint's per-tag page list) and opens a page on click (reuse the existing wiki-page open path).
+- [ ] **Step 2** `make check-js` (tsc --checkJs) green; `make vendor` if the bundle needs rebuilding.
+- [ ] **Step 3: Browser smoke** — Playwright against a local web-only server (`MATTERMOST_ENABLED=false HTTP_PORT=18895`), OR a headless check: load the UI, open the Tags tab, assert tags render + click-through works. NOTE: Playwright can't run while `make dev` is up (shared Chrome cache) — coordinate with Les to pause `make dev`, or use the headless client. Capture a screenshot.
+- [ ] **Step 4: Commit** `feat(web): vault Tags tab (#318)`.
+
+---
+
+## Docs (fold into the phases that touch them, or a final sweep)
+
+- `docs/vault.md` — tags section: the three extraction sources, inline `#tag` rules, tag-filtered search, `vault_tags`, journal behavior, and the reindex note for inline-tag embeddings.
+- `docs/web-ui.md` — the Tags tab.
+- `CLAUDE.md` — key-files entry for `tags.py`.
+
+## Self-review (done at write time)
+
+- **Spec coverage:** tag extractor + normalization (P1), inline `#tags` P4-of-spec (P1 parser + P2 embeddings + P3 journal + P4 search all consume it), tag-filtered search / Part 1 (P4), `vault_tags` + REST / Part 2 backend (P5), Tags tab / Part 2 UI (P6), unified-storage / Part 3 as index-layer + journal emission (P1 extract + P3). ✓
+- **Type consistency:** the five `tags.py` signatures in the cross-phase block are used verbatim by P2–P6. `extract_tags(content, source_type)` and `pages_with_tags(config, tags, any_tag)` names stable across phases. ✓
+- **Ordering:** P1 before all; P4/P5 before P6 (UI needs the endpoint); P5's `tool_choice` case after the tool exists. ✓
+- **Import-cycle risk** flagged in P2 (frontmatter ↔ tags).
+
+## Execution notes
+
+- Subagent-driven, commit per phase, fresh subagent each; each `cd`s into the worktree, uses `uv run`, reads real files before editing, TDD, stops at its commit for review.
+- Checkpoint to Les after Phase 1 (defines the shared interface) and before/at Phase 6 (needs `make dev` paused for the Playwright smoke).
+- Highest-risk phase: P3 (journal format vs #306). Give its review extra attention.

--- a/docs/dev-sessions/2026-07-24-1141-vault-tags/spec.md
+++ b/docs/dev-sessions/2026-07-24-1141-vault-tags/spec.md
@@ -1,0 +1,162 @@
+# Spec: first-class vault tags (#318)
+
+## Problem
+
+The vault has partial tag support: `frontmatter.py` parses a `tags:` list and
+`build_composite_text` folds it into embeddings, so frontmatter tags quietly
+boost semantic search. Beyond that, tags are invisible:
+
+- No way to **filter** search by tag.
+- No way to **enumerate** tags in use (so the agent invents variants — `rust`
+  vs `rust-lang` vs `Rust`).
+- Journal entries store tags as body text (`- **tags:** foo`), not
+  first-class metadata.
+- Obsidian-style inline `#tags` in prose are ignored.
+
+This issue makes tags a coherent, first-class subsystem.
+
+## Prerequisite (satisfied)
+
+Depends on #197 (merged): `vault_update_frontmatter` exists, and the
+file-collision concern that gated this issue is gone. #197 also added
+`read_recent_journal_entries` (#306), which parses the daily-file
+`## YYYY-MM-DD HH:MM` per-entry format — a compatibility constraint this spec
+respects.
+
+## Design decisions (approved at brainstorm)
+
+- **Unify at the index/query layer, not the file bytes.** Journal files keep
+  the daily-file + `## timestamp` format untouched. "First-class tags" means
+  the tag extractor + search/list/filter treat journal tags like page tags —
+  the unification happens where it matters (queries), not in storage.
+- **Inline `#tags` (Part 4) is the native per-entry mechanism.** Per-entry
+  YAML frontmatter blocks were rejected: Obsidian only recognizes a single
+  file-top `---` block; a mid-file `---` renders as a horizontal rule, so
+  per-entry frontmatter would render *broken* in Obsidian and defeat the
+  vault's Obsidian-compatibility. Inline `#tags` is Obsidian's native
+  per-point tagging model.
+- **On-demand scan, no persistent tag index.** `vault_tags()` and pure
+  tag-filter scan pages+journals live per call. At personal-vault scale this
+  is cheap, and it avoids the index-maintenance bug class (rename/delete
+  desync, resolved-path handling) that cost #197 two Critical bugs.
+- **AND by default** across multiple tags, with an `any_tag=true` escape hatch
+  for OR.
+- **Case-insensitive normalization** (lowercase canonical key, preserve
+  first-seen display casing). **No** auto-merge of `-`/`_` variants — `rust`
+  and `rust-lang` stay distinct (that's what `vault_tags()` visibility is
+  for; auto-merging would be lossy).
+- **Scope:** full feature, web UI Tags tab as the last/separable slice.
+
+## Architecture
+
+### `tags.py` — shared tag module (the core everything consumes)
+
+- `normalize_tag(t: str) -> str` — strip leading `#`, lowercase, trim.
+- `parse_inline_tags(body: str) -> set[str]` — inline `#tag` parser.
+  Rules: after `#`, `[A-Za-z_/][A-Za-z0-9_\-/]*`; must not start with a digit
+  (so `#42` is skipped); must be preceded by whitespace or start-of-line;
+  **ignored inside fenced code blocks and inline code**.
+- `extract_tags(content: str, source_type: str) -> set[str]` — the union of
+  tags for one file: frontmatter `tags:` (`frontmatter.parse_frontmatter` +
+  `get_frontmatter_field`) + journal `- **tags:**` bullet (journal source
+  only) + inline `#tags`. Normalized + deduped.
+- `collect_all_tags(config) -> dict[str, TagInfo]` — on-demand scan of all
+  page + journal files → per-tag count + display form (+ page list for the
+  UI click-through). Backs `vault_tags()` and `/api/vault/tags`.
+- `pages_with_tags(config, tags: list[str], any_tag=False) -> list[str]` —
+  pure tag filter over the scan; AND unless `any_tag`.
+
+Fail-open on unreadable files (skip with `log.debug`), consistent with the
+vault tools.
+
+### Part 4 — inline `#tags` at index time
+
+- `build_composite_text` (or the indexer) unions inline `#tags` from the body
+  into the embedded metadata text, alongside frontmatter tags. **Requires a
+  `make reindex`** for existing pages to pick this up — called out in docs.
+
+### Part 3-lite — journal emission
+
+- `vault_journal_append(tags, content)` — **unchanged signature**. Keeps the
+  human-readable `- **tags:** foo` bullet (back-compat; #306 reader
+  unaffected — it treats the entry as an opaque text block) **and**
+  additionally emits the tags as inline `#tags` in the entry body. The
+  extractor dedupes the two, so no double-count.
+
+### Part 1 — tag-filtered `vault_search`
+
+- Add `tags: list[str] = []` and `any_tag: bool = False`.
+  - `query` + `tags` → semantic search, then filter candidates by
+    `extract_tags` ⊇ tags (AND) / ∩ tags (any_tag).
+  - empty `query` + `tags` → pure `pages_with_tags` scan.
+  - Works across `page` / `journal` / `user` source types.
+- Tighten the tool description (control surface). Add a `tool_choice` case +
+  a behavior eval.
+
+### Part 2 — `vault_tags()` + Tags tab (UI last)
+
+- Tool `vault_tags()` → `[{tag, count}]` sorted by count; backed by
+  `collect_all_tags`.
+- REST `GET /api/vault/tags` → tags + counts (+ page list per tag for
+  click-through). Follows existing `/api/vault/*` + `/api/workspace/*`
+  conventions.
+- Web UI: **Tags** tab in `web/static/components/conversation-sidebar.js`
+  (next to Browse/Recent). Lists tags by count; clicking a tag shows its
+  pages. Reuses the existing sidebar row conventions.
+
+## Phases (commit per phase, subagent-driven)
+
+1. **`tags.py` foundation** — `normalize_tag`, `parse_inline_tags`,
+   `extract_tags`, `collect_all_tags`, `pages_with_tags` + full unit tests.
+2. **Inline `#tags` at index time** — fold into `build_composite_text`; note
+   reindex requirement.
+3. **Journal inline emission** — `vault_journal_append` also emits inline
+   `#tags`; back-compat tests (bullet preserved, #306 reader unaffected).
+4. **Tag-filtered `vault_search`** — `tags`/`any_tag` params + description +
+   `tool_choice` + behavior eval.
+5. **`vault_tags()` tool + `/api/vault/tags`** — tool + REST endpoint + tests.
+6. **Tags tab (web UI)** — Lit component + sidebar tab + smoke.
+
+## Testing
+
+- Unit (`tags.py`): extraction from each of the three sources + their union;
+  code-block / inline-code exclusion; `#42` rejected; normalization + display
+  preservation; AND vs `any_tag` filter; count aggregation; fail-open on bad
+  files.
+- Tool: `vault_search` with `tags` (query+tags, empty-query+tags, across
+  source types); `vault_tags` shape/sort.
+- Journal: `vault_journal_append` still writes the bullet AND emits inline
+  `#tags`; `read_recent_journal_entries` still parses entries unchanged.
+- Evals: tag-filtered search behavior; `vault_tags`-vs-`vault_search`
+  `tool_choice` disambiguation.
+- Web: Playwright/JS smoke that the Tags tab renders tags + click-through.
+- `make check` + `make test` green before each phase commit.
+
+## Docs (same PR)
+
+- `docs/vault.md` — tags section (extraction sources, inline `#tags` rules,
+  filter/list, journal behavior, reindex note).
+- Web-ui docs — the Tags tab.
+- `CLAUDE.md` — key-files entry for `tags.py`.
+- `docs/context-composer.md` — only if the composite-text change warrants it.
+
+## Non-goals (follow-ups)
+
+- Tag renaming/merging tools (`rust-lang` → `rust`).
+- Tag autocomplete in the page editor.
+- Tag hierarchies beyond what inline `#foo/bar` naturally gives.
+- Tag match as a third memory-retrieval scoring signal.
+- Journal micro-evolution (the deferred #197 follow-up; now unblocked once
+  journal tags are first-class).
+
+## Risks
+
+- **#306 journal-format compatibility** — the highest-risk integration point.
+  Every journal change must keep `read_recent_journal_entries` +
+  `vault_journal_append`'s existing format working; guarded by tests.
+- **Reindex expectation** — inline-tag embedding boost needs `make reindex`;
+  documented, not automatic.
+- **Inline-tag false positives** — `#` in prose (e.g. `#1`, markdown ATX
+  headings). Digit-start exclusion + whitespace-precedent + code-block
+  exclusion mitigate; ATX headings start at SOL with `# ` (space) so `# Foo`
+  is not a tag (`#Foo` would be) — verify in tests.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -106,7 +106,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_delete(page)` | Delete a page. Pages outside `agent/` trigger a user confirmation. |
 | `vault_rename(from_page, to_page)` | Rename/move a page (preserves links). Pages outside `agent/` trigger a user confirmation. |
 | `vault_grant_folder(folder, reason)` | Request per-conversation trust for a folder. After approval, vault_write/delete/rename under the folder skip confirmation. |
-| `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. |
+| `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. Tags surface both as the back-compat `- **tags:**` bullet and as inline Obsidian-style `#tags` in the body (#318), so `extract_tags`/tag search see them without a separate scan pass. |
 | `vault_search(query, source_type?, days?, folder?)` | Semantic + substring search across the vault. |
 | `vault_list(folder?, pattern?)` | List pages with last-modified dates. |
 | `vault_backlinks(page)` | Find pages linking to this page via `[[wiki-links]]`. |
@@ -270,6 +270,7 @@ The agent follows these principles (encoded in the vault skill's system prompt):
 - **Journal entries** (`vault_journal_append`) are timestamped observations — append-only daily files
 - **Pages** (`vault_write`) are curated knowledge — revised and restructured over time
 - The [dream](dream-consolidation.md) process periodically reviews journal entries and distills insights into pages
+- Journal tags passed to `vault_journal_append` are written twice: the existing `- **tags:** rust, async` bullet (back-compat with #306's `read_recent_journal_entries`, which parses entries on the `## YYYY-MM-DD HH:MM` header and is unaffected by the extra body line) and an inline `#rust #async` line in the body, mirrored into the text used for embedding. A tag containing whitespace is skipped from the inline line (Obsidian-style `#tags` can't contain spaces) but still appears in the bullet. No tags → no inline line, bullet stays `untagged`.
 
 ## Chat Context Integration
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -77,8 +77,13 @@ Fields the system recognizes today (parsed by `frontmatter.py` via `get_frontmat
 |-------|------|----------|
 | `summary` | string | Prepended to body for semantic-search embeddings (via `build_composite_text`); surfaced in UI |
 | `keywords` | list of strings | Prepended to body for embeddings (via `build_composite_text`) |
-| `tags` | list of strings | Prepended to body for embeddings (via `build_composite_text`); loose categorization |
+| `tags` | list of strings | Prepended to body for embeddings (via `build_composite_text`), unioned with inline Obsidian-style `#tags` found in the body (#318); loose categorization |
 | `importance` | float in [0, 1] | Composite scoring weight in memory retrieval (not used by `build_composite_text`) |
+
+Folding inline `#tags` into the composite embedding text is a change to
+what gets embedded, not to any file on disk — it only takes effect for
+pages re-embedded after the change. Run `make reindex` to pick it up for
+existing pages.
 
 Skill-authored conventions (preserved by the parser but not interpreted by core code):
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -107,7 +107,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_rename(from_page, to_page)` | Rename/move a page (preserves links). Pages outside `agent/` trigger a user confirmation. |
 | `vault_grant_folder(folder, reason)` | Request per-conversation trust for a folder. After approval, vault_write/delete/rename under the folder skip confirmation. |
 | `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. Tags surface both as the back-compat `- **tags:**` bullet and as inline Obsidian-style `#tags` in the body (#318), so `extract_tags`/tag search see them without a separate scan pass. |
-| `vault_search(query, source_type?, days?, folder?)` | Semantic + substring search across the vault. |
+| `vault_search(query, source_type?, days?, folder?, tags?, any_tag?)` | Semantic + substring search across the vault. Optional `tags` filters to files whose extracted tags satisfy the request (AND by default; `any_tag=true` for OR); an empty `query` with non-empty `tags` skips search entirely and lists matching pages directly via `pages_with_tags` (#318). Empty/omitted `tags` leaves behavior unchanged — `pages_with_tags` with an empty list would vacuously match everything, so that path only activates when `tags` is non-empty. |
 | `vault_list(folder?, pattern?)` | List pages with last-modified dates. |
 | `vault_backlinks(page)` | Find pages linking to this page via `[[wiki-links]]`. |
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -55,6 +55,8 @@ The vault supports hierarchical folders. The API and web UI provide folder-aware
 
 `PUT /api/vault/{page}` with `{"rename_to": "new/path"}` renames/moves a page. Returns 409 if target exists.
 
+`GET /api/vault/tags` returns `{tags: [{tag, count, pages}, ...]}` — every tag in use across the vault, sorted by count descending (tie-broken by tag name), mirroring the `vault_tags` tool. `pages` lists the vault-relative paths carrying that tag, for click-through UI (#318).
+
 ## Wiki Links
 
 Standard Obsidian `[[wiki-links]]` connect pages:
@@ -109,6 +111,7 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_journal_append(tags, content)` | Append timestamped entry to today's journal file. Tags surface both as the back-compat `- **tags:**` bullet and as inline Obsidian-style `#tags` in the body (#318), so `extract_tags`/tag search see them without a separate scan pass. |
 | `vault_search(query, source_type?, days?, folder?, tags?, any_tag?)` | Semantic + substring search across the vault. Optional `tags` filters to files whose extracted tags satisfy the request (AND by default; `any_tag=true` for OR); an empty `query` with non-empty `tags` skips search entirely and lists matching pages directly via `pages_with_tags` (#318). Empty/omitted `tags` leaves behavior unchanged — `pages_with_tags` with an empty list would vacuously match everything, so that path only activates when `tags` is non-empty. |
 | `vault_list(folder?, pattern?)` | List pages with last-modified dates. |
+| `vault_tags()` | List every tag in use across the vault with usage counts, sorted by count descending (tie-broken by tag name). Thin wrapper over `collect_all_tags` (#318) — enumerates the tag vocabulary itself, distinct from `vault_search`'s content-filtering `tags` parameter. |
 | `vault_backlinks(page)` | Find pages linking to this page via `[[wiki-links]]`. |
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -87,6 +87,14 @@ The tab auto-refreshes on activation. Save/reset actions dispatch a `schedule-sa
 
 See [Schedules](schedules.md) for the full model, overlay semantics, and API.
 
+### Tags tab
+
+The **Tags** tab lists every tag in use across the vault, with usage counts, sorted by count descending:
+
+- Click a tag to see the pages that carry it
+- Click a page to open it in the wiki pane (same side panel as the Vault editor)
+- Backed by `GET /api/vault/tags`
+
 ### Model picker
 
 When multiple model configs are defined, a dropdown in the sidebar lets you switch models per-conversation. See [Model Selection](model-selection.md).

--- a/evals/tool_choice/core_overlaps.yaml
+++ b/evals/tool_choice/core_overlaps.yaml
@@ -267,6 +267,27 @@
     (source_type=user). vault_list would dump the whole journal folder with no
     date filter; vault_search needs a query string.
 
+# -- vault_tags vs vault_search -----------------------------------------------
+
+- name: vault-tags-vs-search-what-tags
+  scenario: "What tags have I used?"
+  expected: vault_tags
+  near_miss: [vault_search]
+  notes: |
+    Asking about the tag vocabulary itself (not filtering content by tag)
+    is vault_tags — it takes no query and just enumerates tags with counts.
+    vault_search is tempting since it also accepts a `tags` filter, but that
+    filter narrows a content search; it doesn't answer "what tags exist."
+
+- name: vault-tags-vs-search-list-all-tags
+  scenario: "List all my tags."
+  expected: vault_tags
+  near_miss: [vault_search]
+  notes: |
+    Same distinction as above: no content query, just "list the tags." A
+    vault_search call with an empty query and no tags filter wouldn't answer
+    this — vault_tags is the direct enumeration tool.
+
 # -- vault_recompute_importance vs vault_update_frontmatter / vault_write ----
 # (#197 Phase 5)
 

--- a/evals/vault-tags.yaml
+++ b/evals/vault-tags.yaml
@@ -6,7 +6,7 @@
 
 - name: "tag-scoped ask surfaces the right page via vault_search tags filter"
   setup:
-    reflection_enabled: false
+    reflection.enabled: false
     workspace_files:
       "vault/agent/pages/storage-notes.md": |
         ---

--- a/evals/vault-tags.yaml
+++ b/evals/vault-tags.yaml
@@ -1,0 +1,33 @@
+# Tag-filtered vault_search (#318 phase 4). Both seeded pages mention BOTH
+# "Rust" and "Python" in their prose — a plain substring/semantic query for
+# "rust" would match both and can't disambiguate. Only the frontmatter
+# `tags:` field distinguishes them, so a correct answer requires the agent
+# to actually use vault_search's `tags` filter rather than a bare query.
+
+- name: "tag-scoped ask surfaces the right page via vault_search tags filter"
+  setup:
+    reflection_enabled: false
+    workspace_files:
+      "vault/agent/pages/storage-notes.md": |
+        ---
+        tags: [rust]
+        ---
+        # Storage Notes
+
+        We compared Rust and Python for the storage layer. The chosen
+        runtime is Zephyr.
+      "vault/agent/pages/compute-notes.md": |
+        ---
+        tags: [python]
+        ---
+        # Compute Notes
+
+        We compared Rust and Python for the compute layer. The chosen
+        runtime is Nimbus.
+  input: "Look up the vault page tagged 'rust' (not 'python') and tell me what runtime it mentions."
+  expect:
+    response_contains: "re:zephyr"
+    response_not_contains: "nimbus"
+    max_tool_calls: 4
+    max_tool_errors: 0
+    expect_tool: vault_search

--- a/src/decafclaw/frontmatter.py
+++ b/src/decafclaw/frontmatter.py
@@ -88,8 +88,10 @@ def get_frontmatter_field(metadata: dict, field: str, default=None):
 def build_composite_text(metadata: dict, body: str) -> str:
     """Build composite text for embedding indexing.
 
-    Prepends summary, keywords, and tags to body content for richer embeddings.
-    Returns body as-is if no relevant frontmatter fields are present.
+    Prepends summary, keywords, and tags (frontmatter ``tags:`` plus inline
+    Obsidian-style ``#tags`` found in the body, #318) to body content for
+    richer embeddings. Returns body as-is if no relevant frontmatter fields
+    or inline tags are present.
     """
     parts: list[str] = []
 
@@ -101,9 +103,29 @@ def build_composite_text(metadata: dict, body: str) -> str:
     if isinstance(keywords, list) and keywords:
         parts.append(", ".join(str(k) for k in keywords))
 
-    tags = get_frontmatter_field(metadata, "tags", [])
-    if isinstance(tags, list) and tags:
-        parts.append(", ".join(str(t) for t in tags))
+    # Function-level import: this breaks a module-level import cycle.
+    # tags.py imports parse_frontmatter/get_frontmatter_field from this
+    # module at module level, so importing tags.py here at module level
+    # would cycle back into a partially-initialized frontmatter module.
+    from decafclaw.tags import normalize_tag, parse_inline_tags
+
+    fm_tags = get_frontmatter_field(metadata, "tags", [])
+    seen_norm: set[str] = set()
+    all_tags: list[str] = []
+    if isinstance(fm_tags, list):
+        for t in fm_tags:
+            raw = str(t)
+            norm = normalize_tag(raw)
+            if norm and norm not in seen_norm:
+                seen_norm.add(norm)
+                all_tags.append(raw)
+    for norm in sorted(parse_inline_tags(body)):
+        if norm not in seen_norm:
+            seen_norm.add(norm)
+            all_tags.append(norm)
+
+    if all_tags:
+        parts.append(", ".join(all_tags))
 
     if not parts:
         return body

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -34,6 +34,7 @@ from .skills.vault._events import (
     KIND_UPDATE,
     publish_vault_changed,
 )
+from .tags import collect_all_tags
 from .web.workspace_paths import (
     IMAGE_EXTENSIONS,
     detect_kind,
@@ -1202,6 +1203,23 @@ async def vault_recent(request: Request, username: str) -> JSONResponse:
 
 
 @_authenticated
+async def vault_tags(request: Request, username: str) -> JSONResponse:
+    """List all tags in use across the vault with usage counts and pages.
+
+    Sorted by count descending, tie-broken by (normalized) tag name
+    ascending — same ordering as the ``vault_tags`` tool.
+    """
+    config = request.app.state.config
+    tag_map = collect_all_tags(config)
+    ordered = sorted(tag_map.items(), key=lambda kv: (-kv[1]["count"], kv[0]))
+    tags = [
+        {"tag": info["display"], "count": info["count"], "pages": info["pages"]}
+        for _, info in ordered
+    ]
+    return JSONResponse({"tags": tags})
+
+
+@_authenticated
 async def vault_read(request: Request, username: str) -> JSONResponse:
     """Read a single vault page as JSON."""
     config = request.app.state.config
@@ -2088,6 +2106,7 @@ def create_app(config, event_bus, app_ctx=None, manager=None) -> Starlette:
         Route("/api/vault", vault_list, methods=["GET"]),
         Route("/api/vault/folders", vault_create_folder, methods=["POST"]),
         Route("/api/vault/recent", vault_recent, methods=["GET"]),
+        Route("/api/vault/tags", vault_tags, methods=["GET"]),
         Route("/api/vault/{page:path}", vault_write, methods=["PUT"]),
         Route("/api/vault/{page:path}", vault_read, methods=["GET"]),
         Route("/api/vault/{page:path}", vault_delete, methods=["DELETE"]),

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -609,7 +609,10 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
     # tag containing whitespace can't round-trip as a single inline token
     # (Obsidian-style #tags don't allow spaces), so it's skipped there and
     # only surfaces via the bullet.
-    inline_tags = [t for t in tags if t and not any(ch.isspace() for ch in t)]
+    stripped_tags = [t.lstrip("#").strip() for t in tags]
+    inline_tags = [
+        t for t in stripped_tags if t and not any(ch.isspace() for ch in t)
+    ]
     inline_tag_line = " ".join(f"#{t}" for t in inline_tags)
 
     entry = f"\n## {now:%Y-%m-%d %H:%M}\n\n"
@@ -789,11 +792,11 @@ def _semantic_result_matches_tags(config, result: dict, req_tags: set[str],
     path = _vault_root(config) / file_path
     try:
         content = path.read_text()
+        source_type = result.get("source_type") or _source_type_for_path(config, path)
+        file_tags = extract_tags(content, source_type)
     except Exception as exc:
-        log.debug(f"vault_search: failed reading {path} for tag filter: {exc}")
+        log.debug(f"vault_search: failed reading/tagging {path} for tag filter: {exc}")
         return False
-    source_type = result.get("source_type") or _source_type_for_path(config, path)
-    file_tags = extract_tags(content, source_type)
     if any_tag:
         return bool(file_tags & req_tags)
     return req_tags <= file_tags

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -28,6 +28,7 @@ from decafclaw.skills.vault._grants import (
     normalize_folder,
 )
 from decafclaw.skills.vault._sections import Document, _insert_into_doc
+from decafclaw.tags import extract_tags, normalize_tag, pages_with_tags
 from decafclaw.tools.confirmation import request_confirmation
 
 log = logging.getLogger(__name__)
@@ -664,10 +665,25 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
 
 
 async def tool_vault_search(ctx, query: str, source_type: str = "",
-                            days: int = 0, folder: str = "") -> str | ToolResult:
-    """Search the vault using semantic or substring matching."""
+                            days: int = 0, folder: str = "",
+                            tags: list[str] | None = None,
+                            any_tag: bool = False) -> str | ToolResult:
+    """Search the vault using semantic or substring matching, optionally
+    filtered by tag.
+
+    Tag filtering has two modes:
+    - Empty ``query`` + non-empty ``tags``: pure tag filter, bypasses
+      semantic/substring search entirely (`pages_with_tags`).
+    - Non-empty ``query`` + non-empty ``tags``: run the normal search, then
+      drop results whose extracted tags don't satisfy the filter.
+    Empty/omitted ``tags`` leaves behavior unchanged (no filtering) — a
+    non-empty `tags` list is required to enter either tag-filter mode, since
+    `pages_with_tags(config, [])` would otherwise vacuously match everything.
+    """
+    req_tags = {normalize_tag(t) for t in tags} if tags else set()
     log.info(f"[tool:vault_search] query={query!r} source_type={source_type} "
-             f"days={days} folder={folder}")
+             f"days={days} folder={folder} tags={sorted(req_tags)} "
+             f"any_tag={any_tag}")
 
     vault = _vault_root(ctx.config)
     if not vault.is_dir():
@@ -678,6 +694,10 @@ async def tool_vault_search(ctx, query: str, source_type: str = "",
         safe = _safe_folder(ctx.config, folder)
         if safe is None:
             return ToolResult(text=f"[error: invalid folder path '{folder}']")
+
+    if not query and req_tags:
+        return _tag_filter_search(ctx.config, req_tags, any_tag,
+                                  source_type=source_type, folder=folder)
 
     # Try semantic search first
     if ctx.config.embedding.search_strategy == "semantic":
@@ -705,6 +725,12 @@ async def tool_vault_search(ctx, query: str, source_type: str = "",
             if folder:
                 results = [r for r in results
                            if r.get("file_path", "").startswith(folder)]
+
+            # Apply tag filter (post-search: drop non-matching results)
+            if req_tags:
+                results = [r for r in results
+                           if _semantic_result_matches_tags(
+                               ctx.config, r, req_tags, any_tag)]
 
             if results:
                 lines = [f"Found {len(results)} result(s):\n"]
@@ -743,11 +769,84 @@ async def tool_vault_search(ctx, query: str, source_type: str = "",
             log.error(f"Semantic search failed, falling back to substring: {e}")
 
     # Substring search across vault
-    return _substring_search(ctx.config, query, days=days, folder=folder)
+    return _substring_search(ctx.config, query, days=days, folder=folder,
+                             req_tags=req_tags, any_tag=any_tag)
 
 
-def _substring_search(config, query: str, days: int = 0,
-                      folder: str = "") -> str | ToolResult:
+def _semantic_result_matches_tags(config, result: dict, req_tags: set[str],
+                                  any_tag: bool) -> bool:
+    """Fail-open per-result tag check for a semantic search result row.
+
+    Reads the result's source file directly (results carry composite
+    embedding text, not raw content) and calls `extract_tags` on it. An
+    unreadable file is excluded rather than raised, matching
+    `pages_with_tags`'s per-file fail-open behavior.
+    """
+    file_path = result.get("file_path", "")
+    if not file_path:
+        return False
+    path = _vault_root(config) / file_path
+    try:
+        content = path.read_text()
+    except Exception as exc:
+        log.debug(f"vault_search: failed reading {path} for tag filter: {exc}")
+        return False
+    source_type = result.get("source_type") or _source_type_for_path(config, path)
+    file_tags = extract_tags(content, source_type)
+    if any_tag:
+        return bool(file_tags & req_tags)
+    return req_tags <= file_tags
+
+
+def _tag_filter_search(config, req_tags: set[str], any_tag: bool,
+                       source_type: str = "", folder: str = "") -> ToolResult:
+    """Pure tag filter (empty query): list vault pages matching the tag
+    filter, formatted like the existing no-query substring search output.
+    """
+    vault = _vault_root(config)
+    matches = pages_with_tags(config, sorted(req_tags), any_tag=any_tag)
+
+    lines: list[str] = []
+    rows: list[dict] = []
+    for rel_path in sorted(matches):
+        if folder and not rel_path.startswith(folder):
+            continue
+        path = vault / rel_path
+        if source_type and _source_type_for_path(config, path) != source_type:
+            continue
+        try:
+            mtime_str = datetime.fromtimestamp(
+                path.stat().st_mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+        except Exception as exc:
+            log.debug(f"vault_search: failed stat'ing {path} for tag filter: {exc}")
+            continue
+        page = str(path.relative_to(vault).with_suffix(""))
+        lines.append(f"- {page} (modified: {mtime_str})")
+        rows.append({"page": page, "modified": mtime_str})
+
+    tag_list = sorted(req_tags)
+    if not lines:
+        return ToolResult(
+            text=f"No pages found matching tags {tag_list}.",
+            display_short_text="tags — no results",
+            data={"query": "", "mode": "tags", "tags": tag_list,
+                 "any_tag": any_tag, "results": []},
+        )
+
+    text = f"Found {len(lines)} result(s):\n\n" + "\n".join(lines)
+    widget = _substring_results_widget("", rows)
+    return ToolResult(
+        text=text,
+        display_short_text=f"tags {tag_list} — {len(lines)} result(s)",
+        widget=widget,
+        data={"query": "", "mode": "tags", "tags": tag_list,
+             "any_tag": any_tag, "results": rows},
+    )
+
+
+def _substring_search(config, query: str, days: int = 0, folder: str = "",
+                      req_tags: set[str] | None = None,
+                      any_tag: bool = False) -> str | ToolResult:
     """Substring search across vault markdown files."""
     vault = _vault_root(config)
     search_root = vault / folder if folder else vault
@@ -787,6 +886,13 @@ def _substring_search(config, query: str, days: int = 0,
         text = path.read_text()
         name = path.stem
         if query_lower in name.lower() or query_lower in text.lower():
+            if req_tags:
+                file_tags = extract_tags(
+                    text, _source_type_for_path(config, path))
+                matches = (bool(file_tags & req_tags) if any_tag
+                          else req_tags <= file_tags)
+                if not matches:
+                    continue
             excerpt = ""
             for line in text.splitlines():
                 if query_lower in line.lower():
@@ -1688,6 +1794,27 @@ TOOL_DEFINITIONS = [
                         "description": (
                             "Limit search to a vault subfolder "
                             "(e.g. 'agent/journal' or 'agent/pages')"
+                        ),
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Filter to pages/entries carrying these tags "
+                            "(case-insensitive, leading '#' optional). "
+                            "Default AND: must have ALL listed tags — set "
+                            "any_tag=true for OR. Empty query + tags = pure "
+                            "tag filter (skips search); query + tags = "
+                            "search first, then drop non-matching results. "
+                            "Empty/omitted = no tag filter."
+                        ),
+                    },
+                    "any_tag": {
+                        "type": "boolean",
+                        "description": (
+                            "With tags set, match ANY listed tag (OR) "
+                            "instead of requiring all (AND, the default). "
+                            "Ignored if tags is empty."
                         ),
                     },
                 },

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -604,6 +604,12 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
 
     filepath = journal_dir / f"{now:%Y-%m-%d}.md"
     tag_str = ", ".join(tags) if tags else "untagged"
+    # Inline #tags mirror the bullet for extract_tags/#318 (see tags.py); a
+    # tag containing whitespace can't round-trip as a single inline token
+    # (Obsidian-style #tags don't allow spaces), so it's skipped there and
+    # only surfaces via the bullet.
+    inline_tags = [t for t in tags if t and not any(ch.isspace() for ch in t)]
+    inline_tag_line = " ".join(f"#{t}" for t in inline_tags)
 
     entry = f"\n## {now:%Y-%m-%d %H:%M}\n\n"
     channel_name = ctx.channel_name
@@ -614,6 +620,8 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
     if thread_id:
         entry += f"- **thread:** {thread_id}\n"
     entry += f"- **tags:** {tag_str}\n"
+    if inline_tag_line:
+        entry += f"{inline_tag_line}\n"
     entry += f"\n{content}\n"
 
     with open(filepath, "a", encoding="utf-8") as f:
@@ -630,7 +638,10 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
             entry_text += f"- **channel:** {channel_name} ({channel_id})\n"
         if thread_id:
             entry_text += f"- **thread:** {thread_id}\n"
-        entry_text += f"- **tags:** {tag_str}\n\n{content}"
+        entry_text += f"- **tags:** {tag_str}\n"
+        if inline_tag_line:
+            entry_text += f"{inline_tag_line}\n"
+        entry_text += f"\n{content}"
         await index_entry(ctx.config, rel_path, entry_text,
                           source_type="journal")
     except Exception as e:

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -28,7 +28,7 @@ from decafclaw.skills.vault._grants import (
     normalize_folder,
 )
 from decafclaw.skills.vault._sections import Document, _insert_into_doc
-from decafclaw.tags import extract_tags, normalize_tag, pages_with_tags
+from decafclaw.tags import collect_all_tags, extract_tags, normalize_tag, pages_with_tags
 from decafclaw.tools.confirmation import request_confirmation
 
 log = logging.getLogger(__name__)
@@ -1182,6 +1182,23 @@ async def tool_vault_recent(ctx, days: int = 7, folder: str = "",
     )
 
 
+async def tool_vault_tags(ctx) -> ToolResult:
+    """List all tags currently in use across the vault, with usage counts."""
+    log.info("[tool:vault_tags]")
+    tag_map = collect_all_tags(ctx.config)
+    if not tag_map:
+        return ToolResult(text="No tags found in the vault.", data={"tags": []})
+
+    # Sorted by count desc, tie-broken by (normalized) tag name asc so the
+    # ordering is deterministic regardless of dict iteration order.
+    ordered = sorted(tag_map.items(), key=lambda kv: (-kv[1]["count"], kv[0]))
+    tags = [{"tag": info["display"], "count": info["count"]} for _, info in ordered]
+
+    lines = [f"- {t['tag']} ({t['count']})" for t in tags]
+    header = f"{len(tags)} tag(s) in use across the vault"
+    return ToolResult(text=f"{header}:\n\n" + "\n".join(lines), data={"tags": tags})
+
+
 _WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
@@ -1548,6 +1565,7 @@ TOOLS = {
     "vault_search": tool_vault_search,
     "vault_list": tool_vault_list,
     "vault_recent": tool_vault_recent,
+    "vault_tags": tool_vault_tags,
     "vault_backlinks": tool_vault_backlinks,
     "vault_show_sections": tool_vault_show_sections,
     "vault_move_lines": tool_vault_move_lines,
@@ -1893,6 +1911,25 @@ TOOL_DEFINITIONS = [
                         ),
                     },
                 },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "vault_tags",
+            "description": (
+                "List all tags currently in use across the vault with usage "
+                "counts, sorted by count descending. Use this to see what "
+                "tags exist before filtering — e.g. 'what tags have I used' "
+                "or 'list all my tags'. Unlike vault_search (which finds or "
+                "filters content by tag/query), vault_tags takes no "
+                "arguments and just enumerates the tag vocabulary itself."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
                 "required": [],
             },
         },

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -697,7 +697,8 @@ async def tool_vault_search(ctx, query: str, source_type: str = "",
 
     if not query and req_tags:
         return _tag_filter_search(ctx.config, req_tags, any_tag,
-                                  source_type=source_type, folder=folder)
+                                  source_type=source_type, folder=folder,
+                                  days=days)
 
     # Try semantic search first
     if ctx.config.embedding.search_strategy == "semantic":
@@ -799,12 +800,17 @@ def _semantic_result_matches_tags(config, result: dict, req_tags: set[str],
 
 
 def _tag_filter_search(config, req_tags: set[str], any_tag: bool,
-                       source_type: str = "", folder: str = "") -> ToolResult:
+                       source_type: str = "", folder: str = "",
+                       days: int = 0) -> ToolResult:
     """Pure tag filter (empty query): list vault pages matching the tag
     filter, formatted like the existing no-query substring search output.
     """
     vault = _vault_root(config)
     matches = pages_with_tags(config, sorted(req_tags), any_tag=any_tag)
+
+    cutoff = None
+    if days > 0:
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
 
     lines: list[str] = []
     rows: list[dict] = []
@@ -815,11 +821,13 @@ def _tag_filter_search(config, req_tags: set[str], any_tag: bool,
         if source_type and _source_type_for_path(config, path) != source_type:
             continue
         try:
-            mtime_str = datetime.fromtimestamp(
-                path.stat().st_mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+            mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
         except Exception as exc:
             log.debug(f"vault_search: failed stat'ing {path} for tag filter: {exc}")
             continue
+        if cutoff and mtime < cutoff:
+            continue
+        mtime_str = mtime.strftime("%Y-%m-%d %H:%M")
         page = str(path.relative_to(vault).with_suffix(""))
         lines.append(f"- {page} (modified: {mtime_str})")
         rows.append({"page": page, "modified": mtime_str})

--- a/src/decafclaw/tags.py
+++ b/src/decafclaw/tags.py
@@ -76,7 +76,15 @@ def extract_tags(content: str, source_type: str) -> set[str]:
             tags.add(normalize_tag(str(t)))
     if source_type == "journal":
         for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
-            for part in m.group(1).split(","):
+            bullet_value = m.group(1).strip()
+            # "untagged" is vault_journal_append's display placeholder for
+            # the no-tags case (see skills/vault/tools.py), not a real tag —
+            # skip it. Only the whole-value sentinel is excluded; a
+            # legitimate multi-tag bullet that merely contains the word
+            # elsewhere is untouched.
+            if bullet_value.lower() == "untagged":
+                continue
+            for part in bullet_value.split(","):
                 if part.strip():
                     tags.add(normalize_tag(part))
     tags |= parse_inline_tags(body)

--- a/src/decafclaw/tags.py
+++ b/src/decafclaw/tags.py
@@ -1,0 +1,181 @@
+"""First-class vault tags (#318): extraction, normalization, on-demand scan.
+
+Tags come from three sources, unioned at the query layer (not stored
+uniformly on disk): page frontmatter ``tags:``, the journal
+``- **tags:**`` bullet, and Obsidian-style inline ``#tags`` in body prose.
+All comparisons use the lowercased canonical form; display casing is the
+first seen (across a full ``collect_all_tags`` scan, in page-then-journal,
+file-then-occurrence order).
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from decafclaw.frontmatter import get_frontmatter_field, parse_frontmatter
+
+log = logging.getLogger(__name__)
+
+# Inline #tag: preceded by whitespace/SOL, starts with letter/_/ '/', then
+# word chars / - / /. Digit-start excluded so "#42" isn't a tag.
+_INLINE_TAG_RE = re.compile(r"(?:(?<=\s)|^)#([A-Za-z_/][\w\-/]*)", re.MULTILINE)
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_JOURNAL_TAGS_BULLET_RE = re.compile(r"^- \*\*tags:\*\* (.+)$", re.MULTILINE)
+
+
+def normalize_tag(tag: str) -> str:
+    """Canonicalize a tag: strip leading '#', trim whitespace, lowercase.
+
+    Hyphen/underscore variants are NOT merged (``rust-lang`` stays distinct
+    from ``rust_lang``) — only case is folded.
+    """
+    return tag.lstrip("#").strip().lower()
+
+
+def _strip_code(body: str) -> str:
+    """Blank out fenced and inline code spans so tag-like text inside code
+    (e.g. a literal ``#fenced-not-tag``) is never mistaken for a real tag."""
+    body = _FENCED_CODE_RE.sub(" ", body)
+    return _INLINE_CODE_RE.sub(" ", body)
+
+
+def _raw_inline_tag_matches(body: str) -> list[str]:
+    """Return inline #tag matches with their original casing intact.
+
+    Shared by ``parse_inline_tags`` (normalizes) and ``collect_all_tags``
+    (needs the pre-normalization form to capture first-seen display casing).
+    """
+    stripped = _strip_code(body)
+    return [m.group(1) for m in _INLINE_TAG_RE.finditer(stripped)]
+
+
+def parse_inline_tags(body: str) -> set[str]:
+    """Extract normalized Obsidian-style inline #tags from markdown body text.
+
+    Excludes tags inside fenced or inline code, digit-led hashes (``#42``),
+    and ATX headings (``# Heading``, since a heading requires a space after
+    the hash and the tag pattern requires a non-space character immediately
+    following it).
+    """
+    return {normalize_tag(t) for t in _raw_inline_tag_matches(body)}
+
+
+def extract_tags(content: str, source_type: str) -> set[str]:
+    """Union of all tag sources for one file's raw content, normalized.
+
+    Sources: frontmatter ``tags:`` (all source types), the journal
+    ``- **tags:**`` bullet (``source_type == "journal"`` only), and inline
+    ``#tags`` in the body.
+    """
+    metadata, body = parse_frontmatter(content)
+    tags: set[str] = set()
+    fm_tags = get_frontmatter_field(metadata, "tags", [])
+    if isinstance(fm_tags, list):
+        for t in fm_tags:
+            tags.add(normalize_tag(str(t)))
+    if source_type == "journal":
+        for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
+            for part in m.group(1).split(","):
+                if part.strip():
+                    tags.add(normalize_tag(part))
+    tags |= parse_inline_tags(body)
+    tags.discard("")
+    return tags
+
+
+def _iter_tag_source_files(config):
+    """Yield (rel_path, content, source_type) for every vault file that can
+    carry tags: pages (agent + user, journal excluded — mirrors
+    ``embeddings._iter_vault_pages``) plus journal daily files explicitly.
+
+    Paths are vault-relative POSIX strings, matching embeddings/backlinks
+    path keying. Fails open per-file: an unreadable file is skipped with a
+    debug log, never raised.
+    """
+    vault = config.vault_root
+    journal_dir = config.vault_agent_journal_dir
+
+    if vault.is_dir():
+        for filepath in sorted(vault.rglob("*.md")):
+            try:
+                if filepath.resolve().is_relative_to(journal_dir.resolve()):
+                    continue
+            except (ValueError, OSError):
+                pass
+            try:
+                content = filepath.read_text()
+            except Exception as exc:
+                log.debug("tags: failed reading page %s: %s", filepath, exc)
+                continue
+            rel_path = filepath.relative_to(vault).as_posix()
+            yield rel_path, content, "page"
+
+    if journal_dir.is_dir():
+        for filepath in sorted(journal_dir.rglob("*.md")):
+            try:
+                content = filepath.read_text()
+            except Exception as exc:
+                log.debug("tags: failed reading journal entry %s: %s", filepath, exc)
+                continue
+            rel_path = filepath.relative_to(vault).as_posix()
+            yield rel_path, content, "journal"
+
+
+def collect_all_tags(config) -> dict[str, dict]:
+    """Scan the vault (pages + journal) and aggregate tags across all files.
+
+    Returns ``{normalized_tag: {"count": int, "display": str, "pages": [str]}}``
+    where ``count`` is the number of distinct files carrying the tag,
+    ``display`` is the original casing as first encountered, and ``pages``
+    lists vault-relative POSIX paths of files carrying the tag.
+    """
+    result: dict[str, dict] = {}
+
+    for rel_path, content, source_type in _iter_tag_source_files(config):
+        metadata, body = parse_frontmatter(content)
+        fm_tags = get_frontmatter_field(metadata, "tags", [])
+        raw_tags: list[str] = [str(t) for t in fm_tags] if isinstance(fm_tags, list) else []
+        if source_type == "journal":
+            for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
+                raw_tags.extend(part.strip() for part in m.group(1).split(",") if part.strip())
+        raw_tags.extend(_raw_inline_tag_matches(body))
+
+        seen_norm_in_file: set[str] = set()
+        for raw in raw_tags:
+            norm = normalize_tag(raw)
+            if not norm:
+                continue
+            entry = result.setdefault(norm, {"count": 0, "display": raw.lstrip("#").strip(), "pages": []})
+            if norm not in seen_norm_in_file:
+                seen_norm_in_file.add(norm)
+                entry["count"] += 1
+                entry["pages"].append(rel_path)
+
+    return result
+
+
+def pages_with_tags(config, tags: list[str], any_tag: bool = False) -> list[str]:
+    """Vault-relative paths of files whose extracted tags match the request.
+
+    Default is AND (file's tags must be a superset of the requested tags);
+    ``any_tag=True`` switches to OR (file's tags intersect the requested set).
+    Requested tags are normalized before comparison.
+    """
+    wanted = {normalize_tag(t) for t in tags}
+    matches: list[str] = []
+
+    for rel_path, content, source_type in _iter_tag_source_files(config):
+        try:
+            file_tags = extract_tags(content, source_type)
+        except Exception as exc:
+            log.debug("tags: failed extracting tags from %s: %s", rel_path, exc)
+            continue
+        if any_tag:
+            if file_tags & wanted:
+                matches.append(rel_path)
+        else:
+            if wanted <= file_tags:
+                matches.append(rel_path)
+
+    return matches

--- a/src/decafclaw/tags.py
+++ b/src/decafclaw/tags.py
@@ -61,19 +61,28 @@ def parse_inline_tags(body: str) -> set[str]:
     return {normalize_tag(t) for t in _raw_inline_tag_matches(body)}
 
 
-def extract_tags(content: str, source_type: str) -> set[str]:
-    """Union of all tag sources for one file's raw content, normalized.
+def _extract_tag_pairs(content: str, source_type: str) -> list[tuple[str, str]]:
+    """Return ``(normalized, display)`` pairs for every tag occurrence in one
+    file's raw content, in encounter order: frontmatter ``tags:`` (all
+    source types), the journal ``- **tags:**`` bullet (``source_type ==
+    "journal"`` only), then inline ``#tags`` in the body.
 
-    Sources: frontmatter ``tags:`` (all source types), the journal
-    ``- **tags:**`` bullet (``source_type == "journal"`` only), and inline
-    ``#tags`` in the body.
+    Single shared extraction path for both ``extract_tags`` (per-file
+    union, normalized) and ``collect_all_tags`` (vault-wide aggregate,
+    needs display casing) — keeps the parsing rules and the journal
+    "untagged" placeholder guard defined exactly once.
     """
     metadata, body = parse_frontmatter(content)
-    tags: set[str] = set()
+    pairs: list[tuple[str, str]] = []
+
     fm_tags = get_frontmatter_field(metadata, "tags", [])
     if isinstance(fm_tags, list):
         for t in fm_tags:
-            tags.add(normalize_tag(str(t)))
+            raw = str(t)
+            norm = normalize_tag(raw)
+            if norm:
+                pairs.append((norm, raw.lstrip("#").strip()))
+
     if source_type == "journal":
         for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
             bullet_value = m.group(1).strip()
@@ -85,11 +94,28 @@ def extract_tags(content: str, source_type: str) -> set[str]:
             if bullet_value.lower() == "untagged":
                 continue
             for part in bullet_value.split(","):
-                if part.strip():
-                    tags.add(normalize_tag(part))
-    tags |= parse_inline_tags(body)
-    tags.discard("")
-    return tags
+                raw = part.strip()
+                if raw:
+                    norm = normalize_tag(raw)
+                    if norm:
+                        pairs.append((norm, raw.lstrip("#").strip()))
+
+    for raw in _raw_inline_tag_matches(body):
+        norm = normalize_tag(raw)
+        if norm:
+            pairs.append((norm, raw.lstrip("#").strip()))
+
+    return pairs
+
+
+def extract_tags(content: str, source_type: str) -> set[str]:
+    """Union of all tag sources for one file's raw content, normalized.
+
+    Sources: frontmatter ``tags:`` (all source types), the journal
+    ``- **tags:**`` bullet (``source_type == "journal"`` only), and inline
+    ``#tags`` in the body.
+    """
+    return {norm for norm, _ in _extract_tag_pairs(content, source_type)}
 
 
 def _iter_tag_source_files(config):
@@ -141,20 +167,15 @@ def collect_all_tags(config) -> dict[str, dict]:
     result: dict[str, dict] = {}
 
     for rel_path, content, source_type in _iter_tag_source_files(config):
-        metadata, body = parse_frontmatter(content)
-        fm_tags = get_frontmatter_field(metadata, "tags", [])
-        raw_tags: list[str] = [str(t) for t in fm_tags] if isinstance(fm_tags, list) else []
-        if source_type == "journal":
-            for m in _JOURNAL_TAGS_BULLET_RE.finditer(content):
-                raw_tags.extend(part.strip() for part in m.group(1).split(",") if part.strip())
-        raw_tags.extend(_raw_inline_tag_matches(body))
+        try:
+            pairs = _extract_tag_pairs(content, source_type)
+        except Exception as exc:
+            log.debug("tags: failed extracting tags from %s: %s", rel_path, exc)
+            continue
 
         seen_norm_in_file: set[str] = set()
-        for raw in raw_tags:
-            norm = normalize_tag(raw)
-            if not norm:
-                continue
-            entry = result.setdefault(norm, {"count": 0, "display": raw.lstrip("#").strip(), "pages": []})
+        for norm, display in pairs:
+            entry = result.setdefault(norm, {"count": 0, "display": display, "pages": []})
             if norm not in seen_norm_in_file:
                 seen_norm_in_file.add(norm)
                 entry["count"] += 1

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -459,7 +459,7 @@ document.addEventListener('sidebar-tab-change', (e) => {
     hideFileView();
     hideSchedulePage();
   }
-  if ((tab === 'wiki' || tab === 'files')
+  if ((tab === 'wiki' || tab === 'files' || tab === 'tags')
       && window.matchMedia('(max-width: 639px)').matches) {
     if (canvasSnapshot().visible) {
       canvasDismiss();

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -4,6 +4,7 @@ import './notification-inbox.js';
 import './vault-sidebar.js';
 import './files-sidebar.js';
 import './schedules-sidebar.js';
+import './tags-sidebar.js';
 
 export class ConversationSidebar extends LitElement {
   static properties = {
@@ -494,6 +495,8 @@ export class ConversationSidebar extends LitElement {
             @click=${() => this.#switchTab('files')}>Files</button>
           <button class="sidebar-tab ${this._sidebarTab === 'schedules' ? 'active' : ''}"
             @click=${() => this.#switchTab('schedules')}>Schedules</button>
+          <button class="sidebar-tab ${this._sidebarTab === 'tags' ? 'active' : ''}"
+            @click=${() => this.#switchTab('tags')}>Tags</button>
         </div>
         <button class="mobile-close-btn dc-overlay-close-x" @click=${() => this.closeMobile()} title="Close sidebar">×</button>
         <button class="collapse-btn dc-icon-btn" @click=${this.#toggleCollapse} title="Collapse sidebar" aria-label="Collapse sidebar">‹</button>
@@ -513,6 +516,10 @@ export class ConversationSidebar extends LitElement {
         .openName=${this._openSchedule}
         style="${this._sidebarTab !== 'schedules' ? 'display:none' : ''}"
       ></schedules-sidebar>
+      <tags-sidebar
+        .active=${this._sidebarTab === 'tags'}
+        style="${this._sidebarTab !== 'tags' ? 'display:none' : ''}"
+      ></tags-sidebar>
       <div class="conv-list" style="${this._sidebarTab !== 'conversations' ? 'display:none' : ''}">
         ${this._chatSection === '' ? html`
           <div class="vault-action-btns">

--- a/src/decafclaw/web/static/components/conversation-sidebar.js
+++ b/src/decafclaw/web/static/components/conversation-sidebar.js
@@ -519,6 +519,7 @@ export class ConversationSidebar extends LitElement {
       <tags-sidebar
         .active=${this._sidebarTab === 'tags'}
         style="${this._sidebarTab !== 'tags' ? 'display:none' : ''}"
+        @wiki-open=${(e) => this.#handleWikiOpen(e)}
       ></tags-sidebar>
       <div class="conv-list" style="${this._sidebarTab !== 'conversations' ? 'display:none' : ''}">
         ${this._chatSection === '' ? html`

--- a/src/decafclaw/web/static/components/tags-sidebar.js
+++ b/src/decafclaw/web/static/components/tags-sidebar.js
@@ -1,0 +1,126 @@
+import { LitElement, html, nothing } from 'lit';
+
+/**
+ * @typedef {{ tag: string, count: number, pages: string[] }} TagEntry
+ */
+
+export class TagsSidebar extends LitElement {
+  static properties = {
+    active: { type: Boolean },
+    _tags: { type: Array, state: true },
+    _loading: { type: Boolean, state: true },
+    _selectedTag: { type: String, state: true },
+  };
+
+  createRenderRoot() { return this; }
+
+  constructor() {
+    super();
+    this.active = false;
+    /** @type {TagEntry[]} */
+    this._tags = [];
+    this._loading = false;
+    /** @type {string|null} */
+    this._selectedTag = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._onVaultChanged = () => {
+      if (this.active) this.#fetchTags();
+    };
+    window.addEventListener('vault-changed', this._onVaultChanged);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('vault-changed', this._onVaultChanged);
+  }
+
+  /** @param {Map} changedProps */
+  updated(changedProps) {
+    // Re-fetch on every false→true transition of `active`.
+    if (changedProps.has('active') && this.active && !changedProps.get('active')) {
+      this.#fetchTags();
+    }
+  }
+
+  async #fetchTags() {
+    this._loading = true;
+    try {
+      const res = await fetch('/api/vault/tags');
+      if (res.ok) {
+        const data = await res.json();
+        this._tags = data.tags || [];
+      } else {
+        this._tags = [];
+      }
+    } catch {
+      this._tags = [];
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  /** @param {string} tag */
+  #selectTag(tag) {
+    this._selectedTag = tag;
+  }
+
+  #clearSelection() {
+    this._selectedTag = null;
+  }
+
+  /** @param {string} page */
+  #openPage(page) {
+    this.dispatchEvent(new CustomEvent('wiki-open', {
+      detail: { page },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  #renderTagList() {
+    if (!this._tags.length) {
+      return html`<p style="padding: 1rem; color: var(--pico-muted-color);">${this._loading ? 'Loading tags...' : 'No tags found.'}</p>`;
+    }
+    return html`
+      ${this._tags.map(t => html`
+        <div class="conv-item wiki-item" @click=${() => this.#selectTag(t.tag)} title=${t.tag}>
+          <span class="conv-title">${t.tag}</span>
+          <span class="conv-type-badge">${t.count}</span>
+        </div>
+      `)}
+    `;
+  }
+
+  #renderTagPages() {
+    const entry = this._tags.find(t => t.tag === this._selectedTag);
+    const pages = entry?.pages || [];
+    return html`
+      <div class="vault-breadcrumbs">
+        <button type="button" class="vault-breadcrumb-segment" @click=${() => this.#clearSelection()}>tags</button>
+        <span class="vault-breadcrumb-sep">/</span>
+        <span class="vault-breadcrumb-segment active">${this._selectedTag}</span>
+      </div>
+      ${pages.length
+        ? pages.map(p => html`
+            <div class="conv-item wiki-item" @click=${() => this.#openPage(p)} title=${p}>
+              <span class="conv-title">${p}</span>
+            </div>
+          `)
+        : html`<p style="padding: 1rem; color: var(--pico-muted-color);">No pages.</p>`
+      }
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="conv-list">
+        ${this._selectedTag ? this.#renderTagPages() : this.#renderTagList()}
+      </div>
+    `;
+  }
+}
+
+customElements.define('tags-sidebar', TagsSidebar);

--- a/src/decafclaw/web/static/styles/sidebar.css
+++ b/src/decafclaw/web/static/styles/sidebar.css
@@ -36,7 +36,8 @@ conversation-sidebar .conv-list {
    of conversation-sidebar and the existing flex:1 rule above applies. */
 conversation-sidebar vault-sidebar,
 conversation-sidebar files-sidebar,
-conversation-sidebar schedules-sidebar {
+conversation-sidebar schedules-sidebar,
+conversation-sidebar tags-sidebar {
   display: contents;
 }
 

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -159,3 +159,18 @@ class TestBuildCompositeText:
         body = "Body."
         result = build_composite_text(meta, body)
         assert result == "alpha, beta\nBody."
+
+    def test_composite_includes_inline_tags(self):
+        out = build_composite_text({"tags": ["rust"]}, "body mentioning #async")
+        # Assert on the tags line specifically, not just substring-anywhere-in-
+        # `out` — the raw body text already contains "#async" as a substring,
+        # so a weaker "in out" check would pass even without folding inline
+        # tags into the tags portion.
+        tags_line = out.splitlines()[0]
+        assert "rust" in tags_line
+        assert "async" in tags_line
+
+    def test_composite_dedups_tag_in_both_frontmatter_and_inline(self):
+        out = build_composite_text({"tags": ["rust"]}, "love #rust here")
+        tags_line = out.splitlines()[0]
+        assert tags_line.count("rust") == 1

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -117,6 +117,28 @@ class TestCollectAllTags:
     def test_empty_vault_returns_empty_dict(self, config):
         assert collect_all_tags(config) == {}
 
+    def test_all_untagged_journal_yields_no_untagged_tag(self, config, agent_journal):
+        # An all-untagged journal entry must not surface a spurious
+        # "untagged" tag in the aggregate — the sentinel guard in
+        # extract_tags must also apply here (#318 follow-on fix).
+        journal_day_dir = agent_journal / "2026"
+        journal_day_dir.mkdir(parents=True, exist_ok=True)
+        (journal_day_dir / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** untagged\n\nsome note"
+        )
+
+        result = collect_all_tags(config)
+
+        assert "untagged" not in result
+        assert result == {}
+
+    def test_frontmatter_display_casing_preserved(self, config, agent_pages):
+        (agent_pages / "Rust.md").write_text("---\ntags: [Rust]\n---\nabout rust")
+
+        result = collect_all_tags(config)
+
+        assert result["rust"]["display"] == "Rust"
+
 
 class TestPagesWithTags:
     def test_and_default_requires_all_tags(self, config, agent_pages):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -66,6 +66,18 @@ def test_extract_journal_bullet_plus_inline():
     assert extract_tags(content, "journal") == {"rust", "async", "extra"}
 
 
+def test_extract_journal_untagged_sentinel_yields_no_tags():
+    # "untagged" is vault_journal_append's display placeholder for the
+    # no-tags case, not a real tag — the bullet should contribute nothing.
+    content = "## 2026-07-24 10:00\n\n- **tags:** untagged\n\nsome note"
+    assert extract_tags(content, "journal") == set()
+
+
+def test_extract_journal_untagged_sentinel_with_inline_tag():
+    content = "## 2026-07-24 10:00\n\n- **tags:** untagged\n\nsome #real note"
+    assert extract_tags(content, "journal") == {"real"}
+
+
 class TestCollectAllTags:
     def test_counts_display_and_pages(self, config, agent_pages, agent_journal):
         (agent_pages / "Rust.md").write_text("---\ntags: [Rust]\n---\nabout rust")

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,135 @@
+"""Tests for decafclaw.tags: extraction, normalization, on-demand scan."""
+
+import pytest
+
+from decafclaw.tags import (
+    collect_all_tags,
+    extract_tags,
+    normalize_tag,
+    pages_with_tags,
+    parse_inline_tags,
+)
+
+
+@pytest.fixture
+def agent_pages(config):
+    """Create the agent pages directory."""
+    d = config.vault_agent_pages_dir
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def agent_journal(config):
+    """Create the agent journal directory."""
+    d = config.vault_agent_journal_dir
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_normalize():
+    assert normalize_tag("#Rust") == "rust"
+    assert normalize_tag("  async ") == "async"
+    assert normalize_tag("rust-lang") == "rust-lang"  # hyphen preserved, distinct from "rust"
+
+
+def test_parse_inline_basic():
+    assert parse_inline_tags("working on #rust and #async-io today") == {"rust", "async-io"}
+
+
+def test_parse_inline_start_of_line_and_slash():
+    assert parse_inline_tags("#project/alpha notes") == {"project/alpha"}
+
+
+def test_parse_inline_rejects_digit_start_and_midword():
+    # "#42" (digit start) is not a tag; "a#b" (not preceded by whitespace/SOL) is not
+    assert parse_inline_tags("issue #42 and foo a#b") == set()
+
+
+def test_parse_inline_ignores_code():
+    body = "text #real\n```\n#fenced-not-tag\n```\ninline `#inline-not-tag` end"
+    assert parse_inline_tags(body) == {"real"}
+
+
+def test_parse_inline_atx_heading_not_a_tag():
+    # "# Heading" (hash + space at SOL) is a markdown heading, not a tag
+    assert parse_inline_tags("# Heading\n#realtag") == {"realtag"}
+
+
+def test_extract_page_frontmatter_plus_inline():
+    content = "---\ntags: [Rust, Async]\n---\nbody with #extra tag"
+    assert extract_tags(content, "page") == {"rust", "async", "extra"}
+
+
+def test_extract_journal_bullet_plus_inline():
+    content = "## 2026-07-24 10:00\n\n- **tags:** rust, async\n\nsome #extra note"
+    assert extract_tags(content, "journal") == {"rust", "async", "extra"}
+
+
+class TestCollectAllTags:
+    def test_counts_display_and_pages(self, config, agent_pages, agent_journal):
+        (agent_pages / "Rust.md").write_text("---\ntags: [Rust]\n---\nabout rust")
+        (agent_pages / "Async.md").write_text("body mentions #Rust and #async")
+        journal_day_dir = agent_journal / "2026"
+        journal_day_dir.mkdir(parents=True, exist_ok=True)
+        (journal_day_dir / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** rust\n\nnotes"
+        )
+
+        result = collect_all_tags(config)
+
+        assert set(result.keys()) >= {"rust", "async"}
+        assert result["rust"]["count"] == 3
+        assert result["rust"]["display"] == "Rust"
+        assert sorted(result["rust"]["pages"]) == sorted(
+            [
+                "agent/pages/Rust.md",
+                "agent/pages/Async.md",
+                "agent/journal/2026/2026-07-24.md",
+            ]
+        )
+
+        assert result["async"]["count"] == 1
+        assert result["async"]["display"] == "async"
+        assert result["async"]["pages"] == ["agent/pages/Async.md"]
+
+    def test_first_seen_display_casing_preserved(self, config, agent_pages):
+        (agent_pages / "A.md").write_text("#RustLang note")
+        (agent_pages / "B.md").write_text("#rustlang note")
+
+        result = collect_all_tags(config)
+
+        assert result["rustlang"]["display"] == "RustLang"
+        assert result["rustlang"]["count"] == 2
+
+    def test_empty_vault_returns_empty_dict(self, config):
+        assert collect_all_tags(config) == {}
+
+
+class TestPagesWithTags:
+    def test_and_default_requires_all_tags(self, config, agent_pages):
+        (agent_pages / "Both.md").write_text("#rust #async here")
+        (agent_pages / "OnlyRust.md").write_text("#rust only")
+
+        result = pages_with_tags(config, ["rust", "async"])
+
+        assert result == ["agent/pages/Both.md"]
+
+    def test_any_tag_true_is_or(self, config, agent_pages):
+        (agent_pages / "Both.md").write_text("#rust #async here")
+        (agent_pages / "OnlyRust.md").write_text("#rust only")
+        (agent_pages / "Neither.md").write_text("no tags here")
+
+        result = pages_with_tags(config, ["rust", "async"], any_tag=True)
+
+        assert sorted(result) == sorted(["agent/pages/Both.md", "agent/pages/OnlyRust.md"])
+
+    def test_normalizes_requested_tags(self, config, agent_pages):
+        (agent_pages / "Rust.md").write_text("#rust")
+
+        assert pages_with_tags(config, ["#Rust"]) == ["agent/pages/Rust.md"]
+
+    def test_no_matches_returns_empty_list(self, config, agent_pages):
+        (agent_pages / "Rust.md").write_text("#rust")
+
+        assert pages_with_tags(config, ["nonexistent"]) == []

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -379,6 +379,35 @@ async def test_vault_recent_excludes_user_pages(client, http_config):
     assert "UserNote" not in titles
 
 
+# -- vault_tags ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vault_tags_empty(client):
+    resp = await client.get("/api/vault/tags")
+    assert resp.status_code == 200
+    assert resp.json()["tags"] == []
+
+
+@pytest.mark.asyncio
+async def test_vault_tags_sorted_by_count_desc(client, http_config):
+    pages_dir = http_config.vault_agent_pages_dir
+    (pages_dir / "Rust.md").write_text("---\ntags: [Rust]\n---\nabout rust")
+    (pages_dir / "Async.md").write_text("body mentions #Rust and #async")
+
+    resp = await client.get("/api/vault/tags")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tags"] == [
+        {
+            "tag": "Rust",
+            "count": 2,
+            "pages": ["agent/pages/Async.md", "agent/pages/Rust.md"],
+        },
+        {"tag": "async", "count": 1, "pages": ["agent/pages/Async.md"]},
+    ]
+
+
 # -- vault_changed event publishing -------------------------------------------
 #
 # These tests verify the REST handlers publish `vault_changed` events on the

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -25,6 +25,7 @@ from decafclaw.skills.vault.tools import (
     tool_vault_recent,
     tool_vault_rename,
     tool_vault_search,
+    tool_vault_tags,
     tool_vault_update_frontmatter,
     tool_vault_write,
 )
@@ -1541,6 +1542,48 @@ class TestVaultRecent:
     async def test_missing_folder_errors(self, ctx, vault_dir):
         result = await tool_vault_recent(ctx, days=7, folder="nope/missing")
         assert "does not exist" in str(result).lower()
+
+
+class TestVaultTags:
+    async def test_sorted_by_count_desc_with_tie_break(
+        self, ctx, agent_pages, agent_journal,
+    ):
+        (agent_pages / "Rust.md").write_text("---\ntags: [Rust]\n---\nabout rust")
+        (agent_pages / "Async.md").write_text("body mentions #Rust and #async")
+        journal_day_dir = agent_journal / "2026"
+        journal_day_dir.mkdir(parents=True, exist_ok=True)
+        (journal_day_dir / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** rust, zeta\n\nnotes"
+        )
+
+        result = await tool_vault_tags(ctx)
+
+        assert result.data["tags"] == [
+            {"tag": "Rust", "count": 3},
+            {"tag": "async", "count": 1},
+            {"tag": "zeta", "count": 1},
+        ]
+        assert "Rust (3)" in result.text
+        assert "3 tag(s)" in result.text
+
+    async def test_all_untagged_journal_yields_no_tags(self, ctx, agent_journal):
+        """Regression guard for the shared collect_all_tags primitive: an
+        all-untagged journal entry must not surface a spurious "untagged"
+        tag via this tool."""
+        journal_day_dir = agent_journal / "2026"
+        journal_day_dir.mkdir(parents=True, exist_ok=True)
+        (journal_day_dir / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** untagged\n\nsome note"
+        )
+
+        result = await tool_vault_tags(ctx)
+
+        assert result.data["tags"] == []
+        assert "No tags found" in result.text
+
+    async def test_empty_vault_returns_no_tags(self, ctx, vault_dir):
+        result = await tool_vault_tags(ctx)
+        assert result.data["tags"] == []
 
 
 class TestVaultUpdateFrontmatter:

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -982,6 +982,90 @@ class TestVaultSearch:
         assert "does not exist" in result.text.lower()
 
 
+class TestVaultSearchTags:
+    """Tag filtering on vault_search (#318 phase 4)."""
+
+    @pytest.mark.asyncio
+    async def test_query_plus_tags_drops_non_matching_results(
+        self, ctx, agent_pages
+    ):
+        (agent_pages / "AsyncPage.md").write_text(
+            "# AsyncPage\n\nWidget notes about async work. #async")
+        (agent_pages / "RustPage.md").write_text(
+            "# RustPage\n\nWidget notes about rust work. #rust")
+
+        result = await tool_vault_search(ctx, "widget", tags=["async"])
+
+        assert "AsyncPage" in result.text
+        assert "RustPage" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_empty_query_pure_tag_filter_is_and_by_default(
+        self, ctx, agent_pages
+    ):
+        (agent_pages / "Both.md").write_text(
+            "---\ntags: [rust, async]\n---\nbody")
+        (agent_pages / "OnlyRust.md").write_text(
+            "---\ntags: [rust]\n---\nbody")
+
+        result = await tool_vault_search(ctx, "", tags=["rust", "async"])
+
+        assert "Both" in result.text
+        assert "OnlyRust" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_any_tag_true_is_or(self, ctx, agent_pages):
+        (agent_pages / "Both.md").write_text(
+            "---\ntags: [rust, async]\n---\nbody")
+        (agent_pages / "OnlyRust.md").write_text(
+            "---\ntags: [rust]\n---\nbody")
+        (agent_pages / "OnlyAsync.md").write_text(
+            "---\ntags: [async]\n---\nbody")
+        (agent_pages / "Neither.md").write_text("no tags here")
+
+        result = await tool_vault_search(
+            ctx, "", tags=["rust", "async"], any_tag=True)
+
+        assert "Both" in result.text
+        assert "OnlyRust" in result.text
+        assert "OnlyAsync" in result.text
+        assert "Neither" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_tag_filter_spans_page_and_journal_source_types(
+        self, ctx, agent_pages, agent_journal
+    ):
+        (agent_pages / "PageTag.md").write_text(
+            "---\ntags: [shared]\n---\nbody")
+        (agent_journal / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** shared\n\nJournal content")
+
+        result = await tool_vault_search(ctx, "", tags=["shared"])
+
+        assert "agent/pages/PageTag" in result.text
+        assert "agent/journal/2026-07-24" in result.text
+
+    @pytest.mark.asyncio
+    async def test_empty_tags_leaves_behavior_unchanged(
+        self, ctx, vault_dir
+    ):
+        """Omitted/empty `tags` must NOT enter the pure-filter path — that
+        path calls `pages_with_tags(config, [])`, which vacuously matches
+        every file (empty AND). Guard against that footgun regressing.
+        """
+        (vault_dir / "Foo.md").write_text("hello")
+
+        with patch(
+            "decafclaw.skills.vault.tools.pages_with_tags"
+        ) as mock_pages_with_tags:
+            result_omitted = await tool_vault_search(ctx, "")
+            result_empty_list = await tool_vault_search(ctx, "", tags=[])
+
+        mock_pages_with_tags.assert_not_called()
+        assert "Foo" in result_omitted.text
+        assert "Foo" in result_empty_list.text
+
+
 class TestVaultList:
     @pytest.mark.asyncio
     async def test_list_pages(self, ctx, vault_dir):

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1084,6 +1084,22 @@ class TestVaultSearchTags:
         assert "agent/pages/PageTag" in result.text
         assert "agent/journal/2026-07-24" not in result.text
 
+    @pytest.mark.asyncio
+    async def test_days_filters_pure_tag_filter(self, ctx, agent_pages):
+        """Pure tag-filter path (empty query) must honor `days` recency,
+        matching the semantic/substring branches — a page whose tag matches
+        but is older than `days` is excluded (#318)."""
+        recent = agent_pages / "RecentRust.md"
+        recent.write_text("---\ntags: [rust]\n---\nbody")
+        stale = agent_pages / "StaleRust.md"
+        stale.write_text("---\ntags: [rust]\n---\nbody")
+        _set_mtime(stale, 30)
+
+        result = await tool_vault_search(ctx, "", tags=["rust"], days=7)
+
+        assert "RecentRust" in result.text
+        assert "StaleRust" not in result.text
+
 
 class TestVaultSearchTagsSemantic:
     """Tag filtering on the SEMANTIC branch of vault_search (#318 phase 4

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -936,6 +936,24 @@ class TestVaultJournalAppend:
         assert extract_tags(text, "journal") == {"rust", "async"}
 
     @pytest.mark.asyncio
+    async def test_inline_tag_normalizes_leading_hash(self, ctx, agent_journal):
+        """A caller-supplied tag that already starts with '#' must not
+        double up to '##' in the inline line, and must still round-trip
+        through extract_tags."""
+        from decafclaw.tags import extract_tags
+
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_journal_append(
+                ctx, tags=["#Rust", "async"], content="x")
+        files = list(agent_journal.rglob("*.md"))
+        text = files[0].read_text()
+
+        assert "##Rust" not in text
+        assert "#Rust" in text
+        assert "#async" in text
+        assert extract_tags(text, "journal") == {"rust", "async"}
+
+    @pytest.mark.asyncio
     async def test_empty_tags_no_inline_line(self, ctx, agent_journal):
         from decafclaw.tags import extract_tags
 
@@ -1194,6 +1212,48 @@ class TestVaultSearchTagsSemantic:
 
         monkeypatch.setattr(
             "decafclaw.embeddings.search_similar", fake_search_similar)
+
+        result = await tool_vault_search(ctx, "widget", tags=["async"])
+
+        paths = [r["path"] for r in result.data["results"]]
+        assert paths == ["agent/pages/AsyncPage"]
+
+    @pytest.mark.asyncio
+    async def test_fail_open_excludes_candidate_when_extract_tags_raises(
+        self, ctx, agent_pages, monkeypatch
+    ):
+        """A candidate whose extract_tags call raises must be excluded
+        from the results, not blow up the whole semantic search branch
+        (which would fall back to the global un-filtered path instead of
+        just dropping that one candidate)."""
+        from decafclaw.tags import extract_tags
+
+        ctx.config.embedding.search_strategy = "semantic"
+        (agent_pages / "AsyncPage.md").write_text(
+            "# AsyncPage\n\nWidget notes about async work. #async")
+        (agent_pages / "BadPage.md").write_text(
+            "# BadPage\n\nWidget notes. #async")
+
+        async def fake_search_similar(*args, **kwargs):
+            return [
+                {"file_path": "agent/pages/AsyncPage.md", "similarity": 0.9,
+                 "source_type": "page", "entry_text": "Widget notes async"},
+                {"file_path": "agent/pages/BadPage.md", "similarity": 0.85,
+                 "source_type": "page", "entry_text": "Widget notes bad"},
+            ]
+
+        monkeypatch.setattr(
+            "decafclaw.embeddings.search_similar", fake_search_similar)
+
+        real_extract_tags = extract_tags
+
+        def fake_extract_tags(content, source_type):
+            if "BadPage" in content:
+                raise ValueError("boom")
+            return real_extract_tags(content, source_type)
+
+        monkeypatch.setattr(
+            "decafclaw.skills.vault.tools.extract_tags", fake_extract_tags)
 
         result = await tool_vault_search(ctx, "widget", tags=["async"])
 

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1065,6 +1065,124 @@ class TestVaultSearchTags:
         assert "Foo" in result_omitted.text
         assert "Foo" in result_empty_list.text
 
+    @pytest.mark.asyncio
+    async def test_source_type_and_tags_compose_in_pure_filter(
+        self, ctx, agent_pages, agent_journal
+    ):
+        """Pure tag-filter path (empty query) must apply source_type as an
+        additional filter on top of the tag match, not just tags alone
+        (P4-M1)."""
+        (agent_pages / "PageTag.md").write_text(
+            "---\ntags: [async]\n---\nbody")
+        (agent_journal / "2026-07-24.md").write_text(
+            "## 2026-07-24 10:00\n\n- **tags:** async\n\nJournal content")
+
+        result = await tool_vault_search(
+            ctx, "", tags=["async"], source_type="page")
+
+        assert "agent/pages/PageTag" in result.text
+        assert "agent/journal/2026-07-24" not in result.text
+
+
+class TestVaultSearchTagsSemantic:
+    """Tag filtering on the SEMANTIC branch of vault_search (#318 phase 4
+    review fix). `TestVaultSearchTags` above only exercises the default
+    test config's `search_strategy = "substring"`; the semantic branch —
+    the path the deployed agent actually uses — otherwise has zero
+    coverage, including `_semantic_result_matches_tags`'s fail-open
+    behavior.
+    """
+
+    @pytest.mark.asyncio
+    async def test_and_filter_drops_non_matching_candidate(
+        self, ctx, agent_pages, monkeypatch
+    ):
+        ctx.config.embedding.search_strategy = "semantic"
+        (agent_pages / "AsyncPage.md").write_text(
+            "# AsyncPage\n\nWidget notes about async work. #async")
+        (agent_pages / "RustPage.md").write_text(
+            "# RustPage\n\nWidget notes about rust work. #rust")
+
+        async def fake_search_similar(*args, **kwargs):
+            return [
+                {"file_path": "agent/pages/AsyncPage.md", "similarity": 0.9,
+                 "source_type": "page", "entry_text": "Widget notes async"},
+                {"file_path": "agent/pages/RustPage.md", "similarity": 0.8,
+                 "source_type": "page", "entry_text": "Widget notes rust"},
+            ]
+
+        monkeypatch.setattr(
+            "decafclaw.embeddings.search_similar", fake_search_similar)
+
+        result = await tool_vault_search(ctx, "widget", tags=["async"])
+
+        assert result.data["mode"] == "semantic"
+        paths = [r["path"] for r in result.data["results"]]
+        assert paths == ["agent/pages/AsyncPage"]
+
+    @pytest.mark.asyncio
+    async def test_any_tag_or_filter(self, ctx, agent_pages, monkeypatch):
+        ctx.config.embedding.search_strategy = "semantic"
+        (agent_pages / "Both.md").write_text(
+            "---\ntags: [rust, async]\n---\nbody about widgets")
+        (agent_pages / "OnlyRust.md").write_text(
+            "---\ntags: [rust]\n---\nbody about widgets")
+        (agent_pages / "OnlyAsync.md").write_text(
+            "---\ntags: [async]\n---\nbody about widgets")
+        (agent_pages / "Neither.md").write_text(
+            "body about widgets, no tags")
+
+        async def fake_search_similar(*args, **kwargs):
+            return [
+                {"file_path": "agent/pages/Both.md", "similarity": 0.9,
+                 "source_type": "page", "entry_text": "Both"},
+                {"file_path": "agent/pages/OnlyRust.md", "similarity": 0.8,
+                 "source_type": "page", "entry_text": "OnlyRust"},
+                {"file_path": "agent/pages/OnlyAsync.md", "similarity": 0.7,
+                 "source_type": "page", "entry_text": "OnlyAsync"},
+                {"file_path": "agent/pages/Neither.md", "similarity": 0.6,
+                 "source_type": "page", "entry_text": "Neither"},
+            ]
+
+        monkeypatch.setattr(
+            "decafclaw.embeddings.search_similar", fake_search_similar)
+
+        result = await tool_vault_search(
+            ctx, "widgets", tags=["rust", "async"], any_tag=True)
+
+        assert "Both" in result.text
+        assert "OnlyRust" in result.text
+        assert "OnlyAsync" in result.text
+        assert "Neither" not in result.text
+
+    @pytest.mark.asyncio
+    async def test_fail_open_excludes_unreadable_candidate(
+        self, ctx, agent_pages, monkeypatch
+    ):
+        """A candidate row whose file is missing/unreadable must be
+        excluded, not raise — matching `pages_with_tags`'s per-file
+        fail-open behavior."""
+        ctx.config.embedding.search_strategy = "semantic"
+        (agent_pages / "AsyncPage.md").write_text(
+            "# AsyncPage\n\nWidget notes about async work. #async")
+
+        async def fake_search_similar(*args, **kwargs):
+            return [
+                {"file_path": "agent/pages/AsyncPage.md", "similarity": 0.9,
+                 "source_type": "page", "entry_text": "Widget notes async"},
+                # Points at a file that was never written to disk.
+                {"file_path": "agent/pages/Ghost.md", "similarity": 0.85,
+                 "source_type": "page", "entry_text": "Ghost entry"},
+            ]
+
+        monkeypatch.setattr(
+            "decafclaw.embeddings.search_similar", fake_search_similar)
+
+        result = await tool_vault_search(ctx, "widget", tags=["async"])
+
+        paths = [r["path"] for r in result.data["results"]]
+        assert paths == ["agent/pages/AsyncPage"]
+
 
 class TestVaultList:
     @pytest.mark.asyncio

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1,6 +1,7 @@
 """Tests for vault tools."""
 
 import os
+import re
 import time
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, patch
@@ -883,6 +884,74 @@ class TestVaultJournalAppend:
         assert len(matching) == 1
         assert matching[0]["kind"] == "journal"
         assert matching[0]["path"].endswith(".md")
+
+    @pytest.mark.asyncio
+    async def test_emits_inline_tags_alongside_bullet(self, ctx, agent_journal):
+        """Phase 3 (#318): tags also surface as inline #tags in the body,
+        in addition to the existing back-compat bullet."""
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_journal_append(
+                ctx, tags=["rust", "async"], content="hi")
+        files = list(agent_journal.rglob("*.md"))
+        assert len(files) == 1
+        text = files[0].read_text()
+        assert "- **tags:** rust, async" in text
+        assert "#rust #async" in text
+
+    @pytest.mark.asyncio
+    async def test_inline_tags_do_not_break_recent_journal_reader(
+        self, ctx, agent_journal,
+    ):
+        """Guard against #306's `read_recent_journal_entries` regressing:
+        the inline #tags line must not split entries or break parsing."""
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_journal_append(
+                ctx, tags=["rust", "async"], content="hi")
+        files = list(agent_journal.rglob("*.md"))
+        text = files[0].read_text()
+
+        entries = read_recent_journal_entries(
+            ctx.config, now=datetime.now(), max_hours=24, max_entries=10)
+        assert len(entries) == 1
+        header_match = re.search(
+            r"^## (\d{4}-\d{2}-\d{2} \d{2}:\d{2})\s*$", text, re.MULTILINE)
+        assert header_match is not None
+        expected_ts = datetime.strptime(header_match.group(1), "%Y-%m-%d %H:%M")
+        assert entries[0].timestamp == expected_ts
+        assert "hi" in entries[0].text
+        assert "#rust #async" in entries[0].text
+
+    @pytest.mark.asyncio
+    async def test_inline_tags_match_extract_tags_no_duplication(
+        self, ctx, agent_journal,
+    ):
+        from decafclaw.tags import extract_tags
+
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_journal_append(
+                ctx, tags=["rust", "async"], content="hi")
+        files = list(agent_journal.rglob("*.md"))
+        text = files[0].read_text()
+        assert extract_tags(text, "journal") == {"rust", "async"}
+
+    @pytest.mark.asyncio
+    async def test_empty_tags_no_inline_line(self, ctx, agent_journal):
+        from decafclaw.tags import extract_tags
+
+        with patch("decafclaw.embeddings.index_entry", new_callable=AsyncMock):
+            await tool_vault_journal_append(ctx, tags=[], content="x")
+        files = list(agent_journal.rglob("*.md"))
+        text = files[0].read_text()
+        assert "- **tags:** untagged" in text
+
+        lines = text.splitlines()
+        tags_line_idx = next(
+            i for i, line in enumerate(lines)
+            if line.startswith("- **tags:**")
+        )
+        # No inline tag line between the bullet and the blank line/content.
+        assert lines[tags_line_idx + 1] == ""
+        assert extract_tags(text, "journal") == set()
 
 
 class TestVaultSearch:


### PR DESCRIPTION
## What

Makes vault tags a coherent **first-class subsystem**. Previously tags only quietly boosted embeddings via frontmatter; now they're searchable, filterable, enumerable, and Obsidian-native inline `#tags` are understood — across pages *and* journal entries.

Closes #318. (Depended on #197, which is merged.)

## Design decisions (approved at brainstorm)

- **Unify at the query/index layer, not the file bytes.** Journal files keep their daily-file `## timestamp` format untouched (so #306's `read_recent_journal_entries` is unaffected). "First-class" means the extractor + search/list/filter treat journal tags like page tags.
- **Inline `#tags` are the native per-entry mechanism** — per-entry YAML frontmatter was rejected because Obsidian renders a mid-file `---` as a horizontal rule (it'd render *broken*).
- **On-demand scan, no persistent tag index** — avoids the index-maintenance bug class (#197 Phase 4 cost two Criticals); cheap at personal-vault scale, never on a retrieval hot path.
- **AND-by-default** (`any_tag=true` for OR); **case-insensitive** (lowercase key, display casing preserved), no `-`/`_` variant merging.

## Phases (each TDD'd + two-stage reviewed)

- **`tags.py`** — one shared extractor (`normalize_tag`/`parse_inline_tags`/`extract_tags`/`collect_all_tags`/`pages_with_tags`) via a single `_extract_tag_pairs` path. Reads frontmatter + journal `- **tags:**` bullet + inline `#tags`, unioned/deduped. Skips the journal `untagged` display-placeholder.
- **Inline `#tags` → composite embeddings** (`build_composite_text`) — needs `make reindex` for existing pages (documented).
- **Journal inline emission** — `vault_journal_append` keeps its bullet (back-compat) *and* emits inline `#tags`; #306 reader verified intact via a regression test.
- **Tag-filtered `vault_search`** — `tags`/`any_tag`; query+tags filters candidates, empty-query+tags is a pure filter; `days`/`folder`/`source_type` compose; guarded against the empty-tags vacuous-AND footgun.
- **`vault_tags()` tool + `GET /api/vault/tags`** (`@_authenticated`, verified 401 unauthenticated) — tags sorted by count.
- **Web UI Tags tab** — `tags-sidebar.js` in the sidebar; tag → pages → open-page via the existing `wiki-open` event; mobile-drawer parity.

## Testing

~40 new unit tests (extraction from all three sources incl. code-block exclusion / `#42` rejection / ATX-heading guard; the untagged sentinel in both `extract_tags` and `collect_all_tags`; AND/OR + empty-tags + `days` + source_type filters; the **semantic** search branch + its fail-open; `vault_tags` tool + REST API; journal back-compat). Evals: `vault-tags.yaml` behavior case + two `vault_tags`-vs-`vault_search` `tool_choice` cases. Full suite **3328 passed**, `make check` + `make check-js` clean.

**Browser smoke (Playwright, real server, 100 real tags):** Tags tab renders count-sorted with display casing preserved → tag→pages drill-down (`tags / cats` breadcrumb) → clicking a page opens it in the wiki pane. ✅

Docs updated in-PR: `docs/vault.md`, `docs/web-ui.md`, `CLAUDE.md` key-files. Session docs at `docs/dev-sessions/2026-07-24-1141-vault-tags/`.

## Follow-ups (filed / noted, not in scope)

- Tag rename/merge tools, autocomplete, hierarchies, tag-as-retrieval-scoring-signal (issue's own scope-out).
- Journal micro-evolution (the deferred #197 follow-up) — now unblocked since journal tags are first-class.
- Open-page highlight parity in the Tags tab (Minor, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
