### PR TITLE
Eval: failure-mode axis scorecard (#528) + per-turn context diagnostics (#531)

### DIFF
--- a/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md
+++ b/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md
@@ -1,0 +1,253 @@
+# Session notes — eval behavioral diagnostics (#528, #531)
+
+## Summary
+
+Combined arc for two related issues, executed as one 13-task plan:
+
+- **#531 — diagnostics plumbing.** `src/decafclaw/eval/diagnostics.py` adds
+  `build_turn_diagnostics` (assembles a per-turn `diagnostics` block by
+  reusing the context sidecar the agent already writes on turn-exit, plus
+  two derived fields: `detect_files_read` / `detect_files_cited`). Wired into
+  `eval/runner.py` so every test result (single- and multi-turn) carries a
+  `diagnostics` block; `--verbose` prints a compact one-line summary of it.
+- **#528 — axis-tagged behavioral scorecard.** A `tests:` key (string or
+  list) on any eval case tags it with one or more of four canonical axes
+  (`retrieval`, `routing`, `answer_quality`, `workflow_discipline`).
+  `aggregate_by_axis` rolls per-test pass/fail up into
+  `results["summary"]["by_axis"]`, printed as a console scorecard after
+  every run. Untagged cases fall into an `untagged` bucket rather than
+  being dropped; an unknown axis value raises rather than silently
+  vanishing.
+- Seven new single-axis behavioral suites (`evals/{vault_answering,
+  tool_routing, source_grounding, context_pressure, clarification,
+  abort_recovery, over_ceremony}.yaml`) exercise the four axes end-to-end
+  against real LLM turns, each suite's cases carrying real-run tuning
+  history in its header comment.
+
+## Final case counts per suite
+
+| Suite | Axis | Cases |
+|-------|------|-------|
+| `vault_answering.yaml` | retrieval | 5 |
+| `tool_routing.yaml` | routing | 5 |
+| `source_grounding.yaml` | answer_quality | 5 |
+| `context_pressure.yaml` | answer_quality | **4** |
+| `clarification.yaml` | workflow_discipline | **4** |
+| `abort_recovery.yaml` | workflow_discipline | 4 |
+| `over_ceremony.yaml` | workflow_discipline | 5 |
+| **Total** | | **32** |
+
+Two suites landed at 4 cases rather than the 5 originally targeted, each
+with a documented dropped 5th case rather than a silently reduced target:
+
+- **`context_pressure.yaml`** — a 5th case (fact placed early in a long
+  history, using the brief's original "buried mid-stream, parenthetical
+  reminder" framing, to isolate recency bias) never stabilized across real
+  runs: one fact type drew a safety-flavored refusal, another repeatedly
+  hit the notes_read-reflex failure (see Behavioral findings below).
+  Superseded by the "longer, higher-volume" case, which already places the
+  fact first ahead of ~20 messages of noise using the framing that *did*
+  stabilize (announcement-style opener + a plausible-but-wrong decoy value).
+- **`clarification.yaml`** — a "two files match, pick which one" variant
+  (e.g. "Delete the Q1 report." with two similarly-named candidate files
+  present) was tried and dropped. It surfaced a genuine, low-frequency
+  (~10-15% across ~25 isolated real-LLM runs, two wordings tried)
+  behavioral gap rather than an eval-design artifact — see Behavioral
+  findings below.
+
+## Behavioral findings surfaced during suite tuning
+
+These are genuine model/harness behaviors discovered while authoring the
+suites against real LLM calls, not eval-design bugs:
+
+1. **`vault_search` tags-filter bypass.** `vault_answering.yaml` case 3
+   ("picks correct page among distractor filenames sharing a stem")
+   originally put frontmatter safety-net tags on only the correct one of
+   three stem-sharing pages. A model-issued tags-qualified search would
+   then filter straight down to the one right answer, bypassing the
+   three-way body disambiguation the case exists to test — a false-pass
+   risk, not a true one. Fixed by putting the same tags on all three pages
+   so a tags-qualified search still returns all three candidates (or
+   none), forcing the model onto the body-reading code path on every run.
+   (Fixed in the eval case; not a product bug — `vault_search`'s
+   tag-filter behavior itself is working as designed. Worth keeping in
+   mind for future tag-filter-adjacent cases: shared tags across
+   distractors are load-bearing for disambiguation tests.)
+2. **Reflexive `notes_read`/`vault_search` before answering, sometimes
+   escalating to a confident "I don't have that" hallucination.** Observed
+   repeatedly across `context_pressure.yaml` and `clarification.yaml`
+   authoring: the model fires a read-only tool before answering even when
+   nothing in the prompt is researchable, and — worse, in
+   `context_pressure.yaml`'s original framing — sometimes got an empty
+   result from that reflexive call and then confidently claimed "I don't
+   have that" instead of falling back to a fact plainly sitting a few
+   messages back in its own visible context. The reflexive-read half is
+   tolerated in assertions (bumped `max_tool_calls`, `expect_no_tool`
+   scoped to the specific mutating tool rather than banning reads
+   outright); the hallucination-after-empty-read half was fixed at the
+   case-design level (announcement-style opener, fact-first placement) but
+   is worth a closer look as a product-level prompt/behavior gap.
+3. **`workspace_delete` fires before asking, on an ambiguous
+   described-but-not-path-given delete target.** The dropped 5th
+   `clarification.yaml` case: given "Delete the Q1 report" with two
+   similarly-named candidate files present, the model occasionally (~10-15%
+   across ~25 real-LLM runs, two wordings) guessed a plausible-but-wrong
+   literal filename and called `workspace_delete` on it without checking
+   the workspace or asking first — sometimes asking for clarification only
+   *after* the delete errored out. Worth a follow-up issue: whether the
+   delete-tool description or system prompt should more strongly nudge
+   "check for a match before acting on a described-but-not-path-given
+   target."
+
+None of these were papered over with a loosened assertion — findings (1)
+was fixed at the eval-case level (shared tags), finding (2)'s tolerated
+half is an explicit, narrowly-scoped `expect_no_tool` (not a blanket
+weakening), and finding (3) was handled by dropping the case rather than
+loosening it to pass. **No assertion was loosened dishonestly to force a
+suite green** — confirmed by re-reading every suite's tuning-note comments
+during this task.
+
+## Full-suite verification
+
+### `make check`
+
+Clean: ruff, pyright (0 errors/0 warnings), tsc `--checkJs`, message-types
+drift check. No changes required.
+
+### `make test`
+
+```
+3354 passed, 2 skipped in 12.36s
+```
+
+Zero warnings. `pytest --durations=25` showed no new outliers — the
+slowest items are pre-existing timeout/heartbeat tests already accounted
+for; nothing added by this arc placed in the top 25.
+
+### Combined behavioral suite run
+
+The eval CLI's `path` argument accepts one file or one directory, not a
+list of files, so the literal seven-file invocation from the task brief
+doesn't run as written. Ran the equivalent instead via a scratch directory
+of symlinks pointing at the same seven target YAML files (no code change,
+no eval-file change — purely a run-time convenience to get one combined
+result bundle covering exactly these seven suites):
+
+```bash
+mkdir /tmp/behavioral_suites
+ln -s .../evals/{vault_answering,tool_routing,source_grounding,context_pressure,clarification,abort_recovery,over_ceremony}.yaml /tmp/behavioral_suites/
+uv run python -m decafclaw.eval /tmp/behavioral_suites/
+```
+
+**First combined run: 31/32 passed, 1 failure.** The failure
+(`abort_recovery.yaml`'s "resumes the abandoned task when explicitly asked
+again") was a Vertex/Gemini API-level flake, not an eval-design or
+assertion problem — the provider returned `MALFORMED_FUNCTION_CALL` for an
+attempted `print(14 * 6)` call twice in a row, and the agent's retry logic
+gave up with an empty response rather than answering in text. Confirmed
+non-reproducible: re-ran `abort_recovery.yaml` alone (4/4 passed, including
+that case) and re-ran the full combined suite a second time (32/32
+passed, see below). Per the honesty rule, this is noted as an infra-level
+flake rather than silently retried into invisibility or fixed by loosening
+the assertion — the assertion (`response_contains: "84"`) is exactly right
+and stays as-is.
+
+**Second combined run (clean): 32/32 passed.**
+
+```
+[1/32] does not resurrect a cancelled single-step intent . PASS  (1.4s, 5478 tokens, 0 tools)
+[2/32] does not resurrect a cancelled multi-step task .... PASS  (1.2s, 5668 tokens, 0 tools)
+[3/32] does not resurrect after an exception-abort marker . PASS  (1.0s, 5949 tokens, 0 tools)
+[4/32] resumes the abandoned task when explicitly asked again . PASS  (1.1s, 5564 tokens, 0 tools)
+[5/32] asks one clarifying question on a genuinely ambiguous ask . PASS  (1.1s, 5645 tokens, 0 tools)
+[6/32] proceeds without over-asking on a clear request ... PASS  (2.1s, 12153 tokens, 1 tools)
+[7/32] creates the requested file directly without asking for confirmation . PASS  (1.9s, 13116 tokens, 1 tools)
+[8/32] asks which file and which folder before moving, when neither is named . PASS  (1.2s, 6272 tokens, 0 tools)
+[9/32] recovers a buried fact from noisy history ......... PASS  (2.2s, 5636 tokens, 0 tools)
+[10/32] recovers a buried fact from a longer, higher-volume noisy history . PASS  (3.3s, 5748 tokens, 0 tools)
+[11/32] recovers the correct on-call name over a topically-similar decoy name . PASS  (5.1s, 5686 tokens, 0 tools)
+[12/32] recovers a fact buried in a large workspace file the agent must read past . PASS  (4.2s, 12841 tokens, 1 tools)
+[13/32] simple ask does not create a checklist ............ PASS  (0.9s, 5611 tokens, 0 tools)
+[14/32] small two-step ask stays inline, no project escalation . PASS  (2.5s, 18373 tokens, 2 tools)
+[15/32] quick arithmetic answered inline, no ceremony ..... PASS  (1.0s, 5437 tokens, 0 tools)
+[16/32] small multi-part factual ask stays inline ......... PASS  (1.3s, 5632 tokens, 0 tools)
+[17/32] unit conversion pair answered inline .............. PASS  (1.2s, 5457 tokens, 0 tools)
+[18/32] grounds the answer in the seeded page, no invented figures . PASS  (3.5s, 11651 tokens, 1 tools)
+[19/32] hedges instead of fabricating an unseeded SLA tier . PASS  (2.9s, 11674 tokens, 1 tools)
+[20/32] grounds a workspace-file fact via an explicit read, not a vault page . PASS  (2.8s, 12209 tokens, 1 tools)
+[21/32] hedges instead of fabricating an unseeded plan's rate limit . PASS  (2.3s, 12239 tokens, 1 tools)
+[22/32] grounds a non-numeric process fact in a seeded vault page . PASS  (3.8s, 11367 tokens, 1 tools)
+[23/32] routes to conversation_search for 'what did I say' history queries . PASS  (1.8s, 13220 tokens, 1 tools)
+[24/32] routes to workspace_read for a concrete workspace file path . PASS  (2.0s, 12181 tokens, 1 tools)
+[25/32] routes to vault_search/vault_read for a vault-knowledge question, not workspace_read . PASS  (2.0s, 12075 tokens, 1 tools)
+[26/32] routes to conversation_search over a topically-similar vault distractor . PASS  (1.7s, 12958 tokens, 1 tools)
+[27/32] routes to workspace_read over a topically-similar vault distractor . PASS  (1.7s, 13141 tokens, 1 tools)
+[28/32] retrieves the right page past a similar-but-wrong distractor . PASS  (4.8s, 11198 tokens, 1 tools)
+[29/32] admits absence when no vault page covers the question . PASS  (2.8s, 12354 tokens, 1 tools)
+[30/32] picks correct page among distractor filenames sharing a stem . PASS  (4.7s, 12651 tokens, 1 tools)
+[31/32] surfaces a page reachable only by semantic match, not keyword overlap . PASS  (3.9s, 6832 tokens, 1 tools)
+[32/32] prefers the specific matching page over a broader distractor covering the same topic . PASS  (4.0s, 11377 tokens, 1 tools)
+
+By axis (failure-mode scorecard):
+  answer_quality         9/9  (100%)
+  retrieval              5/5  (100%)
+  routing                5/5  (100%)
+  workflow_discipline    13/13  (100%)
+
+32 tests, 32 passed, 0 failed (77.4s, 307393 tokens)
+```
+
+### Result bundle spot-check
+
+`evals/results/2026-07-24-1936-vertex-gemini-flash/results.json` (the clean
+32/32 run) confirmed to carry:
+
+- `summary.by_axis` — the four-axis dict shown above (`total`/`passed`/
+  `failed`/`pass_rate` per axis).
+- Per-test `diagnostics` — every entry in `tests[]` has a `diagnostics` key
+  with all documented sub-keys (`tokens_by_section`,
+  `total_tokens_estimated`, `total_tokens_actual`, `context_window_size`,
+  `compaction_threshold`, `active_tools`, `deferred_tools`,
+  `retrieved_candidates`, `files_read`, `files_cited`, `tool_calls`).
+
+## Deferred follow-ups
+
+- **Per-tool-call durations.** The context sidecar the diagnostics block
+  reuses doesn't currently time individual tool calls, so `diagnostics`
+  has no per-tool timing breakdown — only the aggregate turn duration.
+  Would need agent-side instrumentation (`tool_execution.py`), not just an
+  eval-side change.
+- **Per-axis pass-rate history trend.** `evals/history.jsonl` tracks
+  overall pass-rate over time (`make eval-history`); breaking that trend
+  out by axis (mirroring the existing `by_axis` scorecard shape) is not
+  yet implemented.
+- **Retagging existing suites.** The seven new suites are axis-tagged from
+  day one; pre-existing suites (`memory.yaml`, `conversation.yaml`,
+  `vault.yaml`, etc.) are not retroactively tagged and fall into
+  `untagged` in any combined scorecard. Worth a follow-up pass once the
+  axis vocabulary has proven itself over a few more suites.
+- **`persona-customer-support` trigger-word interference.** Multiple
+  suites' comments independently document working around this
+  environment's `extra_skill_paths`-discoverable persona skill firing on
+  "customer" and derailing routing/answer assertions. It's a property of
+  this dev environment's resolved config, not the product, but it cost
+  real authoring time across at least three suites — worth flagging to
+  whoever owns the persona-skill fixtures for eval-environment hygiene.
+- **`workspace_delete`-before-asking on ambiguous delete targets** (finding
+  3 above) — candidate for a tool-description or system-prompt nudge,
+  filed as a behavioral gap rather than fixed in this arc (diagnostics/
+  scorecard scope, not tool-behavior scope).
+
+## Review-polish fixes (this task)
+
+- `evals/tool_routing.yaml` header comment claimed inputs used "client" /
+  "user" substitute vocabulary alongside "billing integration"; only
+  "billing integration" is actually used in the cases. Comment corrected
+  to match.
+- `evals/clarification.yaml` case 3 ("clear request to create a file")
+  used `workspace/reminder.md` in the input text, which the
+  `workspace_write` tool description explicitly warns against (paths
+  should not be prefixed with `workspace/`). Reworded the input to
+  `reminder.md`; `expect_workspace.workspace_file_exists` was already
+  correctly `["reminder.md"]` (unprefixed), so no change needed there.
+  Re-validated: this case passed in both combined runs above.

--- a/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md
+++ b/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md
@@ -30,15 +30,22 @@ Combined arc for two related issues, executed as one 13-task plan:
 |-------|------|-------|
 | `vault_answering.yaml` | retrieval | 5 |
 | `tool_routing.yaml` | routing | 5 |
-| `source_grounding.yaml` | answer_quality | 5 |
+| `source_grounding.yaml` | answer_quality | **4** |
 | `context_pressure.yaml` | answer_quality | **4** |
 | `clarification.yaml` | workflow_discipline | **4** |
 | `abort_recovery.yaml` | workflow_discipline | 4 |
 | `over_ceremony.yaml` | workflow_discipline | 5 |
-| **Total** | | **32** |
+| **Total** | | **31** |
 
-Two suites landed at 4 cases rather than the 5 originally targeted, each
+> Post-rebase update: `source_grounding.yaml` dropped from 5 to 4 (its 5th
+> case depended on the `vault_search` tags bug now tracked as #688 — see the
+> Post-rebase stabilization section at the end). Total is now **31**, still
+> above #528's ~30 floor.
+
+Three suites landed at 4 cases rather than the 5 originally targeted, each
 with a documented dropped 5th case rather than a silently reduced target:
+
+- **`source_grounding.yaml`** — see Post-rebase stabilization below (#688).
 
 - **`context_pressure.yaml`** — a 5th case (fact placed early in a long
   history, using the brief's original "buried mid-stream, parenthetical
@@ -251,3 +258,57 @@ By axis (failure-mode scorecard):
   `reminder.md`; `expect_workspace.workspace_file_exists` was already
   correctly `["reminder.md"]` (unprefixed), so no change needed there.
   Re-validated: this case passed in both combined runs above.
+
+## Post-rebase stabilization (final)
+
+Before opening the PR the branch was rebased onto `origin/main` (which had
+advanced +8 commits during the session, including **#674** "make
+vault_search's tags-only mode callable", **#672** vault frontmatter
+rendering, and **#675** skills tools.py contract). Rebase was clean.
+`make check` clean; `make test` **3448 passed, 2 skipped, zero warnings**
+(count rose from upstream's own added tests).
+
+The post-rebase behavioral re-run surfaced flakes that the pre-rebase
+authoring runs hadn't hit — the #531 diagnostics made each root cause
+visible immediately (`retrieved_candidates`, the self-attached-tags
+tool-call args, `files_read`). Handled in order:
+
+1. **`source_grounding` case 5 (Nightwatch) — dropped.** The model
+   reliably self-attaches an *invented* `tags` filter to its `vault_search`
+   call (e.g. `["P1","incident","on-call","notification"]`, then a
+   different `["incident response","on-call","notification"]` on the next
+   run). `vault_search`'s exact-string AND-logic then returns a false-empty
+   when *any* attached tag isn't on the page, and the model hedges "I don't
+   have that" instead of grounding. Adding frontmatter tags only covers the
+   phrases you anticipate — the model invents new ones each run, so the
+   tag-enumeration safety-net is unbounded whack-a-mole. This is a real
+   **product bug**, filed as **#688**, not an eval-authoring defect (it
+   supersedes the "not a product bug" framing in finding 1 above — that
+   framing held for the *distractor-disambiguation* use of shared tags, but
+   the self-attachment-false-empty interaction is a genuine defect). Per the
+   decision to keep this PR scoped to #528+#531, the flaky case was dropped
+   (source_grounding → 4 solid cases: 2 grounding + 2 hedge) rather than
+   coupling the suite to an unfixed bug. #688 is on the board (Backlog).
+2. **`vault_answering` case 5 (429/100) — reworded (legit tightening).**
+   Retrieval worked (page found at 0.96 relevance, result contained both
+   numbers); the model answered a consequence-only question ("what happens
+   if a client exceeds the limit?") with only "429" and omitted "100", so
+   `response_contains_all: ["429","100"]` failed. Reworded the input to a
+   two-part question ("What's our API rate limit, and what happens if a
+   client exceeds it?") so a complete grounded answer naturally requires
+   both discriminators; assertion unchanged, distractor still contains
+   neither token. Stable 5/5 across 5 re-runs.
+
+**Convergence confirmed:** after those two changes, the full 31-case
+combined suite ran **31/31 twice consecutively** (all four axes 100%),
+plus source_grounding 4/4 in isolation. No assertion was loosened
+dishonestly — case 5 was *dropped* (not weakened), and the 429/100 fix
+made its question stricter, not looser.
+
+**Honest note on stochasticity:** these are real-LLM adversarial suites
+against Flash. Two distinct latent flakes surfaced only under the
+post-rebase runs; both had genuine fixes (one a product-bug-driven drop,
+one a question-framing tightening). The remaining 31 cases held 31/31
+across the final consecutive runs, but as with any real-model eval a rare
+provider-level flake (see the `MALFORMED_FUNCTION_CALL` note above) can
+still occur — the suites are a smartness scorecard, not a bit-exact gate.

--- a/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/plan.md
+++ b/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/plan.md
@@ -1,0 +1,1078 @@
+# Behavioral Eval Suites + Per-Turn Context Diagnostics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #528 (behavioral eval suites grouped by failure-mode axis + aggregate scorecard) and #531 (per-turn context diagnostics in eval result bundles) in one arc.
+
+**Architecture:** A new pure-function module `src/decafclaw/eval/diagnostics.py` holds all deterministic logic (axis parsing, per-axis aggregation, file-read/-cited detection, diagnostics-block assembly). `runner.py`/`__main__.py` wire it in with a few lines each. The per-turn diagnostics **read the existing context sidecar** (`conversations/{conv_id}/context.json`, written on every turn-exit by `agent.py:_write_diagnostics` → `ContextComposer.build_diagnostics`) — no recomputation, no duplication. Seven new adversarial `evals/*.yaml` suites carry an axis tag; the aggregate groups pass-rates by that tag.
+
+**Tech Stack:** Python 3.12, pytest (xdist `-n auto`), PyYAML, dataclasses. LLM-visible suites validated with real model runs via `make eval`.
+
+## Global Constraints
+
+- **Worktree:** all work in `.claude/worktrees/528-531-eval-behavioral-diagnostics/` (branch `528-531-eval-behavioral-diagnostics`, port `HTTP_PORT=18894`). Always `uv run <cmd>` — bare `python` hits the main clone's editable install. Subagents start with their own CWD; every implementer step must `cd` into the worktree and verify branch.
+- **Canonical axes** (exact strings, verbatim): `retrieval`, `routing`, `answer_quality`, `workflow_discipline`. Untagged cases bucket as `untagged`.
+- **Read-tool arg map** (exact): `{"vault_read": "page", "workspace_read": "path"}`.
+- **Strict validation:** an unknown axis in `tests:` raises `ValueError` (consistent with #663's strict `setup.*` stance) — never silently drop.
+- **Eval assertion discipline:** every case bounded by `max_tool_calls` + `max_tool_errors`; `expect_no_tool`/tight-`max_tool_calls` cases set `setup.config_overrides: {reflection.enabled: false}`.
+- **Fail-open diagnostics:** a missing/`None` sidecar must degrade to derived-only fields, never raise.
+- **Verify before commit:** `uv run make check` + `uv run make test` green before every commit. Baseline is clean (3338 passed, 2 skipped, zero warnings) — keep it that way.
+- **Commit trailer:** `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **No field enumeration** when copying dataclasses (CLAUDE.md) — not directly relevant here but keep in mind for any Config touch.
+
+---
+
+## File Structure
+
+- **Create** `src/decafclaw/eval/diagnostics.py` — all pure logic:
+  - `CANONICAL_AXES: frozenset[str]`
+  - `READ_TOOL_ARGS: dict[str, str]`
+  - `parse_axes(case: dict) -> list[str]`
+  - `aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict`
+  - `detect_files_read(tool_calls: list[tuple[str, dict]]) -> list[str]`
+  - `detect_files_cited(response: str, known_paths: list[str]) -> list[str]`
+  - `build_turn_diagnostics(sidecar: dict | None, tool_calls: list[tuple[str, dict]], response: str) -> dict`
+- **Create** `tests/test_eval_diagnostics.py` — unit tests for the module.
+- **Modify** `src/decafclaw/eval/runner.py` — import `read_context_sidecar` + the diagnostics helpers; attach a `diagnostics` block per-turn + top-level in `run_test`; compute `by_axis` in `run_eval`; print the scorecard + `--verbose` diagnostics summary.
+- **Modify** `src/decafclaw/eval/__main__.py` — nothing required (bundle already serializes `results` dict). Verify only.
+- **Create** `evals/vault_answering.yaml`, `evals/tool_routing.yaml`, `evals/source_grounding.yaml`, `evals/context_pressure.yaml`, `evals/clarification.yaml`, `evals/abort_recovery.yaml`, `evals/over_ceremony.yaml`.
+- **Modify** `docs/eval-loop.md` — axis tagging, scorecard, diagnostics block, `--verbose`.
+
+---
+
+## Task 1: diagnostics module scaffold + `parse_axes`
+
+**Files:**
+- Create: `src/decafclaw/eval/diagnostics.py`
+- Test: `tests/test_eval_diagnostics.py`
+
+**Interfaces:**
+- Produces: `CANONICAL_AXES: frozenset[str]`; `parse_axes(case: dict) -> list[str]` — returns the case's axis tags (from top-level `tests:` key: absent→`[]`, str→`[str]`, list→list), validating each against `CANONICAL_AXES` and raising `ValueError` on any unknown value.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_eval_diagnostics.py
+"""Unit tests for the deterministic eval-diagnostics helpers (#528, #531)."""
+
+import pytest
+
+from decafclaw.eval.diagnostics import CANONICAL_AXES, parse_axes
+
+
+def test_parse_axes_absent_returns_empty():
+    assert parse_axes({"name": "x"}) == []
+
+
+def test_parse_axes_string_form():
+    assert parse_axes({"tests": "retrieval"}) == ["retrieval"]
+
+
+def test_parse_axes_list_form():
+    assert parse_axes({"tests": ["routing", "answer_quality"]}) == ["routing", "answer_quality"]
+
+
+def test_parse_axes_unknown_raises():
+    with pytest.raises(ValueError, match="unknown axis"):
+        parse_axes({"tests": "smartness"})
+
+
+def test_parse_axes_unknown_in_list_raises():
+    with pytest.raises(ValueError, match="unknown axis"):
+        parse_axes({"tests": ["retrieval", "bogus"]})
+
+
+def test_canonical_axes_exact_set():
+    assert CANONICAL_AXES == frozenset(
+        {"retrieval", "routing", "answer_quality", "workflow_discipline"}
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd .claude/worktrees/528-531-eval-behavioral-diagnostics && uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'decafclaw.eval.diagnostics'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/decafclaw/eval/diagnostics.py
+"""Deterministic helpers for eval axis tagging + per-turn context diagnostics.
+
+Pure functions — no LLM calls, no I/O. `runner.py` wires these into the eval
+result bundle. Per-turn diagnostics reuse the context sidecar written by
+`agent.py:_write_diagnostics` (see #531); axis aggregation powers the
+failure-mode scorecard (see #528).
+"""
+
+from __future__ import annotations
+
+CANONICAL_AXES: frozenset[str] = frozenset(
+    {"retrieval", "routing", "answer_quality", "workflow_discipline"}
+)
+
+# Read-shaped tool calls whose named arg identifies the file/page read.
+READ_TOOL_ARGS: dict[str, str] = {"vault_read": "page", "workspace_read": "path"}
+
+
+def parse_axes(case: dict) -> list[str]:
+    """Return the axis tags declared on an eval case's top-level ``tests:`` key.
+
+    Absent → ``[]``. A bare string → a one-element list. A list passes through.
+    Every value must be in :data:`CANONICAL_AXES`; an unknown value raises
+    ``ValueError`` rather than silently vanishing from the scorecard (mirrors
+    #663's strict ``setup.*`` handling).
+    """
+    raw = case.get("tests")
+    if raw is None:
+        return []
+    axes = [raw] if isinstance(raw, str) else list(raw)
+    for axis in axes:
+        if axis not in CANONICAL_AXES:
+            raise ValueError(
+                f"unknown axis {axis!r} in tests: — must be one of "
+                f"{sorted(CANONICAL_AXES)}"
+            )
+    return axes
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/eval/diagnostics.py tests/test_eval_diagnostics.py
+git commit -m "feat(eval): axis-tag parsing for behavioral suites (#528)"
+```
+
+---
+
+## Task 2: `aggregate_by_axis` + wire into `run_eval` + scorecard print + docs
+
+**Files:**
+- Modify: `src/decafclaw/eval/diagnostics.py`
+- Modify: `src/decafclaw/eval/runner.py` (in `run_eval`, after the summary loop ~line 900)
+- Modify: `docs/eval-loop.md`
+- Test: `tests/test_eval_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `parse_axes` (Task 1).
+- Produces: `aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict` — maps each axis (plus `untagged`) to `{"total": int, "passed": int, "failed": int, "pass_rate": float}`. `test_results[i]` pairs with `cases[i]` by index; a result's `status` is `"pass"`/`"fail"`. Multi-axis cases count once toward each axis. Also sets `results["summary"]["by_axis"]` in `run_eval`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_eval_diagnostics.py
+from decafclaw.eval.diagnostics import aggregate_by_axis
+
+
+def test_aggregate_single_axis_and_untagged():
+    cases = [
+        {"name": "a", "tests": "retrieval"},
+        {"name": "b", "tests": "retrieval"},
+        {"name": "c"},  # untagged
+    ]
+    results = [
+        {"name": "a", "status": "pass"},
+        {"name": "b", "status": "fail"},
+        {"name": "c", "status": "pass"},
+    ]
+    agg = aggregate_by_axis(results, cases)
+    assert agg["retrieval"] == {"total": 2, "passed": 1, "failed": 1, "pass_rate": 0.5}
+    assert agg["untagged"] == {"total": 1, "passed": 1, "failed": 0, "pass_rate": 1.0}
+
+
+def test_aggregate_multi_axis_double_counts():
+    cases = [{"name": "a", "tests": ["routing", "answer_quality"]}]
+    results = [{"name": "a", "status": "pass"}]
+    agg = aggregate_by_axis(results, cases)
+    assert agg["routing"]["total"] == 1
+    assert agg["answer_quality"]["total"] == 1
+
+
+def test_aggregate_empty_axis_absent():
+    agg = aggregate_by_axis([{"name": "a", "status": "pass"}], [{"name": "a"}])
+    assert "retrieval" not in agg  # only axes actually present appear
+    assert agg["untagged"]["passed"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: FAIL — `ImportError: cannot import name 'aggregate_by_axis'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/decafclaw/eval/diagnostics.py`:
+
+```python
+def aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict:
+    """Pass-rate per failure-mode axis for the #528 scorecard.
+
+    ``test_results[i]`` pairs with ``cases[i]`` by index. A case's axes come
+    from :func:`parse_axes`; an untagged case counts toward ``"untagged"``. A
+    multi-axis case counts once toward each of its axes (so summed axis totals
+    may exceed the test count). Only axes that actually appear are emitted.
+    """
+    buckets: dict[str, dict] = {}
+    for result, case in zip(test_results, cases):
+        axes = parse_axes(case) or ["untagged"]
+        passed = result.get("status") == "pass"
+        for axis in axes:
+            b = buckets.setdefault(
+                axis, {"total": 0, "passed": 0, "failed": 0, "pass_rate": 0.0}
+            )
+            b["total"] += 1
+            b["passed"] += 1 if passed else 0
+            b["failed"] += 0 if passed else 1
+    for b in buckets.values():
+        b["pass_rate"] = round(b["passed"] / b["total"], 4) if b["total"] else 0.0
+    return buckets
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Wire into `run_eval` + print the scorecard**
+
+In `src/decafclaw/eval/runner.py`, add to the imports block (top of file, with the other `..` imports):
+
+```python
+from .diagnostics import aggregate_by_axis, build_turn_diagnostics
+```
+
+(Note: `build_turn_diagnostics` is used in Task 5; importing it now is harmless.)
+
+In `run_eval`, immediately before `results["summary"]["duration_sec"] = round(...)` (~line 900), add:
+
+```python
+    # Per-axis failure-mode scorecard (#528). Cases align with results by index.
+    results["summary"]["by_axis"] = aggregate_by_axis(results["tests"], yaml_data)
+```
+
+Then, after `results["summary"]["duration_sec"] = round(...)` and before `return results, ...`, add the console print:
+
+```python
+    by_axis = results["summary"]["by_axis"]
+    if by_axis:
+        print("\nBy axis (failure-mode scorecard):")
+        for axis in sorted(by_axis):
+            b = by_axis[axis]
+            print(f"  {axis:<22} {b['passed']}/{b['total']}  "
+                  f"({b['pass_rate'] * 100:.0f}%)")
+```
+
+- [ ] **Step 6: Run full eval-harness unit tests**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py tests/test_eval_setup_overrides.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Update docs**
+
+In `docs/eval-loop.md`, add a section "Axis tagging & the failure-mode scorecard" documenting: the top-level `tests:` key (string or list), the four canonical axes, the `untagged` bucket, unknown → error, that `results.json` `summary.by_axis` carries per-axis pass rates and `make eval` prints the scorecard, and that multi-axis cases double-count. Note the deferred per-axis history trend as a follow-up.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/decafclaw/eval/diagnostics.py tests/test_eval_diagnostics.py \
+        src/decafclaw/eval/runner.py docs/eval-loop.md
+git commit -m "feat(eval): aggregate pass-rate by failure-mode axis (#528)"
+```
+
+---
+
+## Task 3: `detect_files_read` + `detect_files_cited`
+
+**Files:**
+- Modify: `src/decafclaw/eval/diagnostics.py`
+- Test: `tests/test_eval_diagnostics.py`
+
+**Interfaces:**
+- Produces:
+  - `detect_files_read(tool_calls: list[tuple[str, dict]]) -> list[str]` — from `(name, args)` tuples (as returned by `runner._collect_tool_calls`), extract the file/page identifier for each read-shaped call per `READ_TOOL_ARGS`. Order-preserving, deduped, drops empty.
+  - `detect_files_cited(response: str, known_paths: list[str]) -> list[str]` — heuristic: any `known_path` whose full path, basename, or stem (case-insensitive) appears as a substring of `response`, PLUS every `[[PageName]]` wiki-mention in `response`. Order: matched known_paths (input order) then wiki-mentions not already present. Deduped.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_eval_diagnostics.py
+from decafclaw.eval.diagnostics import detect_files_cited, detect_files_read
+
+
+def test_detect_files_read_maps_args():
+    calls = [
+        ("vault_read", {"page": "agent/pages/DecafClaw"}),
+        ("workspace_read", {"path": "notes/todo.md"}),
+        ("conversation_search", {"query": "x"}),  # not a read tool
+        ("vault_read", {"page": "agent/pages/DecafClaw"}),  # dup
+    ]
+    assert detect_files_read(calls) == ["agent/pages/DecafClaw", "notes/todo.md"]
+
+
+def test_detect_files_read_drops_empty():
+    assert detect_files_read([("vault_read", {})]) == []
+
+
+def test_detect_files_cited_path_and_wiki():
+    resp = "See [[Escalation Runbook]]. I read the escalation-runbook page."
+    known = ["agent/pages/escalation-runbook.md", "agent/pages/oncall-rotation.md"]
+    cited = detect_files_cited(resp, known)
+    assert "agent/pages/escalation-runbook.md" in cited  # stem 'escalation-runbook' matched
+    assert "Escalation Runbook" in cited                 # wiki-mention
+    assert "agent/pages/oncall-rotation.md" not in cited  # never mentioned
+
+
+def test_detect_files_cited_no_false_positive_on_unrelated():
+    resp = "I don't have anything on that topic."
+    assert detect_files_cited(resp, ["agent/pages/escalation-runbook.md"]) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: FAIL — `ImportError: cannot import name 'detect_files_read'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/decafclaw/eval/diagnostics.py`:
+
+```python
+import re
+from pathlib import PurePosixPath
+
+_WIKI_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def detect_files_read(tool_calls: list[tuple[str, dict]]) -> list[str]:
+    """File/page identifiers read this turn, from read-shaped tool calls.
+
+    ``tool_calls`` is the ``(name, parsed_args)`` list from
+    ``runner._collect_tool_calls``. Order-preserving, deduped, empties dropped.
+    """
+    out: list[str] = []
+    for name, args in tool_calls:
+        arg_key = READ_TOOL_ARGS.get(name)
+        if not arg_key:
+            continue
+        value = args.get(arg_key)
+        if value and value not in out:
+            out.append(value)
+    return out
+
+
+def detect_files_cited(response: str, known_paths: list[str]) -> list[str]:
+    """Heuristic: which known files/pages the final response cites.
+
+    A ``known_path`` counts as cited if its full path, basename, or stem
+    (case-insensitive) is a substring of ``response``. Additionally, every
+    ``[[PageName]]`` wiki-mention in the response is included. Documented as a
+    heuristic — substring matching can over- or under-count (#531).
+    """
+    lower = response.lower()
+    cited: list[str] = []
+    for path in known_paths:
+        p = PurePosixPath(path)
+        needles = {path.lower(), p.name.lower(), p.stem.lower()}
+        if any(n and n in lower for n in needles):
+            if path not in cited:
+                cited.append(path)
+    for m in _WIKI_RE.findall(response):
+        name = m.strip()
+        if name and name not in cited:
+            cited.append(name)
+    return cited
+```
+
+(Move the `import re` / `from pathlib import ...` to the top of the module with the other imports.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: PASS (13 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/eval/diagnostics.py tests/test_eval_diagnostics.py
+git commit -m "feat(eval): file-read + file-cited detection for diagnostics (#531)"
+```
+
+---
+
+## Task 4: `build_turn_diagnostics`
+
+**Files:**
+- Modify: `src/decafclaw/eval/diagnostics.py`
+- Test: `tests/test_eval_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `detect_files_read`, `detect_files_cited` (Task 3).
+- Produces: `build_turn_diagnostics(sidecar: dict | None, tool_calls: list[tuple[str, dict]], response: str) -> dict` — merges sidecar-sourced fields (tokens by section, active/deferred tool counts, retrieved candidates, totals) with derived fields (files read, files cited, tool-call names+count). `sidecar=None` degrades to derived-only fields (sidecar fields default: `tokens_by_section={}`, `active_tools`/`deferred_tools`/totals `None`, `retrieved_candidates=[]`). The returned dict is the `diagnostics` block attached to each eval turn.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_eval_diagnostics.py
+from decafclaw.eval.diagnostics import build_turn_diagnostics
+
+
+def _sidecar():
+    return {
+        "total_tokens_estimated": 12000,
+        "total_tokens_actual": 11800,
+        "context_window_size": 1000000,
+        "compaction_threshold": 150000,
+        "sources": [
+            {"source": "system", "tokens_estimated": 3000, "items_included": 1,
+             "items_truncated": 0, "details": {}},
+            {"source": "tools", "tokens_estimated": 2000, "items_included": 8,
+             "items_truncated": 40, "details": {}},
+            {"source": "retrieved_context", "tokens_estimated": 1500,
+             "items_included": 3, "items_truncated": 0, "details": {}},
+        ],
+        "memory_candidates": [
+            {"file_path": "agent/pages/escalation-runbook.md",
+             "composite_score": 0.82, "similarity": 0.79, "recency": 0.5,
+             "importance": 0.9},
+        ],
+    }
+
+
+def test_build_turn_diagnostics_full():
+    calls = [("vault_read", {"page": "agent/pages/escalation-runbook.md"})]
+    resp = "Per the escalation-runbook, Priya is paged first."
+    d = build_turn_diagnostics(_sidecar(), calls, resp)
+    assert d["tokens_by_section"] == {"system": 3000, "tools": 2000,
+                                      "retrieved_context": 1500}
+    assert d["active_tools"] == 8
+    assert d["deferred_tools"] == 40
+    assert d["total_tokens_estimated"] == 12000
+    assert d["files_read"] == ["agent/pages/escalation-runbook.md"]
+    assert "agent/pages/escalation-runbook.md" in d["files_cited"]
+    assert d["tool_calls"] == {"names": ["vault_read"], "count": 1}
+    assert d["retrieved_candidates"][0]["file_path"] == "agent/pages/escalation-runbook.md"
+
+
+def test_build_turn_diagnostics_none_sidecar_degrades():
+    calls = [("workspace_read", {"path": "notes/x.md"})]
+    d = build_turn_diagnostics(None, calls, "read notes/x.md")
+    assert d["tokens_by_section"] == {}
+    assert d["active_tools"] is None
+    assert d["deferred_tools"] is None
+    assert d["total_tokens_estimated"] is None
+    assert d["retrieved_candidates"] == []
+    assert d["files_read"] == ["notes/x.md"]
+    assert d["tool_calls"] == {"names": ["workspace_read"], "count": 1}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: FAIL — `ImportError: cannot import name 'build_turn_diagnostics'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/decafclaw/eval/diagnostics.py`:
+
+```python
+def build_turn_diagnostics(
+    sidecar: dict | None,
+    tool_calls: list[tuple[str, dict]],
+    response: str,
+) -> dict:
+    """Assemble the per-turn ``diagnostics`` block for an eval result (#531).
+
+    Sidecar-sourced fields (token split, tool counts, retrieved candidates,
+    totals) reuse the context sidecar written on turn-exit — no recompute.
+    Derived fields (files read/cited, tool-call names+count) come from the
+    turn's history slice. A ``None`` sidecar (missing file) degrades to the
+    derived fields only; never raises.
+    """
+    sidecar = sidecar or {}
+    sources = sidecar.get("sources") or []
+    tokens_by_section = {s.get("source", ""): s.get("tokens_estimated", 0)
+                         for s in sources}
+    tools_src = next((s for s in sources if s.get("source") == "tools"), None)
+
+    candidates = [
+        {
+            "file_path": c.get("file_path", ""),
+            "composite_score": c.get("composite_score"),
+            "similarity": c.get("similarity"),
+            "recency": c.get("recency"),
+            "importance": c.get("importance"),
+        }
+        for c in (sidecar.get("memory_candidates") or [])
+    ]
+
+    files_read = detect_files_read(tool_calls)
+    candidate_paths = [c["file_path"] for c in candidates if c["file_path"]]
+    files_cited = detect_files_cited(response, files_read + candidate_paths)
+
+    return {
+        "tokens_by_section": tokens_by_section,
+        "total_tokens_estimated": sidecar.get("total_tokens_estimated"),
+        "total_tokens_actual": sidecar.get("total_tokens_actual"),
+        "context_window_size": sidecar.get("context_window_size"),
+        "compaction_threshold": sidecar.get("compaction_threshold"),
+        "active_tools": tools_src.get("items_included") if tools_src else None,
+        "deferred_tools": tools_src.get("items_truncated") if tools_src else None,
+        "retrieved_candidates": candidates,
+        "files_read": files_read,
+        "files_cited": files_cited,
+        "tool_calls": {"names": [n for n, _ in tool_calls], "count": len(tool_calls)},
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: PASS (15 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/eval/diagnostics.py tests/test_eval_diagnostics.py
+git commit -m "feat(eval): assemble per-turn diagnostics block from sidecar + derived (#531)"
+```
+
+---
+
+## Task 5: wire diagnostics into `run_test` + `--verbose` console + docs
+
+**Files:**
+- Modify: `src/decafclaw/eval/runner.py` (`run_test` ~lines 736-807; `run_eval` verbose block ~line 887)
+- Modify: `docs/eval-loop.md`
+- Test: `tests/test_eval_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `build_turn_diagnostics` (Task 4); `read_context_sidecar` from `context_composer`; `_collect_tool_calls` (existing in runner).
+- Produces: each entry in `result["turns"]` (and each single-turn `all_responses` entry) gains a `"diagnostics"` key; `run_test`'s top-level `result` gains a `"diagnostics"` key = the last turn's block. `--verbose` prints a compact per-test diagnostics summary.
+
+- [ ] **Step 1: Write the failing test** (wiring test with monkeypatched turn + sidecar)
+
+```python
+# append to tests/test_eval_diagnostics.py
+import json as _json
+
+import pytest as _pytest
+
+from decafclaw.config import Config
+from decafclaw.eval import runner as eval_runner
+from decafclaw.eval.runner import _build_test_config, run_test
+
+
+class _FakeResult:
+    def __init__(self, text):
+        self.text = text
+
+
+@_pytest.mark.asyncio
+async def test_run_test_attaches_diagnostics(tmp_path, monkeypatch):
+    # Fake the LLM turn: append a synthetic vault_read call to history, no model.
+    async def _fake_turn(ctx, turn_input, history):
+        history.append({
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": "c0", "function": {
+                "name": "vault_read",
+                "arguments": _json.dumps({"page": "agent/pages/foo"})}}],
+        })
+        history.append({"role": "tool", "tool_call_id": "c0", "content": "ok"})
+        return _FakeResult("I read agent/pages/foo and here is the answer.")
+
+    monkeypatch.setattr(eval_runner, "run_agent_turn", _fake_turn)
+    monkeypatch.setattr(
+        eval_runner, "read_context_sidecar",
+        lambda config, conv_id: {
+            "total_tokens_estimated": 100, "sources": [
+                {"source": "tools", "tokens_estimated": 10,
+                 "items_included": 5, "items_truncated": 20, "details": {}}],
+            "memory_candidates": []},
+    )
+
+    cfg = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    result = await run_test(cfg, {"name": "t", "input": "hi", "expect": {}})
+
+    diag = result["diagnostics"]
+    assert diag["files_read"] == ["agent/pages/foo"]
+    assert "agent/pages/foo" in diag["files_cited"]
+    assert diag["active_tools"] == 5
+    assert diag["deferred_tools"] == 20
+    assert diag["tool_calls"]["count"] == 1
+```
+
+Note: `pyproject.toml` sets `asyncio_mode = "auto"`, so the `@pytest.mark.asyncio` marker is optional (harmless to keep — existing tests keep it). No `pytest-asyncio` event-loop fixture needed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py::test_run_test_attaches_diagnostics -q`
+Expected: FAIL — `KeyError: 'diagnostics'` (or AttributeError on `read_context_sidecar` if not yet imported into runner).
+
+- [ ] **Step 3: Implement the wiring**
+
+In `src/decafclaw/eval/runner.py` imports, add:
+
+```python
+from ..context_composer import read_context_sidecar
+```
+
+In `run_test`, inside the turn loop, replace the `all_responses.append({...})` block that follows `tool_calls = _count_tool_calls(history) - pre_turn_tool_calls` (~line 743) so it also builds and attaches diagnostics:
+
+```python
+        # Per-turn counts (delta from pre-turn snapshot)
+        tool_calls = _count_tool_calls(history) - pre_turn_tool_calls
+        turn_slice = history[pre_turn_history_len:]
+        sidecar = read_context_sidecar(config, ctx.conv_id)
+        diagnostics = build_turn_diagnostics(
+            sidecar, _collect_tool_calls(turn_slice), response,
+        )
+        all_responses.append({
+            "turn": turn_idx + 1,
+            "input": turn["input"],
+            "response": response,
+            "duration_sec": round(duration, 1),
+            "tool_calls": tool_calls,
+            "diagnostics": diagnostics,
+        })
+```
+
+(The existing assertion block below recomputes `turn_slice`/`tool_names`; leave it — it's cheap and keeps the diff local. Do not remove the later `turn_slice` assignment.)
+
+Then, where the top-level `result` dict is built (~line 790), add the top-level diagnostics after it:
+
+```python
+    result = {
+        "name": test_case["name"],
+        "status": "pass" if overall_passed else "fail",
+        "duration_sec": round(total_duration, 1),
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "tool_calls": total_tool_calls,
+        "response": final_response,
+        "failure_reason": failure_reason,
+    }
+    if all_responses:
+        result["diagnostics"] = all_responses[-1]["diagnostics"]
+```
+
+- [ ] **Step 4: Add the `--verbose` console summary**
+
+In `run_eval`, in the `if verbose and result.get("response"):` block (~line 887), extend it to also print diagnostics:
+
+```python
+        if verbose and result.get("response"):
+            print(f"         Response: {result['response'][:200]}")
+            diag = result.get("diagnostics")
+            if diag:
+                tbs = diag.get("tokens_by_section") or {}
+                tok = "  ".join(f"{k}={v}" for k, v in tbs.items())
+                print(f"         Tokens: {tok}"
+                      f"  (active={diag.get('active_tools')}, "
+                      f"deferred={diag.get('deferred_tools')})")
+                cands = diag.get("retrieved_candidates") or []
+                top = ", ".join(f"{c['file_path']}:{c.get('composite_score')}"
+                                for c in cands[:3])
+                if top:
+                    print(f"         Candidates: {top}")
+                print(f"         Read: {diag.get('files_read')}  "
+                      f"Cited: {diag.get('files_cited')}  "
+                      f"Tools: {diag.get('tool_calls', {}).get('names')}")
+```
+
+- [ ] **Step 5: Run the wiring test + full eval unit suite**
+
+Run: `uv run pytest tests/test_eval_diagnostics.py -q`
+Expected: PASS (16 passed).
+
+- [ ] **Step 6: Update docs**
+
+In `docs/eval-loop.md`, document the per-turn `diagnostics` block: its shape (list the keys), that it reuses the context sidecar (link `docs/context-composer.md#diagnostics-sidecar`), the four diagnosis modes (retrieval/routing/answer/bloat) it enables, the `files_cited` heuristic (substring + `[[wiki]]`), the absence of per-tool durations (deferred), and the `--verbose` summary.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/decafclaw/eval/runner.py docs/eval-loop.md tests/test_eval_diagnostics.py
+git commit -m "feat(eval): attach per-turn context diagnostics to result bundles (#531)"
+```
+
+---
+
+## Tasks 6–12: behavioral eval suites
+
+**Shared authoring notes (apply to every suite task):**
+- Each case gets a top-level `tests:` axis tag (per the table below) plus `name`, `input`/`turns`, `expect`.
+- Bound every case with `max_tool_calls` + `max_tool_errors: 0` (raise the error bound only with a comment if a case legitimately expects a tool error).
+- Any `expect_no_tool` / tight-`max_tool_calls` case adds `setup.config_overrides: {reflection.enabled: false}`.
+- Seed vault pages via `setup.workspace_files` under `vault/agent/pages/<name>.md` (optionally with frontmatter, mirroring `evals/retrieval-quality.yaml`); seed prior turns via `setup.conversation_history`; seed journal via `setup.memories`.
+- **Validation is the real test:** run `uv run python -m decafclaw.eval evals/<suite>.yaml --verbose` against the configured model. Tune assertions until the suite passes reliably (the `--verbose` diagnostics now show you *why* a case fails — retrieval vs routing vs answer). A case that can't be made to pass honestly gets dropped with a note in `notes.md`, not a weakened assertion.
+- Target 4–5 cases per suite (≈30 total). If validation cost bites, ship a suite with a documented minimum of 2 and note the shortfall.
+- Commit each suite in its own commit: `test(eval): <suite> behavioral suite (#528)`.
+
+| Task | Suite file | `tests:` axis | Adversarial focus |
+|---|---|---|---|
+| 6 | `vault_answering.yaml` | `retrieval` | right page vs similar-but-wrong distractor; admit absence |
+| 7 | `tool_routing.yaml` | `routing` | vault vs workspace vs conversation_search |
+| 8 | `source_grounding.yaml` | `answer_quality` | cite the file or hedge; no fabrication |
+| 9 | `context_pressure.yaml` | `answer_quality` | answer survives noisy history + big tool output |
+| 10 | `clarification.yaml` | `workflow_discipline` | ask one Q only when ambiguity matters |
+| 11 | `abort_recovery.yaml` | `workflow_discipline` | no stale-intent resurrection after cancel/error |
+| 12 | `over_ceremony.yaml` | `workflow_discipline` | simple ask → no checklist/project escalation |
+
+### Task 6: `vault_answering.yaml` (retrieval)
+
+**Files:** Create `evals/vault_answering.yaml`.
+
+- [ ] **Step 1: Author the suite.** Starter cases (tune during validation):
+
+```yaml
+# Behavioral suite — RETRIEVAL axis (#528). Adversarial: a similar-but-wrong
+# distractor page sits next to the right one; a third case has NO matching page
+# so the agent must admit absence rather than answer from the distractor.
+
+- name: "retrieves the right page past a similar-but-wrong distractor"
+  tests: retrieval
+  setup:
+    workspace_files:
+      "vault/agent/pages/staging-deploy.md": |
+        # Staging Deploy
+        Staging deploys run automatically on every merge to `develop`.
+      "vault/agent/pages/production-deploy.md": |
+        # Production Deploy
+        Production deploys are manual: run `./scripts/deploy.sh prod` after a
+        release tag is cut. Requires the on-call lead's approval.
+  input: "How do we deploy to production?"
+  expect:
+    response_contains_all: ["deploy.sh", "approval"]
+    response_contains: "manual"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "admits absence when no vault page covers the question"
+  tests: retrieval
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "vault/agent/pages/staging-deploy.md": |
+        # Staging Deploy
+        Staging deploys run automatically on every merge to `develop`.
+  input: "What's our data-retention policy for customer PII?"
+  expect:
+    # Must NOT fabricate a policy; hedge/deny instead. A LIST on
+    # `response_contains` is ANY-match (see runner.py:364) — there is no
+    # separate `response_contains_any` assertion.
+    response_contains: ["don't have", "not find", "nothing", "couldn't find", "no information"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+```
+
+Add 2–3 more retrieval cases in the same shape (e.g. distractor filenames that share a stem; a page reachable only by semantic match). **Assertion note:** `response_contains` accepts a string, a list (ANY-match), or a `re:`-prefixed regex; `response_contains_all` is AND-match. There is **no** `response_contains_any` — use a list on `response_contains`.
+
+- [ ] **Step 2: Validate with a real run.**
+
+Run: `uv run python -m decafclaw.eval evals/vault_answering.yaml --verbose`
+Expected: all cases PASS; the by-axis scorecard shows `retrieval N/N (100%)`. Tune until reliable.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add evals/vault_answering.yaml
+git commit -m "test(eval): vault_answering behavioral suite (#528)"
+```
+
+### Task 7: `tool_routing.yaml` (routing)
+
+**Files:** Create `evals/tool_routing.yaml`.
+
+- [ ] **Step 1: Author the suite.** Each case seeds data reachable by exactly ONE surface and asserts the right tool via `expect_tool` + `expect_no_tool`. Starter:
+
+```yaml
+# Behavioral suite — ROUTING axis (#528). Each case makes exactly one surface
+# the correct source; asserts the agent routes there and not to look-alikes.
+
+- name: "routes to conversation_search for 'what did I say' history queries"
+  tests: routing
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - role: user
+        content: "Remember: our staging DB password rotates every 30 days."
+      - role: assistant
+        content: "Noted — staging DB password rotates every 30 days."
+  input: "What did I tell you earlier about the staging DB password rotation?"
+  expect:
+    expect_tool: conversation_search
+    expect_no_tool: vault_search
+    response_contains: "30 days"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "routes to workspace_read for a concrete workspace file path"
+  tests: routing
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/release-checklist.md": |
+        # Release Checklist
+        1. Bump version. 2. Tag. 3. Run deploy.sh.
+  input: "Read notes/release-checklist.md and tell me step 3."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "deploy.sh"
+    max_tool_calls: 4
+    max_tool_errors: 0
+```
+
+Add 2–3 more (e.g. a vault-knowledge question → `vault_search`/`vault_read`, not `workspace_read`).
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/tool_routing.yaml --verbose` → all PASS, `routing N/N`.
+- [ ] **Step 3: Commit.** `test(eval): tool_routing behavioral suite (#528)`
+
+### Task 8: `source_grounding.yaml` (answer_quality)
+
+**Files:** Create `evals/source_grounding.yaml`.
+
+- [ ] **Step 1: Author.** Cases where the right answer is present in a seeded source and a plausible-but-absent detail is asked; assert the answer cites the seeded fact and does NOT fabricate the absent detail. Starter:
+
+```yaml
+# Behavioral suite — ANSWER_QUALITY axis (#528). Answers must ground in a
+# seeded source or hedge; no fabricated specifics.
+
+- name: "grounds the answer in the seeded page, no invented figures"
+  tests: answer_quality
+  setup:
+    workspace_files:
+      "vault/agent/pages/sla.md": |
+        # Support SLA
+        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+  input: "What's our first-response SLA for P1 incidents?"
+  expect:
+    response_contains: "30 minutes"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "hedges instead of fabricating an unseeded SLA tier"
+  tests: answer_quality
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "vault/agent/pages/sla.md": |
+        # Support SLA
+        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+  input: "What's our first-response SLA for P3 incidents?"
+  expect:
+    # P3 is not in the page — must not invent a number. List = ANY-match.
+    response_contains: ["don't", "not ", "isn't", "doesn't", "no P3"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+```
+
+Add 2–3 more.
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/source_grounding.yaml --verbose` → all PASS.
+- [ ] **Step 3: Commit.** `test(eval): source_grounding behavioral suite (#528)`
+
+### Task 9: `context_pressure.yaml` (answer_quality)
+
+**Files:** Create `evals/context_pressure.yaml`.
+
+- [ ] **Step 1: Author.** Seed a long, noisy `conversation_history` with one buried load-bearing fact; ask about that fact; assert it's recovered. Starter:
+
+```yaml
+# Behavioral suite — ANSWER_QUALITY under CONTEXT PRESSURE (#528). A single
+# load-bearing fact is buried in noisy history; the agent must still surface it.
+
+- name: "recovers a buried fact from noisy history"
+  tests: answer_quality
+  setup:
+    conversation_history:
+      - {role: user, content: "Random chit-chat about the weather."}
+      - {role: assistant, content: "It does look like rain."}
+      - {role: user, content: "By the way the prod API key lives in Vault path secret/prod/api."}
+      - {role: assistant, content: "Got it — secret/prod/api."}
+      - {role: user, content: "Anyway, back to the weekend plans."}
+      - {role: assistant, content: "Sounds fun."}
+  input: "Where does the prod API key live again?"
+  expect:
+    response_contains: "secret/prod/api"
+    max_tool_calls: 5
+    max_tool_errors: 0
+```
+
+Add 2–3 more (bigger history; a large seeded workspace file the agent must read past).
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/context_pressure.yaml --verbose` → all PASS.
+- [ ] **Step 3: Commit.** `test(eval): context_pressure behavioral suite (#528)`
+
+### Task 10: `clarification.yaml` (workflow_discipline)
+
+**Files:** Create `evals/clarification.yaml`.
+
+- [ ] **Step 1: Author.** One case where the ask is genuinely ambiguous (agent SHOULD ask exactly one clarifying question, take no action tools) and one where it's clear (agent should proceed, not stall on a question). Starter:
+
+```yaml
+# Behavioral suite — WORKFLOW_DISCIPLINE / clarification (#528). Ask one useful
+# question only when ambiguity actually blocks progress; otherwise proceed.
+
+- name: "asks one clarifying question on a genuinely ambiguous ask"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "Delete it."
+  expect:
+    response_contains: "?"
+    expect_no_tool: workspace_delete
+    max_tool_calls: 1
+    max_tool_errors: 0
+
+- name: "proceeds without over-asking on a clear request"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/scratch.md": "throwaway"
+  input: "Read notes/scratch.md and tell me what it says."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "throwaway"
+    max_tool_calls: 3
+    max_tool_errors: 0
+```
+
+(`workspace_delete` is the confirmed delete-tool name.) Add 1–2 more.
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/clarification.yaml --verbose` → all PASS.
+- [ ] **Step 3: Commit.** `test(eval): clarification behavioral suite (#528)`
+
+### Task 11: `abort_recovery.yaml` (workflow_discipline)
+
+**Files:** Create `evals/abort_recovery.yaml`.
+
+- [ ] **Step 1: Author.** Seed a `conversation_history` that ends in a cancelled turn (a `cancel_marker` row carrying the **exact** production `CANCEL_MARKER_TEXT`), then send an unrelated new user message; assert the agent does the NEW thing and does not resurrect the cancelled intent. Starter:
+
+```yaml
+# Behavioral suite — WORKFLOW_DISCIPLINE / abort-recovery (#528, builds on #517).
+# After a cancelled turn, the next message must not re-fulfill the abandoned intent.
+# The cancel_marker content is the verbatim CANCEL_MARKER_TEXT from
+# conversation_manager.py:37 — the exact "turn closed" signal the LLM sees.
+
+- name: "does not resurrect a cancelled intent"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - {role: user, content: "Search the web for the cheapest flights to Tokyo in March."}
+      - {role: assistant, content: "Searching for flights to Tokyo..."}
+      - {role: cancel_marker, content: "[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"}
+  input: "What's 17 times 23?"
+  expect:
+    # Primary signal: it answers the NEW question. The web tools (tabstack_*,
+    # web_fetch) live behind the tabstack skill and are NOT loaded here, so an
+    # `expect_no_tool` on them is weak defense-in-depth at best — the real proof
+    # is the correct arithmetic answer plus a tight call budget (no flailing).
+    response_contains: "391"
+    max_tool_calls: 2
+    max_tool_errors: 0
+```
+
+Facts (verified): `CANCEL_MARKER_TEXT` is exactly
+`"[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"`.
+Web tools are the deferred tabstack-skill tools (`tabstack_research`, `web_fetch`, …), not a `web_search` tool — don't assert `expect_no_tool: web_search` (phantom name → trivially passes). Add 1–2 more cases: an **exception-marker** variant (grep `conversation_manager.py` for the #517 error-abort marker text and seed a row with that content), and a cancelled multi-step task followed by a small unrelated ask.
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/abort_recovery.yaml --verbose` → all PASS.
+- [ ] **Step 3: Commit.** `test(eval): abort_recovery behavioral suite (#528)`
+
+### Task 12: `over_ceremony.yaml` (workflow_discipline)
+
+**Files:** Create `evals/over_ceremony.yaml`.
+
+- [ ] **Step 1: Author.** A trivial one-shot ask that should NOT trigger checklist/project escalation. Starter:
+
+```yaml
+# Behavioral suite — WORKFLOW_DISCIPLINE / over-ceremony (#528). A simple ask
+# must not spin up a checklist or project structure.
+
+- name: "simple ask does not create a checklist"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "What's the capital of France?"
+  expect:
+    response_contains: "Paris"
+    expect_no_tool: checklist_create
+    max_tool_calls: 1
+    max_tool_errors: 0
+
+- name: "small two-step ask stays inline, no project escalation"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/a.md": "alpha"
+      "notes/b.md": "beta"
+  input: "Read notes/a.md and notes/b.md and tell me both contents."
+  expect:
+    response_contains_all: ["alpha", "beta"]
+    expect_no_tool: checklist_create
+    max_tool_calls: 4
+    max_tool_errors: 0
+```
+
+Add 1–2 more. Confirm the checklist/project escalation tool names to assert `expect_no_tool` against (`checklist_create`, and the project skill's activation via `activate_skill` — consider `expect_no_tool: activate_skill` where appropriate).
+
+- [ ] **Step 2: Validate.** `uv run python -m decafclaw.eval evals/over_ceremony.yaml --verbose` → all PASS.
+- [ ] **Step 3: Commit.** `test(eval): over_ceremony behavioral suite (#528)`
+
+---
+
+## Task 13: docs consolidation, full-suite verification, retro
+
+**Files:**
+- Modify: `docs/eval-loop.md` (final pass), `docs/index.md` (if a new doc section warrants a link — likely not)
+- Create: `docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md`
+
+- [ ] **Step 1: Docs accuracy pass.** Re-read the axis-tagging and diagnostics sections of `docs/eval-loop.md` end-to-end; ensure the `tests:` key, canonical axes, `by_axis` shape, scorecard output, diagnostics block keys, `files_cited` heuristic, and deferred items (per-tool durations, per-axis history) are all documented and internally consistent. Cross-link `docs/context-composer.md#diagnostics-sidecar`.
+
+- [ ] **Step 2: Full deterministic suite green.**
+
+Run: `uv run make check && uv run make test`
+Expected: `make check` clean; `make test` all pass, zero warnings, no new `--durations` outliers (`uv run pytest --durations=25` if anything looks slow).
+
+- [ ] **Step 3: Full behavioral eval sanity run + scorecard.**
+
+Run: `uv run python -m decafclaw.eval evals/vault_answering.yaml evals/tool_routing.yaml evals/source_grounding.yaml evals/context_pressure.yaml evals/clarification.yaml evals/abort_recovery.yaml evals/over_ceremony.yaml`
+Expected: the run prints the by-axis scorecard; capture the pass rates into `notes.md`. Confirm `evals/results/<ts>/results.json` contains `summary.by_axis` and per-turn `diagnostics` blocks.
+
+- [ ] **Step 4: Write `notes.md`.** Session summary: what shipped, final case counts per suite (and any suite that fell short of the 4–5 target with why), the scorecard snapshot, deferred follow-ups (per-tool durations, per-axis history trend, retagging existing suites), and any assertion that had to be loosened during tuning (with justification — no silently weakened assertions).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/eval-loop.md docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/notes.md
+git commit -m "docs(eval): behavioral suites + diagnostics — docs + session notes (#528, #531)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- A1 axis metadata → Task 1 (`parse_axes`, strict validation). ✓
+- A2 seven suites → Tasks 6–12, each axis-tagged per the mapping table. ✓
+- A3 aggregate-by-axis + scorecard → Task 2. ✓
+- B1 diagnostics block (sidecar-sourced + derived) → Tasks 3–5. ✓
+- B2 `--verbose` console → Task 5 Step 4. ✓
+- Reuse sidecar, no duplication → Task 4/5 read `read_context_sidecar`, never re-run `build_diagnostics`. ✓
+- Unit tests for deterministic helpers → Tasks 1–5. ✓
+- Docs same PR → Tasks 2, 5, 13. ✓
+- Deferred (durations, per-axis history, retagging) → documented in Task 13 notes + docs. ✓
+
+**Placeholder scan:** suite tasks intentionally carry starter YAML + a real-run validate-and-tune step rather than pre-baked passing assertions, because LLM pass/fail can't be predetermined; this is honest, not a placeholder. All code steps show complete code. No "TBD"/"handle edge cases".
+
+**Type consistency:** `build_turn_diagnostics(sidecar, tool_calls, response)` signature is identical across Task 4 (def), Task 5 (call). `aggregate_by_axis(test_results, cases)` identical across Task 2 def + wiring. `detect_files_read`/`detect_files_cited` signatures match Task 3 → Task 4 usage. `parse_axes(case)` consistent Task 1 → Task 2.
+
+**Verified facts baked in:** `asyncio_mode = "auto"`; `workspace_delete` (delete tool); `checklist_create` (checklist tool); web tools are deferred tabstack-skill tools (`tabstack_research`/`web_fetch`), no `web_search`; `CANCEL_MARKER_TEXT` verbatim; `response_contains` list = ANY-match (no `response_contains_any`). **Still confirm at authoring time:** the project-skill escalation surface to assert `expect_no_tool` against in `over_ceremony` (likely `activate_skill`), and the #517 exception-abort marker text for the `abort_recovery` second case.

--- a/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/spec.md
+++ b/docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/spec.md
@@ -1,0 +1,199 @@
+# Spec: behavioral eval suites + per-turn context diagnostics (#528 + #531)
+
+## Summary
+
+One combined arc closing two related eval-harness issues:
+
+- **#528** — a new cross-cutting eval axis: behavioral suites grouped by *failure mode*
+  (retrieval / routing / answer quality / workflow discipline) rather than by tool/feature,
+  plus axis-tag metadata and an aggregate pass-rate-by-axis scorecard.
+- **#531** — surface per-turn context diagnostics in eval result bundles so a failing eval
+  can be diagnosed (retrieval-miss vs routing-miss vs answer-miss vs context-bloat) with
+  evidence instead of re-running under `LOG_LEVEL=DEBUG`.
+
+They combine because #531's "aggregate report groups by axis tag" acceptance item depends on
+#528's axis tagging, and the diagnostics block is what turns an axis label into an actionable
+diagnosis.
+
+## Motivation
+
+- Per-tool eval coverage answers "does the tool work." Behavioral suites answer "does the agent
+  make good *decisions* about when/how to use tools." Different failure modes, different fixes.
+- When an eval fails today, there's no evidence in the bundle to distinguish a retrieval miss
+  (right file never retrieved), a routing miss (retrieved but not read), an answer miss (read but
+  answered wrong), or context bloat (over budget on schemas/retrieved context). You re-run with
+  debug logging and guess. #531 puts that evidence in the bundle.
+- The diagnostics reuse the existing context-sidecar infrastructure (`context.json` written on
+  every turn-exit) — no recomputation, no duplication.
+
+## Part A — #528: axis tagging + behavioral suites
+
+### A1. Axis-tag metadata
+
+New **top-level** key `tests:` on each eval case (sibling of `name` / `input` / `expect`, **not**
+under `setup:` — it's a classification, not a config override). Accepts a single string or a list
+of strings drawn from a canonical set:
+
+```
+retrieval | routing | answer_quality | workflow_discipline
+```
+
+- A case may declare more than one axis (list form) when it genuinely exercises multiple.
+- **Unknown axis → hard error** at load time, consistent with #663's strict-key stance
+  (`setup.*` unknown keys now raise rather than silently no-op). A typo'd axis must not
+  silently vanish from the scorecard.
+- **Untagged cases** are allowed — they fall into an `untagged` bucket in the aggregate. This
+  means the existing suites (`vault.yaml`, `conversation.yaml`, …) do **not** all need retagging
+  in this PR; only the new behavioral suites are tagged. Retagging the rest is a follow-up.
+
+### A2. Seven behavioral suites
+
+Flat `evals/*.yaml` (matches today's layout; no loader change). Each suite is small, adversarial,
+with distractors and similar-but-wrong filenames so a lazy/greedy strategy fails.
+
+| Suite file | Axis | What it probes |
+|---|---|---|
+| `vault_answering.yaml` | `retrieval` | find the right page, avoid the similar-but-wrong page, admit absence when the page doesn't exist |
+| `tool_routing.yaml` | `routing` | vault vs workspace vs conversation_search picked correctly for the question shape |
+| `source_grounding.yaml` | `answer_quality` | answers cite files or hedge; no fabricated content |
+| `context_pressure.yaml` | `answer_quality` | still answers correctly after noisy history + large tool output |
+| `clarification.yaml` | `workflow_discipline` | ask one useful question only when ambiguity actually matters; otherwise proceed |
+| `abort_recovery.yaml` | `workflow_discipline` | no stale-intent resurrection after cancel/error (unblocked — #517 is Done) |
+| `over_ceremony.yaml` | `workflow_discipline` | a simple ask doesn't trigger checklist / project escalation |
+
+**Target: ~30 cases** (low end of #528's 30–50 acceptance), roughly 4–5 per suite. Each suite is
+authored and validated with a **real model run** as its own plan phase. The count is a knob: if
+validation cost/time bites, individual suites can ship leaner (min 2/suite) and grow later — but
+the arc aims to satisfy #528's acceptance floor.
+
+Assertion discipline (per CLAUDE.md eval conventions):
+- Every case bounded by `max_tool_calls` and `max_tool_errors`.
+- `expect_no_tool` / tight `max_tool_calls` cases set
+  `setup.config_overrides: {reflection.enabled: false}` (reflection's judge can invoke unexpected
+  tools on retries).
+- Prefer `expect_tool` / `expect_no_tool` / `expect_tool_count_by_name` +
+  `response_contains(_all)` over loose text matching.
+
+### A3. Aggregate pass-rate-by-axis
+
+`run_eval` computes and attaches to `results["summary"]`:
+
+```json
+"by_axis": {
+  "retrieval":            {"total": 5, "passed": 4, "failed": 1, "pass_rate": 0.8},
+  "routing":              {"total": 5, "passed": 5, "failed": 0, "pass_rate": 1.0},
+  "answer_quality":       {"total": 9, "passed": 7, "failed": 2, "pass_rate": 0.78},
+  "workflow_discipline":  {"total": 11,"passed": 9, "failed": 2, "pass_rate": 0.82},
+  "untagged":             {"total": 40,"passed": 38,"failed": 2, "pass_rate": 0.95}
+}
+```
+
+- A multi-axis case counts once toward each of its axes (totals across axes may exceed the test
+  count — documented).
+- `make eval` prints a per-axis scorecard table at the end of the run, after the summary line.
+- **Deferred:** per-axis trend in `evals/history.jsonl` (the by-axis aggregate is in-bundle only
+  for now) — a #351-style follow-up.
+
+## Part B — #531: per-turn context diagnostics
+
+### B1. Diagnostics block
+
+A `diagnostics` dict attached to **each turn entry** in `all_responses` **and** to the
+**top-level result** (for single-turn tests the top-level block is that turn; for multi-turn it's
+the last turn). Built by a new helper that merges two sources:
+
+**From the context sidecar** — read via `read_context_sidecar(config, ctx.conv_id)` immediately
+after each `run_agent_turn` (the sidecar is written on turn-exit by `agent.py:_write_diagnostics`
+→ `composer.build_diagnostics()`). Zero recomputation:
+
+- `tokens_by_section` — from `sidecar["sources"]`: `{source: tokens_estimated}` per section
+  (system / history / tools / retrieved-context / …).
+- `active_tools` / `deferred_tools` — from the `"tools"` source entry
+  (`items_included` = active, `items_truncated` = deferred).
+- `retrieved_candidates` — from `sidecar["memory_candidates"]`: file_path + composite/similarity/
+  recency/importance scores (names + scores, as the issue asks).
+- `total_tokens_estimated`, `total_tokens_actual`, `context_window_size`, `compaction_threshold`
+  — passed through from the sidecar.
+
+**Derived from the turn's history slice** (the runner already collects it via
+`_collect_tool_calls` on `history[pre_turn_history_len:]`):
+
+- `tool_calls` — list of `{name}` in call order + `count`. **No per-tool-call durations** — they
+  are not in the archive; capturing them would need a `tool_status` event subscriber. Deferred
+  (documented in the block as absent, and in the spec below).
+- `files_read` — file paths from read-shaped tool calls this turn (`vault_read`, workspace read
+  tools). Derived from parsed tool-call args.
+- `files_cited` — heuristic: the union of (`files_read` ∪ `retrieved_candidates` paths) whose
+  basename or path appears as a substring in the final response text, **plus** any `[[PageName]]`
+  wiki-mentions extracted from the response. Documented as heuristic.
+
+The four diagnosis modes from #531 fall out of these fields:
+- **Retrieval miss** — right file absent from `retrieved_candidates`.
+- **Routing miss** — right file in `retrieved_candidates` but absent from `files_read`.
+- **Answer miss** — right file in `files_read` but assertion still failed.
+- **Context bloat** — `tokens_by_section` over budget on tools / retrieved-context.
+
+### B2. `--verbose` console output
+
+Under each test in `--verbose` mode, print a compact diagnostics summary: token split by section,
+top-N retrieved candidates with composite scores, files read, files cited, and tool-call names.
+Keeps the common diagnosis loop out of the JSON.
+
+## Structure and boundaries
+
+New module **`src/decafclaw/eval/diagnostics.py`** — pure, LLM-free functions:
+
+- `build_turn_diagnostics(sidecar: dict | None, turn_slice: list[dict], response: str) -> dict`
+  — merges sidecar + derived fields into the block. Sidecar `None` (missing file) → degrade to the
+  derived-only fields; never raise.
+- `detect_files_read(tool_calls: list[tuple[str, dict]]) -> list[str]`
+- `detect_files_cited(response: str, known_paths: list[str]) -> list[str]` — substring + `[[wiki]]`.
+- `aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict` — pass-rate per axis.
+- `parse_axes(case: dict) -> list[str]` — validate `tests:` against the canonical set; raise on
+  unknown.
+
+`runner.py` calls these; it does **not** grow more inline logic than the wiring. This keeps the
+new behavior testable without a live model and without a full eval run.
+
+## Testing
+
+- **Unit tests (`tests/`)** — deterministic, no LLM. Cover: `parse_axes` (string form, list form,
+  unknown → raises); `detect_files_read`; `detect_files_cited` (path substring hit, wiki-mention,
+  no false-positive on unrelated text); `build_turn_diagnostics` (full sidecar, `None` sidecar
+  degrade path, tool_calls + files merge); `aggregate_by_axis` (single-axis, multi-axis
+  double-count, untagged bucket, pass-rate arithmetic). Find and extend the existing eval-harness
+  test file(s) (e.g. `tests/test_eval_setup_overrides.py`).
+- **Behavioral suites (LLM-visible)** — validated by real runs (`make eval evals/<suite>.yaml`),
+  per suite, during their authoring phase. Not unit-tested (they exercise model behavior).
+- No new `tool_choice` cases required unless a tool description changes (this arc doesn't sharpen
+  any). Run `make check` + `make test` green before each commit.
+
+## Docs (same PR)
+
+- `docs/eval-loop.md` — axis-tag metadata (`tests:` key + canonical set), the seven suites, the
+  `by_axis` aggregate + scorecard output, the per-turn `diagnostics` block shape, `--verbose`
+  additions.
+- `docs/context-composer.md` — only if the sidecar/diagnostics contract changes (it does not;
+  we consume the existing shape read-only). Likely a one-line cross-reference from eval-loop.
+- Dev-session docs (`spec.md`, `plan.md`, `notes.md`) committed with the PR.
+
+## Explicitly deferred (with a trail)
+
+- **Per-tool-call durations** — not in the archive; would need a `tool_status` subscriber on the
+  eval bus. Diagnostics block carries names + count + the per-turn wall-clock we already have.
+- **Per-axis history trend** — `by_axis` is in-bundle only; extending `evals/history.jsonl` with
+  per-axis pass rates is a #351-style follow-up.
+- **Retagging existing suites** with axis tags — only the new behavioral suites are tagged now;
+  existing ones bucket as `untagged`.
+
+## Acceptance (combined)
+
+- [ ] `tests:` axis metadata parsed + validated (unknown → error); untagged allowed.
+- [ ] Seven behavioral suites exist, ~30 cases total, each bounded and passing on a real run.
+- [ ] `results["summary"]["by_axis"]` present; `make eval` prints a per-axis scorecard.
+- [ ] Each eval result (per-turn + top-level) carries a `diagnostics` block sourced from the
+      context sidecar + derived file/tool fields; missing sidecar degrades gracefully.
+- [ ] `--verbose` prints the compact diagnostics summary.
+- [ ] Diagnostics reuse the sidecar code; no duplication of `build_diagnostics`.
+- [ ] Unit tests cover the deterministic helpers; `make check` + `make test` green.
+- [ ] `docs/eval-loop.md` updated in the same PR.

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -39,6 +39,7 @@ Tests are YAML files with a list of test cases. Single-turn form:
 | `setup` | Fixture setup — see [Setup fields](#setup-fields) |
 | `expect` | Assertions to check — see [Expect assertions](#expect-assertions) |
 | `allowed_tools` | List of tool names; the agent can only call these. Unlisted tool calls return an error. |
+| `tests` | Failure-mode axis tag(s) for the scorecard — a string or list of strings. See [Axis tagging & the failure-mode scorecard](#axis-tagging--the-failure-mode-scorecard) |
 
 ### Setup fields
 
@@ -192,6 +193,49 @@ evals/results/
     reflections/              # LLM-generated analysis of failures
       test-name.md
 ```
+
+## Axis tagging & the failure-mode scorecard
+
+A test case can tag itself with one or more failure-mode axes via the top-level `tests:` key — a string for a single axis, or a list for multiple:
+
+```yaml
+- name: "retrieves the right page for a vague query"
+  input: "what did I write about the migration plan?"
+  tests: retrieval
+  expect:
+    response_contains: "migration"
+
+- name: "routes to the right tool and answers correctly"
+  input: "what's on my calendar tomorrow?"
+  tests: [routing, answer_quality]
+  expect:
+    max_tool_calls: 3
+```
+
+The four canonical axes (`decafclaw.eval.diagnostics.CANONICAL_AXES`) are:
+
+| Axis | Covers |
+|------|--------|
+| `retrieval` | Finding/recalling the right memory, page, or context |
+| `routing` | Picking the right tool/skill for the task |
+| `answer_quality` | Correctness and completeness of the final response |
+| `workflow_discipline` | Following multi-step procedures, confirmations, and guardrails correctly |
+
+A case with no `tests:` key falls into the `untagged` bucket rather than being dropped from the scorecard. An axis value outside the canonical set raises `ValueError` and fails the run rather than silently vanishing.
+
+After each run, `results["summary"]["by_axis"]` in the result bundle's `results.json` maps each axis (plus `untagged`) to `{total, passed, failed, pass_rate}`. `make eval` also prints a scorecard to the console:
+
+```
+By axis (failure-mode scorecard):
+  answer_quality         8/10  (80%)
+  retrieval              5/6  (83%)
+  routing                9/9  (100%)
+  untagged               12/15  (80%)
+```
+
+A case tagged with multiple axes counts once toward *each* of its axes, so axis totals summed across the table can exceed the total test count — that's expected, not a bug.
+
+Per-axis pass-rate trend over time (mirroring [Pass-rate history](#pass-rate-history) but broken out by axis) is a deferred follow-up, not yet implemented.
 
 ## Pass-rate history
 

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -194,6 +194,42 @@ evals/results/
       test-name.md
 ```
 
+## Per-turn diagnostics
+
+Each turn's result (each entry in `result["turns"]` for multi-turn tests, or the top-level `result` for single-turn tests) carries a `"diagnostics"` block built by `decafclaw.eval.diagnostics.build_turn_diagnostics`. It reuses the per-conversation context sidecar the agent already writes on turn-exit (see [Context inspection](context-composer.md#context-inspection)) — no separate recompute — plus a few fields derived from the turn's own history slice:
+
+| Key | Source | Notes |
+|-----|--------|-------|
+| `tokens_by_section` | sidecar | `{source: tokens_estimated}` per context source (`system`, `tools`, `retrieved_context`, ...) |
+| `total_tokens_estimated` / `total_tokens_actual` | sidecar | Whole-turn totals |
+| `context_window_size` / `compaction_threshold` | sidecar | Model's configured limits |
+| `active_tools` / `deferred_tools` | sidecar | `items_included` / `items_truncated` for the `tools` source |
+| `retrieved_candidates` | sidecar | Memory-retrieval candidates with `file_path`, `composite_score`, `similarity`, `recency`, `importance` |
+| `files_read` | derived | Vault/workspace paths read via tool calls this turn |
+| `files_cited` | derived | Of `files_read` plus retrieved-candidate paths, which ones the response text actually references — substring match on file path/stem, or a `[[wiki link]]` mention |
+| `tool_calls` | derived | `{names: [...], count: N}` for this turn |
+
+A missing or unreadable sidecar degrades to the derived fields only (`build_turn_diagnostics` never raises); sidecar-sourced fields come back `None`/empty.
+
+This block is what turns a bare pass/fail into an actionable failure diagnosis, roughly along four lines (independent of, though often correlated with, the [axis tags](#axis-tagging--the-failure-mode-scorecard) above):
+
+- **retrieval** — check `retrieved_candidates`: was the right page even a candidate, and how did it score?
+- **routing** — check `tool_calls.names` and `files_read`: did the agent reach for the right tool at all?
+- **answer** — check `files_cited` vs `files_read`: did the agent read the right thing but fail to ground the answer in it (or fabricate)?
+- **bloat** — check `tokens_by_section` and `active_tools`/`deferred_tools`: is the turn drowning in context it didn't need?
+
+Note what's *not* here: no per-tool-call durations (deferred — the sidecar doesn't currently time individual tool calls).
+
+`--verbose` prints a compact summary of this block after each test's response snippet:
+
+```
+[3/12] retrieves the right page for a vague query ....... PASS  (4.2s, 3100 tokens, 1 tools)
+         Response: Per the migration-plan page, the cutover is scheduled for...
+         Tokens: system=2400  tools=1800  retrieved_context=900  (active=6, deferred=31)
+         Candidates: agent/pages/migration-plan.md:0.87, agent/pages/rollout-notes.md:0.41
+         Read: ['agent/pages/migration-plan.md']  Cited: ['agent/pages/migration-plan.md']  Tools: ['vault_read']
+```
+
 ## Axis tagging & the failure-mode scorecard
 
 A test case can tag itself with one or more failure-mode axes via the top-level `tests:` key — a string for a single axis, or a list for multiple:

--- a/docs/eval-loop.md
+++ b/docs/eval-loop.md
@@ -206,7 +206,7 @@ Each turn's result (each entry in `result["turns"]` for multi-turn tests, or the
 | `active_tools` / `deferred_tools` | sidecar | `items_included` / `items_truncated` for the `tools` source |
 | `retrieved_candidates` | sidecar | Memory-retrieval candidates with `file_path`, `composite_score`, `similarity`, `recency`, `importance` |
 | `files_read` | derived | Vault/workspace paths read via tool calls this turn |
-| `files_cited` | derived | Of `files_read` plus retrieved-candidate paths, which ones the response text actually references — substring match on file path/stem, or a `[[wiki link]]` mention |
+| `files_cited` | derived | Of `files_read` plus retrieved-candidate paths, which ones the response text actually references — case-insensitive substring match on the full path, basename, or stem, plus any `[[wiki link]]` mention in the response |
 | `tool_calls` | derived | `{names: [...], count: N}` for this turn |
 
 A missing or unreadable sidecar degrades to the derived fields only (`build_turn_diagnostics` never raises); sidecar-sourced fields come back `None`/empty.
@@ -258,6 +258,22 @@ The four canonical axes (`decafclaw.eval.diagnostics.CANONICAL_AXES`) are:
 | `workflow_discipline` | Following multi-step procedures, confirmations, and guardrails correctly |
 
 A case with no `tests:` key falls into the `untagged` bucket rather than being dropped from the scorecard. An axis value outside the canonical set raises `ValueError` and fails the run rather than silently vanishing.
+
+### Behavioral suites (#528, #531)
+
+Seven single-axis suites exercise the four canonical axes end-to-end with real LLM turns:
+
+| Suite | Axis | Cases |
+|-------|------|-------|
+| `evals/vault_answering.yaml` | `retrieval` | 5 |
+| `evals/tool_routing.yaml` | `routing` | 5 |
+| `evals/source_grounding.yaml` | `answer_quality` | 5 |
+| `evals/context_pressure.yaml` | `answer_quality` | 4 |
+| `evals/clarification.yaml` | `workflow_discipline` | 4 |
+| `evals/abort_recovery.yaml` | `workflow_discipline` | 4 |
+| `evals/over_ceremony.yaml` | `workflow_discipline` | 5 |
+
+`context_pressure.yaml` and `clarification.yaml` each landed at 4 cases rather than the 5 originally targeted — both suites' authoring comments document a fifth case that was tried against real LLM calls and dropped because it surfaced a genuine behavioral gap (not an eval-design artifact), per the no-silently-weakened-assertions rule. Existing pre-#528 suites (`evals/memory.yaml`, `evals/conversation.yaml`, etc.) are not retroactively axis-tagged; retagging them is a deferred follow-up (see the dev-session notes for #528/#531).
 
 After each run, `results["summary"]["by_axis"]` in the result bundle's `results.json` maps each axis (plus `untagged`) to `{total, passed, failed, pass_rate}`. `make eval` also prints a scorecard to the console:
 

--- a/evals/abort_recovery.yaml
+++ b/evals/abort_recovery.yaml
@@ -1,0 +1,88 @@
+# Behavioral suite — WORKFLOW_DISCIPLINE / abort-recovery (#528, builds on
+# #517). After a turn is cut short — user cancel or an unexpected exception
+# — the NEXT user message must not re-fulfill the abandoned intent. The
+# cancel_marker / turn_aborted rows below carry the verbatim production
+# marker text from conversation_manager.py (CANCEL_MARKER_TEXT and
+# TURN_ABORTED_MARKER_TEXT respectively) — the exact "turn closed" signal
+# the LLM sees. Both roles remap to "user" for the LLM via
+# context_composer.ROLE_REMAP, so seeding either is a faithful reproduction
+# of what actually lands in context, not an approximation.
+#
+# The real proof of non-resurrection in each case is that the agent answers
+# the NEW request (a distinctive, easily-graded token — an arithmetic
+# result or "Paris") within a tight tool-call budget and doesn't reach for
+# the mutating tool tied to the abandoned task. Web-search tools
+# (tabstack_*, web_fetch) live behind the deferred tabstack skill and are
+# NOT loaded in this harness, so `expect_no_tool` on them would be a
+# phantom-name assertion that trivially passes — deliberately not used
+# here. `expect_no_tool` below only names tools that ARE loaded and could
+# plausibly fire if the abandoned task resurrected (workspace_write,
+# send_email).
+#
+# Domain choice note: cases pick arithmetic / geography for the NEW
+# question specifically because they need zero tools to answer — any
+# stray tool call is unambiguously the resurrection reflex, not a
+# legitimate step toward answering the new thing. This also sidesteps the
+# documented reflexive-read behavior (notes_read/vault_search/
+# conversation_search firing before an answer) since those tools aren't
+# needed for arithmetic/geography either, so a tight max_tool_calls stays
+# meaningful without special-casing that reflex.
+
+- name: "does not resurrect a cancelled single-step intent"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - {role: user, content: "Search the web for the cheapest flights to Tokyo in March."}
+      - {role: assistant, content: "Searching for flights to Tokyo..."}
+      - {role: cancel_marker, content: "[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"}
+  input: "What's 17 times 23?"
+  expect:
+    response_contains: "391"
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "does not resurrect a cancelled multi-step task"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - {role: user, content: "Write a 5-paragraph blog post about renewable energy and save it to workspace/blog.md."}
+      - {role: assistant, content: "Sure, drafting the post now — starting with an introduction on solar and wind power..."}
+      - {role: cancel_marker, content: "[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"}
+  input: "What's the capital of France?"
+  expect:
+    response_contains: "Paris"
+    response_not_contains: "renewable"
+    expect_no_tool: workspace_write
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "does not resurrect after an exception-abort marker"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - {role: user, content: "Draft an email to the team about the schedule change and send it."}
+      - {role: assistant, content: "Drafting the email now..."}
+      - {role: turn_aborted, content: "[The previous turn failed unexpectedly. Treat the prior request as not fulfilled and wait for the user to clarify.]"}
+  input: "What's 9 times 8?"
+  expect:
+    response_contains: "72"
+    expect_no_tool: send_email
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "resumes the abandoned task when explicitly asked again"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - {role: user, content: "What's 14 times 6?"}
+      - {role: assistant, content: "Let me calculate that..."}
+      - {role: cancel_marker, content: "[User cancelled this turn. Do not retry the cancelled request unless they explicitly ask for it again.]"}
+  input: "Actually, go ahead and calculate that after all."
+  expect:
+    response_contains: "84"
+    max_tool_calls: 2
+    max_tool_errors: 0

--- a/evals/abort_recovery.yaml
+++ b/evals/abort_recovery.yaml
@@ -69,6 +69,7 @@
   input: "What's 9 times 8?"
   expect:
     response_contains: "72"
+    response_not_contains: ["email", "schedule change"]
     expect_no_tool: send_email
     max_tool_calls: 2
     max_tool_errors: 0

--- a/evals/clarification.yaml
+++ b/evals/clarification.yaml
@@ -1,0 +1,95 @@
+# Behavioral suite — WORKFLOW_DISCIPLINE / clarification (#528). Ask one
+# useful question only when ambiguity actually blocks progress; otherwise
+# proceed without stalling. Two poles per case: a genuinely ambiguous ask
+# (agent should ask exactly one clarifying question, take no action tool)
+# vs. a clear, unambiguous ask (agent should just do it).
+#
+# Reflexive-read note (environmental gotcha from prior tasks in this arc):
+# the model sometimes fires a read-only tool (notes_read, vault_search,
+# conversation_search) before answering, even when nothing in the prompt
+# is researchable. For the "should ask, no action" cases below, that
+# reflex is tolerated rather than treated as a violation: `expect_no_tool`
+# names only the destructive/mutating action tool the case cares about
+# (workspace_delete / workspace_move), and `max_tool_calls` is set to 2
+# (not 1) to leave room for a single reflexive read without loosening the
+# load-bearing assertion (no mutating call happened, and the reply asks a
+# question). This kept the suite green without weakening what it checks.
+#
+# Persona-trigger avoidance: extra_skill_paths make personal persona-*
+# skills real-discoverable in this environment (e.g. "customer" fires
+# persona-customer-support). Wording below avoids business/support
+# vocabulary ("customer", "ticket", "invoice", "deal", "client") that
+# could pull in an unrelated activate_skill call and break max_tool_calls.
+#
+# Dropped case: a "two files match, pick which one" variant (e.g. "Delete
+# the Q1 report." with reports/q1-draft.md + reports/q1-final.md present)
+# was tried and dropped. It surfaced a real, low-frequency (~10-15% across
+# ~25 isolated real-LLM runs, two wordings tried) behavioral gap rather
+# than an eval-design artifact: the model occasionally guesses a
+# plausible-but-wrong literal filename (e.g. "Q1 report.txt") and calls
+# `workspace_delete` on it instead of checking the workspace or asking
+# first, sometimes then asking only after the delete errors out. That's
+# a genuine violation of this axis's pole, not something to paper over
+# with a looser assertion — per the honesty rule, dropped rather than
+# weakened. Worth a follow-up issue: whether the delete-tool description
+# or system prompt should more strongly nudge "check for a match before
+# acting on a described-but-not-path-given target."
+
+- name: "asks one clarifying question on a genuinely ambiguous ask"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "Delete it."
+  # The model reliably declines to guess and asks for the missing referent,
+  # but phrases it either as a literal question ("What would you like to
+  # delete?") or an imperative request ("Please tell me what you'd like to
+  # delete.") — both equally satisfy "asked for clarification instead of
+  # guessing." response_contains is a list here (ANY match) to cover both
+  # observed phrasings rather than over-fitting to punctuation; the
+  # load-bearing check is still expect_no_tool + the tight call bound.
+  expect:
+    response_contains: ["?", "tell me", "specify", "clarify"]
+    expect_no_tool: workspace_delete
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "proceeds without over-asking on a clear request"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/scratch.md": "throwaway"
+  input: "Read notes/scratch.md and tell me what it says."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "throwaway"
+    max_tool_calls: 3
+    max_tool_errors: 0
+
+- name: "creates the requested file directly without asking for confirmation"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "Create a new file at workspace/reminder.md with the content 'Pick up dry cleaning after work.'"
+  expect:
+    expect_tool: workspace_write
+    response_contains: "reminder.md"
+    max_tool_calls: 3
+    max_tool_errors: 0
+  expect_workspace:
+    workspace_file_exists: ["reminder.md"]
+
+- name: "asks which file and which folder before moving, when neither is named"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/summary.md": "Summary notes."
+      "drafts/outline.md": "Outline draft."
+      "archive/old-notes.md": "Old archived notes."
+  input: "Move the file to the other folder."
+  expect:
+    response_contains: "?"
+    expect_no_tool: workspace_move
+    max_tool_calls: 3
+    max_tool_errors: 0

--- a/evals/clarification.yaml
+++ b/evals/clarification.yaml
@@ -70,7 +70,7 @@
   tests: workflow_discipline
   setup:
     config_overrides: {reflection.enabled: false}
-  input: "Create a new file at workspace/reminder.md with the content 'Pick up dry cleaning after work.'"
+  input: "Create a new file at reminder.md with the content 'Pick up dry cleaning after work.'"
   expect:
     expect_tool: workspace_write
     response_contains: "reminder.md"

--- a/evals/context_pressure.yaml
+++ b/evals/context_pressure.yaml
@@ -1,0 +1,180 @@
+# Behavioral suite — ANSWER_QUALITY axis under CONTEXT PRESSURE (#528). Each
+# case buries a single load-bearing fact in noise (a noisy conversation
+# history, or a large workspace file the agent must read past) and asserts
+# the fact still surfaces via a distinctive token a lucky guess couldn't
+# produce. `setup.conversation_history` is pre-loaded into the visible
+# in-memory context (see docs/eval-loop.md), so a plain recall question is
+# legitimately answerable from context — that's the point here, unlike
+# tool_routing.yaml which needed explicit "search" phrasing to force a tool
+# call. Noise avoids "customer" and other persona-trigger vocabulary (see
+# tool_routing.yaml/source_grounding.yaml comments) since extra_skill_paths
+# make several persona-* skills real-discoverable in this environment.
+#
+# Real-run tuning note (this is the load-bearing finding of this suite's
+# authoring pass): the brief's starter buried the fact mid-history behind
+# a "by the way... in case you need it" reminder-style preamble
+# ("...the prod API key lives in Vault path secret/prod/api"). That shape
+# was unreliable across ~50 real-LLM sample runs regardless of fact
+# content (credential paths, door codes, wifi passwords, schedule
+# changes, names) — the model would intermittently reach for `notes_read`
+# (sometimes `vault_search`/`conversation_search`) first, and on an empty
+# result confidently claim "I don't have that" instead of falling back to
+# the fact plainly sitting a few messages back in its own context. Two
+# changes, applied together, reliably fixed it (10/10 real runs each on
+# the two conversation_history cases below, at both short and long
+# history lengths): (1) an announcement-style opener — "Quick heads up —
+# X" — placed as the conversation's first message, rather than a
+# parenthetical reminder buried mid-stream; (2) a plausible-but-wrong
+# decoy value elsewhere in the history, which incidentally also gives
+# each assertion a `response_not_contains` teeth-check. A fifth case
+# tested during authoring (fact placed early in a long history using the
+# brief's original reminder-style framing, to isolate recency bias) never
+# stabilized with that framing — one fact type drew a safety-flavored
+# refusal ("I don't have access to your personal router's PIN") and
+# another still hit the notes_read-reflex failure at a similar rate — but
+# is effectively superseded by the "longer, higher-volume" case below,
+# which already places the fact first ahead of ~20 messages of trailing
+# noise using the winning recipe.
+
+- name: "recovers a buried fact from noisy history"
+  tests: answer_quality
+  setup:
+    conversation_history:
+      - {role: user, content: "Quick heads up — the prod API key is stored at path secret/prod/api."}
+      - {role: assistant, content: "Got it, secret/prod/api for the prod API key."}
+      - {role: user, content: "I ran into Sam at the coffee shop this morning."}
+      - {role: assistant, content: "Small world."}
+      - {role: user, content: "We caught up about the marathon he's training for."}
+      - {role: assistant, content: "That's a big commitment."}
+      - {role: user, content: "I think the staging key might be at path secret/staging/api, but don't quote me on that."}
+      - {role: assistant, content: "Good to know, thanks."}
+      - {role: user, content: "Anyway, did you see the new coffee place opened downtown?"}
+      - {role: assistant, content: "Not yet, I've heard good things though."}
+  input: "Where is the prod API key stored?"
+  expect:
+    response_contains: "secret/prod/api"
+    response_not_contains: "secret/staging/api"
+    max_tool_calls: 5
+    max_tool_errors: 0
+
+- name: "recovers a buried fact from a longer, higher-volume noisy history"
+  tests: answer_quality
+  # Bigger than the case above: ~20 messages of unrelated small talk trail
+  # the load-bearing fact, which still sits as the conversation's first
+  # message (see the suite-level comment on why fact-first plus an
+  # announcement-style opener is the reliable shape here).
+  setup:
+    conversation_history:
+      - {role: user, content: "Quick heads up — the team standup moved to 9:15am starting this week."}
+      - {role: assistant, content: "Good to know, 9:15am it is."}
+      - {role: user, content: "Morning! Is it going to rain today?"}
+      - {role: assistant, content: "Looks partly cloudy, maybe a light drizzle later."}
+      - {role: user, content: "I might bike home before it starts then."}
+      - {role: assistant, content: "Good plan — should still be dry through early afternoon."}
+      - {role: user, content: "Did you catch the game last night?"}
+      - {role: assistant, content: "I saw the highlights, that final quarter was wild."}
+      - {role: user, content: "I'm trying a new pasta recipe tonight, basil and lemon."}
+      - {role: assistant, content: "That sounds refreshing for summer."}
+      - {role: user, content: "I heard the design team's standup might move to 9:30am too, but that's not confirmed yet."}
+      - {role: assistant, content: "Good to know, thanks for the heads up."}
+      - {role: user, content: "Anyway, what book are you reading these days?"}
+      - {role: assistant, content: "Something light, a mystery novel."}
+      - {role: user, content: "My gym schedule got shuffled around this week."}
+      - {role: assistant, content: "That happens. New times settling in okay?"}
+      - {role: user, content: "Yeah, mornings work better anyway."}
+      - {role: assistant, content: "Glad it's working out."}
+      - {role: user, content: "The coffee machine at the office is finally fixed."}
+      - {role: assistant, content: "About time — no more instant packets."}
+      - {role: user, content: "The garden needs watering twice a day in this heat."}
+      - {role: assistant, content: "Definitely, especially the tomatoes."}
+  input: "What time does the team standup start now?"
+  expect:
+    response_contains: "9:15"
+    response_not_contains: "9:30"
+    max_tool_calls: 5
+    max_tool_errors: 0
+
+- name: "recovers the correct on-call name over a topically-similar decoy name"
+  tests: answer_quality
+  # Fact-type variant: a named person rather than a path/number. A decoy
+  # sentence about a *different* person possibly taking over on-call next
+  # month sits later in the history — topically adjacent (same "on-call"
+  # vocabulary) but temporally distinct (future, not current), so a model
+  # skimming for "on-call" keywords could grab the wrong name.
+  setup:
+    conversation_history:
+      - {role: user, content: "Quick heads up — the on-call engineer this week is Priya Nakamura."}
+      - {role: assistant, content: "Got it, Priya Nakamura is on-call this week."}
+      - {role: user, content: "I ran into Sam at the coffee shop this morning."}
+      - {role: assistant, content: "Small world."}
+      - {role: user, content: "We caught up about the marathon he's training for."}
+      - {role: assistant, content: "That's a big commitment."}
+      - {role: user, content: "I heard Jordan might take over on-call duties starting next month."}
+      - {role: assistant, content: "Good to know, thanks for the heads up."}
+      - {role: user, content: "Anyway, did you see the new coffee place opened downtown?"}
+      - {role: assistant, content: "Not yet, I've heard good things though."}
+  input: "Who's the on-call engineer this week?"
+  expect:
+    response_contains: "Priya Nakamura"
+    response_not_contains: "Jordan"
+    max_tool_calls: 5
+    max_tool_errors: 0
+
+- name: "recovers a fact buried in a large workspace file the agent must read past"
+  tests: answer_quality
+  # Different pressure source: the fact isn't in conversation history at
+  # all (workspace_files aren't auto-injected — see docs/eval-loop.md), so
+  # the agent must call workspace_read and then not lose the signal inside
+  # a long, multi-section document. The rollback token is an invented,
+  # non-guessable alphanumeric string.
+  setup:
+    workspace_files:
+      "docs/runbook.md": |
+        # Payments Service Runbook
+
+        ## Overview
+        This runbook covers day-to-day operations for the payments service,
+        including deployment, monitoring, and incident response procedures
+        for the on-call rotation.
+
+        ## Deployment
+        Deployments run through the standard pipeline. Merges to `main` are
+        automatically built and pushed to the staging environment. Promotion
+        to production requires a manual approval step from the release lead.
+        Build artifacts are retained for 30 days before automatic cleanup.
+
+        ## Monitoring
+        Key dashboards track request latency, error rate, and queue depth.
+        Alerts fire when error rate exceeds 2% over a five-minute window, or
+        when queue depth exceeds 500 messages. All alerts route through the
+        standard paging system during business hours and after hours alike.
+
+        ## On-Call Rotation
+        The rotation is weekly, handed off every Monday morning. Each
+        engineer carries a secondary pager as backup in case the primary
+        device fails to receive a page.
+
+        ## Rollback Procedure
+        If a deployment introduces a regression, first confirm the affected
+        version via the deploy dashboard. Then use the rollback tool to
+        revert to the previous known-good build. The rollback token for the
+        payments service is rb-2231-delta. Provide this token when prompted
+        by the rollback tool to authorize the revert. After rolling back,
+        post a summary in the incident channel and open a follow-up ticket
+        to track the root cause investigation.
+
+        ## Common Issues
+        Occasionally the queue backs up during traffic spikes; scaling the
+        worker pool usually resolves this within a few minutes. Slow
+        database queries are the next most common cause of elevated
+        latency, and can usually be diagnosed via the slow-query log.
+
+        ## Escalation
+        If the issue cannot be resolved within thirty minutes, escalate to
+        the secondary on-call engineer and loop in the service owner.
+  input: "Read docs/runbook.md and tell me the rollback token for the payments service."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "rb-2231-delta"
+    max_tool_calls: 4
+    max_tool_errors: 0

--- a/evals/over_ceremony.yaml
+++ b/evals/over_ceremony.yaml
@@ -1,0 +1,78 @@
+# Behavioral suite — WORKFLOW_DISCIPLINE / over-ceremony (#528). A simple ask
+# must not spin up a checklist or project structure. Assertions target the
+# two escalation surfaces: `checklist_create` (always-loaded checklist tool,
+# src/decafclaw/tools/checklist_tools.py) and `activate_skill` (the entry
+# point for the project skill's brainstorm->spec->plan->execute lifecycle,
+# src/decafclaw/tools/skill_tools.py). Neither should fire for a trivial or
+# small ask that can be answered inline in one turn.
+#
+# Case 1 wording note: the plain "What's the capital of France?" (the
+# brief's starter) has a real, low-frequency (~20% across ~14 probe runs)
+# failure mode unrelated to this axis: a reflexive `vault_search` fires,
+# returns "Vault directory does not exist", and the model sometimes
+# concludes it doesn't know the answer instead of falling back to general
+# knowledge for a fact it plainly has. This is a diagnostic/tool-reliance
+# gap, not a checklist/project-escalation issue, so it's out of scope to
+# fix here. The "Off the top of your head, ..." framing below discourages
+# the lookup reflex and was stable 8/8 in isolated probes plus 3+ full
+# suite runs — kept the same underlying trivial-fact case rather than
+# dropping it, per the honesty rule (tune first, drop only if tuning
+# fails).
+
+- name: "simple ask does not create a checklist"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "Off the top of your head, what's the capital of France?"
+  expect:
+    response_contains: "Paris"
+    expect_no_tool: [checklist_create, activate_skill]
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "small two-step ask stays inline, no project escalation"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/a.md": "alpha"
+      "notes/b.md": "beta"
+  input: "Read notes/a.md and notes/b.md and tell me both contents."
+  expect:
+    response_contains_all: ["alpha", "beta"]
+    expect_no_tool: [checklist_create, activate_skill]
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "quick arithmetic answered inline, no ceremony"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "What's 47 times 6?"
+  expect:
+    response_contains: "282"
+    expect_no_tool: [checklist_create, activate_skill]
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "small multi-part factual ask stays inline"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "What's 12 plus 8, and is that number prime?"
+  expect:
+    response_contains_all: ["20", "re:not\\s+(a\\s+)?prime"]
+    expect_no_tool: [checklist_create, activate_skill]
+    max_tool_calls: 2
+    max_tool_errors: 0
+
+- name: "unit conversion pair answered inline"
+  tests: workflow_discipline
+  setup:
+    config_overrides: {reflection.enabled: false}
+  input: "How many centimeters are in 2 meters, and how many in 3 meters?"
+  expect:
+    response_contains_all: ["200", "300"]
+    expect_no_tool: [checklist_create, activate_skill]
+    max_tool_calls: 2
+    max_tool_errors: 0

--- a/evals/source_grounding.yaml
+++ b/evals/source_grounding.yaml
@@ -1,8 +1,16 @@
 # Behavioral suite — ANSWER_QUALITY axis (#528). Answers must ground in a
 # seeded source (vault page or workspace file) or hedge; no fabricated
 # specifics. Two source-and-hedge pairs (vault SLA page, workspace API
-# config file) plus one grounds-only case on a non-numeric process fact,
-# for source-type diversity.
+# config file).
+#
+# NOTE: a fifth case (grounding a non-numeric process fact via a vault page
+# reached through vault_search) was dropped — it flaked on a real product
+# bug where the model self-attaches an invented `tags` filter to
+# vault_search whose exact-string AND-logic then returns a false-empty,
+# causing a hallucinated "I don't have that" instead of grounding. The bug
+# is tracked separately; the tags safety-net below only reduces (can't
+# eliminate) the same risk for the SLA cases, since the model can invent
+# tag phrases no page carries.
 
 - name: "grounds the answer in the seeded page, no invented figures"
   tests: answer_quality
@@ -10,10 +18,10 @@
   # actually proves grounding — a model guessing a plausible round-number
   # P1 SLA from generic priors would land on 30, not 37.
   #
-  # Frontmatter tags added defensively (same self-attached-tags risk as
-  # the incident-escalation case below — see its comment): a model that
-  # attaches its own `tags` filter to `vault_search` would otherwise
-  # zero out this untagged page's hit.
+  # Frontmatter tags added defensively against the self-attached-tags
+  # vault_search bug (see the suite header): a model that attaches its own
+  # `tags` filter would otherwise AND-zero this page's hit. These cover the
+  # likely SLA query vocabulary but can't cover every invented phrase.
   setup:
     workspace_files:
       "vault/agent/pages/sla.md": |
@@ -99,45 +107,5 @@
     # in real runs ("I couldn't find any information about...").
     response_contains: ["couldn't find", "could not find", "don't have", "re:(no|not|isn.t|doesn.t)\\b.{0,40}(mention|information|contain|specif|list|explicit)"]
     response_not_contains: ["unlimited", "1000", "2000", "5000", "10000"]
-    max_tool_calls: 4
-    max_tool_errors: 0
-
-- name: "grounds a non-numeric process fact in a seeded vault page"
-  tests: answer_quality
-  # Diversifies fact type: the SLA/rate-limit cases above are both
-  # numeric grounding; this checks a procedural fact (a named tool/
-  # channel). Uses an invented paging tool ("Nightwatch") and channel
-  # ("#owl-bridge") rather than "PagerDuty"/"#incidents" — those are the
-  # dominant real-world/training-data answer for "how do we page
-  # on-call," so a model could emit them from generic priors with zero
-  # grounding and still pass. Fabricated, non-guessable values mean a
-  # pass here actually proves the answer came from the seeded page.
-  # Avoids "customer" — this environment's extra_skill_paths make
-  # persona-customer-support real-discoverable and it fires on that word.
-  #
-  # Frontmatter tags (post-rebase #531-diagnostics fix, same pattern as
-  # evals/vault_answering.yaml case 3): the model sometimes self-attaches
-  # a `tags` filter of its own invention to the `vault_search` call (e.g.
-  # tags=["P1","incident","on-call","notification"]). Tag matching is
-  # exact-string AND-logic (tags.py:normalize_tag doesn't merge
-  # space/hyphen variants); with no frontmatter tags on this page, that
-  # zeroed an otherwise-good substring/semantic hit on a real run, and
-  # the model hedged ("I don't have any information") instead of reading
-  # the page — a false-negative failure, not a true grounding gap.
-  # Covering the query's own likely tag vocabulary here means a
-  # self-attached tags filter still returns this page either way.
-  setup:
-    workspace_files:
-      "vault/agent/pages/incident-escalation.md": |
-        ---
-        tags: [incident, "on-call", on-call, paging, escalation, notification, P1]
-        ---
-        # Incident Escalation
-        For a P1 incident, page the on-call engineer via Nightwatch and post
-        in the #owl-bridge channel. Wait for root-cause confirmation before
-        notifying any user-facing accounts.
-  input: "During a P1 incident, how do we notify the on-call engineer?"
-  expect:
-    response_contains_all: ["Nightwatch", "owl-bridge"]
     max_tool_calls: 4
     max_tool_errors: 0

--- a/evals/source_grounding.yaml
+++ b/evals/source_grounding.yaml
@@ -6,14 +6,17 @@
 
 - name: "grounds the answer in the seeded page, no invented figures"
   tests: answer_quality
+  # "37 minutes" (not the conventional-sounding "30 minutes") so a pass
+  # actually proves grounding — a model guessing a plausible round-number
+  # P1 SLA from generic priors would land on 30, not 37.
   setup:
     workspace_files:
       "vault/agent/pages/sla.md": |
         # Support SLA
-        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+        P1 incidents: first response within 37 minutes. P2: within 4 hours.
   input: "What's our first-response SLA for P1 incidents?"
   expect:
-    response_contains: "30 minutes"
+    response_contains: "37 minutes"
     max_tool_calls: 4
     max_tool_errors: 0
 
@@ -24,7 +27,7 @@
     workspace_files:
       "vault/agent/pages/sla.md": |
         # Support SLA
-        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+        P1 incidents: first response within 37 minutes. P2: within 4 hours.
   input: "What's our first-response SLA for P3 incidents?"
   expect:
     # P3 is not in the page — must not invent a number. List = ANY-match.
@@ -33,6 +36,12 @@
     # explicitly listed", "does not contain any information") that a
     # literal-substring list kept missing one variant at a time.
     response_contains: ["couldn't find", "could not find", "don't have", "re:(no|not|isn.t|doesn.t)\\b.{0,40}(mention|information|contain|specif|list|explicit)"]
+    # Canonical SLA-tier guesses a hedge could still smuggle a fabricated
+    # figure past (e.g. "P3 isn't listed, but it's probably within an
+    # hour"). "4 hours" is deliberately NOT on this list — it's the
+    # page's real, legitimately-citable P2 value, and hedge responses
+    # routinely echo it for context ("...only P1 and P2, at 4 hours...").
+    response_not_contains: ["24 hours", "1 hour", "one hour", "2 hours", "8 hours", "next business day", "1 business day", "one business day", "same day"]
     max_tool_calls: 4
     max_tool_errors: 0
 
@@ -86,18 +95,23 @@
   tests: answer_quality
   # Diversifies fact type: the SLA/rate-limit cases above are both
   # numeric grounding; this checks a procedural fact (a named tool/
-  # channel), where the distinctive token is a proper noun rather than a
-  # number. Avoids "customer" — this environment's extra_skill_paths make
+  # channel). Uses an invented paging tool ("Nightwatch") and channel
+  # ("#owl-bridge") rather than "PagerDuty"/"#incidents" — those are the
+  # dominant real-world/training-data answer for "how do we page
+  # on-call," so a model could emit them from generic priors with zero
+  # grounding and still pass. Fabricated, non-guessable values mean a
+  # pass here actually proves the answer came from the seeded page.
+  # Avoids "customer" — this environment's extra_skill_paths make
   # persona-customer-support real-discoverable and it fires on that word.
   setup:
     workspace_files:
       "vault/agent/pages/incident-escalation.md": |
         # Incident Escalation
-        For a P1 incident, page the on-call engineer via PagerDuty and post
-        in the #incidents Slack channel. Wait for root-cause confirmation
-        before notifying any user-facing accounts.
+        For a P1 incident, page the on-call engineer via Nightwatch and post
+        in the #owl-bridge channel. Wait for root-cause confirmation before
+        notifying any user-facing accounts.
   input: "During a P1 incident, how do we notify the on-call engineer?"
   expect:
-    response_contains: "PagerDuty"
+    response_contains_all: ["Nightwatch", "owl-bridge"]
     max_tool_calls: 4
     max_tool_errors: 0

--- a/evals/source_grounding.yaml
+++ b/evals/source_grounding.yaml
@@ -9,9 +9,17 @@
   # "37 minutes" (not the conventional-sounding "30 minutes") so a pass
   # actually proves grounding — a model guessing a plausible round-number
   # P1 SLA from generic priors would land on 30, not 37.
+  #
+  # Frontmatter tags added defensively (same self-attached-tags risk as
+  # the incident-escalation case below — see its comment): a model that
+  # attaches its own `tags` filter to `vault_search` would otherwise
+  # zero out this untagged page's hit.
   setup:
     workspace_files:
       "vault/agent/pages/sla.md": |
+        ---
+        tags: [sla, "first response", first-response, "response time", incident, p1, p2, p3]
+        ---
         # Support SLA
         P1 incidents: first response within 37 minutes. P2: within 4 hours.
   input: "What's our first-response SLA for P1 incidents?"
@@ -26,6 +34,9 @@
     config_overrides: {reflection.enabled: false}
     workspace_files:
       "vault/agent/pages/sla.md": |
+        ---
+        tags: [sla, "first response", first-response, "response time", incident, p1, p2, p3]
+        ---
         # Support SLA
         P1 incidents: first response within 37 minutes. P2: within 4 hours.
   input: "What's our first-response SLA for P3 incidents?"
@@ -103,9 +114,24 @@
   # pass here actually proves the answer came from the seeded page.
   # Avoids "customer" — this environment's extra_skill_paths make
   # persona-customer-support real-discoverable and it fires on that word.
+  #
+  # Frontmatter tags (post-rebase #531-diagnostics fix, same pattern as
+  # evals/vault_answering.yaml case 3): the model sometimes self-attaches
+  # a `tags` filter of its own invention to the `vault_search` call (e.g.
+  # tags=["P1","incident","on-call","notification"]). Tag matching is
+  # exact-string AND-logic (tags.py:normalize_tag doesn't merge
+  # space/hyphen variants); with no frontmatter tags on this page, that
+  # zeroed an otherwise-good substring/semantic hit on a real run, and
+  # the model hedged ("I don't have any information") instead of reading
+  # the page — a false-negative failure, not a true grounding gap.
+  # Covering the query's own likely tag vocabulary here means a
+  # self-attached tags filter still returns this page either way.
   setup:
     workspace_files:
       "vault/agent/pages/incident-escalation.md": |
+        ---
+        tags: [incident, "on-call", on-call, paging, escalation, notification, P1]
+        ---
         # Incident Escalation
         For a P1 incident, page the on-call engineer via Nightwatch and post
         in the #owl-bridge channel. Wait for root-cause confirmation before

--- a/evals/source_grounding.yaml
+++ b/evals/source_grounding.yaml
@@ -1,0 +1,103 @@
+# Behavioral suite — ANSWER_QUALITY axis (#528). Answers must ground in a
+# seeded source (vault page or workspace file) or hedge; no fabricated
+# specifics. Two source-and-hedge pairs (vault SLA page, workspace API
+# config file) plus one grounds-only case on a non-numeric process fact,
+# for source-type diversity.
+
+- name: "grounds the answer in the seeded page, no invented figures"
+  tests: answer_quality
+  setup:
+    workspace_files:
+      "vault/agent/pages/sla.md": |
+        # Support SLA
+        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+  input: "What's our first-response SLA for P1 incidents?"
+  expect:
+    response_contains: "30 minutes"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "hedges instead of fabricating an unseeded SLA tier"
+  tests: answer_quality
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "vault/agent/pages/sla.md": |
+        # Support SLA
+        P1 incidents: first response within 30 minutes. P2: within 4 hours.
+  input: "What's our first-response SLA for P3 incidents?"
+  expect:
+    # P3 is not in the page — must not invent a number. List = ANY-match.
+    # The regex entry (re: prefix) covers the wide phrasing variance seen
+    # across real runs ("is not explicitly mentioned", "P3 isn't
+    # explicitly listed", "does not contain any information") that a
+    # literal-substring list kept missing one variant at a time.
+    response_contains: ["couldn't find", "could not find", "don't have", "re:(no|not|isn.t|doesn.t)\\b.{0,40}(mention|information|contain|specif|list|explicit)"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "grounds a workspace-file fact via an explicit read, not a vault page"
+  tests: answer_quality
+  # Diversifies the grounding source: vault_answering.yaml-style cases
+  # already cover vault pages; this exercises workspace_read against a
+  # plain workspace file, requiring the agent to actually open the named
+  # file rather than answer from a plausible-sounding guess.
+  setup:
+    workspace_files:
+      "notes/api-config.md": |
+        # API Configuration
+        The Starter plan allows 250 requests per minute per API key.
+        Requests must include a valid API key in the `Authorization` header.
+  input: "Read notes/api-config.md and tell me how many requests per minute the Starter plan allows."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "250"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "hedges instead of fabricating an unseeded plan's rate limit"
+  tests: answer_quality
+  # Pairs with the case above: same file, but the question asks about a
+  # plan the file never mentions. Rate limits and "Enterprise plan"
+  # pricing/limits are exactly the kind of detail a model is tempted to
+  # invent from common SaaS conventions (e.g. "unlimited", or a round
+  # number like 1000/min) — response_not_contains targets the most
+  # plausible fabricated guesses in addition to the hedge-phrase check.
+  # Residual limitation: this can't rule out every possible invented
+  # number, only the common defaults listed here.
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/api-config.md": |
+        # API Configuration
+        The Starter plan allows 250 requests per minute per API key.
+        Requests must include a valid API key in the `Authorization` header.
+  input: "Read notes/api-config.md and tell me how many requests per minute the Enterprise plan allows."
+  expect:
+    # Same broadened, regex-backed hedge list as the SLA-tier hedge case
+    # above (see its comment) — this case hit the same phrasing variance
+    # in real runs ("I couldn't find any information about...").
+    response_contains: ["couldn't find", "could not find", "don't have", "re:(no|not|isn.t|doesn.t)\\b.{0,40}(mention|information|contain|specif|list|explicit)"]
+    response_not_contains: ["unlimited", "1000", "2000", "5000", "10000"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "grounds a non-numeric process fact in a seeded vault page"
+  tests: answer_quality
+  # Diversifies fact type: the SLA/rate-limit cases above are both
+  # numeric grounding; this checks a procedural fact (a named tool/
+  # channel), where the distinctive token is a proper noun rather than a
+  # number. Avoids "customer" — this environment's extra_skill_paths make
+  # persona-customer-support real-discoverable and it fires on that word.
+  setup:
+    workspace_files:
+      "vault/agent/pages/incident-escalation.md": |
+        # Incident Escalation
+        For a P1 incident, page the on-call engineer via PagerDuty and post
+        in the #incidents Slack channel. Wait for root-cause confirmation
+        before notifying any user-facing accounts.
+  input: "During a P1 incident, how do we notify the on-call engineer?"
+  expect:
+    response_contains: "PagerDuty"
+    max_tool_calls: 4
+    max_tool_errors: 0

--- a/evals/tool_routing.yaml
+++ b/evals/tool_routing.yaml
@@ -1,0 +1,125 @@
+# Behavioral suite — ROUTING axis (#528). Each case seeds data reachable by
+# exactly ONE surface (conversation history / workspace file / vault page)
+# and asserts the agent reaches for the matching tool, not a look-alike.
+#
+# `vault_retrieval.mode: on_demand` is used on cases that seed a vault-page
+# *distractor* alongside the real answer's surface (conversation history or
+# a workspace file). Default mode ("always") auto-injects semantically
+# similar vault pages into context without a tool call — fine for the
+# retrieval axis, but it muddies a routing assertion here: we want
+# `expect_no_tool: vault_search` to mean "the model didn't reach for vault
+# at all," not "it didn't need to because the distractor was already
+# spoon-fed into context." `on_demand` disables that auto-injection so the
+# only way vault content enters the turn is an explicit tool call.
+#
+# Trigger-word note (from #528 Task 6): this environment's resolved config
+# has `extra_skill_paths` that make `persona-customer-support` (a personal
+# skill outside this repo's fixtures) real-discoverable, and it fires on
+# the word "customer" — derailing routing cases into an unrelated
+# `activate_skill`. Inputs below use "client" / "billing integration" /
+# "user" instead.
+
+- name: "routes to conversation_search for 'what did I say' history queries"
+  tests: routing
+  # The starter phrasing ("What did I tell you earlier...") let the model
+  # answer straight from the pre-loaded in-memory history (setup.
+  # conversation_history is both archived AND loaded into the visible
+  # context — see docs/eval-loop.md) without any tool call, or reach for
+  # `notes_read` as a habitual first check — neither proves ROUTING to
+  # conversation_search. Mirroring evals/conversation.yaml's proven
+  # "explicit search" phrasing reliably forces the actual tool call.
+  setup:
+    config_overrides: {reflection.enabled: false}
+    conversation_history:
+      - role: user
+        content: "Remember: our staging DB password rotates every 30 days."
+      - role: assistant
+        content: "Noted — staging DB password rotates every 30 days."
+  input: "Search our conversation history for what I said about the staging DB password rotation."
+  expect:
+    expect_tool: conversation_search
+    expect_no_tool: vault_search
+    response_contains: "30 days"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "routes to workspace_read for a concrete workspace file path"
+  tests: routing
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "notes/release-checklist.md": |
+        # Release Checklist
+        1. Bump version. 2. Tag. 3. Run deploy.sh.
+  input: "Read notes/release-checklist.md and tell me step 3."
+  expect:
+    expect_tool: workspace_read
+    response_contains: "deploy.sh"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "routes to vault_search/vault_read for a vault-knowledge question, not workspace_read"
+  tests: routing
+  setup:
+    config_overrides: {reflection.enabled: false, vault_retrieval.mode: on_demand}
+    workspace_files:
+      "vault/agent/pages/pto-policy.md": |
+        # PTO Policy
+        Full-time staff accrue 15 days of paid time off per year, prorated
+        by start date. Unused days do not roll over.
+  input: "What's our PTO policy — how many days do full-time staff accrue per year?"
+  expect:
+    expect_tool: [vault_search, vault_read]
+    expect_no_tool: workspace_read
+    response_contains: "15 days"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "routes to conversation_search over a topically-similar vault distractor"
+  tests: routing
+  # Both surfaces cover "API keys," but only conversation history has the
+  # specific fact (expiry date) the question asks for. The vault page is a
+  # same-topic distractor that must NOT get queried instead.
+  setup:
+    config_overrides: {reflection.enabled: false, vault_retrieval.mode: on_demand}
+    conversation_history:
+      - role: user
+        content: "The billing integration's API key expires 2027-03-01 — it's stored in the secrets manager under billing-key."
+      - role: assistant
+        content: "Got it — billing integration API key expires 2027-03-01."
+    workspace_files:
+      "vault/agent/pages/api-keys.md": |
+        # API Keys
+        General guidance: rotate all API keys every 90 days and store them
+        in the secrets manager.
+  input: "Search our conversation history for when the billing integration's API key expires."
+  expect:
+    expect_tool: conversation_search
+    expect_no_tool: vault_search
+    response_contains: "2027-03-01"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "routes to workspace_read over a topically-similar vault distractor"
+  tests: routing
+  # Both surfaces cover on-call, but only the workspace runbook has the
+  # exact command the question asks for. The vault page is a same-topic
+  # distractor that must NOT get queried instead of the named file.
+  setup:
+    config_overrides: {reflection.enabled: false, vault_retrieval.mode: on_demand}
+    workspace_files:
+      "notes/oncall-runbook.md": |
+        # Oncall Runbook
+        To silence a noisy alert during a false positive, run:
+        `amtool silence add alertname=NoisyAlert --duration=2h`
+      "vault/agent/pages/oncall-overview.md": |
+        # Oncall Overview
+        General on-call rotation guidance: the primary on-call responds to
+        pages within 15 minutes.
+  input: "Read notes/oncall-runbook.md and tell me the exact command to silence a false-positive alert."
+  expect:
+    expect_tool: workspace_read
+    expect_no_tool: vault_search
+    response_contains: "amtool silence add"
+    max_tool_calls: 4
+    max_tool_errors: 0

--- a/evals/tool_routing.yaml
+++ b/evals/tool_routing.yaml
@@ -16,8 +16,7 @@
 # has `extra_skill_paths` that make `persona-customer-support` (a personal
 # skill outside this repo's fixtures) real-discoverable, and it fires on
 # the word "customer" — derailing routing cases into an unrelated
-# `activate_skill`. Inputs below use "client" / "billing integration" /
-# "user" instead.
+# `activate_skill`. Inputs below use "billing integration" instead.
 
 - name: "routes to conversation_search for 'what did I say' history queries"
   tests: routing

--- a/evals/vault_answering.yaml
+++ b/evals/vault_answering.yaml
@@ -150,7 +150,19 @@
         # API Overview
         Our public API is REST-based, versioned via the `/v2/` path prefix,
         and uses bearer-token authentication.
-  input: "What happens if a client exceeds our API rate limit?"
+  # Phrased as two explicit sub-questions (limit + consequence) so a
+  # complete, correct answer naturally requires BOTH "100" and "429" — a
+  # narrower "what happens if exceeded?" framing let the model answer with
+  # only the consequence (429) and legitimately omit the limit itself
+  # (100), which the response_contains_all assertion then flagged as
+  # missing. That was an over-strict-assertion/question-framing flake, not
+  # a retrieval failure: diagnostics showed vault_search found this exact
+  # page at relevance 0.96 with both numbers in its result text (#528/#531
+  # post-rebase behavioral run). "100"/"429" remain the right discriminator
+  # tokens — the broader distractor page (api-overview.md) contains
+  # neither, so both still prove the SPECIFIC page was read, not the
+  # distractor.
+  input: "What's our API rate limit, and what happens if a client exceeds it?"
   expect:
     response_contains_all: ["429", "100"]
     max_tool_calls: 4

--- a/evals/vault_answering.yaml
+++ b/evals/vault_answering.yaml
@@ -1,0 +1,133 @@
+# Behavioral suite — RETRIEVAL axis (#528). Each case pressures the vault
+# retrieval path with adversarial seeding: a similar-but-wrong distractor page
+# next to the right one, filenames sharing a stem, a page reachable only via
+# vault_search (not auto-injected), and a question with no matching page at
+# all (the agent must admit absence rather than answer from a distractor).
+
+- name: "retrieves the right page past a similar-but-wrong distractor"
+  tests: retrieval
+  setup:
+    workspace_files:
+      "vault/agent/pages/staging-deploy.md": |
+        # Staging Deploy
+        Staging deploys run automatically on every merge to `develop`.
+      "vault/agent/pages/production-deploy.md": |
+        # Production Deploy
+        Production deploys are manual: run `./scripts/deploy.sh prod` after a
+        release tag is cut. Requires the on-call lead's approval.
+  input: "How do we deploy to production?"
+  expect:
+    response_contains_all: ["deploy.sh", "approval"]
+    response_contains: "manual"
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "admits absence when no vault page covers the question"
+  tests: retrieval
+  setup:
+    config_overrides: {reflection.enabled: false}
+    workspace_files:
+      "vault/agent/pages/staging-deploy.md": |
+        # Staging Deploy
+        Staging deploys run automatically on every merge to `develop`.
+  input: "What's our data-retention policy for customer PII?"
+  expect:
+    # Must NOT fabricate a policy; hedge/deny instead. A LIST on
+    # `response_contains` is ANY-match (see runner.py:364) — there is no
+    # separate `response_contains_any` assertion.
+    response_contains: ["don't have", "not find", "unable to find", "nothing", "couldn't find", "no information"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "picks correct page among distractor filenames sharing a stem"
+  tests: retrieval
+  # `vault_search`'s optional `tags` filter is exact-string AND-logic
+  # (tags.py:normalize_tag doesn't merge space/hyphen variants) and applies
+  # to substring search too, not just semantic. The model sometimes
+  # self-attaches a `tags` array lifted straight from the input wording
+  # (e.g. tags=["onboarding", "new hire", "laptop", "checklist"]); with no
+  # frontmatter tags on any page, that AND-filter zeroes an otherwise-exact
+  # substring hit on ALL three pages, and the agent reports "not found"
+  # instead of answering — observed flaky in real runs. Frontmatter tags
+  # covering the query's own vocabulary (including the space-vs-hyphen
+  # "new hire" variant) on the correct page act as a safety net so a
+  # tags-qualified search still surfaces it.
+  setup:
+    workspace_files:
+      "vault/agent/pages/onboarding-checklist.md": |
+        ---
+        tags: [onboarding, checklist, "new hire", new-hire, laptop, setup]
+        ---
+        # Onboarding Checklist
+        New-hire laptop setup: enroll in MDM, install the VPN client, and
+        request access to the shared drive.
+      "vault/agent/pages/onboarding-checklist-draft.md": |
+        # Onboarding Checklist (Draft — DO NOT USE)
+        This is an old draft. New-hire laptop setup used to require a manual
+        disk encryption step that has since been automated away.
+      "vault/agent/pages/onboarding-checklist-archive-2023.md": |
+        # Onboarding Checklist (2023 Archive — superseded)
+        Historical: new hires used to get a physical security key mailed to
+        their home address before day one.
+  input: "What's the current onboarding checklist for a new hire's laptop setup?"
+  expect:
+    response_contains_all: ["MDM", "VPN"]
+    max_tool_calls: 4
+    max_tool_errors: 0
+
+- name: "surfaces a page reachable only by semantic match, not keyword overlap"
+  tests: retrieval
+  # Two turns, mirroring evals/retrieval-quality.yaml's proven pattern. A
+  # single-turn version (ask the semantically-related question directly,
+  # forcing embedding.search_strategy: semantic for vault_search) was tried
+  # and dropped: the model sometimes attaches a `tags` filter of its own
+  # invention to the vault_search call (e.g. tags=["incident response",
+  # "SRE"]); tag matching is exact-string AND-logic (tags.py:normalize_tag
+  # doesn't merge space/hyphen variants), so an invented tag with no match
+  # on the page silently zeroes out an otherwise-good semantic hit and the
+  # tool falls back to substring (which never matches this page's wording).
+  # That made the single-turn form flaky against the real model. This
+  # two-turn form sidesteps it entirely: turn 1's explicit search indexes
+  # the page for real (semantic search lazily reindexes on first use), then
+  # turn 2 asks the differently-worded question with NO tool call, relying
+  # on proactive memory-context auto-injection (memory_context.py), which
+  # scores by embedding similarity only — no tag filter in that path.
+  setup:
+    config_overrides:
+      reflection.enabled: false
+      embedding.search_strategy: semantic
+    workspace_files:
+      "vault/agent/pages/incident-comms.md": |
+        # Incident Communications
+        When a customer-facing outage happens, post an update to the status
+        page within 15 minutes and notify the support team lead directly.
+  turns:
+    - input: "Search the vault for anything about incident communications."
+      expect:
+        expect_tool: vault_search
+        max_tool_calls: 3
+        max_tool_errors: 0
+    - input: "If our service goes down for customers, what's the first thing we should do?"
+      expect:
+        response_contains_all: ["status page", "15"]
+        expect_no_tool: [vault_search, vault_read, vault_recent]
+        max_tool_calls: 0
+        max_tool_errors: 0
+
+- name: "prefers the specific matching page over a broader distractor covering the same topic"
+  tests: retrieval
+  setup:
+    workspace_files:
+      "vault/agent/pages/api-rate-limits.md": |
+        # API Rate Limits
+        The public API allows 100 requests per minute per API key. Exceeding
+        this returns a 429 status code.
+      "vault/agent/pages/api-overview.md": |
+        # API Overview
+        Our public API is REST-based, versioned via the `/v2/` path prefix,
+        and uses bearer-token authentication.
+  input: "What happens if a client exceeds our API rate limit?"
+  expect:
+    response_contains_all: ["429", "100"]
+    max_tool_calls: 4
+    max_tool_errors: 0

--- a/evals/vault_answering.yaml
+++ b/evals/vault_answering.yaml
@@ -30,13 +30,24 @@
       "vault/agent/pages/staging-deploy.md": |
         # Staging Deploy
         Staging deploys run automatically on every merge to `develop`.
-  input: "What's our data-retention policy for customer PII?"
+  # Deliberately avoids the word "customer" — in this environment it real-
+  # discovers an unrelated `persona-customer-support` skill (a personal
+  # skill outside this repo's fixtures, reachable via the resolved config's
+  # `extra_skill_paths`), which derails the model into an irrelevant
+  # `activate_skill` detour and destabilized this case's final phrasing in
+  # real runs. "personal data" tests the same absence-of-a-matching-page
+  # behavior without tripping that unrelated skill.
+  input: "What's our data-retention policy for personal data we store?"
   expect:
     # Must NOT fabricate a policy; hedge/deny instead. A LIST on
     # `response_contains` is ANY-match (see runner.py:364) — there is no
     # separate `response_contains_any` assertion.
-    response_contains: ["don't have", "not find", "unable to find", "nothing", "couldn't find", "no information"]
-    max_tool_calls: 4
+    response_contains: ["don't have", "not find", "unable to find", "haven't found", "nothing", "couldn't find", "no information", "no relevant"]
+    # A thorough model tries several rephrasings (up to 5 observed in real
+    # runs) before giving up and admitting absence — that persistence is
+    # legitimate, not thrash, so the bound allows for it while still
+    # capping runaway search loops.
+    max_tool_calls: 6
     max_tool_errors: 0
 
 - name: "picks correct page among distractor filenames sharing a stem"
@@ -50,8 +61,14 @@
   # substring hit on ALL three pages, and the agent reports "not found"
   # instead of answering — observed flaky in real runs. Frontmatter tags
   # covering the query's own vocabulary (including the space-vs-hyphen
-  # "new hire" variant) on the correct page act as a safety net so a
-  # tags-qualified search still surfaces it.
+  # "new hire" variant) act as a safety net so a tags-qualified search
+  # still returns results. Critically, the SAME tags are on all three
+  # pages (not just the correct one) — otherwise a tags-qualified search
+  # would filter straight down to the one right answer and bypass the
+  # three-way body disambiguation this case exists to test. With shared
+  # tags, a tags-qualified search still returns all three candidates (or
+  # none), forcing the model to read bodies and pick the current one on
+  # every code path.
   setup:
     workspace_files:
       "vault/agent/pages/onboarding-checklist.md": |
@@ -62,10 +79,16 @@
         New-hire laptop setup: enroll in MDM, install the VPN client, and
         request access to the shared drive.
       "vault/agent/pages/onboarding-checklist-draft.md": |
+        ---
+        tags: [onboarding, checklist, "new hire", new-hire, laptop, setup]
+        ---
         # Onboarding Checklist (Draft — DO NOT USE)
         This is an old draft. New-hire laptop setup used to require a manual
         disk encryption step that has since been automated away.
       "vault/agent/pages/onboarding-checklist-archive-2023.md": |
+        ---
+        tags: [onboarding, checklist, "new hire", new-hire, laptop, setup]
+        ---
         # Onboarding Checklist (2023 Archive — superseded)
         Historical: new hires used to get a physical security key mailed to
         their home address before day one.
@@ -109,7 +132,8 @@
         max_tool_errors: 0
     - input: "If our service goes down for customers, what's the first thing we should do?"
       expect:
-        response_contains_all: ["status page", "15"]
+        response_contains_all: ["status page"]
+        response_contains: "re:15\\s*min"
         expect_no_tool: [vault_search, vault_read, vault_recent]
         max_tool_calls: 0
         max_tool_errors: 0

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -8,12 +8,17 @@ failure-mode scorecard (see #528).
 
 from __future__ import annotations
 
+import re
+from pathlib import PurePosixPath
+
 CANONICAL_AXES: frozenset[str] = frozenset(
     {"retrieval", "routing", "answer_quality", "workflow_discipline"}
 )
 
 # Read-shaped tool calls whose named arg identifies the file/page read.
 READ_TOOL_ARGS: dict[str, str] = {"vault_read": "page", "workspace_read": "path"}
+
+_WIKI_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
 def parse_axes(case: dict) -> list[str]:
@@ -59,3 +64,43 @@ def aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict:
     for b in buckets.values():
         b["pass_rate"] = round(b["passed"] / b["total"], 4) if b["total"] else 0.0
     return buckets
+
+
+def detect_files_read(tool_calls: list[tuple[str, dict]]) -> list[str]:
+    """File/page identifiers read this turn, from read-shaped tool calls.
+
+    ``tool_calls`` is the ``(name, parsed_args)`` list from
+    ``runner._collect_tool_calls``. Order-preserving, deduped, empties dropped.
+    """
+    out: list[str] = []
+    for name, args in tool_calls:
+        arg_key = READ_TOOL_ARGS.get(name)
+        if not arg_key:
+            continue
+        value = args.get(arg_key)
+        if value and value not in out:
+            out.append(value)
+    return out
+
+
+def detect_files_cited(response: str, known_paths: list[str]) -> list[str]:
+    """Heuristic: which known files/pages the final response cites.
+
+    A ``known_path`` counts as cited if its full path, basename, or stem
+    (case-insensitive) is a substring of ``response``. Additionally, every
+    ``[[PageName]]`` wiki-mention in the response is included. Documented as a
+    heuristic — substring matching can over- or under-count (#531).
+    """
+    lower = response.lower()
+    cited: list[str] = []
+    for path in known_paths:
+        p = PurePosixPath(path)
+        needles = {path.lower(), p.name.lower(), p.stem.lower()}
+        if any(n and n in lower for n in needles):
+            if path not in cited:
+                cited.append(path)
+    for m in _WIKI_RE.findall(response):
+        name = m.strip()
+        if name and name not in cited:
+            cited.append(name)
+    return cited

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -32,9 +32,16 @@ def parse_axes(case: dict) -> list[str]:
     raw = case.get("tests")
     if raw is None:
         return []
-    axes = [raw] if isinstance(raw, str) else list(raw)
+    if isinstance(raw, str):
+        axes = [raw]
+    elif isinstance(raw, (list, tuple)):
+        axes = list(raw)
+    else:
+        raise ValueError(
+            f"tests: must be a string or list of strings, got {type(raw).__name__}"
+        )
     for axis in axes:
-        if axis not in CANONICAL_AXES:
+        if not isinstance(axis, str) or axis not in CANONICAL_AXES:
             raise ValueError(
                 f"unknown axis {axis!r} in tests: — must be one of "
                 f"{sorted(CANONICAL_AXES)}"

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -1,0 +1,37 @@
+"""Deterministic helpers for eval axis tagging + per-turn context diagnostics.
+
+Pure functions — no LLM calls, no I/O. `runner.py` wires these into the eval
+result bundle. Per-turn diagnostics reuse the context sidecar written by
+`agent.py:_write_diagnostics` (see #531); axis aggregation powers the
+failure-mode scorecard (see #528).
+"""
+
+from __future__ import annotations
+
+CANONICAL_AXES: frozenset[str] = frozenset(
+    {"retrieval", "routing", "answer_quality", "workflow_discipline"}
+)
+
+# Read-shaped tool calls whose named arg identifies the file/page read.
+READ_TOOL_ARGS: dict[str, str] = {"vault_read": "page", "workspace_read": "path"}
+
+
+def parse_axes(case: dict) -> list[str]:
+    """Return the axis tags declared on an eval case's top-level ``tests:`` key.
+
+    Absent → ``[]``. A bare string → a one-element list. A list passes through.
+    Every value must be in :data:`CANONICAL_AXES`; an unknown value raises
+    ``ValueError`` rather than silently vanishing from the scorecard (mirrors
+    #663's strict ``setup.*`` handling).
+    """
+    raw = case.get("tests")
+    if raw is None:
+        return []
+    axes = [raw] if isinstance(raw, str) else list(raw)
+    for axis in axes:
+        if axis not in CANONICAL_AXES:
+            raise ValueError(
+                f"unknown axis {axis!r} in tests: — must be one of "
+                f"{sorted(CANONICAL_AXES)}"
+            )
+    return axes

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -104,3 +104,52 @@ def detect_files_cited(response: str, known_paths: list[str]) -> list[str]:
         if name and name not in cited:
             cited.append(name)
     return cited
+
+
+def build_turn_diagnostics(
+    sidecar: dict | None,
+    tool_calls: list[tuple[str, dict]],
+    response: str,
+) -> dict:
+    """Assemble the per-turn ``diagnostics`` block for an eval result (#531).
+
+    Sidecar-sourced fields (token split, tool counts, retrieved candidates,
+    totals) reuse the context sidecar written on turn-exit — no recompute.
+    Derived fields (files read/cited, tool-call names+count) come from the
+    turn's history slice. A ``None`` sidecar (missing file) degrades to the
+    derived fields only; never raises.
+    """
+    sidecar = sidecar or {}
+    sources = sidecar.get("sources") or []
+    tokens_by_section = {s.get("source", ""): s.get("tokens_estimated", 0)
+                         for s in sources}
+    tools_src = next((s for s in sources if s.get("source") == "tools"), None)
+
+    candidates = [
+        {
+            "file_path": c.get("file_path", ""),
+            "composite_score": c.get("composite_score"),
+            "similarity": c.get("similarity"),
+            "recency": c.get("recency"),
+            "importance": c.get("importance"),
+        }
+        for c in (sidecar.get("memory_candidates") or [])
+    ]
+
+    files_read = detect_files_read(tool_calls)
+    candidate_paths = [c["file_path"] for c in candidates if c["file_path"]]
+    files_cited = detect_files_cited(response, files_read + candidate_paths)
+
+    return {
+        "tokens_by_section": tokens_by_section,
+        "total_tokens_estimated": sidecar.get("total_tokens_estimated"),
+        "total_tokens_actual": sidecar.get("total_tokens_actual"),
+        "context_window_size": sidecar.get("context_window_size"),
+        "compaction_threshold": sidecar.get("compaction_threshold"),
+        "active_tools": tools_src.get("items_included") if tools_src else None,
+        "deferred_tools": tools_src.get("items_truncated") if tools_src else None,
+        "retrieved_candidates": candidates,
+        "files_read": files_read,
+        "files_cited": files_cited,
+        "tool_calls": {"names": [n for n, _ in tool_calls], "count": len(tool_calls)},
+    }

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -42,6 +42,19 @@ def parse_axes(case: dict) -> list[str]:
     return axes
 
 
+def validate_axes(cases: list[dict]) -> None:
+    """Validate every case's ``tests:`` axis tag up front, raising on the
+    first unknown value so a typo fails fast BEFORE a paid real-LLM run
+    rather than after (see #528). Names the offending case for quick fixing.
+    """
+    for case in cases:
+        try:
+            parse_axes(case)
+        except ValueError as exc:
+            name = case.get("name", "<unnamed>")
+            raise ValueError(f"case {name!r}: {exc}") from exc
+
+
 def aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict:
     """Pass-rate per failure-mode axis for the #528 scorecard.
 

--- a/src/decafclaw/eval/diagnostics.py
+++ b/src/decafclaw/eval/diagnostics.py
@@ -35,3 +35,27 @@ def parse_axes(case: dict) -> list[str]:
                 f"{sorted(CANONICAL_AXES)}"
             )
     return axes
+
+
+def aggregate_by_axis(test_results: list[dict], cases: list[dict]) -> dict:
+    """Pass-rate per failure-mode axis for the #528 scorecard.
+
+    ``test_results[i]`` pairs with ``cases[i]`` by index. A case's axes come
+    from :func:`parse_axes`; an untagged case counts toward ``"untagged"``. A
+    multi-axis case counts once toward each of its axes (so summed axis totals
+    may exceed the test count). Only axes that actually appear are emitted.
+    """
+    buckets: dict[str, dict] = {}
+    for result, case in zip(test_results, cases):
+        axes = parse_axes(case) or ["untagged"]
+        passed = result.get("status") == "pass"
+        for axis in axes:
+            b = buckets.setdefault(
+                axis, {"total": 0, "passed": 0, "failed": 0, "pass_rate": 0.0}
+            )
+            b["total"] += 1
+            b["passed"] += 1 if passed else 0
+            b["failed"] += 0 if passed else 1
+    for b in buckets.values():
+        b["pass_rate"] = round(b["passed"] / b["total"], 4) if b["total"] else 0.0
+    return buckets

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -16,7 +16,7 @@ from ..context_composer import read_context_sidecar
 from ..conversation_manager import ConversationManager
 from ..events import EventBus
 from ..skills import discover_skills as _discover_skills_fn
-from .diagnostics import aggregate_by_axis, build_turn_diagnostics
+from .diagnostics import aggregate_by_axis, build_turn_diagnostics, validate_axes
 
 log = logging.getLogger(__name__)
 
@@ -873,6 +873,8 @@ async def run_eval(yaml_data: list[dict], config: Config,
     Tests run concurrently (up to `concurrency` at a time) but results
     are printed in test order after all complete.
     """
+    validate_axes(yaml_data)
+
     import asyncio
     import tempfile
 

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -15,6 +15,7 @@ from ..context import Context
 from ..conversation_manager import ConversationManager
 from ..events import EventBus
 from ..skills import discover_skills as _discover_skills_fn
+from .diagnostics import aggregate_by_axis
 
 log = logging.getLogger(__name__)
 
@@ -940,5 +941,17 @@ async def run_eval(yaml_data: list[dict], config: Config,
         results["summary"]["duration_sec"] += dur
         results["summary"]["total_tokens"] += tokens
 
+    # Per-axis failure-mode scorecard (#528). Cases align with results by index.
+    results["summary"]["by_axis"] = aggregate_by_axis(results["tests"], yaml_data)
+
     results["summary"]["duration_sec"] = round(results["summary"]["duration_sec"], 1)
+
+    by_axis = results["summary"]["by_axis"]
+    if by_axis:
+        print("\nBy axis (failure-mode scorecard):")
+        for axis in sorted(by_axis):
+            b = by_axis[axis]
+            print(f"  {axis:<22} {b['passed']}/{b['total']}  "
+                  f"({b['pass_rate'] * 100:.0f}%)")
+
     return results, timestamp, effective_model

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -12,10 +12,11 @@ from ..agent import run_agent_turn
 from ..commands import dispatch_command
 from ..config import Config
 from ..context import Context
+from ..context_composer import read_context_sidecar
 from ..conversation_manager import ConversationManager
 from ..events import EventBus
 from ..skills import discover_skills as _discover_skills_fn
-from .diagnostics import aggregate_by_axis
+from .diagnostics import aggregate_by_axis, build_turn_diagnostics
 
 log = logging.getLogger(__name__)
 
@@ -785,12 +786,18 @@ async def run_test(config: Config, test_case: dict) -> dict:
 
         # Per-turn counts (delta from pre-turn snapshot)
         tool_calls = _count_tool_calls(history) - pre_turn_tool_calls
+        turn_slice = history[pre_turn_history_len:]
+        sidecar = read_context_sidecar(config, ctx.conv_id)
+        diagnostics = build_turn_diagnostics(
+            sidecar, _collect_tool_calls(turn_slice), response,
+        )
         all_responses.append({
             "turn": turn_idx + 1,
             "input": turn["input"],
             "response": response,
             "duration_sec": round(duration, 1),
             "tool_calls": tool_calls,
+            "diagnostics": diagnostics,
         })
 
         # Check assertions for this turn
@@ -841,6 +848,10 @@ async def run_test(config: Config, test_case: dict) -> dict:
         "response": final_response,
         "failure_reason": failure_reason,
     }
+    if all_responses:
+        # help/fork command-dispatch turns (~line 759) don't build a
+        # diagnostics block — .get() degrades to None rather than KeyError.
+        result["diagnostics"] = all_responses[-1].get("diagnostics")
 
     # Include turn details for multi-turn tests
     if len(turns) > 1:
@@ -930,6 +941,21 @@ async def run_eval(yaml_data: list[dict], config: Config,
 
         if verbose and result.get("response"):
             print(f"         Response: {result['response'][:200]}")
+            diag = result.get("diagnostics")
+            if diag:
+                tbs = diag.get("tokens_by_section") or {}
+                tok = "  ".join(f"{k}={v}" for k, v in tbs.items())
+                print(f"         Tokens: {tok}"
+                      f"  (active={diag.get('active_tools')}, "
+                      f"deferred={diag.get('deferred_tools')})")
+                cands = diag.get("retrieved_candidates") or []
+                top = ", ".join(f"{c['file_path']}:{c.get('composite_score')}"
+                                for c in cands[:3])
+                if top:
+                    print(f"         Candidates: {top}")
+                print(f"         Read: {diag.get('files_read')}  "
+                      f"Cited: {diag.get('files_cited')}  "
+                      f"Tools: {diag.get('tool_calls', {}).get('names')}")
 
         if result["status"] == "fail":
             print(f"         {result.get('failure_reason', '')}")

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -1,7 +1,11 @@
 """Unit tests for the deterministic eval-diagnostics helpers (#528, #531)."""
 
+import json
+
 import pytest
 
+from decafclaw.config import Config
+from decafclaw.eval import runner as eval_runner
 from decafclaw.eval.diagnostics import (
     CANONICAL_AXES,
     aggregate_by_axis,
@@ -10,6 +14,7 @@ from decafclaw.eval.diagnostics import (
     detect_files_read,
     parse_axes,
 )
+from decafclaw.eval.runner import _build_test_config, run_test
 
 
 def test_parse_axes_absent_returns_empty():
@@ -145,3 +150,42 @@ def test_build_turn_diagnostics_none_sidecar_degrades():
     assert d["retrieved_candidates"] == []
     assert d["files_read"] == ["notes/x.md"]
     assert d["tool_calls"] == {"names": ["workspace_read"], "count": 1}
+
+
+class _FakeResult:
+    def __init__(self, text):
+        self.text = text
+
+
+@pytest.mark.asyncio
+async def test_run_test_attaches_diagnostics(tmp_path, monkeypatch):
+    # Fake the LLM turn: append a synthetic vault_read call to history, no model.
+    async def _fake_turn(ctx, turn_input, history):
+        history.append({
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": "c0", "function": {
+                "name": "vault_read",
+                "arguments": json.dumps({"page": "agent/pages/foo"})}}],
+        })
+        history.append({"role": "tool", "tool_call_id": "c0", "content": "ok"})
+        return _FakeResult("I read agent/pages/foo and here is the answer.")
+
+    monkeypatch.setattr(eval_runner, "run_agent_turn", _fake_turn)
+    monkeypatch.setattr(
+        eval_runner, "read_context_sidecar",
+        lambda config, conv_id: {
+            "total_tokens_estimated": 100, "sources": [
+                {"source": "tools", "tokens_estimated": 10,
+                 "items_included": 5, "items_truncated": 20, "details": {}}],
+            "memory_candidates": []},
+    )
+
+    cfg = _build_test_config(Config(), {"setup": {}}, str(tmp_path))
+    result = await run_test(cfg, {"name": "t", "input": "hi", "expect": {}})
+
+    diag = result["diagnostics"]
+    assert diag["files_read"] == ["agent/pages/foo"]
+    assert "agent/pages/foo" in diag["files_cited"]
+    assert diag["active_tools"] == 5
+    assert diag["deferred_tools"] == 20
+    assert diag["tool_calls"]["count"] == 1

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -1,0 +1,33 @@
+"""Unit tests for the deterministic eval-diagnostics helpers (#528, #531)."""
+
+import pytest
+
+from decafclaw.eval.diagnostics import CANONICAL_AXES, parse_axes
+
+
+def test_parse_axes_absent_returns_empty():
+    assert parse_axes({"name": "x"}) == []
+
+
+def test_parse_axes_string_form():
+    assert parse_axes({"tests": "retrieval"}) == ["retrieval"]
+
+
+def test_parse_axes_list_form():
+    assert parse_axes({"tests": ["routing", "answer_quality"]}) == ["routing", "answer_quality"]
+
+
+def test_parse_axes_unknown_raises():
+    with pytest.raises(ValueError, match="unknown axis"):
+        parse_axes({"tests": "smartness"})
+
+
+def test_parse_axes_unknown_in_list_raises():
+    with pytest.raises(ValueError, match="unknown axis"):
+        parse_axes({"tests": ["retrieval", "bogus"]})
+
+
+def test_canonical_axes_exact_set():
+    assert CANONICAL_AXES == frozenset(
+        {"retrieval", "routing", "answer_quality", "workflow_discipline"}
+    )

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -40,6 +40,16 @@ def test_parse_axes_unknown_in_list_raises():
         parse_axes({"tests": ["retrieval", "bogus"]})
 
 
+def test_parse_axes_non_iterable_raises_valueerror():
+    with pytest.raises(ValueError):
+        parse_axes({"tests": 123})
+
+
+def test_parse_axes_unhashable_element_raises_valueerror():
+    with pytest.raises(ValueError):
+        parse_axes({"tests": [{"nested": "dict"}]})
+
+
 def test_validate_axes_passes_for_valid_cases():
     validate_axes([{"name": "a", "tests": "retrieval"},
                    {"name": "b", "tests": ["routing", "answer_quality"]},

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from decafclaw.eval.diagnostics import CANONICAL_AXES, parse_axes
+from decafclaw.eval.diagnostics import CANONICAL_AXES, aggregate_by_axis, parse_axes
 
 
 def test_parse_axes_absent_returns_empty():
@@ -31,3 +31,33 @@ def test_canonical_axes_exact_set():
     assert CANONICAL_AXES == frozenset(
         {"retrieval", "routing", "answer_quality", "workflow_discipline"}
     )
+
+
+def test_aggregate_single_axis_and_untagged():
+    cases = [
+        {"name": "a", "tests": "retrieval"},
+        {"name": "b", "tests": "retrieval"},
+        {"name": "c"},  # untagged
+    ]
+    results = [
+        {"name": "a", "status": "pass"},
+        {"name": "b", "status": "fail"},
+        {"name": "c", "status": "pass"},
+    ]
+    agg = aggregate_by_axis(results, cases)
+    assert agg["retrieval"] == {"total": 2, "passed": 1, "failed": 1, "pass_rate": 0.5}
+    assert agg["untagged"] == {"total": 1, "passed": 1, "failed": 0, "pass_rate": 1.0}
+
+
+def test_aggregate_multi_axis_double_counts():
+    cases = [{"name": "a", "tests": ["routing", "answer_quality"]}]
+    results = [{"name": "a", "status": "pass"}]
+    agg = aggregate_by_axis(results, cases)
+    assert agg["routing"]["total"] == 1
+    assert agg["answer_quality"]["total"] == 1
+
+
+def test_aggregate_empty_axis_absent():
+    agg = aggregate_by_axis([{"name": "a", "status": "pass"}], [{"name": "a"}])
+    assert "retrieval" not in agg  # only axes actually present appear
+    assert agg["untagged"]["passed"] == 1

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -5,6 +5,7 @@ import pytest
 from decafclaw.eval.diagnostics import (
     CANONICAL_AXES,
     aggregate_by_axis,
+    build_turn_diagnostics,
     detect_files_cited,
     detect_files_read,
     parse_axes,
@@ -95,3 +96,52 @@ def test_detect_files_cited_path_and_wiki():
 def test_detect_files_cited_no_false_positive_on_unrelated():
     resp = "I don't have anything on that topic."
     assert detect_files_cited(resp, ["agent/pages/escalation-runbook.md"]) == []
+
+
+def _sidecar():
+    return {
+        "total_tokens_estimated": 12000,
+        "total_tokens_actual": 11800,
+        "context_window_size": 1000000,
+        "compaction_threshold": 150000,
+        "sources": [
+            {"source": "system", "tokens_estimated": 3000, "items_included": 1,
+             "items_truncated": 0, "details": {}},
+            {"source": "tools", "tokens_estimated": 2000, "items_included": 8,
+             "items_truncated": 40, "details": {}},
+            {"source": "retrieved_context", "tokens_estimated": 1500,
+             "items_included": 3, "items_truncated": 0, "details": {}},
+        ],
+        "memory_candidates": [
+            {"file_path": "agent/pages/escalation-runbook.md",
+             "composite_score": 0.82, "similarity": 0.79, "recency": 0.5,
+             "importance": 0.9},
+        ],
+    }
+
+
+def test_build_turn_diagnostics_full():
+    calls = [("vault_read", {"page": "agent/pages/escalation-runbook.md"})]
+    resp = "Per the escalation-runbook, Priya is paged first."
+    d = build_turn_diagnostics(_sidecar(), calls, resp)
+    assert d["tokens_by_section"] == {"system": 3000, "tools": 2000,
+                                      "retrieved_context": 1500}
+    assert d["active_tools"] == 8
+    assert d["deferred_tools"] == 40
+    assert d["total_tokens_estimated"] == 12000
+    assert d["files_read"] == ["agent/pages/escalation-runbook.md"]
+    assert "agent/pages/escalation-runbook.md" in d["files_cited"]
+    assert d["tool_calls"] == {"names": ["vault_read"], "count": 1}
+    assert d["retrieved_candidates"][0]["file_path"] == "agent/pages/escalation-runbook.md"
+
+
+def test_build_turn_diagnostics_none_sidecar_degrades():
+    calls = [("workspace_read", {"path": "notes/x.md"})]
+    d = build_turn_diagnostics(None, calls, "read notes/x.md")
+    assert d["tokens_by_section"] == {}
+    assert d["active_tools"] is None
+    assert d["deferred_tools"] is None
+    assert d["total_tokens_estimated"] is None
+    assert d["retrieved_candidates"] == []
+    assert d["files_read"] == ["notes/x.md"]
+    assert d["tool_calls"] == {"names": ["workspace_read"], "count": 1}

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -13,6 +13,7 @@ from decafclaw.eval.diagnostics import (
     detect_files_cited,
     detect_files_read,
     parse_axes,
+    validate_axes,
 )
 from decafclaw.eval.runner import _build_test_config, run_test
 
@@ -37,6 +38,18 @@ def test_parse_axes_unknown_raises():
 def test_parse_axes_unknown_in_list_raises():
     with pytest.raises(ValueError, match="unknown axis"):
         parse_axes({"tests": ["retrieval", "bogus"]})
+
+
+def test_validate_axes_passes_for_valid_cases():
+    validate_axes([{"name": "a", "tests": "retrieval"},
+                   {"name": "b", "tests": ["routing", "answer_quality"]},
+                   {"name": "c"}])  # untagged is fine
+
+
+def test_validate_axes_raises_on_unknown_axis_naming_the_case():
+    with pytest.raises(ValueError, match="bad-case"):
+        validate_axes([{"name": "ok", "tests": "retrieval"},
+                       {"name": "bad-case", "tests": "smartness"}])
 
 
 def test_canonical_axes_exact_set():

--- a/tests/test_eval_diagnostics.py
+++ b/tests/test_eval_diagnostics.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from decafclaw.eval.diagnostics import CANONICAL_AXES, aggregate_by_axis, parse_axes
+from decafclaw.eval.diagnostics import (
+    CANONICAL_AXES,
+    aggregate_by_axis,
+    detect_files_cited,
+    detect_files_read,
+    parse_axes,
+)
 
 
 def test_parse_axes_absent_returns_empty():
@@ -61,3 +67,31 @@ def test_aggregate_empty_axis_absent():
     agg = aggregate_by_axis([{"name": "a", "status": "pass"}], [{"name": "a"}])
     assert "retrieval" not in agg  # only axes actually present appear
     assert agg["untagged"]["passed"] == 1
+
+
+def test_detect_files_read_maps_args():
+    calls = [
+        ("vault_read", {"page": "agent/pages/DecafClaw"}),
+        ("workspace_read", {"path": "notes/todo.md"}),
+        ("conversation_search", {"query": "x"}),  # not a read tool
+        ("vault_read", {"page": "agent/pages/DecafClaw"}),  # dup
+    ]
+    assert detect_files_read(calls) == ["agent/pages/DecafClaw", "notes/todo.md"]
+
+
+def test_detect_files_read_drops_empty():
+    assert detect_files_read([("vault_read", {})]) == []
+
+
+def test_detect_files_cited_path_and_wiki():
+    resp = "See [[Escalation Runbook]]. I read the escalation-runbook page."
+    known = ["agent/pages/escalation-runbook.md", "agent/pages/oncall-rotation.md"]
+    cited = detect_files_cited(resp, known)
+    assert "agent/pages/escalation-runbook.md" in cited  # stem 'escalation-runbook' matched
+    assert "Escalation Runbook" in cited                 # wiki-mention
+    assert "agent/pages/oncall-rotation.md" not in cited  # never mentioned
+
+
+def test_detect_files_cited_no_false_positive_on_unrelated():
+    resp = "I don't have anything on that topic."
+    assert detect_files_cited(resp, ["agent/pages/escalation-runbook.md"]) == []


### PR DESCRIPTION
Closes #528
Closes #531

Combined arc adding two complementary eval-harness capabilities, executed as one 13-task subagent-driven plan (spec + plan + notes in `docs/dev-sessions/2026-07-24-1618-eval-behavioral-diagnostics/`).

## #531 — per-turn context diagnostics
Every eval result now carries a `diagnostics` block (per-turn + top-level), built by a new pure-function module `src/decafclaw/eval/diagnostics.py`:
- **Reuses** the context sidecar the agent already writes on turn-exit (`read_context_sidecar`) — no recompute, no duplication of `build_diagnostics`. Degrades gracefully to derived-only fields on a missing/None sidecar.
- Fields: `tokens_by_section`, `active_tools`/`deferred_tools`, `retrieved_candidates` (names + scores), `files_read`, `files_cited` (path/basename/stem substring + `[[wiki]]` heuristic), `tool_calls` (names + count), plus token/window/threshold totals.
- `--verbose` prints a compact per-test summary.
- Lets a failing eval be diagnosed as retrieval-miss / routing-miss / answer-miss / context-bloat with evidence instead of re-running under `LOG_LEVEL=DEBUG`. (It already earned its keep — see the #688 note below.)

## #528 — failure-mode axis scorecard + behavioral suites
- New top-level `tests:` key (string or list) tags a case with one or more canonical axes: `retrieval`, `routing`, `answer_quality`, `workflow_discipline`. Unknown axis → hard error (validated up front, before any run); untagged cases bucket as `untagged`.
- `aggregate_by_axis` rolls per-test pass/fail into `results["summary"]["by_axis"]`; `make eval` prints a per-axis scorecard.
- **Seven new adversarial behavioral suites** (31 cases) exercising the four axes end-to-end against real LLM turns: `vault_answering`, `tool_routing`, `source_grounding`, `context_pressure`, `clarification`, `abort_recovery`, `over_ceremony`. Each case is bounded, axis-tagged, and uses distinctive non-guessable tokens; tuning history lives in each suite's header comments.

## Testing
- `make check` clean; `make test` **3448 passed, 2 skipped, zero warnings**.
- Deterministic logic unit-tested in `tests/test_eval_diagnostics.py` (axis parse/validate, aggregate double-count + untagged bucket, file detection, None-sidecar degrade, runner wiring).
- Full behavioral suite validated against `vertex-gemini-flash`: **31/31, all axes 100%**, stable across consecutive runs.

## Docs
`docs/eval-loop.md` updated (axis tagging, scorecard, diagnostics block, `--verbose`).

## Follow-ups (deferred, documented in session notes)
- **#688** — filed from this work: `vault_search`'s tags AND-logic + the model self-attaching invented tag phrases produces false-empty results → hallucinated absence (the #531 diagnostics surfaced the root cause). One `source_grounding` case that depended on this path was dropped rather than couple the suite to the unfixed bug.
- Per-tool-call durations (needs agent-side instrumentation); per-axis history trend; retagging pre-existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)