### PR TITLE
Clear sticky slot when leaving EXECUTING via project_switch/create

### DIFF
--- a/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/checks.md
+++ b/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/checks.md
@@ -1,0 +1,38 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/656
+**Frozen at:** c49752e (2026-07-27)
+**Check files — read-only from Phase 1 onward:**
+- `tests/test_project_tools.py`
+
+## C1
+
+CRITERION: WHEN `project_switch` changes the active project while the outgoing project is EXECUTING,
+THE SYSTEM SHALL clear the `progress_tracker` sticky slot.
+CHECK: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_switch_away_from_executing_clears` passes.
+AT FREEZE: FAILED — `AssertionError: assert 0 >= 1` where 0 = clear_mock.await_count (correct reason: clear_sticky never called when switching away from EXECUTING project)
+
+## C2
+
+CRITERION: WHEN `project_create` makes a new project active while the outgoing project is EXECUTING,
+THE SYSTEM SHALL clear the `progress_tracker` sticky slot.
+CHECK: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_create_while_executing_clears` passes.
+AT FREEZE: FAILED — `AssertionError: assert 0 >= 1` where 0 = clear_mock.await_count (correct reason: clear_sticky never called when creating new project while current is EXECUTING)
+
+## Guards
+
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- G1a: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_done_clears_sticky` — existing clear path on DONE. Passed at freeze (1 passed in 1.73s).
+- G1b: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_advance_out_of_executing_clears` — existing clear path on advance out of EXECUTING. Passed at freeze (1 passed in 1.73s).
+- G2: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_update_step_emits_during_executing` — tracker must still be SET during EXECUTING. Passed at freeze (1 passed in 1.73s).
+
+## Tamper verdict (pre-squash)
+
+**Recorded at:** acd2d51 (2026-07-27, pre-squash)
+**Command:** `git diff c49752e -- tests/test_project_tools.py`
+**Result:** CLEAN — empty diff
+
+## Amendments
+
+(Append-only. Empty unless an amendment was made.)

--- a/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/plan.md
+++ b/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/plan.md
@@ -1,0 +1,90 @@
+# progress_tracker Switch/Create Clear Implementation Plan
+
+**Goal:** Clear the sticky slot when leaving an EXECUTING project via `project_switch` or `project_create`.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/656 — **Tier:** `auto-ok` (both criteria reduce to concrete assertions, oracle exists, no risk-gated paths)
+
+**Approach:** Per D1 from the spec, call `_clear_project_progress(ctx)` when `project_switch` or `project_create` moves away from an EXECUTING project. This matches the existing pattern used on transition to DONE (line 335) and on `project_advance` out of EXECUTING (line 615).
+
+**Criteria:** C1 — switch away clears · C2 — create while executing clears
+
+---
+
+## Phase 0: Freeze the acceptance checks
+
+Write `checks.md` and author the tests the checks name, per `references/frozen-checks.md`.
+No implementation in this phase.
+
+**Files:**
+- Create: `docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/checks.md`
+- Modify: `tests/test_project_tools.py` — add `test_switch_away_from_executing_clears` and `test_create_while_executing_clears`
+
+**Verification — automated:**
+- [x] C1's check runs and fails for the expected reason: `AssertionError: assert 0 >= 1` (clear_sticky not called)
+- [x] C2's check runs and fails for the expected reason: `AssertionError: assert 0 >= 1` (clear_sticky not called)
+- [x] Guards G1a, G1b, G2 run and pass (3 passed in 1.73s)
+- [x] Freeze commit made; sha c49752e recorded in `checks.md`
+
+---
+
+## Phase 1: Implement the fix
+
+Add calls to `_clear_project_progress(ctx)` in `tool_project_switch` and `tool_project_create` when the outgoing project is EXECUTING.
+
+**Advances:** C1, C2 — both fully satisfied by this phase
+
+**Files:**
+- Modify: `src/decafclaw/skills/project/tools.py` — add clear logic to `tool_project_switch` and `tool_project_create`
+
+**Key changes:**
+
+In `tool_project_switch` (currently lines 413-420), before switching to the new project, check if the current project is EXECUTING and clear its sticky:
+
+```python
+async def tool_project_switch(ctx, project: str) -> str | ToolResult:
+    """Switch the current project context."""
+    # Check if outgoing project is EXECUTING and clear its sticky
+    outgoing_slug = _get_current_project(ctx)
+    if outgoing_slug:
+        outgoing_info = load_project(ctx.config, outgoing_slug)
+        if outgoing_info and outgoing_info.status == ProjectState.EXECUTING:
+            await _clear_project_progress(ctx)
+
+    result = _load_or_error(ctx.config, project)
+    if isinstance(result, ToolResult):
+        return result
+    info = result
+    _set_current_project(ctx, info.slug)
+    return f"Switched to project '{info.slug}' ({info.status.value}). Call project_next_task."
+```
+
+In `tool_project_create` (currently lines 166-175), before setting the new project as current, check if the current project is EXECUTING and clear its sticky:
+
+```python
+async def tool_project_create(ctx, description: str, slug: str = "") -> str | ToolResult:
+    """Create a new structured project."""
+    # Check if outgoing project is EXECUTING and clear its sticky
+    outgoing_slug = _get_current_project(ctx)
+    if outgoing_slug:
+        outgoing_info = load_project(ctx.config, outgoing_slug)
+        if outgoing_info and outgoing_info.status == ProjectState.EXECUTING:
+            await _clear_project_progress(ctx)
+
+    info = create_project(ctx.config, description, slug=slug)
+    _set_current_project(ctx, info.slug)
+    return (
+        f"Project created: {info.slug}\n"
+        f"Directory: {info.directory}\n"
+        f"Status: {info.status.value}\n\n"
+        f"Now call **project_next_task** to get your first instruction."
+    )
+```
+
+**Verification — automated:**
+- [ ] C1's check passes: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_switch_away_from_executing_clears`
+- [ ] C2's check passes: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_create_while_executing_clears`
+- [ ] G1a still passes: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_done_clears_sticky`
+- [ ] G1b still passes: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_advance_out_of_executing_clears`
+- [ ] G2 still passes: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_update_step_emits_during_executing`
+- [ ] `make lint` passes
+- [ ] `make test` passes (no regression)

--- a/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/spec.md
+++ b/docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/spec.md
@@ -1,0 +1,74 @@
+# progress_tracker: stale sticky tracker when leaving EXECUTING via project_switch/project_create
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/656
+
+Follow-up from #414 (PR #653).
+
+The project skill clears its `progress_tracker` from the sticky slot on transition to DONE and on `project_advance` out of EXECUTING, but **not** when the active project changes without a status transition — i.e. `project_switch` or `project_create` while a project is EXECUTING. Since projects and the sticky slot are both per-conversation, switching to another project mid-execution leaves project A's tracker pinned above the chat until project B next enters EXECUTING and emits.
+
+Display-only (no functional harm), and outside #414's enumerated transitions, so it was deliberately deferred. Fix: call `_clear_project_progress(ctx)` (or re-emit for the newly active project) when `project_switch`/`project_create` moves away from an EXECUTING project.
+
+Surfaced by the #414 whole-branch review.
+
+---
+
+## Design decisions (resolved at intake, 2026-07-27)
+
+**D1 — clear the sticky slot; do not re-emit for the newly active project.**
+`project_switch` / `project_create` that moves away from an EXECUTING project calls
+`_clear_project_progress(ctx)` (`skills/project/tools.py:151`), matching what the skill already does
+on transition to DONE (line 335) and on `project_advance` out of EXECUTING (line 615). One rule for
+every way of leaving EXECUTING.
+
+Rejected: re-emitting the newly active project's tracker. It is only defined when the *incoming*
+project is itself EXECUTING, so it still needs the clear as a fallback — making it "clear, then emit
+if applicable", a superset that needs its own criterion for what the incoming project displays. That
+is a UX enhancement, not this bug.
+
+## Acceptance criteria
+
+**C1 — switching away from an EXECUTING project clears its tracker.**
+WHEN `project_switch` changes the active project while the outgoing project is EXECUTING,
+THE SYSTEM SHALL clear the `progress_tracker` sticky slot.
+- CHECK: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_switch_away_from_executing_clears`
+- Demonstrated absent at intake: a throwaway test mirroring the existing
+  `test_advance_out_of_executing_clears` failed with `clear_sticky.await_count == 0`.
+
+**C2 — creating a project while another is EXECUTING clears the outgoing tracker.**
+WHEN `project_create` makes a new project active while the outgoing project is EXECUTING,
+THE SYSTEM SHALL clear the `progress_tracker` sticky slot.
+- CHECK: `uv run pytest tests/test_project_tools.py::TestProgressTrackerEmit::test_create_while_executing_clears`
+- Demonstrated absent at intake: same throwaway, `clear_sticky.await_count == 0`.
+- Kept separate from C1 because these are two distinct call sites; a fix that threads the clear into
+  only one of them satisfies the other criterion and leaves half the bug.
+
+### Regression guards (pass today; must keep passing — not criteria)
+
+- **G1:** `tests/test_project_tools.py::TestProgressTrackerEmit::test_done_clears_sticky` and
+  `::test_advance_out_of_executing_clears` — the two existing clear paths must keep working.
+- **G2 (negative control):** `tests/test_project_tools.py::TestProgressTrackerEmit::test_update_step_emits_during_executing`
+  — the tracker must still be *set* while a project is EXECUTING. Blocks an over-broad fix that
+  clears the slot on every project-tool call.
+- Observed at intake: `2 passed in 1.65s` for the two G1 tests
+  (`-k "clears_sticky or advance_out_of_executing_clears"`).
+
+## What we're NOT doing
+
+- **Not re-emitting the incoming project's tracker** — see D1. If that is wanted, it is its own issue.
+- **Not revisiting #414's enumerated transitions.** DONE and `project_advance` already clear
+  correctly; G1 pins them.
+- **Not touching the sticky mechanism itself** (`decafclaw.sticky`). The fix is call sites in
+  `skills/project/tools.py`.
+
+## Tier: `auto-ok`
+
+Both criteria reduce to concrete assertions using the mock pattern already established in
+`tests/test_project_tools.py`, and both were demonstrated failing today. The oracle exists — the test
+file, the `ctx` fixture, and the `_advance_to_executing` helper are all in place, so no harness needs
+building. No risk-gated path: display-only, no auth/authorization, secrets, data migration or
+deletion, deploy/infra/CI config, or dependency change. The switch-vs-re-emit choice was the only
+withheld decision, and D1 resolves it.
+
+---
+*Decisions resolved and criteria added via `agent-session intake`. Every check was run at intake
+time, not inferred; original issue text preserved verbatim above.*

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -165,6 +165,13 @@ async def _clear_project_progress(ctx) -> None:
 
 async def tool_project_create(ctx, description: str, slug: str = "") -> str | ToolResult:
     """Create a new structured project."""
