### PR TITLE
Eval runner: assemble the system prompt (45/52 → 53/54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ data/
 evals/results/
 evals/history.jsonl
 node_modules/
+tmp/
 .playwright-mcp/
 .claude/

--- a/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/notes.md
+++ b/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/notes.md
@@ -1,0 +1,211 @@
+# Notes — #670 eval runner system-prompt fidelity
+
+## Phase 3 — targeted eval re-run (2026-07-24)
+
+Model `vertex-gemini-flash`, run in this worktree at commit `0a4073f`.
+
+### `evals/memory.yaml` — 7/8
+
+```
+[1/8] finds preference by direct term                        PASS  (2.0s, 13962 tokens, 0 tools)
+[2/8] finds preference by related term                       PASS  (2.3s, 13961 tokens, 0 tools)
+[3/8] recalls recent memories (project + style)              FAIL  (16.5s, 28005 tokens, 0 tools)
+[4/8] handles missing memories gracefully                    PASS  (2.5s, 13830 tokens, 0 tools)
+[5/8] saves memory when asked                                PASS  (4.3s, 28590 tokens, 1 tools)
+[6/8] connects related memories (event bus + async)          PASS  (2.7s, 14149 tokens, 0 tools)
+[7/8] synthesizes from multiple memories for a complex q.    PASS  (4.9s, 14115 tokens, 0 tools)
+[8/8] finds info with indirect phrasing                      PASS  (2.3s, 13972 tokens, 0 tools)
+8 tests, 7 passed, 1 failed (37.5s, 140584 tokens)
+```
+
+**Case 20 "saves memory when asked" → PASS.** This is #670's primary case.
+
+`recalls recent memories (project + style)` also fails, but it was **already
+failing in the 2026-07-24 baseline** (`evals/results/2026-07-24-1621-vertex-gemini-flash/`)
+— not a flip caused by this change. Left alone per spec.
+
+### `evals/vault.yaml` — 6/6
+
+```
+[1/6] saves user-level fact to vault journal on 'remember'   PASS  (4.3s, 28654 tokens, 1 tools)
+[2/6] reaches for vault_search on explicit search request    PASS  (7.8s, 30578 tokens, 1 tools)
+[3/6] finds specific fact under heavy distractor load        PASS  (2.3s, 13952 tokens, 0 tools)
+[4/6] reads a named vault page directly without searching    PASS  (4.1s, 30216 tokens, 1 tools)
+[5/6] reaches for vault_backlinks to find inbound links      PASS  (3.8s, 29557 tokens, 1 tools)
+[6/6] adds a section without rewriting other sections        PASS  (12.9s, 45059 tokens, 2 tools)
+6 tests, 6 passed, 0 failed (35.2s, 178016 tokens)
+```
+
+**Case 43 → PASS.** Bonus: `adds a section without rewriting other sections`
+was a baseline failure and is now green too — that is the #671-adjacent case,
+so #671 may be partly a symptom of the same missing prompt. **Not investigated
+here; worth a look when #671 is picked up.**
+
+### `make eval-tools` — the three control cases hold
+
+All three `vault_journal_append` <-> `notes_append` cases PASS in both runs,
+and the pair overlap stayed clean:
+
+```
+notes_append <-> vault_journal_append     0/1 swapped (0%)
+vault_journal_append <-> notes_append     0/2 swapped (0%)
+```
+
+### Plan checkbox that did NOT hold as written
+
+> "the four #676 failures are the *only* other failures — no new ones"
+
+**False as written, but not a regression from this change.** `tool_choice` has
+its own runner (`eval/tool_choice/runner.py`) that never imports
+`eval/runner.py`, so nothing in this PR can affect it. What the runs show is
+that **`eval-tools`' failure set is not stable run-to-run**:
+
+| run | failures | count |
+|---|---|---|
+| Les's, in #670 (2026-07-24) | workspace-write-vs-canvas, tabstack-automate, tabstack-research, vault-recent-vs-list | 4 |
+| mine, run 1 | workspace-write-vs-canvas, tabstack-automate, tabstack-research, ask-choice-vs-text, frontmatter-vs-write, no-tool-greeting | 6 |
+| mine, run 2 | canvas-vs-workspace-write, tabstack-automate, tabstack-research, ask-choice-vs-text | 4 |
+
+Summaries: 26/32 (81%) then 28/32 (88%).
+
+Only **two** cases fail in all three runs: `tabstack-automate-vs-research-form-fill`
+and `tabstack-research-vs-automate-multi-source` (both pick `web_fetch`). The
+rest move around, and several `<no_tool>` picks look like the model declining
+to act rather than misrouting.
+
+**Implication for #676:** its "4 failures" is a snapshot, not a set. #676 should
+be re-scoped to the two deterministic tabstack cases, with the rest folded into
+#650's noise-floor work. Not doing that here — out of scope — but it's the
+finding.
+
+---
+
+## Phase 4 — full-suite re-baseline (2026-07-24)
+
+| | baseline `2026-07-24-1621` | new `2026-07-24-1822` |
+|---|---|---|
+| result | **45 / 52** (86.5%) | **51 / 52** (98.1%) |
+| duration | 647.2s | 473.0s |
+| tokens | 1,308,185 | 2,272,538 (**1.74x**) |
+
+Token growth came in at 1.74x, below the 2.4x/case I extrapolated from the
+two-case probe — many cases are multi-turn or tool-heavy, so the fixed ~16.6k
+system prompt is a smaller share of their total than it is for a one-shot case.
+
+### Every baseline failure flipped green
+
+All seven. None of them were touched by this PR beyond the system prompt now
+being present.
+
+| case | baseline | new |
+|---|---|---|
+| recalls recent memories (project + style) | fail | **pass** |
+| saves memory when asked *(#670 case 20)* | fail | **pass** |
+| postmortem produces all five sections, blamelessly framed | fail | **pass** |
+| writes spec when asked | fail | **pass** |
+| dream consolidation fills page frontmatter after writing | fail | **pass** |
+| saves user-level fact to vault journal on 'remember' *(#670 case 43)* | fail | **pass** |
+| adds a section without rewriting other sections | fail | **pass** |
+
+That is the measure of how much the empty system prompt was distorting: **six
+of the seven "failures" in the 45/52 baseline were harness artifacts, not agent
+defects.** Anyone who had picked up one of those issues would have been
+debugging an agent that doesn't ship.
+
+Two of them have open issues that should now be re-checked before any work
+starts on them:
+- **#671** (`vault_section` H1-rooted paths) — "adds a section without
+  rewriting other sections" is its eval case and it now passes. #671 may be
+  wholly or partly a harness artifact. **Not investigated here.**
+- The `dream` frontmatter case likewise.
+
+### One new failure — does not reproduce
+
+| case | baseline | new |
+|---|---|---|
+| continues interviewing after first answer | pass | **fail** |
+
+`evals/project-skill.yaml:40`. Turn 1 asserts the response contains a `?`.
+Observed response:
+
+```
+Project "homepage-redesign" has been created.
+
+Please call `project_next_task()` to get your first instruction.
+```
+
+Two things wrong with that: it skipped the interview, and it instructed *the
+user* to call a tool — the phantom-instruction shape `AGENT.md`'s guardrail
+exists to prevent.
+
+**But it does not reproduce.** Re-running turn 1 in isolation, 3 reps:
+**3/3 PASS**. So this is a noise-floor case, not a regression from this change.
+Recorded, not filed — filing a 1-in-4 flake as a bug would be noise. It belongs
+to #650. Flagged to Les for the call.
+
+---
+
+## Phase 5 — Copilot caught a hole in the hermeticity claim
+
+Copilot flagged, on both the code comment and the docs, that
+`load_system_prompt` calls `discover_skills(config)` — which reads
+`config.extra_skill_paths`. Those paths live **outside `data_home`**, so the
+tmp sandbox never reached them. The "bundled tier only" claim was false.
+
+Verified and quantified rather than taken on faith:
+
+```
+extra_skill_paths = ['~/.agents/skills']        # on this machine
+tiers: Counter({'extra': 113, 'bundled': 12})
+
+WITH extra_skill_paths: 34,704 chars, 125 skills
+WITHOUT:                23,262 chars,  12 skills
+extra tier = 11,442 chars — 33% of the eval system prompt
+```
+
+So a third of every eval prompt was one developer's `~/.agents/skills`
+catalog (`gws-*`, `recipe-*`, `persona-*`, `television-*`, …). None are
+always-loaded, so no skill *bodies* leaked, but all 113 catalog entries did.
+Eval results were machine-dependent — precisely the property the design
+decision claimed to deliver.
+
+**Fix:** `_build_test_config` now clears `extra_skill_paths` alongside the
+`data_home` / `agent.id` sandbox, applied last so `config_overrides` can't
+opt back in. Three new tests cover it, including an end-to-end assertion that
+every discovered skill is `trust_tier == "bundled"`.
+
+### Re-baseline under the hermetic config
+
+| | baseline `1621` | with extra skills `1822` | hermetic `2323` |
+|---|---|---|---|
+| result | 45 / 52 (86.5%) | 51 / 52 (98.1%) | **53 / 54 (98.1%)** |
+| tokens | 1,308,185 | 2,272,538 | 2,235,913 |
+
+54 cases, not 52 — the rebase onto current `main` brought in two new ones
+(`nudge_does_not_read_as_user_correction` from #681, `fixes a wrong-shaped
+TOOLS export` from #677). Both pass.
+
+Token total barely moved despite the 33% smaller prompt: fewer catalog
+entries, but several cases spent more tool calls.
+
+**`continues interviewing after first answer` passes here**, confirming the
+earlier read that it was noise rather than a regression.
+
+**One failure: `uses workspace_move for a rename`.** Also flaky — re-running
+it 4 times gives **3/4 PASS**. The failure mode is the agent reaching for a
+vault tool on a path-shaped rename and giving up on the error:
+
+```
+[error: vault page 'drafts/old-name.md' not found]
+I wasn't able to rename `drafts/old-name.md` because it doesn't seem to exist.
+```
+
+That is a `vault_*` vs `workspace_*` disambiguation wobble, which is #683 /
+#650 territory. Recorded, not fixed.
+
+### Note on `evals/history.jsonl`
+
+The trend table now carries seven short probe runs from this session
+(`1734`–`1819`, 2–20 cases each) interleaved with the real 52-case runs. The
+file is gitignored so this stays local, but `make eval-history` output is noisy
+until those age out.

--- a/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/plan.md
+++ b/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/plan.md
@@ -1,0 +1,379 @@
+# Eval runner system-prompt fidelity — Implementation Plan
+
+**Goal:** Make the full-agent eval harness assemble the production system prompt
+(it has been running every case with an empty one), guard the invariant with a
+unit test, document it, and re-baseline the suite.
+
+**Approach:** Assemble inside `run_test` *after* `_build_test_config` applies the
+`data_home=tmp` / `id="eval"` sandbox, so the prompt resolves to bundled
+SOUL.md / AGENT.md / skill catalog / always-loaded skill bodies with no
+per-agent overrides — reproducible across machines. Mirror
+`src/decafclaw/__init__.py:47-50`. No tool-description changes: routing measured
+20/20 correct once the prompt is present.
+
+**Tech stack:** Python 3.13, pytest + pytest-asyncio, `uv run`.
+
+**Working directory for every command below:**
+`/Users/lorchard/devel/decafclaw/.claude/worktrees/670-notes-vs-vault-harness-fidelity`
+Use an absolute `cd` in each verification command — a stray `cd` to the main
+clone makes `make test` report a wrong-tree pass count and `pytest <newfile>`
+say "no tests ran", both of which look like success.
+
+**Baseline for comparison:** `make test` in this worktree = **3417 passed,
+2 skipped** (recorded at session start).
+
+---
+
+## Phase 1: Assemble the system prompt in `run_test`, guarded by a test
+
+Delivers the fix itself: every eval turn sees the same system prompt production
+builds, and a unit test fails if the assembly is ever dropped again. No LLM
+calls in the test.
+
+**Files:**
+- Create: `tests/test_eval_system_prompt.py`
+- Modify: `src/decafclaw/eval/runner.py` — assemble the prompt at the top of
+  `run_test`; split the `skill_tool_owners` build out from under the
+  `discovered_skills` guard.
+
+**Key changes:**
+
+`src/decafclaw/eval/runner.py` — add the module-level import alongside the
+existing ones (line 17 area; `tool_choice/runner.py:17` imports `prompts` at
+module level, so there's no cycle):
+
+```python
+from ..prompts import load_system_prompt
+```
+
+Then replace the existing block at the top of `run_test` (currently
+`runner.py:666-670`):
+
+```python
+    # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
+    if not config.discovered_skills:
+        from ..skills import build_skill_tool_owners
+        config.discovered_skills = _discover_skills_fn(config)
+        config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
+```
+
+with:
+
+```python
+    # Assemble the system prompt exactly as __init__.py:49 does at startup.
+    # Without this, config.system_prompt stays "" (config.py:555 only reads a
+    # SYSTEM_PROMPT env var) and ContextComposer._compose_system_prompt emits a
+    # zero-length system message — no SOUL.md, no AGENT.md, no skill catalog,
+    # no always-loaded skill bodies. Every eval case ran that way until #670.
+    #
+    # Deliberately after _build_test_config's sandbox: load_system_prompt reads
+    # per-agent overrides from config.agent_path, which now points at the tmp
+    # data_home, so this resolves to the bundled tier only. Eval results stay
+    # reproducible instead of tracking whatever is in data/{agent_id}/.
+    if not config.system_prompt:
+        config.system_prompt, config.discovered_skills = load_system_prompt(config)
+
+    # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
+    if not config.discovered_skills:
+        config.discovered_skills = _discover_skills_fn(config)
+    # Separate guard: load_system_prompt populates discovered_skills as a side
+    # effect, so folding this into the branch above would skip it and silently
+    # break command dispatch.
+    if not config.skill_tool_owners:
+        from ..skills import build_skill_tool_owners
+        config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
+```
+
+`tests/test_eval_system_prompt.py` — new. Patches `run_agent_turn` at the seam
+so no model is called; captures the config the turn actually ran with:
+
+```python
+"""The full-agent eval runner must assemble a real system prompt (#670).
+
+Before this guard, ``config.system_prompt`` was only ever set by
+``decafclaw/__init__.py:49`` (the app entry point). The eval CLI calls
+``load_config()`` + ``run_eval()`` directly, so every eval turn ran with a
+zero-length system message: no SOUL.md, no AGENT.md, no <skill_catalog>, and
+no always-loaded skill bodies. Measured effect on tool routing was 1/15 vs
+10/10 — see docs/dev-sessions/2026-07-24-1728-670-*/research.md.
+
+No LLM calls: ``run_agent_turn`` is patched at the seam.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from decafclaw.config import Config
+from decafclaw.eval.runner import _build_test_config, run_test
+from decafclaw.media import ToolResult
+
+
+@pytest.fixture
+def captured_turn():
+    """Patch run_agent_turn; record the ctx it was handed."""
+    seen = {}
+
+    async def _fake_turn(ctx, user_message, history, *args, **kwargs):
+        seen["ctx"] = ctx
+        seen["config"] = ctx.config
+        history.append({"role": "assistant", "content": "ok"})
+        return ToolResult(text="ok")
+
+    with patch("decafclaw.eval.runner.run_agent_turn", _fake_turn):
+        yield seen
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_is_assembled_before_the_turn(tmp_path, captured_turn):
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    assert config.system_prompt == "", "precondition: starts empty"
+
+    await run_test(config, {"name": "t", "input": "hello"})
+
+    prompt = captured_turn["config"].system_prompt
+    assert prompt, "eval turn ran with an empty system prompt (#670)"
+
+
+@pytest.mark.asyncio
+async def test_prompt_carries_the_sections_production_gets(tmp_path, captured_turn):
+    """Non-empty isn't enough — the always-loaded skill bodies are the part
+    #670 turned on, so assert the sections individually."""
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    await run_test(config, {"name": "t", "input": "hello"})
+    prompt = captured_turn["config"].system_prompt
+
+    assert "<skill_catalog>" in prompt
+    assert "<loaded_skills>" in prompt
+    # The vault skill is always-loaded and its body is what documents
+    # vault_journal_append — the specific gap #670 surfaced.
+    assert '<skill name="vault">' in prompt
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_owners_still_populated(tmp_path, captured_turn):
+    """load_system_prompt also returns discovered_skills, which would skip the
+    `if not config.discovered_skills` branch and leave skill_tool_owners empty —
+    silently breaking /foo command dispatch in evals."""
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    await run_test(config, {"name": "t", "input": "hello"})
+
+    ran_with = captured_turn["config"]
+    assert ran_with.discovered_skills
+    assert ran_with.skill_tool_owners
+```
+
+**Order of work (TDD):**
+1. Write `tests/test_eval_system_prompt.py`. Run it. It MUST fail on the first
+   assertion with an empty prompt — that is the reproduction.
+2. Apply the `runner.py` change.
+3. Re-run; all three pass.
+
+**Verification — automated:**
+- [x] `cd <worktree> && uv run pytest tests/test_eval_system_prompt.py -v` fails
+      *before* the runner.py edit, with `eval turn ran with an empty system prompt`
+      — **2 failed, 1 passed**; failure was `AssertionError: ... assert ''`
+- [x] `cd <worktree> && uv run pytest tests/test_eval_system_prompt.py -v` passes
+      after it (3 passed) — **3 passed in 1.24s**
+- [x] `cd <worktree> && make test` passes, count >= 3420 (baseline 3417 + 3 new)
+      — **3420 passed, 2 skipped in 13.00s**
+- [x] `cd <worktree> && make check` passes — **exit 0**; ruff "All checks passed",
+      pyright "0 errors, 0 warnings", tsc clean, message-types drift check clean
+- [x] `cd <worktree> && uv run pytest tests/test_eval_system_prompt.py --durations=5`
+      — no test above ~2s (discovery + file reads only; anything slower means a
+      real scheduler or model call leaked in) — **slowest call 0.04s**
+
+**Verification — manual:**
+- [ ] `git diff src/decafclaw/eval/runner.py` touches only the `run_test` prologue
+      and the new import — no other behavior changed
+- [ ] The import is at module level, not inside the function (CLAUDE.md: stdlib
+      and non-cycle imports at module level)
+
+---
+
+## Phase 2: Document which system prompt each harness uses
+
+Delivers the doc half of the same change, per CLAUDE.md's "update the `docs/`
+page as part of the same PR."
+
+**TDD opt-out:** doc-only, no behavior. No test.
+
+**Files:**
+- Modify: `docs/eval-loop.md` — state the full-agent runner's system prompt in
+  the main eval-loop section, and keep the tool_choice "How it works" step 2
+  (`docs/eval-loop.md:246`) consistent with it.
+
+**Key changes:**
+
+`docs/eval-loop.md:246` currently reads, under tool_choice's "How it works":
+
+> 2. Sends one chat completion with the production system prompt + the case's
+>    user message + the full tool schema.
+
+Add a short subsection to the main (full-agent) eval-loop section stating:
+
+- The full-agent runner assembles the system prompt in `run_test` via
+  `load_system_prompt(config)`, after the per-case `data_home` sandbox is
+  applied.
+- That means the **bundled** tier: bundled SOUL.md + AGENT.md, the skill
+  catalog, and always-loaded skill bodies. Per-agent overrides under
+  `data/{agent_id}/` (including USER.md) are deliberately NOT picked up, so
+  results are reproducible across machines.
+- Note the history discontinuity: runs before 2026-07-24 were measured with an
+  empty system prompt (#670) and are not comparable to later ones.
+
+**Verification — automated:**
+- [x] `cd <worktree> && make check` passes — **exit 0**
+- [x] `cd <worktree> && grep -n "load_system_prompt" docs/eval-loop.md` returns a hit
+      — **2 hits** (new `## System prompt` section at :22, tool_choice step 2 at :269)
+
+**Adaptation (in scope, flagged):** `docs/eval-loop.md` claimed
+`evals/history.jsonl` was "committed to git, unlike the gitignored detail
+bundles". It has been gitignored since #606 (`git ls-files evals/history.jsonl`
+→ 0). Corrected, because the new history-discontinuity note sits in the same
+section and would otherwise contradict it.
+
+**Verification — manual:**
+- [ ] Les reads the new subsection — it says which tier is used and why, not
+      just that a prompt exists
+- [ ] The tool_choice step-2 line and the new subsection don't contradict each other
+
+---
+
+## Phase 3: Confirm #670 is closed — targeted eval re-run
+
+Delivers evidence that the two reported cases actually pass, and that the three
+control cases in `core_overlaps.yaml` are untouched.
+
+**TDD opt-out:** verification phase against real LLM calls; no code changes.
+
+**Files:**
+- Modify: `docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/notes.md`
+  — record the results.
+
+**Commands:**
+
+```bash
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/670-notes-vs-vault-harness-fidelity
+uv run python -m decafclaw.eval evals/memory.yaml    # case 20 lives here
+uv run python -m decafclaw.eval evals/vault.yaml     # case 43 lives here
+make eval-tools                                      # the 3 control cases
+```
+
+Expected: `saves memory when asked` and `saves user-level fact to vault journal
+on 'remember'` both PASS. `make eval-tools` still shows
+`vault_journal_append <-> notes_append  0/N swapped (0%)` and the four known
+unrelated failures (#676) — those are out of scope and must NOT be fixed here.
+
+Note `evals/results/` and `evals/history.jsonl` are both gitignored, so the run
+bundles stay local; `notes.md` is the committed record.
+
+**Verification — automated:**
+- [x] `evals/memory.yaml`: "saves memory when asked" = **PASS** (file 7/8; the
+      one failure, `recalls recent memories`, was already failing in the
+      2026-07-24 baseline)
+- [x] `evals/vault.yaml`: "saves user-level fact to vault journal on 'remember'"
+      = **PASS** (file **6/6** — `adds a section without rewriting other
+      sections` was a baseline failure and is now green too)
+- [x] `make eval-tools`: `vault-vs-notes-remember-preference`,
+      `vault-vs-notes-save-profile-fact`, `notes-vs-vault-follow-up-this-thread`
+      all **PASS**, in both runs; pair overlap 0/1 and 0/2 swapped (0%)
+- [!] `make eval-tools`: the four #676 failures are the *only* other failures —
+      no new ones — **DOES NOT HOLD AS WRITTEN.** Not a regression: `tool_choice`
+      has its own runner that never imports `eval/runner.py`, so this PR cannot
+      affect it. The real finding is that eval-tools' failure *set* is unstable
+      run-to-run (4 / 6 / 4 failures across three runs, only the two tabstack
+      cases constant). See `notes.md` for the table. Implication for #676 is
+      recorded there; not acted on here.
+
+**Verification — manual:**
+- [ ] `notes.md` records pass/fail per case with the actual output pasted, not
+      a summary
+
+---
+
+## Phase 4: Full-suite re-baseline and flip table
+
+Delivers the new baseline. The 45/52 entry in `evals/history.jsonl` was measured
+against an agent with no system prompt, so without this the trend line is
+silently discontinuous and #650 starts from a bad anchor.
+
+**TDD opt-out:** measurement phase; no code changes.
+
+**Files:**
+- Modify: `docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/notes.md`
+  — the flip table.
+
+**Commands:**
+
+```bash
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/670-notes-vs-vault-harness-fidelity
+make eval          # ~11 min; expect ~3M tokens, up from ~1.3M (2.4x/case)
+make eval-history  # trend table including the new run
+```
+
+Then diff against the pre-fix bundle at
+`evals/results/2026-07-24-1621-vertex-gemini-flash/` and write a table into
+`notes.md`:
+
+| case | before (45/52 run) | after | direction |
+|---|---|---|---|
+
+**Scope discipline — this is the phase most likely to sprawl.** Per spec, any
+newly-failing case gets *recorded and filed*, not fixed. Cases that were passing
+against a promptless agent and now fail are measuring the real agent for the
+first time; a total lower than 45/52 is an acceptable outcome. Do not touch tool
+descriptions, prompts, or eval YAML to chase green.
+
+**Verification — automated:**
+- [x] `make eval` completes; new bundle exists under `evals/results/` —
+      **`evals/results/2026-07-24-1822-vertex-gemini-flash/`, 51/52**
+- [x] `make eval-history` shows the new run appended — **`2026-07-24-1822 …
+      51 / 52  98.1%  473s  2.27M`**
+- [x] Token count for the run is materially above the 1.3M pre-fix figure
+      (sanity check that the prompt is actually being sent) —
+      **1,308,185 → 2,272,538 (1.74x)**
+
+**Verification — manual:**
+- [ ] `notes.md` flip table lists every case that changed direction, both ways
+- [ ] Each newly-failing case is either filed as an issue or explicitly noted as
+      "expected under the real prompt" with a reason
+- [ ] Les reviews the flip table before the PR opens — this is the judgment call
+      the re-baseline exists to surface
+
+---
+
+## Plan self-review
+
+**Spec coverage:**
+
+| spec "Desired end state" item | phase |
+|---|---|
+| 1. `run_test` assembles the prompt (bundled tier) | 1 |
+| 2. Unit test guards the assembly, no LLM calls | 1 |
+| 3. `docs/eval-loop.md` states each harness's prompt | 2 |
+| 4. memory.yaml case 20 + vault.yaml case 43 pass | 3 |
+| 5. Fresh baseline + flip table in `notes.md` | 4 |
+
+Spec design decisions all land: hermetic assembly point (Phase 1 comment +
+placement), `skill_tool_owners` guard (Phase 1, its own test), no description
+changes (absent from every phase, and called out in Phase 3/4 scope notes),
+full re-baseline (Phase 4), guard test patches `run_agent_turn` (Phase 1).
+
+**Placeholder scan:** no TBD/TODO. Every test is written out; every command is
+literal and absolutely-pathed.
+
+**Type consistency:** `load_system_prompt(config) -> (prompt_text, skills)`
+matches `prompts/__init__.py:36,124`. `run_agent_turn(ctx, user_message,
+history, archive_text="", attachments=None) -> ToolResult` matches
+`agent.py:1148-1150`; the fake's `*args, **kwargs` tail absorbs the optional
+params. `ToolResult` is defined at `media.py:69` and imported into `agent.py:33`
+from there — the test imports `from decafclaw.media import ToolResult`, not from
+`tool_execution`. `_build_test_config(config, test_case, tmp)` matches `runner.py:617`.
+`run_test(config, test_case)` matches `runner.py:656`. Assertion strings
+`<skill_catalog>` / `<loaded_skills>` / `<skill name="vault">` match
+`prompts/__init__.py:88,115,109` and the vault skill's frontmatter `name: vault`.
+
+**Known risk, accepted:** the Phase 1 tests run real skill discovery and read
+the bundled prompt files. That is file I/O, not a scheduler or a model — the
+`--durations=5` check is there to catch it if something heavier leaks in.

--- a/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/research.md
+++ b/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/research.md
@@ -1,0 +1,138 @@
+# Research — #670 harness disagreement
+
+All numbers below were measured in this worktree on 2026-07-24 against
+`vertex-gemini-flash`. Nothing here is inferred from reading alone unless
+explicitly marked "source-level".
+
+## Answer: the full-agent eval runner runs with an EMPTY system prompt
+
+`config.system_prompt` is assembled exactly once in the codebase —
+`src/decafclaw/__init__.py:49`, the app entry point:
+
+```python
+config.system_prompt, config.discovered_skills = load_system_prompt(config)
+```
+
+The eval CLI (`src/decafclaw/eval/__main__.py`) calls `load_config()` and
+`run_eval()` directly. It never goes through `__init__.py:main()`.
+`config.py:555` only reads `system_prompt` from a `SYSTEM_PROMPT` env var
+(default `""`).
+
+Source-level proof that the eval package never assembles it:
+
+```
+$ grep -rn "load_system_prompt\|system_prompt" src/decafclaw/eval/
+src/decafclaw/eval/tool_choice/runner.py:17:from ...prompts import load_system_prompt
+src/decafclaw/eval/tool_choice/runner.py:70:    system_prompt, _ = load_system_prompt(config)
+src/decafclaw/eval/tool_choice/runner.py:72:        {"role": "system", "content": system_prompt},
+```
+
+Only `tool_choice` builds one. The full-agent runner does not.
+
+`ContextComposer._compose_system_prompt` (`context_composer.py:582-589`) reads
+`config.system_prompt` verbatim, so an unset value emits a **zero-length
+system message**. Confirmed by direct probe of `compose()` under an
+eval-shaped config (`tmp/probe_loadout.py`):
+
+```
+--- role='system'  len=0
+--- role='system'  len=3173     <- <deferred_tools> block
+--- role='user'    len=88
+--- role='system'  len=51       <- [Context: ~9,192 / 100,000 tokens (9%)]
+```
+
+So every full-agent eval turn has been running without SOUL.md, AGENT.md,
+USER.md, the skill catalog, **or the always-loaded skill bodies — including
+the vault SKILL.md** that documents when to journal.
+
+`load_system_prompt` docstring (`prompts/__init__.py:37-46`) lists exactly
+what's missing.
+
+## This inverts hypothesis 1
+
+The issue's leading hypothesis was that `tool_choice` under-reports because
+it can't reproduce the always-loaded / auto-injected `notes_append` context.
+Measured, it's the other way round: **`tool_choice` is the higher-fidelity
+harness on this axis** — it uses the production system prompt
+(`tool_choice/runner.py:70`), and the full-agent runner is the one missing it.
+
+`docs/eval-loop.md:246` already documents tool_choice as using "the production
+system prompt." Nothing documents that the full-agent runner doesn't.
+
+## Measurements
+
+### Baseline — full agent, as shipped (empty system prompt)
+
+`tmp/crossing.yaml`, 2x2 crossing, 5 reps/cell, `expect_tool: vault_journal_append`:
+
+| prompt | no trailing clause | + "Confirm what you saved." |
+|---|---|---|
+| "…my favorite programming language is Python." | **1/5** | **0/5** |
+| "…my dog's name is Luna and she's a border collie mix." | **5/5** | **4/5** |
+
+Plus an earlier 5-rep run of the verbatim case-20 input: **0/5**.
+Case-20 prompt overall: **1/15**. Case-43 prompt overall: **13/15**.
+
+### Same 20 cases, system prompt assembled (probe patch)
+
+**20/20 passed.** Prompt tokens per case: 11.9k → 28.6k (the ~16.6k system
+prompt appearing). Every cell went green, including the 1/5 cell.
+
+### tool_choice, same two sentences, 5 reps each
+
+**10/10 passed.** `vault_journal_append <-> notes_append 0/10 swapped (0%)`.
+The tool_choice PASS is robust, not a lucky sample.
+
+## Hypotheses, resolved
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| 1 | notes auto-injection / always-loaded availability | **Ruled out as the cause; inverted** | Probe shows no `conversation_notes` message at all (fresh tmp workspace → empty notes.md). Both tools are *active* in both harnesses. tool_choice is the more faithful harness here, not the less. |
+| 2 | Loadout differences | **Real, but not the cause** | agent-active = 40 tools + a 3,173-char `<deferred_tools>` prose listing + `tool_search`; tool_choice = 97 tools, all callable, no deferral, no `tool_search`. 58 tools are callable in tool_choice but only prose-listed for the agent. Both `notes_append` and `vault_journal_append` are **active in both**, so nothing flipped here. |
+| 3 | System prompt / AGENT.md nudging toward the scratchpad | **Inverted — the prompt is absent, not misleading** | `grep -rn "notes_append\|scratchpad" src/decafclaw/prompts/` → no hits. The problem is the prompt is missing entirely. |
+| 4 | The trailing "Confirm what you saved." | **Ruled out** | Crossing above: 1/5 → 0/5 and 5/5 → 4/5. Both within noise. Content drives the split, not the clause. |
+| 5 | Reflection retries | **Ruled out** | `reflection.enabled: false`, 3 reps: **0/3**, still `notes_append`, 1 tool call each. |
+
+## Why case 43 looked deterministic in the baseline bundle
+
+It isn't. Measured 13/15 (~87%) under the broken condition — it happened to
+fail in the 2026-07-24 bundle. The issue's "two independent cases failed
+identically, so this is not a one-off" holds for case 20 (0/15) but not
+case 43. Case 43 is a noise-floor case — relevant to #650.
+
+Under the fixed condition both are 10/10.
+
+## Blast radius of the candidate fix
+
+Enabling the system prompt changes **every** full-agent eval case, not just
+these two:
+
+- Prompt tokens/case: 11.9k → 28.6k (**~2.4x**). Extrapolating the 52-case
+  suite: ~1.3M → ~3M tokens/run.
+- The 45/52 baseline was measured against an agent with no system prompt —
+  i.e. not the agent that ships. Cases currently passing were implicitly
+  calibrated against that agent and some may flip in either direction.
+- Unmeasured. Establishing the new baseline needs one full `make eval` run.
+
+## Related facts
+
+- No unit test asserts `config.system_prompt` is populated in `run_test`.
+  Existing eval tests (`tests/test_eval_*.py`) cover assertions, overrides,
+  history, and the tool_choice loadout — none cover prompt assembly.
+- `run_test` populates `config.discovered_skills` (runner.py:667-670) but
+  not `config.system_prompt` — the adjacent gap.
+- `load_system_prompt(config)` under an eval config reads from the sandboxed
+  tmp `data_home`, so it resolves to **bundled** SOUL.md / AGENT.md with no
+  per-agent overrides. That's the hermetic behavior a test harness wants.
+- `load_system_prompt` also returns `discovered_skills`, so wiring it in has
+  to keep `config.skill_tool_owners` built (the current `if not
+  config.discovered_skills:` block would otherwise be skipped).
+
+## Files
+
+- `src/decafclaw/eval/runner.py:666-670` — where the gap is
+- `src/decafclaw/__init__.py:47-50` — the production assembly it should mirror
+- `src/decafclaw/eval/tool_choice/runner.py:70` — how tool_choice does it
+- `src/decafclaw/context_composer.py:582-596` — `_compose_system_prompt`
+- `src/decafclaw/prompts/__init__.py:36-53` — what the prompt contains
+- `docs/eval-loop.md:246` — documents tool_choice's prompt; silent on the runner

--- a/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/spec.md
+++ b/docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/spec.md
@@ -1,0 +1,136 @@
+# Eval runner system-prompt fidelity Spec
+
+**Goal:** Make the full-agent eval harness run the agent that actually ships —
+it has been running every case with an empty system prompt — and re-establish
+the suite baseline against it.
+
+**Source:** [#670](https://github.com/lmorchard/decafclaw/issues/670)
+(use the 2026-07-24 correction comment; the body's "sharpen the descriptions"
+diagnosis is retracted and is measurably wrong — see Design decisions).
+
+## Current state
+
+`config.system_prompt` is assembled in exactly one place —
+`src/decafclaw/__init__.py:49`, the app entry point. The eval CLI
+(`src/decafclaw/eval/__main__.py`) calls `load_config()` and `run_eval()`
+directly and never goes through it, and `config.py:555` only reads the field
+from a `SYSTEM_PROMPT` env var (default `""`).
+
+`ContextComposer._compose_system_prompt` (`context_composer.py:582-589`) reads
+`config.system_prompt` verbatim, so the eval agent gets a **zero-length system
+message**: no SOUL.md, no AGENT.md, no `<skill_catalog>`, and no always-loaded
+skill bodies — including the vault SKILL.md that documents when to journal.
+
+`tool_choice` does not share the gap: it calls `load_system_prompt(config)`
+directly (`eval/tool_choice/runner.py:70`). That is the entire disagreement in
+#670 — and it **inverts** the issue's leading hypothesis. `tool_choice` is the
+*higher*-fidelity harness here; the full-agent runner is the broken one.
+
+Measured (see `research.md` for the full tables, all `vertex-gemini-flash`):
+
+| condition | case-20 prompt | case-43 prompt |
+|---|---|---|
+| as shipped (empty prompt) | **1/15** | **13/15** |
+| system prompt assembled | **10/10** | **10/10** |
+| `tool_choice` | **5/5** | **5/5** |
+
+Hypotheses 4 (trailing clause) and 5 (reflection retries) were ruled out by
+measurement, not reasoning: a 2x2 crossing moved 1/5 → 0/5 and 5/5 → 4/5
+(noise), and `reflection.enabled: false` still gave 0/3.
+
+## Desired end state
+
+1. `run_test` assembles the system prompt before running a turn, so eval turns
+   see the same system prompt production does (bundled tier).
+2. A unit test fails if that assembly is ever dropped again — no LLM calls.
+3. `docs/eval-loop.md` states what system prompt each harness uses.
+4. `evals/memory.yaml` case 20 and `evals/vault.yaml` case 43 pass.
+5. A fresh full-suite baseline bundle exists under `evals/results/`, and
+   `notes.md` records which cases flipped in each direction relative to the
+   2026-07-24 45/52 run.
+
+## Design decisions
+
+- **Decision:** Assemble inside `run_test`, after `_build_test_config` has
+  applied the `data_home=tmp` / `id="eval"` sandbox.
+  - **Why:** `load_system_prompt` reads per-agent overrides from
+    `config.agent_path`. Sandboxed, it resolves to bundled SOUL.md / AGENT.md
+    with no `data/{agent_id}` overrides and no USER.md — so eval results are
+    reproducible across machines and don't shift when the deployed agent's
+    AGENT.md is edited.
+  - **Rejected:** assembling in `eval/__main__.py` against the un-sandboxed
+    config. Higher fidelity to Les's *particular* deployed agent, but makes
+    every eval number machine-dependent.
+
+- **Decision:** Do not touch `notes_append` or `vault_journal_append`
+  descriptions.
+  - **Why:** With the prompt in place, routing is 20/20 correct. There is no
+    description defect to fix. Rewording would be tuning against a symptom and
+    risks the three `tool_choice` cases that must stay passing.
+  - **Rejected:** the fix proposed in the issue body (steps 1 and 2 of it).
+    Step 2 ("add the missing `tool_choice` case") is already done —
+    `evals/tool_choice/core_overlaps.yaml:97-126` has three.
+
+- **Decision:** Keep `load_system_prompt`'s `discovered_skills` return wired
+  in, and build `skill_tool_owners` under its own guard.
+  - **Why:** `load_system_prompt` populates `discovered_skills` as a side
+    effect. Left as-is, the existing `if not config.discovered_skills:` block
+    is skipped and `config.skill_tool_owners` never gets built, silently
+    breaking `/foo` command dispatch in evals. Hit during the probe.
+  - **Rejected:** discarding the returned skills and re-discovering — wasteful
+    and lets the two views drift.
+
+- **Decision:** Run one full `make eval` to re-baseline within this PR.
+  - **Why:** the fix moves ~2.4x tokens/case (11.9k → 28.6k) and changes the
+    inputs to every case. The 45/52 entry in `evals/history.jsonl` was measured
+    against an agent that doesn't ship; without a new bundle the trend line is
+    silently discontinuous and #650's noise-floor work starts from a bad
+    anchor.
+  - **Rejected:** deferring to #650 (leaves the discontinuity) and re-running
+    only memory+vault (confirms the issue closed but hides what flipped).
+
+- **Decision:** Guard test patches `run_agent_turn` rather than calling an LLM.
+  - **Why:** the invariant is "`config.system_prompt` is non-empty by the time
+    a turn runs" — observable at the seam, no model needed. Keeps it in the
+    default `make test` run.
+
+## Patterns to follow
+
+- **The assembly itself:** mirror `src/decafclaw/__init__.py:47-50` —
+  `config.system_prompt, config.discovered_skills = load_system_prompt(config)`.
+- **Where it goes:** `src/decafclaw/eval/runner.py:666-670`, the existing
+  `discovered_skills` population block at the top of `run_test`, which is the
+  adjacent gap.
+- **How tool_choice does it:** `src/decafclaw/eval/tool_choice/runner.py:17,70`
+  — module-level `from ...prompts import load_system_prompt`, called per run.
+- **Test style:** the existing eval-runner tests
+  (`tests/test_eval_runner_assertions.py`, `tests/test_eval_setup_overrides.py`)
+  for fixture and patching conventions.
+- **Docs:** `docs/eval-loop.md:246` already documents tool_choice's system
+  prompt; extend that section rather than starting a new one.
+
+## What we're NOT doing
+
+- **Not rewording `notes_append` / `vault_journal_append` descriptions.**
+  Measured unnecessary. This is the single biggest scope hazard in the issue.
+- **Not modifying `evals/tool_choice/core_overlaps.yaml:97-126.`** Those three
+  cases must stay passing, unchanged, as the control.
+- **Not changing `evals/memory.yaml` case 20 or `evals/vault.yaml` case 43.**
+  Both pass once the harness is fixed; the eval cases were right.
+- **Not fixing the tool_choice loadout gap** (97 callable tools vs the agent's
+  40 active + 58 prose-listed behind `tool_search`). Real, measured, and did
+  NOT cause this. Files as a follow-up issue with the numbers.
+- **Not #676** (the 4 other `eval-tools` failures), **#671**, **#673**, or
+  **#650**.
+- **Not chasing whatever the full re-baseline turns up.** New failures get
+  recorded in `notes.md` and filed as issues; they are not fixed here.
+- **Not adding a config knob** to toggle the eval system prompt. The empty
+  prompt has no defensible use case.
+
+## Open questions
+
+- **Will the re-baseline surface regressions in currently-passing cases?**
+  Unmeasured until the run. **Default:** record the deltas in `notes.md`, file
+  anything that looks like a real behavior bug as a separate issue, and do not
+  fix them in this PR. A lower total than 45/52 is an acceptable outcome if the
+  cases are now measuring the real agent — that is the point of the change.

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -16,6 +16,45 @@ uv run python -m decafclaw.eval --history            # Print history table, no r
 uv run python -m decafclaw.eval --history --history-limit 5  # Last 5 runs only
 ```
 
+## System prompt
+
+Eval turns run with a real system prompt, assembled in `run_test` via
+`load_system_prompt(config)` — the same call `decafclaw/__init__.py` makes at
+startup.
+
+Assembly happens **after** the per-case sandbox is applied, and the sandbox
+clears two separate sources of machine-local state so the result is the
+**bundled tier only** — bundled `SOUL.md` + `AGENT.md`, the `<skill_catalog>`,
+and the bodies of always-loaded bundled skills:
+
+| sandbox field | what it excludes |
+|---|---|
+| `agent.data_home` → tmp | per-agent prompt overrides under `data/{agent_id}/`, including `USER.md` |
+| `extra_skill_paths` → `[]` | skills from configured external dirs (e.g. `~/.agents/skills`) |
+
+The second one is easy to miss: `load_system_prompt` calls `discover_skills`,
+and `extra_skill_paths` entries live *outside* `data_home`, so the tmp
+redirect alone doesn't reach them. Left populated, a developer's personal
+skills land in the `<skill_catalog>` of every eval prompt — measured at 113
+extra skills against 12 bundled, a third of the prompt text
+([#670](https://github.com/lmorchard/decafclaw/issues/670)).
+
+Both are applied last in `_build_test_config`, so a case's
+`setup.config_overrides` cannot opt itself back into either.
+
+Net effect: eval results are reproducible across machines and in CI instead of
+drifting with local agent state.
+
+The tool-choice eval assembles the same prompt (see
+[How it works](#how-it-works) below), so the two harnesses agree on this axis.
+
+> **History discontinuity.** Runs before 2026-07-24 were measured with an
+> **empty** system prompt — the eval CLI never went through the startup path
+> that assembles it, so every case ran without SOUL.md, AGENT.md, the skill
+> catalog, or any always-loaded skill body ([#670](https://github.com/lmorchard/decafclaw/issues/670)).
+> Pass rates from before that date are not comparable to later ones, and cost
+> per case roughly doubled once the prompt was actually being sent.
+
 ## Test case format
 
 Tests are YAML files with a list of test cases. Single-turn form:
@@ -195,7 +234,7 @@ evals/results/
 
 ## Pass-rate history
 
-After each `make eval` run, a one-line summary is appended to `evals/history.jsonl` (committed to git, unlike the gitignored detail bundles in `evals/results/`). The record includes timestamp, model, total / passed / failed counts, pass-rate, duration, total tokens, and per-file pass/total breakdown.
+After each `make eval` run, a one-line summary is appended to `evals/history.jsonl`. Both it and the detail bundles in `evals/results/` are gitignored, so the trend lives on whichever machine ran the suite. The record includes timestamp, model, total / passed / failed counts, pass-rate, duration, total tokens, and per-file pass/total breakdown.
 
 View the trend with `make eval-history`:
 
@@ -243,7 +282,7 @@ uv run python -m decafclaw.eval.tool_choice evals/tool_choice/ --include-mcp  # 
 For each YAML case, the runner:
 
 1. Builds the **fully-loaded** tool schema (every core tool + every discovered skill's `tools.py` exports; MCP off by default). No deferral, no activation gating — the eval measures description overlap under fair conditions.
-2. Sends one chat completion with the production system prompt + the case's user message + the full tool schema.
+2. Sends one chat completion with the system prompt + the case's user message + the full tool schema. Same `load_system_prompt(config)` assembly the full-agent runner uses (see [System prompt](#system-prompt)).
 3. Captures the first tool name from `tool_calls` (or `<no_tool>` if the model emits text only). No tool execution, no agent loop iteration — the overlap signal we care about lives in the *first* decision.
 4. Aggregates results into a per-pair overlap report: for each declared `(expected, near_miss)` pair, what fraction of cases swapped to the near-miss?
 

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -14,6 +14,8 @@ from ..config import Config
 from ..context import Context
 from ..conversation_manager import ConversationManager
 from ..events import EventBus
+from ..prompts import load_system_prompt
+from ..skills import build_skill_tool_owners
 from ..skills import discover_skills as _discover_skills_fn
 
 log = logging.getLogger(__name__)
@@ -629,8 +631,17 @@ def _build_test_config(config: Config, test_case: dict, tmp: str) -> Config:
             vault_retrieval.mode: headlines
             agent.max_tool_iterations: 3
 
-    The sandbox fields (``agent.data_home`` / ``agent.id``) are applied
-    *last* so a case cannot redirect itself out of its temp directory.
+    The sandbox fields (``agent.data_home`` / ``agent.id`` /
+    ``extra_skill_paths``) are applied *last* so a case cannot redirect itself
+    out of its temp directory or pull in machine-local skills.
+
+    ``extra_skill_paths`` is cleared because ``load_system_prompt`` runs
+    ``discover_skills``, which reads those paths — and unlike prompt overrides
+    they live outside ``data_home``, so the tmp sandbox does not reach them.
+    Left populated, a developer's ``~/.agents/skills`` lands in the
+    ``<skill_catalog>`` of every eval prompt (measured: 113 extra skills vs 12
+    bundled, 33% of the prompt text), making results machine-dependent. See
+    #670.
     """
     # `_setup_of` has already rejected non-mappings, removed keys, and
     # unknown keys, so only the config_overrides shape is left to check.
@@ -650,7 +661,11 @@ def _build_test_config(config: Config, test_case: dict, tmp: str) -> Config:
             )
         config = _apply_overrides(config, _nest_overrides(raw))
 
-    return replace(config, agent=replace(config.agent, data_home=tmp, id="eval"))
+    return replace(
+        config,
+        agent=replace(config.agent, data_home=tmp, id="eval"),
+        extra_skill_paths=[],
+    )
 
 
 async def run_test(config: Config, test_case: dict) -> dict:
@@ -663,10 +678,30 @@ async def run_test(config: Config, test_case: dict) -> dict:
     Multi-turn tests share history across turns (same conversation).
     All turns must pass for the test to pass.
     """
+    # Assemble the system prompt the same way decafclaw/__init__.py does at
+    # startup. Without this, config.system_prompt stays "" (config.py only reads
+    # a SYSTEM_PROMPT env var) and ContextComposer._compose_system_prompt emits
+    # a zero-length system message — no SOUL.md, no AGENT.md, no skill catalog,
+    # no always-loaded skill bodies. Every eval case ran that way until #670.
+    #
+    # Deliberately after _build_test_config's sandbox, which supplies both
+    # halves of reproducibility here: the tmp data_home means load_system_prompt
+    # finds no per-agent SOUL.md/AGENT.md/USER.md overrides, and the cleared
+    # extra_skill_paths means its discover_skills call sees bundled skills only.
+    # Without the second half a developer's ~/.agents/skills would land in the
+    # <skill_catalog> of every eval prompt.
+    #
+    # Guarded on falsiness so an explicit SYSTEM_PROMPT env override still wins.
+    if not config.system_prompt:
+        config.system_prompt, config.discovered_skills = load_system_prompt(config)
+
     # Populate discovered_skills so dispatch_command can resolve `/foo` triggers.
     if not config.discovered_skills:
-        from ..skills import build_skill_tool_owners
         config.discovered_skills = _discover_skills_fn(config)
+    # Separate guard: load_system_prompt populates discovered_skills as a side
+    # effect, so folding this into the branch above would skip it and silently
+    # break command dispatch.
+    if not config.skill_tool_owners:
         config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
 
     # setup.auto_confirm: true (default) = auto-approve, false = auto-deny.

--- a/tests/test_eval_system_prompt.py
+++ b/tests/test_eval_system_prompt.py
@@ -1,0 +1,132 @@
+"""The full-agent eval runner must assemble a real system prompt (#670).
+
+Before this guard, ``config.system_prompt`` was only ever set by
+``decafclaw/__init__.py`` (the app entry point). The eval CLI calls
+``load_config()`` + ``run_eval()`` directly, so every eval turn ran with a
+zero-length system message: no SOUL.md, no AGENT.md, no <skill_catalog>, and
+no always-loaded skill bodies. Measured effect on tool routing was 1/15 vs
+10/10 — see docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/research.md.
+
+No LLM calls: ``run_agent_turn`` is patched at the seam.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from decafclaw.config import Config
+from decafclaw.eval.runner import _build_test_config, run_test
+from decafclaw.media import ToolResult
+
+
+@pytest.fixture
+def captured_turn():
+    """Patch run_agent_turn; record the ctx it was handed."""
+    seen = {}
+
+    async def _fake_turn(ctx, user_message, history, *args, **kwargs):
+        seen["ctx"] = ctx
+        seen["config"] = ctx.config
+        history.append({"role": "assistant", "content": "ok"})
+        return ToolResult(text="ok")
+
+    with patch("decafclaw.eval.runner.run_agent_turn", _fake_turn):
+        yield seen
+
+
+@pytest.mark.asyncio
+async def test_system_prompt_is_assembled_before_the_turn(tmp_path, captured_turn):
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    assert config.system_prompt == "", "precondition: starts empty"
+
+    await run_test(config, {"name": "t", "input": "hello"})
+
+    prompt = captured_turn["config"].system_prompt
+    assert prompt, "eval turn ran with an empty system prompt (#670)"
+
+
+@pytest.mark.asyncio
+async def test_prompt_carries_the_sections_production_gets(tmp_path, captured_turn):
+    """Non-empty isn't enough — the always-loaded skill bodies are the part
+    #670 turned on, so assert the sections individually."""
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    await run_test(config, {"name": "t", "input": "hello"})
+    prompt = captured_turn["config"].system_prompt
+
+    assert "<skill_catalog>" in prompt
+    assert "<loaded_skills>" in prompt
+    # The vault skill is always-loaded and its body is what documents
+    # vault_journal_append — the specific gap #670 surfaced.
+    assert '<skill name="vault">' in prompt
+
+
+def test_sandbox_clears_extra_skill_paths(tmp_path):
+    """`load_system_prompt` runs `discover_skills`, which reads
+    `extra_skill_paths`. Those live outside data_home, so the tmp sandbox does
+    not reach them — without clearing, a developer's ~/.agents/skills lands in
+    the <skill_catalog> of every eval prompt and results stop being
+    reproducible across machines."""
+    cfg = Config()
+    cfg.extra_skill_paths = ["~/.agents/skills", "/somewhere/else"]
+
+    out = _build_test_config(cfg, {"setup": {}}, str(tmp_path))
+
+    assert out.extra_skill_paths == []
+
+
+def test_config_overrides_cannot_restore_extra_skill_paths(tmp_path):
+    """Sandbox fields are applied last, so a case can't opt itself back into
+    machine-local skills — symmetric with data_home / agent.id."""
+    out = _build_test_config(
+        Config(),
+        {"setup": {"config_overrides": {"extra_skill_paths": ["/evil"]}}},
+        str(tmp_path),
+    )
+
+    assert out.extra_skill_paths == []
+    assert out.agent.data_home == str(tmp_path)
+    assert out.agent.id == "eval"
+
+
+@pytest.mark.asyncio
+async def test_prompt_excludes_extra_tier_skills(tmp_path, captured_turn):
+    """End-to-end: the assembled prompt carries the bundled always-loaded
+    skill body but no extra-tier catalog entries."""
+    cfg = Config()
+    cfg.extra_skill_paths = ["~/.agents/skills"]
+    config = _build_test_config(cfg, {"setup": {}}, str(tmp_path))
+
+    await run_test(config, {"name": "t", "input": "hello"})
+    prompt = captured_turn["config"].system_prompt
+
+    assert '<skill name="vault">' in prompt
+    assert captured_turn["config"].extra_skill_paths == []
+    # Every discovered skill must come from the bundled tree.
+    tiers = {s.trust_tier for s in captured_turn["config"].discovered_skills}
+    assert tiers == {"bundled"}, f"non-bundled skills leaked in: {tiers}"
+
+
+@pytest.mark.asyncio
+async def test_explicit_system_prompt_is_not_clobbered(tmp_path, captured_turn):
+    """The assembly is guarded on falsiness so a SYSTEM_PROMPT env override
+    (config.py reads it into config.system_prompt) still wins. An unconditional
+    assignment would silently discard it."""
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    config.system_prompt = "PRESET"
+
+    await run_test(config, {"name": "t", "input": "hello"})
+
+    assert captured_turn["config"].system_prompt == "PRESET"
+
+
+@pytest.mark.asyncio
+async def test_skill_tool_owners_still_populated(tmp_path, captured_turn):
+    """load_system_prompt also returns discovered_skills, which would skip the
+    `if not config.discovered_skills` branch and leave skill_tool_owners empty —
+    silently breaking /foo command dispatch in evals."""
+    config = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    await run_test(config, {"name": "t", "input": "hello"})
+
+    ran_with = captured_turn["config"]
+    assert ran_with.discovered_skills
+    assert ran_with.skill_tool_owners


### PR DESCRIPTION
## Summary

The full-agent eval harness has been running **every case with an empty system prompt**. `config.system_prompt` is assembled in exactly one place — `decafclaw/__init__.py`, the app entry point — and the eval CLI calls `load_config()` + `run_eval()` directly, never going through it. `config.py` only reads the field from a `SYSTEM_PROMPT` env var (default `""`).

`ContextComposer._compose_system_prompt` reads that field verbatim, so eval turns got a **zero-length system message**: no SOUL.md, no AGENT.md, no `<skill_catalog>`, and no always-loaded skill bodies — including the vault SKILL.md that documents when to journal.

`tool_choice` doesn't share the gap (it calls `load_system_prompt` directly). That is the entire harness disagreement reported in #670 — and it **inverts** the issue's leading hypothesis: `tool_choice` was the *higher*-fidelity harness; the full-agent runner was the broken one.

## Result: 45/52 → 53/54

| | baseline `1621` | with extra skills `1822` | hermetic `2323` |
|---|---|---|---|
| result | **45 / 52** (86.5%) | 51 / 52 (98.1%) | **53 / 54** (98.1%) |
| duration | 647.2s | 473.0s | 605.8s |
| tokens | 1,308,185 | 2,272,538 | 2,235,913 |

54 cases rather than 52 because the rebase brought in two new ones (#681, #677); both pass. The middle column is the first re-baseline, before review caught the `extra_skill_paths` hole — see "Review round" below.

**All seven baseline failures flipped green:**

| case | baseline | new |
|---|---|---|
| recalls recent memories (project + style) | fail | **pass** |
| saves memory when asked *(#670 case 20)* | fail | **pass** |
| postmortem produces all five sections, blamelessly framed | fail | **pass** |
| writes spec when asked | fail | **pass** |
| dream consolidation fills page frontmatter after writing | fail | **pass** |
| saves user-level fact to vault journal on 'remember' *(#670 case 43)* | fail | **pass** |
| adds a section without rewriting other sections | fail | **pass** |

**Six of the seven "failures" in the 45/52 baseline were harness artifacts, not agent defects.** Anyone who had picked up one of those issues would have been debugging an agent that doesn't ship.

## Evidence

Measured on `vertex-gemini-flash`, `expect_tool: vault_journal_append`:

| condition | case-20 prompt | case-43 prompt |
|---|---|---|
| as shipped (empty prompt) | **1/15** | **13/15** |
| system prompt assembled | **10/10** | **10/10** |
| `tool_choice` | **5/5** | **5/5** |

Both of the issue's cheap-to-rule-out hypotheses were ruled out by measurement, not reasoning:

- **Trailing "Confirm what you saved."** — a 2×2 crossing moved 1/5 → 0/5 and 5/5 → 4/5. Both within noise; *content* drives the per-case split, not the clause.
- **Reflection retries** — `reflection.enabled: false`, 3 reps: 0/3, still `notes_append`, 1 tool call each.

Also corrects the issue's framing: **case 43 is flaky (13/15), not deterministic.** "Two cases failed identically, so not a one-off" holds for case 20 (0/15) only.

## Design decisions

- **Assembly happens in `run_test`, after `_build_test_config` applies the sandbox.** The sandbox clears *two* sources of machine-local state so the prompt resolves to the bundled tier only:

  | sandbox field | excludes |
  |---|---|
  | `agent.data_home` → tmp | `data/{agent_id}` prompt overrides, incl. USER.md |
  | `extra_skill_paths` → `[]` | skills from external dirs (`~/.agents/skills`) |

  Both applied last, so `setup.config_overrides` can't opt back into either. Rejected: assembling in `__main__.py` against the un-sandboxed config (higher fidelity to one deployed agent, but machine-dependent numbers).
- **Guarded on falsiness**, so an explicit `SYSTEM_PROMPT` env override still wins. Covered by a test.
- **`skill_tool_owners` moved under its own guard.** `load_system_prompt` populates `discovered_skills` as a side effect, so folding it into the `if not config.discovered_skills` branch would skip it and silently break `/foo` command dispatch in evals. Hit this during the probe.
- **No tool-description changes.** With the prompt present, routing is 20/20 correct — there is no description defect. The issue body proposed rewording `notes_append` / `vault_journal_append`; that is measurably unnecessary and would have risked the passing control cases.

## Testing

- `tests/test_eval_system_prompt.py` — **7 tests**, no LLM calls (`run_agent_turn` patched at the seam): prompt is non-empty at turn time; it carries `<skill_catalog>` / `<loaded_skills>` / `<skill name="vault">`; `skill_tool_owners` survives; an explicit prompt isn't clobbered; the sandbox clears `extra_skill_paths`; `config_overrides` can't restore it; every discovered skill is `trust_tier == "bundled"`.
- TDD: the first two failed before the fix with `AssertionError: assert ''`. The env-override test was verified to have teeth by making the guard unconditional (fails), then restoring.
- `make test` **3449 passed, 2 skipped**. `make check` clean (ruff, pyright 0 errors, tsc, message-types drift).
- The three `vault_journal_append` ↔ `notes_append` control cases in `evals/tool_choice/core_overlaps.yaml` **pass, untouched** — pair overlap 0/1 and 0/2 swapped (0%).

## Things reviewers should know

**Two noise-floor failures surfaced, neither a regression.** Both were checked by re-running in isolation rather than assumed:

- `continues interviewing after first answer` failed in the `1822` run (answering *"Project ... has been created. Please call `project_next_task()`"* — skipping the interview and instructing the **user** to call a tool). Re-ran turn 1: **3/3 PASS**. It also passes in the final `2323` run.
- `uses workspace_move for a rename` is the single failure in the final run. Re-ran: **3/4 PASS**. The agent reaches for a vault tool on a path-shaped rename and gives up on `[error: vault page 'drafts/old-name.md' not found]` — a `vault_*` vs `workspace_*` disambiguation wobble.

Both recorded in `notes.md`, neither filed; they belong to #650 / #683.

**#671 may be a harness artifact.** Its eval case (`adds a section without rewriting other sections`) now passes. Worth re-checking before anyone starts on it. Same for the `dream` frontmatter case. Not investigated here.

**#676's "4 failures" is a snapshot, not a set.** Across three `make eval-tools` runs the failure set was 4 / 6 / 4, with only the two tabstack cases (`tabstack-automate-vs-research-form-fill`, `tabstack-research-vs-automate-multi-source`) failing every time. This PR can't affect `tool_choice` — it has its own runner that never imports `eval/runner.py` — so this is pre-existing instability. #676 likely wants re-scoping to those two, with the rest folded into #650.

**Two adjacent changes, both flagged:**
- Corrected a stale claim in `docs/eval-loop.md` that `evals/history.jsonl` is "committed to git" — it has been gitignored since #606. The new history-discontinuity note references that file, so leaving the contradiction beside it would have been worse.
- Added `tmp/` to `.gitignore` (untracked, wasn't ignored).

## Review round

Copilot caught a real hole, flagged on both the code comment and the docs: `load_system_prompt` calls `discover_skills(config)`, which reads `config.extra_skill_paths` — and those live *outside* `data_home`, so the tmp sandbox never reached them. The "bundled tier only" claim was false.

Verified and quantified rather than taken on faith:

```
extra_skill_paths = ['~/.agents/skills']
tiers: Counter({'extra': 113, 'bundled': 12})

WITH extra_skill_paths: 34,704 chars, 125 skills
WITHOUT:                23,262 chars,  12 skills
-> 11,442 chars, 33% of the eval system prompt
```

A third of every eval prompt was one developer's personal skill catalog. No skill *bodies* leaked (none are always-loaded), but all 113 catalog entries did — so eval results were machine-dependent, exactly what the design decision claimed to prevent.

**Fixed** by clearing `extra_skill_paths` in the sandbox, plus three tests and corrected comment/docs wording. The suite was then re-baselined a second time under the hermetic config, which is the `2323` column above.

## References

- Closes #670
- Session docs: [`docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/`](docs/dev-sessions/2026-07-24-1728-670-notes-vs-vault-harness-fidelity/) — `spec.md`, `research.md` (full measurement tables + hypothesis verdicts), `plan.md`, `notes.md` (flip table)
- Follow-up filed during diagnosis: #683 — `tool_choice` loadout doesn't reproduce production tool deferral (97 callable vs 40 active + 58 prose-listed). Did **not** cause #670; independent of this fix.
- Related, not addressed: #671, #676, #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
