### PR TITLE
docs: preserve the parked #471 session docs

### DIFF
--- a/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/notes.md
+++ b/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/notes.md
@@ -1,0 +1,27 @@
+# Session notes
+
+## Status: parked, not shipped
+
+PR [#518](https://github.com/lmorchard/decafclaw/pull/518) was **closed without merge** on 2026-05-17. The second Copilot review surfaced a framing-vs-reality gap: the "sandbox" was a subprocess runner with stdlib unrestricted, so a script could `import subprocess` and bypass the shell-confirmation gate, `import urllib.request` and bypass the `http_request` gate, or `import os` and bypass workspace-write guards. Issue [#471](https://github.com/lmorchard/decafclaw/issues/471) remains **open**.
+
+Read the plan below as a record of an attempt, not a description of shipped behavior — no `code_execution` skill exists on `main`. The technical findings further down (macOS `RLIMIT_AS`, the `delegate.py` wire-format bug, the `copy.copy` fork race) are independent of the parked design and still hold.
+
+**These docs are also incomplete.** They were last written 2026-05-15 14:50, and the branch continued for seven commits after that (through 2026-05-16 12:44) — allowlisting `workspace_glob`/`workspace_search`, auto-injecting the dc-proxy import, and several `ToolResult.data` corrections. None of that is reflected here, and no retro was written before the PR was parked. For the final state of the attempt, read the branch itself: `origin/programmatic-tool-calling-471` at `00c51ae`, kept alive on the remote for exactly that reason.
+
+These four files were only ever untracked in a local worktree; they are committed here so they survive that worktree's cleanup.
+
+## Pre-existing issues surfaced during review (out of scope — file as follow-ups)
+
+- **`src/decafclaw/tools/delegate.py:394`** — calls `parent_ctx.publish("tool_status", {"tool": ..., "message": ...})` passing a positional dict where the rest of the codebase uses `**kwargs`. The dict is silently dropped by consumers (`web/websocket.py:555-562` reads `event.get("tool")` from the top-level event). Phase 4's `_sandbox.py:147` uses the correct `**kwargs` form; spotted by the reviewer while verifying wire-format compatibility. Worth a one-line fix in a separate PR.
+
+## Phase 4 review notes
+
+- Test `test_progress_events_published` could be tightened by mixing in a limit-overrun (e.g. `max_tool_calls=2`, loop 3 times, expect 2 events) — that would catch a regression where publish accidentally moves above the limit check. Not gating Phase 4, but worth doing during Phase 5 polish if time permits.
+
+## Phase 3 design note
+
+- `copy.copy(parent_ctx)` shares mutable subobjects (`tools.current_call_id`, `tools.extra`, `event_bus`, `composer`) with the parent. If two `code_execution` calls run concurrently in one parent turn (possible — `max_concurrent_tools=5` default), they would race on `ctx.tools` mutations. Phase 3's `_make_tool_handler` explicitly does NOT mutate `sandbox_ctx.tools.allowed` to avoid one slice of this; the rest is a deeper architectural concern for whoever next touches `Context.fork_for_tool_call`. Forward-looking only.
+
+## RLIMIT_AS reality (vs. plan's assumption)
+
+- The plan assumed `setrlimit(RLIMIT_AS, ...)` on macOS would silently be best-effort. In practice it raises `ValueError: current limit exceeds maximum limit` because RLIM_INFINITY is the hard cap and the kernel refuses to lower it (would propagate as `subprocess.SubprocessError` post-fork). Phase 2 gated the call behind `_RLIMIT_AS_OK = sys.platform.startswith("linux")` at module load. Documented in `_sandbox.py:147-155`. Phase 4's memory test correctly uses `pytest.mark.skipif(sys.platform == "darwin", ...)`.

--- a/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/plan.md
+++ b/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/plan.md
@@ -1,0 +1,680 @@
+# Programmatic tool calling — Implementation Plan
+
+**Goal:** Add a bundled always-loaded `code_execution` skill that runs LLM-authored Python scripts in a subprocess with UDS-based RPC into a curated subset of decafclaw tools, so deterministic multi-step work runs as one tool call and keeps intermediate outputs off the conversation transcript.
+
+**Approach:** New skill at `src/decafclaw/skills/code_execution/`. The tool spawns a Python subprocess (`sys.executable`) writing a generated `decafclaw_tools.py` proxy and the LLM's `script.py` to a temp dir. The parent runs an `asyncio.start_unix_server` that accepts one connection, reads line-delimited JSON requests, dispatches via `execute_tool` against a forked ctx (`request_confirmation=None`, `tools.allowed=ALLOWLIST`), and writes a JSON response per call. Hard caps: 300s wall-clock, 50 RPC calls, 50KB stdout / 10KB stderr (head 40% + tail 60% truncation), 512MB RLIMIT_AS. All caps configurable via `SkillConfig`.
+
+**Tech stack:** Python stdlib only — `asyncio` (subprocess + UDS server), `tempfile`, `json`, `resource` (POSIX RLIMIT_AS), `dataclasses`. Reuses `decafclaw.tools.execute_tool` for actual tool invocation. No new dependencies.
+
+**Allowlist constant (single source of truth — same list lives in stub generator AND server-side check):**
+
+```
+SANDBOX_ALLOWED_TOOLS = (
+    "vault_read", "vault_search", "vault_journal_append", "vault_write",
+    "workspace_read", "workspace_list",
+    "notes_read", "notes_append",
+    "tabstack_extract_markdown", "tabstack_extract_json", "tabstack_research",
+)
+```
+
+11 tools. `http_request` is deliberately excluded (confirmation-gated; would deadlock the subprocess). Tabstack tools depend on the `tabstack` skill being activated in the conversation — when not active, `tools/__init__.py:execute_tool` will dispatch to `tool_tabstack_*` which raises in `_get_client()` (`skills/tabstack/tools.py:35-38`), and the RPC handler catches that and returns `.error` to the script.
+
+---
+
+## Phase 1: Skeleton bundled skill with stub tool
+
+Establish the bundled-skill module so the tool is reachable from the LLM. No subprocess, no RPC — the tool just returns a fixed string. This locks in the SKILL.md frontmatter, `tools.py` shape, `SkillConfig` resolution, and the always-loaded activation contract before any subprocess complexity lands.
+
+**Files:**
+- Create: `src/decafclaw/skills/code_execution/__init__.py` — empty package marker (matches `skills/vault/__init__.py`).
+- Create: `src/decafclaw/skills/code_execution/SKILL.md` — frontmatter `name: code_execution`, `description: ...`, `always-loaded: true`. Body explains the intended use (multi-step deterministic work; keep intermediate outputs off-context).
+- Create: `src/decafclaw/skills/code_execution/tools.py` — `SkillConfig` dataclass (all caps as fields, defaults from the spec), `init(config, skill_config)` that stashes `skill_config` on a module-level `_settings`, `tool_code_execution(ctx, code: str) -> ToolResult` stub that returns `ToolResult(text="[stub: not yet implemented]")`, `TOOLS = {"code_execution": tool_code_execution}`, `TOOL_DEFINITIONS` with `priority: "low"` and `timeout: None` (matching the precedent at `tools/delegate.py:528` for `delegate_task`).
+- Test: `tests/skills/test_code_execution_skill_loading.py` — verifies (a) `discover_skills` finds it under bundled, (b) it's classified `always-loaded`, (c) `init` runs and `_settings` matches `SkillConfig()` defaults when no overrides, (d) `code_execution` appears in `build_tool_list()` output as critical.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/code_execution/tools.py
+
+from dataclasses import dataclass, field
+from decafclaw.media import ToolResult
+
+@dataclass
+class SkillConfig:
+    timeout_seconds: float = 300.0
+    max_tool_calls: int = 50
+    max_stdout_bytes: int = 50_000
+    max_stderr_bytes: int = 10_000
+    memory_cap_bytes: int = 512 * 1024 * 1024
+
+_settings: SkillConfig = SkillConfig()
+
+def init(config, skill_config: SkillConfig) -> None:
+    global _settings
+    _settings = skill_config
+
+async def tool_code_execution(ctx, code: str) -> ToolResult:
+    return ToolResult(text="[stub: not yet implemented]")
+
+TOOLS = {"code_execution": tool_code_execution}
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "priority": "normal",  # always-loaded skill tools are force-promoted
+                                # to critical regardless; "normal" reflects
+                                # the declared default without misleading.
+        "timeout": None,  # internal cap is authoritative
+        "function": {
+            "name": "code_execution",
+            "description": (
+                "Run a Python script that calls a curated set of decafclaw "
+                "tools via the `dc.*` proxy. Use ONLY for deterministic "
+                "multi-step work where intermediate per-tool outputs would "
+                "be wasted context (e.g. read 5 pages, extract a field from "
+                "each, return the earliest). Do NOT use for single lookups — "
+                "call the underlying tool directly. See SKILL.md for the "
+                "allowlist."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": (
+                            "Python script. Import `from decafclaw_tools "
+                            "import dc` to access tools. `print(...)` what "
+                            "you want returned."
+                        ),
+                    },
+                },
+                "required": ["code"],
+            },
+        },
+    },
+]
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `pytest tests/skills/test_code_execution_skill_loading.py -v` passes (3+ assertions)
+- [x] `make test` passes (baseline 2507 → 2510+, no regressions)
+
+**Verification — manual:**
+- [ ] Run `make config` and confirm `skills.code_execution` section is present with default values
+- [ ] Run `python -c "from decafclaw.skills import discover_skills; ..."` snippet to verify the new skill shows up classified as always-loaded
+
+---
+
+## Phase 2: Subprocess + UDS RPC plumbing with synthetic `dc.ping`
+
+Spin up the actual subprocess and round-trip one synthetic RPC call. Still no real tools. This locks in the spawn / cleanup / framing / timeout / capture mechanics in isolation before tool dispatch lands.
+
+**Files:**
+- Create: `src/decafclaw/skills/code_execution/_sandbox.py` — async sandbox runner. Public surface: `async def run_script(ctx, code: str, settings: SkillConfig, handler: Callable[[str, dict], Awaitable[dict]]) -> SandboxResult` where `handler(tool_name, args) -> {text, data, error}` is the RPC dispatch hook (injected so Phase 3 can swap in real tool dispatch without touching this module).
+- Create: `src/decafclaw/skills/code_execution/_stub.py` — `generate_stub_source(allowed_tools: tuple[str, ...]) -> str` returns the source for `decafclaw_tools.py`. Phase 2 calls it with `("ping",)`; Phase 3 calls it with the full allowlist.
+- Modify: `src/decafclaw/skills/code_execution/tools.py` — replace stub body of `tool_code_execution`; inject a `_ping_handler` that returns `{"text": "pong", "data": None, "error": None}`; pass it to `_sandbox.run_script`. Convert the returned `SandboxResult` into a `ToolResult`.
+- Test: `tests/skills/test_code_execution_sandbox.py`:
+  - `test_ping_round_trip` — script `print(dc.ping().text)`; verify stdout == `"pong\n"`, exit 0, `tool_calls == [{"tool": "ping", "ok": True, ...}]`.
+  - `test_timeout_kills_subprocess` — script `import time; time.sleep(10)`; settings.timeout_seconds=0.5; verify status == `"timeout"`, elapsed < 2.0, subprocess no longer running.
+  - `test_script_crash_captures_traceback` — script `raise RuntimeError("boom")`; verify status == `"error"`, stderr contains `"boom"`, exit non-zero.
+  - `test_stdout_capture` — script `print("hello")`; verify stdout == `"hello\n"`.
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/code_execution/_sandbox.py
+
+import asyncio
+import json
+import logging
+import os
+import resource
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ._stub import generate_stub_source
+
+log = logging.getLogger(__name__)
+
+# Env vars that pass through to the subprocess.
+_SAFE_PREFIX_ALLOW = (
+    "PATH", "HOME", "USER", "LANG", "LC_", "TERM", "TMPDIR",
+    "PYTHONPATH", "VIRTUAL_ENV", "DECAFCLAW_",
+)
+# Substrings that block any var name regardless of prefix match.
+_SECRET_SUBSTRING_BLOCK = (
+    "KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "PASSWD", "AUTH",
+)
+
+
+def _scrub_env() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name, val in os.environ.items():
+        upper = name.upper()
+        if any(b in upper for b in _SECRET_SUBSTRING_BLOCK):
+            continue
+        if any(upper.startswith(p) or upper == p.rstrip("_")
+               for p in _SAFE_PREFIX_ALLOW):
+            out[name] = val
+    return out
+
+
+@dataclass
+class SandboxResult:
+    status: str  # "success" | "error" | "timeout" | "tool_call_limit"
+    elapsed_seconds: float
+    tool_calls: list[dict] = field(default_factory=list)
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int | None = None
+
+
+def _truncate(s: str, cap: int) -> str:
+    """Head 40% + tail 60% truncation with explicit marker."""
+    if len(s) <= cap:
+        return s
+    head = int(cap * 0.4)
+    tail = cap - head - 64  # leave room for marker
+    return (s[:head]
+            + f"\n[... truncated {len(s) - head - tail} bytes ...]\n"
+            + s[-tail:])
+
+
+async def _serve_rpc(reader, writer, *, handler, max_calls, allowed,
+                     calls_made: list[int], call_log: list[dict]):
+    """One client connection, one line per request, one line per response."""
+    try:
+        while True:
+            line = await reader.readline()
+            if not line:
+                break
+            try:
+                req = json.loads(line)
+                tool = req["tool"]
+                args = req.get("args", {})
+            except (json.JSONDecodeError, KeyError) as exc:
+                resp = {"text": "", "data": None,
+                        "error": f"malformed request: {exc}"}
+                writer.write((json.dumps(resp) + "\n").encode())
+                await writer.drain()
+                continue
+
+            calls_made[0] += 1
+            if calls_made[0] > max_calls:
+                resp = {"text": "", "data": None,
+                        "error": f"tool call limit ({max_calls}) exceeded"}
+            elif tool not in allowed:
+                resp = {"text": "", "data": None,
+                        "error": f"tool '{tool}' not in sandbox allowlist"}
+            else:
+                start = asyncio.get_event_loop().time()
+                resp = await handler(tool, args)
+                duration_ms = int((asyncio.get_event_loop().time() - start) * 1000)
+                call_log.append({
+                    "tool": tool, "args_keys": sorted(args.keys()),
+                    "duration_ms": duration_ms,
+                    "ok": resp.get("error") is None,
+                })
+            writer.write((json.dumps(resp) + "\n").encode())
+            await writer.drain()
+    finally:
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception as exc:
+            log.debug("RPC writer close failed: %s", exc)
+
+
+def _preexec(mem_cap: int):
+    """Set RLIMIT_AS before exec. POSIX only. macOS enforcement is best-effort."""
+    resource.setrlimit(resource.RLIMIT_AS, (mem_cap, mem_cap))
+
+
+async def run_script(ctx, code: str, settings, *,
+                     handler, allowed: tuple[str, ...]) -> SandboxResult:
+    tmp = Path(tempfile.mkdtemp(prefix="dc-codeexec-"))
+    sock_path = tmp / "rpc.sock"
+    try:
+        (tmp / "decafclaw_tools.py").write_text(
+            generate_stub_source(allowed, sock_path=str(sock_path))
+        )
+        (tmp / "script.py").write_text(code)
+
+        calls_made = [0]
+        call_log: list[dict] = []
+        server = await asyncio.start_unix_server(
+            lambda r, w: _serve_rpc(
+                r, w, handler=handler,
+                max_calls=settings.max_tool_calls,
+                allowed=set(allowed),
+                calls_made=calls_made,
+                call_log=call_log,
+            ),
+            path=str(sock_path),
+        )
+
+        env = _scrub_env()
+        env["DECAFCLAW_RPC_SOCKET"] = str(sock_path)
+
+        loop_start = asyncio.get_event_loop().time()
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "script.py",
+            cwd=str(tmp),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            preexec_fn=lambda: _preexec(settings.memory_cap_bytes),
+            start_new_session=True,
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(), timeout=settings.timeout_seconds
+            )
+            elapsed = asyncio.get_event_loop().time() - loop_start
+            stdout = stdout_b.decode("utf-8", errors="replace")
+            stderr = stderr_b.decode("utf-8", errors="replace")
+            if calls_made[0] > settings.max_tool_calls:
+                status = "tool_call_limit"
+            elif proc.returncode == 0:
+                status = "success"
+            else:
+                status = "error"
+            return SandboxResult(
+                status=status, elapsed_seconds=elapsed,
+                tool_calls=call_log,
+                stdout=_truncate(stdout, settings.max_stdout_bytes),
+                stderr=_truncate(stderr, settings.max_stderr_bytes),
+                exit_code=proc.returncode,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                log.warning("subprocess did not exit after SIGKILL")
+            elapsed = asyncio.get_event_loop().time() - loop_start
+            stdout_b = await proc.stdout.read() if proc.stdout else b""
+            stderr_b = await proc.stderr.read() if proc.stderr else b""
+            return SandboxResult(
+                status="timeout", elapsed_seconds=elapsed,
+                tool_calls=call_log,
+                stdout=_truncate(stdout_b.decode("utf-8", errors="replace"),
+                                 settings.max_stdout_bytes),
+                stderr=_truncate(stderr_b.decode("utf-8", errors="replace"),
+                                 settings.max_stderr_bytes),
+                exit_code=None,
+            )
+        finally:
+            server.close()
+            await server.wait_closed()
+    finally:
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+```
+
+```python
+# src/decafclaw/skills/code_execution/_stub.py
+
+_STUB_TEMPLATE = '''
+"""Generated proxy module for the decafclaw code-execution sandbox."""
+
+import json
+import os
+import socket
+import threading
+from dataclasses import dataclass
+
+_SOCKET_PATH = os.environ["DECAFCLAW_RPC_SOCKET"]
+_lock = threading.Lock()
+_sock = None
+_rfile = None
+
+
+def _connect():
+    global _sock, _rfile
+    if _sock is None:
+        _sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        _sock.connect(_SOCKET_PATH)
+        _rfile = _sock.makefile("rb")
+
+
+@dataclass
+class ToolResultProxy:
+    text: str = ""
+    data: dict | None = None
+    error: str | None = None
+
+
+def _call(tool: str, args: dict) -> ToolResultProxy:
+    with _lock:
+        _connect()
+        _sock.sendall((json.dumps({{"tool": tool, "args": args}}) + "\\n").encode())
+        line = _rfile.readline()
+        if not line:
+            return ToolResultProxy(error="rpc connection closed")
+        resp = json.loads(line)
+        return ToolResultProxy(
+            text=resp.get("text", "") or "",
+            data=resp.get("data"),
+            error=resp.get("error"),
+        )
+
+
+class _DCNamespace:
+    """`dc.<tool_name>(**kwargs)` → ToolResultProxy."""
+    {accessors}
+
+
+dc = _DCNamespace()
+'''
+
+
+def generate_stub_source(allowed: tuple[str, ...], *, sock_path: str) -> str:
+    """Generate the proxy module source. `sock_path` is informational only;
+    the actual socket path comes from `DECAFCLAW_RPC_SOCKET` at runtime."""
+    accessors = "\n    ".join(
+        f"def {name}(self, **kwargs): return _call({name!r}, kwargs)"
+        for name in allowed
+    )
+    return _STUB_TEMPLATE.format(accessors=accessors)
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `pytest tests/skills/test_code_execution_sandbox.py -v` passes (4 tests)
+- [x] `make test` passes (no regressions)
+- [x] `pytest tests/skills/test_code_execution_sandbox.py --durations=10` — slowest test < 5s (timeout test is 0.57s wall)
+
+**Verification — manual:**
+- [x] No `/tmp/dc-codeexec-*` directories left behind after running tests (verified empty)
+- [x] No zombie Python processes after timeout test (verified)
+
+---
+
+## Phase 3: Real tool dispatch via `execute_tool`
+
+Replace the `ping` handler with a real dispatcher that forks ctx and calls `decafclaw.tools.execute_tool` against the allowlist. Stub generator emits proxy functions for every allowlisted name. End-to-end: an LLM script can do `dc.vault_read("Foo")` and get a real ToolResultProxy back.
+
+**Files:**
+- Modify: `src/decafclaw/skills/code_execution/tools.py`:
+  - Add `SANDBOX_ALLOWED_TOOLS` constant (the 11-tuple above).
+  - Replace `_ping_handler` with `_make_tool_handler(ctx)` that returns an async closure dispatching via `execute_tool` against a forked ctx.
+  - Wire `run_script(..., handler=_make_tool_handler(ctx), allowed=SANDBOX_ALLOWED_TOOLS)`.
+  - Convert `SandboxResult` → `ToolResult` for the LLM (structured text + machine-readable data).
+- Modify: `src/decafclaw/skills/code_execution/_sandbox.py` — no changes (handler-injection already in place from Phase 2).
+- Test: `tests/skills/test_code_execution_dispatch.py`:
+  - `test_dc_notes_read_round_trip` — seed a notes entry; script `print(dc.notes_read().text)`; verify the entry is in stdout.
+  - `test_dc_workspace_list_returns_data` — write a tmp file in workspace; script `print(dc.workspace_list().text)`; verify filename in stdout.
+  - `test_non_allowlisted_tool_rejected` — script `print(dc.shell(command="ls").error)`; verify error mentions "not in sandbox allowlist" AND the agent's real `shell` tool was never invoked (mock or assert no shell-related events).
+  - `test_vault_write_outside_agent_returns_non_interactive_error` — script `r = dc.vault_write(page="not-agent/foo", content="x"); print(r.error or r.text)`; verify text mentions "requires interactive confirmation".
+  - `test_tabstack_inactive_surfaces_error` — without activating tabstack; script calls `dc.tabstack_extract_markdown(url="x")`; verify `.error` mentions "not initialized" (matches `_get_client()` raise).
+
+**Key changes:**
+
+```python
+# src/decafclaw/skills/code_execution/tools.py — additions
+
+import copy
+import json
+from typing import Awaitable, Callable
+from decafclaw.tools import execute_tool
+
+SANDBOX_ALLOWED_TOOLS: tuple[str, ...] = (
+    "vault_read", "vault_search", "vault_journal_append", "vault_write",
+    "workspace_read", "workspace_list",
+    "notes_read", "notes_append",
+    "tabstack_extract_markdown", "tabstack_extract_json", "tabstack_research",
+)
+
+
+def _make_tool_handler(parent_ctx) -> Callable[[str, dict], Awaitable[dict]]:
+    async def handler(tool_name: str, args: dict) -> dict:
+        # Defense in depth: the sandbox server already checks allowlist,
+        # but a misbehaving stub could submit unknown names.
+        if tool_name not in SANDBOX_ALLOWED_TOOLS:
+            return {"text": "", "data": None,
+                    "error": f"tool '{tool_name}' not in sandbox allowlist"}
+
+        # Fork ctx so confirmation-gated tools fall through to their
+        # NON_INTERACTIVE_ERROR paths instead of blocking the script.
+        sandbox_ctx = copy.copy(parent_ctx)
+        sandbox_ctx.request_confirmation = None
+        # Note: ctx.tools.allowed is per-tool-restriction within a turn;
+        # we use the explicit allowlist check above instead. Don't mutate
+        # ctx.tools.allowed here — it would also affect concurrent tool
+        # calls in the parent.
+
+        try:
+            result = await execute_tool(sandbox_ctx, tool_name, args)
+        except Exception as exc:
+            log.exception("sandbox tool '%s' raised", tool_name)
+            return {"text": "", "data": None, "error": str(exc)}
+
+        text = result.text or ""
+        # decafclaw convention: error tools return text starting with "[error".
+        error = None
+        if text.startswith("[error"):
+            error = text
+            text = ""
+        return {"text": text, "data": result.data, "error": error}
+
+    return handler
+
+
+async def tool_code_execution(ctx, code: str) -> ToolResult:
+    handler = _make_tool_handler(ctx)
+    sandbox = await _sandbox.run_script(
+        ctx, code, _settings,
+        handler=handler, allowed=SANDBOX_ALLOWED_TOOLS,
+    )
+    return _render_result(sandbox)
+
+
+def _render_result(s: "_sandbox.SandboxResult") -> ToolResult:
+    lines = [
+        f"**status:** {s.status}",
+        f"**elapsed:** {s.elapsed_seconds:.2f}s",
+        f"**tool_calls:** {len(s.tool_calls)}",
+    ]
+    if s.tool_calls:
+        for c in s.tool_calls:
+            lines.append(
+                f"  - {c['tool']}({', '.join(c['args_keys'])}) "
+                f"{'ok' if c['ok'] else 'err'} {c['duration_ms']}ms"
+            )
+    if s.stdout:
+        lines.append("**stdout:**\n```\n" + s.stdout + "\n```")
+    if s.stderr:
+        lines.append("**stderr:**\n```\n" + s.stderr + "\n```")
+    return ToolResult(
+        text="\n".join(lines),
+        data={
+            "status": s.status,
+            "elapsed_seconds": s.elapsed_seconds,
+            "tool_calls": s.tool_calls,
+            "stdout": s.stdout,
+            "stderr": s.stderr,
+            "exit_code": s.exit_code,
+        },
+    )
+```
+
+The `ctx.tools.allowed` note in the comment is load-bearing: the rule "don't mutate ctx.tools fields on a forked ctx" follows the CLAUDE.md guidance that runtime state goes on the dataclass and shouldn't be repurposed for cross-cutting filtering. The allowlist check above is the trust boundary.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `pytest tests/skills/test_code_execution_dispatch.py -v` passes (5 tests)
+- [x] `pytest tests/skills/test_code_execution_skill_loading.py tests/skills/test_code_execution_sandbox.py -v` still pass
+- [x] `make test` passes (no regressions; baseline + new tests)
+- [x] `make check` passes
+
+**Verification — manual:** (deferred to Phase 6)
+- [ ] In a real conversation, the LLM can call `code_execution` with a script that does `dc.vault_search(query="foo")` and the result is parseable.
+
+---
+
+## Phase 4: Resource caps + observability
+
+Phase 2 already shipped most of the resource enforcement (timeout, tool-call cap, RLIMIT_AS, I/O truncation). This phase adds the missing piece — per-RPC progress events — and tightens the corner cases discovered in Phase 3 testing. Test cases here are *property* tests for the limits, separate from happy-path tests in earlier phases.
+
+**Files:**
+- Modify: `src/decafclaw/skills/code_execution/_sandbox.py` — in the RPC server, after dispatching a tool call, `await ctx.publish("tool_status", tool="code_execution", message=f"dc.{tool_name}", call_index=calls_made[0])`. This requires plumbing `parent_ctx` into `_serve_rpc` — add a `progress_publish: Callable[[str, dict], Awaitable[None]] | None` parameter so `_sandbox` stays decoupled from `ctx` directly.
+- Modify: `src/decafclaw/skills/code_execution/tools.py` — pass `progress_publish=ctx.publish` into `run_script`.
+- Test: `tests/skills/test_code_execution_limits.py`:
+  - `test_tool_call_limit_enforced` — settings.max_tool_calls=3; script loops `for _ in range(10): dc.notes_read()`; verify status == `"tool_call_limit"` and `len(tool_calls) == 3` (server stops dispatching after limit).
+  - `test_stdout_truncation_head_and_tail` — settings.max_stdout_bytes=200; script prints 1000 bytes; verify stdout contains `"truncated"` marker and is ≤ 200 bytes.
+  - `test_stderr_truncation` — script raises with a long message; verify stderr is truncated similarly.
+  - `test_memory_cap_on_linux` — `pytest.mark.skipif(sys.platform == "darwin", reason="RLIMIT_AS unreliable on macOS")`; settings.memory_cap_bytes=64 MB; script `x = bytearray(128 * 1024 * 1024)`; verify status == `"error"`, stderr contains `MemoryError` OR exit_code != 0.
+  - `test_progress_events_published` — record `tool_status` events via a subscriber on `ctx.event_bus`; script does 3 `dc.notes_read()` calls; verify 3 progress events with monotonically increasing `call_index`.
+
+**Key changes:**
+
+```python
+# _sandbox.py — _serve_rpc signature gains progress_publish
+
+async def _serve_rpc(reader, writer, *, handler, max_calls, allowed,
+                     calls_made: list[int], call_log: list[dict],
+                     progress_publish):
+    ...
+    if tool not in allowed:
+        resp = ...
+    else:
+        ...
+        resp = await handler(tool, args)
+        ...
+        call_log.append({...})
+        if progress_publish is not None:
+            try:
+                await progress_publish(
+                    "tool_status", tool="code_execution",
+                    message=f"dc.{tool}", call_index=calls_made[0],
+                )
+            except Exception as exc:
+                log.debug("progress publish failed: %s", exc)
+    ...
+
+# run_script signature gains progress_publish; forwarded to _serve_rpc.
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `pytest tests/skills/test_code_execution_limits.py -v` passes (5 tests; memory test skipped on macOS)
+- [x] `make test` passes (2524 passed, 1 skipped)
+- [x] `pytest tests/skills/test_code_execution_limits.py --durations=10` — slowest test 0.20s
+
+**Verification — manual:** (deferred to Phase 6)
+- [ ] In a real `make dev` session, run a code_execution script that does 3 dc calls and watch the web UI — three "tool_status" progress lines should appear inline before the final result.
+
+---
+
+## Phase 5: Tool description tightening, docs, eval
+
+Polish the tool description (it's a control surface per CLAUDE.md), write user-facing docs, and add an eval test for disambiguation against existing tools (`vault_read`, `notes_read`) so the LLM doesn't reach for the heavy hammer on simple lookups.
+
+**Files:**
+- Modify: `src/decafclaw/skills/code_execution/tools.py` — refine `TOOL_DEFINITIONS[0]["function"]["description"]` based on eval results from this phase. Initial wording from Phase 1 may need adjustment.
+- Modify: `src/decafclaw/skills/code_execution/SKILL.md` body — document the allowlist (11 tools), caps, the "deterministic multi-step" framing, and *non-uses* (single lookups → call the tool directly).
+- Create: `docs/code-execution.md` — feature doc. Sections: Overview, Allowlist (with one-line descriptions of each tool's role), Caps & overrides (SkillConfig field-by-field), Security boundary (what's trusted, what isn't, the env scrub, why http_request is excluded), Adding tools to the allowlist (how to extend, what to verify).
+- Modify: `docs/index.md` — add `code-execution.md` link under an appropriate section (likely "Tools" or "Skills"; check current grouping).
+- Modify: `CLAUDE.md` — update the "Skills (bundled)" line to note `code_execution` is among the always-loaded set (`vault`, `background`, `mcp`, **`code_execution`**).
+- Modify: `docs/context-composer.md` — per CLAUDE.md "update for any change to system prompt / tool definitions", add a brief mention that `code_execution` is an always-loaded tool with internal timeout (so it doesn't appear in deferred catalogs).
+- Create: `src/decafclaw/eval/cases/code_execution_disambiguation.py` (or equivalent — check existing eval pattern via `make eval-tools` and `src/decafclaw/eval/` layout). The case asserts that for a single-page lookup, the LLM picks `vault_read` not `code_execution`; for a multi-page synthesis, it picks `code_execution`. If the eval framework doesn't make a per-case file pattern obvious, add the case to the existing tool-disambiguation eval fixture.
+
+**Key changes:**
+
+Final tool description draft (tune via `make eval-tools`):
+
+```
+Run a Python script that calls a curated set of decafclaw tools via the
+`dc.*` proxy. Use ONLY when work is genuinely multi-step AND deterministic
+AND intermediate per-tool outputs would be wasted context — for example:
+read 5 vault pages, extract a field from each, return the one with the
+earliest date.
+
+DO NOT use for:
+- single lookups (call the underlying tool directly)
+- work that requires user confirmation (shell, send_email — call those
+  directly outside the sandbox)
+- exploratory work where you don't know what to compute yet
+
+Allowlist: vault_read, vault_search, vault_journal_append, vault_write,
+workspace_read, workspace_list, notes_read, notes_append,
+tabstack_extract_markdown, tabstack_extract_json, tabstack_research.
+Limits: 300s wall-clock, 50 tool calls per script. Script imports the
+proxy as `from decafclaw_tools import dc`. Each `dc.<tool>(...)` returns
+a ToolResultProxy with `.text`, `.data`, `.error`. `print(...)` what you
+want returned to the conversation.
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make typecheck` passes
+- [x] `make check` passes
+- [x] `make eval-tools` — 3 of 4 new cases pass (all anti-overuse cases); positive case fails with LLM picking `vault_list` (defensible exploratory behavior, not a description bug; now in `near_miss` for the eval signal)
+- [x] `make test` passes (2524, no regressions)
+- [x] `grep -r "always-loaded" CLAUDE.md docs/` shows updated list
+
+**Verification — manual:** (deferred to Phase 6)
+- [ ] Read `docs/code-execution.md` end-to-end; a future contributor adding a tool to the allowlist should be able to follow it without asking
+- [ ] Run `make config` and confirm `skills.code_execution` shows up with the documented field names
+
+---
+
+## Phase 6: Manual smoke against `make dev`
+
+Live test in the web UI. This is opt-out of TDD (manual UI verification only).
+
+**Files:** none.
+
+**Verification — automated:** none (covered in Phases 1–5).
+
+**Verification — manual:**
+- [ ] Check with Les that `make dev` isn't running on the bot account before starting a local instance, OR run `make run` in interactive mode for this phase
+- [ ] Single-page lookup prompt ("read agent/pages/DecafClaw and summarize") → LLM picks `vault_read`, not `code_execution`
+- [ ] Multi-page synthesis prompt ("read 3 most recent journal entries and list the topics across them") → LLM picks `code_execution`, script does 3 dc calls
+- [ ] Conversation transcript does NOT contain the 3 individual vault_read results — only the final code_execution summary
+- [ ] Three `tool_status` progress lines appear inline during the code_execution call
+- [ ] Force a timeout: prompt that asks the LLM to run a sandbox script with `while True: pass` (or `time.sleep(400)`) → result returns `status: timeout` within ~302s
+- [ ] Force an allowlist rejection: prompt that has the LLM script call `dc.shell(...)` → result returns `.error` mentioning allowlist; no shell confirmation appears in the UI
+- [ ] No `/tmp/dc-codeexec-*` directories left behind after a few sandbox runs
+- [ ] Resume across page reload: start a sandbox script, reload the web UI mid-run, verify the result still arrives (or fails cleanly if a refresh kills the WS connection)
+
+---
+
+## Out-of-scope cleanup items (do NOT fix in this PR)
+
+Captured here per CLAUDE.md "document worth-fixing items separately" — not load-bearing for this feature, candidates for future sessions:
+
+- `_check_user_write_allowed`'s `NON_INTERACTIVE_ERROR` text mentions "agent folder" even when grants are in play (`vault/tools.py:319-323`). Minor wording.
+- `http_request`'s allow-pattern mechanism could be reused if we ever add `http_request` to the sandbox; would need a non-interactive fail-closed path inside `request_confirmation` itself.
+
+## Spec coverage check
+
+| Spec requirement | Implementing phase |
+|---|---|
+| Bundled, always-loaded skill | Phase 1 |
+| `SkillConfig` with all caps + env override | Phase 1 |
+| `dc.<tool>(...) -> ToolResultProxy(text, data, error)` | Phase 2 (shape) + Phase 3 (real tools) |
+| Subprocess via `sys.executable` + UDS, JSON-line framing | Phase 2 |
+| Env scrubbing (safe-prefix + secret-substring block) | Phase 2 |
+| Defense-in-depth allowlist (stub + server) | Phase 2 (server) + Phase 3 (stub generator with full list) |
+| 300s wall-clock timeout with kill | Phase 2 |
+| `threading.Lock` serialization in stub | Phase 2 |
+| 50 tool calls per script cap | Phase 2 (mechanism) + Phase 4 (property test) |
+| 50KB stdout / 10KB stderr head+tail truncation | Phase 2 (mechanism) + Phase 4 (property test) |
+| 512MB RLIMIT_AS via `preexec_fn` | Phase 2 (mechanism) + Phase 4 (Linux-only test) |
+| Forked ctx with `request_confirmation=None` so vault_write outside agent fails cleanly | Phase 3 |
+| ToolResult shape returned to LLM (status / elapsed / tool_calls / stdout / stderr) | Phase 3 |
+| Per-RPC progress events | Phase 4 |
+| Tool description tuned for "multi-step deterministic only" | Phase 5 |
+| `timeout: None` on TOOL_DEFINITIONS entry | Phase 1 |
+| Docs + CLAUDE.md updates | Phase 5 |
+| Eval disambiguation against single-lookup tools | Phase 5 |
+| Manual smoke in dev | Phase 6 |

--- a/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/research.md
+++ b/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/research.md
@@ -1,0 +1,129 @@
+# Codebase research — programmatic tool calling sandbox
+
+## 1. Tool registration + dispatch
+
+**Registration**
+- `src/decafclaw/tool_definitions.py:18-50` — `TOOLS` dict + `TOOL_DEFINITIONS` list merged from core, skill, heartbeat, health, delegate, attachment, email, notification, canvas, notes registries.
+- `src/decafclaw/tools/tool_registry.py:12-25` — `Priority` enum (`CRITICAL`, `NORMAL`, `LOW`), rank mapping. Tools declare priority via `"priority"` field.
+- `src/decafclaw/tools/tool_registry.py:33-46` — `get_critical_names()` = env override (`config.agent.critical_tools`) ∪ `config.always_loaded_skill_tools`.
+
+**Classification + budget**
+- `src/decafclaw/tools/tool_registry.py:70-159` — `classify_tools()` hard floor for critical, fills budget/count with normal then low, rest deferred. Budget = `config.tool_context_budget`, count = `config.agent.max_active_tools` (default 40).
+- `src/decafclaw/tool_definitions.py:85-124` — `collect_all_tool_defs()` gathers skill-provided + preloaded skill native + core + MCP tools.
+- `src/decafclaw/tool_definitions.py:126-167` — `build_tool_list()` applies classification + allowed_tools filter + appends deferred catalog text.
+- `src/decafclaw/tools/tool_registry.py:204-268` — `build_deferred_list_text()` groups by source (Core/Skills/MCP), wraps in `<deferred_tools>`.
+
+**Dynamic per-turn refresh**
+- `src/decafclaw/tool_definitions.py:38-83` — `refresh_dynamic_tools()` calls each skill's `get_tools(ctx)` per turn, updates `ctx.tools.extra` + `ctx.tools.extra_definitions`, prunes stale entries.
+
+**Dispatch**
+- `src/decafclaw/tools/__init__.py:195-250` — `execute_tool(ctx, name, arguments)`. Checks `ctx.tools.allowed`, routes MCP (`mcp__` prefix) to registry, else skill-provided/global `TOOLS`. Returns `ToolResult`.
+- `src/decafclaw/tool_execution.py:210-280` — `execute_single_tool()` runs one call under semaphore, forks ctx (`fork_for_tool_call`), publishes tool_start/tool_end events.
+- `src/decafclaw/tool_execution.py:282-364` — `execute_tool_calls()` `asyncio.Semaphore(ctx.config.agent.max_concurrent_tools)`, `gather(return_exceptions=True)`.
+
+**Timeout**
+- `src/decafclaw/tools/__init__.py:113-150` — `_resolve_tool_timeout()` walks `ctx.tools.extra_definitions`, `TOOL_DEFINITIONS`, `SEARCH_TOOL_DEFINITIONS` for explicit `timeout`; falls back to `config.agent.tool_timeout_sec`. `<= 0` = disabled.
+- `src/decafclaw/tools/__init__.py:53-108` — `_run_with_cancel()` races against cancel + timeout. Cancel > timeout on tie.
+
+**ToolResult shape**
+- `src/decafclaw/media.py:68-88` — `ToolResult`: `text` (required), `media`, `display_text`, `display_short_text`, `data` (optional dict), `end_turn` (False/True/`EndTurnConfirm`/`WidgetInputPause`), `widget`.
+- `src/decafclaw/tool_execution.py:262-279` — Result rendered as `{"role": "tool", "tool_call_id": ..., "content": text + data JSON, "display_short_text": ..., "widget": ...}`.
+
+**Read-only metadata**
+- **No `read_only` field exists on tool definitions.** Read-only enforcement is per-tool inline (shell via `check_shell_approval()`, email via `check_email_approval()`).
+
+---
+
+## 2. Skill system
+
+**Frontmatter contract**
+- `src/decafclaw/skills/__init__.py:41-100` — `parse_skill_md()` fields: `name`, `description` (required), `requires.env`, `user-invocable` (default True), `allowed-tools` (CSV; `shell(pattern)` for shell), `context` (inline/fork), `argument-hint`, `model`/`effort`, `required-skills`, `always-loaded` (bundled only), `schedule` (cron), `enabled`, `auto-approve` (bundled only). Body = markdown.
+
+**Discovery order**
+- `src/decafclaw/skills/__init__.py:215-292` — `discover_skills()` priority: (1) workspace, (2) agent-level, (3) bundled (`src/decafclaw/skills/`), (4) `extra_skill_paths`. First match wins. `auto_approve`/`always_loaded` stripped from non-bundled.
+
+**Loading `tools.py`**
+- `src/decafclaw/tools/skill_tools.py:42-59` — `_load_native_tools()` `importlib.util.spec_from_file_location()`, extracts `TOOLS`, `TOOL_DEFINITIONS`, returns module for `get_tools` retrieval.
+- `src/decafclaw/tools/skill_tools.py:61-88` — `_call_init()` checks for `SkillConfig` dataclass; calls `load_sub_config(SkillConfig, raw_dict, prefix)` with `config.skills[name]` + env vars (`SKILLS_{SKILL_NAME_UPPER}`). Invokes `init(config, skill_config)` async or sync.
+
+**Activation**
+- `src/decafclaw/skills/__init__.py:294-333` — `build_catalog_text()` separates always-loaded from on-demand.
+- `src/decafclaw/tools/skill_tools.py:90-125` — `restore_skills()` re-activates from `ctx.skills.activated` at turn start.
+- `src/decafclaw/tools/skill_tools.py:127-172` — `tool_activate_skill()`: requests confirmation unless heartbeat OR `perms[name] == "always"` OR `skill_info.auto_approve`. Permissions at `config.agent_path / skill_permissions.json`.
+- `src/decafclaw/tools/skill_tools.py:174-210` — `activate_skill_internal()` loads tools, calls `_call_init()`, registers on `ctx.tools.extra` + dynamic provider if `get_tools()` present, marks active.
+
+---
+
+## 3. Subprocess management (MCP)
+
+**Spawn**
+- `src/decafclaw/mcp_client.py:583-603` — `_connect_stdio()` builds `StdioServerParameters(command, args, env)`, uses `mcp.stdio_client()`, enters into `AsyncExitStack`, creates `ClientSession`, calls `initialize()`.
+
+**Discovery + notification handling**
+- `src/decafclaw/mcp_client.py:509-571` — `connect_server()` lists tools, wraps each via `_make_tool_caller()`, stores in `state.tools` + `state.tool_definitions`.
+- `src/decafclaw/mcp_client.py:481-507` — Notification handler for `ToolListChangedNotification` etc. triggers refresh.
+
+**Reconnect backoff**
+- `src/decafclaw/mcp_client.py:660-703` — `_maybe_reconnect()` max_retries=3, backoff `2^retry_count` (min 8s).
+- `src/decafclaw/mcp_client.py:628-658` — `_make_tool_caller()` calls `asyncio.wait_for(state.session.call_tool(...), timeout=server_config.timeout / 1000)`.
+
+**Framing**
+- JSON-RPC 2.0 over stdio (line-delimited JSON), delegated to `mcp` SDK. Decafclaw doesn't manually frame — only translates `ContentBlock` results via `_convert_mcp_response()` (`mcp_client.py:232-271`).
+
+**Shutdown**
+- `src/decafclaw/mcp_client.py:717-756` — `disconnect_server()` exits `_exit_stack`. `disconnect_all()` with 5s timeout.
+
+---
+
+## 4. Confirmation + write-tool gating
+
+**Entry point**
+- `src/decafclaw/tools/confirmation.py:106-141` — `request_confirmation(ctx, tool_name, command, message, timeout=60, **extra_event_fields)`. Routes via `ctx.request_confirmation` manager if available, else legacy event-bus. Returns `{"approved": bool}` plus optional `{"always": bool, "add_pattern": bool}`.
+- `src/decafclaw/tools/confirmation.py:14-29` — `_get_tool_action_map()` maps `"shell"` → `RUN_SHELL_COMMAND`, `"activate_skill"` → `ACTIVATE_SKILL`, `"end_turn_confirm"` → `CONTINUE_TURN`.
+
+**EndTurnConfirm**
+- `src/decafclaw/media.py:17-33` — `EndTurnConfirm(message, approve_label, deny_label, on_approve, on_deny)`. Loop renders buttons; if approved, calls `on_approve()` then continues; if denied, ends.
+- `src/decafclaw/tool_execution.py:335-363` — End-turn signal priority in batch: `WidgetInputPause` > `EndTurnConfirm` > `True`.
+
+**Email allowlist**
+- `src/decafclaw/tools/email_tools.py:31-58` — `_recipient_allowed()`: case-insensitive exact match OR `@domain.com` suffix.
+- `src/decafclaw/tools/email_tools.py:133-158` — `check_email_approval()` unions `config.email.allowed_recipients` + `ctx.tools.preapproved_email_recipients`. All-allowed → pre-approved; else `request_confirmation()`.
+
+**Shell approval tiers**
+- `src/decafclaw/tools/shell_tools.py:15-129` — Tiers: (1) heartbeat-admin auto, (2) `"shell"` in `ctx.tools.preapproved`, (3) pattern in `ctx.tools.preapproved_shell_patterns` AND no metacharacters, (4) pattern in `shell_allow_patterns.json`, (5) `request_confirmation()`.
+- Metacharacter detection: `;`, `&&`, `||`, `|`, backtick, `$(`, newline.
+- Pattern suggestion heuristic: executable + script path kept, args wildcarded.
+
+---
+
+## 5. hermes-agent reference (`/Users/lorchard/devel/hermes-agent/tools/code_execution_tool.py`)
+
+**Entry**
+- `code_execution_tool.py:1036-1071` — `execute_code(code, task_id=None, enabled_tools=None) -> str`. Routes to local UDS or remote file-based RPC based on `_get_env_config()["env_type"]`.
+
+**Allowlist**
+- `code_execution_tool.py:60-68` — `SANDBOX_ALLOWED_TOOLS = frozenset([web_search, web_extract, read_file, write_file, search_files, patch, terminal])`. Intersected with session `enabled_tools` to generate stubs.
+
+**Local backend (UDS)**
+- `code_execution_tool.py:307-366` — Generated `hermes_tools.py` stub: opens AF_UNIX socket (TCP fallback on Windows), `_call(name, args)` sends JSON-RPC over socket, returns parsed result, serialized via `threading.Lock`.
+- `code_execution_tool.py:439-557` — `_rpc_server_loop()` in parent thread accepts one client, reads newline-delimited JSON, enforces allowlist + call limit, dispatches via `handle_function_call()`, writes JSON response.
+
+**Remote backend (file RPC)**
+- `code_execution_tool.py:371-427` — Stub `_call()` writes `req_{seq:06d}` files (seq via thread-safe lock), polls `res_{seq:06d}` with adaptive backoff (50ms → 250ms), deletes file when done.
+- `code_execution_tool.py:699-838` — `_rpc_poll_loop()` polls remote FS via shell commands (`ls`, `cat`, `mv`).
+
+**Env management**
+- `code_execution_tool.py:563-663` — `_get_or_create_env()` reuses terminal environment (container/sandbox/SSH/local).
+- `code_execution_tool.py:118-154` — `_scrub_child_env()` filters parent env: passthrough vars always pass; names containing KEY/TOKEN/SECRET/PASSWORD/CREDENTIAL/PASSWD/AUTH blocked; safe-prefix list (PATH, HOME, USER, LANG, LC_, TERM, TMPDIR, PYTHONPATH, VIRTUAL_ENV, CONDA, HERMES_).
+
+**Limits**
+- `code_execution_tool.py:70-74` — `DEFAULT_TIMEOUT = 300` (5min), `DEFAULT_MAX_TOOL_CALLS = 50`, `MAX_STDOUT_BYTES = 50_000`, `MAX_STDERR_BYTES = 10_000`. Per-tool RPC timeout 300s.
+- `code_execution_tool.py:444-445` — Server enforces max tool calls; over-limit returns error instead of dispatching.
+
+**Return shape**
+- Both backends return JSON string `{"status": "success"|"error"|"timeout"|"interrupted", "output": stdout, "tool_calls_made": int, "duration_seconds": float, "error": str?}`.
+- Output truncation: head 40% + tail 60% to fit MAX_STDOUT_BYTES; ANSI stripped, secrets redacted.
+- Exit codes: 124 timeout, 130 interrupted.
+
+**Tool error propagation**
+- `handle_function_call()` exceptions caught, returned as `{"error": str(exc)}` per call (script sees dict, continues).

--- a/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/spec.md
+++ b/docs/dev-sessions/2026-05-15-1244-programmatic-tool-calling-471/spec.md
@@ -1,0 +1,124 @@
+# Programmatic tool calling: LLM-written Python sandbox
+
+**Goal:** Let the LLM author a Python script that calls a curated subset of decafclaw tools over local RPC, so deterministic multi-step work (read N pages → extract fields → compute → return one answer) runs as a single tool call with intermediate per-tool outputs kept off the conversation transcript.
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/471
+
+## Current state
+
+Today, multi-step deterministic work goes through the regular agent loop: each tool call is a round-trip, each result lands in the conversation transcript, each intermediate output consumes context. A "read 5 vault pages → extract dates → return earliest" task takes ~10+ tool messages.
+
+Relevant existing surface:
+
+- **Tool dispatch:** `tool_definitions.py:18-50` merges core/skill/MCP tools; `tool_execution.py:282-364` runs calls concurrently via `asyncio.Semaphore`, forks `ctx` per call (`fork_for_tool_call`), wraps in timeout (`tools/__init__.py:53-108`).
+- **ToolResult shape:** `media.py:68-88` — `text` (required), optional `data` (dict for structured output), `end_turn`, `widget`. Rendered into the tool message as text + fenced JSON data block (`tool_execution.py:262-279`).
+- **Skill loading:** `skills/__init__.py:215-292` discovers from workspace > agent > bundled > extra paths; `tools/skill_tools.py:42-88` loads `tools.py` via `importlib`, calls `_call_init(SkillConfig)` with merged env + `config.skills[name]`. Always-loaded bundled skills are auto-activated and exempt from deferral.
+- **Subprocess pattern (reference):** `mcp_client.py:583-603` spawns stdio MCP servers via `StdioServerParameters` + `AsyncExitStack`; `mcp_client.py:628-703` wraps tool calls with `asyncio.wait_for` and `2^n` reconnect backoff. Framing is JSON-RPC line-delimited (delegated to the `mcp` SDK).
+- **Confirmation gating:** `tools/confirmation.py:106-141` returns `{"approved": bool, ...}`. Only `shell`, `shell_background_start`, `send_email` (when not allowlisted), and `activate_skill` request confirmation today. Other vault/workspace/notes/http/tabstack tools complete without prompting.
+- **No `read_only` metadata exists** on tool definitions today. Confirmation-vs-not is enforced inline per tool, not declared on the definition object.
+
+Reference implementation (out-of-tree): `~/devel/hermes-agent/tools/code_execution_tool.py` — particularly `:60-68` (`SANDBOX_ALLOWED_TOOLS`), `:307-366` (UDS stub generation), `:439-557` (`_rpc_server_loop`), `:118-154` (`_scrub_child_env`).
+
+## Desired end state
+
+A new bundled skill at `src/decafclaw/skills/code_execution/` with:
+
+- `SKILL.md` frontmatter declaring `always-loaded: true` and a tight description that emphasizes "for deterministic multi-step work where intermediate outputs are wasted context."
+- `tools.py` exposing one tool — `code_execution` — that accepts a Python script string and returns a `ToolResult` with:
+  - `text`: a structured summary — exit status, elapsed time, tool calls made (name + arg keys, no values), truncated stdout, truncated stderr.
+  - `data`: structured dict with the same fields, machine-readable.
+- The tool spawns a subprocess running the project's Python interpreter (via `sys.executable` from the agent process, so the worktree's venv is reused), writes a generated `decafclaw_tools.py` stub module and the LLM's `script.py` into a temp directory, and starts a Unix-domain-socket RPC server in the agent process.
+- The stub module exposes a `dc` namespace; each allowlisted tool becomes `dc.<tool_name>(**kwargs) -> ToolResultProxy`. `ToolResultProxy` is a small dataclass with `.text: str`, `.data: dict | None`, `.error: str | None`. Calls serialize on a `threading.Lock` inside the subprocess (one RPC at a time).
+- Sandbox-callable tools (v1):
+  - **Read:** `vault_read`, `vault_search`, `workspace_read`, `workspace_list`, `notes_read`
+  - **Safe writes:** `notes_append`, `vault_journal_append`, `vault_write` — `vault_write` gates on path: writes inside `agent/` are silent, writes outside return `NON_INTERACTIVE_ERROR` text (the existing path when `ctx.request_confirmation is None`); the RPC handler forces ctx into that mode.
+  - **Web extraction:** `tabstack_extract_markdown`, `tabstack_extract_json`, `tabstack_research` — these live in the (lazy-loaded) `tabstack` skill, which must be activated in the conversation before scripts can use them. If not yet active, the RPC returns an error to the script (`_get_client()` raises in `skills/tabstack/tools.py:35-38`).
+  - **Excluded for v1:** `http_request` (always gates on confirmation unless URL matches admin allow-pattern at `http_tools.py:99-115`; inside the sandbox this would deadlock or silently deny after 60s timeout). Tabstack covers the load-bearing web-fetch use case.
+- The RPC server enforces the allowlist server-side (defense in depth — the script-side stub only generates allowlisted names, but the server rejects anything else too) and a per-script tool-call count cap.
+- Hard limits enforced on the subprocess:
+  - 300s wall-clock timeout (kill with SIGTERM, then SIGKILL after 2s grace).
+  - 50 tool calls per script.
+  - 50KB stdout cap (head 40% + tail 60% on overflow with an explicit `[... truncated N bytes ...]` marker).
+  - 10KB stderr cap (same scheme).
+  - 512MB address-space cap via `resource.setrlimit(RLIMIT_AS, ...)` (Linux/macOS only).
+- Environment scrubbing on child env: passthrough only safe-prefix vars (PATH, HOME, USER, LANG, LC_*, TERM, TMPDIR, PYTHONPATH, VIRTUAL_ENV, DECAFCLAW_*); block any var whose name contains KEY/TOKEN/SECRET/PASSWORD/CREDENTIAL/PASSWD/AUTH.
+- All caps configurable via `SkillConfig` dataclass in `tools.py`, resolved through `load_sub_config` (env-var prefix `SKILLS_CODE_EXECUTION_*`, `config.skills.code_execution` JSON override).
+
+`ToolResult` shape returned to the LLM:
+
+```
+status: success|error|timeout|tool_call_limit
+elapsed_seconds: 12.34
+tool_calls: [
+  {tool: "vault_read", args_keys: ["path"], duration_ms: 45, ok: true},
+  ...
+]
+stdout: "<truncated to 50KB>"
+stderr: "<truncated to 10KB>"
+return_value: <last expression value if printable, else null>
+```
+
+## Design decisions
+
+- **Decision:** Bundled, always-loaded skill (`skills/code_execution/`, `always-loaded: true`).
+  - **Why:** Broadly useful enough to justify the always-loaded tool slot. The skill abstraction gives us `SkillConfig` for per-instance customization (allowlist tweaks, cap overrides) without inflating top-level `Config`. Bundled-only so `auto_approve` semantics apply if we ever need them.
+  - **Rejected:** On-demand activation — adds a confirmation step per conversation for a tool whose value is "use it freely when the work fits." Core tool (no skill) — loses `SkillConfig` ergonomics and the skill discovery patterns we already have.
+
+- **Decision:** Exclude confirmation-requiring tools (`shell`, `send_email`, `activate_skill`, etc.) from the allowlist.
+  - **Why:** A subprocess can't pause for user confirmation mid-execution without elaborate RPC-driven UI pausing. The curated allowlist IS the trust boundary — anything in it must complete without prompting.
+  - **Rejected:** Bridging confirmation events back via RPC (hermes doesn't do this; the LLM can call gated tools outside the sandbox when it needs them). Pre-approving a confirmation budget at sandbox entry (forces the LLM to declare write intent up front; can't branch dynamically).
+
+- **Decision:** Subprocess sandbox via `sys.executable` + UDS, not in-process `exec()`.
+  - **Why:** Isolation, kill-ability, hard wall-clock timeout, memory cap via `RLIMIT_AS`, fresh globals per call. `exec()` shares the agent's namespace and can't be timed out cleanly.
+  - **Rejected:** `RestrictedPython`, custom AST walker — gives a false sense of safety and breaks many useful constructs.
+
+- **Decision:** UDS with JSON-line framing for RPC.
+  - **Why:** Stdlib-only, fast on macOS/Linux. Hand-rolled framing keeps the dependency surface flat (no JSON-RPC SDK, no MCP-style negotiation). Each request is one `{"tool": ..., "args": {...}}` line; each response is one `{"text": ..., "data": ..., "error": ...}` line.
+  - **Rejected:** TCP loopback (binds a port unnecessarily, requires port allocation), shared memory (overkill), pipes (no concurrent r/w abstraction).
+
+- **Decision:** `ToolResultProxy` dataclass returned from `dc.<tool>(...)` — `.text` / `.data` / `.error`.
+  - **Why:** Mirrors decafclaw's existing `ToolResult` shape; scripts can branch cleanly on `if result.error`. Surfacing both `.text` and `.data` is important because many tools (e.g., `vault_search`) put the load-bearing payload in `.data` and only a summary in `.text`.
+  - **Rejected:** Raw dict (less typed, less self-documenting in the stub), "smart" return (`.data` if present else `.text`, raises on error — too magical).
+
+- **Decision:** Defense-in-depth allowlist check (both client stub and RPC server).
+  - **Why:** The script can `import socket` and write raw bytes to the UDS — server-side enforcement is non-negotiable. The client-side stub generation just keeps `dc.*` clean for the LLM.
+  - **Rejected:** Trusting the stub alone — the sandbox isn't a security boundary against the script, only against accidental tool surface expansion.
+
+- **Decision:** Match hermes resource caps verbatim (300s / 50 calls / 50KB stdout / 10KB stderr / 512MB).
+  - **Why:** Proven shape from the reference impl. Tighter caps will frustrate the load-bearing use case; looser caps blow up turn footprint.
+  - **Rejected:** Tighter (120s/30 calls) — too short for "research 10 vault pages." Looser (600s/100 calls) — invites runaway scripts.
+
+- **Decision:** Serialize tool calls within one script invocation (one in-flight RPC at a time via `threading.Lock` in the stub).
+  - **Why:** The script is single-threaded by default; concurrency from inside the script would force us to fork the agent's `ctx` per concurrent call and is unlikely to be load-bearing for v1.
+  - **Rejected:** Concurrent RPC — extra complexity for no clear v1 win. The outer `max_concurrent_tools` semaphore still allows multiple `code_execution` calls in parallel.
+
+## Patterns to follow
+
+- **Tool definition layout:** mirror an existing skill `tools.py` (e.g., `src/decafclaw/skills/vault/tools.py`). Export `TOOLS` dict, `TOOL_DEFINITIONS` list, `SkillConfig` dataclass, `init(config, skill_config)`.
+- **SkillConfig resolution:** `tools/skill_tools.py:61-88` via `load_sub_config`.
+- **Always-loaded frontmatter:** `skills/__init__.py:294-333` for activation contract.
+- **Subprocess + AsyncExitStack:** `mcp_client.py:583-603` for spawn pattern; we won't use the `mcp` SDK but the lifecycle shape (spawn → init → call → cleanup via context manager) carries over.
+- **Per-call timeout wrapping:** `tools/__init__.py:53-108` — `_run_with_cancel()` for racing the subprocess against the outer tool timeout. Note: the outer `code_execution` tool itself should override the default `tool_timeout_sec` (set `timeout=None` in its `TOOL_DEFINITIONS` entry so the 300s internal cap is authoritative), following the precedent at `tool_definitions.py` for `delegate_task` / `conversation_compact`.
+- **Event publishing for progress:** `ctx.publish('tool_status', ...)` per RPC call so the UI can show a "running script… 12 tool calls so far" indicator if we want it.
+- **`ToolResult.data` for structured output:** other tools that return both text + data (e.g., `vault_search`) for the rendering precedent.
+
+## What we're NOT doing
+
+- **Windows support.** UDS + `RLIMIT_AS` are POSIX-only. macOS + Linux for v1.
+- **Network sandboxing.** The subprocess can `import urllib` and hit the network directly. The contract is "use `dc.http_get`" — we're not trying to enforce it with seccomp / network namespaces.
+- **Filesystem sandboxing.** The script runs as the agent user with full FS access. No chroot, no `--restrict-to-cwd` flag. The trust boundary is the LLM-author + the allowlist, not the OS.
+- **Persistent state between invocations.** Each call gets a fresh subprocess and fresh temp dir. No pickling locals across calls.
+- **Streaming partial output.** stdout/stderr captured and returned at end of run. Progress events are at the per-RPC-call granularity, not per-line.
+- **Concurrent RPC from inside one script.** Serialized via `threading.Lock`.
+- **Bridging mid-script confirmation prompts back to the user.** Excluded tools stay excluded.
+- **`shell` / `send_email` / `activate_skill` / writes-that-require-approval in the allowlist.** Period.
+- **Auto-derived allowlist from tool metadata.** No `read_only: true` field on tool defs to lean on; v1 keeps the list hand-curated and inspectable in one place.
+- **Class-of-bug analogues considered.** No comparable subprocess+RPC tool already lives in the agent — MCP is the closest, but its framing is delegated to the `mcp` SDK and lifecycle is server-managed. We're explicitly NOT generalizing this into a "subprocess RPC framework" — it's one tool with one purpose.
+
+## Open questions
+
+- **Should the `code_execution` tool description encourage or discourage use?** Default: phrasing emphasizes "for deterministic multi-step work where intermediate results are wasted context" — the LLM should NOT reach for it for one-off lookups. Tune wording during execute; run `make eval-tools` if disambiguation drifts vs. existing tools.
+- **Where do we put the UDS socket + temp dir?** Default: `tempfile.mkdtemp(prefix="dc-codeexec-")` per invocation, cleaned up in a `finally`. Socket lives inside that dir as `rpc.sock`.
+- **What happens if the script itself raises an unhandled exception?** Default: capture the traceback into stderr, exit non-zero, return `status: "error"` with the truncated traceback in stderr. Don't try to surface the exception object structurally to the LLM in v1.
+- **How does the `dc` stub get imported in the script?** Default: the generated `decafclaw_tools.py` lives alongside `script.py` in the temp dir; the script imports as `from decafclaw_tools import dc`. The `dc` symbol is the module-level namespace object (an instance with `__getattr__` returning bound `_call(name, kwargs)` closures).
+- **Logging on the agent side?** Default: log each RPC dispatch at DEBUG (tool name, arg keys, duration), summary at INFO (script start, script end with status/elapsed/call count). Errors at WARNING.


### PR DESCRIPTION
Rescues four session docs that existed **only** as untracked files in a local worktree — not on `main`, and not in PR #518 either, since they were never committed. Cleaning up that worktree would have destroyed them.

Found while clearing out stale worktrees after #715 merged.

## Why keep them

PR #518 was [closed without merge](https://github.com/lmorchard/decafclaw/pull/518) over a framing-vs-reality gap: the "sandbox" was a subprocess runner with stdlib unrestricted, so a script could `import subprocess` and bypass the shell-confirmation gate, `import urllib.request` and bypass the `http_request` gate, or `import os` and bypass workspace-write guards.

**Issue #471 is still open.** The spec and that architectural finding are the starting point for whoever picks it up, and re-deriving them costs a full brainstorm-and-plan cycle.

Three findings in `notes.md` are independent of the parked design and still hold:

- macOS `setrlimit(RLIMIT_AS, ...)` raises `ValueError: current limit exceeds maximum limit` — the kernel refuses to lower `RLIM_INFINITY`. The plan had assumed it was silently best-effort.
- `tools/delegate.py` publishes `tool_status` with a **positional dict** where consumers read `**kwargs` off the top-level event, so the payload is silently dropped.
- `copy.copy(parent_ctx)` shares mutable subobjects, so concurrent tool calls in one parent turn can race on `ctx.tools`.

The `delegate.py` one looks like a live bug on `main` and is worth its own issue — I did not touch it here.

## Notes

- Added a **status header** to `notes.md` so the 680-line plan doesn't read as shipped behavior. No `code_execution` skill exists on `main`, and nothing in these docs describes current code.
- Files are otherwise byte-identical to the worktree copies (verified with `diff -rq` before committing).
- Docs only — no code, no tests. Nothing for CI to exercise beyond the lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)