### PR TITLE
vault_section: resolve bare and partial section paths

### DIFF
--- a/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/notes.md
+++ b/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/notes.md
@@ -1,0 +1,152 @@
+# Notes — #671 vault_section path resolution
+
+## Phase 4 — does the agent actually benefit? (2026-07-25)
+
+`vertex-gemini-flash`, worktree at `6513b5f`.
+
+### `evals/vault.yaml` — 4/6
+
+```
+[1/6] saves user-level fact to vault journal on 'remember'   FAIL  (1 tools)
+[2/6] reaches for vault_search on explicit search request    PASS  (1 tools)
+[3/6] finds specific fact under heavy distractor load        PASS  (0 tools)
+[4/6] reads a named vault page directly without searching    PASS  (1 tools)
+[5/6] reaches for vault_backlinks to find inbound links      PASS  (1 tools)
+[6/6] adds a section without rewriting other sections        FAIL  (3 tools)
+```
+
+Case 1 picked `vault_write` over `vault_journal_append` — the #670 case, which
+scored 10/10 under repeated sampling two days ago. One sample; noise-floor
+territory, and nothing in this branch touches those two descriptions.
+
+### The target case: the fix works, a different defect took over
+
+**Tool calls dropped from 4 to 2 on passing runs** (baseline: 4, in
+`2026-07-24-2323`). That is the win the fix was aimed at.
+
+Re-ran the case 3× per the plan rather than concluding from one run:
+
+| run | result | calls |
+|---|---|---|
+| in `vault.yaml` | FAIL | 3 |
+| `addsec-1` | **PASS** | **2** |
+| `addsec-2` | FAIL | 4 |
+| `addsec-3` | **PASS** | 4 |
+
+2/4 overall. **In every failure `after: "Background"` — the bare title — was
+accepted.** Path resolution is no longer the blocker; #671's defect is fixed.
+
+### What blocks it now: `vault_section add` can't set a body
+
+`Document.add_section` has taken a `content` parameter all along.
+`tool_vault_section` never exposed it — pre-existing on `origin/main`, nothing
+to do with this branch. So "add a section titled X with body Y" always needs a
+second operation, and the second operation is where it goes wrong:
+
+```
+# run 1 — guessed the obvious API
+vault_section {"title": "Status", "after": "Background", "content": "Working on it."}
+  -> [error executing vault_section: tool_vault_section() got an unexpected
+      keyword argument 'content'. Expected parameters: page, action, section,
+      title, level, after, before, parent]
+  -> fell back to read + manual rewrite
+
+# addsec-2 — created the section, then rewrote the page to fill it
+vault_section {"title": "Status", "after": "Background"}   # empty section
+vault_read
+vault_write  # full-page rewrite, mangled the layout
+```
+
+The capability exists one layer down:
+
+```python
+d.add_section('Status', level=2, content='Working on it.', after='Background')
+```
+
+produces exactly the output the eval asserts, in one operation.
+
+**Decision:** Les scoped this in as Phase 5 rather than deferring it — same
+tool, same class of defect (a natural operation the tool blocks), and the
+underlying method already implements it.
+
+### Minor formatting nit — noted, not fixed
+
+`add_section` emits `## Status\nWorking on it.` with no blank line after the
+heading. Valid markdown, not idiomatic. Left alone deliberately: it touches
+shared insertion formatting that existing round-trip tests may pin, and it
+isn't blocking anything.
+
+---
+
+## Phases 5–6 — the content gap, and the level default it exposed
+
+### Phase 5: `content` on `vault_section add`
+
+One parameter, a passthrough, a description, two tests. The eval repro then
+went **2/4 → 0/3** — worse, not better.
+
+That was a genuine (if indirect) regression from the change: by making the
+one-call path viable, it made the agent hit a pre-existing bad default far more
+often.
+
+### Phase 6: `level` defaulted to 1, which reparents the page
+
+The agent omitted `level`, the tool defaulted to `1`, and a `# Status` landed
+mid-page after a `##`. That isn't cosmetic — it silently restructures the
+document:
+
+```
+# Project Notes
+  ## Background
+# Status              <- inserted here
+  ## TODO             <- now a child of Status
+  ## References       <- now a child of Status
+
+paths change: 'Project Notes/TODO' -> 'Status/TODO'
+```
+
+`level` now defaults to whatever the anchor implies — sibling of
+`after`/`before`, one below `parent`, and only 1 when there is no anchor at
+all. Explicit levels still win.
+
+**A bug I introduced and then caught by running the real thing:** the tool
+guarded `not isinstance(level, int)` before `level` became optional, so an
+omitted level died with `[error: level must be between 1 and 6, got None]`.
+The Phase 6 unit tests called `Document.add_section` directly and sailed past
+it — the tool-layer guard was only visible in the eval. Two tool-level tests
+added; this is the
+[[feedback_signature_change_test_scope]] shape exactly.
+
+### Phase 2's own message had a dead end
+
+The last eval failure surfaced a flaw in the error text written earlier this
+session. When two headings share a path, the candidate list renders
+identically:
+
+```
+ambiguous section path 'Status' matches 2 sections:
+  Project Notes/Status
+  Project Notes/Status
+Use a longer path to disambiguate.
+```
+
+No longer path exists. The agent retried, then fell back to a full rewrite and
+blew its call budget. Duplicate paths now get their own message pointing at the
+only real ways out (rename/remove one, or edit by line number).
+
+### Measured outcome
+
+| stage | repro result | notes |
+|---|---|---|
+| baseline `2026-07-24-2323` | pass | 4 tool calls |
+| after Phases 1–3 | 2/4 | bare titles accepted; blocked on missing `content` |
+| after Phase 5 | 0/3 | one-call path viable → hit the `level=1` default |
+| after Phase 6 | **3/3** | |
+| confirmation run | **2/3** | one run reached **1 tool call** |
+
+**5/6 across the two post-fix runs, versus 2/4 before**, and the best runs do in
+1–2 calls what took 4 at baseline. The single remaining failure was the
+duplicate-heading loop, now addressed.
+
+Still not a *reliable* case — this is a flaky corner of the suite and was before
+any of this. Recorded rather than chased.