+    # Clear sticky if outgoing project is EXECUTING (#656)
+    outgoing_slug = _get_current_project(ctx)
+    if outgoing_slug:
+        outgoing_info = load_project(ctx.config, outgoing_slug)
+        if outgoing_info and outgoing_info.status == ProjectState.EXECUTING:
+            await _clear_project_progress(ctx)
+
     info = create_project(ctx.config, description, slug=slug)
     _set_current_project(ctx, info.slug)
     return (
@@ -412,10 +419,19 @@ async def tool_project_list(ctx) -> str | ToolResult:
 
 async def tool_project_switch(ctx, project: str) -> str | ToolResult:
     """Switch the current project context."""
+    outgoing_slug = _get_current_project(ctx)
+
     result = _load_or_error(ctx.config, project)
     if isinstance(result, ToolResult):
         return result
     info = result
+
+    # Clear sticky if outgoing project is EXECUTING and we're actually changing (#656)
+    if outgoing_slug and outgoing_slug != info.slug:
+        outgoing_info = load_project(ctx.config, outgoing_slug)
+        if outgoing_info and outgoing_info.status == ProjectState.EXECUTING:
+            await _clear_project_progress(ctx)
+
     _set_current_project(ctx, info.slug)
     return f"Switched to project '{info.slug}' ({info.status.value}). Call project_next_task."
 

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -476,3 +476,40 @@ class TestProgressTrackerEmit:
         result = await tool_project_advance(ctx, target_status="planning")
         assert "reverted" in _text(result).lower()
         assert clear_mock.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_switch_away_from_executing_clears(self, ctx, monkeypatch):
+        """C1: Switching to another project while current is EXECUTING clears its tracker."""
+        from unittest.mock import AsyncMock
+        clear_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+        # Create and advance project A to EXECUTING
+        await _advance_to_executing(ctx, slug="pt-switch-a")
+        # Create project B (which will be in BRAINSTORMING)
+        await tool_project_create(ctx, description="Project B", slug="pt-switch-b")
+        clear_mock.reset_mock()
+        # Switch back to project A (still EXECUTING) then switch to B
+        await tool_project_switch(ctx, project="pt-switch-a")
+        clear_mock.reset_mock()  # reset again after switch to A
+        # Now switch away from the EXECUTING project A to project B
+        result = await tool_project_switch(ctx, project="pt-switch-b")
+        assert "pt-switch-b" in _text(result).lower()
+        # The sticky slot should have been cleared when leaving the EXECUTING project
+        assert clear_mock.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_create_while_executing_clears(self, ctx, monkeypatch):
+        """C2: Creating a new project while current is EXECUTING clears the tracker."""
+        from unittest.mock import AsyncMock
+        clear_mock = AsyncMock()
+        monkeypatch.setattr("decafclaw.sticky.set_sticky", AsyncMock())
+        monkeypatch.setattr("decafclaw.sticky.clear_sticky", clear_mock)
+        # Create and advance project A to EXECUTING
+        await _advance_to_executing(ctx, slug="pt-create-a")
+        clear_mock.reset_mock()
+        # Create a new project, which makes it active — should clear A's tracker
+        result = await tool_project_create(ctx, description="Project B", slug="pt-create-b")
+        assert "pt-create-b" in _text(result).lower()
+        # The sticky slot should have been cleared when leaving the EXECUTING project
+        assert clear_mock.await_count >= 1


### PR DESCRIPTION
## Summary

Clear the `progress_tracker` sticky slot when leaving an EXECUTING project via `project_switch` or `project_create`.

Previously, switching to a different project or creating a new one while the current project was in EXECUTING state left a stale progress tracker pinned. Now, the sticky slot is cleared on these exit paths, matching the existing behavior when transitioning to DONE or advancing out of EXECUTING.

The clearing happens after validating the switch will succeed and actually changes projects (not a no-op switch to the same project).

Closes #656

## Acceptance Criteria

| ID | Criterion | Check | Result |
|----|-----------|-------|--------|
| C1 | `project_switch` clears sticky when leaving EXECUTING | `test_switch_away_from_executing_clears` | ✅ pass |
| C2 | `project_create` clears sticky when leaving EXECUTING | `test_create_while_executing_clears` | ✅ pass |
| G1a | Existing clear on DONE still works | `test_done_clears_sticky` | ✅ pass |
| G1b | Existing clear on advance out of EXECUTING still works | `test_advance_out_of_executing_clears` | ✅ pass |
| G2 | Tracker still emits during EXECUTING | `test_update_step_emits_during_executing` | ✅ pass |

## Review Fixes

- Addressed Copilot review: moved sticky clearing to after validation, ensuring clear only happens when the switch succeeds and actually changes projects (not on failed/no-op switches)

## References

- Spec: [spec.md](docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/spec.md)
- Checks: [checks.md](docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/checks.md)
- Plan: [plan.md](docs/dev-sessions/2026-07-27-1528-progress-tracker-switch/plan.md)

---

<!-- agent-session:gate -->
```yaml
verdict: eligible-for-auto-merge
reason: all gate conditions satisfied
tier: auto-ok
tamper: clean (acd2d51 vs c49752e)
ci: 2/2 pass (js-test, lint-and-test) on f42c0f1
unresolved_threads: 0
local_gates: make check passed
risk_paths: none touched
```