### PR TITLE
docs: add a machine-readable declaration of the project board

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,18 @@ make config       # Show resolved config
 - Move to **In progress** on start, **In review** on PR, **Done** on merge (or let `Closes #N` auto-close).
 - File new issues onto the board with priority and size.
 
+Machine-readable declaration, for tools that automate the transitions above. Column values are
+the board's exact option names — note the lowercase `progress`/`review`:
+
+- **Owner:** `lmorchard`
+- **Number:** `6`
+- **Status field:** `Status`
+- **Columns:**
+  - `ready: Ready`
+  - `in_progress: In progress`
+  - `in_review: In review`
+  - `done: Done`
+
 ## Dev sessions
 
 Session docs at `docs/dev-sessions/YYYY-MM-DD-HHMM-slug/` (`spec.md`, `plan.md`, `notes.md`).


### PR DESCRIPTION
## Summary
- The board is already documented here in prose — URL, all five columns, and the move-on-start/PR/merge protocol. That's fine for a human and not parseable, so tools that automate those transitions were treating the board as unconfigured and silently doing nothing.
- Adds the owner / number / status-field / column keys alongside the existing prose rather than as a second section, so there's still one place to look.

## Why the exact strings matter

Column values are the board's real option names, read from `gh project field-list` rather than transcribed from memory: they are **`In progress`** and **`In review`** — lowercase second word, not title case. An exact-match transition against `In Progress` fails.

## Changes

`CLAUDE.md` — 12 lines added under the existing `## Project board` section. No prose removed, no behaviour changed anywhere in the codebase.

## Test plan

Nothing to test — documentation only, no code paths touched. Verified the declared values against the live board:

```
$ gh project field-list 6 --owner lmorchard
Status | ProjectV2SingleSelectField | ['Backlog', 'Ready', 'In progress', 'In review', 'Done']
```

and confirmed a transition using these resolved ids moves an item as expected (#649 → In progress → In review → Done over the course of that issue's work).