### PR TITLE
fix(web-ui): wiki-editor Reload follows saveEndpoint instead of hardcoding /api/vault/

### DIFF
--- a/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/notes.md
+++ b/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/notes.md
@@ -1,0 +1,67 @@
+# Notes — #666
+
+## Side mission first: finishing #672
+
+Les asked to close out PR #672 (vault frontmatter UI) before shipping this,
+since it rewrites the same `#reload()` lines. One Copilot comment was
+outstanding: `vault_write`'s "nothing to write" 400 still read
+`content (string) required` after the endpoint grew `frontmatter` and
+`frontmatter_raw` payload shapes. Fixed with a regression test asserting all
+four accepted key names appear in the message
+(`request must include body (or its alias content), frontmatter, or
+frontmatter_raw`), replied on the thread, merged as `00334d7`, and rebased
+this branch onto it.
+
+## The issue's fix description was incomplete
+
+#666 says "the vault endpoint returns `body` while schedules and config
+return `content`." Only half right, and the wrong half matters:
+`schedules_get` returns `{"schedule": {...}}` — a nested envelope, not a flat
+body field. Pointing the fetch at `saveEndpoint` without touching the server
+would have swapped a 404 for `data.body === undefined` and blanked the editor,
+which is arguably worse than the bug being fixed. The `data.body ??
+data.content ?? ''` fallback the issue calls "genuinely load-bearing once the
+URL is correct" doesn't reach into an envelope.
+
+Aliased `body`/`modified` to the top level in `schedules_get` instead of
+unwrapping client-side. `schedules_update` already does exactly this for
+`modified` on the PUT side, with a comment naming wiki-editor as the reason —
+the GET side was simply never given the same treatment, because nothing had
+ever successfully fetched it.
+
+## First component test in the repo
+
+`vitest.config.js` already globbed `components/**/*.test.js`, but nothing had
+ever landed there, so the resolution gap was undiscovered: the app reaches
+`@milkdown/kit` through an **import map** pointing at a vendor bundle built
+from `milkdown-entry.js`, and that entry re-exports from subpaths
+(`@milkdown/kit/utils`, `/core`, …). The npm package *root* exports none of
+those names, so `import { $remark } from '@milkdown/kit'` in
+`lib/milkdown-wiki-link.js` fails under plain node resolution.
+
+Fixed with a vitest `resolve.alias` mirroring the import map. It has to be an
+anchored regex (`/^@milkdown\/kit$/`) — Vite's string aliases are prefix
+matches, so `'@milkdown/kit'` also rewrites `@milkdown/kit/core` inside the
+entry itself and breaks resolution one level down. `codemirror` and `hljs`
+have the same import-map shape and will need the same treatment whenever
+`file-editor` gets a test.
+
+The `Editor` stub records `action()` calls rather than resolving to nothing.
+First pass had `create()` return a never-resolving promise, which left
+`#editor` null and quietly skipped the `replaceAll` branch — the branch that
+does the only user-visible part of a reload, since Milkdown reads `.content`
+once at init and ignores it after.
+
+## Teeth check
+
+Before the client fix: 4 of 7 JS tests failed (both URL assertions and both
+content assertions for schedule-page/config-panel). The URL-keyed fetch mock
+is what gives the content assertions teeth — an unconditional
+`mockResolvedValue` answers the wrong URL just as happily as the right one, so
+the two content tests passed against the bug until the mock started 404ing
+anything but the expected URL. Before the server fix: `KeyError: 'body'`.
+
+## Verification
+
+`make check` clean, `make test` 3418 passed / 2 skipped, `make test-js` 22
+passed. No evals — nothing here is LLM-visible.

