### PR TITLE
Never report an abnormally-terminated turn as heartbeat-OK

### DIFF
--- a/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/checks.md
+++ b/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/checks.md
@@ -1,0 +1,150 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/710
+**Frozen at:** `0d08b2d` (2026-07-27) — re-anchor this sha if the branch is rebased.
+**Check files — read-only from Phase 1 onward:**
+- `tests/test_heartbeat.py`
+
+Note: this file is *also* the implementation's neighbour in one respect — the guards G1–G3 and
+the criterion's new test all live in `tests/test_heartbeat.py`. The whole file is frozen; the
+implementation lives in `src/decafclaw/heartbeat.py`, which is disjoint from it.
+
+## C1
+
+CRITERION: IF a turn's delivered text carries an abnormal-termination marker, THEN
+`is_heartbeat_ok` SHALL return `False`, regardless of whether the sentinel appears within the
+first 300 characters.
+
+- Markers, verbatim: `[Agent reached max tool iterations` and `[loop-breaker] Stopped`.
+- The assertion must cover **both** markers. A test covering only `max tool iterations` would
+  pass while the loop-breaker path stays broken.
+
+CHECK: `uv run pytest tests/test_heartbeat.py::test_is_heartbeat_ok_false_on_abnormal_termination`
+
+AT FREEZE: **fails**, for the correct reason — a genuine behavioural assertion, not a
+collection or import error.
+
+```
+E           AssertionError: max-iterations: abnormal termination reported as OK
+E           assert True is False
+E            +  where True = is_heartbeat_ok('\n\n[Agent reached max tool iterations (30) without a final response]\n\nNothing new since the last check — HEARTBEAT_OK.')
+tests/test_heartbeat.py:192: AssertionError
+1 failed in 4.31s
+```
+
+- **pytest exit code 1**, 1 test collected, 1 failed. (Not exit 5 — the check has teeth.)
+- The test's `for` loop short-circuits at the max-iterations case, so the loop-breaker half's
+  failure is masked in that output. Verified independently that **both** halves fail today, so
+  a partial fix covering one marker cannot pass this check:
+
+  | marker | sentinel index | text len | `is_heartbeat_ok` today |
+  |---|---|---|---|
+  | `[Agent reached max tool iterations` | 104 | 117 | `True` (should be `False`) |
+  | `[loop-breaker] Stopped` | 161 | 174 | `True` (should be `False`) |
+
+- Both sentinels sit well inside the 300-char window, and the test asserts that premise
+  (`sentinel_index < 300`) so it cannot silently degrade into re-testing the beyond-300 path
+  that `test_is_heartbeat_ok_beyond_300_chars` already covers.
+- Whole-file run at freeze: `1 failed, 32 passed` — only the new check fails.
+
+## Guards
+
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- **G1:** `uv run pytest tests/test_heartbeat.py::test_is_heartbeat_ok_present
+  tests/test_heartbeat.py::test_is_heartbeat_ok_case_insensitive
+  tests/test_heartbeat.py::test_is_heartbeat_ok_not_present` — normal sentinel detection must
+  not regress. A fix that returns `False` too eagerly would defeat the heartbeat-quiet
+  mechanism and spam alerts.
+- **G2:** `uv run pytest tests/test_heartbeat.py::test_is_heartbeat_ok_beyond_300_chars` — the
+  300-char window stays in place under option 1. #712 is where it goes away.
+- **G3 (negative control):** `uv run pytest
+  tests/test_heartbeat.py::test_is_background_wake_ok_detects_sentinel` — this fix must not
+  incidentally alter the parallel sentinel path.
+- **G4 (added at freeze, not in the spec):** `uv run pytest
+  tests/test_agent_loop_breaker.py::test_loop_break_note_comes_first_for_unwatched_turns` —
+  this test already asserts `not is_heartbeat_ok(result.text)` on a real loop-broken heartbeat
+  turn, so it is a behavioural guard over the same predicate from the production side. The
+  spec did not list it; it passes today and must keep passing. Recorded as a guard rather than
+  a criterion precisely because it passes.
+
+Baselines observed at freeze — every guard confirmed **passing** before implementation:
+
+- G1–G3 together:
+  `uv run pytest tests/test_heartbeat.py -k "is_heartbeat_ok or is_background_wake_ok" -q`
+  → `6 passed in 1.36s` (6 collected, 6 passed). Matches intake's recorded observation.
+  (This `-k` selection predates the new check, which the expression does match — after the
+  freeze it selects 7. Guard verdicts are read per-test by name at the gate, not from this
+  aggregate.)
+- G4: `uv run pytest
+  tests/test_agent_loop_breaker.py::test_loop_break_note_comes_first_for_unwatched_turns -q`
+  → `1 passed in 5.02s` (1 collected, 1 passed).
+- Whole suite: `3581 passed, 2 skipped in 20.62s` before the freeze commit.
+
+## Amendments
+
+(Append-only. Empty — no amendment was made.)
+
+## Clarification log
+
+(Not an amendment: no criterion or guard wording changed, and no verdict changed.)
+
+- **CL1 — the spec's `loop_breaker` measurement does not reproduce.** The intake correction
+  claims a ~167-char loop-breaker note via `loop_breaker.last_signal()`; that method does not
+  exist, and `_finalize_loop_break` appends an unconditional ~193-char handoff paragraph that
+  floors the note at ~296 chars. Measured: note 303 chars → sentinel at 317 →
+  `is_heartbeat_ok == False`. C1's loop-breaker half still fails at freeze as a pure-function
+  assertion on a directly-constructed string, so the criterion stands and still discriminates;
+  what changes is only the claim that the loop-breaker path is a *live* production bug. It is
+  currently guarded by note length, and C1 makes that guard unnecessary. Full reasoning in
+  `notes.md`.
+- **CL2 — `file:line` drift.** The spec cites `agent.py:1080-1097` for the marker strings;
+  they now live at `agent.py:1150-1178`. Strings unchanged.
+
+## Pre-squash tamper verdict
+
+**`clean`** — recorded 2026-07-27, immediately before the squash. This record *is* the
+evidence: `git reset --soft origin/main` collapses the freeze commit, so `0d08b2d` stops being
+an ancestor of the branch and is absent from `origin` — the command below is not reproducible
+by a reviewer or by CI afterwards.
+
+- `git diff 0d08b2d -- tests/test_heartbeat.py` → **empty**. The one frozen check file is
+  byte-identical to the freeze.
+- Broadened by the independent verifier to both collection roots,
+  `git diff 0d08b2d --stat -- tests contrib` → **empty**. No test file anywhere in the suite
+  changed since the freeze.
+- `git diff 0d08b2d --stat` → 5 files: `checks.md` (this file), `notes.md`, `docs/heartbeat.md`,
+  `docs/schedules.md`, `src/decafclaw/heartbeat.py`. No lockfile, no generated file, no test
+  file. All on-subject.
+- This file's only change since the freeze is the `Frozen at` sha line — a sanctioned append.
+  No CRITERION line, CHECK command, or guard command differs from the freeze version.
+  Independently confirmed by the verifier, which quoted the one-line diff.
+
+Not `clean-by-substitute`: `Check files` is non-empty, so the real tamper command ran and
+returned a genuine empty diff rather than an absent result.
+
+## Verification results (independent verifier, fresh context, `checks.md` + repo only)
+
+| id | command (args after `pytest`) | exit | collected / passed | verdict |
+|---|---|---|---|---|
+| C1 | `tests/test_heartbeat.py::test_is_heartbeat_ok_false_on_abnormal_termination` | 0 | 1 / 1 | **pass** |
+| G1 | `tests/test_heartbeat.py::test_is_heartbeat_ok_present …_case_insensitive …_not_present` | 0 | 3 / 3 | **pass** |
+| G2 | `tests/test_heartbeat.py::test_is_heartbeat_ok_beyond_300_chars` | 0 | 1 / 1 | **pass** |
+| G3 | `tests/test_heartbeat.py::test_is_background_wake_ok_detects_sentinel` | 0 | 1 / 1 | **pass** |
+| G4 | `tests/test_agent_loop_breaker.py::test_loop_break_note_comes_first_for_unwatched_turns` | 0 | 1 / 1 | **pass** |
+
+No check or guard collected zero (exit 5 would have been a failed check). Whole suite:
+`3582 passed, 2 skipped` — the freeze baseline of 3581 plus C1's now-passing check.
+
+The verifier also stated affirmatively that the diff could not be passing for a reason other
+than doing the work: zero test surface changed, no `skip`/`xfail` added, no assertion narrowed,
+and the freeze-time predicate body provably returns `True` for both of the test's fixtures.
+
+### Unasserted properties (verifier's observation, recorded not fixed)
+
+Two properties of the implementation are measured by no criterion or guard here: marker matching
+is **case-sensitive**, and markers match against the **whole response** rather than the first
+300 characters. Both are deliberate and documented, but C1 does not discriminate on either.
+Coverage was NOT added, because `tests/test_heartbeat.py` is the frozen check file and adding a
+variant alongside a frozen check post-freeze is not sanctioned — it would also dirty the tamper
+diff above. #712 rewrites this predicate and is the place to pin both.

