### PR TITLE
fix(skills): make the tools.py contract enforceable at every layer

### DIFF
--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -60,6 +60,17 @@ hard-stop's final summary, by contrast, *is* archived normally — it's a
 real assistant response the user should see and the agent should remember
 saying.
 
+### The hard stop archives only its own note
+
+A turn that ran many iterations has already archived each iteration's
+assistant preamble as it was emitted (`_handle_tool_calls`). The finalizer
+therefore delivers the accumulated preambles plus the note to the transport
+— so the turn reads as a whole — but persists **only the note**. Archiving
+the joined text as well duplicated every preamble in the record: invisible
+on a one-preamble turn, a wall of repeated text on a long thrash, which is
+exactly when the transcript most needs to be readable (#675). The
+iteration-limit finalizer shares the same helper (`_finalize_with_note`).
+
 ## Prompt guardrails (`AGENT.md`)
 
 Two related, prompt-only behaviors from the same investigation live as

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -342,6 +342,20 @@ surface the reason instead of failing silently:
   - `tools.py` imports cleanly (catches `SyntaxError`, undefined names, bad imports)
   - `tools.py` exports `get_tools(ctx)` (must accept `ctx`) **or**
     `TOOLS` / `TOOL_DEFINITIONS`
+  - those exports have the right **shape**, not merely the right names:
+    `TOOLS` must be a `dict` mapping tool name → callable, and
+    `TOOL_DEFINITIONS` must be a `list` of function schemas each carrying a
+    non-empty `function.name`
+
+  The shape check matters because wrong-typed exports import perfectly
+  cleanly. `TOOLS = [my_tool]` (a list) only fails later, inside
+  `ctx.tools.extra.update()`, as `cannot convert dictionary update sequence
+  element #0 to a sequence`. Before #675 `skill_validate` checked names but
+  not types and reported PASS on skills that could never load — leaving the
+  author with a validator and a loader that flatly contradicted each other.
+  The same contract check (`check_tools_contract`) now backs both, so they
+  cannot diverge: `_load_native_tools` raises `SkillContractError` naming the
+  offending export instead of failing opaquely downstream.
 
 Minimal correct workspace skill:
 

--- a/evals/skill-authoring.yaml
+++ b/evals/skill-authoring.yaml
@@ -14,3 +14,70 @@
     max_tool_calls: 10
     max_tool_errors: 1
     expect_tool: activate_skill
+
+# #675 — the "validator and loader contradict each other" failure mode.
+# Distinct from evals/diagnostic_discipline.yaml's broken_skill fixture,
+# which has invalid *frontmatter*: here the frontmatter is valid and
+# tools.py imports perfectly cleanly. The only defect is the shape of the
+# export — `TOOLS` is a list where the loader requires a dict.
+#
+# Before #675 this was unrecoverable by construction: skill_validate
+# reported PASS (it checked only that the name existed) while activation
+# failed with `cannot convert dictionary update sequence element #0 to a
+# sequence`, which names neither the file nor the contract. A real session
+# burned an entire conversation on it and hit the loop breaker.
+#
+# Now `check_tools_contract` backs both the validator and the loader, so
+# whichever the agent reaches for reports the same actionable problem. The
+# assertion is the outcome, not the route: TOOLS ends up a dict. Which tool
+# the model tries first varies run to run (same reasoning as the
+# diagnostic_discipline note), so it isn't asserted.
+#
+# Note the skill is written via setup.workspace_files, which lands on disk
+# AFTER config.discovered_skills is populated — so activate_skill also
+# exercises the catalog-miss rediscovery path from the same issue.
+- name: "fixes a wrong-shaped TOOLS export instead of thrashing"
+  setup:
+    workspace_files:
+      "skills/shapely/SKILL.md": |
+        ---
+        name: shapely
+        description: Greets a person by name. Use when asked to greet someone.
+        ---
+
+        # Shapely (eval fixture)
+
+        A one-tool skill whose tools.py exports TOOLS in the wrong shape.
+      "skills/shapely/tools.py": |
+        from decafclaw.media import ToolResult
+
+
+        def greet(ctx, who: str) -> ToolResult:
+            """Greet someone by name."""
+            return ToolResult(text=f"hello {who}")
+
+
+        TOOLS = [greet]
+
+        TOOL_DEFINITIONS = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "greet",
+                    "description": "Greet someone by name.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"who": {"type": "string"}},
+                        "required": ["who"],
+                    },
+                },
+            },
+        ]
+  input: >
+    The "shapely" skill in my workspace won't activate. Figure out why and fix it.
+  expect:
+    max_tool_calls: 15
+    max_tool_errors: 6
+  expect_workspace:
+    workspace_files:
+      "skills/shapely/tools.py": "re:TOOLS\\s*=\\s*\\{"

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -1072,15 +1072,7 @@ class TurnRunner:
             f"\n\n[Agent reached max tool iterations "
             f"({self.config.agent.max_tool_iterations}) without a final response]"
         )