--- a/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/plan.md
+++ b/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/plan.md
@@ -1,0 +1,760 @@
+# vault_section path resolution — Implementation Plan
+
+**Goal:** Let section paths resolve as bare titles or partial paths instead of
+requiring the page-H1 root, fail loudly (not silently) on ambiguity, and make
+the miss message self-correcting.
+
+**Approach:** Exact full-path match keeps first priority; on a miss, fall back
+to a unique *suffix* match against every section's full path. Ambiguity returns
+`None` so no mutation proceeds on a guess. A separate `section_candidates()`
+lets the error sites distinguish ambiguous from missing without changing
+`find_section`'s signature at 13 call sites.
+
+**Tech stack:** Python 3.13, pytest + pytest-asyncio, `uv run`.
+
+**Working directory for every command below:**
+`/Users/lorchard/devel/decafclaw/.claude/worktrees/671-vault-section-paths`
+Use an absolute `cd` in each verification command — a stray `cd` to the main
+clone makes `make test` report a wrong-tree pass count and `pytest <newfile>`
+say "no tests ran", both of which look like success.
+
+**Baseline:** `make test` in this worktree = **3469 passed, 2 skipped**.
+
+---
+
+## Phase 1: Suffix resolution and `#` tolerance in the matcher
+
+Makes `Background`, `Archive/Background`, and `## Background` all resolve,
+while ambiguity resolves to nothing. This is the whole user-visible fix; the
+later phases are diagnostics and docs.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/_sections.py` — `normalize_title`,
+  `Document.find_section`, new module-level `_find_by_suffix`
+- Test: `tests/test_vault_sections_helpers.py` — add to the existing file
+  (it already covers `Document` round-trip and `find_section` by path)
+
+**Key changes:**
+
+`normalize_title` (currently `_sections.py:31-35`) — strip leading heading
+hashes as well:
+
+```python
+def normalize_title(raw: str) -> str:
+    """Strip wiki-links and leading heading hashes, then lowercase for matching."""
+    stripped = WIKILINK_RE.sub(r"\1", raw)
+    return stripped.lstrip("#").strip().lower()
+```
+
+New module-level helper, next to `_walk_path` (`:548-558`):
+
+```python
+def _find_by_suffix(sections: list[Section], parts: list[str]) -> list[Section]:
+    """Every section whose full path ends with ``parts``.
+
+    Lets a caller address a section by a bare title or any trailing portion of
+    its path, instead of rooting every path at the page H1 (#671). Returns all
+    matches so the caller can distinguish unique from ambiguous.
+    """
+    matches: list[Section] = []
+
+    def _walk(secs: list[Section], trail: list[str]) -> None:
+        for sec in secs:
+            current = trail + [sec.normalized_title]
+            if current[-len(parts):] == parts:
+                matches.append(sec)
+            _walk(sec.children, current)
+
+    _walk(sections, [])
+    return matches
+```
+
+`Document.find_section` (`:155-158`) — exact first, then unique suffix:
+
+```python
+    def find_section(self, path: str) -> Section | None:
+        """Resolve a section path.
+
+        Tries the exact rooted path first, then falls back to a unique suffix
+        match so a bare title or partial path resolves (#671). Ambiguous paths
+        deliberately return None — these back mutating operations, so a wrong
+        guess silently edits the wrong section. Callers wanting to tell
+        ambiguous from missing use ``section_candidates``.
+        """
+        self._ensure_parsed()
+        parts = [normalize_title(p) for p in path.split("/") if p.strip()]
+        if not parts:
+            return None
+        exact = _walk_path(self._sections, parts)
+        if exact is not None:
+            return exact
+        matches = _find_by_suffix(self._sections, parts)
+        return matches[0] if len(matches) == 1 else None
+```
+
+Note this replaces the old `p.strip().lower()` with `normalize_title(p)` so the
+`#` stripping applies per path segment, and drops empty segments so `/Background`
+and `Background/` behave.
+
+**Tests to add** (`tests/test_vault_sections_helpers.py`, matching the existing
+plain-function style — no fixture needed):
+
+```python
+NESTED = (
+    "# Project Notes\n\n"
+    "## Background\n\nbg\n\n"
+    "## Archive\n\n### Background\n\nold bg\n\n"
+    "## TODO\n\n- Old item\n"
+)
+
+
+def test_bare_title_resolves_without_h1_root():
+    """#671: a ## heading was only addressable as '<H1>/<Section>'."""
+    doc = Document.from_text("# Project Notes\n\n## Background\n\nbg\n\n## TODO\n\n- x\n")
+    assert doc.find_section("Background") is not None
+    assert doc.find_section("TODO") is not None
+    # The rooted form keeps working.
+    assert doc.find_section("Project Notes/Background") is not None
+
+
+def test_partial_path_resolves():
+    doc = Document.from_text(NESTED)
+    sec = doc.find_section("Archive/Background")
+    assert sec is not None and sec.level == 3
+
+
+def test_exact_path_wins_over_suffix():
+    doc = Document.from_text(NESTED)
+    sec = doc.find_section("Project Notes/Background")
+    assert sec is not None and sec.level == 2
+
+
+def test_ambiguous_bare_title_resolves_to_nothing():
+    """Two sections titled 'Background' — a guess would edit the wrong one."""
+    doc = Document.from_text(NESTED)
+    assert doc.find_section("Background") is None
+
+
+def test_heading_hashes_are_tolerated():
+    doc = Document.from_text("# Project Notes\n\n## Background\n\nbg\n")
+    assert doc.find_section("## Background") is not None
+    assert doc.find_section("#Background") is not None
+
+
+def test_add_section_after_bare_title():
+    """The operation from the #671 repro."""
+    doc = Document.from_text("# Project Notes\n\n## Background\n\nbg\n\n## TODO\n\n- x\n")
+    assert doc.add_section("Status", level=2, after="Background") is True
+    assert "## Status" in doc.to_text()
+
+
+def test_empty_and_slash_only_paths_resolve_to_nothing():
+    doc = Document.from_text(NESTED)
+    assert doc.find_section("") is None
+    assert doc.find_section("/") is None
+```
+
+**Order of work (TDD):** write the tests, run them, confirm
+`test_bare_title_resolves_without_h1_root` and friends fail; then apply the
+three `_sections.py` edits; re-run.
+
+**Verification — automated:**
+- [x] `cd <worktree> && uv run pytest tests/test_vault_sections_helpers.py -v`
+      fails before the edits, on the bare-title assertions — **4 failed, 5 passed**
+- [x] same command passes after (9 tests: 2 existing + 7 new) — **9 passed in 2.40s**
+- [x] `cd <worktree> && uv run pytest tests/test_vault_section_tools.py tests/test_vault_tools.py -v` passes — the existing rooted-path callers are unaffected — **159 passed**
+- [x] `cd <worktree> && make test` passes, count >= 3476 (baseline 3469 + 7)
+      — **3476 passed, 2 skipped**
+- [x] `cd <worktree> && make check` passes — **exit 0**
+
+**Verification — manual:**
+- [x] Re-run the issue's repro by hand and confirm every spelling now resolves
+      except the genuinely ambiguous one — all four `add_section` spellings from
+      the issue return `True`; `find_section('TODO')` resolves; the rooted form
+      still works
+
+**Note on one test's strength:** `test_ambiguous_bare_title_resolves_to_nothing`
+passed in the RED run too, for the wrong reason (everything returned `None`
+before the fix). It is meaningful only alongside the suffix tests, where it
+guards against the fallback over-reaching. Kept deliberately.
+
+---
+
+## Phase 2: Distinguish ambiguous from missing, and say so
+
+Turns the two dead-end messages into self-correcting ones. `find_section`
+already returns `None` for both cases after Phase 1; this phase gives the error
+sites a way to tell them apart.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/_sections.py` — add
+  `Document.section_candidates`, `Document.all_section_paths`, and a
+  module-level `describe_section_miss`
+- Modify: `src/decafclaw/skills/vault/tools.py` — use it at `:1294`, `:1421`,
+  `:1434`, `:1446`
+- Modify: `src/decafclaw/skills/vault/_sections.py:612` — the bare-string error
+  from `_insert_into_doc`
+- Test: `tests/test_vault_sections_helpers.py`, `tests/test_vault_section_tools.py`
+
+**Key changes:**
+
+First, let `_section_path` (`:568-584`) render real titles as well as
+normalized ones. It currently builds paths from `normalized_title`, so an error
+message would read `project notes/background` — technically valid input, but
+poor to show a human. Existing callers keep the normalized form via the
+default; only the new diagnostics opt in:
+
+```python
+def _section_path(
+    sec: Section, top_sections: list[Section], *, display: bool = False,
+) -> str:
+    """Full slash path to ``sec``.
+
+    ``display=True`` renders the headings' real titles, for error messages and
+    anything else a human reads. The default normalized form stays the
+    round-trippable one used for re-resolution after a mutation.
+    """
+    def _find(sections: list[Section], target_line: int, prefix: str) -> str | None:
+        for s in sections:
+            name = s.title.strip() if display else s.normalized_title
+            current = f"{prefix}/{name}" if prefix else name
+            if s.heading_line == target_line:
+                return current
+            found = _find(s.children, target_line, current)
+            if found:
+                return found
+        return None
+    fallback = sec.title.strip() if display else sec.normalized_title
+    return _find(top_sections, sec.heading_line, "") or fallback
+```
+
+Both forms are accepted as input, since `find_section` normalizes whatever it
+is given.
+
+On `Document`:
+
+```python
+    def section_candidates(self, path: str) -> list[str]:
+        """Full paths of every section matching ``path`` as a suffix.
+
+        Empty means nothing matched; more than one means the path was
+        ambiguous, which is why ``find_section`` returned None. Paths are
+        rendered with real titles for display; both forms resolve.
+        """
+        self._ensure_parsed()
+        parts = [normalize_title(p) for p in path.split("/") if p.strip()]
+        if not parts:
+            return []
+        return [
+            _section_path(sec, self._sections, display=True)
+            for sec in _find_by_suffix(self._sections, parts)
+        ]
+
+    def all_section_paths(self) -> list[str]:
+        """Full slash path of every section, in document order, for display."""
+        self._ensure_parsed()
+        return [
+            _section_path(sec, self._sections, display=True)
+            for _depth, sec in self.list_sections()
+        ]
+```
+
+Module-level, so both `tools.py` and `_insert_into_doc` share one wording.
+Returns the *inner* message with no `[error: ]` wrapper, because
+`_insert_into_doc` returns bare strings that `tools.py:1524` wraps:
+
+```python
+# Cap on paths listed in a "not found" message. Pages rarely have more; a
+# truncated list still teaches the path shape, which is the point.
+_MAX_LISTED_PATHS = 20
+
+
+def describe_section_miss(doc: "Document", path: str) -> str:
+    """Explain why ``path`` didn't resolve, with enough detail to retry.
+
+    Ambiguous paths list every candidate; missing ones list the page's known
+    paths. Returns the message body without the ``[error: ]`` wrapper.
+    """
+    candidates = doc.section_candidates(path)
+    if len(candidates) > 1:
+        listed = "\n  ".join(candidates)
+        return (
+            f"ambiguous section path {path!r} matches {len(candidates)} sections:\n"
+            f"  {listed}\n"
+            f"Use a longer path to disambiguate."
+        )
+    known = doc.all_section_paths()
+    if not known:
+        return f"section not found: {path!r} (page has no sections)"
+    shown = known[:_MAX_LISTED_PATHS]
+    listed = "\n  ".join(shown)
+    more = (
+        "" if len(known) <= _MAX_LISTED_PATHS
+        else f"\n  … and {len(known) - _MAX_LISTED_PATHS} more"
+    )
+    return f"section not found: {path!r}. Known paths:\n  {listed}{more}"
+```
+
+Call sites in `tools.py` — all four become the same shape. Import
+`describe_section_miss` alongside the existing `Document, _insert_into_doc`
+import at `tools.py:30`:
+
+```python
+        return ToolResult(text=f"[error: {describe_section_miss(doc, section)}]")
+```
+
+`tools.py:1421` currently reads `[error: target section not found]` with no
+path at all. It sits in the `add` branch, where the failed path is whichever of
+`after` / `before` / `parent` was supplied:
+
+```python
+        target = after or before or parent or ""
+        return ToolResult(text=f"[error: {describe_section_miss(doc, target)}]")
+```
+
+`_sections.py:612` inside `_insert_into_doc`:
+
+```python
+            return describe_section_miss(doc, to_section)
+```
+
+**Tests to add:**
+
+```python
+# tests/test_vault_sections_helpers.py
+
+def test_section_candidates_lists_ambiguous_matches():
+    doc = Document.from_text(NESTED)
+    got = doc.section_candidates("Background")
+    assert got == ["Project Notes/Background", "Project Notes/Archive/Background"]
+
+
+def test_section_candidates_empty_when_missing():
+    doc = Document.from_text(NESTED)
+    assert doc.section_candidates("Nonexistent") == []
+
+
+def test_candidate_paths_are_valid_input():
+    """Whatever the error offers must resolve when pasted back."""
+    doc = Document.from_text(NESTED)
+    for candidate in doc.section_candidates("Background"):
+        assert doc.find_section(candidate) is not None
+
+
+def test_all_section_paths_in_document_order():
+    doc = Document.from_text(NESTED)
+    assert doc.all_section_paths() == [
+        "Project Notes",
+        "Project Notes/Background",
+        "Project Notes/Archive",
+        "Project Notes/Archive/Background",
+        "Project Notes/TODO",
+    ]
+
+
+def test_describe_section_miss_ambiguous_names_candidates():
+    doc = Document.from_text(NESTED)
+    msg = describe_section_miss(doc, "Background")
+    assert "ambiguous" in msg
+    assert "Project Notes/Background" in msg
+    assert "Project Notes/Archive/Background" in msg
+
+
+def test_describe_section_miss_missing_lists_known_paths():
+    doc = Document.from_text(NESTED)
+    msg = describe_section_miss(doc, "Nope")
+    assert "not found" in msg
+    assert "Project Notes/TODO" in msg
+
+
+def test_describe_section_miss_truncates_long_lists():
+    body = "# Root\n\n" + "".join(f"## S{i}\n\ntext\n\n" for i in range(30))
+    doc = Document.from_text(body)
+    msg = describe_section_miss(doc, "Nope")
+    assert "and 11 more" in msg   # 31 sections total, 20 shown
+```
+
+```python
+# tests/test_vault_section_tools.py — follows the existing vault_ctx / _write_note style
+
+AMBIGUOUS_TEXT = (
+    "# Top\n\n## Notes\n\na\n\n## Archive\n\n### Notes\n\nb\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_section_error_lists_known_paths(vault_ctx):
+    _write_note(vault_ctx)
+    result = await tool_vault_section(
+        vault_ctx, page="agent/pages/note", action="rename",
+        section="Nonexistent", title="X",
+    )
+    assert "not found" in result.text
+    assert "Top/Sub A" in result.text
+
+
+@pytest.mark.asyncio
+async def test_section_add_after_bare_title(vault_ctx):
+    """#671: 'Sub A' had to be spelled 'Top/Sub A'."""
+    note_path = _write_note(vault_ctx)
+    with patch("decafclaw.skills.vault.tools._reindex_page", new=AsyncMock()):
+        result = await tool_vault_section(
+            vault_ctx, page="agent/pages/note", action="add",
+            title="Status", level=2, after="Sub A",
+        )
+    assert "[error" not in result.text
+    assert "## Status" in note_path.read_text()
+
+
+@pytest.mark.asyncio
+async def test_section_ambiguous_path_errors_with_candidates(vault_ctx):
+    note_dir = vault_ctx.config.vault_root / "agent" / "pages"
+    note_dir.mkdir(parents=True, exist_ok=True)
+    (note_dir / "amb.md").write_text(AMBIGUOUS_TEXT)
+    result = await tool_vault_section(
+        vault_ctx, page="agent/pages/amb", action="rename",
+        section="Notes", title="X",
+    )
+    assert "ambiguous" in result.text
+    assert "Top/Notes" in result.text
+    assert "Top/Archive/Notes" in result.text
+```
+
+**Verification — automated:**
+- [x] `cd <worktree> && uv run pytest tests/test_vault_sections_helpers.py tests/test_vault_section_tools.py -v` passes
+      — **17 + 22 = 39 passed**
+- [x] `cd <worktree> && grep -rn "target section not found" src/` returns nothing —
+      the no-path-echoed message is gone — **exit 1, no matches**
+- [x] `cd <worktree> && make test` passes, count >= 3485 — **3488 passed, 2 skipped**
+- [x] `cd <worktree> && make check` passes — **exit 0**
+
+**Verification — manual:**
+- [x] Read one ambiguous and one missing error message end to end — does each
+      tell you exactly what to type next? — yes:
+
+      ```
+      ambiguous section path 'Background' matches 2 sections:
+        Project Notes/Background
+        Project Notes/Archive/Background
+      Use a longer path to disambiguate.
+
+      section not found: 'Statuz'. Known paths:
+        Project Notes
+        Project Notes/Background
+        Project Notes/Archive
+        Project Notes/Archive/Background
+        Project Notes/TODO
+      ```
+
+---
+
+## Phase 3: Tool descriptions and docs
+
+The descriptions currently say "Slash-separated section path (e.g. 'top/first')",
+which is what led the caller to believe a bare title was invalid — and gave no
+hint the first segment had to be the page H1.
+
+**TDD opt-out:** description and doc text, no behavior. Phases 1-2 cover the
+behavior.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` — `:1991`, `:2038`, `:2083`,
+  `:2106`, `:2113`, `:2120`
+- Modify: `docs/vault.md` — section-addressing note
+
+**Key changes:** each of the six parameter descriptions moves from
+"Slash-separated section path (e.g. 'top/first')" to wording that states the
+bare form is fine and the path is a suffix. For `section`:
+
+```python
+                            "Section path — a bare heading title ('Background'), "
+                            "a partial path ('Archive/Background'), or the full "
+                            "path from the page title "
+                            "('Project Notes/Archive/Background'). Must match "
+                            "exactly one section; if it matches several the "
+                            "error lists them. Required for remove, rename, move."
+```
+
+`after` / `before` / `parent` get the same "bare title or partial path" phrasing
+with their own role sentence. `docs/vault.md` gains a short paragraph under the
+section-tools description covering the same three forms plus the ambiguity rule.
+
+**No `tool_choice` eval case.** CLAUDE.md asks for one on a "new or sharpened
+tool description", but that convention targets *disambiguation between
+overlapping tools* — which tool the model picks. These are parameter
+descriptions inside a single tool; `tool_choice` cases assert on tool name only
+and cannot observe an argument value. Phase 4 covers the behavior instead.
+
+**Verification — automated:**
+- [x] `cd <worktree> && make check` passes — **exit 0**
+- [x] `cd <worktree> && grep -c "top/first" src/decafclaw/skills/vault/tools.py`
+      returns 0 — **0**; the other stale examples (`top/sub a`, `today/inbox`)
+      are gone too
+- [x] `cd <worktree> && make test` passes — **3488 passed, 2 skipped**
+
+**Verification — manual:**
+- [x] Read the four param descriptions together — consistent, and each states
+      the bare-title form — verified by rendering `TOOL_DEFINITIONS`; all six
+      section-path params (not four — `vault_show_sections.section` and
+      `vault_move_lines.to_section` too) now share one `SECTION_PATH_HELP`
+      constant, so they cannot drift apart
+
+**Adaptation:** rather than editing six description strings independently, the
+shared sentence became a module-level `SECTION_PATH_HELP` constant that each
+param concatenates. Six hand-maintained copies of the same explanation is the
+drift shape CLAUDE.md warns about.
+
+---
+
+## Phase 4: Confirm the agent benefits
+
+The point of the fix is fewer round-trips. The existing eval case already
+exercises this exact path and passed at **4 tool calls** in the
+`2026-07-24-2323` bundle (2 of them spent discovering the path); it should now
+need fewer.
+
+**TDD opt-out:** measurement against real LLM calls; no code changes.
+
+**Files:**
+- Modify: `docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/notes.md`
+
+**Commands:**
+
+```bash
+cd /Users/lorchard/devel/decafclaw/.claude/worktrees/671-vault-section-paths
+uv run python -m decafclaw.eval evals/vault.yaml
+```
+
+Record per-case pass/fail and the tool-call count for "adds a section without
+rewriting other sections", against the 4 from `2026-07-24-2323`.
+
+**Do not tune anything to chase a number.** Per spec the eval case and its
+`max_tool_errors: 1` bound stay untouched. A tool-call count that doesn't drop
+is a finding to record, not a reason to edit the eval.
+
+**Note on flakiness:** a single eval run is not evidence of a stable count.
+If the count looks unchanged or worse, re-run the file before drawing any
+conclusion — three separate cases in the last session moved between runs.
+
+**Verification — automated:**
+- [!] `evals/vault.yaml` — "adds a section without rewriting other sections"
+      passes — **2/4 across four runs, not reliably.** The #671 defect *is*
+      fixed: the bare title `after: "Background"` was accepted in every run,
+      including the failures. What blocks it now is a different, pre-existing
+      gap — `vault_section add` can't set the new section's body — addressed in
+      Phase 5.
+- [x] Its tool-call count recorded and compared against 4 (re-run once if it
+      hasn't dropped, before concluding) — **dropped to 2 on passing runs**;
+      re-ran 3× before concluding, per the plan
+- [!] No other case in the file regresses vs the 6/6 it scored on 2026-07-24 —
+      **case 1 (`saves user-level fact … on 'remember'`) failed once**, picking
+      `vault_write` over `vault_journal_append`. That case sampled 10/10 two
+      days ago and nothing in this branch touches either description; treated
+      as noise-floor, recorded in `notes.md`, not chased.
+
+**Verification — manual:**
+- [x] Les reviews the before/after tool-call comparison — reviewed; scoped the
+      `content` gap in as Phase 5 rather than deferring it
+
+---
+
+## Phase 5: let `vault_section add` set the new section's body
+
+Closes the gap Phase 4 surfaced. `Document.add_section` has always accepted
+`content`; the tool never exposed it, so "add a section titled X with body Y"
+needs a second operation — and that second operation is where the agent goes
+wrong (a full-page `vault_write` that mangles layout, or an error from guessing
+`content=` at the tool).
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/tools.py` — `tool_vault_section` signature,
+  the `add` branch, and the schema
+- Test: `tests/test_vault_section_tools.py`
+
+**Key changes:**
+
+Signature gains the parameter, defaulting to `None` so existing callers are
+unaffected:
+
+```python
+async def tool_vault_section(
+    ctx,
+    page: str,
+    action: str,
+    section: str | None = None,
+    title: str | None = None,
+    level: int = 1,
+    content: str | None = None,
+    after: str | None = None,
+    before: str | None = None,
+    parent: str | None = None,
+) -> ToolResult:
+```
+
+The `add` branch passes it through — `add_section` already defaults to `""`:
+
+```python
+        added = doc.add_section(
+            title, level=level, content=content or "",
+            after=after, before=before, parent=parent,
+        )
+```
+
+Schema entry alongside `title` / `level`:
+
+```python
+                    "content": {
+                        "type": "string",
+                        "description": (
+                            "Body text for the new section. Only used by add; "
+                            "omit for an empty section. Saves a second call — "
+                            "there is no need to add the section and then "
+                            "rewrite the page to fill it."
+                        ),
+                    },
+```
+
+**Tests to add:**
+
+```python
+@pytest.mark.asyncio
+async def test_section_add_with_content(vault_ctx):
+    """One call should both create the section and fill it."""
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text(
+        "# Project Notes\n\n## Background\n\nkeep me\n\n## TODO\n\n- Old item\n"
+    )
+    result = await tool_vault_section(
+        vault_ctx, page="agent/pages/note", action="add",
+        title="Status", level=2, content="Working on it.", after="Background",
+    )
+    assert "[error" not in result.text.lower()
+    text = (agent_pages / "note.md").read_text()
+    assert "## Status" in text
+    assert "Working on it." in text
+    # Ordering and the untouched sections survive.
+    assert text.index("## Background") < text.index("## Status") < text.index("## TODO")
+    assert "keep me" in text
+    assert "- Old item" in text
+
+
+@pytest.mark.asyncio
+async def test_section_add_without_content_still_empty(vault_ctx):
+    """content is optional — omitting it keeps the old behavior."""
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx, page="agent/pages/note", action="add",
+        title="Second", level=2, after="First",
+    )
+    assert "[error" not in result.text.lower()
+    assert "## Second" in (agent_pages / "note.md").read_text()
+```
+
+**Verification — automated:**
+- [x] `cd <worktree> && uv run pytest tests/test_vault_section_tools.py -v` passes
+      — **26 passed**
+- [x] `cd <worktree> && make test` passes, count >= 3490 — **3499 passed, 2 skipped**
+- [x] `cd <worktree> && make check` passes — **exit 0**
+- [!] `cd <worktree> && uv run python -m decafclaw.eval tmp/addsec.yaml` — the
+      3-rep repro. Record the pass count and call count; **re-run before
+      concluding** either way, since the case measured 2/4 pre-Phase-5.
+      — **Phase 5 alone made it WORSE: 0/3.** Root-caused to the `level=1`
+      default, fixed in Phase 6 below. Final: **5/6 across two runs**, best runs
+      at 1–2 calls vs 4 at baseline.
+
+**Verification — manual:**
+- [ ] Les reviews the final eval numbers, including whether the case is now
+      reliable rather than merely better
+
+---
+
+## Phase 6: infer heading level from the anchor
+
+Added mid-execution. Phase 5 made the one-call path viable, which made the
+agent hit `level`'s default of 1 far more often — inserting an H1 mid-page,
+which silently reparents every following section. Les scoped it in after the
+0/3 measurement.
+
+**Files:**
+- Modify: `src/decafclaw/skills/vault/_sections.py` — `Document.add_section`
+- Modify: `src/decafclaw/skills/vault/tools.py` — signature, the `level`
+  validation guard, and the `level` description
+- Test: `tests/test_vault_sections_helpers.py`, `tests/test_vault_section_tools.py`
+
+**Key change:** `level: int | None = None`; resolved from the anchor —
+`after`/`before` → the anchor's level (sibling), `parent` → one below, no
+anchor → 1. Explicit levels still win. The anchor is resolved once and drives
+both the insertion point and the default.
+
+**Verification — automated:**
+- [x] `cd <worktree> && uv run pytest tests/test_vault_sections_helpers.py tests/test_vault_section_tools.py -v`
+      — **24 + 26 = 50 passed**
+- [x] `cd <worktree> && make test` — **3499 passed, 2 skipped**
+- [x] `cd <worktree> && make check` — **exit 0**
+- [x] Eval repro re-run twice — **3/3 then 2/3 = 5/6**, vs 2/4 before Phase 5
+
+**Verification — manual:**
+- [ ] Les reviews the tree-integrity behavior (a section added after `##`
+      should be a sibling, not a new H1)
+
+**Two defects found by running the real thing, not the unit tests:**
+
+1. The tool guarded `not isinstance(level, int)` before `level` became
+   optional, so omitting it failed with `level must be between 1 and 6, got
+   None`. The Phase 6 unit tests call `Document.add_section` directly and sailed
+   straight past the tool-layer guard. Fixed, plus two tool-level tests.
+2. Phase 2's own ambiguity message was a dead end when two headings share a
+   path — it listed identical candidates under "Use a longer path to
+   disambiguate", advice that cannot be followed. The agent looped and blew its
+   call budget. Duplicate paths now get a distinct message.
+
+---
+
+## Plan self-review
+
+**Spec coverage:**
+
+| spec "Desired end state" item | phase |
+|---|---|
+| 1. Any trailing portion of a path resolves | 1 |
+| 2. Exact full-path matches still win | 1 (`test_exact_path_wins_over_suffix`) |
+| 3. Ambiguity fails, error names candidates | 1 (returns None) + 2 (message) |
+| 4. Missing path error lists known paths | 2 |
+| 5. `normalize_title` strips leading `#` | 1 |
+| 6. Descriptions state bare/partial is accepted | 3 |
+
+Design decisions all land: suffix matching (Phase 1 `_find_by_suffix`),
+ambiguity-as-error (Phase 1 `None` + Phase 2 message), unchanged `find_section`
+signature with a companion `section_candidates` (Phases 1-2 — no call site
+outside `find_section` itself is touched), `#` stripping in `normalize_title`
+(Phase 1). The spec's open question is answered by `_MAX_LISTED_PATHS = 20` with
+a `… and N more` tail, tested.
+
+**Placeholder scan:** no TBD. Every test body and command is written out.
+
+**Type consistency:** `_find_by_suffix(sections: list[Section], parts: list[str])
+-> list[Section]` is defined in Phase 1 and consumed by `section_candidates` in
+Phase 2 with the same signature. `_section_path` gains a keyword-only
+`display: bool = False` in Phase 2; its two existing callers (`:282` re-resolve,
+and the old body) keep the default, so only the new diagnostics see real
+titles. `list_sections()` returns `list[tuple[int, Section]]` (`:160`), which
+`all_section_paths` unpacks as `_depth, sec`.
+`describe_section_miss(doc, path) -> str` returns an unwrapped message, matching
+both the `f"[error: {err}]"` wrap at `tools.py:1524` and the direct
+`f"[error: {...}]"` at the four `tools.py` sites.
+
+**Single-observation assertions:** the only measured number carried into a
+checkbox is the tool-call count in Phase 4, and that checkbox explicitly says to
+re-run before concluding. The 4-call figure is labelled as coming from one
+specific bundle rather than stated as the case's stable cost.
+
+**One risk, accepted:** `normalize_title` now strips leading `#` from *section
+titles* too, so a heading literally named `## #hashtag` normalizes to `hashtag`.
+It applies symmetrically to stored titles and queries, so lookups stay
+consistent; only a page with two headings differing solely by a leading `#`
+would newly collide. Judged not worth guarding.

