### PR TITLE
refactor(conversations): drop redundant conversations_dir guard in startup_scan

### DIFF
--- a/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/checks.md
+++ b/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/checks.md
@@ -1,0 +1,79 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/586
+**Frozen at:** 9347eb3 (2026-07-24)
+**Check files — read-only from Phase 1 onward:**
+- *(none)* — both criteria are `grep` commands over the implementation file itself. There is no
+  acceptance-test file to author, so the `Check files` list is empty and the `git diff <freeze-sha>`
+  tamper check is vacuous for this run. The oracle for this run lives entirely in **this file**,
+  which the tamper baseline does not cover. See the run note at the bottom.
+
+## C1
+CRITERION: the redundant guard block is gone.
+CHECK: `grep -c 'if not conversations_dir.exists():' src/decafclaw/conversation_manager.py` returns `0`.
+AT FREEZE: fails — returns `1` (`src/decafclaw/conversation_manager.py:1809`). Correct reason:
+the guard is genuinely present, not a path/typo error (the same grep with the file omitted errors
+differently, and `grep -n` locates the line).
+
+## C2
+CRITERION: the now-unused local is gone with it.
+CHECK: `grep -c 'conversations_dir = self.config.workspace_path' src/decafclaw/conversation_manager.py` returns `0`.
+AT FREEZE: fails — returns `1` (`src/decafclaw/conversation_manager.py:1808`). Correct reason as
+above: `grep -n` shows the assignment on that line.
+
+## Guards
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- G1: `uv run pytest tests/test_conversation_manager.py -k startup_scan -q` — `startup_scan`
+  behaviour unchanged: still recovers pending confirmations, still returns 0 on an empty/missing
+  conversations dir, still respects the 24h staleness cutoff, still skips resolved confirmations.
+  Passed at freeze: `12 passed in 1.60s`, 12 tests collected (not 0 — the `-k` filter matches).
+- G2 (project gate): `make test` — full suite. Passed at freeze:
+  `3338 passed, 2 skipped in 36.58s`. Recorded as a *relative* invariant, not an absolute count:
+  nothing previously passing may be lost, newly skipped, or newly failing. (An absolute count
+  here would trip on any upstream test added during a rebase — the #638 run hit exactly that.)
+
+## Amendments
+(Append-only. Empty unless an amendment was made.)
+
+*None.*
+
+## Tamper verdict, recorded pre-squash
+
+Recorded here because `git reset --soft origin/main` collapses the freeze commit and `9347eb3`
+stops being reachable from the branch afterwards. This record is the durable evidence the gate
+cites.
+
+Run at `26e8dab`, immediately before the squash:
+
+- `git diff 9347eb3 -- <Check files>` — **vacuous**: `Check files` is empty, so there is nothing to
+  diff. This is not a clean tamper diff; it is an *absent* one. See the run note above.
+- `git diff 9347eb3 --stat` — 3 files: this manifest (1 line), `plan.md` (new), and
+  `src/decafclaw/conversation_manager.py` (−4). **No test file touched.**
+- `git diff 9347eb3 -- checks.md` — one line, the `Frozen at:` placeholder replaced by the sha.
+  No CRITERION, CHECK, or guard command altered. (Note: this diff can never be empty, because the
+  contract's own freeze procedure records the sha in a follow-up commit.)
+- Independent verifier cross-checked C1's, C2's, and G1's commands **byte-for-byte against the
+  issue body** — identical, including under `cat -vet`. The issue is the pre-existing record the
+  manifest was copied from, so this substitutes for the missing file-level baseline.
+
+**Verdict: no tampering detected.** Basis is the manifest-vs-issue equality plus the
+no-test-files-touched stat, not a `Check files` diff.
+
+---
+
+## Run note — the tamper baseline does not cover this manifest
+
+Both of C1/C2 are shell commands rather than test files, so:
+
+- Freeze step 2 ("author the tests the checks name") is a no-op — nothing to author.
+- `Check files` is empty, so the read-only rule protects nothing and
+  `git diff <freeze-sha> -- <Check files>` is trivially empty.
+- The full text of the oracle is the two CHECK lines *in this file*, and `checks.md` is not
+  itself listed in the tamper baseline. An implementer that edited a CHECK command here would not
+  be caught by any mechanical check in the contract.
+
+Mitigation for this run: the CHECK commands are copied verbatim from the issue body, and the
+issue body is the independent, pre-existing record. The verifier is instructed to take the
+commands from the **issue**, not from this file, and the diff of this file against the freeze
+commit is reported alongside the (vacuous) `Check files` diff.

--- a/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/notes.md
+++ b/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/notes.md
@@ -1,0 +1,55 @@
+# Notes — #586 redundant `conversations_dir` guard
+
+Run driven by `agent-session express` (the mode's first-ever run; this session doubled as its
+dogfood, so some notes are about the skill rather than the change).
+
+## What changed
+
+Four lines deleted from `ConversationManager.startup_scan` — the `conversations_dir` local, its
+`exists()` early return, and the blank line. Nothing added.
+
+## Evidence
+
+| Item | At freeze (`9347eb3`) | After Phase 1 | Verified by |
+|---|---|---|---|
+| C1 grep | `1` | `0` | independent verifier |
+| C2 grep | `1` | `0` | independent verifier |
+| G1 `-k startup_scan` | `12 passed` | `12 passed` | independent verifier |
+| G2 `make test` | `3338 passed, 2 skipped` | `3338 passed, 2 skipped` | independent verifier |
+| `make lint` / `make typecheck` | green | `All checks passed!` / `0 errors` | independent verifier |
+
+Tamper diff: `Check files` is empty (both checks are greps), so the diff is vacuous by
+construction. The verifier instead diffed `checks.md` itself against the freeze commit and
+cross-checked all three commands byte-for-byte against the issue body — identical.
+
+## Behaviour-preservation argument, verified not assumed
+
+`iter_conversation_archives` (`src/decafclaw/conversation_paths.py:59-63`) resolves the same path
+via `conversations_root(config)` and early-returns when it is missing, so the loop yields nothing
+and `startup_scan` reaches `return recovered` with `recovered == 0` — the same value the deleted
+guard returned.
+
+Checked empirically that a test actually covers that path: the `config` fixture's `data_home` is a
+bare `tmp_path`, and `Config(...).workspace_path` is **not** created eagerly (confirmed by
+instantiating it — `workspace_path exists: False`, `conversations dir exists: False`). So
+`test_startup_scan_empty_archive` runs with the conversations directory *absent*, which is exactly
+the branch the deleted guard used to short-circuit. It passes after the deletion.
+
+## Caveat on G1's precision (found in self-review, not a defect in this change)
+
+`-k startup_scan` collects 12 tests, but **8 of them are `test_startup_scan_workflows_*`** —
+`startup_scan_workflows` is the separate #581 workflow-recovery method, which the deleted guard
+never touched. Only 4 tests exercise `startup_scan` itself
+(`finds_pending_confirmation`, `ignores_resolved_confirmations`, `ignores_stale_confirmations`,
+`empty_archive`), and exactly **one** of those covers the missing-directory path this change
+affects.
+
+So "12 passed" reads as broader coverage than it is. The guard still does its job — the one test
+that matters is inside the selection — but the count is mostly made of unrelated tests, and a
+future reader should not treat 12 as 12 relevant tests. Recorded rather than fixed: narrowing the
+`-k` expression would edit a frozen guard mid-run, which is exactly what the contract forbids.
+
+## Out of scope, noted for later
+
+- Nothing. The deletion is complete; `grep -n 'conversations_dir\|conversations_root'` over
+  `conversation_manager.py` now returns zero hits, so no half-renamed remnant is left behind.

--- a/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/plan.md
+++ b/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/plan.md
@@ -1,0 +1,94 @@
+# Redundant `conversations_dir.exists()` guard in `startup_scan` — Implementation Plan
+
+**Goal:** Delete the redundant `conversations_dir` local and its `exists()` early-return from
+`ConversationManager.startup_scan`, whose work is already done by `iter_conversation_archives`.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/586 — **Tier:** `auto-ok`
+(both criteria reduce to greps that fail today; internal cleanup, no risk-gated path touched,
+existing tests pin the observable behaviour)
+
+**Approach:** Delete the two lines outright rather than rewriting them as
+`conversations_root(config)`. The issue offers both and declares the choice style-not-scope; the
+local has exactly one consumer (its own `exists()` check), so once the guard goes there is nothing
+left for a `conversations_root(config)` call to serve. Deleting is the smaller change and both
+criteria are satisfied either way.
+
+**Criteria:** C1 the guard block is gone · C2 the now-unused local is gone with it
+(Full text + checks live in `checks.md`.)
+
+---
+
+## Phase 0: Freeze the acceptance checks
+
+Write `checks.md` per `references/frozen-checks.md`. No implementation in this phase.
+
+**Files:**
+- Create: `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/checks.md` — criteria + checks
+  copied verbatim from the issue, ids assigned
+- Create: *(no acceptance-test file)* — both checks are `grep` commands over the implementation
+  file. Nothing to author; `Check files` is empty. Recorded in `checks.md`, with the consequence
+  (the tamper diff is vacuous for this run) stated there rather than left implicit.
+
+**Verification — automated:**
+- [x] Every criterion's check runs and **fails for the expected reason** — C1 → `1` at
+      `conversation_manager.py:1809`; C2 → `1` at `:1808`. Both located by `grep -n`, so the
+      failure is the guard's presence, not a bad path.
+- [x] Every guard runs and **passes** — G1 `12 passed in 1.60s` (12 collected, `-k` matches);
+      G2 `make test` → `3338 passed, 2 skipped in 36.58s`.
+- [x] Freeze commit made; sha recorded in `checks.md` in a follow-up commit.
+
+---
+
+## Phase 1: Delete the redundant local and guard
+
+Remove the two-line dead guard from `startup_scan`. Single vertical slice: the whole issue is
+two lines in one function, and there is no layer below or above it to stage.
+
+**Advances:** C1, C2 — completely; nothing remains for a later phase.
+
+**Files:**
+- Modify: `src/decafclaw/conversation_manager.py` — delete lines 1808–1810 (the local, the
+  `exists()` guard, and its `return 0`) from `startup_scan`.
+- Test: *(none)* — pure deletion of dead code with no behaviour change. TDD opt-out per
+  `plan.md` step 8: there is no new behaviour to drive out with a failing test, and the
+  behaviour that must not change is already covered by G1's 12 tests (which include the
+  missing/empty-conversations-dir case that the deleted guard used to short-circuit).
+
+**Key changes:**
+
+Before (`src/decafclaw/conversation_manager.py:1806-1812`):
+
+```python
+        from datetime import datetime, timedelta
+
+        conversations_dir = self.config.workspace_path / "conversations"
+        if not conversations_dir.exists():
+            return 0
+
+        # Staleness threshold: ignore confirmations older than 24 hours
+```
+
+After:
+
+```python
+        from datetime import datetime, timedelta
+
+        # Staleness threshold: ignore confirmations older than 24 hours
+```
+
+Why this is behaviour-preserving: `iter_conversation_archives`
+(`src/decafclaw/conversation_paths.py:59-63`) resolves the same path via
+`conversations_root(config)` and early-returns when it does not exist, so the loop yields
+nothing and `startup_scan` falls through to `return recovered` with `recovered == 0` — the same
+value the deleted guard returned.
+
+**Verification — automated:**
+- [x] C1's check passes: `grep -c 'if not conversations_dir.exists():' src/decafclaw/conversation_manager.py` returns `0` — observed `0`
+- [x] C2's check passes: `grep -c 'conversations_dir = self.config.workspace_path' src/decafclaw/conversation_manager.py` returns `0` — observed `0`
+- [x] G1 still passes: `uv run pytest tests/test_conversation_manager.py -k startup_scan -q` — observed `12 passed in 2.37s` (same 12 collected as at freeze)
+- [x] G2 still passes: `make test` — observed `3338 passed, 2 skipped in 21.55s`, identical pass/skip counts to the freeze baseline
+- [x] `make lint` passes — observed `All checks passed!`; `make typecheck` also clean (`0 errors`)
+
+**Verification — manual:**
+- [ ] None. No human-judgment criterion in this spec; the tier is `auto-ok` precisely because
+      every criterion resolved to a command.

--- a/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/spec.md
+++ b/docs/dev-sessions/2026-07-24-1619-586-redundant-guard/spec.md
@@ -1,0 +1,59 @@
+# Redundant conversations_dir.exists() guard in startup_scan
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/586
+
+Captured from the issue body (marker line and trailing attribution footer stripped;
+otherwise verbatim).
+
+---
+
+Follow-up to #576 / #578.
+
+`ConversationManager.startup_scan` (`src/decafclaw/conversation_manager.py`) keeps a `conversations_dir = workspace_path / "conversations"` + `if not conversations_dir.exists(): return 0` guard, but the actual iteration now uses `iter_conversation_archives`, which already no-ops (and fails open) when the root is missing. The local + guard are redundant.
+
+Minor cleanup: drop the local/guard (or switch to `conversations_root(config)` for consistency with the other discovery sites). Cosmetic — no behavior change.
+
+Context: `docs/dev-sessions/2026-06-10-1728-conversation-sidecar-dirs/notes.md`.
+
+---
+
+## Acceptance criteria (agent-session triage)
+
+**C1 — the redundant guard block is gone.**
+- CHECK: `grep -c 'if not conversations_dir.exists():' src/decafclaw/conversation_manager.py` returns `0`.
+- Verified discriminating at triage: returns `1` today (`conversation_manager.py:1809`).
+
+**C2 — the now-unused local is gone with it.**
+- CHECK: `grep -c 'conversations_dir = self.config.workspace_path' src/decafclaw/conversation_manager.py` returns `0`.
+- Verified discriminating at triage: returns `1` today (line 1808).
+
+Either resolution satisfies both criteria — deleting the guard outright, or replacing it with a `conversations_root(config)` call for consistency with `iter_conversation_archives` / `conversation_dir` / `sidecar_path`. That choice is style, not scope: it does not change which criteria apply, so it does not affect the tier.
+
+### Regression guards (pass today; must keep passing — not criteria)
+
+- **G1:** `uv run pytest tests/test_conversation_manager.py -k startup_scan -q` — `startup_scan` behaviour unchanged: still recovers pending confirmations, still returns 0 on an empty/missing conversations dir, still respects the 24h staleness cutoff, still skips resolved confirmations. Observed at triage: `12 passed in 3.35s`.
+
+## Tier: `auto-ok`
+
+Both criteria reduce to greps that fail today; internal cleanup of redundant guard logic with no risk-gated path touched, and the existing tests pin the externally observable behaviour across the empty-dir, resolved, stale, and pending-confirmation cases.
+
+---
+
+## Run notes (added at session setup, not part of the issue)
+
+**Readiness checklist** (`references/spec-template.md`): items 1–5 and 7 pass. Item 6
+("`What we're NOT doing` present and concrete") has no corresponding section — the issue was
+produced by `triage`'s augment path, which emits marker + criteria + guards + tier only.
+Proceeding under the reading that scope is bounded in substance ("Cosmetic — no behavior
+change"; the resolution choice explicitly declared style-not-scope) even though the named
+section is absent. Flagged as a skill finding.
+
+**Re-confirmed at setup** (plan step 4, against `2649bfe`):
+- C1 grep → `1` (line 1809). Still discriminates.
+- C2 grep → `1` (line 1808). Still discriminates.
+- G1 → `12 passed in 1.60s`. Passes.
+- Baseline `make test` → `3338 passed, 2 skipped in 36.58s`. Green.
+- The issue's central factual claim holds: `iter_conversation_archives`
+  (`src/decafclaw/conversation_paths.py:61-62`) early-returns when `conversations_root(config)`
+  does not exist, so the guard is genuinely redundant and `startup_scan`'s `return 0` path is
+  reachable identically via the loop yielding nothing.

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -1805,10 +1805,6 @@ class ConversationManager:
         """
         from datetime import datetime, timedelta
 
-        conversations_dir = self.config.workspace_path / "conversations"
-        if not conversations_dir.exists():
-            return 0
-
         # Staleness threshold: ignore confirmations older than 24 hours
         stale_cutoff = (datetime.now() - timedelta(hours=24)).isoformat()
         recovered = 0


### PR DESCRIPTION
## Summary
- Deletes the `conversations_dir` local and its `if not conversations_dir.exists(): return 0` guard from `ConversationManager.startup_scan`. Four lines removed, none added.
- The guard predates #576/#578, which moved conversation discovery behind the `conversation_paths` helpers. Since then it has been dead code sitting in front of a helper that already handles the same case.

## Design Decisions

The issue offered two resolutions — delete the guard, or rewrite it as `conversations_root(config)` for consistency with the other discovery sites — and declared the choice style, not scope. **Deleted outright**, because the local's only consumer was its own `exists()` call: once the guard goes, a `conversations_root(config)` call would have nothing left to serve.

Why it is behaviour-preserving: `iter_conversation_archives` (`src/decafclaw/conversation_paths.py:59-63`) resolves the same path via `conversations_root(config)` and early-returns when it is missing, so the loop yields nothing and `startup_scan` reaches `return recovered` with `recovered == 0` — the same value the deleted guard returned.

That path is covered by an existing test, checked rather than assumed: the `config` fixture's `data_home` is a bare `tmp_path` and `Config(...).workspace_path` is not created eagerly (verified by instantiating it — `conversations dir exists: False`), so `test_startup_scan_empty_archive` genuinely runs with the conversations directory absent. It passes unchanged.

## Changes

- `src/decafclaw/conversation_manager.py` — `startup_scan`: −4 lines.
- `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/` — session artifacts (spec, frozen checks, plan, notes).

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | the redundant guard block is gone | `grep -c 'if not conversations_dir.exists():' src/decafclaw/conversation_manager.py` returns `0` | pass |
| C2 | the now-unused local is gone with it | `grep -c 'conversations_dir = self.config.workspace_path' src/decafclaw/conversation_manager.py` returns `0` | pass |

Guards: **G1** `uv run pytest tests/test_conversation_manager.py -k startup_scan -q` → `12 passed` (unchanged from freeze). **G2** `make test` → `3338 passed, 2 skipped`, identical pass/skip counts to the freeze baseline.

Verified by an independent verifier (fresh context, `checks.md` only, no write tools). Frozen at `9347eb3`.

**Two honest caveats a reviewer should have:**

1. **The tamper diff is vacuous, not clean.** Both criteria are `grep` commands rather than test files, so `checks.md`'s `Check files` list is empty and `git diff <freeze-sha> -- <check files>` has nothing to compare. What stands in for it: the verifier cross-checked all three commands byte-for-byte against the issue body (identical, including under `cat -vet`), and `git diff 9347eb3 --stat` shows no test file was touched. Recorded in `checks.md` under "Tamper verdict, recorded pre-squash".
2. **G1's `12 passed` is broader than it looks.** 8 of those 12 are `test_startup_scan_workflows_*` — `startup_scan_workflows` is the separate #581 workflow-recovery method, untouched here. Only 4 exercise `startup_scan`, and exactly 1 (`test_startup_scan_empty_archive`) covers the missing-directory path this change affects. The guard still catches what matters; the count just shouldn't be read as 12 relevant tests. Left as-is rather than narrowed, because editing a frozen guard mid-run is what the verification contract forbids.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass · C2 pass
guards: G1 pass · G2 pass
tamper: clean-by-substitute — no frozen check files exist (both criteria are greps), so
  `git diff <freeze-sha> -- <check files>` has nothing to compare. Basis: manifest integrity
  (no CRITERION/CHECK/guard line differs from the freeze version), CHECK and guard commands
  byte-identical to the issue body, and no test file touched.
freeze: 9347eb3 (dangling local object post-squash; not on origin, not an ancestor of HEAD)
project-gates: make check green
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: n/a — all gate rows satisfied; reported as a finding, not acted on
```

## References
- Spec: `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/spec.md`
- Checks: `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/checks.md`
- Plan: `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/plan.md`
- Notes: `docs/dev-sessions/2026-07-24-1619-586-redundant-guard/notes.md`
- Closes #586