-        accumulated = "\n\n".join(self.accumulated_text_parts)
-        msg = accumulated + limit_note if accumulated else limit_note.strip()
-        final_msg = {"role": "assistant", "content": msg}
-        self.history.append(final_msg)
-        _archive(self.ctx, final_msg)
-        await _maybe_compact(
-            self.ctx, self.config, self.history, self.prompt_tokens,
-        )
-        return ToolResult(text=msg)
+        return await self._finalize_with_note(limit_note)
 
     async def _finalize_loop_break(self) -> "ToolResult":
         """Loop-breaker hard-stop: end the turn with a summary of the thrash
@@ -1090,15 +1082,28 @@ class TurnRunner:
             "without progress. Next: read the relevant logs, build a minimal "
             "repro, and re-check the contract before retrying."
         )
+        return await self._finalize_with_note(note)
+
+    async def _finalize_with_note(self, note: str) -> "ToolResult":
+        """End an abnormally-terminated turn (iteration limit / loop-breaker)
+        by appending `note` to whatever text the turn accumulated.
+
+        The delivered text includes the accumulated preambles so the turn
+        reads as a whole, but only the note is persisted: each preamble was
+        already appended to history and archived as it was emitted (see
+        _handle_tool_calls). Archiving the join too duplicated every
+        preamble in the record — invisible on a one-preamble turn, a wall of
+        repeated text on a long thrash (#675).
+        """
         accumulated = "\n\n".join(self.accumulated_text_parts)
-        msg = accumulated + note if accumulated else note.strip()
-        final_msg = {"role": "assistant", "content": msg}
+        delivered = accumulated + note if accumulated else note.strip()
+        final_msg = {"role": "assistant", "content": note.strip()}
         self.history.append(final_msg)
         _archive(self.ctx, final_msg)
         await _maybe_compact(
             self.ctx, self.config, self.history, self.prompt_tokens,
         )
-        return ToolResult(text=msg)
+        return ToolResult(text=delivered)
 
     def _extract_workspace_media(self, content: str) -> "ToolResult":
         """Extract workspace:// refs only for channels that need it.

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -14,6 +14,72 @@ from .confirmation import request_confirmation
 log = logging.getLogger(__name__)
 
 
+class SkillContractError(Exception):
+    """A skill's tools.py exports don't match the native-tool contract.
+
+    Raised at load time so the failure names the contract instead of
+    surfacing downstream as an opaque `dict.update()` TypeError (#675).
+    """
+
+
+def check_tools_contract(module) -> list[str]:
+    """Return contract violations in a skill's imported tools.py module.
+
+    The loader requires `TOOLS` to be a dict mapping tool name -> callable
+    and `TOOL_DEFINITIONS` to be a list of OpenAI function schemas; a skill
+    exporting only `get_tools(ctx)` has neither and is fine. Both an empty
+    list of problems and the absence of the exports mean "no violations".
+
+    Shared by `skill_validate` (reports them as a check) and
+    `_load_native_tools` (raises), so the validator can never green-light a
+    skill the loader will reject.
+    """
+    problems: list[str] = []
+
+    tools = getattr(module, "TOOLS", None)
+    if tools is not None:
+        if not isinstance(tools, dict):
+            problems.append(
+                "TOOLS must be a dict mapping tool name -> function "
+                f"(e.g. {{'my_tool': my_tool}}), got {type(tools).__name__}"
+            )
+        else:
+            for key, value in tools.items():
+                if not isinstance(key, str):
+                    problems.append(
+                        f"TOOLS keys must be str tool names, got {type(key).__name__}"
+                    )
+                elif not callable(value):
+                    problems.append(
+                        f"TOOLS[{key!r}] must be callable, got {type(value).__name__}"
+                    )
+
+    tool_defs = getattr(module, "TOOL_DEFINITIONS", None)
+    if tool_defs is not None:
+        if not isinstance(tool_defs, list | tuple):
+            problems.append(
+                "TOOL_DEFINITIONS must be a list of function schemas "
+                "(e.g. [{'type': 'function', 'function': {'name': 'my_tool'}}]), "
+                f"got {type(tool_defs).__name__}"
+            )
+        else:
+            for i, td in enumerate(tool_defs):
+                if not isinstance(td, dict):
+                    problems.append(
+                        f"TOOL_DEFINITIONS[{i}] must be a dict, got "
+                        f"{type(td).__name__}"
+                    )
+                    continue
+                fn = td.get("function")
+                if not isinstance(fn, dict) or not isinstance(fn.get("name"), str) \
+                        or not fn["name"]:
+                    problems.append(
+                        f"TOOL_DEFINITIONS[{i}] needs a non-empty function.name string"
+                    )
+
+    return problems
+
+
 def _permissions_path(config) -> Path:
     """Path to the skill permissions file (outside workspace, read-only to agent)."""
     return config.agent_path / "skill_permissions.json"
@@ -133,6 +199,22 @@ def _lint_tools_py(skill_dir: Path) -> list[CheckResult]:
             "tools_exports", False,
             "tools.py exports neither get_tools(ctx) nor TOOLS / TOOL_DEFINITIONS",
         ))