--- a/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/plan.md
+++ b/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/plan.md
@@ -1,0 +1,61 @@
+# Plan — #666
+
+Branch `fix/666-wiki-editor-reload-endpoint`, worktree
+`.claude/worktrees/666-wiki-editor-reload-endpoint`, based on `00334d7`
+(post-#672 main).
+
+## Phase 1 — Server: satisfy the GET contract on schedules
+
+**Test first** (`tests/test_web_schedules_api.py`): `GET /api/schedules/{name}`
+exposes `body` and `modified` at the top level, matching the values nested
+under `schedule`. Expected failure: `KeyError`/absent keys.
+
+**Fix** (`http_server.py`, `schedules_get`): mirror the aliasing comment and
+shape that `schedules_update` already uses.
+
+```python
+sched = _schedule_to_dict(config, task)
+# wiki-editor's reload reads body/modified at the top level (see
+# schedules_update for the matching PUT-side alias)
+return JSONResponse({
+    "schedule": sched,
+    "body": sched["body"],
+    "modified": sched["modified"],
+})
+```
+
+Verify `schedule-page.js` still reads `data.schedule` — the aliases are
+additive, nothing is removed.
+
+## Phase 2 — Client: reload the endpoint the editor actually saves to
+
+**Test first** — first component test in this repo. `vitest.config.js`
+already includes `components/**/*.test.js`; no config change needed.
+
+`components/wiki-editor.test.js`:
+
+- `vi.mock('@milkdown/kit')` so no real editor boots in jsdom. `#reload()`
+  guards on `this.#editor`, so a null editor exercises the fetch path fine.
+- Per host endpoint (`/api/vault/`, `/api/schedules/`, `/api/config/files/`):
+  mount the element, force `_status = 'conflict'`, click the Reload button,
+  assert the stubbed `fetch` received `{saveEndpoint}{page}`.
+- One test per body field so the `body ?? content ?? ''` fallback is
+  genuinely covered: vault/schedules return `body`, config returns `content`.
+
+Expected failure: every URL assertion sees `/api/vault/...`.
+
+**Fix** (`wiki-editor.js`, `#reload()`): fetch
+`${this.saveEndpoint}${encodePagePath(this.page)}`, and rewrite the stale
+comment — it currently documents the bug ("hardcoded to /api/vault
+regardless of `saveEndpoint`") as if it were permanent.
+
+## Phase 3 — Docs
+
+`docs/web-ui.md`: state the wiki-editor GET/PUT contract the three hosts
+share, and note the schedules aliases. Cross-check `docs/schedules.md` for a
+response-shape table that needs the new keys.
+
+## Verification
+
+`make check` · `make test` · `make test-js`, then squash + PR with
+`Closes #666`.

--- a/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/spec.md
+++ b/docs/dev-sessions/2026-07-24-1700-666-wiki-editor-reload-endpoint/spec.md
@@ -1,0 +1,89 @@
+# Spec — `wiki-editor#reload()` ignores `saveEndpoint`
+
+Closes [#666](https://github.com/lmorchard/decafclaw/issues/666).
+
+## Problem
+
+`wiki-editor.js`'s `#reload()` fetches a hardcoded URL:
+
+```js
+const res = await fetch(`/api/vault/${encodePagePath(this.page)}`);
+```
+
+It ignores the component's own `saveEndpoint`, which the save and force-save
+paths both honor. Three hosts share the component with three endpoints:
+
+| Host | `save-endpoint` |
+| --- | --- |
+| `wiki-page.js` | `/api/vault/` (default) |
+| `schedule-page.js` | `/api/schedules/` |
+| `config-panel.js` | `/api/config/files/` |
+
+`#reload()` backs the **Reload** button in the conflict banner (`_status ===
+'conflict'`). On a schedule or config file, resolving a 409 by clicking Reload
+fetches a *vault page* named after that schedule/config file — 404, or (worse)
+an unrelated vault page's body silently loaded into the wrong editor.
+
+## Correction to the issue's premise
+
+The issue states "the vault endpoint returns `body` while schedules and config
+return `content`." That is not what main returns. Actual GET shapes:
+
+| Endpoint | Body field | Envelope |
+| --- | --- | --- |
+| `/api/vault/{page}` | `body` | flat |
+| `/api/config/files/{path}` | `content` | flat |
+| `/api/schedules/{name}` | `body` | **nested under `schedule`** |
+
+So pointing the fetch at `saveEndpoint` is necessary but not sufficient:
+`schedules_get` returns `{"schedule": {...}}`, and `data.content` /
+`data.body` are both `undefined` at the top level. The existing
+`data.body ?? data.content ?? ''` fallback does not reach into the envelope.
+
+## Decision: normalize server-side
+
+Add top-level `body` and `modified` aliases to the `schedules_get`
+response. This mirrors the alias `schedules_update` already applies twenty
+lines above in the same file — that handler flattens `modified` to the top
+level with the comment *"wiki-editor reads data.modified at the top level of
+the PUT response."* The GET side needs the same treatment for the same
+consumer.
+
+Rejected alternative: unwrap the envelope client-side
+(`const doc = data.schedule ?? data`). It works, but bakes knowledge of one
+host's response shape into a component shared by three, and contradicts the
+established direction of adaptation in this codebase (server adapts to the
+wiki-editor contract, not the reverse).
+
+## The wiki-editor GET contract
+
+After this change, all three endpoints satisfy one rule, which the component
+can rely on without special-casing:
+
+> A `GET {saveEndpoint}{page}` returns the editable markdown at the top level
+> as `body` (preferred) or `content`, and its mtime as `modified`.
+
+Aliasing to `body` rather than `content` puts schedules on the same shape as
+the vault endpoint, so two of three hosts hit the contract's preferred branch
+and only config relies on the `content` fallback.
+
+## Scope
+
+- `schedules_get` gains top-level `body` + `modified`.
+- `#reload()` fetches `${this.saveEndpoint}${encodePagePath(this.page)}`.
+- Regression coverage: a Python test for the schedules GET contract, and a
+  `wiki-editor` component test per host asserting the reload URL.
+- `docs/web-ui.md` records the GET contract alongside the existing PUT one.
+
+## What we're NOT doing
+
+- Not flattening `schedules_get` outright (would break `schedule-page.js`,
+  which reads `data.schedule`) — the envelope stays, aliases are additive.
+- Not touching the config endpoint; it already satisfies the contract.
+- Not changing `#save()` / `#forceSave()`; they already use `saveEndpoint`.
+- Not adding evals — no LLM-visible behavior changes.
+- Not fixing the `modified: null` case for a config file that has never been
+  written (bundled default). Reload sets `this.modified = null`, the next save
+  sends no mtime, and the server skips the conflict check. That is the same
+  state as a fresh page load of an unwritten config file, so reload does not
+  make it worse.

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -271,7 +271,7 @@ Returns all discovered schedules with metadata.
 
 ### `GET /api/schedules/{name}`
 
-Returns a single schedule entry by name. Same shape as a list entry wrapped in `{"schedule": ...}`.
+Returns a single schedule entry by name. Same shape as a list entry wrapped in `{"schedule": ...}`, plus top-level `body` and `modified` mirroring `schedule.body` / `schedule.modified` — the same wiki-editor contract the `PUT` response satisfies (see [web-ui.md](web-ui.md#the-wiki-editor-host-contract)). The editor's conflict-banner Reload fetches this endpoint and has no knowledge of the `schedule` envelope.
 
 **Error codes:**
 - `404` — name not found

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -247,7 +247,7 @@ Lit web components in `src/decafclaw/web/static/`:
 | `chat-input` | `components/chat-input.js` | Message input with file upload |
 | `chat-message` | `components/chat-message.js` | Individual message rendering |
 | `conversation-sidebar` | `components/conversation-sidebar.js` | Conversation list, folders, vault browser, model picker |
-| `wiki-editor` | `components/wiki-editor.js` | WYSIWYG markdown page editor |
+| `wiki-editor` | `components/wiki-editor.js` | WYSIWYG markdown page editor (see [host contract](#the-wiki-editor-host-contract)) |
 | `wiki-page` | `components/wiki-page.js` | Page viewer/renderer |
 | `wiki-metadata` | `components/wiki-metadata.js` | Frontmatter strip/panel: view-mode summary + tags, edit-mode typed controls and raw YAML editor |
 | `context-inspector` | `components/context-inspector.js` | Context diagnostics popover |
@@ -259,6 +259,34 @@ Lit web components in `src/decafclaw/web/static/`:
 | `theme-toggle` | `components/theme-toggle.js` | Light/dark mode switch |
 
 Service layer: `AuthClient`, `WebSocketClient`, `ConversationStore`, `MessageStore`, `ToolStatusStore`, `CanvasState`.
+
+#### The wiki-editor host contract
+
+`<wiki-editor>` is shared by three hosts, each pointing it at a different API
+prefix via `save-endpoint`:
+
+| Host | `save-endpoint` |
+|------|-----------------|
+| `wiki-page` | `/api/vault/` (default) |
+| `schedule-page` | `/api/schedules/` |
+| `config-panel` | `/api/config/files/` |
+
+Every request the editor makes — autosave, force-save, and the conflict
+banner's **Reload** — goes to `{saveEndpoint}{page}`. A host that sets
+`save-endpoint` must therefore serve both verbs there, and both responses must
+put the editor's fields at the **top level**, since the component knows nothing
+about any per-endpoint envelope:
+
+- `GET` returns the editable markdown as `body` (`content` is accepted as a
+  fallback, which is how config files are served) and its mtime as `modified`.
+- `PUT` accepts `{content, modified}` and returns `modified`.
+
+`/api/schedules/{name}` wraps its payload in `{"schedule": ...}` for
+`schedule-page`, so it aliases `body` and `modified` to the top level for this
+contract. Before [#666](https://github.com/lmorchard/decafclaw/issues/666)
+Reload ignored `save-endpoint` entirely and always fetched `/api/vault/`,
+which 404'd on a schedule or config file — or loaded a same-named vault page's
+body into the wrong editor.
 
 ### Backend
 

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -2134,7 +2134,15 @@ async def schedules_get(request: Request, username: str) -> JSONResponse:
     task = tasks.get(name)
     if task is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    return JSONResponse({"schedule": _schedule_to_dict(config, task)})
+    sched = _schedule_to_dict(config, task)
+    # wiki-editor's conflict-banner reload reads body/modified at the top
+    # level and knows nothing of the `schedule` envelope — same alias
+    # schedules_update applies above for the same consumer.
+    return JSONResponse({
+        "schedule": sched,
+        "body": sched["body"],
+        "modified": sched["modified"],
+    })
 
 
 @_authenticated

--- a/src/decafclaw/web/static/components/wiki-editor.js
+++ b/src/decafclaw/web/static/components/wiki-editor.js
@@ -5,7 +5,10 @@
  *   page (String) — page name for API path
  *   content (String) — initial markdown
  *   modified (Number) — file mtime for conflict detection
- *   saveEndpoint (String) — API prefix, default '/api/vault/'
+ *   saveEndpoint (String) — API prefix, default '/api/vault/'. Used by every
+ *     request the editor makes — save, force-save, and conflict reload. A host
+ *     that sets it must serve GET and PUT at `{saveEndpoint}{page}`; see
+ *     docs/web-ui.md for the shared request/response contract.
  *
  * Behavior:
  *   Dispatches a 'close' CustomEvent when the public close() method is called.
@@ -240,14 +243,13 @@ export class WikiEditor extends LitElement {
 
   async #reload() {
     try {
-      const res = await fetch(`/api/vault/${encodePagePath(this.page)}`);
+      const res = await fetch(
+        `${this.saveEndpoint}${encodePagePath(this.page)}`,
+      );
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      // The vault endpoint returns `body`; `content` is insurance only. Note
-      // this fetch is hardcoded to /api/vault regardless of `saveEndpoint`, so
-      // schedule-page / config-panel *do* reach this path — it's wired to their
-      // conflict banner — but they reach it against the wrong endpoint. The
-      // `content` fallback exists for whenever that hardcoding is fixed.
+      // Every host's GET returns the editable markdown at the top level: the
+      // vault and schedule endpoints as `body`, config files as `content`.
       // Assigned once so all four uses stay in sync.
       const newContent = data.body ?? data.content ?? '';
       this.content = newContent;

--- a/src/decafclaw/web/static/components/wiki-editor.test.js
+++ b/src/decafclaw/web/static/components/wiki-editor.test.js
@@ -1,0 +1,151 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+// Milkdown needs a real contenteditable surface and contributes nothing to the
+// fetch paths under test. Override only `Editor` with a recording stub — the
+// rest of the kit stays real, since the wiki-link plugin imports from it.
+vi.mock('@milkdown/kit', async (importOriginal) => {
+  const actual = /** @type {object} */ (await importOriginal());
+  /** @type {{actions: unknown[]}[]} */
+  const editors = [];
+  const make = () => {
+    const editor = {
+      /** @type {unknown[]} */ actions: [],
+      /** @param {unknown} fn */ action: (fn) => editor.actions.push(fn),
+      destroy: () => {},
+    };
+    /** @type {Record<string, Function>} */
+    const chainable = {
+      config: () => chainable,
+      use: () => chainable,
+      create: async () => { editors.push(editor); return editor; },
+    };
+    return chainable;
+  };
+  return { ...actual, Editor: { make }, __editors: editors };
+});
+
+await import('./wiki-editor.js');
+/** Editors built by the stub above, in mount order. */
+const { __editors: editors } = /** @type {any} */ (await import('@milkdown/kit'));
+
+/**
+ * Mount a `wiki-editor` already sitting in the conflict state, so the
+ * conflict banner (and its Reload button) is rendered.
+ * @param {{page: string, saveEndpoint?: string}} opts
+ */
+async function mountInConflict({ page, saveEndpoint }) {
+  const el = /** @type {import('./wiki-editor.js').WikiEditor} */ (
+    document.createElement('wiki-editor')
+  );
+  el.page = page;
+  if (saveEndpoint !== undefined) el.saveEndpoint = saveEndpoint;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  // firstUpdated builds the editor asynchronously, outside the update cycle.
+  await vi.waitFor(() => expect(editors).toHaveLength(1));
+  el._status = 'conflict';
+  await el.updateComplete;
+  return el;
+}
+
+/** @param {HTMLElement} el */
+function clickReload(el) {
+  const buttons = [...el.querySelectorAll('.wiki-editor-conflict button')];
+  const reload = buttons.find(b => b.textContent?.trim() === 'Reload');
+  if (!reload) throw new Error('Reload button not rendered');
+  /** @type {HTMLButtonElement} */ (reload).click();
+}
+
+describe('wiki-editor #reload', () => {
+  /** @type {ReturnType<typeof vi.fn>} */
+  let fetchMock;
+
+  beforeEach(() => {
+    editors.length = 0;
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Serve `payload` at exactly one URL and 404 everywhere else — the real
+   * failure mode in #666 is a request landing on the wrong endpoint, so a
+   * mock that answers any URL would let the bug pass.
+   * @param {string} url
+   * @param {object} payload
+   */
+  const respondAt = (url, payload) => fetchMock.mockImplementation(
+    async (/** @type {string} */ requested) => requested === url
+      ? { ok: true, status: 200, json: async () => payload }
+      : { ok: false, status: 404, json: async () => ({ error: 'not found' }) },
+  );
+
+  // Each host wires wiki-editor to a different endpoint. Reload must follow
+  // `saveEndpoint`, not the vault default (#666), and must read the body field
+  // that endpoint actually returns.
+  const HOSTS = [
+    {
+      host: 'wiki-page',
+      saveEndpoint: undefined,  // default
+      page: 'Some Page',
+      expectedUrl: '/api/vault/Some%20Page',
+      payload: { body: 'vault body', modified: 111 },
+    },
+    {
+      host: 'schedule-page',
+      saveEndpoint: '/api/schedules/',
+      page: 'dream',
+      expectedUrl: '/api/schedules/dream',
+      payload: { body: 'schedule body', modified: 222 },
+    },
+    {
+      host: 'config-panel',
+      saveEndpoint: '/api/config/files/',
+      page: 'AGENT.md',
+      expectedUrl: '/api/config/files/AGENT.md',
+      payload: { content: 'config body', modified: 333 },
+    },
+  ];
+
+  for (const { host, saveEndpoint, page, expectedUrl, payload } of HOSTS) {
+    it(`reloads from saveEndpoint for ${host}`, async () => {
+      respondAt(expectedUrl, payload);
+      const el = await mountInConflict({ page, saveEndpoint });
+
+      clickReload(el);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(fetchMock.mock.calls[0][0]).toBe(expectedUrl);
+    });
+
+    it(`applies the reloaded content for ${host}`, async () => {
+      respondAt(expectedUrl, payload);
+      const el = await mountInConflict({ page, saveEndpoint });
+
+      clickReload(el);
+      await vi.waitFor(() => expect(el._status).toBe('saved'));
+
+      expect(el.content).toBe(payload.body ?? payload.content);
+      expect(el.modified).toBe(payload.modified);
+      expect(el._error).toBe('');
+      // Setting `.content` alone doesn't move Milkdown — it only reads that
+      // once, at init. The visible refresh is this replaceAll action.
+      expect(editors[0].actions).toHaveLength(1);
+    });
+  }
+
+  it('surfaces a failed reload instead of blanking the editor', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    const el = await mountInConflict({ page: 'dream', saveEndpoint: '/api/schedules/' });
+    el.content = 'unsaved work';
+
+    clickReload(el);
+    await vi.waitFor(() => expect(el._error).toContain('Reload failed'));
+
+    expect(el.content).toBe('unsaved work');
+  });
+});

--- a/src/decafclaw/web/static/vitest.config.js
+++ b/src/decafclaw/web/static/vitest.config.js
@@ -1,6 +1,22 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+/** @param {string} p */
+const here = (p) => fileURLToPath(new URL(p, import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    // Mirror the browser import map in index.html: bare specifiers that point
+    // at a vendor bundle resolve to that bundle's *entry*, not the npm package
+    // root. `@milkdown/kit`'s root export has none of the names the entry
+    // re-exports from its subpaths (`$remark`, `commonmark`, …), so without
+    // this a component test importing wiki-editor fails at module load.
+    // Anchored so only the bare specifier is rewritten — the entry's own
+    // `@milkdown/kit/core` etc. must still resolve to the npm package.
+    alias: [
+      { find: /^@milkdown\/kit$/, replacement: here('./milkdown-entry.js') },
+    ],
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.js'],

--- a/tests/test_web_schedules_api.py
+++ b/tests/test_web_schedules_api.py
@@ -229,6 +229,20 @@ class TestSchedulesAPI:
         assert r.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_get_single_schedule_aliases_body_and_modified(self, client):
+        """wiki-editor's reload reads body/modified at the top level (#666).
+
+        It has no knowledge of this endpoint's `schedule` envelope, so the GET
+        must alias both the way the PUT already aliases `modified`.
+        """
+        r = await client.get("/api/schedules/dream")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["body"] == data["schedule"]["body"]
+        assert data["modified"] == data["schedule"]["modified"]
+        assert isinstance(data["modified"], (int, float))
+
+    @pytest.mark.asyncio
     async def test_put_response_includes_modified(self, client):
         r = await client.put("/api/schedules/dream", json={"enabled": False})
         assert r.status_code == 200


### PR DESCRIPTION
Closes #666.

## Problem

`wiki-editor`'s conflict-banner **Reload** fetched `/api/vault/{page}` regardless of the component's own `saveEndpoint`, which its save and force-save paths both honor. Two of its three hosts point elsewhere:

| Host | `save-endpoint` |
|---|---|
| `wiki-page` | `/api/vault/` (default) |
| `schedule-page` | `/api/schedules/` |
| `config-panel` | `/api/config/files/` |

So resolving a 409 on a schedule or config file fetched a *vault page* named after it — a 404, or an unrelated page's body silently loaded into the wrong editor.

## The issue's fix description was incomplete

#666 states the vault endpoint returns `body` while schedules and config return `content`. Config does; **schedules returns `{"schedule": {…, body, modified}}`** — a nested envelope. Swapping the URL alone leaves `data.body` and `data.content` both `undefined` at the top level, so the existing `data.body ?? data.content ?? ''` fallback resolves to `''` and blanks the editor. That's worse than the 404 it replaces.

## Fix

Two halves:

- **Server** — `schedules_get` aliases `body` and `modified` to the top level. `schedules_update` already does this for `modified` on the PUT side, with a comment naming wiki-editor as the reason; the GET side just never got the same treatment, because nothing had ever successfully fetched it. The `schedule` envelope stays for `schedule-page`; the aliases are additive.
- **Client** — `#reload()` fetches `${this.saveEndpoint}${encodePagePath(this.page)}`, and the comment that documented the bug as permanent is replaced with the contract that now holds.

Chose the server alias over unwrapping client-side (`data.schedule ?? data`) to keep a component shared by three hosts from carrying knowledge of one host's response shape, and to match the direction adaptation already runs in this codebase.

## Tests

First `components/**` test in the repo. That glob was already in `vitest.config.js`, but nothing had landed there, so a resolution gap went undiscovered: the app reaches `@milkdown/kit` through an **import map** pointing at a vendor bundle built from `milkdown-entry.js`, whose re-exports come from subpaths (`@milkdown/kit/utils`, `/core`, …) that the npm package root doesn't expose. A vitest `resolve.alias` mirrors the import map — anchored (`/^@milkdown\/kit$/`), since Vite string aliases are prefix matches and would rewrite the entry's own subpath imports. `codemirror` and `hljs` will need the same when `file-editor` gets a test.

Coverage: reload URL and applied content per host, plus a failed-reload case asserting unsaved work survives. The fetch mock is URL-keyed rather than unconditional — an always-answering mock let the content assertions pass against the bug. Before the fix, 4 of 7 failed; the server test failed with `KeyError: 'body'`.

## Verification

`make check` clean · `make test` 3418 passed, 2 skipped · `make test-js` 22 passed. No evals — nothing here is LLM-visible.

## Docs

`docs/web-ui.md` gains a "wiki-editor host contract" section stating the GET/PUT shape all three endpoints must satisfy; `docs/schedules.md` documents the new top-level aliases on `GET /api/schedules/{name}`.

## Note on #672

Its outstanding Copilot comment (the misleading `content (string) required` 400 on `vault_write`) was fixed and the PR merged first, so this branch sits on top of it rather than conflicting with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)