### PR TITLE
fix(tools): never send duplicate function declarations to the provider

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -114,7 +114,19 @@ TOOL_DEFINITIONS = [
         }
     }
 ]
+```
 
+#### Tool names must not collide with core tools
+
+Pick a name no core tool already uses. `debug_context`, `shell`, `read_file` and friends are taken — check `docs/tools.md` or the catalog before choosing.
+
+Shadowing is *permitted*: `execute_tool` checks `ctx.tools.extra` before the global registry, so an activated skill's version genuinely wins, and activation now says so in its result rather than overriding in silence. What you must not do is assume it's free.
+
+Until #684 a collision was fatal. Both declarations were concatenated into the list sent to the provider, and providers reject duplicate function names outright — Vertex answers `400 Duplicate function declaration found: <name>`. That lands at the provider call, *before* any tool runs, so the agent never sees a tool result and cannot diagnose or recover; from inside the conversation the model just appears to break. `collect_all_tool_defs` now dedupes by name, keeping the first declaration (skill defs are positioned first, matching dispatch order, so the schema the model sees belongs to the implementation that will run).
+
+The reason this bites in practice: the agent can write `workspace/skills/` itself, and the tool names it reaches for first are exactly the ones already taken.
+
+```python
 def init(config, skill_config: SkillConfig):
     """Optional. Called once on first activation. Can be async.
 

--- a/src/decafclaw/tool_definitions.py
+++ b/src/decafclaw/tool_definitions.py
@@ -120,7 +120,50 @@ def collect_all_tool_defs(ctx) -> list:
     if mcp_registry:
         all_tools = all_tools + mcp_registry.get_tool_definitions()
 
-    return all_tools
+    return _dedupe_by_name(all_tools)
+
+
+def _dedupe_by_name(tool_defs: list) -> list:
+    """Drop later declarations of an already-declared function name.
+
+    Providers reject a request carrying the same function name twice outright
+    — Vertex answers 400 "Duplicate function declaration found: X" — and that
+    lands at the provider call, before any tool runs. The agent never sees a
+    tool result, so it cannot diagnose or recover; from inside the
+    conversation the model simply appears to break (#684).
+
+    The sources concatenated above are not disjoint. An activated skill can
+    export a tool named for a core one (the agent may author workspace skills,
+    and the names it reaches for first are the ones already taken), and
+    nothing upstream prevents it.
+
+    Keep-FIRST is the required tiebreak, not an arbitrary one. Skill
+    definitions are positioned first, and ``execute_tool`` checks
+    ``ctx.tools.extra`` before the global registry — so keeping the first
+    declaration means the schema the model is shown belongs to the same
+    implementation that will run. Keep-last would leave the two silently
+    disagreeing, which is worse than the crash it replaces.
+    """
+    seen: set[str] = set()
+    deduped = []
+    for td in tool_defs:
+        name = td.get("function", {}).get("name")
+        if not name:
+            # Malformed entries aren't this function's business — pass them
+            # through so whatever validates shape still gets to complain.
+            deduped.append(td)
+            continue
+        if name in seen:
+            log.warning(
+                "Dropping duplicate declaration of tool %r — an earlier "
+                "definition of that name wins (skill tools shadow core "
+                "tools, matching execute_tool's dispatch order).",
+                name,
+            )
+            continue
+        seen.add(name)
+        deduped.append(td)
+    return deduped
 
 
 def build_tool_list(ctx) -> tuple[list, str | None]:

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -472,7 +472,11 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
             # silence, and the agent authoring the skill has no way to know
             # which names are taken. Say so, in the result the LLM reads
             # (#684).
-            for shadowed in _core_tool_names() & set(tool_names):
+            # sorted(): set iteration order for strings varies between
+            # processes (hash randomization), and this text goes into the
+            # activation result the LLM reads. Stable ordering keeps the
+            # output reproducible when a skill shadows more than one name.
+            for shadowed in sorted(_core_tool_names() & set(tool_names)):
                 result_parts.append(
                     f"\n\nNote: this skill's '{shadowed}' shadows the "
                     f"built-in tool of the same name. The skill's version "

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -344,6 +344,20 @@ async def restore_skills(ctx) -> None:
             log.error(f"Failed to restore skill '{name}': {e}")
 
 
+def _core_tool_names() -> set[str]:
+    """Names of the always-registered core tools.
+
+    Function-level import: `tools/__init__` imports this module, so a
+    module-level import would close the cycle.
+    """
+    from . import TOOL_DEFINITIONS  # noqa: PLC0415 — breaks an import cycle
+
+    return {
+        td.get("function", {}).get("name", "")
+        for td in TOOL_DEFINITIONS
+    }
+
+
 def _find_skill(discovered, name: str):
     """Return the discovered SkillInfo named `name`, or None."""
     for s in discovered:
@@ -451,6 +465,24 @@ async def activate_skill_internal(ctx, skill_info) -> str | ToolResult:
                 f"\n\nThe following tools are now available: {', '.join(tool_names)}"
             )
             log.info(f"Activated native skill '{name}' with tools: {tool_names}")
+
+            # Shadowing a core tool name is legal — execute_tool checks
+            # ctx.tools.extra before the global registry, so the skill's
+            # version really does win — but it used to happen in total
+            # silence, and the agent authoring the skill has no way to know
+            # which names are taken. Say so, in the result the LLM reads
+            # (#684).
+            for shadowed in _core_tool_names() & set(tool_names):
+                result_parts.append(
+                    f"\n\nNote: this skill's '{shadowed}' shadows the "
+                    f"built-in tool of the same name. The skill's version "
+                    f"will be used for the rest of this conversation. Rename "
+                    f"it if that wasn't intended."
+                )
+                log.warning(
+                    "Skill %r tool %r shadows a core tool of the same name.",
+                    name, shadowed,
+                )
 
             # Cache tool names for always-loaded skills so tool_registry
             # can exempt them from deferral

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1761,3 +1761,33 @@ async def test_activation_warns_when_skill_tool_shadows_core_tool(ctx):
     assert "shadower" in ctx.skills.activated, "shadowing must not block activation"
     assert "debug_context" in result
     assert "shadow" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_shadow_warnings_are_ordered_deterministically(ctx):
+    """Shadow notes go into the activation result the LLM reads, so their
+    order must not depend on set iteration — string hashing is randomized
+    per process, so an unsorted set would emit these in a different order
+    between runs."""
+    from decafclaw.tools.skill_tools import _save_permission, tool_activate_skill
+
+    _write_ws_skill(
+        ctx, "multishadow",
+        "name: multishadow\ndescription: Shadows two core tools.",
+        tools_py=(
+            "def debug_context(ctx):\n    return 'mine'\n\n"
+            "def shell(ctx):\n    return 'mine'\n\n"
+            "TOOLS = {'debug_context': debug_context, 'shell': shell}\n"
+            "TOOL_DEFINITIONS = [\n"
+            "    {'type': 'function', 'function': {'name': 'debug_context'}},\n"
+            "    {'type': 'function', 'function': {'name': 'shell'}},\n"
+            "]\n"
+        ),
+    )
+    _save_permission(ctx.config, "multishadow", "always")
+    ctx.config.discovered_skills = discover_skills(ctx.config)
+
+    result = _text(await tool_activate_skill(ctx, name="multishadow"))
+
+    # Both reported, in sorted order.
+    assert result.index("'debug_context' shadows") < result.index("'shell' shadows")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1728,3 +1728,36 @@ async def test_activate_skill_still_reports_genuinely_missing_skill(ctx):
     ctx.config.discovered_skills = []
     result = await tool_activate_skill(ctx, name="no-such-skill-anywhere")
     assert "not found" in _text(result)
+
+
+@pytest.mark.asyncio
+async def test_activation_warns_when_skill_tool_shadows_core_tool(ctx):
+    """Shadowing a core tool name is legal — execute_tool checks
+    ctx.tools.extra before the global registry, so the skill's version
+    genuinely wins — but nothing used to say a word about it. The agent that
+    hit #684 wrote a `debug_context` tool with no idea one already existed.
+
+    Inform rather than reject: the override is supported, the silence isn't.
+    """
+    from decafclaw.tools import TOOL_DEFINITIONS
+    from decafclaw.tools.skill_tools import _save_permission, tool_activate_skill
+
+    assert "debug_context" in {td["function"]["name"] for td in TOOL_DEFINITIONS}
+
+    _write_ws_skill(
+        ctx, "shadower", "name: shadower\ndescription: Shadows a core tool.",
+        tools_py=(
+            "def debug_context(ctx):\n    return 'mine'\n\n"
+            "TOOLS = {'debug_context': debug_context}\n"
+            "TOOL_DEFINITIONS = [{'type': 'function', "
+            "'function': {'name': 'debug_context'}}]\n"
+        ),
+    )
+    _save_permission(ctx.config, "shadower", "always")
+    ctx.config.discovered_skills = discover_skills(ctx.config)
+
+    result = _text(await tool_activate_skill(ctx, name="shadower"))
+
+    assert "shadower" in ctx.skills.activated, "shadowing must not block activation"
+    assert "debug_context" in result
+    assert "shadow" in result.lower()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -537,3 +537,66 @@ class TestCoreToolsDeclarePriority:
                 name = td.get("function", {}).get("name", "<unknown>")
                 invalid.append((name, prio))
         assert not invalid, f"Invalid priority values: {invalid}"
+
+
+# -- No duplicate function declarations reach the provider (#684) --------------
+#
+# Providers reject a request carrying two declarations of the same function
+# name outright (Vertex: 400 "Duplicate function declaration found: X"). That
+# failure lands at the provider call, before any tool runs, so the agent never
+# sees a tool result and can't diagnose it. The agent can also cause it
+# unaided, since it may author workspace skills and the tool names it reaches
+# for first are the ones already taken.
+
+
+def _shadow_def(name):
+    return _make_tool_def(name, description="Shadowing definition from a skill.")
+
+
+def test_collect_dedupes_skill_tool_shadowing_core_tool(ctx):
+    """The live failure: a workspace skill exporting `debug_context`, which
+    is already a core tool."""
+    from decafclaw.tool_definitions import collect_all_tool_defs
+
+    core_names = {td["function"]["name"] for td in TOOL_DEFINITIONS}
+    assert "debug_context" in core_names, "fixture assumes debug_context is core"
+
+    ctx.tools.extra_definitions.extend([_shadow_def("debug_context")])
+
+    names = [td.get("function", {}).get("name")
+             for td in collect_all_tool_defs(ctx)]
+    assert names.count("debug_context") == 1
+
+
+def test_collect_keeps_the_skill_definition_on_collision(ctx):
+    """Keep-first, and skill defs come first — so the schema the model sees
+    belongs to the same implementation `execute_tool` will dispatch to
+    (ctx.tools.extra is checked before the global registry). A keep-last
+    dedup would silently desync the two."""
+    from decafclaw.tool_definitions import collect_all_tool_defs
+
+    ctx.tools.extra_definitions.extend([_shadow_def("debug_context")])
+
+    kept = next(td for td in collect_all_tool_defs(ctx)
+                if td.get("function", {}).get("name") == "debug_context")
+    assert kept["function"]["description"] == "Shadowing definition from a skill."
+
+
+def test_collect_never_emits_duplicate_names(ctx):
+    """The general invariant, not just the one reported collision — covers
+    MCP defs and any future concatenated source."""
+    from decafclaw.tool_definitions import collect_all_tool_defs
+
+    ctx.tools.extra_definitions.extend([
+        _shadow_def("debug_context"),
+        _shadow_def("shell"),
+        _shadow_def("a_genuinely_new_tool"),
+        _shadow_def("a_genuinely_new_tool"),  # skill duplicating itself
+    ])
+
+    names = [td.get("function", {}).get("name")
+             for td in collect_all_tool_defs(ctx)]
+    dupes = {n for n in names if names.count(n) > 1}
+    assert not dupes, f"duplicate declarations would be sent to the provider: {dupes}"
+    # Deduping must not drop the tool entirely.
+    assert "a_genuinely_new_tool" in names


### PR DESCRIPTION
Closes #684.

## The failure

```
Agent turn failed: Vertex API error (400):
  "Duplicate function declaration found: debug_context"
```

The agent wrote `workspace/skills/debug-skill/tools.py` exporting a tool named `debug_context` — already a core tool (`tools/core.py:453`). On activation its definition joined `ctx.tools.extra_definitions`, and `collect_all_tool_defs` concatenated that with the core list unguarded:

```python
all_tools = list(ctx.tools.extra_definitions) + list(TOOL_DEFINITIONS)   # :93
```

Both went to Vertex; the request was rejected. Reproduced locally before fixing — one injected shadowing definition yields `total defs: 51, DUPLICATES SENT TO PROVIDER: {'debug_context'}`.

## Why it deserved more than a one-line dedup

The rejection lands at the *provider call*, before any tool executes. The agent never sees a tool result, never gets to inspect its own tool list, and the error names a symptom with no indication that a skill it wrote thirty seconds ago is the cause. From inside the conversation the model just appears to break — which is exactly how it read in the transcript.

It's also self-inflicted by design. The agent can write `workspace/skills/`, and the tool names it reaches for first (`debug_context`, `shell`, `read_file`) are the ones already taken. This will recur.

## The fix

**Dedupe by function name in `collect_all_tool_defs`, keep-first.** The tiebreak is load-bearing, not arbitrary: skill definitions are positioned first and `execute_tool` checks `ctx.tools.extra` before the global registry, so keeping the *first* declaration means the schema the model is shown belongs to the implementation that will actually run. Keep-last would leave the two silently disagreeing — a quieter bug than the crash it replaces, and harder to ever notice.

**Report the shadowing at activation.** The override stays legal, because dispatch already lets skills win and that's a defensible feature. What wasn't acceptable was doing it in total silence, leaving the author no way to discover the name was taken.

## Scope notes

- The *pre-load* path for discovered-but-unactivated skills already deduped (`:111-116`), so a colliding skill sitting on disk was harmless. Only activation detonated. That's why the deployment ran fine until the agent activated its own skill.
- MCP definitions are concatenated at `:121` with no dedup either. Namespacing makes a collision unlikely, but the third test asserts the general invariant across *all* sources rather than just the one reported pair.

## Verification

- Three tests, written failing first: the reported collision, the keep-first tiebreak, and "no duplicate names, ever."
- One test that activation warns and still activates.
- `make check` clean; `make test` 3433 passed / 2 skipped.
- `docs/skills.md` gains a "Tool names must not collide with core tools" section — the failure mode is invisible from the authoring side otherwise.

No eval added: the dedup is deterministic and unit-tested, and the activation notice is informational rather than routing-affecting. Happy to add one if you'd rather have the agent's response to the notice pinned down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)