### PR TITLE
Make the loop-breaker redirect a thrashing agent instead of only stopping it (#707)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `prompts/` — System prompt assembly
 - `commands.py` — User-invokable commands
 - `reflection.py` — Self-reflection (Reflexion pattern)
-- `loop_breaker.py` — Per-turn autonomous tool-call thrash detector (nudge → hard-stop escalation, #598)
+- `loop_breaker.py` — Per-turn autonomous tool-call thrash detector (watermarked trip detection; nudge → redirect → hard-stop escalation, #598/#707)
 - `tool_telemetry.py` — Tool-usage telemetry subscriber + report (#310); `make tool-usage-report`
 - `reflection_metrics.py` — Reflection cost/effectiveness telemetry subscriber + stats (#409); `make reflection-stats`
 - `heartbeat.py`, `schedules.py`, `polling.py`

--- a/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
+++ b/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
@@ -158,3 +158,77 @@ failed on the bound, so there was nothing to tune down either.
   live verification in a real session (deliberately deferred — no bot
   instance was started per instructions), and filing the follow-up issue
   about `interactive_terminal.py` having no `text_before_tools` handler.
+
+## Retro
+
+**The reported symptom was not the bug.** Les reported that the loop-breaker
+stops the agent without prompting it to do anything different. The natural
+reading is "the message is too generic" — and the message *was* generic. But
+the actual cause was that the detector latched: `_counts` never decayed and
+`_tripped_reason` tested `count >= threshold`, a standing condition that stays
+true forever once crossed. The round after a nudge therefore always tripped
+again and hard-stopped the turn, *no matter what the agent did*. No wording
+could have fixed that, because there was no round in which complying could pay
+off. Grounding the text (Task 2) and adding the redirect rung (Task 3) are only
+worth anything on top of Task 1.
+
+**The bug lived in the gap between two individually-correct components.** The
+detector answered "does a bad condition hold?" while the escalator asked "did
+something new go wrong?" Both were reasonable in isolation and both were
+tested. Wiring one-way escalation to a latching predicate is what produced the
+symptom. Worth watching for wherever a state-check feeds an event-driven state
+machine.
+
+**Test design hid it, and then hid it again.** `test_repeat_threshold_trips_nudge_then_stop`
+replayed the *same* fingerprint every round, which makes latching and correct
+escalation observationally identical. The discriminating case is always the
+*compliance* path — and nobody writes that one, because the interesting-looking
+assertion is on the offense path. Then the exact same blind spot recurred one
+level down: after Task 1, every repeat test still recorded exactly ONE
+`CallSignature` per round, which is why the final review's Critical (watermarks
+advancing for only the worst offender in a batched round) survived four task
+reviews. Tool calls run concurrently via `asyncio.gather` here, so batched
+repeats are the *normal* thrash shape, not an edge case.
+
+**The plan caused both of the final review's serious findings.** Neither was an
+implementer slip — the implementers transcribed `plan.md`'s pseudocode
+faithfully. The plan under-specified the multi-fingerprint case and the
+cross-signal interaction. Writing complete code into a plan buys transcription
+accuracy and transfers the design risk to the plan author; it does not remove
+it.
+
+**"All transports render it live" was a true sentence doing false work.** The
+justification for dropping the accumulated-preamble join enumerated
+*transports* when the real question was *consumers of the return value*. A
+parent agent consuming `delegate_task` output is a consumer and not a
+transport, and `delegate.py:254` also disables reflection for children, so both
+of the mitigations that supposedly covered them were inapplicable in exactly
+the case that mattered. Reviewing against a named list of callers
+(`delegate.py`, `eval/runner.py`, `schedules.py`, `compaction.py`,
+`workflow/handle.py`) is what caught it; "check for other consumers" would not
+have.
+
+**#675 is a good example of a half-fix passing review.** It correctly diagnosed
+preamble duplication, fixed the archive, documented the reasoning, and added a
+test — but the test asserted on `read_archive()` while the user-visible symptom
+lives in `result.text`. It then recorded a justification for keeping the
+delivery half ("so the turn reads as a whole") that was already false for every
+transport we ship.
+
+**Incidental find:** `interactive_terminal.py` read `config.heartbeat_suppress_ok`,
+which does not exist (`config.heartbeat.suppress_ok` does), so `make run` has
+crashed at startup since `2e5ff3f` in March. It surfaced only because making the
+terminal's missing `text_before_tools` handler testable required driving
+`run_interactive` at all — there was no test coverage of that function
+whatsoever. Interactive mode now has its first two tests.
+
+**Open, tracked:** #710 — `is_heartbeat_ok` substring-matches a sentinel in the
+first 300 chars, so an abnormally-terminated heartbeat turn whose preamble
+mentions `HEARTBEAT_OK` can suppress its own alert. Note-first ordering closes
+this for the ~336-char loop-breaker note and only narrows it for the ~65-char
+max-iterations note (measured, see above). Pre-existing on `main`, which
+delivers `accumulated + note` unconditionally for every turn kind.
+
+**Still to do after merge:** live verification in a real Mattermost/web session.
+No bot instance was started during this work — Les likely has `make dev`
+running and a second instance silently misses websocket events.

--- a/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
+++ b/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
@@ -1,0 +1,160 @@
+# Notes — #707 loop-breaker redirect
+
+## Task 5: docs and eval headroom
+
+Task 5 was documentation- and eval-only. One exception noted in the amended
+brief: the module docstring at the top of `src/decafclaw/loop_breaker.py`
+still described the pre-#707 two-rung mechanism ("nudge, then a hard stop"),
+so it was corrected as part of this task alongside the doc rewrite.
+
+### Docs rewritten
+
+`docs/loop-breaker.md`'s "How it works" section was restructured around what
+Tasks 1-4 actually shipped, which had diverged from the original plan in one
+way the brief flagged explicitly: `_finalize_with_note`'s delivery gate is
+`ctx.is_child`-conditional, not a blanket "note only." Interactive turns
+(Mattermost/web UI/terminal) still deliver the note alone — the transport
+already rendered every preamble live via `text_before_tools`. Child turns
+(`delegate_task` sub-agents) deliver the accumulated preamble join *plus* the
+note, same as pre-#707, because a parent agent consuming `ToolResult.text` is
+not a transport — it never subscribes to the event bus, so the join is its
+only channel to see what the child did before hitting the wall. The doc's
+old "so the turn reads as a whole" claim (which described a
+this-branch-always join) was deleted per the brief and replaced with this
+split, not with a blanket "delivers only the note."
+
+Also documented: watermarked trips (`_Offender.last_tripped_count`,
+`_errors_at_last_trip`/`_total_errors`) and why the old standing-condition
+test made post-nudge compliance mechanically impossible; the three-rung
+ladder (`LoopVerdict.NUDGE`/`REDIRECT`/`STOP`); that the redirect's "do NOT
+call X again" is prose only (no mutating-tool taxonomy exists to filter on);
+evidence retention (`CallSignature`, `Offense`, `summarize_args()` /
+`summarize_error()` at 400/300 chars, `_render_args()` shared with
+`fingerprint()`); that both nudge and redirect are ephemeral and carry the
+#680 non-authorship disclaimer; and the deferred diagnosis-child-agent rung
+(recorded verbatim from the brief so the next reader doesn't re-derive it).
+
+`last_signal()` never actually appeared in the pre-existing `docs/loop-breaker.md`
+Files section (only `fingerprint()` did), so there was nothing literally to
+replace there — but `offense()`, `CallSignature`, `Offense`,
+`summarize_args()`, and `summarize_error()` were all added to the
+`loop_breaker.py` bullet as instructed, and `LoopBreaker.offense()` is now
+named explicitly in the "Evidence" subsection.
+
+`grep -rn "last_signal\|reads as a whole" docs/ src/ tests/ evals/` still
+matches inside `docs/dev-sessions/2026-07-23-1506-598-diagnostic-guardrails/`
+and `docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/plan.md` and
+`spec.md` — these are historical planning artifacts from earlier
+tasks/sessions (already committed before Task 5), not living documentation,
+and Task 5's scope is `docs/loop-breaker.md` + the eval + CLAUDE.md. Outside
+`docs/dev-sessions/`, the grep returns zero hits.
+
+Config section: no `redirect_enabled` knob exists or was added —
+`LoopBreakerConfig` and its four fields (`enabled`, `repeat_threshold`,
+`error_threshold`, `error_window`) are untouched, per the brief's constraint.
+Added one paragraph to the Configuration section stating explicitly that
+there's deliberately no separate knob for the redirect rung, since the doc's
+existing config table might otherwise leave a reader wondering.
+
+### Eval changes
+
+`evals/diagnostic_discipline.yaml`:
+- Updated the stale quoted stop text in the header comment to the current
+  wording (`"Stopped after repeated failures: you called activate_skill 3×
+  with the same args without progress."`), marked illustrative/not-asserted.
+- Added a note that trips are now watermarked and the ladder has three
+  rungs, so a compliant agent gets a genuine reprieve.
+- `nudge_does_not_read_as_user_correction`: raised `max_tool_calls` /
+  `max_tool_errors` from 6 to 8 (with a comment explaining the extra rung),
+  and added `"i was stuck in a loop"` to `response_not_contains` — the exact
+  #675 confabulation phrase, previously uncovered as a literal string.
+- Added `redirect_rung_does_not_read_as_user_correction`, forcing
+  `repeat_threshold: 1` against a two-read input so the ladder deterministically
+  fires NUDGE on the first call and REDIRECT on the second.
+
+## Real-LLM eval run (Step 8)
+
+Command:
+
+```
+uv run python -m decafclaw.eval evals/diagnostic_discipline.yaml
+```
+
+Model: `vertex-gemini-flash`. Result: **3/3 PASS**, 39.8s wall time, 245,924
+tokens.
+
+| Case | Result | Duration | Tool calls |
+|---|---|---|---|
+| `loop_breaker_caps_edit_thrash` | PASS | 25.6s | 11 |
+| `nudge_does_not_read_as_user_correction` | PASS | 5.2s | 1 |
+| `redirect_rung_does_not_read_as_user_correction` | PASS | 9.0s | 3 |
+
+`make eval-history` trend:
+
+```
+Timestamp          Model                       Pass / Total    Rate       Δ   Duration    Tokens
+-------------------------------------------------------------------------------------------------
+2026-07-25-1200    vertex-gemini-flash            2 /     4   50.0%    --          37s    221.6k
+2026-07-26-1603    vertex-gemini-flash            3 /     3  100.0%  +50.0%        39s    245.9k
+```
+
+(The 2026-07-25-1200 row reflects an earlier state of this branch during
+Tasks 1-4's own iteration, not a comparable baseline for this file's current
+3 cases.)
+
+### Was the raised `max_tool_calls`/`max_tool_errors` bound (6 → 8) actually needed?
+
+**Not in this particular run — the actual counts came in well under even
+the old bound of 6:**
+
+- `nudge_does_not_read_as_user_correction` used only **1** tool call. With
+  `repeat_threshold: 1`, the very first call already trips NUDGE (count 1 ≥
+  threshold 1, fresh since the watermark starts at 0). The model read the
+  nonexistent file once, got the nudge, and answered without retrying — the
+  genuine reprieve the watermarking change is meant to produce, working as
+  intended.
+- `redirect_rung_does_not_read_as_user_correction` used **3** tool calls:
+  first read (NUDGE fires), second identical read per the prompt's "read it
+  again to be sure" (REDIRECT fires — this is the case's whole point, a
+  fresh offense on the second call), then one different, read-only action
+  in response to the redirect's diagnosis-contract requirement, and the
+  model stopped there. It never reached a third repeat, so STOP never fired
+  and the bound was never approached.
+
+So the raise to 8 was not exercised as a hard limit in this run — no case
+came close to hitting even 6. It stays as headroom for a less-compliant
+model (one that ignores the redirect and repeats a third time, which would
+need nudge + redirect + stop, each preceded by the offending call, i.e. up
+to ~5-6 calls minimum, and more if the model interleaves other legitimate
+tool use around the thrash) rather than something this run demonstrated was
+strictly required. Not loosened beyond what the brief specified; no case
+failed on the bound, so there was nothing to tune down either.
+
+## Deviations from the brief
+
+- The brief's original text for the "hard stop archives only its own note"
+  section assumed delivery was unconditionally note-only. Per the task
+  instructions (which explicitly superseded the brief on this point), the
+  doc instead documents the actual `ctx.is_child` split. This is not a
+  deviation from instructions — it's following the corrected instructions
+  over the stale brief.
+- Added one clarifying paragraph to the Configuration section (no
+  `redirect_enabled` knob) that wasn't explicitly requested by the brief's
+  step list, per the task instructions' direction to "say so if the doc's
+  config section would otherwise imply one exists."
+- Fixed `src/decafclaw/loop_breaker.py`'s module docstring (only file outside
+  docs/CLAUDE.md/evals touched), per the task instructions.
+
+## Concerns / follow-ups (not actioned here, out of scope for Task 5)
+
+- `make eval-tools` shows 5/32 pre-existing failures (`vault-read-vs-workspace-read-known-page`,
+  `web-fetch-vs-http-article`, `workspace-write-vs-canvas-save-blog-post`,
+  `ask-choice-vs-text-deploy-target`, `frontmatter-vs-write-metadata-only`).
+  Verified these are **not** introduced by this branch: reproduced identically
+  by stashing all Task 5 changes and re-running on the pre-Task-5 tree. They
+  are pre-existing tool-disambiguation flakiness unrelated to the loop
+  breaker, and out of scope here.
+- Two post-implementation follow-ups from the plan remain for after merge:
+  live verification in a real session (deliberately deferred — no bot
+  instance was started per instructions), and filing the follow-up issue
+  about `interactive_terminal.py` having no `text_before_tools` handler.

--- a/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
+++ b/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
@@ -232,3 +232,67 @@ delivers `accumulated + note` unconditionally for every turn kind.
 **Still to do after merge:** live verification in a real Mattermost/web session.
 No bot instance was started during this work — Les likely has `make dev`
 running and a second instance silently misses websocket events.
+
+## Live verification (2026-07-27)
+
+Run against a real model with real tools, in an isolated `DATA_HOME=/tmp/dc-live-707`
+so the real conversation archive and vault were untouched.
+
+**`make run` starts again.** The full runner reached "Application startup complete",
+confirming the `config.heartbeat_suppress_ok` → `config.heartbeat.suppress_ok` fix.
+Before it, interactive mode died at startup.
+
+**Run 1 — `repeat_threshold=2`, the behaviour the PR exists to produce.**
+The agent read a nonexistent file, repeated the identical call once, and the nudge
+fired. Its next move was genuinely different:
+
+> "I understand that `workspace_read` failed twice … I should not repeat that action
+> without further investigation" → `workspace_list` → `workspace_glob`
+
+Rung events for the whole turn: `['nudge']`. **Because it stopped repeating, no further
+rung fired.** Under the pre-#707 detector this round would have hard-stopped regardless.
+The turn ended normally with a real conclusion (341 chars) and no preamble duplication.
+
+**Run 2 — `repeat_threshold=1`, forcing all three rungs.**
+Rung events: `['nudge', 'redirect', 'stop']`. The redirect produced exactly the response
+shape it demands — and the hypothesis was correct (it had passed `folder` where the tool
+wanted `path`):
+
+> Hypothesis: The `workspace_list` tool expects the argument `path` … not `folder`.
+> Observation: A successful listing of the contents of the `notes/` directory when …
+
+The hard stop delivered **only** its note (360 chars, no preambles), quoting the real
+error: `[error: path not found: notes/]`.
+
+**Attribution held (#680).** The agent referred to "the system has indicated that I should
+not retry" — it never attributed the diagnostic to Les, and never produced the
+"You're right, I was stuck in a loop" confabulation from #675.
+
+Caveats, stated plainly:
+- `repeat_threshold=1` in run 2 is artificial (every distinct call is a fresh offense). It
+  was needed to force all three rungs inside one short turn.
+- The standalone harness skipped `init_providers()` (called at
+  `src/decafclaw/__init__.py:33` during real startup), so model resolution fell back to the
+  litellm proxy (`gemini-2.5-flash`) instead of the direct Vertex path. Real LLM and real
+  tools either way; the loop-breaker logic under test is provider-independent.
+- A first attempt used the full runner, which connected to the real Mattermost account and
+  fired the bundled `dream`/`garden`/`newsletter` schedules — a fresh `DATA_HOME` makes them
+  "never run → due", the same trap CLAUDE.md documents for tests. Killed and replaced with
+  the direct-turn harness.
+
+## PR review follow-up
+
+Copilot flagged one real defect in `summarize_args()` (fixed in `b2afec7`): `_truncate`
+collapsed *all* whitespace, including whitespace inside JSON string values, so displayed
+args could differ from the args `fingerprint()` hashed — and two calls with different
+fingerprints could display identically. That defeated the whole reason `_render_args` is
+shared between the two. `summarize_args` now length-caps only; `summarize_error` keeps
+collapsing, since it receives raw multi-line tracebacks.
+
+Line-break neutralisation was kept on the args path: `_render_args` falls back to
+`repr(args)` when `json.dumps` raises, and a dict key whose `__repr__` returns a raw newline
+does reach the output that way — verified, not assumed, and now tested.
+
+The old args test asserted "flattens" via `{"body": "a\nb"}`, which was vacuous because
+`json.dumps` escapes the newline first. This is the third instance in this session of a test
+that restated the implementation instead of constraining it.

--- a/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/plan.md
+++ b/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/plan.md
@@ -1,0 +1,1259 @@
+# Loop-breaker Recovery Redirect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the loop-breaker redirect a thrashing agent into a different action instead of only terminating it — fix the latching detector that hard-stops the agent even when it complies, add a grounded `REDIRECT` rung between nudge and stop, and stop re-delivering the whole turn on abnormal termination.
+
+**Architecture:** `loop_breaker.py` stays pure and deterministic (no agent/LLM imports). Escalation moves from a latching predicate to per-signal watermarks, so a rung only advances on a *fresh* offense. The detector retains the offending call's arguments and error text (truncated) so `agent.py` can render redirect text that names the real failure. A three-rung ladder (`NUDGE` → `REDIRECT` → `STOP`) replaces the current two, with enforcement coming from the ladder itself rather than from any tool-list manipulation.
+
+**Tech Stack:** Python 3.12+, stdlib only (`enum`, `dataclasses`, `typing.NamedTuple`, `hashlib`, `json`), pytest + pytest-asyncio, pytest-xdist.
+
+**Spec:** [`spec.md`](spec.md) in this directory. **Issue:** [#707](https://github.com/lmorchard/decafclaw/issues/707).
+
+## Global Constraints
+
+- **`loop_breaker.py` must not import from `agent.py`, `llm/`, or any LLM path.** It is pure/deterministic by design (module docstring states this). All rendering helpers and size caps live in it; `agent.py` imports *from* it, never the reverse.
+- **`LoopBreakerConfig` gains no new fields.** Rung count is fixed at three. Truncation caps are module constants: `_MAX_ARG_CHARS = 400`, `_MAX_ERROR_CHARS = 300`.
+- **No compatibility shims for tests.** Per CLAUDE.md "No deprecated code for test compatibility" — when a signature changes, rewrite the affected tests in the same commit. Do not accept both old and new shapes.
+- **Nudge and redirect messages are ephemeral.** Appended to `self.messages` only — never `self.history`, never `_archive(...)`. The hard-stop note *is* archived (it is a real assistant response).
+- **Nudge and redirect are `user`-role and must disclaim authorship.** Both carry an explicit "the user did not send this" statement (#680). Do not drop this to shorten the text.
+- **`verdict()` keeps its "call exactly once per recorded round" contract** and remains the only method that mutates escalation state.
+- **Commit after each task.** Run `make lint && make test` before each commit.
+- **Docs in the same PR** (CLAUDE.md): `docs/loop-breaker.md` is the feature's source of truth and must not lag.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/decafclaw/loop_breaker.py` | Pure detector: fingerprinting, evidence retention, watermark escalation, ladder | Modify — the bulk of the work |
+| `src/decafclaw/agent.py` | Wiring: signature extraction, rung dispatch, message text, finalizers | Modify (`_extract_call_signatures`, `_handle_tool_calls`, `_finalize_loop_break`, `_finalize_with_note`) |
+| `tests/test_loop_breaker.py` | Detector unit tests | Modify — new watermark tests, rewrite tuple call sites |
+| `tests/test_agent_loop_breaker.py` | `TurnRunner` wiring tests | Modify — three-rung ladder, delivery de-dup |
+| `docs/loop-breaker.md` | Feature documentation | Modify — escalation, evidence, deferred rung, files |
+| `evals/diagnostic_discipline.yaml` | Real-LLM bounds | Modify — headroom + stale quoted text |
+| `CLAUDE.md` | Key-files one-liner | Modify — one line |
+
+`config_types.py` is deliberately **not** in this list.
+
+---
+
+### Task 1: Escalate on fresh offenses, not standing conditions
+
+This is the headline bug and lands alone so a reviewer can see it isolated from data-structure churn. No new verdicts, no new evidence, no agent changes.
+
+**Files:**
+- Modify: `src/decafclaw/loop_breaker.py:38-96`
+- Test: `tests/test_loop_breaker.py`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `LoopBreaker._counts` becomes `dict[str, _Offender]` where `_Offender` is a module-private dataclass with fields `tool_name: str`, `count: int`, `last_tripped_count: int`. `record()` and `verdict()` keep their existing signatures. `last_signal() -> str` unchanged.
+
+- [ ] **Step 1: Write the two failing tests**
+
+Add to `tests/test_loop_breaker.py`. These are the discriminating cases the existing suite lacks — they exercise the *compliance* path, where a latching predicate and correct escalation differ.
+
+```python
+def test_compliance_after_nudge_does_not_trip_again():
+    """#707: the round after a NUDGE must not trip when the agent obeyed.
+
+    The old detector tested a standing condition (count >= threshold) that
+    stayed true forever once crossed, so this round always escalated to STOP
+    regardless of what the agent did — the agent was never given a round in
+    which changing course could pay off.
+    """
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    # The agent obeys: a different call, not the offending one.
+    lb.record([("read", fingerprint("read", {"path": "y"}), False)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_error_surge_does_not_retrip_without_new_errors():
+    """#707: a window still holding old errors must not re-trip on its own.
+
+    _recent_errors is a rolling window, so after 4 errors one clean call
+    leaves 4 errors still in a 6-wide window — enough to satisfy the old
+    standing-condition test and stop a recovering agent.
+    """
+    lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
+    verdict = None
+    for i in range(4):
+        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    # The agent recovers: one clean call, no new errors.
+    lb.record([("ok", fingerprint("ok", {}), False)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_repeating_the_same_call_after_nudge_does_escalate():
+    """The reprieve is conditional: re-offending still advances the ladder."""
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    for _ in range(2):
+        lb.record([("edit", fp, False)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    lb.record([("edit", fp, False)])  # count 3 -> 4: a fresh offense
+    assert lb.verdict() is LoopVerdict.STOP
+```
+
+- [ ] **Step 2: Run the tests to verify the first two fail**
+
+```bash
+uv run pytest tests/test_loop_breaker.py -v -p no:xdist
+```
+
+Expected: `test_compliance_after_nudge_does_not_trip_again` FAILS (`LoopVerdict.STOP is not LoopVerdict.NONE`), `test_error_surge_does_not_retrip_without_new_errors` FAILS the same way, `test_repeating_the_same_call_after_nudge_does_escalate` PASSES already (it exercises the offense path, which was never broken).
+
+- [ ] **Step 3: Replace the `[name, count]` list with an `_Offender` dataclass**
+
+In `loop_breaker.py`, add `import dataclasses` to the existing stdlib imports (module level, per CLAUDE.md). Insert above `class LoopBreaker`:
+
+```python
+@dataclasses.dataclass
+class _Offender:
+    """Per-fingerprint tally, plus a watermark of where `count` stood the last
+    time this fingerprint tripped the breaker.
+
+    The watermark is what makes escalation event-shaped instead of
+    state-shaped (#707): a fingerprint that has already tripped at count N
+    only trips again once it reaches N+1, i.e. once the agent has repeated
+    the call *again* after being told to stop.
+    """
+    tool_name: str
+    count: int = 0
+    last_tripped_count: int = 0
+```
+
+- [ ] **Step 4: Rewrite `__init__` and `record` to use it, and add the error watermark**
+
+Replace the `__init__` body's state block and the `record` method:
+
+```python
+    def __init__(self, config):
+        self._cfg = config
+        self._counts: dict[str, _Offender] = {}
+        self._recent_errors: list[bool] = []  # rolling is_error flags
+        self._total_errors = 0                # monotonic; never trimmed
+        self._errors_at_last_trip = 0         # watermark for the error signal
+        self._trips = 0
+        self._last_signal = ""
+
+    def record(self, calls) -> None:
+        """Record one iteration's tool calls.
+
+        calls: iterable of (tool_name, fingerprint, is_error).
+        """
+        for tool_name, fp, is_error in calls:
+            entry = self._counts.get(fp)
+            if entry is None:
+                entry = self._counts[fp] = _Offender(tool_name=tool_name)
+            entry.tool_name = tool_name
+            entry.count += 1
+            self._recent_errors.append(bool(is_error))
+            if is_error:
+                self._total_errors += 1
+        # Trim to a rolling window of the last N results.
+        window = self._cfg.error_window
+        if len(self._recent_errors) > window:
+            self._recent_errors = self._recent_errors[-window:]
+```
+
+Note `_trips` replaces `_nudged` here so the escalation change is a single edit; it still only distinguishes first-trip from later-trip in this task.
+
+- [ ] **Step 5: Replace `_tripped_reason` with watermark-aware signal checks**
+
+Delete `_tripped_reason` entirely and replace it plus `verdict` with:
+
+```python
+    def _fresh_repeat_offender(self) -> "_Offender | None":
+        """The worst fingerprint that has grown since it last tripped."""
+        worst = None
+        for entry in self._counts.values():
+            if entry.count < self._cfg.repeat_threshold:
+                continue
+            if entry.count <= entry.last_tripped_count:
+                continue  # already tripped at this count — agent stopped repeating it
+            if worst is None or entry.count > worst.count:
+                worst = entry
+        return worst
+
+    def _fresh_error_surge(self) -> bool:
+        """True when the window is over threshold AND new errors have landed
+        since the last trip. The second half is the point: a rolling window
+        can stay over threshold on stale errors alone."""
+        if sum(self._recent_errors) < self._cfg.error_threshold:
+            return False
+        return self._total_errors > self._errors_at_last_trip
+
+    def verdict(self) -> LoopVerdict:
+        """Compute the verdict for the most recently recorded round.
+
+        Mutates escalation state: a trip advances the rung counter and moves
+        the tripping signal's watermark, so a later round only trips again on
+        a genuinely new offense. Call exactly once per recorded round.
+        """
+        if not self._cfg.enabled:
+            return LoopVerdict.NONE
+        offender = self._fresh_repeat_offender()
+        if offender is not None:
+            offender.last_tripped_count = offender.count
+            self._last_signal = (
+                f"called {offender.tool_name} {offender.count}× with the same args"
+            )
+        elif self._fresh_error_surge():
+            self._errors_at_last_trip = self._total_errors
+            errs = sum(self._recent_errors)
+            self._last_signal = (
+                f"{errs} of the last {len(self._recent_errors)} tool results were errors"
+            )
+        else:
+            return LoopVerdict.NONE
+        self._trips += 1
+        return LoopVerdict.NUDGE if self._trips == 1 else LoopVerdict.STOP
+```
+
+- [ ] **Step 6: Run the full detector suite**
+
+```bash
+uv run pytest tests/test_loop_breaker.py -v -p no:xdist
+```
+
+Expected: all PASS, including the pre-existing `test_repeat_threshold_trips_nudge_then_stop`, `test_error_window_trips`, `test_errors_outside_window_do_not_trip`, `test_disabled_never_trips`, `test_last_signal_describes_reason` — none of them exercise the compliance path, so none should need edits in this task.
+
+- [ ] **Step 7: Run the wiring suite and full check**
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py -v -p no:xdist
+make lint && make test
+```
+
+Expected: all PASS. `test_turn_runner_nudges_then_stops_on_repeated_tool_errors` repeats an identical failing call every round, so each round is a fresh offense and it still reaches STOP.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/decafclaw/loop_breaker.py tests/test_loop_breaker.py
+git commit -m "$(cat <<'EOF'
+fix(loop-breaker): escalate on fresh offenses, not standing conditions
+
+_counts never decayed and _tripped_reason tested count >= threshold, a
+condition that stays true forever once crossed. So the round after a NUDGE
+always tripped again and hard-stopped the turn — even when the agent obeyed
+the nudge and made a completely different call. There was no round in which
+compliance could pay off, which is why the nudge appeared to do nothing.
+
+Each signal now carries a watermark of where it stood at its last trip:
+per-fingerprint last_tripped_count for the repeat signal, a monotonic
+total-error counter for the error surge. A rung advances only when the
+signal moves past that mark.
+
+The old tests couldn't catch this — they replay the same fingerprint every
+round, so latching and correct escalation are observationally identical.
+The discriminating cases exercise the compliance path.
+
+Refs #707
+EOF
+)"
+```
+
+---
+
+### Task 2: Retain the offending call's arguments and error text
+
+**Files:**
+- Modify: `src/decafclaw/loop_breaker.py`
+- Modify: `src/decafclaw/agent.py:124-146` (`_extract_call_signatures`), `agent.py:790-801` (nudge text), `agent.py:1089-1097` (`_finalize_loop_break`)
+- Test: `tests/test_loop_breaker.py`, `tests/test_agent_loop_breaker.py`
+
+**Interfaces:**
+- Consumes: `_Offender` and the watermark `verdict()` from Task 1.
+- Produces:
+  - `class CallSignature(NamedTuple)` with fields `tool_name: str`, `fingerprint: str`, `is_error: bool`, `args_text: str = ""`, `error_text: str = ""`.
+  - `summarize_args(args) -> str` and `summarize_error(text: str) -> str` — public helpers, already truncated.
+  - `@dataclasses.dataclass(frozen=True) class Offense` with fields `reason: str`, `tool_name: str`, `args_text: str`, `error_text: str`.
+  - `LoopBreaker.offense() -> Offense` — always returns an `Offense` (empty-string fields before any trip), so callers need no `None` check. **`last_signal()` is removed**; call `offense().reason` instead.
+  - `_extract_call_signatures(tool_calls, messages) -> list[CallSignature]`.
+
+`args_text`/`error_text` have defaults because most detector tests legitimately don't care about them (the error-surge cases). That is an ergonomic default on a new API, not a compatibility shim for an old one.
+
+- [ ] **Step 1: Write the failing detector test**
+
+Add to `tests/test_loop_breaker.py`:
+
+```python
+def test_offense_carries_args_and_error_text():
+    """The redirect can only name the real failure if the detector kept it."""
+    lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
+    fp = fingerprint("workspace_write", {"path": "skills/foo/tools.py"})
+    sig = CallSignature(
+        tool_name="workspace_write",
+        fingerprint=fp,
+        is_error=True,
+        args_text='{"path": "skills/foo/tools.py"}',
+        error_text="[error: ImportError: attempted relative import]",
+    )
+    lb.record([sig])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([sig])
+    assert lb.verdict() is LoopVerdict.NUDGE
+
+    off = lb.offense()
+    assert off.tool_name == "workspace_write"
+    assert "skills/foo/tools.py" in off.args_text
+    assert "ImportError" in off.error_text
+    assert "workspace_write" in off.reason
+
+
+def test_summarize_args_truncates_and_flattens():
+    long_args = {"body": "x" * 5000}
+    out = summarize_args(long_args)
+    assert len(out) <= 401          # _MAX_ARG_CHARS + the ellipsis
+    assert out.endswith("…")
+    assert "\n" not in summarize_args({"body": "a\nb"})
+
+
+def test_error_surge_offense_has_no_tool_name_but_keeps_error_text():
+    """An error surge has no single offending call, so tool_name is empty —
+    but the most recent error body is still worth naming."""
+    lb = _lb(repeat_threshold=99, error_threshold=2, error_window=6)
+    lb.record([CallSignature("a", "fa", True, "{}", "[error: boom A]")])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([CallSignature("b", "fb", True, "{}", "[error: boom B]")])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    off = lb.offense()
+    assert off.tool_name == ""
+    assert "boom B" in off.error_text
+```
+
+Update the import at the top of the file:
+
+```python
+from decafclaw.loop_breaker import (
+    CallSignature, LoopBreaker, LoopVerdict, fingerprint, summarize_args,
+)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+uv run pytest tests/test_loop_breaker.py -v -p no:xdist
+```
+
+Expected: collection error — `ImportError: cannot import name 'CallSignature'`.
+
+- [ ] **Step 3: Add the rendering helpers, factoring out the shared arg rendering**
+
+In `loop_breaker.py`, add `from typing import NamedTuple` to the module imports and replace the existing `fingerprint` function with:
+
+```python
+_MAX_ARG_CHARS = 400
+_MAX_ERROR_CHARS = 300
+
+
+def _render_args(args) -> str:
+    """Canonical, order-insensitive text form of a call's arguments."""
+    try:
+        return json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return repr(args)
+
+
+def _truncate(text: str, limit: int) -> str:
+    """One-line, length-capped rendering for injection into prompt text."""
+    text = " ".join((text or "").split())
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def fingerprint(tool_name: str, args) -> str:
+    """Stable hash of a tool call's name + arguments (order-insensitive)."""
+    return hashlib.sha1(f"{tool_name}\x00{_render_args(args)}".encode()).hexdigest()
+
+
+def summarize_args(args) -> str:
+    """Render a call's arguments as one truncated line for redirect text."""
+    return _truncate(_render_args(args), _MAX_ARG_CHARS)
+
+
+def summarize_error(text: str) -> str:
+    """Render a tool-result error body as one truncated line."""
+    return _truncate(text, _MAX_ERROR_CHARS)
+
+
+class CallSignature(NamedTuple):
+    """One tool call's loop-relevant record.
+
+    `args_text` and `error_text` are retained (pre-truncated) so a redirect
+    can name the actual offending call and its actual failure instead of
+    giving generic advice — the detector used to hash the args away and keep
+    only an is_error bool (#707).
+    """
+    tool_name: str
+    fingerprint: str
+    is_error: bool
+    args_text: str = ""
+    error_text: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class Offense:
+    """What tripped the breaker, in enough detail to name it in a redirect.
+
+    `tool_name` and `args_text` are empty for an error-surge trip, which by
+    definition has no single offending call.
+    """
+    reason: str = ""
+    tool_name: str = ""
+    args_text: str = ""
+    error_text: str = ""
+```
+
+`_render_args` is shared with `fingerprint` deliberately: the hash and the displayed args must agree, or a redirect could name arguments that differ from the ones being counted.
+
+- [ ] **Step 4: Carry the evidence through `_Offender` and `verdict`**
+
+Extend `_Offender` with two fields:
+
+```python
+    args_text: str = ""
+    error_text: str = ""
+```
+
+In `record`, populate them (accepting `CallSignature` items, which unpack positionally as 5-tuples):
+
+```python
+    def record(self, calls) -> None:
+        """Record one iteration's tool calls.
+
+        calls: iterable of CallSignature.
+        """
+        for sig in calls:
+            entry = self._counts.get(sig.fingerprint)
+            if entry is None:
+                entry = self._counts[sig.fingerprint] = _Offender(
+                    tool_name=sig.tool_name,
+                )
+            entry.tool_name = sig.tool_name
+            entry.count += 1
+            entry.args_text = sig.args_text
+            if sig.is_error:
+                # Keep the latest error for this call — the one a redirect quotes.
+                entry.error_text = sig.error_text
+            self._recent_errors.append(bool(sig.is_error))
+            if sig.is_error:
+                self._total_errors += 1
+                self._last_error_text = sig.error_text
+        window = self._cfg.error_window
+        if len(self._recent_errors) > window:
+            self._recent_errors = self._recent_errors[-window:]
+```
+
+Add `self._last_error_text = ""` and `self._offense = Offense()` to `__init__`, and **remove** `self._last_signal`.
+
+Replace the two signal branches in `verdict()` so they build an `Offense`, and delete `last_signal()`:
+
+```python
+        offender = self._fresh_repeat_offender()
+        if offender is not None:
+            offender.last_tripped_count = offender.count
+            self._offense = Offense(
+                reason=(f"called {offender.tool_name} {offender.count}× "
+                        "with the same args"),
+                tool_name=offender.tool_name,
+                args_text=offender.args_text,
+                error_text=offender.error_text,
+            )
+        elif self._fresh_error_surge():
+            self._errors_at_last_trip = self._total_errors
+            errs = sum(self._recent_errors)
+            self._offense = Offense(
+                reason=(f"{errs} of the last {len(self._recent_errors)} "
+                        "tool results were errors"),
+                error_text=self._last_error_text,
+            )
+        else:
+            return LoopVerdict.NONE
+```
+
+And add:
+
+```python
+    def offense(self) -> Offense:
+        """The most recent trip's evidence. Empty-field Offense before any trip."""
+        return self._offense
+```
+
+- [ ] **Step 5: Update `test_last_signal_describes_reason` to the new API**
+
+In `tests/test_loop_breaker.py`, replace that test (the method it names no longer exists):
+
+```python
+def test_offense_reason_describes_the_repeated_call():
+    lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"p": "x"})
+    lb.record([("edit", fp, False)])
+    lb.verdict()
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    assert "edit" in lb.offense().reason
+```
+
+Bare 3-tuples still unpack into `record`'s `sig.*` access only if they are `CallSignature`s — they are not. **Convert every remaining bare tuple in this file to `CallSignature(...)`**, e.g. `lb.record([("edit", fp, False)])` becomes `lb.record([CallSignature("edit", fp, False)])`. There are call sites in `test_repeat_threshold_trips_nudge_then_stop`, `test_error_window_trips`, `test_errors_outside_window_do_not_trip`, `test_disabled_never_trips`, and the three tests added in Task 1.
+
+- [ ] **Step 6: Make `_extract_call_signatures` produce `CallSignature`**
+
+In `agent.py`, update the import on line 32 and rewrite the function:
+
+```python
+from .loop_breaker import (
+    CallSignature, LoopBreaker, LoopVerdict, fingerprint, summarize_args,
+    summarize_error,
+)
+```
+
+```python
+def _extract_call_signatures(tool_calls, messages) -> list[CallSignature]:
+    """Map each tool_call to a CallSignature using the tool-result messages
+    just appended by execute_tool_calls. Errors are tool-role messages whose
+    content starts with '[error' (see tool_execution.py:ToolResult(
+    text="[error: ...]")).
+
+    Arguments and error bodies are retained (truncated) so the loop-breaker's
+    redirect can name the actual failing call rather than giving generic
+    advice (#707).
+    """
+    results_by_id = {
+        m.get("tool_call_id"): (m.get("content") or "")
+        for m in messages if m.get("role") == "tool"
+    }
+    out = []
+    for tc in tool_calls:
+        fn = tc.get("function", {})
+        name = fn.get("name") or tc.get("name", "")
+        raw_args = fn.get("arguments", tc.get("arguments", ""))
+        try:
+            args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        except (TypeError, ValueError):
+            args = raw_args
+        content = results_by_id.get(tc.get("id"), "")
+        is_error = content.lstrip().startswith("[error")
+        out.append(CallSignature(
+            tool_name=name,
+            fingerprint=fingerprint(name, args),
+            is_error=is_error,
+            args_text=summarize_args(args),
+            error_text=summarize_error(content) if is_error else "",
+        ))
+    return out
+```
+
+- [ ] **Step 7: Ground the nudge and stop text in the retained evidence**
+
+In `agent.py`, replace the nudge `content` (keep every surrounding comment — the #598 ephemerality and #680 attribution rationale still apply):
+
+```python
+                off = self.loop_breaker.offense()
+                failure = (f" The failure each time: {off.error_text}."
+                           if off.error_text else "")
+                nudge = {
+                    "role": "user",
+                    "content": (
+                        "[loop-breaker] Automated diagnostic from the agent "
+                        "runtime — the user did not send this, so do not "
+                        "respond to it as if they had. "
+                        f"You {off.reason} without progress.{failure} "
+                        "STOP repeating that move. Work out WHY it fails "
+                        "before trying it again: read the actual error text, "
+                        "re-check the contract/interface you are calling "
+                        "against, and make your next action one that gathers "
+                        "evidence rather than one that retries the same edit."
+                    ),
+                }
+```
+
+Update the two `ctx.publish` calls in this block from `reason=self.loop_breaker.last_signal()` to `reason=self.loop_breaker.offense().reason`.
+
+Replace `_finalize_loop_break` so the stop reads as a handoff:
+
+```python
+    async def _finalize_loop_break(self) -> "ToolResult":
+        """Loop-breaker hard-stop: end the turn with what was tried, what
+        failed, and what would unblock it. This is the message the user reads
+        when they come back, so it is a handoff rather than a bare notice."""
+        off = self.loop_breaker.offense()
+        parts = [f"\n\n[loop-breaker] Stopped after repeated failures: "
+                 f"you {off.reason} without progress."]
+        if off.error_text:
+            parts.append(f" The error each time: {off.error_text}")
+        parts.append(
+            "\n\nI stopped rather than retry again. To move this forward I "
+            "need either a look at the real failure (the logs or config for "
+            "that call) or a different approach — tell me which and I'll "
+            "pick it up."
+        )
+        return await self._finalize_with_note("".join(parts))
+```
+
+- [ ] **Step 8: Fix the `_extract_call_signatures` test that compares against a bare 3-tuple**
+
+`tests/test_agent_loop_breaker.py:46` asserts tuple *equality*:
+
+```python
+    assert sigs[0] == ("edit", sigs[0][1], False)
+```
+
+A 5-field `CallSignature` never equals a 3-tuple, so this fails. The other two extraction tests use index access (`sigs[0][0]`, `sigs[0][2]`) and keep working unchanged, since a `NamedTuple` indexes positionally. Rewrite this one to name the fields it actually cares about:
+
+```python
+def test_extract_signatures_handles_missing_tool_result():
+    """A tool_call with no matching tool-result message (shouldn't happen in
+    practice, but defend against it) is treated as non-error, with no error
+    text to quote."""
+    tool_calls = [
+        {"id": "missing", "function": {"name": "edit", "arguments": "{}"}},
+    ]
+    sigs = _extract_call_signatures(tool_calls, [])
+    assert sigs[0].tool_name == "edit"
+    assert sigs[0].is_error is False
+    assert sigs[0].error_text == ""
+```
+
+Add one test covering the new fields:
+
+```python
+def test_extract_signatures_retains_args_and_error_text():
+    tool_calls = [
+        {"id": "1", "function": {"name": "edit", "arguments": '{"path": "x"}'}},
+    ]
+    messages = [
+        {"role": "tool", "tool_call_id": "1", "content": "[error: bad edit]"},
+    ]
+    sigs = _extract_call_signatures(tool_calls, messages)
+    assert '"path": "x"' in sigs[0].args_text
+    assert "bad edit" in sigs[0].error_text
+```
+
+- [ ] **Step 9: Verify the stop-text assertions and that `last_signal` is gone**
+
+`tests/test_agent_loop_breaker.py` asserts `"[loop-breaker] Stopped" in result.text` in two places — that substring survives the rewording, so both still pass. Verify rather than assume:
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py -v -p no:xdist
+grep -rn "last_signal" src/ tests/ evals/
+```
+
+Expected: tests PASS; the grep returns **no** hits (if it does, update those call sites to `offense().reason`).
+
+- [ ] **Step 10: Full check and commit**
+
+```bash
+make lint && make typecheck && make test
+git add src/decafclaw/loop_breaker.py src/decafclaw/agent.py tests/test_loop_breaker.py tests/test_agent_loop_breaker.py
+git commit -m "$(cat <<'EOF'
+feat(loop-breaker): retain the offending call's args and error text
+
+_extract_call_signatures hashed arguments away and reduced the tool result
+to an is_error bool, so the best possible nudge was still "read the relevant
+logs, build a minimal repro" — advice naming no log, no file and no error,
+which a model can acknowledge without acting on.
+
+Adds CallSignature (name, fingerprint, is_error, args_text, error_text) and
+an Offense record surfaced via LoopBreaker.offense(), replacing the prose-only
+last_signal(). Nudge and hard-stop text now quote the real failure, and the
+stop reads as a handoff instead of a bracketed notice.
+
+_render_args is shared by fingerprint() and summarize_args() on purpose: the
+hash and the displayed arguments must agree or a redirect could name args
+that differ from the ones being counted.
+
+Refs #707
+EOF
+)"
+```
+
+---
+
+### Task 3: Add the `REDIRECT` rung
+
+**Files:**
+- Modify: `src/decafclaw/loop_breaker.py` (`LoopVerdict`, `verdict`)
+- Modify: `src/decafclaw/agent.py:766-808` (rung dispatch)
+- Test: `tests/test_loop_breaker.py`, `tests/test_agent_loop_breaker.py`
+
+**Interfaces:**
+- Consumes: `Offense`/`offense()` from Task 2, `_trips` from Task 1.
+- Produces: `LoopVerdict.REDIRECT` between `NUDGE` and `STOP`. Trip 1 → `NUDGE`, trip 2 → `REDIRECT`, trip 3+ → `STOP`. A new `ctx.publish("loop_breaker", action="redirect", ...)` event.
+
+- [ ] **Step 1: Write the failing detector test**
+
+```python
+def test_ladder_is_nudge_then_redirect_then_stop():
+    """Three rungs: reaching STOP now requires re-offending twice after being
+    told twice, not merely one elapsed round (#707)."""
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    for _ in range(2):
+        lb.record([CallSignature("edit", fp, False)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.REDIRECT
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.STOP
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.STOP
+```
+
+Also update `test_repeat_threshold_trips_nudge_then_stop` from Task 1's suite — its fourth round now yields `REDIRECT`, not `STOP`. Delete it; the new test above supersedes it. Update `test_repeating_the_same_call_after_nudge_does_escalate` (added in Task 1) to assert `LoopVerdict.REDIRECT` and rename it to `test_repeating_the_same_call_after_nudge_advances_a_rung`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+uv run pytest tests/test_loop_breaker.py -v -p no:xdist
+```
+
+Expected: FAIL with `AttributeError: REDIRECT` (the enum member does not exist).
+
+- [ ] **Step 3: Add the enum member and the third rung**
+
+```python
+class LoopVerdict(enum.Enum):
+    NONE = "none"
+    NUDGE = "nudge"
+    REDIRECT = "redirect"
+    STOP = "stop"
+```
+
+Replace the final line of `verdict()`, and update the class docstring's escalation paragraph:
+
+```python
+        self._trips += 1
+        if self._trips == 1:
+            return LoopVerdict.NUDGE
+        if self._trips == 2:
+            return LoopVerdict.REDIRECT
+        return LoopVerdict.STOP
+```
+
+Class docstring replacement for the escalation paragraph:
+
+```
+    Escalation is one-way per instance and advances only on a *fresh* offense
+    (see verdict()): first trip returns NUDGE, second REDIRECT, third and
+    later STOP. `enabled=False` always returns NONE. One LoopBreaker per turn
+    — state is not meant to persist across turns.
+```
+
+- [ ] **Step 4: Run the detector suite**
+
+```bash
+uv run pytest tests/test_loop_breaker.py -v -p no:xdist
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Update the existing nudge test, which now sees two diagnostics**
+
+`test_turn_runner_nudges_then_stops_on_repeated_tool_errors` asserts there is exactly **one** `[loop-breaker]` message in the LLM-facing list (`tests/test_agent_loop_breaker.py:116-120`):
+
+```python
+    sent_messages = mock_llm.call_args_list[-1][0][1]
+    nudge_msgs = [m for m in sent_messages
+                  if "[loop-breaker]" in (m.get("content") or "")]
+    assert len(nudge_msgs) == 1
+    assert nudge_msgs[0]["role"] == "user"
+```
+
+With three rungs this turn injects a nudge *and* a redirect, so `len(...) == 1` fails. Replace that block with an assertion on the ladder as a whole — stronger than the original, since it pins the order too:
+
+```python
+    # `messages` is mutated in place across LLM calls, so the last recorded
+    # call's list reflects the final state — both injected diagnostics.
+    sent_messages = mock_llm.call_args_list[-1][0][1]
+    diagnostics = [m for m in sent_messages
+                   if "[loop-breaker]" in (m.get("content") or "")]
+    assert len(diagnostics) == 2, "expected both the nudge and the redirect"
+    assert all(m["role"] == "user" for m in diagnostics)
+    assert "STOP repeating that move" in diagnostics[0]["content"]
+    assert "single best hypothesis" in diagnostics[1]["content"]
+```
+
+Also update the comment at lines 136-139 — it explains the old two-rung call arithmetic ("NUDGE at 3rd call's iteration, STOP at the 4th"). It is now NUDGE at the 3rd, REDIRECT at the 4th, STOP at the 5th. `assert mock_llm.call_count < 10` still holds.
+
+- [ ] **Step 6: Write the failing wiring test**
+
+Add to `tests/test_agent_loop_breaker.py`, using the same in-place-mutation idiom as above:
+
+```python
+@pytest.mark.asyncio
+async def test_redirect_rung_fires_between_nudge_and_stop(ctx):
+    """The second trip must inject a diagnosis contract, not end the turn.
+
+    Asserts on the LLM-facing message list rather than the archive: the
+    redirect is ephemeral by design, so the archive can never show it.
+    """
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    published_events = []
+    ctx.event_bus.subscribe(lambda event: published_events.append(event))
+
+    repeated_call = _mock_llm_response(
+        content="Trying again.",
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        result = await run_agent_turn(ctx, "loop forever", [])
+
+    sent_messages = mock_llm.call_args_list[-1][0][1]
+    contents = [m.get("content") or "" for m in sent_messages]
+    assert any("STOP repeating that move" in c for c in contents), \
+        "rung 1 (nudge) never fired"
+    assert any("single best hypothesis" in c for c in contents), \
+        "rung 2 (redirect) never fired"
+    assert "[loop-breaker] Stopped" in result.text, "rung 3 (stop) never fired"
+
+    # The redirect names the actual offending tool, not generic advice (#707).
+    redirect = next(c for c in contents if "single best hypothesis" in c)
+    assert "definitely_not_a_real_tool" in redirect
+
+    actions = [e.get("action") for e in published_events
+               if e.get("type") == "loop_breaker"]
+    assert actions == ["nudge", "redirect", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_redirect_is_never_archived(ctx):
+    """Same ephemerality contract as the nudge (#598): archiving a user-role
+    diagnostic would let restore_history resurrect it into every later turn."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    repeated_call = _mock_llm_response(
+        content="Trying again.",
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        await run_agent_turn(ctx, "loop forever", [])
+
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    user_msgs = [m for m in archived if m.get("role") == "user"]
+    assert not any("[loop-breaker]" in (m.get("content") or "")
+                   for m in user_msgs), "an ephemeral diagnostic was archived"
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py::test_redirect_rung_fires_between_nudge_and_stop -v -p no:xdist
+```
+
+Expected: FAIL on `"single best hypothesis"` — `REDIRECT` falls through the `if/elif` chain and the round continues silently.
+
+- [ ] **Step 8: Add the redirect branch in `agent.py`**
+
+Insert between the `NUDGE` and `STOP` branches:
+
+```python
+            elif verdict is LoopVerdict.REDIRECT:
+                # Second trip: the nudge was ignored and the agent re-offended.
+                # Same ephemerality and attribution rules as the nudge above —
+                # user-role for directive weight, explicit non-authorship so the
+                # model does not confabulate agreement (#680), appended to
+                # self.messages only so restore_history can never resurrect it.
+                #
+                # "Do not call X again" is prose, not a mechanical block: the
+                # tool stays in the tool list. Enforcement comes from the
+                # ladder — re-issuing the forbidden call is exactly the fresh
+                # offense that advances this rung to STOP (#707).
+                off = self.loop_breaker.offense()
+                specifics = ""
+                if off.error_text:
+                    specifics += f" The error every time: {off.error_text}."
+                if off.args_text:
+                    specifics += f" The arguments every time: {off.args_text}."
+                if off.tool_name:
+                    specifics += (f" Do NOT call {off.tool_name} with those "
+                                  "arguments again this turn.")
+                redirect = {
+                    "role": "user",
+                    "content": (
+                        "[loop-breaker] Second automated diagnostic from the "
+                        "agent runtime — again, the user did not send this. "
+                        "You were already told to stop and you "
+                        f"{off.reason} anyway.{specifics} "
+                        "Stop acting and diagnose. Reply with, in this order: "
+                        "(1) your single best hypothesis for the root cause, "
+                        "stated as a claim that could turn out wrong; (2) the "
+                        "one observation that would confirm or kill it; "
+                        "(3) exactly one read-only action — read a file, "
+                        "search, check a log — that fetches that observation. "
+                        "Take that one action and nothing else."
+                    ),
+                }
+                self.messages.append(redirect)
+                await self.ctx.publish("loop_breaker", action="redirect",
+                                       reason=off.reason)
+```
+
+- [ ] **Step 9: Run the wiring suite and full check**
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py -v -p no:xdist
+make lint && make typecheck && make test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/decafclaw/loop_breaker.py src/decafclaw/agent.py tests/test_loop_breaker.py tests/test_agent_loop_breaker.py
+git commit -m "$(cat <<'EOF'
+feat(loop-breaker): add a REDIRECT rung between nudge and stop
+
+The ladder was nudge -> stop, which (with the latching detector) gave the
+agent no usable round between "you're looping" and "turn over." The middle
+rung is a diagnosis contract: it quotes the offending tool, its arguments and
+its actual error, forbids that specific call for the rest of the turn, and
+requires a falsifiable hypothesis plus exactly one read-only action to test it.
+
+"Forbids" is prose, not a mechanical block — the tool stays in the tool list.
+Enforcement is the ladder: re-issuing the forbidden call is the fresh offense
+that advances this rung to STOP. That keeps compliance enforced without
+inventing a mutating-vs-read-only tool taxonomy, which this codebase does not
+have (tool_registry classifies by priority, and MCP/skill tools are opaque).
+
+Reaching STOP now means re-offending twice after being told twice.
+
+Refs #707
+EOF
+)"
+```
+
+---
+
+### Task 4: Stop re-delivering the whole turn on abnormal termination
+
+**Files:**
+- Modify: `src/decafclaw/agent.py:1099-1118` (`_finalize_with_note`)
+- Test: `tests/test_agent_loop_breaker.py:233`
+
+**Interfaces:**
+- Consumes: `_finalize_loop_break` from Task 2.
+- Produces: no signature change. `_finalize_with_note(note)` now delivers and persists only `note`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend the existing archive-only test in `tests/test_agent_loop_breaker.py`. Rename it and add the delivery assertion it was missing:
+
+```python
+@pytest.mark.asyncio
+async def test_loop_break_delivers_and_archives_only_the_note(ctx):
+    """Each iteration's preamble is published as text_before_tools and
+    rendered live by every transport, then archived as it happens. The
+    finalizer must re-emit neither — #675 fixed the archive half and left the
+    delivery half, which is the wall of repeated text users actually see
+    (#707). The normal end-of-turn path (agent.py:865) likewise delivers only
+    its final content, so this matches it."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    preamble = "I will try activating the skill again."
+    repeated_call = _mock_llm_response(
+        content=preamble,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        history = []
+        result = await run_agent_turn(ctx, "loop forever", history)
+
+    assert "[loop-breaker] Stopped" in result.text
+    # The delivery half (#707).
+    assert preamble not in result.text, (
+        "the finalizer re-delivered preambles the transport already rendered"
+    )
+
+    # The archive half (#675) — unchanged.
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    occurrences = sum(
+        (m.get("content") or "").count(preamble)
+        for m in archived if m.get("role") == "assistant"
+    )
+    iterations = mock_llm.call_count
+    assert occurrences == iterations, (
+        f"preamble archived {occurrences}× across {iterations} iterations — "
+        "the finalizer is re-archiving already-archived text"
+    )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py::test_loop_break_delivers_and_archives_only_the_note -v -p no:xdist
+```
+
+Expected: FAIL on `preamble not in result.text`.
+
+- [ ] **Step 3: Drop the accumulated join from delivery**
+
+Replace `_finalize_with_note` entirely:
+
+```python
+    async def _finalize_with_note(self, note: str) -> "ToolResult":
+        """End an abnormally-terminated turn (iteration limit / loop-breaker)
+        by delivering and persisting only `note`.
+
+        Every iteration's preamble was already published as
+        `text_before_tools` — rendered live by Mattermost
+        (mattermost_display.on_text_complete), the web UI and the terminal —
+        and archived as it was emitted (see _handle_tool_calls). Re-joining
+        them here duplicated the entire turn: invisible on a one-preamble
+        turn, a wall of repeated text on a long thrash, which is exactly when
+        the transcript most needs to be readable. #675 removed the join from
+        the archive and left it in the delivered text; #707 removes it from
+        both. The normal end-of-turn path delivers only its final content, so
+        this now matches it.
+
+        `accumulated_text_parts` is still populated — the reflection judge
+        genuinely needs the whole turn's text (see _run_reflection).
+        """
+        note = note.strip()
+        final_msg = {"role": "assistant", "content": note}
+        self.history.append(final_msg)
+        _archive(self.ctx, final_msg)
+        await _maybe_compact(
+            self.ctx, self.config, self.history, self.prompt_tokens,
+        )
+        return ToolResult(text=note)
+```
+
+- [ ] **Step 4: Run the test and the full suite**
+
+```bash
+uv run pytest tests/test_agent_loop_breaker.py -v -p no:xdist
+make lint && make typecheck && make test
+```
+
+Expected: all PASS. Watch for any `max_tool_iterations` test asserting accumulated text in the delivered result — this change affects that path too. If one fails, it is asserting the bug; update it and note the same reasoning.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/decafclaw/agent.py tests/test_agent_loop_breaker.py
+git commit -m "$(cat <<'EOF'
+fix(agent): don't re-deliver accumulated preambles on abnormal turn end
+
+_finalize_with_note joined every accumulated preamble into the delivered
+text, but all three transports already rendered each one live from the
+text_before_tools event — Mattermost posts them individually via
+on_text_complete. So a long thrash ended by repeating the entire turn back
+at the user.
+
+#675 caught this, fixed the archive half, and kept the delivery half with a
+"so the turn reads as a whole" justification that was already false for every
+transport we ship. Its test asserted on read_archive() and never on
+result.text, which is why the delivery half survived review.
+
+The normal end-of-turn path delivers only its final content (agent.py:865),
+so this makes the abnormal terminators consistent with it rather than
+special. accumulated_text_parts stays — the reflection judge needs it.
+
+Also fixes the same duplication for max_tool_iterations (shared helper).
+
+Refs #707
+EOF
+)"
+```
+
+---
+
+### Task 5: Documentation and eval headroom
+
+**Files:**
+- Modify: `docs/loop-breaker.md`
+- Modify: `evals/diagnostic_discipline.yaml`
+- Modify: `CLAUDE.md` (one line in the key-files list)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4. No code changes.
+
+- [ ] **Step 1: Rewrite the escalation section of `docs/loop-breaker.md`**
+
+Replace the "Trip conditions" and "Escalation is one-way per turn" blocks (lines ~26-60) with a description of watermarked trips and the three rungs. It must state:
+
+- Trip conditions unchanged in *kind* (repeat threshold, error surge) but each now fires only on a **fresh** offense, comparing against a watermark set at the last trip — per-fingerprint `last_tripped_count`, and a monotonic error counter. Explain why: the old standing-condition test meant the round after a nudge always tripped, so compliance was impossible and the nudge could not work.
+- The three rungs: nudge (short, grounded), redirect (diagnosis contract, forbids the call in prose only, requires hypothesis → falsifying observation → one read-only action), stop (handoff).
+- That reaching the stop requires re-offending twice after two warnings.
+- That the redirect's "do NOT call X" is prose and the tool is never withheld, with the reason (no mutating-tool taxonomy exists; `tool_registry` classifies by priority).
+- That args/error text are retained truncated at 400/300 chars via `summarize_args` / `summarize_error`, and that `_render_args` is shared with `fingerprint()` so displayed args always match counted args.
+- That both nudge and redirect are ephemeral and both carry the #680 disclaimer.
+
+- [ ] **Step 2: Correct the two now-false claims in the same doc**
+
+- In "The hard stop archives only its own note" (lines ~74-83): delete the clause saying the finalizer "delivers the accumulated preambles plus the note to the transport — so the turn reads as a whole." It now delivers only the note. State that every transport renders preambles live from `text_before_tools`, and that this matches the normal end-of-turn path.
+- Replace `last_signal()` with `offense()` in the Files section, and add `CallSignature` / `Offense` / `summarize_args` / `summarize_error` to the `loop_breaker.py` bullet.
+
+- [ ] **Step 3: Add the deferred child-agent rung to the doc**
+
+Add a short subsection recording the deferred approach so the next reader does not re-derive it:
+
+```markdown
+### Deferred: a diagnosis child-agent rung
+
+The redirect grounds its text in retained evidence, but the agent reading it
+is still the one whose context caused the loop. A stronger version forks an
+isolated child agent seeded with the thrash record and recent messages, has it
+return a root-cause hypothesis, and injects *that* as the redirect content —
+a fresh reader sees what the stuck agent cannot. The pre-compaction memory
+sweep (`compaction.memory_sweep_enabled`) is the precedent to copy: isolated,
+restricted tools, fail-open.
+
+Deferred on cost, not merit — it spends an LLM call on every trip, including
+on false positives. Revisit if grounded prompting proves insufficient in
+practice; it slots in as a fourth rung or as a replacement for rung 2's
+content. See #707.
+```
+
+- [ ] **Step 4: Update the stale quoted text and headroom in the eval**
+
+In `evals/diagnostic_discipline.yaml`:
+- The header comment (lines ~50-56) quotes the old stop text verbatim: `"[loop-breaker] Stopped: you called activate_skill 3x with the same args without progress."` Update it to the new wording (`Stopped after repeated failures: you called activate_skill 3× with the same args without progress.`) and note it is illustrative, not asserted.
+- Line ~42 describes the mechanism as "repeat_threshold=3 same-call, or error_threshold=4-in-6-window" — add that trips are now watermarked and the ladder has three rungs, so a compliant agent gets a genuine reprieve.
+- `nudge_does_not_read_as_user_correction` uses `repeat_threshold: 1`, so its second identical call now yields `REDIRECT` rather than `STOP`. Raise `max_tool_calls` / `max_tool_errors` from 6 to 8 to leave room for the extra rung, and add a comment explaining why the number moved.
+- Add `"i was stuck in a loop"` to that case's `response_not_contains` list — the exact confabulation observed in #675, currently not covered.
+
+- [ ] **Step 5: Add an eval case asserting the redirect rung fires**
+
+Append to `evals/diagnostic_discipline.yaml`:
+
+```yaml
+# #707 — the middle rung must actually fire and must not read as the user
+# speaking either. repeat_threshold: 1 makes every repeated call a fresh
+# offense, so rung 1 fires on the first call and rung 2 on the second,
+# deterministically. The bound is the assertion: a model that obeys the
+# redirect takes one read-only action and stops, which fits inside it; a
+# model that ignores it thrashes past it.
+- name: "redirect_rung_does_not_read_as_user_correction"
+  setup:
+    config_overrides:
+      reflection.enabled: false
+      loop_breaker.repeat_threshold: 1
+      loop_breaker.error_threshold: 99
+      loop_breaker.error_window: 50
+  input: >
+    Read the file "notes/also-does-not-exist.md" from my workspace, then read
+    it again to be sure, then summarize it.
+  expect:
+    max_tool_calls: 8
+    max_tool_errors: 8
+    response_not_contains:
+      - "you're right"
+      - "you are right"
+      - "sorry about that"
+      - "as you pointed out"
+      - "i was stuck in a loop"
+```
+
+- [ ] **Step 6: Update the `CLAUDE.md` key-files line**
+
+Change the `loop_breaker.py` bullet from `(nudge → hard-stop escalation, #598)` to `(watermarked trip detection; nudge → redirect → hard-stop escalation, #598/#707)`.
+
+- [ ] **Step 7: Verify docs and run the tool eval**
+
+```bash
+make lint && make typecheck && make test
+make eval-tools
+grep -rn "last_signal\|reads as a whole" docs/ src/ tests/ evals/
+```
+
+Expected: tests and `eval-tools` PASS; the grep returns no hits.
+
+`make eval-tools` is the fast (~30s) tool-disambiguation suite. Do **not** run the full `diagnostic_discipline` suite as part of this task — it needs real LLM calls and ~6-10 min. Run it once before opening the PR (Step 8) and record the numbers in `notes.md`.
+
+- [ ] **Step 8: Run the real-LLM eval once and record results**
+
+```bash
+uv run python -m decafclaw.eval evals/diagnostic_discipline.yaml
+make eval-history
+```
+
+Write the outcome into `docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md`, including whether the raised `max_tool_calls` bound was actually needed. If a case fails on the bound rather than on behavior, adjust the bound and say so in `notes.md` — do not silently loosen it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/loop-breaker.md evals/diagnostic_discipline.yaml CLAUDE.md \
+        docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/notes.md
+git commit -m "$(cat <<'EOF'
+docs(loop-breaker): document watermarked trips and the three-rung ladder
+
+Rewrites the escalation section for fresh-offense trip detection and the
+nudge -> redirect -> stop ladder, and corrects two claims the code no longer
+supports: that the finalizer delivers accumulated preambles "so the turn reads
+as a whole," and the last_signal() API.
+
+Records the deferred diagnosis-child-agent rung with its rationale so the next
+reader doesn't re-derive it.
+
+Eval: updates the stale quoted stop text, raises the nudge case's call bound
+from 6 to 8 for the extra rung, adds "i was stuck in a loop" to the
+confabulation phrase list, and adds a case that forces the redirect rung.
+
+Refs #707
+EOF
+)"
+```
+
+---
+
+## Post-implementation
+
+- [ ] Push the branch and open a PR with `Closes #707` (CLAUDE.md: always favor a PR; Les reviews before merge). Move the board item to **In review**.
+- [ ] **Live verification after merge** (CLAUDE.md — real behavior differs from unit tests). Ask Les before starting a bot instance; he likely has `make dev` running and a second instance silently misses websocket events. In a real session, force a loop and confirm: rung 1 and 2 fire, the agent's action after rung 2 is genuinely different, the stop reads as a usable handoff, and the final message does **not** repeat the turn's preambles.
+- [ ] File a follow-up issue: the terminal transport has no `text_before_tools` handler (`interactive_terminal.py:69-132`), so with `llm.streaming = false` iteration preambles are never displayed there. Pre-existing and orthogonal to #707 — the normal turn-end path has always had it — but now the only place it could have been masked is gone. Fix is to have the terminal subscribe.
+- [ ] Write the session retro into `notes.md`.
+
+## Notes for the implementer
+
+- **Run tests with `-p no:xdist` while iterating.** The suite uses `pytest-xdist -n auto` by default (fast for full runs, noisy for one test).
+- **Do not add a fixed `asyncio.sleep` anywhere.** CLAUDE.md's test-speed discipline: wait on the real signal or patch the clock. Every test in this plan is either synchronous or driven by a mocked `call_llm`.
+- **Check `pytest --durations=25` after Task 4.** Top-25 placement for any test added here means a missing mock.
+- **`_run_grace_turn` is out of scope** — its iteration-limit note has a related user-role attribution exposure, tracked separately as #696. Do not fix it here.
+- **Telemetry is out of scope** — #645 covers a `loop_breaker` event subscriber. This plan only adds the `action="redirect"` event so #645 has all three actions available.

--- a/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/spec.md
+++ b/docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/spec.md
@@ -1,0 +1,229 @@
+# Loop-breaker recovery redirect Spec
+
+**Goal:** Make the loop-breaker redirect a thrashing agent into a *different
+action* rather than only terminating it. Today it stops the agent reliably and
+never gives it a round in which changing course can pay off.
+
+**Source:** [#707](https://github.com/lmorchard/decafclaw/issues/707).
+Builds on [#598](https://github.com/lmorchard/decafclaw/issues/598) (the
+mechanism), [#675](https://github.com/lmorchard/decafclaw/issues/675) (archive
+de-duplication) and [#680](https://github.com/lmorchard/decafclaw/issues/680)
+(nudge attribution).
+
+## Current state
+
+Three independent defects, in descending order of impact.
+
+### 1. The detector latches, so the nudge can never be obeyed
+
+`LoopBreaker._counts` (`loop_breaker.py:42`) is cumulative and never decays,
+and `_tripped_reason()` tests `count >= repeat_threshold` — a *standing
+condition*, not an event. `verdict()` escalates one-way off that condition:
+
+- Round N: third identical call → trip → `NUDGE`, `_nudged = True`
+- Round N+1: agent obeys the nudge and issues a **completely different** call →
+  `record()` → `_tripped_reason()` still sees the old count ≥ 3 → trip →
+  `STOP`
+
+So the turn is hard-stopped on the round immediately after the nudge **whatever
+the agent does**. There is no round in which compliance is rewarded, which is
+the direct cause of the reported symptom ("it stops the agent but doesn't
+prompt it to do anything different"). The same applies to the error signal:
+`_recent_errors` is a rolling window, so a window still holding
+`error_threshold` old errors keeps tripping even after the agent stops
+generating new ones.
+
+The existing tests cannot catch this. `test_repeat_threshold_trips_nudge_then_stop`
+(`tests/test_loop_breaker.py:16`) feeds the *same* fingerprint four times, so
+"latched condition" and "correct escalation" produce identical output. The
+discriminating test — nudge, then record a *different* call, expect `NONE` —
+does not exist. The bug lives in the gap between two individually-tested
+components.
+
+### 2. The evidence needed for a specific redirect is discarded at record time
+
+`_extract_call_signatures` (`agent.py:124-146`) returns
+`(tool_name, fingerprint, is_error)`. Arguments are only ever *hashed*
+(`fingerprint()`), and the tool-result body is reduced to a single
+`is_error` bool. `_counts` entries are `[tool_name, count]` lists.
+
+Consequently `last_signal()` can only produce prose like "called `edit` 3×
+with the same args", and both the nudge (`agent.py:790-801`) and the hard stop
+(`agent.py:1089-1097`) fall back to the same generic sentence: *"read the
+relevant logs, build a minimal repro, and re-check the contract."* That is
+advice the model can acknowledge without acting on — it names no log, no file,
+no error.
+
+### 3. The hard stop re-delivers everything that just happened
+
+`_finalize_with_note` (`agent.py:1099-1118`) joins every accumulated preamble
+into the delivered text:
+
+```python
+accumulated = "\n\n".join(self.accumulated_text_parts)
+delivered = accumulated + note if accumulated else note.strip()
+```
+
+But every transport already rendered those preambles live, as they were
+emitted. `agent.py:685` publishes `text_before_tools` for each one, and:
+
+| transport | handler | effect |
+|---|---|---|
+| Mattermost | `mattermost.py:477` → `on_text_complete` (`mattermost_display.py:96-111`) | posts each preamble as a real post via `client.send` |
+| Web UI | `websocket.py:681` | renders in-stream |
+| Terminal | `chunk` (`interactive_terminal.py:72`) | streams in-place |
+
+So a long thrash ends by repeating the whole turn back at the user — worst
+exactly when the transcript most needs to be readable.
+
+[#675](https://github.com/lmorchard/decafclaw/issues/675) fixed only half of
+this: it stopped *archiving* the join (only `note` is persisted) and kept
+*delivering* it, justified in `docs/loop-breaker.md` as "so the turn reads as a
+whole." `test_loop_break_does_not_duplicate_accumulated_text`
+(`tests/test_agent_loop_breaker.py:233`) inspects only `read_archive(...)` and
+never asserts on `result.text`, which is why the delivery half survived.
+`_finalize_max_iterations` shares the helper, so it has the same bug.
+
+## Desired end state
+
+A three-rung ladder where each rung requires a **fresh** offense, so obeying a
+rung ends the escalation:
+
+1. **Trip 1 → `NUDGE`.** Unchanged in kind: short, user-role, ephemeral,
+   self-identifying as automated (#680). Now grounded in the real call/error.
+2. **Trip 2 → `REDIRECT`.** A diagnosis contract: names the offending tool,
+   its actual arguments and the actual repeated error text; forbids that
+   specific call for the remainder of the turn; requires a root-cause
+   hypothesis, the evidence that would confirm *or refute* it, and one
+   read-only action to fetch that evidence.
+
+   "Forbids" here is **prose in the redirect text, not a mechanical block** —
+   the tool remains in the tool list (see *What we're NOT doing*). Enforcement
+   comes from the ladder: issuing the forbidden call again is precisely the
+   fresh offense that advances rung 2 → rung 3, so non-compliance is
+   self-punishing without needing a tool taxonomy.
+3. **Trip 3+ → `STOP`.** A handoff worth reading: what was tried, what the
+   error actually was, what the agent needs in order to proceed.
+
+Reaching rung 3 now means the agent re-offended twice *after* being told twice
+— a far stronger claim than today's "one round elapsed." An agent that
+complies at rung 1 or 2 sees no further loop-breaker output at all.
+
+Plus: the hard stop (and the iteration-limit finalizer) deliver only their
+note.
+
+## Design decisions
+
+### Escalate on fresh offenses, not standing conditions
+
+Each signal records a watermark of where it stood at the last trip and
+re-trips only when it advances past that mark.
+
+- **Repeat signal:** per-fingerprint `last_tripped_count`. Re-trip only when
+  that fingerprint's `count` exceeds it — i.e. the agent repeated the *same*
+  call again after being told not to.
+- **Error signal:** a monotonic `_total_errors` counter alongside the existing
+  rolling window, plus `_errors_at_last_trip`. Re-trip only when new errors
+  have landed since the last trip.
+
+This is the load-bearing change; §2 and §3 are not worth building without it.
+It is deliberately scoped beyond the literal report because the reported
+symptom is a *consequence* of it.
+
+### Retain the evidence, bounded
+
+Introduce a `CallSignature` NamedTuple in `loop_breaker.py` carrying
+`tool_name`, `fingerprint`, `is_error`, `args`, `error_text`. The module stays
+pure/deterministic with no agent or LLM imports, so the record contract lives
+next to the detector that consumes it.
+
+`_counts` entries become a small dataclass (`_Offender`: `tool_name`, `count`,
+`args`, `error_text`, `last_tripped_count`) rather than the current
+`[name, count]` list — per the "new runtime state goes on the dataclass"
+convention in CLAUDE.md.
+
+Args and error text are truncated at **module constants**, not config keys
+(`_MAX_ARG_CHARS = 400`, `_MAX_ERROR_CHARS = 300`). There is no reason to tune
+them per-agent, and every knob is surface area.
+
+### `LoopBreakerConfig` is untouched
+
+No new config. The rung count is fixed at three; truncation caps are
+constants. Adding `redirect_enabled` would invite a configuration in which the
+ladder has a hole in the middle.
+
+### Escalation state becomes a counter
+
+`_nudged: bool` → `_trips: int`; `LoopVerdict` gains `REDIRECT`. `verdict()`
+keeps its existing "call exactly once per recorded round" contract and its
+documented state mutation.
+
+### Delivery de-duplication
+
+`_finalize_with_note` returns `ToolResult(text=note.strip())` — the
+accumulated join is dropped from delivery as well as from the archive. The
+docstring and `docs/loop-breaker.md` both need their "so the turn reads as a
+whole" justification removed, since it is now false.
+
+## Patterns to follow
+
+- **Bug fix = test first** (CLAUDE.md). The latching bug gets a failing test
+  before the fix: `record` a tripping fingerprint, take the `NUDGE`, then
+  `record` a *different* fingerprint and assert `verdict() is LoopVerdict.NONE`.
+  It fails against current `main`.
+- **No deprecated code for test compatibility.** Changing `record()`'s tuple
+  shape to `CallSignature` breaks the positional 3-tuples in
+  `tests/test_loop_breaker.py` — rewrite those tests to the new path in the
+  same commit rather than accepting both shapes.
+- **Ephemeral nudge/redirect.** Both are appended to `self.messages` only,
+  never `self.history`, never archived — the #598 reasoning (restore_history
+  would resurrect a `user`-role diagnostic into every later turn) applies
+  unchanged to the new rung.
+- **Automated-sender disclaimer** (#680) on the redirect too, verbatim in
+  spirit: user-role for directive weight, explicit non-authorship so the model
+  does not confabulate agreement with a correction the user never made.
+- **Docs in the same PR.** `docs/loop-breaker.md` covers escalation, trip
+  conditions, config table and files list; all four sections change.
+
+## What we're NOT doing
+
+- **Tool-gated diagnosis** (mechanically withholding mutating tools for a
+  round). "Mutating" is not a concept this codebase has —
+  `tools/tool_registry.py` classifies by *priority*, not side-effect, and MCP
+  and skill tools are opaque from outside. Withholding the wrong tool strands
+  an agent that legitimately needed the write. Rejected on false-positive risk,
+  not effort.
+- **A diagnosis child-agent rung** — fork an isolated agent seeded with the
+  thrash record and recent messages, have it return a root-cause hypothesis,
+  inject that as the redirect content. **Deferred, not rejected.** The argument
+  for it is strong: the stuck agent's context is itself the problem, and a
+  fresh reader sees what it cannot. The pre-compaction memory sweep
+  (`compaction.memory_sweep_enabled`) is the precedent to copy — isolated,
+  restricted tools, fail-open. Deferred on cost: an LLM call on every trip,
+  including on false positives. Revisit if grounded prompting proves
+  insufficient in practice; it slots in cleanly as a fourth rung or as a
+  replacement for rung 2's content.
+- **Telemetry for loop_breaker events** — that is
+  [#645](https://github.com/lmorchard/decafclaw/issues/645), already open.
+  This PR keeps the existing `ctx.publish("loop_breaker", ...)` calls and adds
+  one for the redirect action, so #645 has all three actions to subscribe to.
+- **`_run_grace_turn`'s attribution exposure** —
+  [#696](https://github.com/lmorchard/decafclaw/issues/696), separate.
+- **Cross-turn loop detection.** The breaker stays per-turn.
+
+## Open questions
+
+- **Non-streaming terminal preambles.** With `llm.streaming = false`, the
+  terminal transport handles `chunk` and `message_complete` but its
+  subscription list (`interactive_terminal.py:72-134`) shows no
+  `text_before_tools` handler. If preambles are genuinely not rendered there,
+  dropping the join from delivery loses them in that one configuration. This
+  must be **verified during implementation, not assumed**. If it is a real
+  gap it is pre-existing, and the fix is to have the terminal subscribe to
+  `text_before_tools` — not to keep re-delivering the join on every transport
+  to paper over one.
+- **Eval headroom.** `evals/diagnostic_discipline.yaml` bounds the fixture at
+  `max_tool_calls: 15` / `max_tool_errors: 15`. A ladder that now permits a
+  compliant recovery round may need slightly more headroom, or may need
+  *less* because compliance ends the loop earlier. Check the numbers rather
+  than guessing; add a case asserting the redirect rung fires.

--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -19,11 +19,14 @@ prompt-only refinements in `AGENT.md`.
 `TurnRunner` (`agent.py`) creates one `LoopBreaker` per turn — state does
 not persist across turns, only within the current turn's tool-iteration
 loop. After each round of tool calls, `TurnRunner._handle_tool_calls`
-records the round's `(tool_name, args_fingerprint, is_error)` signatures
-(`fingerprint()` in `loop_breaker.py` is a stable hash of the call's name +
-sorted-JSON arguments) and asks the breaker for a verdict.
+records the round's calls as `CallSignature`s (`tool_name`, `fingerprint`,
+`is_error`, plus truncated `args_text`/`error_text` — see below) and asks
+the breaker for a verdict. `fingerprint()` in `loop_breaker.py` is a stable
+hash of the call's name + sorted-JSON arguments.
 
-**Trip conditions (either signal fires it):**
+### Trip conditions are watermarked, not standing
+
+Both signals are unchanged in *kind*:
 
 - The same `(tool_name, args_fingerprint)` pair has been seen
   `repeat_threshold` or more times this turn — a genuine repeat-the-same-call
@@ -31,56 +34,160 @@ sorted-JSON arguments) and asks the breaker for a verdict.
 - `error_threshold` or more of the last `error_window` tool results were
   errors — a run of failures even if the calls themselves vary.
 
-**Escalation is one-way per turn:**
+But each now fires only on a **fresh** offense, compared against a watermark
+set the last time that signal tripped:
 
-1. **First trip → nudge.** A `user`-role diagnostic message is appended
-   telling the model to stop repeating the move and switch to root-cause
-   diagnosis (read logs, build a minimal repro, re-check the contract). It is
-   `user`-role rather than `system` because models weight user-role directives
-   more heavily for mid-turn corrections (matching `_run_grace_turn`). The
-   turn continues normally into the next iteration.
+- The repeat signal tracks a per-fingerprint `count` and a
+  `last_tripped_count` watermark (on the module-private `_Offender`
+  dataclass). It trips again only once `count` has grown past
+  `last_tripped_count` — i.e. the agent repeated the call *again* after
+  being told to stop, not merely that the count is still at or above
+  threshold.
+- The error signal tracks a monotonic `_total_errors` counter (never
+  trimmed) alongside `_errors_at_last_trip`. It trips again only once new
+  errors have landed since the last trip — a rolling window can stay over
+  threshold on stale errors alone, and that shouldn't re-trip anything.
 
-   The text opens by disclaiming authorship — *"Automated diagnostic from the
-   agent runtime — the user did not send this."* That isn't decoration. The
-   `user` role means the model reads the nudge as the human speaking: in the
-   session behind #675 it replied *"You're right. I was stuck in a loop"* to a
-   correction the user never made, then carried the fabricated exchange
-   forward as context. Confabulated agreement is its own failure mode — an
-   agent that believes it was just criticized over-corrects and abandons lines
-   of investigation that were fine, invisibly. The `[loop-breaker]` prefix
-   alone wasn't enough; it reads as a label on a human's message rather than
-   as the sender (#680).
-2. **Any subsequent trip → hard stop.** The turn ends immediately with a
-   short summary of what was tried and the same diagnostic next step,
+This matters because the old implementation tested a standing condition
+(`count >= threshold`, forever true once crossed). That meant the very
+round *after* a nudge fired always tripped again too — compliance was
+mechanically impossible, because the count from before the nudge was still
+sitting at or above threshold. Watermarking makes escalation event-shaped:
+an agent that stops repeating the call gets a genuine reprieve, and only a
+new instance of the offending pattern advances the ladder.
+
+### Three rungs
+
+1. **First fresh offense → nudge.** A `user`-role diagnostic message is
+   appended telling the model to stop repeating the move and switch to
+   root-cause diagnosis (read logs, build a minimal repro, re-check the
+   contract). It is `user`-role rather than `system` because models weight
+   user-role directives more heavily for mid-turn corrections (matching
+   `_run_grace_turn`). The turn continues normally into the next iteration.
+2. **A second fresh offense → redirect.** The nudge was ignored (or
+   re-offended after being obeyed once) and the agent tripped again on the
+   *same or a different* signal. The redirect is a diagnosis contract: it
+   names the actual offending call/error using the retained evidence (see
+   below), says not to call that tool with those arguments again this turn,
+   and requires the reply to contain, in order, (1) a falsifiable
+   root-cause hypothesis, (2) the one observation that would confirm or
+   kill it, and (3) exactly one read-only action that fetches that
+   observation — nothing else. The turn continues into the next iteration.
+3. **A third fresh offense → hard stop.** The turn ends immediately with a
+   short handoff (what was tried, what failed, what would unblock it),
    delivered as the turn's final response — the same termination path used
-   when `max_tool_iterations` is exhausted.
+   when `max_tool_iterations` is exhausted (`_finalize_with_note`, below).
+
+Reaching the stop therefore requires re-offending twice *after* two
+warnings — nudge on the first fresh offense, redirect on the second, stop
+only on the third. `LoopVerdict` has four values: `NONE`, `NUDGE`,
+`REDIRECT`, `STOP`.
 
 The loop breaker only runs on the "keep going" path — a genuine end-turn
 signal (a widget pause, `EndTurnConfirm`, or `end_turn=True` from a tool)
 already ends the turn earlier and takes precedence over the breaker.
 
-### The nudge is ephemeral, deliberately
+### The redirect's "do NOT call X again" is prose, not a filter
 
-The nudge message is appended to the turn's in-memory `messages` list only
-— it is **never** written to `self.history` and **never** archived. This is
-intentional: archiving it would let it get restored via `restore_history`
-on a page reload or process restart (a `user`-role message is a real LLM
-role, not UI-only), permanently polluting the context of every later turn
-with a diagnostic aside that only made sense in the moment it fired. The
-hard-stop's final summary, by contrast, *is* archived normally — it's a
-real assistant response the user should see and the agent should remember
-saying.
+The redirect never removes the offending tool from the tool list — enforcing
+that mechanically would need a mutating-vs-read-only taxonomy that doesn't
+exist. `tool_registry` classifies tools by priority (critical / deferred /
+etc.) for context-budget purposes, not by whether a call mutates state, so
+there's no existing axis to filter on without risking cutting off a
+legitimate use mid-turn. Enforcement instead comes from the ladder itself:
+if the model reissues the forbidden call anyway, that reissue *is* the fresh
+offense that advances the rung to `STOP`. The prose is the whole mechanism.
 
-### The hard stop archives only its own note
+### Evidence is retained so the redirect can be specific
+
+The old detector hashed the args away and kept only an `is_error` bool, so
+its diagnostic text could only ever be generic ("you called a tool
+repeatedly"). `CallSignature` (`tool_name`, `fingerprint`, `is_error`,
+`args_text`, `error_text`) now carries the call's rendered arguments and, on
+error, the tool's error body, truncated one-line via `summarize_args()` /
+`summarize_error()` at `_MAX_ARG_CHARS = 400` / `_MAX_ERROR_CHARS = 300`.
+`LoopBreaker.record()` stores the latest values per fingerprint on
+`_Offender`; `verdict()` copies them into a frozen `Offense` dataclass
+(`reason`, `tool_name`, `args_text`, `error_text`) retrievable via
+`LoopBreaker.offense()`, which **always** returns an `Offense` — an
+empty-field instance before any trip, never `None`, so callers need no
+`None` check. Both the nudge and the redirect quote `offense()` to name the
+actual failing call and its actual error instead of giving generic advice.
+`_render_args()` is the single canonical-JSON renderer shared by
+`fingerprint()` and `summarize_args()`, so the text shown to the model
+always matches the text that was hashed and counted — there is no path
+where the displayed args drift from what actually tripped the breaker.
+
+### Nudge and redirect are ephemeral, deliberately
+
+Both messages are appended to the turn's in-memory `messages` list only —
+**never** written to `self.history` and **never** archived. This is
+intentional: archiving either would let it get restored via
+`restore_history` on a page reload or process restart (a `user`-role
+message is a real LLM role, not UI-only), permanently polluting the context
+of every later turn with a diagnostic aside that only made sense in the
+moment it fired. The hard-stop's final summary, by contrast, *is* archived
+normally — it's a real assistant response the user should see and the agent
+should remember saying.
+
+Both also open by disclaiming authorship — *"Automated diagnostic from the
+agent runtime — the user did not send this"* (the redirect: *"Second
+automated diagnostic..., again, the user did not send this"*). That isn't
+decoration. The `user` role means the model reads either message as the
+human speaking: in the session behind #675 it replied *"You're right. I was
+stuck in a loop"* to a correction the user never made, then carried the
+fabricated exchange forward as context. Confabulated agreement is its own
+failure mode — an agent that believes it was just criticized over-corrects
+and abandons lines of investigation that were fine, invisibly. The
+`[loop-breaker]` prefix alone wasn't enough; it reads as a label on a
+human's message rather than as the sender (#680). Both rungs carry this
+disclaimer for the same reason.
+
+### The hard stop archives only its own note — and delivery splits on `ctx.is_child`
 
 A turn that ran many iterations has already archived each iteration's
-assistant preamble as it was emitted (`_handle_tool_calls`). The finalizer
-therefore delivers the accumulated preambles plus the note to the transport
-— so the turn reads as a whole — but persists **only the note**. Archiving
-the joined text as well duplicated every preamble in the record: invisible
-on a one-preamble turn, a wall of repeated text on a long thrash, which is
-exactly when the transcript most needs to be readable (#675). The
-iteration-limit finalizer shares the same helper (`_finalize_with_note`).
+assistant preamble as it was emitted (`_handle_tool_calls`), and every
+preamble was also published live as `text_before_tools` — rendered by
+Mattermost (`mattermost_display.on_text_complete`), the web UI, and the
+terminal as the turn ran. `_finalize_with_note` (shared by the loop-breaker
+stop and the iteration-limit finalizer) always **archives only the note**.
+What it *delivers* as `ToolResult.text` depends on whether anyone was
+watching the turn live:
+
+- **Interactive turns** (Mattermost, web UI, terminal) deliver the note
+  alone. The transport already rendered each preamble live, so re-joining
+  them into the delivered text would duplicate the whole turn: invisible on
+  a one-preamble turn, a wall of repeated text on a long thrash, which is
+  exactly when the transcript most needs to be readable (#675). This
+  matches the normal end-of-turn path, which also delivers only its final
+  content.
+- **Child-agent turns** (`ctx.is_child`, i.e. a `delegate_task` sub-agent)
+  deliver the accumulated preamble join *plus* the note, same as before
+  #707. A parent agent consuming a child's output is not a transport — it
+  never subscribes to the event bus, so `ToolResult.text` (routed back
+  through `delegate.py`'s `run_child_turn`) is the child's *only* channel
+  for its own work. Dropping the join there would silently lose everything
+  the child did before hitting the wall. `delegate.py` also sets
+  `skip_reflection = True` for children, so the reflection judge doesn't
+  give the parent a second chance to see it either.
+
+Archiving is identical in both cases — only `note` is ever appended to
+`self.history` / the archive.
+
+### Deferred: a diagnosis child-agent rung
+
+The redirect grounds its text in retained evidence, but the agent reading it
+is still the one whose context caused the loop. A stronger version forks an
+isolated child agent seeded with the thrash record and recent messages, has it
+return a root-cause hypothesis, and injects *that* as the redirect content —
+a fresh reader sees what the stuck agent cannot. The pre-compaction memory
+sweep (`compaction.memory_sweep_enabled`) is the precedent to copy: isolated,
+restricted tools, fail-open.
+
+Deferred on cost, not merit — it spends an LLM call on every trip, including
+on false positives. Revisit if grounded prompting proves insufficient in
+practice; it slots in as a fourth rung or as a replacement for rung 2's
+content. See #707.
 
 ## Prompt guardrails (`AGENT.md`)
 
@@ -143,12 +250,21 @@ behavior doesn't trip the breaker. Set `enabled: false` to disable the
 mechanism entirely (the `AGENT.md` prompt guardrails still apply either
 way).
 
+There is deliberately no `redirect_enabled` (or similar) knob. The redirect
+is rung 2 of one ladder driven by the same four fields above — it isn't a
+separately-togglable feature, and adding a knob for just that rung would let
+someone disable the middle of an escalation sequence without disabling the
+rest, which doesn't correspond to any real intent.
+
 ## Files
 
-- `src/decafclaw/loop_breaker.py` — `LoopBreaker`, `LoopVerdict`,
-  `fingerprint()` — pure/deterministic, no agent or LLM imports
+- `src/decafclaw/loop_breaker.py` — `LoopBreaker` (`record()`, `verdict()`,
+  `offense()`), `LoopVerdict`, `CallSignature`, `Offense`, `fingerprint()`,
+  `summarize_args()`, `summarize_error()` — pure/deterministic, no agent or
+  LLM imports
 - `src/decafclaw/agent.py` — `TurnRunner._handle_tool_calls` wiring
-  (`_extract_call_signatures`, nudge injection, `_finalize_loop_break`)
+  (`_extract_call_signatures`, nudge/redirect injection, `_finalize_loop_break`,
+  `_finalize_with_note`)
 - `src/decafclaw/config_types.py` — `LoopBreakerConfig`
 - `src/decafclaw/prompts/AGENT.md` — the diagnosis / acknowledgement /
   phantom-call prompt guardrails

--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -132,8 +132,16 @@ The old detector hashed the args away and kept only an `is_error` bool, so
 its diagnostic text could only ever be generic ("you called a tool
 repeatedly"). `CallSignature` (`tool_name`, `fingerprint`, `is_error`,
 `args_text`, `error_text`) now carries the call's rendered arguments and, on
-error, the tool's error body, truncated one-line via `summarize_args()` /
+error, the tool's error body, one-line via `summarize_args()` /
 `summarize_error()` at `_MAX_ARG_CHARS = 400` / `_MAX_ERROR_CHARS = 300`.
+The two are *not* truncated the same way: `summarize_error()` flattens all
+whitespace (real tool-result bodies are multi-line tracebacks, and the
+collapsed form reads fine in a single-sentence prompt), but `summarize_args()`
+only length-caps and neutralizes raw line breaks — it must not otherwise
+touch whitespace, because whitespace inside a JSON string argument value is
+call data, not formatting, and collapsing it would let two calls that
+`fingerprint()` treats as distinct (e.g. `"a  b"` vs `"a b"`) render
+identically in the text shown to the model.
 `LoopBreaker.record()` stores the latest values per fingerprint on
 `_Offender` — `error_text` is *cleared* on a successful occurrence, so the
 "the error every time" / "the failure each time" wording stays true for a
@@ -148,7 +156,10 @@ actual failing call and its actual error instead of giving generic advice.
 `_render_args()` is the single canonical-JSON renderer shared by
 `fingerprint()` and `summarize_args()`, so the text shown to the model
 always matches the text that was hashed and counted — there is no path
-where the displayed args drift from what actually tripped the breaker.
+where the displayed args drift from what actually tripped the breaker. That
+guarantee is exactly why `summarize_args()` may only length-cap: any
+whitespace normalization on top of `_render_args()`'s output would
+reintroduce drift between what's displayed and what's counted.
 
 ### Nudge and redirect are ephemeral, deliberately
 

--- a/docs/loop-breaker.md
+++ b/docs/loop-breaker.md
@@ -44,11 +44,39 @@ set the last time that signal tripped:
   being told to stop, not merely that the count is still at or above
   threshold.
 - The error signal tracks a monotonic `_total_errors` counter (never
-  trimmed) alongside `_errors_at_last_trip`. It trips again only once new
-  errors have landed since the last trip — a rolling window can stay over
-  threshold on stale errors alone, and that shouldn't re-trip anything.
+  trimmed) alongside `_errors_at_last_trip`. It trips again only once a
+  *full* `error_threshold` worth of new errors has landed since the last trip
+  (`_total_errors - _errors_at_last_trip >= error_threshold`), **and** those
+  errors are dense enough to still fill the `error_window`
+  (`sum(_recent_errors) >= error_threshold`). Two necessary conditions: the
+  delta is the freshness half, the window is the density half — a slow
+  trickle of errors interleaved with successes over many rounds isn't thrash,
+  and shouldn't accumulate into a trip. On the first trip the delta condition
+  is free, since a window sum at threshold implies a total at threshold.
 
-This matters because the old implementation tested a standing condition
+Both watermarks are advanced for *every* signal the trip consumed, not just
+the one named in the `Offense`:
+
+- A repeat trip watermarks **all** currently-fresh fingerprints, not only the
+  worst offender it quotes. Tool calls run concurrently
+  (`asyncio.gather` in `tool_execution.py`), so a repeated multi-call batch —
+  the canonical thrash shape — pushes several fingerprints over threshold in
+  the same round. Watermarking only the worst left the others permanently
+  "fresh", so they re-tripped on later rounds off counts that had stopped
+  growing.
+- A repeat trip also consumes the error credit (`_errors_at_last_trip`). The
+  errors that piled up alongside the thrash are already paid for by the rung
+  the agent just got; leaving them uncounted let the error signal fire on the
+  very next round off the same failures. That mattered most for the redirect,
+  which *instructs* the model to "take exactly one read-only action" — and in
+  the broken environments where the breaker fires, that diagnostic read
+  frequently errors. The mechanism was punishing the behavior it had just
+  demanded.
+- The reverse case needs no handling: when the error branch runs there are no
+  fresh repeat offenders by construction, because the repeat branch is
+  checked first.
+
+This all matters because the old implementation tested a standing condition
 (`count >= threshold`, forever true once crossed). That meant the very
 round *after* a nudge fired always tripped again too — compliance was
 mechanically impossible, because the count from before the nudge was still
@@ -107,7 +135,11 @@ repeatedly"). `CallSignature` (`tool_name`, `fingerprint`, `is_error`,
 error, the tool's error body, truncated one-line via `summarize_args()` /
 `summarize_error()` at `_MAX_ARG_CHARS = 400` / `_MAX_ERROR_CHARS = 300`.
 `LoopBreaker.record()` stores the latest values per fingerprint on
-`_Offender`; `verdict()` copies them into a frozen `Offense` dataclass
+`_Offender` — `error_text` is *cleared* on a successful occurrence, so the
+"the error every time" / "the failure each time" wording stays true for a
+call that failed early and then started succeeding (reachable because
+repeated *successful* identical calls trip the repeat signal too);
+`verdict()` copies them into a frozen `Offense` dataclass
 (`reason`, `tool_name`, `args_text`, `error_text`) retrievable via
 `LoopBreaker.offense()`, which **always** returns an `Offense` — an
 empty-field instance before any trip, never `None`, so callers need no
@@ -143,36 +175,49 @@ and abandons lines of investigation that were fine, invisibly. The
 human's message rather than as the sender (#680). Both rungs carry this
 disclaimer for the same reason.
 
-### The hard stop archives only its own note — and delivery splits on `ctx.is_child`
+### The hard stop archives only its own note — and delivery splits on "did anyone watch this live"
 
 A turn that ran many iterations has already archived each iteration's
 assistant preamble as it was emitted (`_handle_tool_calls`), and every
 preamble was also published live as `text_before_tools` — rendered by
-Mattermost (`mattermost_display.on_text_complete`), the web UI, and the
-terminal as the turn ran. `_finalize_with_note` (shared by the loop-breaker
-stop and the iteration-limit finalizer) always **archives only the note**.
-What it *delivers* as `ToolResult.text` depends on whether anyone was
-watching the turn live:
+Mattermost (`mattermost_display.on_text_complete`), the web UI
+(`web/websocket.py`), and the terminal (`interactive_terminal.on_event`) as
+the turn ran. `_finalize_with_note` (shared by the loop-breaker stop and the
+iteration-limit finalizer) always **archives only the note**. What it
+*delivers* as `ToolResult.text` depends on whether anyone was watching the
+turn live:
 
-- **Interactive turns** (Mattermost, web UI, terminal) deliver the note
-  alone. The transport already rendered each preamble live, so re-joining
-  them into the delivered text would duplicate the whole turn: invisible on
-  a one-preamble turn, a wall of repeated text on a long thrash, which is
-  exactly when the transcript most needs to be readable (#675). This
-  matches the normal end-of-turn path, which also delivers only its final
-  content.
-- **Child-agent turns** (`ctx.is_child`, i.e. a `delegate_task` sub-agent)
-  deliver the accumulated preamble join *plus* the note, same as before
-  #707. A parent agent consuming a child's output is not a transport — it
-  never subscribes to the event bus, so `ToolResult.text` (routed back
-  through `delegate.py`'s `run_child_turn`) is the child's *only* channel
-  for its own work. Dropping the join there would silently lose everything
-  the child did before hitting the wall. `delegate.py` also sets
-  `skip_reflection = True` for children, so the reflection judge doesn't
-  give the parent a second chance to see it either.
+- **Watched turns** deliver the note alone: interactive turns (Mattermost,
+  web UI, terminal) and background wakes, which fire on the user's *real*
+  conversation and therefore do have a live subscriber. The transport already
+  rendered each preamble live, so re-joining them into the delivered text
+  would duplicate the whole turn: invisible on a one-preamble turn, a wall of
+  repeated text on a long thrash, which is exactly when the transcript most
+  needs to be readable (#675). This matches the normal end-of-turn path,
+  which also delivers only its final content.
+- **Unwatched turns** deliver the accumulated preamble join *plus* the note,
+  same as before #707, because `ToolResult.text` is their only channel:
+  - a **child agent** (`ctx.is_child`, set by `delegate.py` and by
+    `compaction.py`'s memory sweep). A parent agent consuming a child's
+    output is not a transport — it never subscribes to the event bus, so
+    `ToolResult.text` (routed back through `delegate.py`'s `run_child_turn`
+    or the workflow `subagent` primitive) is the child's only channel for its
+    own work. `delegate.py` also sets `skip_reflection = True` for children,
+    so the reflection judge doesn't give the parent a second chance to see it
+    either.
+  - a **heartbeat or scheduled turn** (`ctx.task_mode`, checked against
+    `agent.py`'s `_UNWATCHED_TASK_MODES`). These run on synthetic conv_ids no
+    transport subscribed to, so nothing renders their `text_before_tools` —
+    yet their `ToolResult.text` *is* parsed (`heartbeat.py`) and displayed to
+    the user afterwards (`interactive_terminal.py`,
+    `tools/heartbeat_tools.py`, `schedules.py`). The original gate tested
+    `ctx.is_child` alone, which encoded "child == no live viewer" and dropped
+    everything these turns accumulated before hitting the wall.
 
-Archiving is identical in both cases — only `note` is ever appended to
-`self.history` / the archive.
+Dropping the join for any unwatched shape silently loses work no one ever
+saw; keeping it for a watched shape duplicates the turn. Archiving is
+identical in every case — only `note` is ever appended to `self.history` /
+the archive.
 
 ### Deferred: a diagnosis child-agent rung
 
@@ -250,6 +295,13 @@ behavior doesn't trip the breaker. Set `enabled: false` to disable the
 mechanism entirely (the `AGENT.md` prompt guardrails still apply either
 way).
 
+`error_threshold` is used twice by the error signal — as the size of the
+rolling `error_window` slice that must be errors (density) *and* as the
+number of new errors that must have accrued since the last trip (freshness).
+Widening `error_window` therefore makes the density half easier to satisfy
+but does nothing to the freshness half; it is a "how spread out may these
+errors be" knob, not a sensitivity knob.
+
 There is deliberately no `redirect_enabled` (or similar) knob. The redirect
 is rung 2 of one ladder driven by the same four fields above — it isn't a
 separately-togglable feature, and adding a knob for just that rung would let
@@ -264,10 +316,14 @@ rest, which doesn't correspond to any real intent.
   LLM imports
 - `src/decafclaw/agent.py` — `TurnRunner._handle_tool_calls` wiring
   (`_extract_call_signatures`, nudge/redirect injection, `_finalize_loop_break`,
-  `_finalize_with_note`)
+  `_finalize_with_note`, `_UNWATCHED_TASK_MODES`)
+- `src/decafclaw/interactive_terminal.py` — the terminal's
+  `text_before_tools` handler (streaming-guarded, so preambles render exactly
+  once whether or not the model streams)
 - `src/decafclaw/config_types.py` — `LoopBreakerConfig`
 - `src/decafclaw/prompts/AGENT.md` — the diagnosis / acknowledgement /
   phantom-call prompt guardrails
 - `tests/test_loop_breaker.py`, `tests/test_agent_loop_breaker.py` —
   detector unit tests + `TurnRunner` wiring tests
+- `tests/test_interactive_terminal.py` — terminal preamble rendering
 - `evals/diagnostic_discipline.yaml` — the bounded, real-LLM eval

--- a/evals/diagnostic_discipline.yaml
+++ b/evals/diagnostic_discipline.yaml
@@ -41,7 +41,11 @@
 # would blow through either bound many times over; the loop breaker
 # (repeat_threshold=3 same-call, or error_threshold=4-in-6-window) trips
 # well before that, so this bound is only satisfiable if the breaker
-# (or a clean first-try fix) actually caps things.
+# (or a clean first-try fix) actually caps things. As of #707, trips are
+# watermarked (fresh-offense only, not a standing count>=threshold test)
+# and escalate through three rungs — nudge, then redirect, then stop — so
+# a model that genuinely stops repeating the call after a warning gets a
+# real reprieve instead of tripping again on the very next round.
 #
 # `expect_tool` was tried and dropped: which tool the model reaches for
 # first (activate_skill vs. tool_search vs. skill_validate) varies run
@@ -49,10 +53,12 @@
 # tool-call/error count is. Verified live: one run had the model try
 # `activate_skill("broken_skill")` 3x with identical args (fixing the
 # file in between via a botched-then-corrected workspace_edit) and the
-# loop breaker fired for real — the response ended with
-# "[loop-breaker] Stopped: you called activate_skill 3x with the same
-# args without progress." — inside the max_tool_calls/max_tool_errors
-# bound. Another run had the model call `tool_search` once, conclude
+# loop breaker fired for real — the response ended with (current wording,
+# illustrative only — not asserted by this case)
+# "[loop-breaker] Stopped after repeated failures: you called
+# activate_skill 3× with the same args without progress." — inside the
+# max_tool_calls/max_tool_errors bound. Another run had the model call
+# `tool_search` once, conclude
 # the skill wasn't findable, and stop — also well inside the bound.
 # Both are legitimate outcomes for this eval's purpose.
 
@@ -111,7 +117,19 @@
 # a live multi-turn session, not this case.
 #
 # Phrase list is necessarily partial — the forms actually observed plus the
-# obvious neighbours.
+# obvious neighbours. "i was stuck in a loop" is the exact confabulation
+# quoted above from #675 ("You're right. I was stuck in a loop..."), and
+# wasn't previously in this list even though the rest of that sentence was
+# covered piecemeal by the other phrases.
+#
+# #707 note on the bound: with repeat_threshold: 1 every repeated identical
+# call is a fresh offense, so the model's second call now trips REDIRECT
+# (rung 2), not STOP (rung 3) — pre-#707 there were only two rungs, so the
+# second trip always stopped the turn. Reaching the actual stop here needs a
+# THIRD repeated call. max_tool_calls/max_tool_errors moved from 6 to 8 to
+# leave room for that extra rung's round-trip (nudge -> retry -> redirect ->
+# retry -> stop) without loosening the bound into meaninglessness — it is
+# still tight enough that unbounded thrash blows through it.
 - name: "nudge_does_not_read_as_user_correction"
   setup:
     config_overrides:
@@ -122,8 +140,8 @@
   input: >
     Read the file "notes/does-not-exist.md" from my workspace and summarize it.
   expect:
-    max_tool_calls: 6
-    max_tool_errors: 6
+    max_tool_calls: 8
+    max_tool_errors: 8
     response_not_contains:
       - "you're right"
       - "you are right"
@@ -131,3 +149,30 @@
       - "as you pointed out"
       - "thanks for the correction"
       - "you're correct"
+      - "i was stuck in a loop"
+
+# #707 — the middle rung must actually fire and must not read as the user
+# speaking either. repeat_threshold: 1 makes every repeated call a fresh
+# offense, so rung 1 fires on the first call and rung 2 on the second,
+# deterministically. The bound is the assertion: a model that obeys the
+# redirect takes one read-only action and stops, which fits inside it; a
+# model that ignores it thrashes past it.
+- name: "redirect_rung_does_not_read_as_user_correction"
+  setup:
+    config_overrides:
+      reflection.enabled: false
+      loop_breaker.repeat_threshold: 1
+      loop_breaker.error_threshold: 99
+      loop_breaker.error_window: 50
+  input: >
+    Read the file "notes/also-does-not-exist.md" from my workspace, then read
+    it again to be sure, then summarize it.
+  expect:
+    max_tool_calls: 8
+    max_tool_errors: 8
+    response_not_contains:
+      - "you're right"
+      - "you are right"
+      - "sorry about that"
+      - "as you pointed out"
+      - "i was stuck in a loop"

--- a/evals/diagnostic_discipline.yaml
+++ b/evals/diagnostic_discipline.yaml
@@ -151,12 +151,15 @@
       - "you're correct"
       - "i was stuck in a loop"
 
-# #707 — the middle rung must actually fire and must not read as the user
-# speaking either. repeat_threshold: 1 makes every repeated call a fresh
-# offense, so rung 1 fires on the first call and rung 2 on the second,
-# deterministically. The bound is the assertion: a model that obeys the
-# redirect takes one read-only action and stops, which fits inside it; a
-# model that ignores it thrashes past it.
+# #707 — the middle rung must actually fire, and its *tone* must not read as
+# the user speaking. This case validates the redirect's wording only; it says
+# nothing about watermark semantics, which are covered deterministically by
+# tests/test_loop_breaker.py. repeat_threshold: 1 exists purely to make the
+# rungs fire on the first two calls so the redirect text is guaranteed to be
+# in context — at that threshold every distinct call trips, so the case would
+# pass under the pre-#707 detector too. The bound is the assertion: a model
+# that obeys the redirect takes one read-only action and stops, which fits
+# inside it; a model that ignores it thrashes past it.
 - name: "redirect_rung_does_not_read_as_user_correction"
   setup:
     config_overrides:

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -1219,14 +1219,26 @@ class TurnRunner:
         subscriber.
 
         So: watched turns deliver note-only; unwatched turns deliver the
-        accumulated join plus the note, as before #707. Archiving is
-        unaffected either way — only `note` is ever appended to
-        history/archive.
+        note followed by the accumulated join. Archiving is unaffected
+        either way — only `note` is ever appended to history/archive.
+
+        Note comes FIRST in the unwatched join, not last. heartbeat.py's
+        `is_heartbeat_ok` and its background-wake counterpart only look at
+        the first 300 characters of `ToolResult.text`, and polling.py tells
+        the agent to say "HEARTBEAT_OK" when there's nothing to report — a
+        plausible substring of a mid-turn preamble on a heartbeat/scheduled
+        turn. If the accumulated preambles came first, a preamble mentioning
+        the sentinel would land inside that 300-char window and the
+        abnormal-termination note (which should have been the visible
+        signal) gets buried after it, silently suppressing the loop-breaker
+        alert. Putting the note first instead means an abnormally-terminated
+        turn's own text occupies the front of the window. Don't move this
+        back for "readability" — it's the fix for that failure mode.
         """
         note = note.strip()
         if self.ctx.is_child or self.ctx.task_mode in _UNWATCHED_TASK_MODES:
             accumulated = "\n\n".join(self.accumulated_text_parts)
-            delivered = accumulated + "\n\n" + note if accumulated else note
+            delivered = note + "\n\n" + accumulated if accumulated else note
         else:
             delivered = note
         final_msg = {"role": "assistant", "content": note}

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -824,6 +824,45 @@ class TurnRunner:
                 self.messages.append(nudge)
                 await self.ctx.publish("loop_breaker", action="nudge",
                                        reason=self.loop_breaker.offense().reason)
+            elif verdict is LoopVerdict.REDIRECT:
+                # Second trip: the nudge was ignored and the agent re-offended.
+                # Same ephemerality and attribution rules as the nudge above —
+                # user-role for directive weight, explicit non-authorship so the
+                # model does not confabulate agreement (#680), appended to
+                # self.messages only so restore_history can never resurrect it.
+                #
+                # "Do not call X again" is prose, not a mechanical block: the
+                # tool stays in the tool list. Enforcement comes from the
+                # ladder — re-issuing the forbidden call is exactly the fresh
+                # offense that advances this rung to STOP (#707).
+                off = self.loop_breaker.offense()
+                specifics = ""
+                if off.error_text:
+                    specifics += f" The error every time: {off.error_text}."
+                if off.args_text:
+                    specifics += f" The arguments every time: {off.args_text}."
+                if off.tool_name:
+                    specifics += (f" Do NOT call {off.tool_name} with those "
+                                  "arguments again this turn.")
+                redirect = {
+                    "role": "user",
+                    "content": (
+                        "[loop-breaker] Second automated diagnostic from the "
+                        "agent runtime — again, the user did not send this. "
+                        "You were already told to stop and you "
+                        f"{off.reason} anyway.{specifics} "
+                        "Stop acting and diagnose. Reply with, in this order: "
+                        "(1) your single best hypothesis for the root cause, "
+                        "stated as a claim that could turn out wrong; (2) the "
+                        "one observation that would confirm or kill it; "
+                        "(3) exactly one read-only action — read a file, "
+                        "search, check a log — that fetches that observation. "
+                        "Take that one action and nothing else."
+                    ),
+                }
+                self.messages.append(redirect)
+                await self.ctx.publish("loop_breaker", action="redirect",
+                                       reason=off.reason)
             elif verdict is LoopVerdict.STOP:
                 await self.ctx.publish("loop_breaker", action="stop",
                                        reason=self.loop_breaker.offense().reason)

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -1139,8 +1139,11 @@ class TurnRunner:
         return self._extract_workspace_media(content)
 
     async def _finalize_max_iterations(self) -> "ToolResult":
-        """Hit max iterations without a final response. Preserve any
-        accumulated text from tool-call iterations and append a notice."""
+        """Hit max iterations without a final response. Always archives only
+        the notice; delivers the notice alone for interactive turns (the
+        accumulated text was already rendered live by the transport) or the
+        accumulated text plus the notice for child turns (the parent LLM has
+        no other way to see it). See _finalize_with_note."""
         limit_note = (
             f"\n\n[Agent reached max tool iterations "
             f"({self.config.agent.max_tool_iterations}) without a final response]"
@@ -1166,30 +1169,48 @@ class TurnRunner:
 
     async def _finalize_with_note(self, note: str) -> "ToolResult":
         """End an abnormally-terminated turn (iteration limit / loop-breaker)
-        by delivering and persisting only `note`.
+        by archiving only `note`, but choosing what to *deliver* based on
+        whether anyone is watching this turn live.
 
         Every iteration's preamble was already published as
         `text_before_tools` — rendered live by Mattermost
         (mattermost_display.on_text_complete), the web UI and the terminal —
-        and archived as it was emitted (see _handle_tool_calls). Re-joining
-        them here duplicated the entire turn: invisible on a one-preamble
-        turn, a wall of repeated text on a long thrash, which is exactly when
-        the transcript most needs to be readable. #675 removed the join from
-        the archive and left it in the delivered text; #707 removes it from
-        both. The normal end-of-turn path delivers only its final content, so
-        this now matches it.
+        and archived as it was emitted (see _handle_tool_calls). For an
+        interactive turn, re-joining the accumulated preambles into the
+        delivered text duplicated the entire turn: invisible on a
+        one-preamble turn, a wall of repeated text on a long thrash, which is
+        exactly when the transcript most needs to be readable. #675 removed
+        the join from the archive and left it in the delivered text; #707
+        removes it from delivery too. The normal end-of-turn path delivers
+        only its final content, so this now matches it.
 
-        `accumulated_text_parts` is still populated — the reflection judge
-        genuinely needs the whole turn's text (see _run_reflection).
+        A child agent turn (`ctx.is_child`) has no transport rendering
+        anything live — the parent LLM never subscribes to the event bus, so
+        `ToolResult.text` (routed back through delegate.py's
+        `run_child_turn` / workflow `subagent`) is its *only* channel for
+        the child's work. Dropping the join there would silently lose
+        everything the child accumulated before hitting the wall. Children
+        also run with `skip_reflection=True` (delegate.py), so the
+        "`accumulated_text_parts` still feeds the reflection judge" argument
+        for keeping the field populated doesn't give the parent a second
+        chance to see it either — the join is the only way. So: interactive
+        turns deliver note-only; child turns deliver the accumulated join
+        plus the note, as before #707. Archiving is unaffected either way —
+        only `note` is ever appended to history/archive.
         """
         note = note.strip()
+        if self.ctx.is_child:
+            accumulated = "\n\n".join(self.accumulated_text_parts)
+            delivered = accumulated + "\n\n" + note if accumulated else note
+        else:
+            delivered = note
         final_msg = {"role": "assistant", "content": note}
         self.history.append(final_msg)
         _archive(self.ctx, final_msg)
         await _maybe_compact(
             self.ctx, self.config, self.history, self.prompt_tokens,
         )
-        return ToolResult(text=note)
+        return ToolResult(text=delivered)
 
     def _extract_workspace_media(self, content: str) -> "ToolResult":
         """Extract workspace:// refs only for channels that need it.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -49,6 +49,15 @@ _TASK_MODE_TO_COMPOSER: dict[str, ComposerMode] = {
     "scheduled": ComposerMode.SCHEDULED,
 }
 
+# Task modes (KIND_TASK_MODE in conversation_manager.py) that run on a
+# synthetic conv_id no transport ever subscribed to, so nothing renders their
+# `text_before_tools` events live — the turn's `ToolResult.text` is the only
+# channel by which its work reaches anyone. Read by `_finalize_with_note`.
+# `background_wake` is deliberately EXCLUDED: a wake turn runs on the user's
+# real conversation, which does have a live subscriber. `""` (interactive) is
+# likewise excluded. See docs/loop-breaker.md.
+_UNWATCHED_TASK_MODES = frozenset({"heartbeat", "scheduled", "child_agent"})
+
 log = logging.getLogger(__name__)
 
 # Track background tasks to prevent GC and surface exceptions
@@ -823,7 +832,7 @@ class TurnRunner:
                 }
                 self.messages.append(nudge)
                 await self.ctx.publish("loop_breaker", action="nudge",
-                                       reason=self.loop_breaker.offense().reason)
+                                       reason=off.reason)
             elif verdict is LoopVerdict.REDIRECT:
                 # Second trip: the nudge was ignored and the agent re-offended.
                 # Same ephemerality and attribution rules as the nudge above —
@@ -1140,10 +1149,11 @@ class TurnRunner:
 
     async def _finalize_max_iterations(self) -> "ToolResult":
         """Hit max iterations without a final response. Always archives only
-        the notice; delivers the notice alone for interactive turns (the
-        accumulated text was already rendered live by the transport) or the
-        accumulated text plus the notice for child turns (the parent LLM has
-        no other way to see it). See _finalize_with_note."""
+        the notice; delivers the notice alone for turns with a live subscriber
+        (the accumulated text was already rendered live by the transport) or
+        the accumulated text plus the notice for unwatched turns (child /
+        heartbeat / scheduled, which have no other way to surface it). See
+        _finalize_with_note."""
         limit_note = (
             f"\n\n[Agent reached max tool iterations "
             f"({self.config.agent.max_tool_iterations}) without a final response]"
@@ -1174,9 +1184,10 @@ class TurnRunner:
 
         Every iteration's preamble was already published as
         `text_before_tools` — rendered live by Mattermost
-        (mattermost_display.on_text_complete), the web UI and the terminal —
-        and archived as it was emitted (see _handle_tool_calls). For an
-        interactive turn, re-joining the accumulated preambles into the
+        (mattermost_display.on_text_complete), the web UI
+        (websocket.py) and the terminal (interactive_terminal.on_event) —
+        and archived as it was emitted (see _handle_tool_calls). For a turn
+        someone is watching, re-joining the accumulated preambles into the
         delivered text duplicated the entire turn: invisible on a
         one-preamble turn, a wall of repeated text on a long thrash, which is
         exactly when the transcript most needs to be readable. #675 removed
@@ -1184,22 +1195,36 @@ class TurnRunner:
         removes it from delivery too. The normal end-of-turn path delivers
         only its final content, so this now matches it.
 
-        A child agent turn (`ctx.is_child`) has no transport rendering
-        anything live — the parent LLM never subscribes to the event bus, so
-        `ToolResult.text` (routed back through delegate.py's
-        `run_child_turn` / workflow `subagent`) is its *only* channel for
-        the child's work. Dropping the join there would silently lose
-        everything the child accumulated before hitting the wall. Children
-        also run with `skip_reflection=True` (delegate.py), so the
-        "`accumulated_text_parts` still feeds the reflection judge" argument
-        for keeping the field populated doesn't give the parent a second
-        chance to see it either — the join is the only way. So: interactive
-        turns deliver note-only; child turns deliver the accumulated join
-        plus the note, as before #707. Archiving is unaffected either way —
-        only `note` is ever appended to history/archive.
+        The real predicate is "did anyone see the preambles live", not
+        "is this a child". Three shapes of turn have no live subscriber:
+
+        - a child agent (`ctx.is_child`, set by delegate.py and
+          compaction.py's memory sweep) — the parent LLM never subscribes to
+          the event bus, so `ToolResult.text` (routed back through
+          delegate.py's `run_child_turn` / workflow `subagent`) is its *only*
+          channel for the child's work;
+        - heartbeat and scheduled turns (`ctx.task_mode`, see
+          `_UNWATCHED_TASK_MODES`) — they run on synthetic conv_ids no
+          transport subscribed to, yet their `ToolResult.text` is parsed
+          (heartbeat.py) and shown to the user afterwards
+          (interactive_terminal.py, heartbeat_tools.py, schedules.py).
+
+        Dropping the join for any of those silently loses everything the turn
+        accumulated before hitting the wall. Children also run with
+        `skip_reflection=True` (delegate.py), so the "`accumulated_text_parts`
+        still feeds the reflection judge" argument for keeping the field
+        populated doesn't give the parent a second chance to see it either —
+        the join is the only way. Background wakes are NOT in this set: they
+        fire on the user's real conversation, which does have a live
+        subscriber.
+
+        So: watched turns deliver note-only; unwatched turns deliver the
+        accumulated join plus the note, as before #707. Archiving is
+        unaffected either way — only `note` is ever appended to
+        history/archive.
         """
         note = note.strip()
-        if self.ctx.is_child:
+        if self.ctx.is_child or self.ctx.task_mode in _UNWATCHED_TASK_MODES:
             accumulated = "\n\n".join(self.accumulated_text_parts)
             delivered = accumulated + "\n\n" + note if accumulated else note
         else:

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -29,7 +29,14 @@ from .context_cleanup import clear_old_tool_results
 from .context_composer import ComposerMode, ContextComposer
 from .iteration_budget import IterationBudget
 from .llm import call_llm
-from .loop_breaker import LoopBreaker, LoopVerdict, fingerprint
+from .loop_breaker import (
+    CallSignature,
+    LoopBreaker,
+    LoopVerdict,
+    fingerprint,
+    summarize_args,
+    summarize_error,
+)
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause, extract_workspace_media
 from .persistence import read_skill_data, read_skills_state, write_skill_data, write_skills_state
 from .reflection_metrics import classify_outcome, response_delta
@@ -121,11 +128,15 @@ async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
             log.error(f"Compaction failed: {e}")
 
 
-def _extract_call_signatures(tool_calls, messages):
-    """Map each tool_call to (tool_name, fingerprint, is_error) using the
-    tool-result messages just appended by execute_tool_calls. Errors are
-    tool-role messages whose content starts with '[error' (see
-    tool_execution.py:ToolResult(text="[error: ...]")).
+def _extract_call_signatures(tool_calls, messages) -> list[CallSignature]:
+    """Map each tool_call to a CallSignature using the tool-result messages
+    just appended by execute_tool_calls. Errors are tool-role messages whose
+    content starts with '[error' (see tool_execution.py:ToolResult(
+    text="[error: ...]")).
+
+    Arguments and error bodies are retained (truncated) so the loop-breaker's
+    redirect can name the actual failing call rather than giving generic
+    advice (#707).
     """
     results_by_id = {
         m.get("tool_call_id"): (m.get("content") or "")
@@ -142,7 +153,13 @@ def _extract_call_signatures(tool_calls, messages):
             args = raw_args
         content = results_by_id.get(tc.get("id"), "")
         is_error = content.lstrip().startswith("[error")
-        out.append((name, fingerprint(name, args), is_error))
+        out.append(CallSignature(
+            tool_name=name,
+            fingerprint=fingerprint(name, args),
+            is_error=is_error,
+            args_text=summarize_args(args),
+            error_text=summarize_error(content) if is_error else "",
+        ))
     return out
 
 
@@ -787,24 +804,29 @@ class TurnRunner:
                 # restore_history on a restart/reload (role "user" is equally an
                 # LLM role that gets resurrected), permanently polluting context
                 # on all later turns.
+                off = self.loop_breaker.offense()
+                failure = (f" The failure each time: {off.error_text}."
+                           if off.error_text else "")
                 nudge = {
                     "role": "user",
                     "content": (
                         "[loop-breaker] Automated diagnostic from the agent "
                         "runtime — the user did not send this, so do not "
                         "respond to it as if they had. "
-                        f"You {self.loop_breaker.last_signal()} without "
-                        "progress. STOP repeating it. Switch to root-cause diagnosis: "
-                        "read the relevant logs, build a minimal repro, and re-check the "
-                        "contract/interface before any further edits."
+                        f"You {off.reason} without progress.{failure} "
+                        "STOP repeating that move. Work out WHY it fails "
+                        "before trying it again: read the actual error text, "
+                        "re-check the contract/interface you are calling "
+                        "against, and make your next action one that gathers "
+                        "evidence rather than one that retries the same edit."
                     ),
                 }
                 self.messages.append(nudge)
                 await self.ctx.publish("loop_breaker", action="nudge",
-                                       reason=self.loop_breaker.last_signal())
+                                       reason=self.loop_breaker.offense().reason)
             elif verdict is LoopVerdict.STOP:
                 await self.ctx.publish("loop_breaker", action="stop",
-                                       reason=self.loop_breaker.last_signal())
+                                       reason=self.loop_breaker.offense().reason)
                 return _Final(result=await self._finalize_loop_break())
 
         return _Continue()
@@ -1087,14 +1109,21 @@ class TurnRunner:
         return await self._finalize_with_note(limit_note)
 
     async def _finalize_loop_break(self) -> "ToolResult":
-        """Loop-breaker hard-stop: end the turn with a summary of the thrash
-        and a diagnostic next step, preserving any accumulated text."""
-        note = (
-            f"\n\n[loop-breaker] Stopped: you {self.loop_breaker.last_signal()} "
-            "without progress. Next: read the relevant logs, build a minimal "
-            "repro, and re-check the contract before retrying."
+        """Loop-breaker hard-stop: end the turn with what was tried, what
+        failed, and what would unblock it. This is the message the user reads
+        when they come back, so it is a handoff rather than a bare notice."""
+        off = self.loop_breaker.offense()
+        parts = [f"\n\n[loop-breaker] Stopped after repeated failures: "
+                 f"you {off.reason} without progress."]
+        if off.error_text:
+            parts.append(f" The error each time: {off.error_text}")
+        parts.append(
+            "\n\nI stopped rather than retry again. To move this forward I "
+            "need either a look at the real failure (the logs or config for "
+            "that call) or a different approach — tell me which and I'll "
+            "pick it up."
         )
-        return await self._finalize_with_note(note)
+        return await self._finalize_with_note("".join(parts))
 
     async def _finalize_with_note(self, note: str) -> "ToolResult":
         """End an abnormally-terminated turn (iteration limit / loop-breaker)

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -1166,24 +1166,30 @@ class TurnRunner:
 
     async def _finalize_with_note(self, note: str) -> "ToolResult":
         """End an abnormally-terminated turn (iteration limit / loop-breaker)
-        by appending `note` to whatever text the turn accumulated.
+        by delivering and persisting only `note`.
 
-        The delivered text includes the accumulated preambles so the turn
-        reads as a whole, but only the note is persisted: each preamble was
-        already appended to history and archived as it was emitted (see
-        _handle_tool_calls). Archiving the join too duplicated every
-        preamble in the record — invisible on a one-preamble turn, a wall of
-        repeated text on a long thrash (#675).
+        Every iteration's preamble was already published as
+        `text_before_tools` — rendered live by Mattermost
+        (mattermost_display.on_text_complete), the web UI and the terminal —
+        and archived as it was emitted (see _handle_tool_calls). Re-joining
+        them here duplicated the entire turn: invisible on a one-preamble
+        turn, a wall of repeated text on a long thrash, which is exactly when
+        the transcript most needs to be readable. #675 removed the join from
+        the archive and left it in the delivered text; #707 removes it from
+        both. The normal end-of-turn path delivers only its final content, so
+        this now matches it.
+
+        `accumulated_text_parts` is still populated — the reflection judge
+        genuinely needs the whole turn's text (see _run_reflection).
         """
-        accumulated = "\n\n".join(self.accumulated_text_parts)
-        delivered = accumulated + note if accumulated else note.strip()
-        final_msg = {"role": "assistant", "content": note.strip()}
+        note = note.strip()
+        final_msg = {"role": "assistant", "content": note}
         self.history.append(final_msg)
         _archive(self.ctx, final_msg)
         await _maybe_compact(
             self.ctx, self.config, self.history, self.prompt_tokens,
         )
-        return ToolResult(text=delivered)
+        return ToolResult(text=note)
 
     def _extract_workspace_media(self, content: str) -> "ToolResult":
         """Extract workspace:// refs only for channels that need it.

--- a/src/decafclaw/interactive_terminal.py
+++ b/src/decafclaw/interactive_terminal.py
@@ -65,12 +65,29 @@ async def run_interactive(ctx):
     turn_done = asyncio.Event()
     last_response_text = {"text": ""}
 
+    def is_streaming():
+        """Resolve streaming for the conversation's active model."""
+        conv_state = manager.get_state(conv_id)
+        model = conv_state.persisted.active_model if conv_state else ""
+        return resolve_streaming(config, model)
+
     # Subscribe to conversation events for terminal display
     async def on_event(event):
         event_type = event.get("type", "")
 
         if event_type == "chunk":
             print(event.get("text", ""), end="", flush=True)
+
+        elif event_type == "text_before_tools":
+            # An iteration's prose preamble before its tool calls. When
+            # streaming is ON the same text already arrived as `chunk`s above,
+            # so printing it here would duplicate it; when streaming is OFF
+            # nothing else renders it and the terminal showed the agent's
+            # mid-turn reasoning nowhere at all. Same guard as
+            # mattermost.py's text_before_tools handler.
+            text = event.get("text", "")
+            if text and not is_streaming():
+                print(f"\nagent> {text}")
 
         elif event_type == "tool_call_start":
             name = event.get("name", "tool")
@@ -140,7 +157,10 @@ async def run_interactive(ctx):
 
     # Start heartbeat timer
     shutdown_event = asyncio.Event()
-    suppress_ok = config.heartbeat_suppress_ok
+    # `config.heartbeat_suppress_ok` (no such attribute) raised AttributeError
+    # here on every `make run`, so interactive mode never started — found by
+    # the first test to actually drive run_interactive (#707 review).
+    suppress_ok = config.heartbeat.suppress_ok
 
     async def interactive_heartbeat_reporter(results):
         from datetime import datetime
@@ -186,7 +206,7 @@ async def run_interactive(ctx):
             # Wait for the turn to complete
             await turn_done.wait()
 
-            if resolve_streaming(config):
+            if is_streaming():
                 print()  # final newline after streamed text
             else:
                 text = last_response_text["text"]

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -6,6 +6,7 @@ import dataclasses
 import enum
 import hashlib
 import json
+from typing import NamedTuple
 
 
 class LoopVerdict(enum.Enum):
@@ -14,13 +15,65 @@ class LoopVerdict(enum.Enum):
     STOP = "stop"
 
 
+_MAX_ARG_CHARS = 400
+_MAX_ERROR_CHARS = 300
+
+
+def _render_args(args) -> str:
+    """Canonical, order-insensitive text form of a call's arguments."""
+    try:
+        return json.dumps(args, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return repr(args)
+
+
+def _truncate(text: str, limit: int) -> str:
+    """One-line, length-capped rendering for injection into prompt text."""
+    text = " ".join((text or "").split())
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
 def fingerprint(tool_name: str, args) -> str:
     """Stable hash of a tool call's name + arguments (order-insensitive)."""
-    try:
-        arg_repr = json.dumps(args, sort_keys=True, default=str)
-    except (TypeError, ValueError):
-        arg_repr = repr(args)
-    return hashlib.sha1(f"{tool_name}\x00{arg_repr}".encode()).hexdigest()
+    return hashlib.sha1(f"{tool_name}\x00{_render_args(args)}".encode()).hexdigest()
+
+
+def summarize_args(args) -> str:
+    """Render a call's arguments as one truncated line for redirect text."""
+    return _truncate(_render_args(args), _MAX_ARG_CHARS)
+
+
+def summarize_error(text: str) -> str:
+    """Render a tool-result error body as one truncated line."""
+    return _truncate(text, _MAX_ERROR_CHARS)
+
+
+class CallSignature(NamedTuple):
+    """One tool call's loop-relevant record.
+
+    `args_text` and `error_text` are retained (pre-truncated) so a redirect
+    can name the actual offending call and its actual failure instead of
+    giving generic advice — the detector used to hash the args away and keep
+    only an is_error bool (#707).
+    """
+    tool_name: str
+    fingerprint: str
+    is_error: bool
+    args_text: str = ""
+    error_text: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class Offense:
+    """What tripped the breaker, in enough detail to name it in a redirect.
+
+    `tool_name` and `args_text` are empty for an error-surge trip, which by
+    definition has no single offending call.
+    """
+    reason: str = ""
+    tool_name: str = ""
+    args_text: str = ""
+    error_text: str = ""
 
 
 @dataclasses.dataclass
@@ -36,6 +89,8 @@ class _Offender:
     tool_name: str
     count: int = 0
     last_tripped_count: int = 0
+    args_text: str = ""
+    error_text: str = ""
 
 
 class LoopBreaker:
@@ -58,7 +113,8 @@ class LoopBreaker:
         self._total_errors = 0                # monotonic; never trimmed
         self._errors_at_last_trip = 0         # watermark for the error signal
         self._trips = 0
-        self._last_signal = ""
+        self._last_error_text = ""
+        self._offense = Offense()
 
     @property
     def enabled(self) -> bool:
@@ -67,18 +123,24 @@ class LoopBreaker:
     def record(self, calls) -> None:
         """Record one iteration's tool calls.
 
-        calls: iterable of (tool_name, fingerprint, is_error).
+        calls: iterable of CallSignature.
         """
-        for tool_name, fp, is_error in calls:
-            entry = self._counts.get(fp)
+        for sig in calls:
+            entry = self._counts.get(sig.fingerprint)
             if entry is None:
-                entry = self._counts[fp] = _Offender(tool_name=tool_name)
-            entry.tool_name = tool_name
+                entry = self._counts[sig.fingerprint] = _Offender(
+                    tool_name=sig.tool_name,
+                )
+            entry.tool_name = sig.tool_name
             entry.count += 1
-            self._recent_errors.append(bool(is_error))
-            if is_error:
+            entry.args_text = sig.args_text
+            if sig.is_error:
+                # Keep the latest error for this call — the one a redirect quotes.
+                entry.error_text = sig.error_text
+            self._recent_errors.append(bool(sig.is_error))
+            if sig.is_error:
                 self._total_errors += 1
-        # Trim to a rolling window of the last N results.
+                self._last_error_text = sig.error_text
         window = self._cfg.error_window
         if len(self._recent_errors) > window:
             self._recent_errors = self._recent_errors[-window:]
@@ -115,19 +177,26 @@ class LoopBreaker:
         offender = self._fresh_repeat_offender()
         if offender is not None:
             offender.last_tripped_count = offender.count
-            self._last_signal = (
-                f"called {offender.tool_name} {offender.count}× with the same args"
+            self._offense = Offense(
+                reason=(f"called {offender.tool_name} {offender.count}× "
+                        "with the same args"),
+                tool_name=offender.tool_name,
+                args_text=offender.args_text,
+                error_text=offender.error_text,
             )
         elif self._fresh_error_surge():
             self._errors_at_last_trip = self._total_errors
             errs = sum(self._recent_errors)
-            self._last_signal = (
-                f"{errs} of the last {len(self._recent_errors)} tool results were errors"
+            self._offense = Offense(
+                reason=(f"{errs} of the last {len(self._recent_errors)} "
+                        "tool results were errors"),
+                error_text=self._last_error_text,
             )
         else:
             return LoopVerdict.NONE
         self._trips += 1
         return LoopVerdict.NUDGE if self._trips == 1 else LoopVerdict.STOP
 
-    def last_signal(self) -> str:
-        return self._last_signal
+    def offense(self) -> Offense:
+        """The most recent trip's evidence. Empty-field Offense before any trip."""
+        return self._offense

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -2,6 +2,7 @@
 a diagnostic nudge, then a hard stop. Pure/deterministic — no agent or LLM
 imports; driven by TurnRunner. See docs/loop-breaker.md (#598)."""
 
+import dataclasses
 import enum
 import hashlib
 import json
@@ -22,6 +23,21 @@ def fingerprint(tool_name: str, args) -> str:
     return hashlib.sha1(f"{tool_name}\x00{arg_repr}".encode()).hexdigest()
 
 
+@dataclasses.dataclass
+class _Offender:
+    """Per-fingerprint tally, plus a watermark of where `count` stood the last
+    time this fingerprint tripped the breaker.
+
+    The watermark is what makes escalation event-shaped instead of
+    state-shaped (#707): a fingerprint that has already tripped at count N
+    only trips again once it reaches N+1, i.e. once the agent has repeated
+    the call *again* after being told to stop.
+    """
+    tool_name: str
+    count: int = 0
+    last_tripped_count: int = 0
+
+
 class LoopBreaker:
     """Detects tool-call thrash within a single turn and escalates.
 
@@ -37,11 +53,11 @@ class LoopBreaker:
 
     def __init__(self, config):
         self._cfg = config
-        # fingerprint -> [tool_name, count]. Tracks the name alongside the
-        # count so last_signal() can name the offending tool.
-        self._counts: dict[str, list] = {}
+        self._counts: dict[str, _Offender] = {}
         self._recent_errors: list[bool] = []  # rolling is_error flags
-        self._nudged = False
+        self._total_errors = 0                # monotonic; never trimmed
+        self._errors_at_last_trip = 0         # watermark for the error signal
+        self._trips = 0
         self._last_signal = ""
 
     @property
@@ -54,46 +70,64 @@ class LoopBreaker:
         calls: iterable of (tool_name, fingerprint, is_error).
         """
         for tool_name, fp, is_error in calls:
-            entry = self._counts.setdefault(fp, [tool_name, 0])
-            entry[0] = tool_name
-            entry[1] += 1
+            entry = self._counts.get(fp)
+            if entry is None:
+                entry = self._counts[fp] = _Offender(tool_name=tool_name)
+            entry.tool_name = tool_name
+            entry.count += 1
             self._recent_errors.append(bool(is_error))
+            if is_error:
+                self._total_errors += 1
         # Trim to a rolling window of the last N results.
         window = self._cfg.error_window
         if len(self._recent_errors) > window:
             self._recent_errors = self._recent_errors[-window:]
 
-    def _tripped_reason(self) -> str | None:
-        # Repeated identical call?
-        top_name, top_n = None, 0
-        for name, n in self._counts.values():
-            if n > top_n:
-                top_name, top_n = name, n
-        if top_n >= self._cfg.repeat_threshold:
-            return f"called {top_name} {top_n}× with the same args"
-        # Repeated errors in the window?
-        errs = sum(self._recent_errors)
-        if errs >= self._cfg.error_threshold:
-            return f"{errs} of the last {len(self._recent_errors)} tool results were errors"
-        return None
+    def _fresh_repeat_offender(self) -> "_Offender | None":
+        """The worst fingerprint that has grown since it last tripped."""
+        worst = None
+        for entry in self._counts.values():
+            if entry.count < self._cfg.repeat_threshold:
+                continue
+            if entry.count <= entry.last_tripped_count:
+                continue  # already tripped at this count — agent stopped repeating it
+            if worst is None or entry.count > worst.count:
+                worst = entry
+        return worst
+
+    def _fresh_error_surge(self) -> bool:
+        """True when the window is over threshold AND new errors have landed
+        since the last trip. The second half is the point: a rolling window
+        can stay over threshold on stale errors alone."""
+        if sum(self._recent_errors) < self._cfg.error_threshold:
+            return False
+        return self._total_errors > self._errors_at_last_trip
 
     def verdict(self) -> LoopVerdict:
         """Compute the verdict for the most recently recorded round.
 
-        Mutates escalation state: a NUDGE verdict flips the one-way "already
-        nudged" flag, so a second call without an intervening `record()`
-        will escalate NUDGE -> STOP. Call exactly once per recorded round.
+        Mutates escalation state: a trip advances the rung counter and moves
+        the tripping signal's watermark, so a later round only trips again on
+        a genuinely new offense. Call exactly once per recorded round.
         """
         if not self._cfg.enabled:
             return LoopVerdict.NONE
-        reason = self._tripped_reason()
-        if reason is None:
+        offender = self._fresh_repeat_offender()
+        if offender is not None:
+            offender.last_tripped_count = offender.count
+            self._last_signal = (
+                f"called {offender.tool_name} {offender.count}× with the same args"
+            )
+        elif self._fresh_error_surge():
+            self._errors_at_last_trip = self._total_errors
+            errs = sum(self._recent_errors)
+            self._last_signal = (
+                f"{errs} of the last {len(self._recent_errors)} tool results were errors"
+            )
+        else:
             return LoopVerdict.NONE
-        self._last_signal = reason
-        if not self._nudged:
-            self._nudged = True
-            return LoopVerdict.NUDGE
-        return LoopVerdict.STOP
+        self._trips += 1
+        return LoopVerdict.NUDGE if self._trips == 1 else LoopVerdict.STOP
 
     def last_signal(self) -> str:
         return self._last_signal

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -102,12 +102,14 @@ class LoopBreaker:
 
     Trips on either signal:
     - the same (tool_name, args_fingerprint) seen >= repeat_threshold times
-    - >= error_threshold of the last error_window tool results are errors
+    - >= error_threshold errors, both within the last error_window results and
+      newly accrued since the last trip
 
     Escalation is one-way per instance and advances only on a *fresh* offense
-    (see verdict()): first trip returns NUDGE, second REDIRECT, third and
-    later STOP. `enabled=False` always returns NONE. One LoopBreaker per turn
-    — state is not meant to persist across turns.
+    (see verdict(), _fresh_repeat_offenders() and _fresh_error_surge()): first
+    trip returns NUDGE, second REDIRECT, third and later STOP.
+    `enabled=False` always returns NONE. One LoopBreaker per turn — state is
+    not meant to persist across turns.
     """
 
     def __init__(self, config):
@@ -138,9 +140,13 @@ class LoopBreaker:
             entry.tool_name = sig.tool_name
             entry.count += 1
             entry.args_text = sig.args_text
-            if sig.is_error:
-                # Keep the latest error for this call — the one a redirect quotes.
-                entry.error_text = sig.error_text
+            # Keep the latest error for this call — the one a redirect quotes.
+            # Cleared on a successful occurrence: the nudge/redirect wording is
+            # "the error every time", and a call that failed early then started
+            # succeeding would otherwise keep quoting a stale failure forever.
+            # Reachable because repeated *successful* identical calls trip the
+            # repeat signal too.
+            entry.error_text = sig.error_text if sig.is_error else ""
             self._recent_errors.append(bool(sig.is_error))
             if sig.is_error:
                 self._total_errors += 1
@@ -149,38 +155,75 @@ class LoopBreaker:
         if len(self._recent_errors) > window:
             self._recent_errors = self._recent_errors[-window:]
 
-    def _fresh_repeat_offender(self) -> "_Offender | None":
-        """The worst fingerprint that has grown since it last tripped."""
-        worst = None
-        for entry in self._counts.values():
-            if entry.count < self._cfg.repeat_threshold:
-                continue
-            if entry.count <= entry.last_tripped_count:
-                continue  # already tripped at this count — agent stopped repeating it
-            if worst is None or entry.count > worst.count:
-                worst = entry
-        return worst
+    def _fresh_repeat_offenders(self) -> "list[_Offender]":
+        """Every fingerprint at/over threshold that has grown since it last
+        tripped.
+
+        Returns all of them, not just the worst, because `verdict()` has to
+        watermark *all* of them when it trips — tool calls run concurrently
+        (`asyncio.gather`), so a repeated multi-call batch pushes several
+        fingerprints over threshold in the same round. Advancing only the
+        worst one's watermark left the rest permanently "fresh", so they
+        re-tripped on later rounds with counts that had stopped growing, and
+        a fully compliant agent still got walked to a hard stop (#707).
+        """
+        return [
+            entry for entry in self._counts.values()
+            if entry.count >= self._cfg.repeat_threshold
+            # count == last_tripped_count → already tripped at this count, so
+            # the agent stopped repeating it.
+            and entry.count > entry.last_tripped_count
+        ]
 
     def _fresh_error_surge(self) -> bool:
-        """True when the window is over threshold AND new errors have landed
-        since the last trip. The second half is the point: a rolling window
-        can stay over threshold on stale errors alone."""
+        """True when a full threshold's worth of *new* errors has landed since
+        the last trip, and those errors are recent.
+
+        Two necessary conditions, each doing a distinct job:
+
+        - `_total_errors - _errors_at_last_trip >= error_threshold` — the
+          freshness half. A whole new surge, not one new error tacked onto a
+          window still holding pre-trip failures. Requiring only "any new
+          error" meant the round after a trip started already loaded, so the
+          redirect's own instruction ("take exactly one read-only action")
+          escalated the ladder whenever that diagnostic read errored — the
+          mechanism punished the behavior it had just demanded (#707).
+        - `sum(_recent_errors) >= error_threshold` — the density half. A slow
+          trickle of errors interleaved with successes over many rounds isn't
+          thrash; `error_window` is what keeps it from accumulating into one.
+
+        The first trip is unaffected by the freshness half: with
+        `_errors_at_last_trip == 0`, a window sum at threshold implies a total
+        at threshold.
+        """
         if sum(self._recent_errors) < self._cfg.error_threshold:
             return False
-        return self._total_errors > self._errors_at_last_trip
+        return (self._total_errors - self._errors_at_last_trip
+                >= self._cfg.error_threshold)
 
     def verdict(self) -> LoopVerdict:
         """Compute the verdict for the most recently recorded round.
 
         Mutates escalation state: a trip advances the rung counter and moves
-        the tripping signal's watermark, so a later round only trips again on
-        a genuinely new offense. Call exactly once per recorded round.
+        *every* watermark the trip consumed, so a later round only trips again
+        on a genuinely new offense. Call exactly once per recorded round.
+
+        A repeat trip consumes the error credit too (`_errors_at_last_trip`).
+        The errors that piled up alongside the thrash have already been
+        accounted for by the rung the agent just got; leaving them uncounted
+        let the error signal fire on the very next round off the same
+        failures, double-charging one offense (#707). The reverse doesn't need
+        handling: when the error branch runs there are no fresh repeat
+        offenders by construction, since the repeat branch is checked first.
         """
         if not self._cfg.enabled:
             return LoopVerdict.NONE
-        offender = self._fresh_repeat_offender()
-        if offender is not None:
-            offender.last_tripped_count = offender.count
+        fresh = self._fresh_repeat_offenders()
+        if fresh:
+            offender = max(fresh, key=lambda e: e.count)
+            for entry in fresh:
+                entry.last_tripped_count = entry.count
+            self._errors_at_last_trip = self._total_errors
             self._offense = Offense(
                 reason=(f"called {offender.tool_name} {offender.count}× "
                         "with the same args"),

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -12,6 +12,7 @@ from typing import NamedTuple
 class LoopVerdict(enum.Enum):
     NONE = "none"
     NUDGE = "nudge"
+    REDIRECT = "redirect"
     STOP = "stop"
 
 
@@ -100,10 +101,10 @@ class LoopBreaker:
     - the same (tool_name, args_fingerprint) seen >= repeat_threshold times
     - >= error_threshold of the last error_window tool results are errors
 
-    Escalation is one-way per instance: the first trip returns NUDGE; any
-    subsequent trip after that returns STOP. `enabled=False` always returns
-    NONE. One LoopBreaker per turn — state is not meant to persist across
-    turns.
+    Escalation is one-way per instance and advances only on a *fresh* offense
+    (see verdict()): first trip returns NUDGE, second REDIRECT, third and
+    later STOP. `enabled=False` always returns NONE. One LoopBreaker per turn
+    — state is not meant to persist across turns.
     """
 
     def __init__(self, config):
@@ -195,7 +196,11 @@ class LoopBreaker:
         else:
             return LoopVerdict.NONE
         self._trips += 1
-        return LoopVerdict.NUDGE if self._trips == 1 else LoopVerdict.STOP
+        if self._trips == 1:
+            return LoopVerdict.NUDGE
+        if self._trips == 2:
+            return LoopVerdict.REDIRECT
+        return LoopVerdict.STOP
 
     def offense(self) -> Offense:
         """The most recent trip's evidence. Empty-field Offense before any trip."""

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -1,6 +1,9 @@
 """Per-turn loop-breaker: detects autonomous tool-call thrash and escalates
-a diagnostic nudge, then a hard stop. Pure/deterministic — no agent or LLM
-imports; driven by TurnRunner. See docs/loop-breaker.md (#598)."""
+through three rungs — a diagnostic nudge, then a redirect that demands a
+diagnosis before another action, then a hard stop. Trips are watermarked per
+fingerprint so a rung only advances on a genuinely fresh offense, not a
+standing condition. Pure/deterministic — no agent or LLM imports; driven by
+TurnRunner. See docs/loop-breaker.md (#598, #707)."""
 
 import dataclasses
 import enum

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -32,9 +32,26 @@ def _render_args(args) -> str:
 
 
 def _truncate(text: str, limit: int) -> str:
-    """One-line, length-capped rendering for injection into prompt text."""
-    text = " ".join((text or "").split())
+    """Length-cap only. Preserves the text otherwise (no whitespace changes)."""
+    text = text or ""
     return text if len(text) <= limit else text[:limit] + "…"
+
+
+def _neutralize_linebreaks(text: str) -> str:
+    """Strip CR/LF so the text can't break a single-line prompt sentence.
+
+    Unlike `_flatten`, this leaves runs of spaces/tabs alone — only line
+    breaks are prompt-structurally dangerous for `summarize_args`, and the
+    normal `json.dumps` path already escapes them (`\\n` stays literal
+    backslash-n), so this only ever fires via `_render_args`'s `repr()`
+    fallback for inputs `json.dumps` rejects (e.g. a circular reference).
+    """
+    return (text or "").replace("\r", "").replace("\n", " ")
+
+
+def _flatten(text: str) -> str:
+    """Collapse all whitespace runs to single spaces (for raw error bodies)."""
+    return " ".join((text or "").split())
 
 
 def fingerprint(tool_name: str, args) -> str:
@@ -43,13 +60,22 @@ def fingerprint(tool_name: str, args) -> str:
 
 
 def summarize_args(args) -> str:
-    """Render a call's arguments as one truncated line for redirect text."""
-    return _truncate(_render_args(args), _MAX_ARG_CHARS)
+    """Render a call's arguments as one length-capped line for redirect text.
+
+    Must not otherwise alter `_render_args()`'s output: the model is told
+    these are the arguments being counted toward the loop-breaker's
+    fingerprint, so this can only line-break-neutralize (in case of the
+    `repr()` fallback) and length-cap — never whitespace-collapse, since a
+    JSON string value's internal whitespace is call data, not formatting,
+    and collapsing it can make two calls that fingerprint differently
+    display identically (#711 review).
+    """
+    return _truncate(_neutralize_linebreaks(_render_args(args)), _MAX_ARG_CHARS)
 
 
 def summarize_error(text: str) -> str:
-    """Render a tool-result error body as one truncated line."""
-    return _truncate(text, _MAX_ERROR_CHARS)
+    """Render a tool-result error body as one flattened, truncated line."""
+    return _truncate(_flatten(text), _MAX_ERROR_CHARS)
 
 
 class CallSignature(NamedTuple):

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -38,12 +38,27 @@ def test_extract_signatures_flags_errors():
 
 def test_extract_signatures_handles_missing_tool_result():
     """A tool_call with no matching tool-result message (shouldn't happen in
-    practice, but defend against it) is treated as non-error."""
+    practice, but defend against it) is treated as non-error, with no error
+    text to quote."""
     tool_calls = [
         {"id": "missing", "function": {"name": "edit", "arguments": "{}"}},
     ]
     sigs = _extract_call_signatures(tool_calls, [])
-    assert sigs[0] == ("edit", sigs[0][1], False)
+    assert sigs[0].tool_name == "edit"
+    assert sigs[0].is_error is False
+    assert sigs[0].error_text == ""
+
+
+def test_extract_signatures_retains_args_and_error_text():
+    tool_calls = [
+        {"id": "1", "function": {"name": "edit", "arguments": '{"path": "x"}'}},
+    ]
+    messages = [
+        {"role": "tool", "tool_call_id": "1", "content": "[error: bad edit]"},
+    ]
+    sigs = _extract_call_signatures(tool_calls, messages)
+    assert '"path": "x"' in sigs[0].args_text
+    assert "bad edit" in sigs[0].error_text
 
 
 def test_extract_signatures_handles_malformed_json_args():

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -126,10 +126,9 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     # ...and confirm the nudge that WAS injected into the live LLM-facing
     # message list carries role "user", not "system" (models weight
     # user-role directives more heavily for mid-turn corrections). The same
-    # `messages` list object is mutated in place across LLM calls, so any
-    # recorded call's `messages` arg reflects the final state.
-    # `messages` is mutated in place across LLM calls, so the last recorded
-    # call's list reflects the final state — both injected diagnostics.
+    # `messages` list object is mutated in place across LLM calls, so the last
+    # recorded call's list reflects the final state — both injected
+    # diagnostics.
     sent_messages = mock_llm.call_args_list[-1][0][1]
     diagnostics = [m for m in sent_messages
                    if "[loop-breaker]" in (m.get("content") or "")]
@@ -368,6 +367,83 @@ async def test_loop_break_delivers_and_archives_only_the_note(ctx):
         f"preamble archived {occurrences}× across {iterations} iterations — "
         "the finalizer is re-archiving already-archived text"
     )
+
+
+@pytest.mark.parametrize("task_mode", ["heartbeat", "scheduled"])
+@pytest.mark.asyncio
+async def test_loop_break_delivers_preambles_for_unwatched_task_turns(ctx, task_mode):
+    """#707 review: the delivery gate is "did anyone watch this live", not
+    `ctx.is_child`.
+
+    Heartbeat and scheduled turns run on synthetic conv_ids no transport
+    subscribed to, so nothing rendered their `text_before_tools` — yet their
+    `ToolResult.text` is parsed (heartbeat.py) and shown to the user afterwards
+    (interactive_terminal.py, heartbeat_tools.py, schedules.py). Gating on
+    `is_child` alone dropped everything those turns did before hitting the
+    wall.
+    """
+    ctx.task_mode = task_mode
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    preamble = "Checking the feed again."
+    repeated_call = _mock_llm_response(
+        content=preamble,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        result = await run_agent_turn(ctx, "check the feed", [])
+
+    assert "[loop-breaker] Stopped" in result.text
+    assert preamble in result.text, (
+        "an unwatched turn's accumulated work was dropped from delivery"
+    )
+
+    # Archiving stays note-only regardless of the delivery branch (#675).
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    occurrences = sum(
+        (m.get("content") or "").count(preamble)
+        for m in archived if m.get("role") == "assistant"
+    )
+    assert occurrences == mock_llm.call_count
+
+
+@pytest.mark.asyncio
+async def test_loop_break_delivers_only_the_note_for_a_background_wake(ctx):
+    """A wake turn fires on the user's real conversation, which DOES have a
+    live subscriber — so it stays on the note-only branch. This is the
+    boundary of `_UNWATCHED_TASK_MODES`."""
+    ctx.task_mode = "background_wake"
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    preamble = "Following up on that job."
+    repeated_call = _mock_llm_response(
+        content=preamble,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        result = await run_agent_turn(ctx, "wake up", [])
+
+    assert "[loop-breaker] Stopped" in result.text
+    assert preamble not in result.text
 
 
 # -- The nudge must not read as the user speaking (#680) -----------------------

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -128,11 +128,15 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     # user-role directives more heavily for mid-turn corrections). The same
     # `messages` list object is mutated in place across LLM calls, so any
     # recorded call's `messages` arg reflects the final state.
+    # `messages` is mutated in place across LLM calls, so the last recorded
+    # call's list reflects the final state — both injected diagnostics.
     sent_messages = mock_llm.call_args_list[-1][0][1]
-    nudge_msgs = [m for m in sent_messages
-                  if "[loop-breaker]" in (m.get("content") or "")]
-    assert len(nudge_msgs) == 1
-    assert nudge_msgs[0]["role"] == "user"
+    diagnostics = [m for m in sent_messages
+                   if "[loop-breaker]" in (m.get("content") or "")]
+    assert len(diagnostics) == 2, "expected both the nudge and the redirect"
+    assert all(m["role"] == "user" for m in diagnostics)
+    assert "STOP repeating that move" in diagnostics[0]["content"]
+    assert "single best hypothesis" in diagnostics[1]["content"]
 
     # ...while the hard-stop's final assistant message IS archived (it's the
     # turn's actual output, correctly durable).
@@ -149,10 +153,84 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     assert len(stop_events) == 1
 
     # Tripped at repeat_threshold=3, and the LLM was called once per
-    # iteration up to and including the stop iteration (NUDGE at 3rd call's
-    # iteration, STOP at the 4th) — well short of the 10 stubbed responses
-    # or the 50-iteration budget.
+    # iteration up to and including the stop iteration (NUDGE at the 3rd
+    # call's iteration, REDIRECT at the 4th, STOP at the 5th) — well short
+    # of the 10 stubbed responses or the 50-iteration budget.
     assert mock_llm.call_count < 10
+
+
+@pytest.mark.asyncio
+async def test_redirect_rung_fires_between_nudge_and_stop(ctx):
+    """The second trip must inject a diagnosis contract, not end the turn.
+
+    Asserts on the LLM-facing message list rather than the archive: the
+    redirect is ephemeral by design, so the archive can never show it.
+    """
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    published_events = []
+    ctx.event_bus.subscribe(lambda event: published_events.append(event))
+
+    repeated_call = _mock_llm_response(
+        content="Trying again.",
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        result = await run_agent_turn(ctx, "loop forever", [])
+
+    sent_messages = mock_llm.call_args_list[-1][0][1]
+    contents = [m.get("content") or "" for m in sent_messages]
+    assert any("STOP repeating that move" in c for c in contents), \
+        "rung 1 (nudge) never fired"
+    assert any("single best hypothesis" in c for c in contents), \
+        "rung 2 (redirect) never fired"
+    assert "[loop-breaker] Stopped" in result.text, "rung 3 (stop) never fired"
+
+    # The redirect names the actual offending tool, not generic advice (#707).
+    redirect = next(c for c in contents if "single best hypothesis" in c)
+    assert "definitely_not_a_real_tool" in redirect
+
+    actions = [e.get("action") for e in published_events
+               if e.get("type") == "loop_breaker"]
+    assert actions == ["nudge", "redirect", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_redirect_is_never_archived(ctx):
+    """Same ephemerality contract as the nudge (#598): archiving a user-role
+    diagnostic would let restore_history resurrect it into every later turn."""
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    repeated_call = _mock_llm_response(
+        content="Trying again.",
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        await run_agent_turn(ctx, "loop forever", [])
+
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    user_msgs = [m for m in archived if m.get("role") == "user"]
+    assert not any("[loop-breaker]" in (m.get("content") or "")
+                   for m in user_msgs), "an ephemeral diagnostic was archived"
 
 
 # -- Integration: a genuine end-turn signal always wins over the breaker ------

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -319,14 +319,17 @@ async def test_end_turn_signal_preempts_loop_breaker(ctx):
     assert mock_execute.call_count == 3
 
 
-# -- Hard-stop must not re-archive text it already archived (#675) -------------
+# -- Hard-stop must not re-deliver or re-archive text it already emitted (#675, #707) --
 
 
 @pytest.mark.asyncio
-async def test_loop_break_does_not_duplicate_accumulated_text(ctx):
-    """Each iteration's assistant preamble is archived as it happens. The
-    hard-stop finalizer must not re-emit all of them joined together — on a
-    long thrash that produced a wall of duplicated text in the transcript."""
+async def test_loop_break_delivers_and_archives_only_the_note(ctx):
+    """Each iteration's preamble is published as text_before_tools and
+    rendered live by every transport, then archived as it happens. The
+    finalizer must re-emit neither — #675 fixed the archive half and left the
+    delivery half, which is the wall of repeated text users actually see
+    (#707). The normal end-of-turn path (agent.py:865) likewise delivers only
+    its final content, so this matches it."""
     ctx.config.llm.streaming = False
     ctx.config.agent.max_tool_iterations = 50
     ctx.config.loop_breaker.repeat_threshold = 3
@@ -348,15 +351,18 @@ async def test_loop_break_does_not_duplicate_accumulated_text(ctx):
         result = await run_agent_turn(ctx, "loop forever", history)
 
     assert "[loop-breaker] Stopped" in result.text
+    # The delivery half (#707).
+    assert preamble not in result.text, (
+        "the finalizer re-delivered preambles the transport already rendered"
+    )
 
+    # The archive half (#675) — unchanged.
     from decafclaw.archive import read_archive
     archived = read_archive(ctx.config, ctx.conv_id)
     occurrences = sum(
         (m.get("content") or "").count(preamble)
         for m in archived if m.get("role") == "assistant"
     )
-    # The preamble was emitted once per iteration and archived once per
-    # iteration. The stop message must not repeat any of them.
     iterations = mock_llm.call_count
     assert occurrences == iterations, (
         f"preamble archived {occurrences}× across {iterations} iterations — "

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -418,6 +418,64 @@ async def test_loop_break_delivers_preambles_for_unwatched_task_turns(ctx, task_
 
 
 @pytest.mark.asyncio
+async def test_loop_break_note_comes_first_for_unwatched_turns(ctx):
+    """The note must lead the unwatched-turn join, not trail it.
+
+    heartbeat.py's `is_heartbeat_ok` only scans the first 300 characters of
+    `ToolResult.text`, and polling.py tells the agent to say HEARTBEAT_OK
+    when there's nothing to report — a plausible substring of a mid-turn
+    preamble. If the accumulated preamble came first, a preamble mentioning
+    the sentinel would sit inside that window and bury the loop-breaker
+    note that should have been the visible signal. Note-first fixes that
+    for this (long) loop-breaker note; see task-5-report.md for the
+    max-iterations note's narrower case.
+    """
+    ctx.task_mode = "heartbeat"
+    ctx.config.llm.streaming = False
+    ctx.config.agent.max_tool_iterations = 50
+    ctx.config.loop_breaker.repeat_threshold = 3
+    ctx.config.loop_breaker.error_threshold = 99
+    ctx.config.loop_breaker.error_window = 50
+
+    preamble = "Checking the feed again, HEARTBEAT_OK for now."
+    repeated_call = _mock_llm_response(
+        content=preamble,
+        tool_calls=[{
+            "id": "tc-repeat",
+            "function": {"name": "definitely_not_a_real_tool", "arguments": "{}"},
+        }],
+    )
+
+    with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+        mock_llm.side_effect = [repeated_call] * 10
+        result = await run_agent_turn(ctx, "check the feed", [])
+
+    note_index = result.text.find("[loop-breaker] Stopped")
+    preamble_index = result.text.find(preamble)
+    assert note_index != -1 and preamble_index != -1
+    assert note_index < preamble_index, (
+        "the note must lead the delivered text so the sentinel check's "
+        "300-char window sees the abnormal-termination note, not a stray "
+        "preamble mention of HEARTBEAT_OK"
+    )
+
+    from decafclaw.heartbeat import is_heartbeat_ok
+    assert not is_heartbeat_ok(result.text), (
+        "note-first should push this (long) loop-breaker note's own text "
+        "to the front, keeping the sentinel out of the 300-char window"
+    )
+
+    # Archiving stays note-only regardless of delivery ordering (#675).
+    from decafclaw.archive import read_archive
+    archived = read_archive(ctx.config, ctx.conv_id)
+    occurrences = sum(
+        (m.get("content") or "").count(preamble)
+        for m in archived if m.get("role") == "assistant"
+    )
+    assert occurrences == mock_llm.call_count
+
+
+@pytest.mark.asyncio
 async def test_loop_break_delivers_only_the_note_for_a_background_wake(ctx):
     """A wake turn fires on the user's real conversation, which DOES have a
     live subscriber — so it stays on the note-only branch. This is the

--- a/tests/test_agent_turn.py
+++ b/tests/test_agent_turn.py
@@ -696,7 +696,12 @@ async def test_run_agent_turn_empty_retry_refunds_budget(ctx):
 @pytest.mark.asyncio
 async def test_run_agent_turn_grace_turn_fallback_on_empty_content(ctx):
     """When the grace LLM call succeeds but returns empty content, fall back
-    to accumulated text + notice (always-something contract)."""
+    to the notice alone (always-something contract) — not accumulated text
+    joined with the notice. Each iteration's preamble ("Working on it...")
+    was already published as text_before_tools and rendered live by every
+    transport, then archived as it happened; re-delivering it here would
+    duplicate the whole turn (#707), same reasoning as
+    test_loop_break_delivers_and_archives_only_the_note."""
     ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
     ctx.config.agent.max_tool_iterations = 2
@@ -722,14 +727,20 @@ async def test_run_agent_turn_grace_turn_fallback_on_empty_content(ctx):
         history = []
         result = await run_agent_turn(ctx, "loop forever", history)
 
-    # Falls back to accumulated text + notice (always-something contract).
-    assert "Working on it..." in result.text
+    # Falls back to the notice only — accumulated text was already delivered
+    # live by the transport, so it must not be re-delivered here (#707).
+    assert "Working on it..." not in result.text
     assert "max tool iterations" in result.text
 
 
 @pytest.mark.asyncio
 async def test_run_agent_turn_grace_turn_fallback_on_exception(ctx):
-    """When the grace LLM call raises, fall back to accumulated text + notice."""
+    """When the grace LLM call raises, fall back to the notice alone — not
+    accumulated text joined with the notice. Each iteration's preamble ("Let
+    me check that for you.") was already published as text_before_tools and
+    rendered live by every transport, then archived as it happened;
+    re-delivering it here would duplicate the whole turn (#707), same
+    reasoning as test_loop_break_delivers_and_archives_only_the_note."""
     ctx.config.llm.streaming = False
     ctx.config.system_prompt = "You are a test bot."
     ctx.config.agent.max_tool_iterations = 2
@@ -755,8 +766,9 @@ async def test_run_agent_turn_grace_turn_fallback_on_exception(ctx):
         history = []
         result = await run_agent_turn(ctx, "loop forever", history)
 
-    # Falls back to accumulated text + notice.
-    assert "Let me check that for you." in result.text
+    # Falls back to the notice only — accumulated text was already delivered
+    # live by the transport, so it must not be re-delivered here (#707).
+    assert "Let me check that for you." not in result.text
     assert "max tool iterations" in result.text
 
 

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -734,3 +734,131 @@ class TestDelegateTasks:
 
         child_ctx = mock_run.call_args[0][0]
         assert child_ctx.event_context_id == "parent-subscriber-id"
+
+
+# -- Abnormal child termination must still hand back accumulated work (#707 round 1) --
+
+
+class TestChildAbnormalTermination:
+    """#707 stopped `_finalize_with_note` from re-delivering accumulated
+    preambles on abnormal turn end, because interactive transports already
+    render each one live via `text_before_tools`. A child agent turn has no
+    transport watching it live — the parent LLM never subscribes to the
+    event bus — so `ToolResult.text` (routed back through
+    `run_child_turn`) is its only channel for the child's work. These tests
+    drive a REAL child turn (only `call_llm` is mocked, not
+    `run_agent_turn`) through `ConversationManager.enqueue_turn` so the
+    actual `TurnRunner._finalize_max_iterations` /
+    `_finalize_with_note` code runs with a real `ctx.is_child` flag,
+    matching the review finding that flagged this as an untested
+    programmatic-caller path."""
+
+    @pytest.mark.asyncio
+    async def test_child_max_iterations_delivers_accumulated_text(self, ctx):
+        """Child hits max_tool_iterations; the grace-turn LLM call returns
+        empty content, so the turn falls back to `_finalize_max_iterations`.
+        Because the real child ctx has `is_child=True`, the delivered text
+        must still include what the child accumulated before hitting the
+        wall — dropping it here would silently lose the child's work with
+        no other channel back to the parent (children also run with
+        `skip_reflection=True`, so the reflection judge doesn't get a
+        second look either)."""
+        ctx.config.llm.streaming = False
+
+        preamble = "Let me check the workspace files for that."
+        tool_call_response = {
+            "content": preamble,
+            "tool_calls": [{
+                "id": "tc1",
+                "function": {
+                    "name": "definitely_not_a_real_tool",
+                    "arguments": "{}",
+                },
+            }],
+            "role": "assistant",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        empty_grace_response = {
+            "content": "",
+            "tool_calls": None,
+            "role": "assistant",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+
+        with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+            # Two tool-call iterations (budget=2), then the grace-turn call
+            # returns empty content, forcing the max-iterations fallback.
+            mock_llm.side_effect = [
+                tool_call_response,
+                tool_call_response,
+                empty_grace_response,
+            ]
+            text, data = await run_child_turn(ctx, "loop forever", max_iterations=2)
+
+        assert data is None
+        assert "max tool iterations" in text
+        assert preamble in text, (
+            "child's accumulated preamble was dropped from the delivered "
+            "text — the parent agent has no other channel to see it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_child_max_iterations_archives_only_the_note(self, ctx, monkeypatch):
+        """The is_child delivery gate must not reopen the archive
+        duplication #675 fixed: only the note is ever appended to
+        history/archive, for children exactly as for interactive turns."""
+        ctx.config.llm.streaming = False
+
+        seen_conv_ids: list[str] = []
+        orig_enqueue = ctx.manager.enqueue_turn
+
+        async def spy_enqueue(conv_id, *, kind, prompt, **kwargs):
+            seen_conv_ids.append(conv_id)
+            return await orig_enqueue(conv_id, kind=kind, prompt=prompt, **kwargs)
+
+        monkeypatch.setattr(ctx.manager, "enqueue_turn", spy_enqueue)
+
+        preamble = "Let me check the workspace files for that."
+        tool_call_response = {
+            "content": preamble,
+            "tool_calls": [{
+                "id": "tc1",
+                "function": {
+                    "name": "definitely_not_a_real_tool",
+                    "arguments": "{}",
+                },
+            }],
+            "role": "assistant",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        empty_grace_response = {
+            "content": "",
+            "tool_calls": None,
+            "role": "assistant",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+
+        with patch("decafclaw.agent.call_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.side_effect = [
+                tool_call_response,
+                tool_call_response,
+                empty_grace_response,
+            ]
+            text, _ = await run_child_turn(ctx, "loop forever", max_iterations=2)
+
+        assert preamble in text  # sanity: delivery half still holds here
+
+        from decafclaw.archive import read_archive
+        assert len(seen_conv_ids) == 1
+        archived = read_archive(ctx.config, seen_conv_ids[0])
+        occurrences = sum(
+            (m.get("content") or "").count(preamble)
+            for m in archived if m.get("role") == "assistant"
+        )
+        # The preamble was emitted and archived once per tool-call iteration
+        # (2). The finalizer's note must not add a third occurrence.
+        assert occurrences == 2, (
+            f"preamble archived {occurrences}x — the finalizer is "
+            "re-archiving already-archived text even though it now "
+            "re-delivers it to the parent"
+        )

--- a/tests/test_interactive_terminal.py
+++ b/tests/test_interactive_terminal.py
@@ -1,0 +1,71 @@
+"""Display-layer tests for the interactive terminal transport.
+
+`run_interactive`'s `on_event` closure is the terminal's whole rendering
+surface, so these drive it directly: run the loop with `input` answering
+"quit", capture the callback it registered with the manager, then feed it
+events.
+"""
+
+import asyncio
+
+import pytest
+
+from decafclaw.conversation_manager import ConversationManager
+from decafclaw.interactive_terminal import run_interactive
+
+
+async def _capture_on_event(ctx, monkeypatch) -> object:
+    """Run `run_interactive` to immediate exit and return its event callback."""
+    captured = {}
+    real_subscribe = ConversationManager.subscribe
+
+    def capturing_subscribe(self, conv_id, callback):
+        captured["cb"] = callback
+        return real_subscribe(self, conv_id, callback)
+
+    async def never_returns(*args, **kwargs):
+        # A real signal to wait on, not a sleep — the caller cancels this task.
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(ConversationManager, "subscribe", capturing_subscribe)
+    monkeypatch.setattr("decafclaw.mcp_client.init_mcp", _noop_async)
+    monkeypatch.setattr("decafclaw.mcp_client.shutdown_mcp", _noop_async)
+    monkeypatch.setattr("decafclaw.heartbeat.run_heartbeat_timer", never_returns)
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "quit")
+
+    await run_interactive(ctx)
+    return captured["cb"]
+
+
+async def _noop_async(*args, **kwargs):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_text_before_tools_is_rendered_when_not_streaming(
+        ctx, monkeypatch, capsys):
+    """#707: the loop-breaker docs claimed every transport rendered each
+    iteration's preamble live, and the terminal rendered it nowhere — so
+    `_finalize_with_note` was dropping text no one had ever seen."""
+    ctx.config.llm.streaming = False
+    on_event = await _capture_on_event(ctx, monkeypatch)
+    capsys.readouterr()  # discard the banner / prompt noise
+
+    await on_event({"type": "text_before_tools", "text": "Trying the skill again."})
+
+    assert "Trying the skill again." in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_text_before_tools_is_suppressed_when_streaming(
+        ctx, monkeypatch, capsys):
+    """With streaming on, the same text already arrived as `chunk` events —
+    printing it again would duplicate every preamble."""
+    ctx.config.llm.streaming = True
+    on_event = await _capture_on_event(ctx, monkeypatch)
+    capsys.readouterr()
+
+    await on_event({"type": "chunk", "text": "Trying the skill again."})
+    await on_event({"type": "text_before_tools", "text": "Trying the skill again."})
+
+    assert capsys.readouterr().out.count("Trying the skill again.") == 1

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -3,6 +3,7 @@ from decafclaw.loop_breaker import (
     CallSignature,
     LoopBreaker,
     LoopVerdict,
+    _render_args,
     fingerprint,
     summarize_args,
     summarize_error,
@@ -81,15 +82,60 @@ def test_offense_carries_args_and_error_text():
     assert "workspace_write" in off.reason
 
 
-def test_summarize_args_truncates_and_flattens():
+def test_summarize_args_matches_render_args_byte_for_byte_under_cap():
+    """summarize_args() must not alter _render_args()'s output beyond a
+    length cap — the model is told the summary IS the arguments being
+    counted toward the loop-breaker's fingerprint, so any extra
+    normalization (e.g. whitespace-collapsing) would let the displayed args
+    disagree with what was actually hashed."""
+    args = {"body": "hello  world", "cmd": "grep\tfoo"}
+    assert summarize_args(args) == _render_args(args)
+
+
+def test_summarize_args_does_not_collapse_whitespace_inside_values():
+    """Whitespace inside a JSON string argument value is call data, not
+    formatting. Two dicts that fingerprint differently (#711) must not
+    summarize identically."""
+    a, b = {"body": "a  b"}, {"body": "a b"}
+    assert fingerprint("t", a) != fingerprint("t", b)
+    assert summarize_args(a) != summarize_args(b)
+
+
+def test_summarize_args_truncates_long_values():
     long_args = {"body": "x" * 5000}
     out = summarize_args(long_args)
     assert len(out) <= 401          # _MAX_ARG_CHARS + the ellipsis
     assert out.endswith("…")
-    # Newline-free, though trivially so: json.dumps already escapes a real
-    # newline to a two-character "\\n" before _truncate ever sees it. The
-    # genuine newline-collapsing path is summarize_error() below.
-    assert "\n" not in summarize_args({"body": "a\nb"})
+
+
+def test_summarize_args_neutralizes_raw_linebreaks_from_repr_fallback():
+    """json.dumps escapes real newlines inside string *values* to a literal
+    two-char "\\n", so the normal path can't introduce a raw line break.
+    But _render_args() falls back to repr() when json.dumps rejects the
+    input outright (e.g. a non-str/int/float/bool/None dict key raises
+    TypeError) — and if that key's own __repr__ returns a raw multi-line
+    string, dict repr embeds it verbatim, with a genuine newline character.
+    summarize_args() must still neutralize that without collapsing
+    surrounding whitespace runs."""
+
+    class Weird:
+        def __repr__(self):
+            return "weird\nkey"
+
+        def __hash__(self):
+            return 1
+
+        def __eq__(self, other):
+            return self is other
+
+    args = {Weird(): "a  b"}
+    rendered = _render_args(args)
+    assert "\n" in rendered  # confirms the repr() fallback path is in play
+    out = summarize_args(args)
+    assert "\n" not in out
+    assert "\r" not in out
+    # Line-break neutralization only — whitespace elsewhere is untouched.
+    assert "a  b" in out
 
 
 def test_summarize_error_truncates_and_collapses_newlines():

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -19,19 +19,6 @@ def test_fingerprint_stable_and_arg_sensitive():
     assert fingerprint("edit", {"a": 1}) != fingerprint("read", {"a": 1})
 
 
-def test_repeat_threshold_trips_nudge_then_stop():
-    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
-    fp = fingerprint("edit", {"path": "x"})
-    lb.record([CallSignature("edit", fp, False)])
-    assert lb.verdict() is LoopVerdict.NONE          # 1 occurrence
-    lb.record([CallSignature("edit", fp, False)])
-    assert lb.verdict() is LoopVerdict.NONE           # 2
-    lb.record([CallSignature("edit", fp, False)])
-    assert lb.verdict() is LoopVerdict.NUDGE           # 3 → first trip
-    lb.record([CallSignature("edit", fp, False)])
-    assert lb.verdict() is LoopVerdict.STOP            # trips again after nudge
-
-
 def test_error_window_trips():
     lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
     # 3 distinct erroring calls, then a 4th → 4 errors in window
@@ -153,7 +140,7 @@ def test_error_surge_does_not_retrip_without_new_errors():
     assert lb.verdict() is LoopVerdict.NONE
 
 
-def test_repeating_the_same_call_after_nudge_does_escalate():
+def test_repeating_the_same_call_after_nudge_advances_a_rung():
     """The reprieve is conditional: re-offending still advances the ladder."""
     lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
     fp = fingerprint("edit", {"path": "x"})
@@ -163,4 +150,22 @@ def test_repeating_the_same_call_after_nudge_does_escalate():
     lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE
     lb.record([CallSignature("edit", fp, False)])  # count 3 -> 4: a fresh offense
+    assert lb.verdict() is LoopVerdict.REDIRECT
+
+
+def test_ladder_is_nudge_then_redirect_then_stop():
+    """Three rungs: reaching STOP now requires re-offending twice after being
+    told twice, not merely one elapsed round (#707)."""
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    for _ in range(2):
+        lb.record([CallSignature("edit", fp, False)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.REDIRECT
+    lb.record([CallSignature("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.STOP
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.STOP

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -1,5 +1,11 @@
 from decafclaw.config_types import LoopBreakerConfig
-from decafclaw.loop_breaker import LoopBreaker, LoopVerdict, fingerprint
+from decafclaw.loop_breaker import (
+    CallSignature,
+    LoopBreaker,
+    LoopVerdict,
+    fingerprint,
+    summarize_args,
+)
 
 
 def _lb(**kw):
@@ -16,13 +22,13 @@ def test_fingerprint_stable_and_arg_sensitive():
 def test_repeat_threshold_trips_nudge_then_stop():
     lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
     fp = fingerprint("edit", {"path": "x"})
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NONE          # 1 occurrence
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NONE           # 2
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE           # 3 → first trip
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.STOP            # trips again after nudge
 
 
@@ -30,38 +36,82 @@ def test_error_window_trips():
     lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
     # 3 distinct erroring calls, then a 4th → 4 errors in window
     for i in range(3):
-        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        lb.record([CallSignature(f"t{i}", fingerprint(f"t{i}", {}), True)])
         assert lb.verdict() is LoopVerdict.NONE
-    lb.record([("t3", fingerprint("t3", {}), True)])
+    lb.record([CallSignature("t3", fingerprint("t3", {}), True)])
     assert lb.verdict() is LoopVerdict.NUDGE
 
 
 def test_errors_outside_window_do_not_trip():
     lb = _lb(repeat_threshold=99, error_threshold=3, error_window=3)
-    lb.record([("a", "fa", True)])
+    lb.record([CallSignature("a", "fa", True)])
     lb.verdict()
-    lb.record([("b", "fb", False)])
+    lb.record([CallSignature("b", "fb", False)])
     lb.verdict()
-    lb.record([("c", "fc", False)])
+    lb.record([CallSignature("c", "fc", False)])
     lb.verdict()
-    lb.record([("d", "fd", True)])  # window now [b?,c,d] errors=1 (a aged out)
+    lb.record([CallSignature("d", "fd", True)])  # window now [b?,c,d] errors=1 (a aged out)
     assert lb.verdict() is LoopVerdict.NONE
 
 
 def test_disabled_never_trips():
     lb = _lb(enabled=False, repeat_threshold=1, error_threshold=1, error_window=1)
-    lb.record([("edit", "fp", True)])
+    lb.record([CallSignature("edit", "fp", True)])
     assert lb.verdict() is LoopVerdict.NONE
 
 
-def test_last_signal_describes_reason():
+def test_offense_reason_describes_the_repeated_call():
     lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
     fp = fingerprint("edit", {"p": "x"})
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     lb.verdict()
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE
-    assert "edit" in lb.last_signal()
+    assert "edit" in lb.offense().reason
+
+
+def test_offense_carries_args_and_error_text():
+    """The redirect can only name the real failure if the detector kept it."""
+    lb = _lb(repeat_threshold=2, error_threshold=99, error_window=6)
+    fp = fingerprint("workspace_write", {"path": "skills/foo/tools.py"})
+    sig = CallSignature(
+        tool_name="workspace_write",
+        fingerprint=fp,
+        is_error=True,
+        args_text='{"path": "skills/foo/tools.py"}',
+        error_text="[error: ImportError: attempted relative import]",
+    )
+    lb.record([sig])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([sig])
+    assert lb.verdict() is LoopVerdict.NUDGE
+
+    off = lb.offense()
+    assert off.tool_name == "workspace_write"
+    assert "skills/foo/tools.py" in off.args_text
+    assert "ImportError" in off.error_text
+    assert "workspace_write" in off.reason
+
+
+def test_summarize_args_truncates_and_flattens():
+    long_args = {"body": "x" * 5000}
+    out = summarize_args(long_args)
+    assert len(out) <= 401          # _MAX_ARG_CHARS + the ellipsis
+    assert out.endswith("…")
+    assert "\n" not in summarize_args({"body": "a\nb"})
+
+
+def test_error_surge_offense_has_no_tool_name_but_keeps_error_text():
+    """An error surge has no single offending call, so tool_name is empty —
+    but the most recent error body is still worth naming."""
+    lb = _lb(repeat_threshold=99, error_threshold=2, error_window=6)
+    lb.record([CallSignature("a", "fa", True, "{}", "[error: boom A]")])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([CallSignature("b", "fb", True, "{}", "[error: boom B]")])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    off = lb.offense()
+    assert off.tool_name == ""
+    assert "boom B" in off.error_text
 
 
 def test_compliance_after_nudge_does_not_trip_again():
@@ -74,14 +124,14 @@ def test_compliance_after_nudge_does_not_trip_again():
     """
     lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
     fp = fingerprint("edit", {"path": "x"})
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NONE
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NONE
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE
     # The agent obeys: a different call, not the offending one.
-    lb.record([("read", fingerprint("read", {"path": "y"}), False)])
+    lb.record([CallSignature("read", fingerprint("read", {"path": "y"}), False)])
     assert lb.verdict() is LoopVerdict.NONE
 
 
@@ -95,11 +145,11 @@ def test_error_surge_does_not_retrip_without_new_errors():
     lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
     verdict = None
     for i in range(4):
-        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        lb.record([CallSignature(f"t{i}", fingerprint(f"t{i}", {}), True)])
         verdict = lb.verdict()
     assert verdict is LoopVerdict.NUDGE
     # The agent recovers: one clean call, no new errors.
-    lb.record([("ok", fingerprint("ok", {}), False)])
+    lb.record([CallSignature("ok", fingerprint("ok", {}), False)])
     assert lb.verdict() is LoopVerdict.NONE
 
 
@@ -108,9 +158,9 @@ def test_repeating_the_same_call_after_nudge_does_escalate():
     lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
     fp = fingerprint("edit", {"path": "x"})
     for _ in range(2):
-        lb.record([("edit", fp, False)])
+        lb.record([CallSignature("edit", fp, False)])
         assert lb.verdict() is LoopVerdict.NONE
-    lb.record([("edit", fp, False)])
+    lb.record([CallSignature("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE
-    lb.record([("edit", fp, False)])  # count 3 -> 4: a fresh offense
+    lb.record([CallSignature("edit", fp, False)])  # count 3 -> 4: a fresh offense
     assert lb.verdict() is LoopVerdict.STOP

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -5,6 +5,7 @@ from decafclaw.loop_breaker import (
     LoopVerdict,
     fingerprint,
     summarize_args,
+    summarize_error,
 )
 
 
@@ -85,7 +86,19 @@ def test_summarize_args_truncates_and_flattens():
     out = summarize_args(long_args)
     assert len(out) <= 401          # _MAX_ARG_CHARS + the ellipsis
     assert out.endswith("…")
+    # Newline-free, though trivially so: json.dumps already escapes a real
+    # newline to a two-character "\\n" before _truncate ever sees it. The
+    # genuine newline-collapsing path is summarize_error() below.
     assert "\n" not in summarize_args({"body": "a\nb"})
+
+
+def test_summarize_error_truncates_and_collapses_newlines():
+    """Error bodies are raw multi-line tracebacks, and they get interpolated
+    into a single-sentence prompt ("The error every time: ..."), so an
+    embedded newline would visibly mangle the diagnostic."""
+    assert "\n" not in summarize_error("Traceback:\n  File x\nImportError: boom")
+    assert summarize_error("e" * 5000).endswith("…")
+    assert len(summarize_error("e" * 5000)) <= 301  # _MAX_ERROR_CHARS + ellipsis
 
 
 def test_error_surge_offense_has_no_tool_name_but_keeps_error_text():
@@ -151,6 +164,95 @@ def test_repeating_the_same_call_after_nudge_advances_a_rung():
     assert lb.verdict() is LoopVerdict.NUDGE
     lb.record([CallSignature("edit", fp, False)])  # count 3 -> 4: a fresh offense
     assert lb.verdict() is LoopVerdict.REDIRECT
+
+
+def test_compliance_after_a_multi_call_batch_does_not_trip_again():
+    """#707 review: EVERY fresh offender's watermark must advance, not just the
+    worst one's.
+
+    Tool calls run concurrently (asyncio.gather), so a repeated multi-call
+    batch is the canonical thrash shape — and it pushes several fingerprints
+    over threshold in the same round. Advancing only the worst one's watermark
+    left the others permanently "fresh", so they re-tripped on later rounds
+    with counts that had stopped growing three rounds earlier: a fully
+    compliant agent got walked REDIRECT -> STOP anyway, quoting stale counts.
+    Every other repeat test records exactly ONE signature per round, which is
+    why this survived.
+    """
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=50)
+    batch = [
+        CallSignature("shell", fingerprint("shell", {"c": "make test"}), False),
+        CallSignature("read", fingerprint("read", {"p": "a.py"}), False),
+        CallSignature("edit", fingerprint("edit", {"p": "b.py"}), False),
+    ]
+    verdict = None
+    for _ in range(3):
+        lb.record(batch)
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    # The agent obeys completely: brand-new, non-repeating, non-erroring calls.
+    for i in range(3):
+        lb.record([CallSignature(f"new{i}", fingerprint(f"new{i}", {"n": i}), False)])
+        assert lb.verdict() is LoopVerdict.NONE, (
+            "a compliant round escalated off a co-offender's stale count"
+        )
+
+
+def test_compliant_but_erroring_round_after_a_nudge_does_not_escalate():
+    """#707 review: the error signal must not enter its first round loaded.
+
+    The redirect *instructs* the model to "take exactly one read-only action",
+    and in the broken environments where the breaker fires that diagnostic read
+    frequently errors. Requiring only "any new error" on top of a window still
+    full of pre-trip failures meant the mechanism escalated on the very
+    behavior it had just demanded.
+    """
+    lb = _lb(repeat_threshold=3, error_threshold=4, error_window=6)
+    fp = fingerprint("edit", {"p": "b.py"})
+    verdict = None
+    for _ in range(3):
+        lb.record([CallSignature("edit", fp, True, '{"p": "b.py"}', "[error: boom]")])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    # The agent obeys: distinct read-only calls — which happen to error.
+    for i in range(3):
+        lb.record([CallSignature(
+            f"read{i}", fingerprint("read", {"p": f"log{i}"}), True,
+            "{}", "[error: no such file]")])
+        assert lb.verdict() is LoopVerdict.NONE, (
+            "the ladder punished the diagnostic read it asked for"
+        )
+
+
+def test_a_genuine_new_error_surge_after_a_nudge_still_escalates():
+    """The counterpart to the test above: fixing the false positive must not
+    disable the signal. A full fresh threshold of errors still advances."""
+    lb = _lb(repeat_threshold=99, error_threshold=3, error_window=6)
+    verdict = None
+    for i in range(3):
+        lb.record([CallSignature(f"a{i}", fingerprint(f"a{i}", {}), True)])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    for i in range(3):
+        lb.record([CallSignature(f"b{i}", fingerprint(f"b{i}", {}), True)])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.REDIRECT
+
+
+def test_error_text_clears_when_the_call_starts_succeeding():
+    """The nudge says "the failure each time" — so a fingerprint that failed
+    early and then succeeded must not keep quoting the stale error. Repeated
+    *successful* identical calls trip the repeat signal too, so this is
+    reachable."""
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=50)
+    fp = fingerprint("read", {"p": "x"})
+    lb.record([CallSignature("read", fp, True, "{}", "[error: transient]")])
+    assert lb.verdict() is LoopVerdict.NONE
+    for _ in range(2):
+        lb.record([CallSignature("read", fp, False, "{}", "")])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    assert lb.offense().error_text == ""
 
 
 def test_ladder_is_nudge_then_redirect_then_stop():

--- a/tests/test_loop_breaker.py
+++ b/tests/test_loop_breaker.py
@@ -62,3 +62,55 @@ def test_last_signal_describes_reason():
     lb.record([("edit", fp, False)])
     assert lb.verdict() is LoopVerdict.NUDGE
     assert "edit" in lb.last_signal()
+
+
+def test_compliance_after_nudge_does_not_trip_again():
+    """#707: the round after a NUDGE must not trip when the agent obeyed.
+
+    The old detector tested a standing condition (count >= threshold) that
+    stayed true forever once crossed, so this round always escalated to STOP
+    regardless of what the agent did — the agent was never given a round in
+    which changing course could pay off.
+    """
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    # The agent obeys: a different call, not the offending one.
+    lb.record([("read", fingerprint("read", {"path": "y"}), False)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_error_surge_does_not_retrip_without_new_errors():
+    """#707: a window still holding old errors must not re-trip on its own.
+
+    _recent_errors is a rolling window, so after 4 errors one clean call
+    leaves 4 errors still in a 6-wide window — enough to satisfy the old
+    standing-condition test and stop a recovering agent.
+    """
+    lb = _lb(repeat_threshold=99, error_threshold=4, error_window=6)
+    verdict = None
+    for i in range(4):
+        lb.record([(f"t{i}", fingerprint(f"t{i}", {}), True)])
+        verdict = lb.verdict()
+    assert verdict is LoopVerdict.NUDGE
+    # The agent recovers: one clean call, no new errors.
+    lb.record([("ok", fingerprint("ok", {}), False)])
+    assert lb.verdict() is LoopVerdict.NONE
+
+
+def test_repeating_the_same_call_after_nudge_does_escalate():
+    """The reprieve is conditional: re-offending still advances the ladder."""
+    lb = _lb(repeat_threshold=3, error_threshold=99, error_window=6)
+    fp = fingerprint("edit", {"path": "x"})
+    for _ in range(2):
+        lb.record([("edit", fp, False)])
+        assert lb.verdict() is LoopVerdict.NONE
+    lb.record([("edit", fp, False)])
+    assert lb.verdict() is LoopVerdict.NUDGE
+    lb.record([("edit", fp, False)])  # count 3 -> 4: a fresh offense
+    assert lb.verdict() is LoopVerdict.STOP


### PR DESCRIPTION
Closes #707.

The loop-breaker reliably *stopped* a thrashing agent but never redirected it into a
different action. The reported symptom looked like a wording problem. It wasn't.

## The actual bug: the detector latched

`LoopBreaker._counts` never decayed and `_tripped_reason()` tested `count >= threshold` — a
**standing condition** that stays true forever once crossed. So:

- Round N: third identical call → trip → `NUDGE`
- Round N+1: agent obeys the nudge and makes a **completely different** call → still
  `count >= threshold` → trip → `STOP`

The turn was hard-stopped on the round right after the warning **no matter what the agent
did**. There was no round in which changing course could pay off, which is precisely why
the nudge appeared to do nothing. No amount of better wording could have fixed that.

Each signal now compares against a watermark set at its last trip — per-fingerprint
`last_tripped_count`, and a monotonic error counter — so a rung advances only on a
genuinely **new** offense. Compliance earns a real reprieve.

## What else changed

**Evidence retention.** The detector hashed call arguments away and kept only an
`is_error` bool, so the best possible message was generic advice naming no file and no
error. `CallSignature` and a frozen `Offense` record (via `LoopBreaker.offense()`, replacing
prose-only `last_signal()`) now carry the real tool, arguments and error text, truncated at
module constants. `_render_args()` is shared by `fingerprint()` and `summarize_args()` so
the arguments quoted at the model can never drift from the arguments being counted.

**A `REDIRECT` rung** between nudge and stop: a diagnosis contract quoting the real failure
and requiring a falsifiable hypothesis, the observation that would kill it, and exactly one
read-only action to fetch that observation. Trip 1 nudge, 2 redirect, 3+ stop — so reaching
the stop now means re-offending twice after two warnings.

Its "do NOT call X again" is **prose only**; the tool list is never filtered. Enforcement is
the ladder — re-issuing the forbidden call is the fresh offense that advances to STOP. That
avoids inventing a mutating-vs-read-only tool taxonomy, which this codebase deliberately
does not have.

**Delivery de-duplication.** `_finalize_with_note` joined every accumulated preamble into the
delivered text, but interactive transports already render each live from `text_before_tools` —
Mattermost posts each as its own message. A long thrash ended by repeating the whole turn back
at the user. #675 fixed the *archive* half of this and kept the *delivery* half; its test
asserted on `read_archive()` and never on `result.text`, which is why it survived.

Now gated on whether anyone is watching: interactive turns get the note alone; child,
heartbeat and scheduled turns keep the join, because their consumer is a parent agent or a
reporter that never subscribes to the event bus and only ever sees `ToolResult.text`.
Archiving stays note-only on **every** branch.

**Incidental bug fixed:** `interactive_terminal.py` read `config.heartbeat_suppress_ok`,
which does not exist (`config.heartbeat.suppress_ok` does), so `make run` has crashed at
startup since `2e5ff3f`. Found because making the terminal's missing `text_before_tools`
handler testable required driving `run_interactive`, which had no test coverage at all.

## Review history worth knowing about

Two serious defects survived into the final whole-branch review, and **both trace to
under-specification in the plan rather than to the implementation**:

1. **Critical** — watermarks advanced for only the *worst* offender, so co-tripping
   fingerprints from a batched round (tool calls run concurrently via `asyncio.gather`)
   re-tripped forever. Reproduced: a perfectly compliant agent still walked
   NUDGE → REDIRECT → STOP, quoting counts that had stopped growing three rounds earlier.
   The #707 bug was surviving inside its own fix.
2. **Important** — the error signal escalated off a stale window plus one new error. Since
   the redirect *demands* a read-only diagnostic action, and that read often errors in the
   broken environment that tripped the breaker, the mechanism punished the behavior it had
   just demanded.

Both are fixed, and true positives were re-verified: 6 identical repeats give
`NONE NONE NUDGE REDIRECT STOP STOP`, and each error rung now requires `error_threshold`
genuinely new errors.

The same test blind spot hid the defect twice — every repeat test recorded exactly one
`CallSignature` per round, so latching and correct escalation were observationally
identical. Discriminating tests now record multiple fingerprints per round and exercise the
compliance path.

## Testing

- `make test`: 3547 passed, 2 skipped. `make lint`, `make typecheck` clean.
- Real-LLM `evals/diagnostic_discipline.yaml`: 3/3 pass. The new redirect-rung case was
  confirmed to actually exercise rung 2 (nudge → redirect → one read-only action → stop
  never fired).
- `make eval-tools` has 5 pre-existing failures, unrelated: this branch touches zero tool
  definitions, `tools/`, or `skills/`, and that suite tests tool-description disambiguation.
- **Not yet done:** live verification in a real Mattermost/web session. No bot instance was
  started during this work, since a second one silently misses websocket events.

## Follow-ups filed

- #710 — `is_heartbeat_ok` substring-matches its sentinel in the first 300 chars, so an
  abnormally-terminated heartbeat turn whose preamble mentions `HEARTBEAT_OK` can suppress
  its own alert. Note-first ordering closes this for the ~336-char loop-breaker note and
  only narrows it for the ~65-char max-iterations note (measured). Pre-existing on `main`,
  which delivers `accumulated + note` unconditionally for every turn kind.

Deferred and documented in `docs/loop-breaker.md`: a diagnosis child-agent rung (fork an
isolated agent seeded with the thrash record, inject its root-cause hypothesis as the
redirect). Deferred on cost — an LLM call per trip, including false positives — not merit.

Spec, plan and retro: `docs/dev-sessions/2026-07-26-1158-707-loop-breaker-redirect/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)