+
+    # Shape, not just presence: exports of the wrong type import cleanly
+    # and pass every check above, then fail at activation with an opaque
+    # error. A validator that green-lights an unloadable skill is worse
+    # than none — it makes the failure unresolvable (#675).
+    if has_static:
+        problems = check_tools_contract(module)
+        if problems:
+            checks.append(CheckResult(
+                "tools_shape", False, "; ".join(problems),
+            ))
+        else:
+            checks.append(CheckResult(
+                "tools_shape", True,
+                "TOOLS / TOOL_DEFINITIONS match the native-tool contract",
+            ))
     return checks
 
 
@@ -176,6 +258,21 @@ def _load_native_tools(skill_info) -> tuple[dict, list, object]:
         raise ImportError(f"Could not load module spec for {tools_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+
+    # Reject wrong-shaped exports here rather than letting them surface
+    # downstream as `cannot convert dictionary update sequence element #0`
+    # from ctx.tools.extra.update() or `'str' object has no attribute 'get'`
+    # from a consumer iterating TOOL_DEFINITIONS (#675). Callers that
+    # already guard _load_native_tools (activation, build_skill_tool_owners)
+    # get an actionable message and skip the skill instead of crashing.
+    problems = check_tools_contract(module)
+    if problems:
+        raise SkillContractError(
+            f"{tools_path} does not match the native-tool contract "
+            f"(TOOLS: dict[str, callable], TOOL_DEFINITIONS: list of function "
+            f"schemas) — {'; '.join(problems)}"
+        )
+
     tools = getattr(module, "TOOLS", {})
     tool_defs = getattr(module, "TOOL_DEFINITIONS", [])
     return tools, tool_defs, module
@@ -247,17 +344,31 @@ async def restore_skills(ctx) -> None:
             log.error(f"Failed to restore skill '{name}': {e}")
 
 
+def _find_skill(discovered, name: str):
+    """Return the discovered SkillInfo named `name`, or None."""
+    for s in discovered:
+        if s.name == name:
+            return s
+    return None
+
+
 async def tool_activate_skill(ctx, name: str) -> str | ToolResult:
     """Activate a skill to make its capabilities available in this conversation."""
     log.info(f"[tool:activate_skill] name={name}")
 
     # Find the skill in discovered skills
-    discovered = ctx.config.discovered_skills
-    skill_info = None
-    for s in discovered:
-        if s.name == name:
-            skill_info = s
-            break
+    skill_info = _find_skill(ctx.config.discovered_skills, name)
+
+    if skill_info is None:
+        # Catalog miss. The skill may have been written earlier in this same
+        # turn, or a `refresh_skills` call in the same batch may still be
+        # running — tool calls in a batch run concurrently under
+        # asyncio.gather, so this read can race the catalog replacement and
+        # report "not found" for a skill refresh_skills just listed (#675).
+        # Re-scan once before giving up, which also repairs the catalog so
+        # restore_skills finds the skill on later turns.
+        await asyncio.to_thread(rediscover_skills, ctx.config)
+        skill_info = _find_skill(ctx.config.discovered_skills, name)
 
     if skill_info is None:
         return ToolResult(text=f"[error: skill '{name}' not found. Check Available Skills in your instructions.]")
@@ -404,22 +515,35 @@ def tool_skill_validate(ctx, path: str) -> ToolResult:
     return _render_validation(path, checks)
 
 
-def tool_refresh_skills(ctx) -> str | ToolResult:
-    """Re-discover skills and update the system prompt catalog."""
-    log.info("[tool:refresh_skills]")
+def rediscover_skills(config) -> list:
+    """Re-scan skill directories and update `config` in place.
+
+    The single mutation path for the runtime skill catalog — used by
+    `refresh_skills` and by `activate_skill`'s catalog-miss path. Returns
+    the list of SkillRejections so callers can surface them.
+
+    Intentional mutation: runtime fields need to update the shared config
+    object that the agent loop holds. dataclasses.replace() would create
+    a disconnected copy.
+    """
     from ..prompts import load_system_prompt
-    from ..tool_definitions import invalidate_skill_cache  # deferred: circular dep
-    # Intentional mutation: runtime fields need to update the shared config
-    # object that the agent loop holds. dataclasses.replace() would create
-    # a disconnected copy.
-    config = ctx.config
     from ..skills import build_skill_tool_owners
+    from ..tool_definitions import invalidate_skill_cache  # deferred: circular dep
+
     rejections: list = []
     config.system_prompt, config.discovered_skills = load_system_prompt(
         config, rejections=rejections
     )
     config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
     invalidate_skill_cache(config)
+    return rejections
+
+
+def tool_refresh_skills(ctx) -> str | ToolResult:
+    """Re-discover skills and update the system prompt catalog."""
+    log.info("[tool:refresh_skills]")
+    config = ctx.config
+    rejections = rediscover_skills(config)
     # List all discovered skills — text-only, native-tools, and user-invocable
     # are all valid activatable skills
     names = [s.name for s in config.discovered_skills]
@@ -486,11 +610,13 @@ SKILL_TOOL_DEFINITIONS = [
                 "Validate a workspace skill directory BEFORE it loads, and get the "
                 "specific reasons it would be rejected. Checks SKILL.md frontmatter "
                 "(must have name + description), that native tools live in tools.py "
-                "(NOT main.py), that tools.py imports without error, and that it "
-                "exports get_tools(ctx) or TOOLS/TOOL_DEFINITIONS. Use this when a "
-                "skill you authored isn't appearing, or before refresh_skills, "
-                "instead of guessing. Takes a workspace-relative path like "
-                "'skills/my-skill'."
+                "(NOT main.py), that tools.py imports without error, and that its "
+                "exports match the loader's contract: TOOLS must be a dict mapping "
+                "tool name -> function, TOOL_DEFINITIONS must be a list of "
+                "OpenAI-style function schemas, and/or get_tools(ctx) -> (dict, list). "
+                "Use this when a skill you authored isn't appearing, or before "
+                "refresh_skills, instead of guessing. Takes a workspace-relative path "
+                "like 'skills/my-skill'."
             ),
             "parameters": {
                 "type": "object",

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -224,3 +224,48 @@ async def test_end_turn_signal_preempts_loop_breaker(ctx):
     # 3 tool-call iterations + 1 final no-tools call after end_turn=True.
     assert mock_llm.call_count == 4
     assert mock_execute.call_count == 3
+
+
+# -- Hard-stop must not re-archive text it already archived (#675) -------------
+
+
+@pytest.mark.asyncio
+async def test_loop_break_does_not_duplicate_accumulated_text(ctx):
+    """Each iteration's assistant preamble is archived as it happens. The
+    hard-stop finalizer must not re-emit all of them joined together — on a
+    long thrash that produced a wall of duplicated text in the transcript."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    preamble = "I will try activating the skill again."
+    repeated_call = _mock_llm_response(
+        content=preamble,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        history = []
+        result = await run_agent_turn(ctx, "loop forever", history)
+
+    assert "[loop-breaker] Stopped" in result.text
+
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    occurrences = sum(
+        (m.get("content") or "").count(preamble)
+        for m in archived if m.get("role") == "assistant"
+    )
+    # The preamble was emitted once per iteration and archived once per
+    # iteration. The stop message must not repeat any of them.
+    iterations = mock_llm.call_count
+    assert occurrences == iterations, (
+        f"preamble archived {occurrences}× across {iterations} iterations — "
+        "the finalizer is re-archiving already-archived text"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1546,3 +1546,185 @@ def test_skill_validate_stray_main_py(ctx):
 def test_skill_validate_outside_workspace(ctx):
     result = tool_skill_validate(ctx, path="../../etc")
     assert "outside the workspace" in _text(result)
+
+
+# -- tools.py shape contract (#675) --
+#
+# The loader needs TOOLS to be dict[str, callable] and TOOL_DEFINITIONS to be
+# a list of OpenAI function schemas. Before #675 skill_validate only checked
+# that the names EXISTED, so it reported PASS on skills that could not
+# possibly load — the contradiction that derailed a whole session.
+
+
+def test_skill_validate_rejects_tools_as_list(ctx):
+    """TOOLS = [fn] imports cleanly but breaks ctx.tools.extra.update()."""
+    _write_ws_skill(
+        ctx, "toolslist", "name: toolslist\ndescription: Wrong TOOLS shape.",
+        tools_py="def hello():\n    return 'hi'\n\nTOOLS = [hello]\n",
+    )
+    result = tool_skill_validate(ctx, path="skills/toolslist")
+    assert result.data["ok"] is False
+    shape = next(c for c in result.data["checks"] if c["name"] == "tools_shape")
+    assert shape["passed"] is False
+    # Actionable: names the expected type, not just "invalid".
+    assert "dict" in shape["message"]
+    assert "TOOLS" in shape["message"]
+
+
+def test_skill_validate_rejects_tool_definitions_as_dict(ctx):
+    """TOOL_DEFINITIONS = {name: fn} imports cleanly but breaks every
+    consumer that iterates it as a list of schema dicts."""
+    _write_ws_skill(
+        ctx, "defsdict", "name: defsdict\ndescription: Wrong defs shape.",
+        tools_py=(
+            "def hello(ctx):\n    return 'hi'\n\n"
+            "TOOLS = {'hello': hello}\n"
+            "TOOL_DEFINITIONS = {'hello': hello}\n"
+        ),
+    )
+    result = tool_skill_validate(ctx, path="skills/defsdict")
+    assert result.data["ok"] is False
+    shape = next(c for c in result.data["checks"] if c["name"] == "tools_shape")
+    assert shape["passed"] is False
+    assert "TOOL_DEFINITIONS" in shape["message"]
+    assert "list" in shape["message"]
+
+
+def test_skill_validate_rejects_non_callable_tool_value(ctx):
+    _write_ws_skill(
+        ctx, "notcallable", "name: notcallable\ndescription: Bad value.",
+        tools_py="TOOLS = {'hello': 'not a function'}\n",
+    )
+    result = tool_skill_validate(ctx, path="skills/notcallable")
+    assert result.data["ok"] is False
+    shape = next(c for c in result.data["checks"] if c["name"] == "tools_shape")
+    assert shape["passed"] is False
+    assert "callable" in shape["message"]
+
+
+def test_skill_validate_rejects_definition_without_function_name(ctx):
+    _write_ws_skill(
+        ctx, "nofname", "name: nofname\ndescription: Missing name.",
+        tools_py=(
+            "def hello(ctx):\n    return 'hi'\n\n"
+            "TOOLS = {'hello': hello}\n"
+            "TOOL_DEFINITIONS = [{'type': 'function', 'function': {}}]\n"
+        ),
+    )
+    result = tool_skill_validate(ctx, path="skills/nofname")
+    assert result.data["ok"] is False
+    shape = next(c for c in result.data["checks"] if c["name"] == "tools_shape")
+    assert shape["passed"] is False
+    assert "function.name" in shape["message"]
+
+
+def test_skill_validate_accepts_correct_tools_shape(ctx):
+    """The happy path still passes, and reports the shape check explicitly."""
+    _write_ws_skill(
+        ctx, "goodshape", "name: goodshape\ndescription: Correct shape.",
+        tools_py=(
+            "def hello(ctx):\n    return 'hi'\n\n"
+            "TOOLS = {'hello': hello}\n"
+            "TOOL_DEFINITIONS = [{'type': 'function', "
+            "'function': {'name': 'hello'}}]\n"
+        ),
+    )
+    result = tool_skill_validate(ctx, path="skills/goodshape")
+    assert result.data["ok"] is True
+    shape = next(c for c in result.data["checks"] if c["name"] == "tools_shape")
+    assert shape["passed"] is True
+
+
+def test_load_native_tools_rejects_wrong_shape_with_actionable_error(tmp_path):
+    """_load_native_tools raises a message naming the contract, not an
+    opaque 'cannot convert dictionary update sequence element #0'."""
+    from decafclaw.skills import SkillInfo
+    from decafclaw.tools.skill_tools import SkillContractError, _load_native_tools
+
+    d = tmp_path / "badshape"
+    d.mkdir()
+    (d / "tools.py").write_text("def hello():\n    return 'hi'\n\nTOOLS = [hello]\n")
+    info = SkillInfo(name="badshape", description="d", location=d,
+                     has_native_tools=True)
+    with pytest.raises(SkillContractError) as exc:
+        _load_native_tools(info)
+    assert "TOOLS" in str(exc.value)
+    assert "dict" in str(exc.value)
+
+
+def test_build_skill_tool_owners_survives_malformed_definitions(tmp_path, config):
+    """A workspace skill with the wrong TOOL_DEFINITIONS shape must not take
+    down startup — build_skill_tool_owners is called unguarded from
+    decafclaw.main()."""
+    from decafclaw.skills import build_skill_tool_owners
+
+    root = tmp_path / "skills-root"
+    bad = root / "badskill"
+    _write_skill(bad, "name: badskill\ndescription: Bad.", tools_py=False)
+    (bad / "tools.py").write_text(
+        "def hello(ctx):\n    return 'hi'\n\n"
+        "TOOLS = {'hello': hello}\n"
+        "TOOL_DEFINITIONS = {'hello': hello}\n"  # dict, not list
+    )
+    good = root / "goodskill"
+    _write_skill(good, "name: goodskill\ndescription: Good.", tools_py=False)
+    (good / "tools.py").write_text(
+        "TOOLS = {'good_one': lambda ctx: None}\n"
+        "TOOL_DEFINITIONS = [{'type': 'function', "
+        "'function': {'name': 'good_one'}}]\n"
+    )
+    config.extra_skill_paths = [str(root)]
+    skills = discover_skills(config)
+
+    owners = build_skill_tool_owners(skills)  # must not raise
+    # The malformed skill contributes nothing; the healthy one is unaffected.
+    assert owners.get("good_one") == "goodskill"
+    assert "hello" not in owners
+
+
+def test_refresh_skills_survives_malformed_workspace_skill(ctx):
+    """refresh_skills must report the broken skill rather than erroring out
+    of the tool entirely."""
+    _write_ws_skill(
+        ctx, "badrefresh", "name: badrefresh\ndescription: Bad shape.",
+        tools_py=(
+            "def hello(ctx):\n    return 'hi'\n\n"
+            "TOOLS = {'hello': hello}\n"
+            "TOOL_DEFINITIONS = {'hello': hello}\n"
+        ),
+    )
+    text = _text(tool_refresh_skills(ctx))  # must not raise
+    assert "Skills refreshed" in text
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_rediscovers_when_missing_from_catalog(ctx):
+    """activate_skill and refresh_skills run concurrently under
+    asyncio.gather, so activate can read config.discovered_skills before
+    refresh replaces it. On a miss, re-discover before reporting not-found
+    rather than emitting a nondeterministic contradiction."""
+    from decafclaw.tools.skill_tools import _save_permission, tool_activate_skill
+
+    _write_ws_skill(ctx, "latecomer", "name: latecomer\ndescription: New skill.",
+                    body="Latecomer body.")
+    # Pre-approve: this test is about the catalog miss, not the workspace-tier
+    # confirmation gate that would otherwise block activation.
+    _save_permission(ctx.config, "latecomer", "always")
+    # Simulate the stale snapshot: the skill exists on disk but the catalog
+    # this call sees predates it.
+    ctx.config.discovered_skills = []
+
+    result = await tool_activate_skill(ctx, name="latecomer")
+    assert "not found" not in _text(result)
+    assert "latecomer" in ctx.skills.activated
+    # The catalog is repaired too, so restore_skills finds it on later turns.
+    assert "latecomer" in {s.name for s in ctx.config.discovered_skills}
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_still_reports_genuinely_missing_skill(ctx):
+    from decafclaw.tools.skill_tools import tool_activate_skill
+
+    ctx.config.discovered_skills = []
+    result = await tool_activate_skill(ctx, name="no-such-skill-anywhere")
+    assert "not found" in _text(result)


### PR DESCRIPTION
Closes #675.

Diagnosed from a real session on the deployed agent that spent its entire length unable to load a skill it had just written.

## Root cause (environmental, already cleared)

A stale copy of the upstream Anthropic `skill-creator` sat at `workspace/skills/skill-creator/` on the deployment — 22 mentions of "Codex", zero of `TOOL_DEFINITIONS`. Workspace tier outranks bundled, so it shadowed our decaf-specific guide. The agent asked how to author a skill and got instructions for a different system, hence `from default_api import shell` and `scripts/` subprocess wrappers. Les deleted it; our bundled `skill-creator` is already correct and needed no change.

Nothing to fix in-repo for that. But the failure modes it exposed are all real, and each one is why a wrong turn became an unrecoverable one.

## What's fixed

**`skill_validate` passed skills that could not load.** It checked that `TOOLS`/`TOOL_DEFINITIONS` *existed*, never their type. `TOOLS = [fn]` imports cleanly, passes every check, then dies in `ctx.tools.extra.update()` as `cannot convert dictionary update sequence element #0 to a sequence` — naming neither the file nor the contract. A validator that green-lights an unloadable skill is worse than none: the agent correctly spotted PASS-plus-failure as a contradiction and had nowhere to go. `check_tools_contract` now backs both `skill_validate` and `_load_native_tools`, so they cannot diverge, and the loader raises `SkillContractError` naming the offending export.

**A malformed workspace skill crashed startup.** `build_skill_tool_owners` iterated `tool_defs` outside the `try` wrapping the import, and is called unguarded from `main()`. A skill with `TOOL_DEFINITIONS` as a dict took the whole agent down on next boot — the exact state the deployment was left in. The contract check runs inside the guarded import, so the bad skill is warned about and skipped.

**`activate_skill` raced `refresh_skills`.** Batched tool calls run under `asyncio.gather`, so activate could read `config.discovered_skills` while refresh replaced it — the session shows a skill listed as available and reported not-found in the same result block. On a catalog miss activate now re-scans once before giving up, which also repairs the catalog so `restore_skills` finds it on later turns. `rediscover_skills` is now the single mutation path.

**The loop-breaker hard stop re-archived text it had already archived.** Each iteration's preamble is archived as emitted; the finalizer archived the join of all of them too. Invisible on a one-preamble turn, a wall of duplicated text on a long thrash — exactly when the transcript most needs to be readable. It now delivers the full text but persists only its note; the iteration-limit finalizer shared the bug and now shares the helper.

## Not fixed here

The loop-breaker nudge is injected with `role: "user"` (deliberate, per the comment at `agent.py:771`). The model read it as Les speaking and opened with "You're right. I was stuck in a loop" — apologizing for something the user never said. The user-role choice is defensible for compliance; the text arguably should self-identify as automated. Left alone as a separate judgement call, noted on the issue.

## Verification

- Each defect has a regression test, written failing first. The duplicate-archive one failed with `preamble archived 8x across 4 iterations` — the exact doubling.
- `make check` clean, `make test` 3358 passed / 2 skipped.
- New eval case in `evals/skill-authoring.yaml` covers the shape-mismatch recovery. Distinct from `diagnostic_discipline.yaml`'s fixture, which has invalid *frontmatter*; here the frontmatter is valid and the import is clean, so only the contract check can catch it. It asserts the outcome (`TOOLS` ends up a dict) rather than the route, since which tool the agent tries first varies run to run.

  **Run, and it has teeth.** On this branch it passes in 4 tool calls / 10.2s, with the agent reporting: *"The `TOOLS` variable in its `tools.py` file was defined as a list instead of a dictionary. I've corrected `tools.py`..."* — the actionable diagnosis the contract check now makes available.

  Run against unfixed `main` (same case, via a temp file) it fails exactly the way the original session did: the agent calls `skill_validate`, gets **PASS**, and concludes *"The 'shapely' skill validates correctly, so it should be activatable"* — never fixing the file. The old validator actively talked it out of the fix.

- **Pre-existing failure, not from this PR:** the other case in that file ("activates the authoring guide when asked to create a skill") fails on this branch *and* identically on `main` — the agent asks a clarifying question about the skill name instead of activating `skill-creator`. No baseline for it in `evals/history.jsonl`. Worth its own issue; untouched here.
- Docs updated in `docs/skills.md` and `docs/loop-breaker.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
