### PR TITLE
build: fail install-js when npm rewrites the lockfile (#706)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,29 @@ install:
 	uv sync
 	cd src/decafclaw/web/static && npm install
 
-# Install JS dependencies in static/
+# Install JS dependencies in static/, failing if the install rewrites the
+# lockfile. `check` / `check-js` / `test-js` all depend on this, so a silent
+# rewrite here rides into whatever branch happens to be checked out — it has
+# swept into an unrelated PR once and nearly a second time (#706). Deliberate
+# dependency changes go through `make vendor`, which is allowed to write.
+#
+# Snapshots around the install rather than diffing against HEAD, so a lockfile
+# you were *already* editing doesn't trip it — only a rewrite caused by this
+# install does.
 install-js:
-	cd src/decafclaw/web/static && npm install
+	@cd src/decafclaw/web/static && \
+	  before=$$(git hash-object package-lock.json) && \
+	  npm install && \
+	  after=$$(git hash-object package-lock.json) && \
+	  if [ "$$before" != "$$after" ]; then \
+	    echo ""; \
+	    echo "ERROR: npm install rewrote package-lock.json during a check."; \
+	    echo "  Intentional dependency change?  run 'make vendor' and commit the lockfile."; \
+	    echo "  Otherwise restore it:  git checkout -- src/decafclaw/web/static/package-lock.json"; \
+	    echo "  Background: #706 (silent rewrites have ridden into unrelated PRs)."; \
+	    echo ""; \
+	    exit 1; \
+	  fi
 
 # Type check JS (runs npm install if needed)
 check-js: install-js


### PR DESCRIPTION
Closes #706.

## The headline: the reported symptom no longer reproduces

I could not reproduce the 512-deletion rewrite on current `main` (`053c1bb`) in any configuration:

| Scenario | Lockfile drift |
|---|---|
| `make check` (Node 22) | none, exit 0 |
| `make check` again | none |
| fresh `npm install`, Node 22 | none |
| fresh `npm install`, Node 20.9 (engine guard bypassed) | none |
| Node 22 install on top of a 20.9-built tree | none |
| Node 20.9 install on top of a 22-built tree | none |

`main`'s lockfile is byte-identical to the one #703 committed (`git diff b928d4f origin/main -- package-lock.json` is empty — the reverted `e2af4c8` left no net change), so this is testing the repaired file. #703 also added `.nvmrc` (22), `engines`, and an `.npmrc` with `engine-strict=true`, which turns "wrong Node" from a silent mis-resolution into `EBADENGINE` exit 1. Between the repaired lockfile and that guard, the path that produced the pruning appears closed.

One incidental finding while probing it: `npm install` does **not** re-add removed cross-platform `@esbuild/*` entries even on a clean `node_modules` — npm doesn't maintain them. That's consistent with the pruning direction described in the issue, and it means the committed set can only be restored deliberately, which is what #703 did.

## Why still land a guard

Because the failure mode is *silence*, and it has already cost real work twice: #700 swept 485 insertions / 30 deletions in (via `git add src/`, which stages tracked modifications regardless of `-A`), and #705 caught it only because a diffstat looked wrong at final review. A rewrite that no longer happens today is one dependency bump away from happening again, and the guard costs two `git hash-object` calls.

## What changed

`install-js` snapshots the lockfile hash either side of `npm install` and fails if it moved:

```
ERROR: npm install rewrote package-lock.json during a check.
  Intentional dependency change?  run 'make vendor' and commit the lockfile.
  Otherwise restore it:  git checkout -- src/decafclaw/web/static/package-lock.json
  Background: #706 (silent rewrites have ridden into unrelated PRs).
```

Snapshotting **around the install** rather than diffing against `HEAD` matters: a lockfile you were already editing must not trip a check run. Only a rewrite caused by this install does. `make vendor` (`npm install && npm run build`) remains the deliberate write path and is untouched, as is `make install`.

This is the issue's option 4. Option 1 (`npm ci`) also works — it never writes the lockfile — but it wipes and reinstalls `node_modules` every run: **8.25s vs 0.88s** for a warm `npm install`, measured here. A ~7.4s tax on the most-run target isn't worth paying for a fault that doesn't currently occur, and the guard catches it either way if it returns.

## Verification

- `make check` — exit 0, `All checks passed!`, pyright `0 errors`, lockfile clean afterward
- `make test-js` — 41 passed
- `make test` — **3556 passed, 2 skipped**
- Guard silent on a clean install (exit 0)
- Guard logic fires when the file changes between snapshots (`GUARD FIRED: before=0b5cb02c after=5b5d07c2`, exit 1)

**Caveat, stated plainly:** I verified the guard fires on a file change between snapshots, but I could not make `npm install` itself produce a rewrite on current `main` — which is the same finding as the table above. The npm-caused path is therefore untested end to end, by absence of a reproduction rather than by omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)