--- a/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/notes.md
+++ b/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/notes.md
@@ -1,0 +1,168 @@
+# Notes — #710 `is_heartbeat_ok` vs. abnormal termination
+
+Mode: `agent-session express`. Tier `auto-ok`. Started 2026-07-27 12:07.
+
+## Setup
+
+- Worktree `.claude/worktrees/fix-710-heartbeat-ok-abnormal-termination`, branch
+  `fix/710-heartbeat-ok-abnormal-termination` off `origin/main` @ `076f89e`.
+- Baseline `make test`: `3581 passed, 2 skipped in 20.62s`.
+- Guards baseline: `uv run pytest tests/test_heartbeat.py -k "is_heartbeat_ok or
+  is_background_wake_ok" -q` → `6 passed in 1.36s`. Matches intake's recorded observation.
+- Board: #710 → In progress.
+- Deviation: appending `HTTP_PORT` to the worktree `.env` was blocked by the sandbox. No
+  server is started in this run, so it costs nothing here.
+
+## Readiness gate (express Phase 0)
+
+Applied the **augmented existing issue** variant of the readiness checklist — the body is the
+original author's text with `## Design decisions` / `## Acceptance criteria` / guards / tier
+appended by `intake` below a `---`, not a spec written to the template. Items 1–5 and 7 pass;
+item 6 passes in its variant form (an explicit "What we're NOT doing" section bounds scope).
+
+## Re-confirming the spec's evidence (plan step 4)
+
+The spec's `file:line` refs had drifted — `agent.py:1080-1097` now reads
+`agent.py:1150-1178` (`_finalize_max_iterations` / `_finalize_loop_break`). The marker
+strings themselves are unchanged and still verbatim correct.
+
+### `max_tool_iterations` path — reproduces as claimed
+
+Note `[Agent reached max tool iterations (25) without a final response]` (65 chars after
+`.strip()`, spec said 67) + `"Nothing needs attention on the feed right now, so
+HEARTBEAT_OK."` → sentinel at index **117**, `is_heartbeat_ok == True`. The bug is live.
+
+### `loop_breaker` path — the spec's measurement does NOT reproduce
+
+The intake correction claims that with "a shorter `loop_breaker.last_signal()`" the note runs
+~167 chars, putting a sentinel-bearing preamble back inside the 300-char window
+(`is_heartbeat_ok == True`). Measured against current code, that is not reachable:
+
+- There is no `last_signal()` on `LoopBreaker`. `_finalize_loop_break` uses `offense()`
+  (`loop_breaker.py:277`).
+- `_finalize_loop_break` appends an **unconditional** ~193-char handoff paragraph ("I stopped
+  rather than retry again. …"). With the 69 chars of fixed framing around `off.reason`, the
+  note has a hard floor of ~264 + `len(reason)` chars — ~296 at the very shortest reason the
+  two `Offense` builders can produce (`called <3-char-tool> 3× with the same args`).
+- Measured with a realistic short reason (`called check_feed 3× with the same args`, no
+  `error_text`): note = 303 chars, sentinel at 317 (long preamble) / 317 (short preamble),
+  `is_heartbeat_ok == False` both ways.
+
+So in production, under #707's note-first ordering, the loop-breaker path is currently
+**not** exposed for any plausible preamble — the sentinel can only land inside the window if
+the note lands under ~298 chars AND the first preamble begins with the sentinel within 2
+characters. The issue's *original* table was right, and right for a structural reason the
+intake correction talked itself out of: the unconditional handoff paragraph is the floor.
+
+**What this changes, and what it doesn't.** It does not change C1, its check, or the tier:
+
+- C1 asserts a contract on the pure predicate `is_heartbeat_ok`, not on what
+  `_finalize_with_note` happens to emit. As a pure-function assertion **both** halves fail at
+  freeze — a directly-constructed string carrying `[loop-breaker] Stopped` with the sentinel
+  inside the window returns `True` today.
+- Covering the loop-breaker marker is therefore *defensive* rather than a live-bug fix: it
+  stops the loop-breaker path's safety from depending on the note-length floor, which is the
+  exact length-contingency the issue set out to remove. It is not a criterion that already
+  passes, so `frozen-checks.md`'s "a check passes at freeze → stop" does not fire.
+- No check or guard wording changes, so no verdict changes: this is a clarification of the
+  record, not an amendment. Tier stays `auto-ok`.
+
+Recorded here and in the PR body so the next reader doesn't inherit the wrong measurement.
+
+## Freeze
+
+See `checks.md`. Freeze commit `0d08b2d`, per-criterion `AT FREEZE` output recorded there.
+
+## Execute
+
+One phase, as planned: the marker tuple + early return in `is_heartbeat_ok`, plus the two docs
+pages that state the predicate's contract (`docs/heartbeat.md` for heartbeat,
+`docs/schedules.md` for the scheduler). No implementer subagent — the slice is one predicate.
+
+All five gate commands pass individually: C1 `1 passed`; G1 `3 passed`; G2 `1 passed`; G3
+`1 passed`; G4 `1 passed`. Full suite `3582 passed, 2 skipped` against the `3581 passed,
+2 skipped` baseline — the +1 is C1's check.
+
+### `make check` is blocked by a pre-existing lockfile guard
+
+`make check` fails at its first step, `install-js`, before reaching anything this branch
+touches:
+
+```
+ERROR: npm install rewrote package-lock.json during a check.
+```
+
+That is #709's guard (added to catch #706's silent lockfile rewrites) firing correctly on a
+condition that predates this branch. `npm install` deterministically prunes 27 nested
+`node_modules/vitest/node_modules/@esbuild/*` platform-optional entries — 512 lines — from the
+committed lockfile, every run, with `node_modules` already present. This branch modifies no JS
+and no dependency file, and the failure reproduces with the lockfile at its committed
+`origin/main` content, so it is not caused by this work. **Worth a separate issue:** in a fresh
+worktree `make check` / `make check-js` / `make test-js` cannot pass at all until the lockfile
+is regenerated, which makes the guard un-actionable rather than protective there.
+
+Ran all four of `check`'s steps natively instead, and all four pass:
+
+- `make check-message-types` → clean (no diff)
+- `uv run ruff check src/ tests/` → `All checks passed!`
+- `uv run pyright` → `0 errors, 0 warnings, 0 informations`
+- `npx tsc --noEmit` in `src/decafclaw/web/static` → clean
+
+Also worth recording as a near-miss: `git commit -a` swept the npm-rewritten lockfile into the
+Phase 1 commit (512 deletions). Caught by reading the commit's `--stat`, amended out. The
+lockfile guard's failure mode and `-a`'s breadth compound each other.
+
+## Independent verification
+
+Dispatched with `checks.md` and the repo only — no plan, no notes, no rationale. Reported:
+C1 `pass` (exit 0, 1 collected / 1 passed); G1 `pass` (3/3); G2 `pass` (1/1); G3 `pass` (1/1);
+G4 `pass` (1/1); no check or guard collected zero. Tamper diff
+`git diff 0d08b2d -- tests/test_heartbeat.py` **empty**; broadened to `-- tests contrib`, also
+empty. `checks.md`'s only change since the freeze is the `Frozen at` sha line — no CRITERION,
+CHECK, or guard command differs. It confirmed the diff could not be passing for a reason other
+than doing the work: zero test surface changed, no skip/xfail added, the freeze-time body
+provably returns `True` for both of the test's fixtures.
+
+### Known limit the verifier flagged, recorded rather than fixed
+
+Two properties of the implementation are asserted by no criterion or guard: marker matching is
+**case-sensitive**, and markers are matched against the **whole response** rather than the
+first 300 characters. Both are deliberate and documented in the docstring and
+`docs/heartbeat.md`, but C1 doesn't discriminate on either — its fixtures use exact-case
+literals with the markers inside the window.
+
+Not fixed here on purpose: `tests/test_heartbeat.py` is the frozen check file, so adding
+coverage to it after the freeze would make the tamper diff non-empty, and `frozen-checks.md` is
+explicit that adding a passing variant alongside a frozen check is not sanctioned. The honest
+handling is to record the gap. #712 rewrites this predicate anyway, and that is the natural
+place to pin both properties.
+
+## Rebase (initial, pre-PR)
+
+`origin/main` had not advanced (`git log HEAD..origin/main` empty), so no rebase was needed and
+the freeze sha `0d08b2d` stays reachable — no re-anchoring, and the verifier's report describes
+the current tree.
+
+## Resume rebase (post-PR, after host crash)
+
+Session resumed after host crashed mid-review-cycle. `origin/main` had advanced to `3af093d`
+(#716/#717 — the lockfile install-js fix). Rebased the branch:
+- `git rebase origin/main` → success, no conflicts
+- New HEAD: `3be3b07`
+- Freeze sha re-anchoring: `git diff 0d08b2d HEAD -- tests/test_heartbeat.py` → empty, check file
+  byte-identical. The old freeze sha is still valid for the tamper verdict.
+- Re-ran criteria and guards post-rebase: `make test` → `3582 passed, 2 skipped` (unchanged)
+- `make check` now passes (the #716/#717 fix changed install-js to use `npm ci`)
+- CI re-triggered on force-push, watched with `gh pr checks 714 --watch`
+- CI: 2/2 pass (lint-and-test, js-test)
+- Review threads: 0 unresolved (copilot review landed with COMMENTED state, 0 inline comments)
+
+## Self-review of `git diff origin/main..HEAD`
+
+No bugs, no incomplete changes, no convention violations. Specifically checked: both consumers
+(`heartbeat.py:182`, `schedules.py:516`) call through the predicate, so neither needs its own
+change; the `None`/empty guard still runs first; the module-level constant follows the
+stdlib-imports-and-constants-at-module-level convention; no new config option and no new module,
+so CLAUDE.md's key-files list is unaffected (`heartbeat.py` is already listed). Long single-line
+paragraphs in the two docs edits match those files' existing style. Left `docs/loop-breaker.md`
+alone — it documents the producer's escalation behaviour, which this doesn't change.

--- a/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/plan.md
+++ b/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/plan.md
@@ -1,0 +1,142 @@
+# `is_heartbeat_ok` vs. abnormal termination — Implementation Plan
+
+**Goal:** An abnormally-terminated heartbeat or scheduled turn is never reported as OK, no
+matter where the HEARTBEAT_OK sentinel lands in its delivered text.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/710 — **Tier:** `auto-ok`
+(the one criterion reduces to a pure-function assertion on `is_heartbeat_ok`, the oracle
+already exists in `tests/test_heartbeat.py`, and the diff touches no auth, secret, migration,
+deploy/CI, or dependency surface)
+
+**Approach:** D1 from the spec — fix at the consumer. `is_heartbeat_ok` returns `False` when
+the response carries an abnormal-termination marker, before the sentinel window is consulted at
+all. The structured-termination plumbing that would remove the 300-char window is deliberately
+out of scope and filed as #712; guard G2 pins the window in place here.
+
+**Criteria:** C1 — an abnormally-terminated turn is never reported OK, wherever the sentinel
+sits, for **both** markers. (Full text + check in `checks.md`.)
+
+---
+
+## Phase 0: Freeze the acceptance checks — DONE
+
+Written per `references/frozen-checks.md`. No implementation in this phase.
+
+**Files:**
+- Create: `docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/checks.md`
+- Modify: `tests/test_heartbeat.py` — adds
+  `test_is_heartbeat_ok_false_on_abnormal_termination`, authored by a check-author subagent
+  that was given the criterion but not the implementation approach
+
+**Verification — automated:**
+- [x] C1's check runs and **fails for the expected reason**: `AssertionError: max-iterations:
+      abnormal termination reported as OK / assert True is False`. pytest exit 1, 1 collected,
+      1 failed — not exit 5. Both marker halves independently verified failing (see
+      `checks.md` AT FREEZE), so a one-marker fix cannot pass.
+- [x] Every guard runs and **passes**: G1–G3 `6 passed in 1.36s`; G4 `1 passed in 5.02s`.
+- [x] Freeze commit made; sha recorded in `checks.md` in a follow-up commit.
+
+---
+
+## Phase 1: Reject abnormal termination in `is_heartbeat_ok`
+
+The whole fix, end to end: the predicate learns that an abnormally-terminated turn is never
+OK, the docs that describe the predicate's contract are updated to match, and C1's frozen check
+goes green.
+
+**Advances:** C1 — fully; nothing remains for a later phase.
+
+**Files:**
+- Modify: `src/decafclaw/heartbeat.py` — add the marker constant and the early return in
+  `is_heartbeat_ok`
+- Modify: `docs/heartbeat.md` — the `## HEARTBEAT_OK` section (line 78) states the contract as
+  "case-insensitive, within the first 300 characters" with no mention of the override
+- Modify: `docs/schedules.md` — line 124 describes the same predicate from the scheduler's side
+- Test: none of the implementer's own. C1's frozen check in `tests/test_heartbeat.py` is the
+  test for this slice, and it is **read-only from here on** — the whole file is frozen
+
+**Key changes:**
+
+`src/decafclaw/heartbeat.py`, above `is_heartbeat_ok`:
+
+```python
+# Substrings that mark a turn as abnormally terminated, emitted verbatim by
+# agent.py's _finalize_max_iterations / _finalize_loop_break. A turn that ended
+# this way is never "nothing to report", whatever its text happens to contain —
+# see is_heartbeat_ok.
+_ABNORMAL_TERMINATION_MARKERS = (
+    "[Agent reached max tool iterations",
+    "[loop-breaker] Stopped",
+)
+```
+
+and the predicate becomes:
+
+```python
+def is_heartbeat_ok(response: str | None) -> bool:
+    """Check if a response indicates nothing to report.
+
+    Returns True if HEARTBEAT_OK appears (case-insensitive) within the first
+    300 characters — but always False for an abnormally terminated turn.
+
+    The override exists because heartbeat and scheduled turns have no live
+    transport subscriber, so agent.py's _finalize_with_note delivers the
+    turn's accumulated mid-turn preambles alongside the termination note. Since
+    polling.py tells the agent to say HEARTBEAT_OK when there is nothing to
+    report, a preamble mentioning the sentinel is a plausible utterance, and one
+    landing inside the 300-char window used to suppress the very alert the
+    abnormal termination should have raised (#710). The real predicate is "did
+    this turn end normally", not "how long is the prefix".
+
+    Markers are matched against the whole response, not the first 300
+    characters: #707 puts the note first, but scoping the marker check to the
+    window would quietly re-couple this to that ordering. #712 tracks replacing
+    the substring match with a structured termination signal.
+    """
+    if not response:
+        return False
+    if any(marker in response for marker in _ABNORMAL_TERMINATION_MARKERS):
+        return False
+    return "heartbeat_ok" in response[:300].lower()
+```
+
+Marker matching is case-**sensitive** deliberately: these are literal strings the code emits,
+not user prose, and an exact match is the narrower reading. The sentinel search stays
+case-insensitive, unchanged.
+
+`docs/heartbeat.md` — extend the contract sentence at line 78 with the override and a pointer
+to why it exists. `docs/schedules.md` — same, at line 124.
+
+**Verification — automated:**
+- [ ] C1's check passes: `uv run pytest
+      tests/test_heartbeat.py::test_is_heartbeat_ok_false_on_abnormal_termination`
+- [ ] G1 still passes: `uv run pytest tests/test_heartbeat.py::test_is_heartbeat_ok_present
+      tests/test_heartbeat.py::test_is_heartbeat_ok_case_insensitive
+      tests/test_heartbeat.py::test_is_heartbeat_ok_not_present`
+- [ ] G2 still passes: `uv run pytest
+      tests/test_heartbeat.py::test_is_heartbeat_ok_beyond_300_chars`
+- [ ] G3 still passes: `uv run pytest
+      tests/test_heartbeat.py::test_is_background_wake_ok_detects_sentinel`
+- [ ] G4 still passes: `uv run pytest
+      tests/test_agent_loop_breaker.py::test_loop_break_note_comes_first_for_unwatched_turns`
+- [ ] `make check` passes (lint + typecheck, Python and JS)
+- [ ] `make test` passes with no regression against the `3581 passed, 2 skipped` baseline
+
+**Verification — manual:**
+- [ ] None. C1 is a pure-function assertion with no human-judgment component, which is what
+      makes this run `auto-ok`. No live Mattermost / web-UI check is meaningful for a predicate
+      change of this shape — reproducing a real thrashing heartbeat turn on a live bot to watch
+      an alert *not* get suppressed is what G4 already does deterministically in-process.
+
+---
+
+## Not in this plan
+
+- **No eval case.** `make eval-tools` and `evals/*.yaml` cover LLM-visible behaviour — tool
+  descriptions, routing, prompt changes. This is a pure predicate on text the code itself
+  emits; nothing about the model's choices changes. Per CLAUDE.md's "skip evals for
+  non-LLM-visible work".
+- **No change to `is_background_wake_ok`** (G3 pins it) and **no removal of the 300-char
+  window** (G2 pins it). Both belong to #712.
+- **No change to `_finalize_with_note`, note text, or delivery ordering.** The spec rules all
+  three out, and G4 depends on the current ordering.

--- a/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/spec.md
+++ b/docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/spec.md
@@ -1,0 +1,131 @@
+# Spec — #710: `is_heartbeat_ok` can be fooled by a mid-turn preamble on an abnormally-terminated turn
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/710
+
+Captured verbatim from the issue body (the `<!-- agent-session:spec -->` marker line is
+stripped; everything else is the issue as filed and augmented at intake).
+
+---
+
+Split out of #707, where it was measured but deliberately not fixed.
+
+## The problem
+
+`is_heartbeat_ok()` (`heartbeat.py:115-124`) returns True if the case-insensitive
+substring `heartbeat_ok` appears **anywhere in the first 300 characters** of the turn's
+delivered text. `polling.py:63` explicitly instructs the agent: *"If there is nothing to
+report, respond with HEARTBEAT_OK."* So a mid-turn preamble mentioning the sentinel is a
+plausible utterance, not a contrived one.
+
+Heartbeat and scheduled turns have no live transport subscriber, so
+`_finalize_with_note` delivers the accumulated iteration preambles alongside the
+termination note (that is deliberate — the consumer only ever sees `ToolResult.text`).
+If such a turn thrashes and terminates abnormally, a sentinel inside a preamble can land
+in the first 300 chars and silently suppress the alert that should have surfaced.
+Consumers: `heartbeat.py:182`, `schedules.py:516`.
+
+## Current state after #707
+
+#707 put the note **first** in the unwatched-turn join as a partial mitigation. Measured
+with a realistic sentinel-bearing preamble:
+
+| note | length | `is_heartbeat_ok` | outcome |
+|---|---|---|---|
+| `_finalize_loop_break` | ~336 chars | `False` | alert surfaces correctly |
+| `_finalize_max_iterations` | ~65 chars | `True` | **alert still suppressed** |
+
+So the loop-breaker path is protected (the note alone exceeds the 300-char window) and the
+`max_tool_iterations` path is not — its note is far too short to push a sentinel out of
+range. This is pre-existing behavior, not a #707 regression: on `main`,
+`delivered = accumulated + note` unconditionally for every turn kind, so the hazard
+predates that branch entirely.
+
+## Suggested fix
+
+Fix it at the consumer rather than by padding notes or reordering text — the real predicate
+is "did this turn end normally," not "how long is the prefix." An abnormally-terminated turn
+should never count as OK regardless of what its text happens to contain. Options:
+
+1. Have `is_heartbeat_ok()` return False when the text carries an abnormal-termination
+   marker (`[loop-breaker] Stopped`, `reached max tool iterations`). Cheap, but
+   string-matching a different string to fix a string-matching bug.
+2. Better: plumb the termination reason out of the turn rather than re-deriving it from
+   prose. `_finalize_with_note` already knows the turn ended abnormally; carrying that as
+   structured state (on the `ToolResult`, or via the existing `loop_breaker` event) lets
+   both `heartbeat.py:182` and `schedules.py:516` ask directly instead of guessing from a
+   substring.
+
+Option 2 also removes the 300-character magic number, which is the root fragility here.
+
+---
+
+## Design decisions (resolved at intake, 2026-07-27)
+
+**D1 — fix at the consumer by detecting the abnormal-termination marker (the issue's option 1).
+Option 2 is filed separately as #712.**
+
+Option 1 fully closes the alert-suppression bug and is purely *additive*: every existing
+`is_heartbeat_ok` assertion keeps holding, so all four become guards rather than casualties.
+
+Rejected *for this issue* (not on the merits): option 2's structured-termination plumbing. It is the
+better end state — it removes the 300-char window, which is the root fragility — but it changes
+`is_heartbeat_ok`'s contract, so it rewrites `test_is_heartbeat_ok_beyond_300_chars` instead of
+preserving it, and it should change `is_background_wake_ok` in the same pass to avoid leaving the two
+asymmetric. That is a refactor with its own scope. See **#712**.
+
+**Correction to the issue's own measurement, found at intake:** the table reports the
+`_finalize_loop_break` path as safe (`False`) because that note ran ~336 chars. That safety is
+**length-contingent, not structural**. With a shorter `loop_breaker.last_signal()` the note is ~167
+chars and a sentinel-bearing preamble still lands inside the window — measured `is_heartbeat_ok ==
+True`. **Both** abnormal-termination paths are exposed, so C1 covers both markers rather than only
+the `max_tool_iterations` one.
+
+## Acceptance criteria
+
+**C1 — an abnormally-terminated turn is never reported OK, wherever the sentinel sits.**
+IF a turn's delivered text carries an abnormal-termination marker, THEN `is_heartbeat_ok` SHALL
+return `False`, regardless of whether the sentinel appears within the first 300 characters.
+- Markers, verbatim from `agent.py:1080-1097`: `[Agent reached max tool iterations` and
+  `[loop-breaker] Stopped`.
+- CHECK: `uv run pytest tests/test_heartbeat.py::test_is_heartbeat_ok_false_on_abnormal_termination`
+- The assertion must cover **both** markers. A test covering only `max tool iterations` would pass
+  while the loop-breaker path stays broken.
+- Demonstrated absent at intake, both paths, with the note placed first as #707 leaves it:
+  - `max_tool_iterations` note (67 chars) + `"…nothing needs attention…, so HEARTBEAT_OK."` →
+    sentinel at index 134, `is_heartbeat_ok == True`.
+  - `loop_breaker` note (~167 chars) + same preamble → sentinel at ~index 243,
+    `is_heartbeat_ok == True`.
+
+### Regression guards (pass today; must keep passing — not criteria)
+
+- **G1:** `tests/test_heartbeat.py::test_is_heartbeat_ok_present`, `::test_is_heartbeat_ok_case_insensitive`,
+  `::test_is_heartbeat_ok_not_present` — normal sentinel detection must not regress. A fix that
+  returns `False` too eagerly would defeat the whole heartbeat-quiet mechanism and spam alerts.
+- **G2:** `tests/test_heartbeat.py::test_is_heartbeat_ok_beyond_300_chars` — the 300-char window
+  stays in place under option 1. #712 is where it goes away.
+- **G3 (negative control):** the `is_background_wake_ok` assertions in
+  `tests/test_heartbeat.py::test_is_background_wake_ok_detects_sentinel` — this fix must not
+  incidentally alter the parallel sentinel path.
+- Observed at intake, all together: `6 passed in 1.72s`
+  (`uv run pytest tests/test_heartbeat.py -k "is_heartbeat_ok or is_background_wake_ok"`).
+
+## What we're NOT doing
+
+- **Not removing the 300-char window** — that is #712, and G2 pins it here.
+- **Not changing `is_background_wake_ok`** — G3 pins it. Same reason.
+- **Not padding notes or reordering delivered text.** The issue is explicit that the fix belongs at
+  the consumer; #707 already tried ordering and it is length-contingent.
+- **Not changing what `_finalize_with_note` delivers.** Delivering accumulated preambles alongside
+  the note is deliberate, since the consumer only ever sees `ToolResult.text`.
+
+## Tier: `auto-ok`
+
+The one criterion reduces to a pure-function assertion on `is_heartbeat_ok`, demonstrated failing
+today on both paths; the oracle (`tests/test_heartbeat.py`) exists and already tests this function.
+No risk-gated path: no auth/authorization, secrets, data migration or deletion, deploy/infra/CI
+config, or dependency change — the diff is one predicate in `heartbeat.py`. The issue's two-option
+choice was the only thing withholding a decision, and D1 resolves it.
+
+---
+*Decisions resolved and criteria added via `agent-session intake`. Every check was run at intake
+time, not inferred; original issue text preserved verbatim above.*

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -83,6 +83,8 @@ If a section has nothing to report, the agent should respond with `HEARTBEAT_OK`
 
 Set `HEARTBEAT_SUPPRESS_OK=false` to see full output for all sections.
 
+**An abnormally terminated section is never OK.** `is_heartbeat_ok()` returns `False` — whatever the text contains and wherever the sentinel sits — if the response carries one of the abnormal-termination markers the agent loop emits: `[Agent reached max tool iterations` or `[loop-breaker] Stopped`. Heartbeat and scheduled turns have no live transport subscriber, so `_finalize_with_note` delivers the turn's accumulated mid-turn preambles alongside the termination note; since the agent is told to say `HEARTBEAT_OK` when there's nothing to report, a preamble mentioning the sentinel could land inside the 300-char window and silently suppress the alert the termination should have raised ([#710](https://github.com/lmorchard/decafclaw/issues/710)). The markers are matched against the whole response, not just the window, so this doesn't depend on the note's position in the delivered text. [#712](https://github.com/lmorchard/decafclaw/issues/712) tracks replacing the substring match with a structured termination signal, which is what would remove the 300-char window itself.
+
 ## Mattermost reporting
 
 Each heartbeat cycle creates a thread:

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -123,6 +123,8 @@ The scheduled-task preamble instructs the agent to end its turn with a short nar
 
 When the cycle was genuinely quiet (nothing notable happened, no changes made), the agent prefixes its summary with `HEARTBEAT_OK` on a leading line before the quiet-cycle note. The scheduler's `is_heartbeat_ok()` check (case-insensitive, first 300 chars) picks up the marker and logs a tidy `Schedule 'name': HEARTBEAT_OK` line instead of the response preview. The narrative still gets archived in full so the newsletter has material to quote.
 
+A task whose turn ended abnormally is never treated as quiet: `is_heartbeat_ok()` returns `False` if the response carries `[Agent reached max tool iterations` or `[loop-breaker] Stopped`, regardless of a stray `HEARTBEAT_OK` in a mid-turn preamble. See [heartbeat docs](heartbeat.md#heartbeat_ok).
+
 Historical note: older runs may end with a bare `HEARTBEAT_OK` token without narrative; the newsletter's `_is_status_token` filter handles those correctly for retrospective windows that reach into pre-change archives. Heartbeat also uses `HEARTBEAT_OK`; see [heartbeat docs](heartbeat.md).
 
 ## Reporting

--- a/src/decafclaw/heartbeat.py
+++ b/src/decafclaw/heartbeat.py
@@ -112,13 +112,41 @@ def _split_sections(text: str) -> list[dict]:
     return sections
 
 
+# Substrings that mark a turn as abnormally terminated, emitted verbatim by
+# agent.py's _finalize_max_iterations / _finalize_loop_break. A turn that ended
+# this way is never "nothing to report", whatever its text happens to contain —
+# see is_heartbeat_ok.
+_ABNORMAL_TERMINATION_MARKERS = (
+    "[Agent reached max tool iterations",
+    "[loop-breaker] Stopped",
+)
+
+
 def is_heartbeat_ok(response: str | None) -> bool:
     """Check if a response indicates nothing to report.
 
-    Returns True if HEARTBEAT_OK appears (case-insensitive) within
-    the first 300 characters.
+    Returns True if HEARTBEAT_OK appears (case-insensitive) within the first
+    300 characters — but always False for an abnormally terminated turn.
+
+    The override exists because heartbeat and scheduled turns have no live
+    transport subscriber, so agent.py's _finalize_with_note delivers the turn's
+    accumulated mid-turn preambles alongside the termination note. Since
+    polling.py tells the agent to say HEARTBEAT_OK when there is nothing to
+    report, a preamble mentioning the sentinel is a plausible utterance, and one
+    landing inside the 300-char window used to suppress the very alert the
+    abnormal termination should have raised (#710). The real predicate is "did
+    this turn end normally", not "how long is the prefix".
+
+    Markers are matched against the whole response, not the first 300
+    characters: #707 puts the note first, but scoping the marker check to the
+    window would quietly re-couple this to that ordering. Matching is
+    case-sensitive — these are literal strings the code emits, not user prose.
+    #712 tracks replacing the substring match with a structured termination
+    signal, which is what removes the 300-char window itself.
     """
     if not response:
+        return False
+    if any(marker in response for marker in _ABNORMAL_TERMINATION_MARKERS):
         return False
     return "heartbeat_ok" in response[:300].lower()
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -147,6 +147,53 @@ def test_is_heartbeat_ok_not_present():
     assert is_heartbeat_ok("Something happened that needs attention.") is False
 
 
+def test_is_heartbeat_ok_false_on_abnormal_termination():
+    """An abnormally-terminated heartbeat/scheduled turn must never be reported
+    as OK, even when the HEARTBEAT_OK sentinel lands inside the 300-char window
+    (#710).
+
+    `_finalize_with_note` in agent.py delivers the termination note first and
+    the turn's accumulated mid-turn preambles after it, so an abnormally
+    terminated turn's `ToolResult.text` always carries one of the two markers.
+    polling.py instructs the agent to say "HEARTBEAT_OK" when there is nothing
+    to report, which makes a sentinel-bearing preamble a plausible utterance —
+    and the old "sentinel anywhere in the first 300 characters wins" rule then
+    reported the turn as OK, silently suppressing the alert the user should
+    have seen. Both markers are covered here; asserting only the max-iterations
+    one would let the loop-breaker path stay broken.
+    """
+    # Mirrors _finalize_max_iterations / _finalize_loop_break (agent.py). The
+    # real loop-breaker note continues with a handoff paragraph; trimmed here
+    # so the sentinel genuinely lands inside the 300-char window.
+    max_iterations_text = (
+        "\n\n[Agent reached max tool iterations (30) without a final response]"
+        "\n\nNothing new since the last check — HEARTBEAT_OK."
+    )
+    loop_breaker_text = (
+        "\n\n[loop-breaker] Stopped after repeated failures: you called "
+        "vault_search 3 times with identical arguments without progress."
+        "\n\nNothing new since the last check — HEARTBEAT_OK."
+    )
+
+    # Premise guards: the markers really are present, verbatim.
+    assert "[Agent reached max tool iterations" in max_iterations_text
+    assert "[loop-breaker] Stopped" in loop_breaker_text
+
+    for label, text in (
+        ("max-iterations", max_iterations_text),
+        ("loop-breaker", loop_breaker_text),
+    ):
+        sentinel_index = text.lower().index("heartbeat_ok")
+        # Premise guard: this is the in-window case, not the beyond-300-chars
+        # case that test_is_heartbeat_ok_beyond_300_chars already covers.
+        assert sentinel_index < 300, (
+            f"{label}: sentinel at index {sentinel_index}, outside the window"
+        )
+        assert is_heartbeat_ok(text) is False, (
+            f"{label}: abnormal termination reported as OK"
+        )
+
+
 # -- BACKGROUND_WAKE_OK detection tests --
 
 


### PR DESCRIPTION
## Summary

- `is_heartbeat_ok` reported an abnormally-terminated heartbeat/scheduled turn as "nothing to report" whenever a stray `HEARTBEAT_OK` landed in the first 300 characters of its delivered text — silently suppressing the alert the termination should have raised. It now returns `False` for any turn carrying an abnormal-termination marker, before the sentinel window is consulted.
- Why it's reachable rather than theoretical: heartbeat and scheduled turns have no live transport subscriber, so `_finalize_with_note` delivers the turn's accumulated mid-turn preambles alongside the termination note — and `polling.py` explicitly instructs the agent to say `HEARTBEAT_OK` when there's nothing to report. A preamble mentioning the sentinel is a plausible utterance. Both consumers were affected: `heartbeat.py:182` and `schedules.py:516`.

## Design Decisions

**D1 — fix at the consumer (the issue's option 1).** The real predicate is "did this turn end normally", not "how long is the prefix". Option 1 is purely additive: every existing `is_heartbeat_ok` assertion keeps holding, so all of them become guards rather than casualties. Option 2's structured-termination plumbing is the better end state — it removes the 300-char window, the root fragility — but it changes the predicate's contract and should change `is_background_wake_ok` in the same pass. That's #712.

**Markers match the whole response, not the window.** #707 puts the note first, but scoping the marker check to the first 300 characters would quietly re-couple this to that ordering — the exact length-contingency the fix exists to remove. Matching is case-sensitive: these are literal strings the agent loop emits, not user prose.

**Deliberately unchanged**, each pinned by a guard: the 300-char window itself (G2), `is_background_wake_ok` (G3), and `_finalize_with_note`'s delivery/ordering (G4).

### Correction to the issue's own record

Re-confirming the spec's evidence turned up a measurement that doesn't reproduce. The intake note claims the loop-breaker path is live-exposed via a "~167-char note" from `loop_breaker.last_signal()`. That method does not exist, and `_finalize_loop_break` appends an **unconditional ~193-char handoff paragraph** that floors the note at ~296 chars — so no plausible preamble puts a sentinel inside the window on that path. Measured: note 303 chars → sentinel at 317 → `False`.

The issue's *original* table was right, and right for a structural reason the intake correction talked itself out of. This does not change C1: as a pure-function assertion **both** marker halves fail at freeze (verified independently — see below), so the criterion stands and still discriminates. What changes is only the claim that the loop-breaker path is a *live* production bug. It isn't; it's currently guarded by note length, and covering that marker makes the guard unnecessary. No check or guard wording changed, so no verdict changed and the tier stays `auto-ok`.

## Changes

- `src/decafclaw/heartbeat.py` — `_ABNORMAL_TERMINATION_MARKERS` tuple + an early `return False` in `is_heartbeat_ok`; docstring records why the override exists and why the scope/case choices are what they are.
- `docs/heartbeat.md`, `docs/schedules.md` — both pages state this predicate's contract; both now describe the override.
- `tests/test_heartbeat.py` — the frozen acceptance test, authored **before** the implementation by a subagent given the criterion but not the approach.
- Session docs: spec, frozen-check manifest, plan, notes.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | An abnormally-terminated turn is never reported OK, wherever the sentinel sits — for **both** markers | `pytest tests/test_heartbeat.py::test_is_heartbeat_ok_false_on_abnormal_termination` | pass |

| id | guard | check | result |
|---|---|---|---|
| G1 | normal sentinel detection doesn't regress (a too-eager `False` would spam alerts) | `pytest tests/test_heartbeat.py::test_is_heartbeat_ok_present …_case_insensitive …_not_present` | pass (3/3) |
| G2 | the 300-char window stays in place | `pytest tests/test_heartbeat.py::test_is_heartbeat_ok_beyond_300_chars` | pass |
| G3 | negative control — `is_background_wake_ok` unaffected | `pytest tests/test_heartbeat.py::test_is_background_wake_ok_detects_sentinel` | pass |
| G4 | behavioural guard from the production side, on a real loop-broken heartbeat turn | `pytest tests/test_agent_loop_breaker.py::test_loop_break_note_comes_first_for_unwatched_turns` | pass |

Verified by an independent verifier (fresh context, `checks.md` + repo only — no plan, no notes, no rationale). Frozen at `0d08b2d`; **tamper diff empty** (`git diff 0d08b2d -- tests/test_heartbeat.py`, and broadened to `-- tests contrib`). No check or guard collected zero. The verifier stated affirmatively that the diff could not be passing for a reason other than doing the work: zero test surface changed, no `skip`/`xfail` added, no assertion narrowed, and the freeze-time body provably returns `True` for both of the test's fixtures.

**At freeze**, both marker halves were verified failing independently, so a one-marker fix could not have passed:

| marker | sentinel index | `is_heartbeat_ok` before |
|---|---|---|
| `[Agent reached max tool iterations` | 104 | `True` (should be `False`) |
| `[loop-breaker] Stopped` | 161 | `True` (should be `False`) |

## Two things a reviewer should know

**1. Two properties are asserted by no check**, and were deliberately not covered: the marker match is case-sensitive, and it scans the whole response rather than the window. Both are documented, but C1 doesn't discriminate on either. Coverage wasn't added because `tests/test_heartbeat.py` is the frozen check file — adding a variant alongside a frozen check post-freeze isn't sanctioned and would dirty the tamper diff above. #712 rewrites this predicate and is the place to pin both.

**2. Rebased after initial PR open.** The branch was rebased onto `origin/main` (`3af093d`) to pick up #716/#717 (the lockfile install-js fix). Freeze sha `0d08b2d` remained valid — `git diff 0d08b2d HEAD -- tests/test_heartbeat.py` is empty. All criteria and guards re-verified post-rebase.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass · G3 pass · G4 pass
tamper: clean
freeze: 0d08b2d
project-gates: make check green
ci: 2/2 pass @ e8f0338
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
```

**Provenance note on the `ci` row.** The run graded CI, then force-pushed amended session docs, so
its `2/2 pass` described a commit that was no longer the head — `lint-and-test` was `pending` and
`mergeStateStatus` was `UNSTABLE` when the verdict was published. CI has since gone green on the
actual head `e8f03389` (`lint-and-test` pass, 11m40s), so the row is now true, but it was **re-graded
after the fact and not by the run**. The sha is recorded above so the claim is auditable rather than
perpetually current.

Process fix landed in the skill: derive the CI row last, after the final push, and record the sha it
describes.

## References

- Spec: `docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/spec.md`
- Checks: `docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/checks.md`
- Plan: `docs/dev-sessions/2026-07-27-1207-710-heartbeat-ok-abnormal-termination/plan.md`
- Follow-up already filed: #712 (structured termination signal; removes the 300-char window)
- Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

