### PR TITLE
fix(build): install-js uses npm ci, so a check cannot rewrite the lockfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,26 +29,35 @@ install:
 	uv sync
 	cd src/decafclaw/web/static && npm install
 
-# Install JS dependencies in static/, failing if the install rewrites the
-# lockfile. `check` / `check-js` / `test-js` all depend on this, so a silent
-# rewrite here rides into whatever branch happens to be checked out — it has
-# swept into an unrelated PR once and nearly a second time (#706). Deliberate
-# dependency changes go through `make vendor`, which is allowed to write.
+# Install JS dependencies in static/ for a *check*. Uses `npm ci`, which installs
+# strictly from the lockfile and cannot write it — `npm install` can and does.
 #
-# Snapshots around the install rather than diffing against HEAD, so a lockfile
-# you were *already* editing doesn't trip it — only a rewrite caused by this
-# install does.
+# `check` / `check-js` / `test-js` all depend on this, so a rewrite here rides
+# into whatever branch happens to be checked out; it swept into an unrelated PR
+# once and nearly a second time (#706). Deliberate dependency changes go through
+# `make vendor`, which is allowed to write.
+#
+# Why `npm ci` rather than the guard alone (#716): npm 11 prunes nested optional
+# `@esbuild/*` platform entries that npm 10 records, so on any machine whose npm
+# is newer than CI's (node 22 per .nvmrc / ci.yml) `npm install` rewrote the
+# lockfile deterministically and the guard failed *every* run — leaving `make
+# check` unpassable locally while CI stayed green. `npm ci` removes the mutation
+# instead of detecting it, and is stricter: it fails outright when package.json
+# and package-lock.json disagree, which is the drift #706 was about.
+#
+# The guard stays as a regression detector. Under `npm ci` it should never fire.
 install-js:
 	@cd src/decafclaw/web/static && \
 	  before=$$(git hash-object package-lock.json) && \
-	  npm install && \
+	  npm ci && \
 	  after=$$(git hash-object package-lock.json) && \
 	  if [ "$$before" != "$$after" ]; then \
 	    echo ""; \
-	    echo "ERROR: npm install rewrote package-lock.json during a check."; \
+	    echo "ERROR: npm ci rewrote package-lock.json during a check."; \
+	    echo "  This should be impossible — npm ci does not write the lockfile."; \
 	    echo "  Intentional dependency change?  run 'make vendor' and commit the lockfile."; \
 	    echo "  Otherwise restore it:  git checkout -- src/decafclaw/web/static/package-lock.json"; \
-	    echo "  Background: #706 (silent rewrites have ridden into unrelated PRs)."; \
+	    echo "  Background: #706 (silent rewrites have ridden into unrelated PRs), #716."; \
 	    echo ""; \
 	    exit 1; \
 	  fi


### PR DESCRIPTION
## Summary

- `make check` was **unpassable** on any machine whose npm is newer than CI's, and had been for as long as #709's guard has existed.
- A verification target was running `npm install`, whose job is to mutate the lockfile. `npm ci` cannot write it.

Closes #716.

## Root cause

npm 11 prunes 27 nested optional `node_modules/vitest/node_modules/@esbuild/<platform>` entries that npm 10 records, so `npm install` rewrote `package-lock.json` deterministically — a 512-line deletion — and #709's guard failed every run.

| | node | npm |
|---|---|---|
| affected local machine | v26.0.0 | 11.12.1 |
| CI (`ci.yml:44`) | 22 | 10.x |
| `.nvmrc` | **22** | — |

CI stayed green, which is why this was invisible in PR checks while blocking every local run.

**#709's guard was not wrong** — `npm install` really did rewrite the lockfile. `npm ci` removes the mutation rather than detecting it, and is *stricter* than the guard besides: it fails outright when `package.json` and `package-lock.json` disagree, which is the drift #706 was about. The guard stays as a regression detector and should now never fire.

## Verification

Fresh worktree off `origin/main`:

| Command | Result |
|---|---|
| `make check` | **exit 0** — was failing at `install-js` before |
| lockfile after `make check` | **byte-identical** (`git hash-object` before == after) |
| `make test-js` | **exit 0**, 41 tests passed — the path CI's `js-test` job runs |

Cost: `npm ci` ~13.0s vs `npm install` ~3.8s, so **+9s** per check — marginal against the ~69s python suite.

## Why this mattered beyond local annoyance

Three independent unattended agent runs hit this. Each worked around it by running `check`'s four steps natively and reporting the "project gates green" row as satisfied **by substitute** rather than by the cited command. A merge gate whose project-gates row is routinely satisfied by a substitute is measurably weaker than one that runs the real target.

## Not addressed here

`.nvmrc` pins node 22 and local environments aren't honoring it, while `package.json` `engines` allows `>=24.0.0`. Worth its own change — but `npm ci` fixes the whole class regardless of npm version, so it shouldn't wait on the version question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)