### PR TITLE
fix(web-ui): stop the chat input stealing focus on every agent message

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -38,6 +38,14 @@ Real-time streaming chat over WebSocket. Messages stream token-by-token as the L
 - Cancel in-progress turns
 - Confirmation prompts for shell commands and skill activation
 
+**Input focus.** The composer takes focus on a conversation switch, and again
+when the agent finishes a turn — but only if the user hasn't moved focus
+somewhere else in the meantime (canvas terminal, wiki editor, a widget). It
+never grabs focus mid-turn. The policy lives in `static/lib/chat-focus.js`;
+`app.js` consults it from the conversation store's `change` handler, which
+fires on *every* WebSocket message, so a looser condition there steals focus
+on each streamed chunk.
+
 ### Conversations
 
 The sidebar lists conversations organized into folders:

--- a/src/decafclaw/web/static/app.js
+++ b/src/decafclaw/web/static/app.js
@@ -9,6 +9,7 @@ import { WebSocketClient } from './lib/websocket-client.js';
 import { ConversationStore } from './lib/conversation-store.js';
 import { MESSAGE_TYPES, KNOWN_MESSAGE_TYPES } from './lib/message-types.js';
 import { setupResizeHandle } from './lib/utils.js';
+import { shouldFocusChatInput } from './lib/chat-focus.js';
 import { showToast } from './lib/toast.js';
 import {
   setActiveConv,
@@ -69,19 +70,31 @@ if (chatView) chatView.store = store;
 let wasBusy = false;
 let lastConvId = null;
 store.addEventListener('change', () => {
+  const cur = store.currentConvId || null;
+  const convChanged = cur !== lastConvId;
   if (chatInput) {
     chatInput.busy = store.isBusy;
     chatInput.disabled = store.isReadOnly;
     chatInput.convId = store.currentConvId || '';
     chatInput.placeholder = store.isReadOnly ? 'Read-only conversation' : 'Type a message...';
-    // Focus when agent finishes or conversation changes
-    if (!store.isReadOnly && ((wasBusy && !store.isBusy) || store.currentConvId)) {
-      requestAnimationFrame(() => chatInput.focus());
+    // `change` fires on every WebSocket message, so the focus decision has to
+    // name the transitions it cares about — see lib/chat-focus.js.
+    const focusOpts = {
+      readOnly: store.isReadOnly,
+      convChanged: convChanged && !!cur,
+      turnFinished: wasBusy && !store.isBusy,
+      chatInputEl: chatInput,
+    };
+    if (shouldFocusChatInput(focusOpts)) {
+      // Re-check after layout: an in-flight click may land focus elsewhere
+      // between the store event and the frame.
+      requestAnimationFrame(() => {
+        if (shouldFocusChatInput(focusOpts)) chatInput.focus();
+      });
     }
     wasBusy = store.isBusy;
   }
-  const cur = store.currentConvId || null;
-  if (cur !== lastConvId) {
+  if (convChanged) {
     lastConvId = cur;
     setActiveConv(cur);
     stickySetActiveConv(cur);

--- a/src/decafclaw/web/static/lib/chat-focus.js
+++ b/src/decafclaw/web/static/lib/chat-focus.js
@@ -1,0 +1,51 @@
+/**
+ * Auto-focus policy for the chat input.
+ *
+ * The conversation store emits a `change` event after *every* WebSocket
+ * message, so anything that focuses the chat input from that handler has to
+ * be explicit about which state transition it reacts to. Focusing on plain
+ * "something changed" yanks the caret back to the composer on every streamed
+ * chunk, which makes the canvas terminal (or any other input on the page)
+ * unusable while the agent is talking.
+ */
+
+/**
+ * Is the user's focus currently parked somewhere we must not disturb?
+ *
+ * "Nowhere" (body / documentElement / nothing) and "already inside the chat
+ * input" both count as free — re-focusing then is either the point or a
+ * no-op. Anything else is a deliberate focus the user placed, including a
+ * shadow-DOM widget (whose host element shows up as `activeElement`).
+ *
+ * @param {Element|null} chatInputEl
+ * @returns {boolean}
+ */
+function isFocusParkedElsewhere(chatInputEl) {
+  const active = document.activeElement;
+  if (!active || active === document.body || active === document.documentElement) return false;
+  if (chatInputEl && chatInputEl.contains(active)) return false;
+  return true;
+}
+
+/**
+ * Decide whether a store `change` should move focus into the chat input.
+ *
+ * - Conversation switch: always focus. It only happens from an explicit
+ *   navigation, and landing in the composer is the whole point.
+ * - Agent finished a turn: focus only if it wouldn't steal — the user may
+ *   have moved to the canvas terminal, the wiki editor, or a widget mid-turn.
+ * - Anything else (a streamed chunk, a tool status, a busy flip): never.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.readOnly     - Conversation is read-only (composer disabled)
+ * @param {boolean} opts.convChanged  - The current conversation id just changed
+ * @param {boolean} opts.turnFinished - The agent went busy → idle on this change
+ * @param {Element|null} [opts.chatInputEl] - The chat-input element, for focus containment
+ * @returns {boolean}
+ */
+export function shouldFocusChatInput({ readOnly, convChanged, turnFinished, chatInputEl = null }) {
+  if (readOnly) return false;
+  if (convChanged) return true;
+  if (!turnFinished) return false;
+  return !isFocusParkedElsewhere(chatInputEl);
+}

--- a/src/decafclaw/web/static/lib/chat-focus.test.js
+++ b/src/decafclaw/web/static/lib/chat-focus.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldFocusChatInput } from './chat-focus.js';
+
+/**
+ * Build a chat-input stand-in containing a textarea, plus a sibling input
+ * that stands in for "somewhere else the user is typing" (canvas terminal,
+ * wiki editor, ...).
+ */
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="chat-input"><textarea id="composer"></textarea></div>
+    <div id="canvas"><textarea id="terminal"></textarea></div>
+  `;
+  return {
+    chatInputEl: document.getElementById('chat-input'),
+    composer: /** @type {HTMLTextAreaElement} */ (document.getElementById('composer')),
+    terminal: /** @type {HTMLTextAreaElement} */ (document.getElementById('terminal')),
+  };
+}
+
+describe('shouldFocusChatInput', () => {
+  /** @type {ReturnType<typeof setupDom>} */
+  let dom;
+
+  beforeEach(() => { dom = setupDom(); });
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  const base = () => ({
+    readOnly: false,
+    convChanged: false,
+    turnFinished: false,
+    chatInputEl: dom.chatInputEl,
+  });
+
+  it('does not focus on an ordinary change (streamed chunk, tool status)', () => {
+    // The regression this guards: the store emits `change` after every
+    // WebSocket message, so "a conversation is open" must not imply "focus".
+    expect(shouldFocusChatInput(base())).toBe(false);
+  });
+
+  it('does not focus mid-turn while the user is typing elsewhere', () => {
+    dom.terminal.focus();
+    expect(shouldFocusChatInput(base())).toBe(false);
+  });
+
+  it('focuses when the agent finishes a turn and focus is unclaimed', () => {
+    expect(shouldFocusChatInput({ ...base(), turnFinished: true })).toBe(true);
+  });
+
+  it('does not steal focus at turn end when the user is typing elsewhere', () => {
+    dom.terminal.focus();
+    expect(document.activeElement).toBe(dom.terminal);
+    expect(shouldFocusChatInput({ ...base(), turnFinished: true })).toBe(false);
+  });
+
+  it('still focuses at turn end when focus is already inside the chat input', () => {
+    dom.composer.focus();
+    expect(shouldFocusChatInput({ ...base(), turnFinished: true })).toBe(true);
+  });
+
+  it('focuses on conversation switch', () => {
+    expect(shouldFocusChatInput({ ...base(), convChanged: true })).toBe(true);
+  });
+
+  it('focuses on conversation switch even from a focused element elsewhere', () => {
+    // Switching conversations is an explicit navigation — landing in the
+    // composer is the point, and the click that caused it may have left
+    // focus on a sidebar control.
+    dom.terminal.focus();
+    expect(shouldFocusChatInput({ ...base(), convChanged: true })).toBe(true);
+  });
+
+  it('never focuses a read-only conversation', () => {
+    expect(shouldFocusChatInput({ ...base(), readOnly: true, convChanged: true })).toBe(false);
+    expect(shouldFocusChatInput({ ...base(), readOnly: true, turnFinished: true })).toBe(false);
+  });
+
+  it('tolerates a missing chat input element', () => {
+    dom.composer.focus();
+    // No element to compare containment against — the focused composer now
+    // reads as "somewhere else", so a turn end must not yank it.
+    expect(shouldFocusChatInput({ ...base(), chatInputEl: null, turnFinished: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

With the web UI open, every message from the agent yanked focus back to the chat composer. Working in a canvas terminal pane while the agent talked was impossible — focus was stolen on every streamed chunk.

## Cause

`ConversationStore` fires its `change` event at the end of *every* WebSocket message handler (`lib/conversation-store.js:630`). The focus condition in `app.js` was:

```js
if (!store.isReadOnly && ((wasBusy && !store.isBusy) || store.currentConvId)) {
  requestAnimationFrame(() => chatInput.focus());
}
```

The comment says "focus when agent finishes or conversation changes", but `|| store.currentConvId` is truthy whenever *any* conversation is open. So the second clause meant "always", not "the conversation changed".

## Fix

Extract the decision into `lib/chat-focus.js` (`shouldFocusChatInput`) and narrow it to the two transitions that were actually intended:

- **Conversation switch** — always focus. It only happens from an explicit navigation, and landing in the composer is the point.
- **Agent finished a turn** (`busy → idle`) — focus only if the user hasn't parked focus somewhere else. Focus inside the chat input, or nowhere at all (`body`), counts as free; anything else (canvas terminal, wiki editor, a widget host) is left alone.
- **Everything else** — never.

The predicate is re-checked inside the `requestAnimationFrame` callback so a click landing between the store event and the frame still wins.

Considered and rejected: a `document.hasFocus()` guard for the popped-out-canvas case. `element.focus()` in a background tab doesn't steal OS-level focus anyway, and the guard would break "open the UI in a background tab, come back later" — no autofocus on arrival.

## Testing

New `lib/chat-focus.test.js` (9 cases). Verified the tests have teeth: loosening the predicate back to "always if not read-only" fails 4 of them, including the streamed-chunk regression case.

- `make test-js` — 24 passed
- `make check` — clean (ruff, pyright, tsc)

Not yet exercised live in a browser against a real streaming turn — worth a quick look before merge.

## Docs

Added an "Input focus" note to the Chat section of `docs/web-ui.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)