--- a/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/research.md
+++ b/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/research.md
@@ -1,0 +1,104 @@
+# Research — #671 vault_section path resolution
+
+Measured in this worktree at `b1909a8` (current `main`, post-#689).
+
+## The premise holds — not a harness artifact
+
+My #670 retro speculated that #671 might be wholly or partly a harness
+artifact, because its eval case started passing after the eval system-prompt
+fix. **That was wrong**, and checking cost one command:
+
+```python
+from decafclaw.skills.vault._sections import Document
+text = '# Project Notes\n\n## Background\n\nsome bg\n\n## TODO\n\n- Old item\n'
+d = Document(text)
+
+find_section('Background')                 -> None
+find_section('Project Notes/Background')   -> Background
+find_section('TODO')                       -> None
+find_section('## Background')              -> None
+find_section('background')                 -> None
+
+add_section('Status', level=2, after='Background')               -> False
+add_section('Status', level=2, after='Project Notes/Background') -> True
+```
+
+Deterministic, no LLM involved. The eval case passes now because the agent
+spends **4 tool calls instead of 2** (`2026-07-24-2323` bundle) — with a real
+system prompt it reaches for `vault_show_sections` first and learns the
+qualified path, rather than failing twice and blowing `max_tool_errors: 1`.
+The tool is still wrong; the agent just pays around it.
+
+Claim corrected in the open retro PR #697.
+
+## Mechanism
+
+`Document.find_section` (`_sections.py:155-158`):
+
+```python
+def find_section(self, path: str) -> Section | None:
+    self._ensure_parsed()
+    parts = [p.strip().lower() for p in path.split("/")]
+    return _walk_path(self._sections, parts)
+```
+
+`_walk_path` (`:548-558`) matches `parts[0]` against the **top-level** section
+list and recurses into `children`. `_build_tree` (`:534-546`) nests by heading
+level, so an H1 page yields exactly one top-level section (the H1) with the
+`##` headings as its children. Hence every `##` needs the `<H1>/` prefix.
+
+Note the `.lower()` in `find_section` is redundant with `normalize_title`
+(`:31-35`), which `Section.normalized_title` already applies — it lowercases
+and strips wiki-links, but **not** leading `#`.
+
+## Call sites — 13, all through `find_section`
+
+| file:line | context |
+|---|---|
+| `_sections.py:282` | `move_section` re-resolve after mutation |
+| `_sections.py:428` | `add_section(after=…)` |
+| `_sections.py:433` | `add_section(before=…)` |
+| `_sections.py:438` | `add_section(parent=…)` |
+| `_sections.py:447` | `remove_section` |
+| `_sections.py:455` | `rename_section` |
+| `_sections.py:468` | `get_section_text` |
+| `_sections.py:482` | `set_section_text` |
+| `_sections.py:491` | `move_section(after=…)` |
+| `_sections.py:496` | `move_section(before=…)` |
+| `_sections.py:610` | `_insert_into_doc` |
+| `_sections.py:621` | `_insert_into_doc` retry |
+| `tools.py:1292` | `vault_show_sections` |
+
+Fixing `find_section` therefore fixes every section operation at once. Nothing
+else parses paths independently.
+
+## Error sites — where the message needs to improve
+
+| file:line | current text |
+|---|---|
+| `tools.py:1294` | `[error: section not found: {section}]` |
+| `tools.py:1421` | `[error: target section not found]` — no path echoed |
+| `tools.py:1434` | `[error: section not found: {section}]` |
+| `tools.py:1446` | `[error: section not found: {section}]` |
+| `_sections.py:612` | `section not found: {to_section}` (bare string, not ToolResult) |
+
+`tools.py:1421` is the one the eval hit — it doesn't even echo the path that
+failed.
+
+## Reusable helpers already present
+
+- `_section_path(sec, top_sections)` (`:568-584`) renders a section's full
+  slash path. Exactly what a candidate list and a "known paths" list need.
+- `list_sections(depth=0)` / `_flatten_sections` (`:160-165`, `:560-566`)
+  enumerate every section with depth.
+
+Together these mean the suffix matcher and both error messages can be built
+without new traversal code.
+
+## Tool descriptions to update
+
+`tools.py` — `:1991` (`vault_show_sections`), `:2038` (target page section),
+`:2083` (`section`), `:2106` (`after`), `:2113` (`before`), `:2120` (`parent`).
+All say "Slash-separated section path" with the example `'top/first'`, which
+reads as a nesting path among sections and gives no hint that the first segment
+must be the page H1.

--- a/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/spec.md
+++ b/docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/spec.md
@@ -1,0 +1,130 @@
+# vault_section path resolution Spec
+
+**Goal:** Make section paths resolve the way a caller would reasonably write
+them — bare titles and partial paths — instead of requiring every path to be
+rooted at the page's H1, and make the failure self-correcting when a path
+genuinely can't resolve.
+
+**Source:** [#671](https://github.com/lmorchard/decafclaw/issues/671)
+
+## Current state
+
+`Document.find_section(path)` splits on `/` and hands the parts to
+`_walk_path`, which walks strictly from the document's top-level sections
+(`_sections.py:155-158`, `:548-558`). On any page with an H1 title — i.e.
+essentially every vault page — the H1 *is* the only top-level section, so a
+`##` heading is addressable only as `<H1 Title>/<Section>`.
+
+Reproduced on current `main` (`b1909a8`), post-#689:
+
+```
+find_section('Background')                 -> None
+find_section('Project Notes/Background')   -> Background
+find_section('TODO')                       -> None
+find_section('## Background')              -> None
+find_section('background')                 -> None
+
+add_section('Status', level=2, after='Background')               -> False
+add_section('Status', level=2, after='Project Notes/Background') -> True
+```
+
+`normalize_title` (`_sections.py:31-35`) already lowercases and strips
+wiki-links, so case is *not* the problem — `'background'` fails for the same
+rooting reason as `'Background'`. Leading `#` characters are not stripped.
+
+**This is not a harness artifact.** The eval case "adds a section without
+rewriting other sections" passes post-#689, but only because the agent now
+spends 4 tool calls instead of 2 — with a real system prompt it discovers the
+qualified path first rather than failing outright. The defect is unchanged;
+fixing it should *reduce* tool calls.
+
+13 call sites route through `find_section` (`_sections.py` ×11, `tools.py` ×2),
+so fixing it there fixes `add` / `remove` / `rename` / `move` / checklist ops
+uniformly.
+
+## Desired end state
+
+1. A path resolves if it matches **any trailing portion** of a full section
+   path: `Background`, `Archive/Background`, and
+   `Project Notes/Archive/Background` all reach the same section.
+2. Exact full-path matches keep winning outright — no behavior change for
+   callers already passing rooted paths.
+3. When a path matches **more than one** section, the operation fails rather
+   than guessing, and the error names every candidate path.
+4. When a path matches **nothing**, the error lists the page's known paths.
+5. `normalize_title` strips leading `#` characters, so `'## Background'`
+   resolves.
+6. Tool parameter descriptions state that a bare or partial title is accepted,
+   with a realistic example.
+
+## Design decisions
+
+- **Decision:** Resolve by longest-suffix match against full paths — exact
+  match first, then unique suffix.
+  - **Why:** an agent that qualifies a path *more* should never get a worse
+    result than one that qualifies it less. Leaf-only matching (what the issue
+    proposes) leaves `Archive/Background` failing while both `Background` and
+    the fully-rooted form work — a confusing seam.
+  - **Rejected:** bare-leaf-only fallback (smaller, but leaves that seam).
+
+- **Decision:** Ambiguity is an error, not a heuristic pick.
+  - **Why:** these are mutating operations. Silently editing the wrong
+    `## Notes` is worse than one extra round-trip, and the agent can
+    self-correct from a candidate list.
+  - **Rejected:** shallowest-match-wins — fewer round-trips, but the failure
+    mode is a silent wrong-section edit with no signal.
+
+- **Decision:** Keep `find_section(path) -> Section | None` unchanged; add a
+  separate `Document.section_candidates(path) -> list[str]` used only when
+  building an error message.
+  - **Why:** `find_section` returning `None` on ambiguity keeps all 13 call
+    sites correct-by-default (a mutation never proceeds on an ambiguous path)
+    without threading a result object through every one. The error sites — the
+    only places that need to *distinguish* ambiguous from missing — ask for
+    candidates explicitly: non-empty means ambiguous, empty means missing.
+  - **Rejected:** raising `AmbiguousSectionError` (turns a lookup into control
+    flow across 13 sites); returning a `SectionLookup` dataclass everywhere
+    (churns every call site for a diagnostic two of them need).
+
+- **Decision:** Strip leading `#` in `normalize_title`.
+  - **Why:** one line, applies uniformly to every caller, and `'## Background'`
+    is a spelling the agent demonstrably reaches for — it's in the issue's
+    repro.
+
+## Patterns to follow
+
+- `_sections.py:548-558` `_walk_path` — the existing exact-path walk. The
+  suffix matcher goes alongside it, not inside it.
+- `_sections.py:568-584` `_section_path` — already renders a section's full
+  path; reuse for both the candidate list and the error text.
+- `_sections.py:160-165` `list_sections` / `_flatten_sections` — the existing
+  full-document walk to enumerate sections.
+- `_sections.py:31-35` `normalize_title` — where `#` stripping belongs.
+- Error style: `ToolResult(text="[error: ...]")` per CLAUDE.md — see
+  `tools.py:1421`, `:1434`, `:1446`, and the bare-string variant at
+  `_sections.py:612`.
+- Tool descriptions at `tools.py:2083-2124` (`section`, `after`, `before`,
+  `parent`) plus `:1991` and `:2038`.
+
+## What we're NOT doing
+
+- **Not changing `find_section`'s signature or return type.** The 13 call sites
+  stay untouched.
+- **Not making ambiguity resolvable by heuristic** (depth, document order,
+  heading level).
+- **Not touching the eval case** `adds a section without rewriting other
+  sections` or its `max_tool_errors: 1` bound. The issue is explicit that the
+  bound is right and the tool should be fixed instead.
+- **Not restructuring document parsing or how the H1 is treated.** The H1
+  remains a real section and a valid path segment.
+- **Not fuzzy matching** — no edit distance, substring, or prefix matching.
+  Segment titles still compare by exact normalized equality; only the *rooting*
+  relaxes.
+- **Not #683 / #676 / #650.**
+
+## Open questions
+
+- **How many paths should the "not found" error list on a large page?**
+  **Default:** list up to 20, then truncate with `… and N more`. Per-page
+  section counts are small in practice, and even a truncated list teaches the
+  path shape, which is the point.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -146,8 +146,45 @@ The vault skill is **always loaded** — its tools are available in every conver
 | `vault_backlinks(page)` | Find pages linking to this page via `[[wiki-links]]`. |
 | `vault_show_sections(page, section?)` | Show a page's section outline or a specific section's content with absolute line numbers. |
 | `vault_move_lines(from_page, to_page, lines, to_section?, position?)` | Move specific lines (by line number) from one agent page to another. Both pages must be under `agent/`. |
-| `vault_section(page, action, section?, title?, level?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. |
+| `vault_section(page, action, section?, title?, level?, content?, after?, before?, parent?)` | Section ops: `add`, `remove`, `rename`, or `move`. Page must be under `agent/`. `add` takes `content` so a new section arrives with its body in one call; `level` is inferred from the anchor when omitted (see [Section paths](#section-paths-671)). |
 | `vault_update_frontmatter(page, fields, overwrite?)` | Merge frontmatter fields (`summary`, `importance`, `tags`, `keywords`, etc.) into a page's existing metadata without touching the body. Fills absent/empty fields by default; `overwrite=true` replaces existing values. Reindexes the page. Shared write primitive for the self-improving vault arc (#197) — [dream](dream-consolidation.md) calls it (`overwrite=false`) after every `vault_write` in its Consolidate phase; the `backfill-frontmatter` CLI and garden importance tuning build on the same primitive. Interactive callers writing outside `agent/` go through the same confirmation gate as `vault_write`; non-interactive callers (scheduled dream/garden) proceed without confirmation by design — the one mutating vault tool that doesn't error in non-interactive contexts. |
+
+### Section paths (#671)
+
+Every section-path parameter — `vault_section`'s `section` / `after` / `before`
+/ `parent`, `vault_show_sections`' `section`, and `vault_move_lines`'
+`to_section` — accepts three equivalent forms:
+
+| form | example |
+|---|---|
+| bare heading title | `Background` |
+| partial path | `Archive/Background` |
+| full path from the page title | `Project Notes/Archive/Background` |
+
+The path is matched against the **end** of each section's full path, so
+qualifying a path further never makes it stop working. Matching is
+case-insensitive, ignores `[[wiki-link]]` syntax, and tolerates leading `#`
+characters (`## Background` is fine).
+
+A path must resolve to exactly one section. If it matches several, the
+operation fails rather than guessing — these tools mutate pages, so editing the
+wrong `## Notes` silently would be worse than a failed call — and the error
+lists every candidate:
+
+```
+[error: ambiguous section path 'Background' matches 2 sections:
+  Project Notes/Background
+  Project Notes/Archive/Background
+Use a longer path to disambiguate.]
+```
+
+When nothing matches, the error lists the page's known paths (capped at 20)
+so the next attempt can be correct.
+
+Before #671, paths were resolved strictly from the page's top level. Since an
+H1 page has exactly one top-level section — the H1 — every `##` heading was
+addressable *only* as `<H1 Title>/<Section>`, which nothing in the schema
+conveyed and a caller had no way to guess.
 
 ### Frontmatter merge (#197)
 

--- a/src/decafclaw/skills/vault/_sections.py
+++ b/src/decafclaw/skills/vault/_sections.py
@@ -29,9 +29,14 @@ def extract_tags(text: str) -> list[str]:
 
 
 def normalize_title(raw: str) -> str:
-    """Strip wiki-links and lowercase for matching."""
+    """Strip wiki-links and leading heading hashes, then lowercase for matching.
+
+    Hashes are stripped so a caller can pass a heading as it appears in the
+    document ('## Background') and have it match the parsed title (#671).
+    Applied to both stored titles and lookup paths, so the two stay symmetric.
+    """
     stripped = WIKILINK_RE.sub(r"\1", raw)
-    return stripped.strip().lower()
+    return stripped.lstrip("#").strip().lower()
 
 
 def _ensure_newlines(text: str) -> list[str]:
@@ -153,9 +158,50 @@ class Document:
     # --- Section lookup ---
 
     def find_section(self, path: str) -> Section | None:
+        """Resolve a section path.
+
+        Tries the exact rooted path first, then falls back to a unique suffix
+        match, so a bare title ('Background') or a partial path
+        ('Archive/Background') resolves without knowing that paths are rooted
+        at the page H1 (#671).
+
+        An ambiguous path deliberately returns None. These back mutating
+        operations, so guessing would silently edit the wrong section. Callers
+        that need to tell ambiguous from missing use ``section_candidates``.
+        """
         self._ensure_parsed()
-        parts = [p.strip().lower() for p in path.split("/")]
-        return _walk_path(self._sections, parts)
+        parts = [normalize_title(p) for p in path.split("/") if p.strip()]
+        if not parts:
+            return None
+        exact = _walk_path(self._sections, parts)
+        if exact is not None:
+            return exact
+        matches = _find_by_suffix(self._sections, parts)
+        return matches[0] if len(matches) == 1 else None
+
+    def section_candidates(self, path: str) -> list[str]:
+        """Full paths of every section matching ``path`` as a suffix.
+
+        Empty means nothing matched; more than one means the path was
+        ambiguous, which is why ``find_section`` returned None. Rendered with
+        real titles for display — both forms resolve.
+        """
+        self._ensure_parsed()
+        parts = [normalize_title(p) for p in path.split("/") if p.strip()]
+        if not parts:
+            return []
+        return [
+            _section_path(sec, self._sections, display=True)
+            for sec in _find_by_suffix(self._sections, parts)
+        ]
+
+    def all_section_paths(self) -> list[str]:
+        """Full slash path of every section, in document order, for display."""
+        self._ensure_parsed()
+        return [
+            _section_path(sec, self._sections, display=True)
+            for _depth, sec in self.list_sections()
+        ]
 
     def list_sections(self, depth: int = 0) -> list[tuple[int, Section]]:
         self._ensure_parsed()
@@ -411,12 +457,47 @@ class Document:
     def add_section(
         self,
         title: str,
-        level: int = 1,
+        level: int | None = None,
         content: str = "",
         after: str | None = None,
         before: str | None = None,
         parent: str | None = None,
     ) -> bool:
+        """Insert a new section, optionally with body ``content``.
+
+        ``level`` defaults to whatever the anchor implies: a sibling of the
+        ``after`` / ``before`` section, or one level below ``parent``. Only an
+        unanchored add falls back to 1. Defaulting to 1 unconditionally meant
+        "add a section after ## Background" inserted an H1 mid-page, which
+        silently reparents every following section under the new heading
+        (#671).
+        """
+        # Resolve the anchor once; it fixes the insertion point, the placement
+        # rule, and the default level. `placement` is derived here rather than
+        # re-tested below, so a caller passing several of after/before/parent
+        # gets one consistent precedence instead of the anchor coming from one
+        # argument and the insertion point from another.
+        if after:
+            anchor_path, placement = after, "after"
+        elif before:
+            anchor_path, placement = before, "before"
+        elif parent:
+            anchor_path, placement = parent, "under"
+        else:
+            anchor_path, placement = None, "end"
+
+        anchor = self.find_section(anchor_path) if anchor_path else None
+        if anchor_path and anchor is None:
+            return False
+
+        if level is None:
+            if anchor is None:
+                level = 1
+            elif placement == "under":
+                level = min(anchor.level + 1, 6)
+            else:
+                level = anchor.level
+
         heading = f"{'#' * level} {title}\n"
         new_lines = ["\n", heading]
         if content:
@@ -424,23 +505,13 @@ class Document:
         if new_lines[-1].strip():
             new_lines.append("\n")
 
-        if after:
-            sec = self.find_section(after)
-            if not sec:
-                return False
-            self._insert_lines(sec.content_end, new_lines)
-        elif before:
-            sec = self.find_section(before)
-            if not sec:
-                return False
-            self._insert_lines(sec.heading_line, new_lines)
-        elif parent:
-            sec = self.find_section(parent)
-            if not sec:
-                return False
-            self._insert_lines(sec.content_end, new_lines)
-        else:
+        if placement == "end" or anchor is None:
             self._insert_lines(len(self.lines), new_lines)
+        elif placement == "before":
+            self._insert_lines(anchor.heading_line, new_lines)
+        else:
+            # "after" and "under" both append at the end of the anchor's content.
+            self._insert_lines(anchor.content_end, new_lines)
         return True
 
     def rename_section(self, path: str, new_title: str) -> bool:
@@ -557,6 +628,26 @@ def _walk_path(sections: list[Section], parts: list[str]) -> Section | None:
     return None
 
 
+def _find_by_suffix(sections: list[Section], parts: list[str]) -> list[Section]:
+    """Every section whose full path ends with ``parts``.
+
+    Lets a caller address a section by a bare title or any trailing portion of
+    its path, instead of rooting every path at the page H1 (#671). Returns all
+    matches so the caller can tell unique from ambiguous.
+    """
+    matches: list[Section] = []
+
+    def _walk(secs: list[Section], trail: list[str]) -> None:
+        for sec in secs:
+            current = trail + [sec.normalized_title]
+            if current[-len(parts):] == parts:
+                matches.append(sec)
+            _walk(sec.children, current)
+
+    _walk(sections, [])
+    return matches
+
+
 def _flatten_sections(
     sections: list[Section], depth: int, result: list[tuple[int, Section]]
 ) -> None:
@@ -565,17 +656,71 @@ def _flatten_sections(
         _flatten_sections(sec.children, depth + 1, result)
 
 
-def _section_path(sec: Section, top_sections: list[Section]) -> str:
+def _section_path(
+    sec: Section, top_sections: list[Section], *, display: bool = False,
+) -> str:
+    """Full slash path to ``sec``.
+
+    ``display=True`` renders the headings' real titles, for error messages and
+    anything else a human reads. The default normalized form stays the one used
+    for re-resolution after a mutation. Both are valid input to
+    ``find_section``, which normalizes whatever it is given.
+    """
     def _find(sections: list[Section], target_line: int, prefix: str) -> str | None:
         for s in sections:
-            current = f"{prefix}/{s.normalized_title}" if prefix else s.normalized_title
+            name = s.title.strip() if display else s.normalized_title
+            current = f"{prefix}/{name}" if prefix else name
             if s.heading_line == target_line:
                 return current
             found = _find(s.children, target_line, current)
             if found:
                 return found
         return None
-    return _find(top_sections, sec.heading_line, "") or sec.normalized_title
+    fallback = sec.title.strip() if display else sec.normalized_title
+    return _find(top_sections, sec.heading_line, "") or fallback
+
+
+# Cap on paths listed in a "not found" message. Pages rarely have more, and a
+# truncated list still teaches the path shape, which is the point.
+_MAX_LISTED_PATHS = 20
+
+
+def describe_section_miss(doc: Document, path: str) -> str:
+    """Explain why ``path`` didn't resolve, with enough detail to retry.
+
+    ``find_section`` returns None for both ambiguous and missing paths (#671);
+    this tells them apart. Ambiguous paths list every candidate, missing ones
+    list the page's known paths. Returns the message body without the
+    ``[error: ]`` wrapper, since ``_insert_into_doc`` returns bare strings that
+    its caller wraps.
+    """
+    candidates = doc.section_candidates(path)
+    if len(candidates) > 1:
+        if len(set(candidates)) == 1:
+            # Duplicate headings: every candidate renders identically, so
+            # "use a longer path" is impossible advice and sends the caller
+            # into a retry loop. Point at the only ways out instead.
+            return (
+                f"ambiguous section path {path!r} matches {len(candidates)} "
+                f"sections that share the path {candidates[0]!r}. No path can "
+                f"separate duplicate headings — rename or remove one, or use "
+                f"vault_show_sections and edit by line number."
+            )
+        listed = "\n  ".join(candidates)
+        return (
+            f"ambiguous section path {path!r} matches {len(candidates)} sections:\n"
+            f"  {listed}\n"
+            f"Use a longer path to disambiguate."
+        )
+    known = doc.all_section_paths()
+    if not known:
+        return f"section not found: {path!r} (page has no sections)"
+    listed = "\n  ".join(known[:_MAX_LISTED_PATHS])
+    more = (
+        "" if len(known) <= _MAX_LISTED_PATHS
+        else f"\n  … and {len(known) - _MAX_LISTED_PATHS} more"
+    )
+    return f"section not found: {path!r}. Known paths:\n  {listed}{more}"
 
 
 # ---------------------------------------------------------------------------
@@ -609,7 +754,7 @@ def _insert_into_doc(
     if to_section:
         sec = doc.find_section(to_section)
         if not sec:
-            return f"section not found: {to_section}"
+            return describe_section_miss(doc, to_section)
         if position == "prepend":
             # Insert before first list item in section, or at content start
             target = _find_first_list_item(doc.lines, sec.content_start, sec.content_end)

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -27,7 +27,11 @@ from decafclaw.skills.vault._grants import (
     is_path_in_grants,
     normalize_folder,
 )
-from decafclaw.skills.vault._sections import Document, _insert_into_doc
+from decafclaw.skills.vault._sections import (
+    Document,
+    _insert_into_doc,
+    describe_section_miss,
+)
 from decafclaw.tags import collect_all_tags, extract_tags, normalize_tag, pages_with_tags
 from decafclaw.tools.confirmation import request_confirmation
 
@@ -1291,7 +1295,7 @@ async def tool_vault_show_sections(
     # Specific section: show heading + body with 1-based line numbers
     sec = doc.find_section(section)
     if sec is None:
-        return ToolResult(text=f"[error: section not found: {section}]")
+        return ToolResult(text=f"[error: {describe_section_miss(doc, section)}]")
     start = sec.heading_line
     end = sec.content_end  # exclusive
     numbered = [
@@ -1387,7 +1391,8 @@ async def tool_vault_section(
     action: str,
     section: str | None = None,
     title: str | None = None,
-    level: int = 1,
+    level: int | None = None,
+    content: str | None = None,
     after: str | None = None,
     before: str | None = None,
     parent: str | None = None,
@@ -1409,16 +1414,21 @@ async def tool_vault_section(
     if action == "add":
         if not title:
             return ToolResult(text="[error: 'title' required for add]")
-        if not isinstance(level, int) or level < 1 or level > 6:
+        # None means "infer from the anchor" — add_section resolves it.
+        if level is not None and (not isinstance(level, int) or level < 1 or level > 6):
             return ToolResult(text=f"[error: level must be between 1 and 6, got {level}]")
-        if doc.add_section(title, level=level, after=after, before=before, parent=parent):
+        if doc.add_section(
+            title, level=level, content=content or "",
+            after=after, before=before, parent=parent,
+        ):
             path.write_text(doc.to_text(), encoding="utf-8")
             await _reindex_page(ctx, path)
             await publish_vault_changed(
                 ctx.event_bus, ctx.config, kind=KIND_SECTION, path=path,
             )
             return ToolResult(text=f"Added section: {title}")
-        return ToolResult(text="[error: target section not found]")
+        target = after or before or parent or ""
+        return ToolResult(text=f"[error: {describe_section_miss(doc, target)}]")
 
     elif action == "remove":
         if not section:
@@ -1431,7 +1441,7 @@ async def tool_vault_section(
                 ctx.event_bus, ctx.config, kind=KIND_SECTION, path=path,
             )
             return ToolResult(text=f"Removed section: {section}")
-        return ToolResult(text=f"[error: section not found: {section}]")
+        return ToolResult(text=f"[error: {describe_section_miss(doc, section)}]")
 
     elif action == "rename":
         if not section or not title:
@@ -1443,7 +1453,7 @@ async def tool_vault_section(
                 ctx.event_bus, ctx.config, kind=KIND_SECTION, path=path,
             )
             return ToolResult(text=f"Renamed section: {section} → {title}")
-        return ToolResult(text=f"[error: section not found: {section}]")
+        return ToolResult(text=f"[error: {describe_section_miss(doc, section)}]")
 
     elif action == "move":
         if not section:
@@ -1570,6 +1580,16 @@ TOOLS = {
     "vault_section": tool_vault_section,
     "vault_update_frontmatter": tool_vault_update_frontmatter,
 }
+
+# Shared across every section-path parameter below. Section paths used to be
+# rooted at the page H1, which nothing conveyed and callers could not guess
+# (#671); they are suffix-matched now, and this says so.
+SECTION_PATH_HELP = (
+    "A bare heading title ('Background'), a partial path ('Archive/Background'), "
+    "or the full path from the page title ('Project Notes/Archive/Background') "
+    "all work — the path is matched against the end of each section's full path. "
+    "It must match exactly one section; if several match, the error lists them."
+)
 
 TOOL_DEFINITIONS = [
     {
@@ -1988,9 +2008,9 @@ TOOL_DEFINITIONS = [
                     "section": {
                         "type": "string",
                         "description": (
-                            "Optional slash-separated section path to show that "
-                            "section's content with line numbers "
-                            "(e.g. 'top/sub a'). Omit to get the full outline."
+                            "Optional section path to show that section's content "
+                            "with line numbers. " + SECTION_PATH_HELP + " "
+                            "Omit to get the full outline."
                         ),
                     },
                 },
@@ -2035,8 +2055,8 @@ TOOL_DEFINITIONS = [
                     "to_section": {
                         "type": "string",
                         "description": (
-                            "Slash-separated section path in the target page "
-                            "(e.g. 'today/inbox'). Omit to append to the whole file."
+                            "Section path in the target page. " + SECTION_PATH_HELP + " "
+                            "Omit to append to the whole file."
                         ),
                     },
                     "position": {
@@ -2080,8 +2100,8 @@ TOOL_DEFINITIONS = [
                     "section": {
                         "type": "string",
                         "description": (
-                            "Slash-separated section path to operate on "
-                            "(e.g. 'top/sub a'). Required for remove, rename, move."
+                            "Section path to operate on. " + SECTION_PATH_HELP + " "
+                            "Required for remove, rename, move."
                         ),
                     },
                     "title": {
@@ -2096,28 +2116,41 @@ TOOL_DEFINITIONS = [
                         "minimum": 1,
                         "maximum": 6,
                         "description": (
-                            "Heading level (1–6) for the new section. "
-                            "Only used by add. Default: 1."
+                            "Heading level (1–6) for the new section. Only used by "
+                            "add. Defaults to whatever the anchor implies: a sibling "
+                            "of the after/before section, or one level below parent. "
+                            "Leave it unset unless you specifically want a different "
+                            "level — forcing 1 next to a ## heading inserts a second "
+                            "top-level heading, which reparents every section below it."
+                        ),
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": (
+                            "Body text for the new section. Only used by add; "
+                            "omit for an empty section. Set it here rather than "
+                            "adding an empty section and rewriting the page to "
+                            "fill it — one call does both."
                         ),
                     },
                     "after": {
                         "type": "string",
                         "description": (
-                            "Slash-separated section path to insert/move after "
-                            "(e.g. 'top/first'). Used by add and move."
+                            "Section path to insert/move after. " + SECTION_PATH_HELP + " "
+                            "Used by add and move."
                         ),
                     },
                     "before": {
                         "type": "string",
                         "description": (
-                            "Slash-separated section path to insert/move before. "
+                            "Section path to insert/move before. " + SECTION_PATH_HELP + " "
                             "Used by add and move."
                         ),
                     },
                     "parent": {
                         "type": "string",
                         "description": (
-                            "Slash-separated section path to nest the new section under. "
+                            "Section path to nest the new section under. " + SECTION_PATH_HELP + " "
                             "Only used by add."
                         ),
                     },

--- a/tests/test_vault_section_tools.py
+++ b/tests/test_vault_section_tools.py
@@ -411,3 +411,181 @@ async def test_vault_move_lines_publishes_vault_changed_for_both_pages(vault_ctx
     paths = {e["path"] for e in matching}
     assert any(p.endswith("src.md") for p in paths)
     assert any(p.endswith("dst.md") for p in paths)
+
+
+# --- Section path resolution and miss diagnostics (#671) --------------------
+
+
+@pytest.mark.asyncio
+async def test_section_add_after_bare_title(vault_ctx):
+    """#671: 'First' previously had to be spelled 'top/first'."""
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Second",
+        level=2,
+        after="First",
+    )
+    assert "[error" not in result.text.lower()
+    assert "## Second" in (agent_pages / "note.md").read_text()
+
+
+@pytest.mark.asyncio
+async def test_section_miss_lists_known_paths(vault_ctx):
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="rename",
+        section="Nonexistent",
+        title="X",
+    )
+    assert "not found" in result.text
+    assert "Top/First" in result.text
+
+
+@pytest.mark.asyncio
+async def test_section_add_miss_echoes_the_failed_path(vault_ctx):
+    """The add branch used to say 'target section not found' with no path."""
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Second",
+        level=2,
+        after="Nowhere",
+    )
+    assert "Nowhere" in result.text
+    assert "Top/First" in result.text
+
+
+@pytest.mark.asyncio
+async def test_section_ambiguous_path_errors_with_candidates(vault_ctx):
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "amb.md").write_text(
+        "# Top\n\n## Notes\n\na\n\n## Archive\n\n### Notes\n\nb\n"
+    )
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/amb",
+        action="rename",
+        section="Notes",
+        title="X",
+    )
+    assert "ambiguous" in result.text
+    assert "Top/Notes" in result.text
+    assert "Top/Archive/Notes" in result.text
+    # Nothing was renamed.
+    assert "## Notes" in (agent_pages / "amb.md").read_text()
+
+
+@pytest.mark.asyncio
+async def test_section_add_with_content(vault_ctx):
+    """One call should both create the section and fill it (#671 Phase 5).
+
+    Document.add_section always supported `content`; the tool didn't expose
+    it, so the agent had to add an empty section and then rewrite the page.
+    """
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text(
+        "# Project Notes\n\n## Background\n\nkeep me\n\n## TODO\n\n- Old item\n"
+    )
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Status",
+        level=2,
+        content="Working on it.",
+        after="Background",
+    )
+    assert "[error" not in result.text.lower()
+    text = (agent_pages / "note.md").read_text()
+    assert "## Status" in text
+    assert "Working on it." in text
+    # Ordering holds and the untouched sections survive.
+    assert text.index("## Background") < text.index("## Status") < text.index("## TODO")
+    assert "keep me" in text
+    assert "- Old item" in text
+
+
+@pytest.mark.asyncio
+async def test_section_add_without_content_still_empty(vault_ctx):
+    """content is optional — omitting it keeps the old behavior."""
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Second",
+        level=2,
+        after="First",
+    )
+    assert "[error" not in result.text.lower()
+    assert "## Second" in (agent_pages / "note.md").read_text()
+
+
+@pytest.mark.asyncio
+async def test_section_add_infers_level_from_anchor(vault_ctx):
+    """Omitting level must reach add_section's inference, not trip validation.
+
+    The tool guarded `not isinstance(level, int)` before `level` became
+    optional, so an omitted level failed with "level must be between 1 and 6,
+    got None" — caught only at the tool layer, since the Document-level tests
+    call add_section directly.
+    """
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text(
+        "# Project Notes\n\n## Background\n\nkeep me\n\n## TODO\n\n- Old item\n"
+    )
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Status",
+        content="Working on it.",
+        after="Background",
+    )
+    assert "[error" not in result.text.lower()
+    text = (agent_pages / "note.md").read_text()
+    assert "## Status" in text
+    # A sibling, not a second H1 that would reparent TODO.
+    assert "\n# Status" not in text
+
+
+@pytest.mark.asyncio
+async def test_section_add_still_rejects_out_of_range_level(vault_ctx):
+    vault = vault_ctx.config.vault_root
+    agent_pages = vault / "agent" / "pages"
+    agent_pages.mkdir(parents=True)
+    (agent_pages / "note.md").write_text("# Top\n\n## First\n")
+    result = await tool_vault_section(
+        vault_ctx,
+        page="agent/pages/note",
+        action="add",
+        title="Nope",
+        level=9,
+        after="First",
+    )
+    assert "level must be between 1 and 6" in result.text

--- a/tests/test_vault_sections_helpers.py
+++ b/tests/test_vault_sections_helpers.py
@@ -1,4 +1,4 @@
-from decafclaw.skills.vault._sections import Document
+from decafclaw.skills.vault._sections import Document, describe_section_miss
 
 
 def test_document_round_trip():
@@ -13,3 +13,211 @@ def test_section_walk_by_path():
     sec = doc.find_section("top/child")
     assert sec is not None
     assert sec.normalized_title == "child"
+
+
+# --- Path resolution (#671) -------------------------------------------------
+#
+# Section paths used to be resolved strictly from the document's top-level
+# sections. Since an H1 page has exactly one top-level section (the H1), every
+# `##` heading was addressable only as '<H1 Title>/<Section>' — so the obvious
+# spelling, a bare heading title, always missed.
+
+NESTED = (
+    "# Project Notes\n\n"
+    "## Background\n\nbg\n\n"
+    "## Archive\n\n### Background\n\nold bg\n\n"
+    "## TODO\n\n- Old item\n"
+)
+
+FLAT = "# Project Notes\n\n## Background\n\nbg\n\n## TODO\n\n- x\n"
+
+
+def test_bare_title_resolves_without_h1_root():
+    doc = Document.from_text(FLAT)
+    assert doc.find_section("Background") is not None
+    assert doc.find_section("TODO") is not None
+    # The rooted form keeps working.
+    assert doc.find_section("Project Notes/Background") is not None
+
+
+def test_partial_path_resolves():
+    doc = Document.from_text(NESTED)
+    sec = doc.find_section("Archive/Background")
+    assert sec is not None and sec.level == 3
+
+
+def test_exact_path_wins_over_suffix():
+    doc = Document.from_text(NESTED)
+    sec = doc.find_section("Project Notes/Background")
+    assert sec is not None and sec.level == 2
+
+
+def test_ambiguous_bare_title_resolves_to_nothing():
+    """Two sections titled 'Background' — a guess would edit the wrong one."""
+    doc = Document.from_text(NESTED)
+    assert doc.find_section("Background") is None
+
+
+def test_heading_hashes_are_tolerated():
+    doc = Document.from_text("# Project Notes\n\n## Background\n\nbg\n")
+    assert doc.find_section("## Background") is not None
+    assert doc.find_section("#Background") is not None
+
+
+def test_add_section_after_bare_title():
+    """The operation from the #671 repro."""
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Status", level=2, after="Background") is True
+    assert "## Status" in doc.to_text()
+
+
+def test_empty_and_slash_only_paths_resolve_to_nothing():
+    doc = Document.from_text(NESTED)
+    assert doc.find_section("") is None
+    assert doc.find_section("/") is None
+
+
+# --- Miss diagnostics (#671) ------------------------------------------------
+#
+# find_section returns None for both "ambiguous" and "missing". These let the
+# error sites tell them apart and say something the caller can act on.
+
+
+def test_section_candidates_lists_ambiguous_matches():
+    doc = Document.from_text(NESTED)
+    got = doc.section_candidates("Background")
+    assert got == ["Project Notes/Background", "Project Notes/Archive/Background"]
+
+
+def test_section_candidates_empty_when_missing():
+    doc = Document.from_text(NESTED)
+    assert doc.section_candidates("Nonexistent") == []
+
+
+def test_candidate_paths_are_valid_input():
+    """Whatever the error offers must resolve when pasted back."""
+    doc = Document.from_text(NESTED)
+    candidates = doc.section_candidates("Background")
+    assert candidates
+    for candidate in candidates:
+        assert doc.find_section(candidate) is not None
+
+
+def test_all_section_paths_in_document_order():
+    doc = Document.from_text(NESTED)
+    assert doc.all_section_paths() == [
+        "Project Notes",
+        "Project Notes/Background",
+        "Project Notes/Archive",
+        "Project Notes/Archive/Background",
+        "Project Notes/TODO",
+    ]
+
+
+def test_describe_section_miss_ambiguous_names_candidates():
+    doc = Document.from_text(NESTED)
+    msg = describe_section_miss(doc, "Background")
+    assert "ambiguous" in msg
+    assert "Project Notes/Background" in msg
+    assert "Project Notes/Archive/Background" in msg
+
+
+def test_describe_section_miss_missing_lists_known_paths():
+    doc = Document.from_text(NESTED)
+    msg = describe_section_miss(doc, "Nope")
+    assert "not found" in msg
+    assert "Project Notes/TODO" in msg
+
+
+def test_describe_section_miss_truncates_long_lists():
+    body = "# Root\n\n" + "".join(f"## S{i}\n\ntext\n\n" for i in range(30))
+    doc = Document.from_text(body)
+    msg = describe_section_miss(doc, "Nope")
+    assert "and 11 more" in msg  # 31 sections total, 20 shown
+
+
+def test_describe_section_miss_on_page_with_no_sections():
+    doc = Document.from_text("just body text, no headings\n")
+    msg = describe_section_miss(doc, "Anything")
+    assert "no sections" in msg
+
+
+# --- Heading level inference (#671 Phase 6) ---------------------------------
+#
+# `level` defaulted to 1, so "add a section after ## Background" inserted an
+# H1 mid-page — which reparents every section below it under the new heading.
+
+
+def test_level_defaults_to_sibling_of_after_anchor():
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Status", content="Working on it.", after="Background") is True
+    added = Document.from_text(doc.to_text()).find_section("Status")
+    assert added is not None
+    assert added.level == 2  # sibling of ## Background, not a new H1
+
+
+def test_level_defaults_to_sibling_of_before_anchor():
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Status", before="TODO") is True
+    assert "## Status" in doc.to_text()
+
+
+def test_level_defaults_to_child_of_parent_anchor():
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Detail", parent="Background") is True
+    assert "### Detail" in doc.to_text()
+
+
+def test_explicit_level_still_wins():
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Deep", level=4, after="Background") is True
+    assert "#### Deep" in doc.to_text()
+
+
+def test_level_defaults_to_one_with_no_anchor():
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Appendix") is True
+    assert "\n# Appendix\n" in doc.to_text()
+
+
+def test_inferred_level_keeps_the_tree_intact():
+    """The point of the inference: following sections must not be reparented."""
+    doc = Document.from_text(FLAT)
+    doc.add_section("Status", content="Working on it.", after="Background")
+    reparsed = Document.from_text(doc.to_text())
+    assert reparsed.all_section_paths() == [
+        "Project Notes",
+        "Project Notes/Background",
+        "Project Notes/Status",
+        "Project Notes/TODO",
+    ]
+
+
+def test_describe_section_miss_duplicate_headings_dont_advise_a_longer_path():
+    """Two headings with the same path can't be separated by a longer path.
+
+    Telling the caller to lengthen it is a dead end — observed sending the
+    agent into a retry loop until it blew its tool budget.
+    """
+    doc = Document.from_text(
+        "# Project Notes\n\n## Status\n\na\n\n## Status\n\nb\n"
+    )
+    msg = describe_section_miss(doc, "Status")
+    assert "Use a longer path" not in msg
+    assert "duplicate headings" in msg
+    assert "vault_show_sections" in msg
+
+
+def test_after_wins_when_several_anchors_are_passed():
+    """Anchor selection and insertion must use the same precedence.
+
+    The refactor picked the anchor by after > before > parent but re-tested
+    `before` at the insertion branch, so passing both put the section at the
+    `after` target's *heading* line — i.e. before it. Caught in review.
+    """
+    doc = Document.from_text(FLAT)
+    assert doc.add_section("Status", after="Background", before="TODO") is True
+    text = doc.to_text()
+    # 'after=Background' wins: Status sits between Background's body and TODO.
+    assert text.index("## Background") < text.index("## Status") < text.index("## TODO")
+    assert text.index("bg") < text.index("## Status")


### PR DESCRIPTION
## Summary

`find_section` walked strictly from the document's top-level sections. An H1 page has exactly one of those — the H1 — so every `##` heading was addressable **only** as `<H1 Title>/<Section>`. Nothing in the schema conveyed that, and a caller had no way to guess it:

```
find_section('Background')                   -> None
find_section('Project Notes/Background')     -> Background
add_section('Status', 2, after='Background') -> False
```

The error was a flat `target section not found` — which reads as "no such heading" rather than "your path is under-qualified", and didn't even echo the path.

## Resolution

Exact rooted path first, then a unique **suffix** match against every section's full path. `Background`, `Archive/Background`, and `Project Notes/Archive/Background` all reach the same section, so qualifying a path *further* never makes it stop working. `normalize_title` also strips leading heading hashes, so `## Background` matches.

Ambiguous paths resolve to `None` rather than picking a winner — these back mutating operations, and silently editing the wrong `## Notes` is worse than a failed call.

**All 13 call sites route through `find_section`**, so `add` / `remove` / `rename` / `move` / checklist ops were all fixed by that one change. None of them needed touching.

## Diagnostics

`section_candidates()` and `all_section_paths()` let the error sites tell ambiguous from missing, via a shared `describe_section_miss`. It returns an unwrapped message so `tools.py` and `_insert_into_doc`'s bare-string return share one wording. Paths render with real titles, and a test asserts every candidate offered resolves when pasted back.

```
[error: ambiguous section path 'Background' matches 2 sections:
  Project Notes/Background
  Project Notes/Archive/Background
Use a longer path to disambiguate.]

[error: section not found: 'Statuz'. Known paths:
  Project Notes
  Project Notes/Background
  ...]
```

Duplicate headings get a distinct message: when two sections share a path, "use a longer path" is advice that **cannot be followed** — observed sending the agent into a retry loop until it blew its tool budget.

## Two further defects, found by running the eval rather than the tests

Fixing the paths let the agent reach the next problem, twice over. Both are pre-existing on `main`; the path fix just made them reachable.

**1. `vault_section action=add` could create a section but not fill it** — though `Document.add_section` has always taken `content`. So "add a section titled X with body Y" needed a second operation, and that operation is where it went wrong: one run guessed `content=` and got a `TypeError`, another rewrote the whole page and mangled the layout.

**2. `level` defaulted to 1**, so adding a section after a `##` inserted a second H1 mid-page — which silently reparents everything below it:

```
# Project Notes            # Project Notes
  ## Background              ## Background
  ## TODO             ->   # Status
  ## References              ## TODO         <- reparented
                             ## References   <- reparented

'Project Notes/TODO' silently becomes 'Status/TODO'
```

`level` now defaults to what the anchor implies — sibling of `after`/`before`, one below `parent`, 1 only when unanchored. Explicit levels still win.

Worth being explicit: **exposing `content` alone made the eval repro *worse*** (2/4 → 0/3), by making a one-call path viable and so exposing that default underneath it. Fixing the default is what turned it around.

## Measured

Eval repro across the session, `vertex-gemini-flash`:

| stage | repro | notes |
|---|---|---|
| baseline `2026-07-24-2323` | pass | 4 tool calls |
| after path resolution | 2/4 | bare titles accepted; blocked on `content` |
| after `content` | 0/3 | hit the `level=1` default |
| after level inference | **5/6** | best runs at **1–2 calls** |

Not yet a *reliable* case — it is a flaky corner of the suite and was before any of this — but the defect is fixed and the good path is half the calls.

## Testing

- `tests/test_vault_sections_helpers.py` — 22 new: suffix resolution, exact-wins, ambiguity, `#` tolerance, empty paths, candidate/known-path diagnostics, truncation, duplicate-heading message, level inference, tree integrity.
- `tests/test_vault_section_tools.py` — 6 new at the tool layer.
- TDD throughout; each phase's tests were run red first.
- `make test` **3555 passed, 2 skipped**. `make check` clean.

**One bug I introduced and the unit tests missed:** the tool guarded `not isinstance(level, int)` before `level` became optional, so omitting it died with `level must be between 1 and 6, got None`. The `Document`-level tests call `add_section` directly and sailed straight past the tool-layer guard — only the eval caught it. Two tool-level tests added.

## Things reviewers should know

**No `tool_choice` eval case.** CLAUDE.md asks for one on a sharpened tool description, but that convention targets disambiguation *between* overlapping tools — which tool the model picks. These are parameter descriptions inside a single tool, and a `tool_choice` case asserts on tool name only; it cannot observe an argument value. The eval repro above covers the behavior instead.

**Accepted risk:** `normalize_title` now strips `#` from stored titles too, so a heading literally named `## #hashtag` normalizes to `hashtag`. It applies symmetrically to stored titles and queries, so lookups stay consistent; only a page with two headings differing *solely* by a leading `#` would newly collide.

**Not fixed, noted:** `add_section` emits `## Status\nWorking on it.` with no blank line after the heading. Valid markdown, not idiomatic. Left alone — it touches shared insertion formatting that existing round-trip tests may pin, and it isn't blocking anything.

**Unrelated trap found while preparing this PR:** `make check` mutates `src/decafclaw/web/static/package-lock.json`, deleting 512 lines (the cross-platform optional `esbuild` entries). It got swept into a commit here via `git add -A src/` and had to be backed out. Since #703 just repaired that lockfile, the next person to run `make check` and stage broadly will silently re-break it. Filing separately.

## References

- Closes #671
- Session docs: [`docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/`](docs/dev-sessions/2026-07-25-0920-671-vault-section-paths/) — `research.md` (call-site inventory, deterministic repro), `plan.md`, `notes.md` (per-phase measurements)
- Context: found during #670's full-suite re-baseline. My #670 retro speculated #671 might be a harness artifact because its eval case started passing — that was **wrong**, and this PR's `research.md` records the check that disproved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
