### PR TITLE
fix(tests): declare an explicit pytest collection scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ See [docs/conversations.md](docs/conversations.md), [docs/web-ui.md](docs/web-ui
   - **Don't `asyncio.sleep(X)` to wait for work.** Wait on the right signal: `await job.reader_task`, `asyncio.wait_for(event.wait(), ...)`, or patch the clock (`_now_iso`/`time.monotonic`). Fixed sleeps are slower *and* flakier.
   - **Anything that runs a real scheduler/timer must patch the work function.** `discover_schedules` picks up bundled scheduled skills (`dream`, `garden`); on a fresh `tmp_path` config they're "never run → due" and fire real `run_agent_turn` calls (one test bled to ~66s this way). Patch `decafclaw.schedules.run_schedule_task` even for "no tasks" scenarios.
 - **Check `pytest --durations=25` when adding tests.** Top-25 placement → missing mock or fixed sleep masquerading as a sync primitive.
+- **Collection scope is explicit: `testpaths = ["tests", "contrib"]`.** New tests must live under one of those two roots or they won't run. `contrib` is listed because contrib skill tests are colocated with the skill. Don't drop it back to rootdir collection — `data/` is the agent's writable workspace, and anything it scaffolds matching `test_*.py` would join the suite (#682). That failure is invisible in CI and in worktrees, since neither has a `data/` dir; it only shows up on a main clone. `tests/test_pytest_collection.py` enforces both halves.
 
 ### Evals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,19 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Collection scope, declared explicitly (#682). Without this pytest collects
+# from the rootdir, which in a working clone includes `data/` — the agent's
+# own writable workspace. Anything it scaffolds there matching `test_*.py`
+# joins our suite: a `playtime` scratch project it generated failed locally
+# with `FileNotFoundError: 'playtime'` while the same commit was green in CI
+# and in worktrees (neither has a `data/` dir, which is why this stayed
+# invisible for so long).
+#
+# `contrib` is here because contrib skill tests are colocated with the skill
+# rather than living under `tests/` — dropping it would silently stop running
+# them. tests/test_pytest_collection.py enforces both halves: no agent data,
+# no orphaned tracked test files.
+testpaths = ["tests", "contrib"]
 # Promote pytest's unraisable-exception warning to an error so a leaked
 # resource (e.g. an unclosed asyncio subprocess transport GC'd after its event
 # loop closes) fails the suite deterministically instead of flakily dirtying it

--- a/tests/test_pytest_collection.py
+++ b/tests/test_pytest_collection.py
@@ -1,0 +1,72 @@
+"""Guards on what pytest collects (#682).
+
+Without `testpaths`, pytest collects from the rootdir — which in a working
+clone includes `data/`, the agent's own writable workspace. Anything the
+agent scaffolds there matching `test_*.py` becomes part of our suite. That
+actually happened: a `playtime` scratch project the agent generated failed
+locally with `FileNotFoundError: 'playtime'` while the same commit passed
+in CI and in worktrees.
+
+The failure is invisible in the two places we normally look — CI has no
+`data/` (it's gitignored) and worktrees have no `data/` of their own — so
+it only ever appears on a developer's main clone, attributable to code
+nobody on the project wrote.
+"""
+
+import pathlib
+import subprocess
+import tomllib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _pytest_config() -> dict:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["tool"]["pytest"]["ini_options"]
+
+
+def _testpaths() -> list[str]:
+    return _pytest_config().get("testpaths", [])
+
+
+def test_testpaths_is_declared():
+    """An explicit collection scope, rather than 'whatever is on disk'."""
+    assert _testpaths(), (
+        "pyproject.toml declares no [tool.pytest.ini_options] testpaths, so "
+        "pytest collects from the rootdir — including the agent's writable "
+        "data/ directory. See #682."
+    )
+
+
+def test_testpaths_excludes_the_agent_data_directory():
+    """`data/` is agent-writable by design. It must never be a test root."""
+    for entry in _testpaths():
+        top = pathlib.PurePosixPath(entry).parts[0]
+        assert top != "data", (
+            f"testpaths entry {entry!r} would collect the agent's own "
+            "workspace as part of our test suite"
+        )
+
+
+def test_every_tracked_test_file_is_still_collected():
+    """Narrowing the scope must not silently orphan real tests.
+
+    Uses `git ls-files`, so gitignored trees (notably `data/`) are excluded
+    for free and only tests we actually own are considered. This is the
+    check that catches someone setting `testpaths = ["tests"]` and quietly
+    dropping the colocated contrib skill tests.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "test_*.py", "*/test_*.py", "**/test_*.py",
+         "*_test.py", "*/*_test.py", "**/*_test.py"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert tracked, "expected to find tracked test files"
+
+    roots = tuple(f"{pathlib.PurePosixPath(p).as_posix().rstrip('/')}/"
+                  for p in _testpaths())
+    orphaned = [f for f in tracked if not f.startswith(roots)]
+    assert not orphaned, (
+        f"these tracked test files fall outside testpaths {list(roots)} and "
+        f"would no longer run: {orphaned}"
+    )

--- a/tests/test_pytest_collection.py
+++ b/tests/test_pytest_collection.py
@@ -38,14 +38,45 @@ def test_testpaths_is_declared():
     )
 
 
+def _overlaps(entry: str, target: pathlib.Path) -> bool:
+    """Do the `entry` and `target` trees intersect at all?
+
+    Overlap in either direction, not a name match, because the two ways to
+    get this wrong are different shapes:
+
+    - an entry ABOVE the target (`"."`) names no directory but sweeps up
+      every one, reintroducing precisely the problem testpaths prevents;
+    - an entry BELOW it (`"data/decafclaw"`) never reaches `data/` itself
+      yet still collects agent-authored files.
+
+    A leading-component check misses the first; plain containment misses
+    the second.
+    """
+    root = (REPO_ROOT / entry).resolve()
+    return target.is_relative_to(root) or root.is_relative_to(target)
+
+
+def test_overlaps_catches_entries_above_and_below_the_target():
+    """The guard below is the actual deliverable here, so it gets its own
+    test — a guard that silently stops guarding is worse than none."""
+    data_dir = (REPO_ROOT / "data").resolve()
+    assert _overlaps("data", data_dir)
+    assert _overlaps("data/decafclaw", data_dir)   # below — plain containment misses
+    assert _overlaps(".", data_dir)                # above — a name check misses
+    assert _overlaps("./", data_dir)
+    assert not _overlaps("tests", data_dir)
+    assert not _overlaps("contrib", data_dir)
+
+
 def test_testpaths_excludes_the_agent_data_directory():
-    """`data/` is agent-writable by design. It must never be a test root."""
-    for entry in _testpaths():
-        top = pathlib.PurePosixPath(entry).parts[0]
-        assert top != "data", (
-            f"testpaths entry {entry!r} would collect the agent's own "
-            "workspace as part of our test suite"
-        )
+    """`data/` is agent-writable by design. It must never be reachable from
+    a test root — whether named directly or swept up by a broader entry."""
+    data_dir = (REPO_ROOT / "data").resolve()
+    offenders = [e for e in _testpaths() if _overlaps(e, data_dir)]
+    assert not offenders, (
+        f"testpaths entries {offenders} reach the agent's own workspace, "
+        "which would collect agent-authored files as part of our suite (#682)"
+    )
 
 
 def test_every_tracked_test_file_is_still_collected():
@@ -56,6 +87,14 @@ def test_every_tracked_test_file_is_still_collected():
     check that catches someone setting `testpaths = ["tests"]` and quietly
     dropping the colocated contrib skill tests.
     """
+    # `.git` is a directory in a normal clone and a file in a worktree, so
+    # exists() rather than is_dir(). Checked explicitly because otherwise a
+    # non-checkout (source zip, sdist) fails with a bare CalledProcessError
+    # that says nothing about the requirement.
+    assert (REPO_ROOT / ".git").exists(), (
+        "this guard needs git metadata to tell tracked tests from "
+        "agent-authored files; run it from a checkout"
+    )
     tracked = subprocess.run(
         ["git", "ls-files", "test_*.py", "*/test_*.py", "**/test_*.py",
          "*_test.py", "*/*_test.py", "**/*_test.py"],


### PR DESCRIPTION
Closes #682.

## The problem

No `testpaths` in `[tool.pytest.ini_options]`, so pytest collects from the rootdir — which in a working clone includes `data/`, the agent's own writable workspace. Anything it scaffolds matching `test_*.py` becomes part of our suite:

```
FAILED data/decafclaw/workspace/projects/.../playtime/tests/test_playtime.py::test_cli_output
E   FileNotFoundError: [Errno 2] No such file or directory: 'playtime'
```

Same commit: `1 failed, 3429 passed` in the main clone, `3430 passed` in a worktree.

What makes it worth more than a one-liner is *where it hides*. `data/` is gitignored, so CI has nothing to collect. Worktrees have no `data/` of their own, so the worktree-based verification we do by default misses it too. It appears only on a developer's main clone, only depending on what the agent has built lately, and points at code nobody on the project wrote. It cost me a few minutes of believing my own changes had broken something.

## The change

`testpaths = ["tests", "contrib"]`.

`contrib` is load-bearing, not decoration — contrib skill tests are colocated with the skill rather than under `tests/`, so the obvious `["tests"]` would have silently stopped running 75 of them. That's exactly the kind of quiet coverage loss this issue is about, so it gets its own guard rather than a comment.

`tests/test_pytest_collection.py` enforces both halves:
- no `data/` in testpaths;
- **no tracked test file left outside testpaths.** Uses `git ls-files`, so gitignored trees drop out for free and only tests we own are considered. This is the one that catches the contrib mistake.

## Verification

Checked both directions rather than trusting the config:

- Planted an intentionally-failing test at `data/fake-agent/.../test_agent_scratch.py`: **not collected**, suite still green.
- Same file with `-o testpaths=.` (rootdir scope, i.e. today's behaviour): **collected** — so the fix has teeth and the guard isn't vacuous.
- Collection 3445 → 3447: minus the one agent file, plus the three new guards. `contrib/` stays at exactly 75.
- Guards fail before the change, pass after.
- `make check` clean; `make test` 3445 passed / 2 skipped.

CLAUDE.md gains a line under the test conventions, since "where new tests may live" is now a rule rather than a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)