### PR TITLE
Fix delegate_tasks progress events, and let pyright see ctx calls at all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ AI agent testbed: chat bot (Mattermost), web UI, terminal REPL. Multi-provider L
 
 See [docs/tools.md](docs/tools.md), [docs/tool-priority.md](docs/tool-priority.md), [docs/tool-search.md](docs/tool-search.md), [docs/preemptive-tool-search.md](docs/preemptive-tool-search.md).
 
-- **Tools receive `ctx` as first param.** Always, even if unused.
+- **Tools receive `ctx` as first param.** Always, even if unused. **Annotate it** — `ctx: "Context"`, with the import under `if TYPE_CHECKING:`. An unannotated `ctx` is implicit `Any`, so pyright cannot check a single `ctx.*` call: that is how #721 shipped a `ctx.publish("tool_status", {...})` positional-dict call that raised `TypeError` on every invocation while `make check` stayed green for two months. Two constraints make the exact form load-bearing:
+  - **The import must be `TYPE_CHECKING`-guarded.** `decafclaw.context` → `context_composer` → skill modules is a real cycle; a runtime `from decafclaw.context import Context` in a tool or skill module raises `cannot import name 'Context' from partially initialized module`.
+  - **Quote the annotation; do NOT add `from __future__ import annotations`** to a skill's `tools.py`. The skill loader `exec`s modules without registering them in `sys.modules`, and CPython's `dataclasses._is_type` resolves *string* annotations via `sys.modules.get(cls.__module__).__dict__` — so the future import turns any `@dataclass` in that file into `AttributeError: 'NoneType' object has no attribute '__dict__'` at load time, which surfaces as a skill silently missing from the tool catalog.
 - **`execute_tool` auto-detects sync vs async.** Sync tools run via `asyncio.to_thread`.
 - **Tool calls run concurrently** via `asyncio.gather` with a semaphore (`max_concurrent_tools`, default 5). Each call gets a forked ctx with its own `current_tool_call_id`.
 - **Errors return `ToolResult(text="[error: ...]")`**, not bare strings. `ToolResult.data` for structured results — auto-rendered as a fenced JSON block.

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -19,6 +19,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from decafclaw.context import Context
+
+if TYPE_CHECKING:
     from .context_composer import ComposedContext
     from .reflection import ReflectionResult
 
@@ -63,12 +66,12 @@ log = logging.getLogger(__name__)
 # Track background tasks to prevent GC and surface exceptions
 
 
-def _conv_id(ctx) -> str:
+def _conv_id(ctx: "Context") -> str:
     """Get conversation ID from context."""
     return ctx.conv_id or ctx.channel_id or "unknown"
 
 
-def _archive(ctx, msg) -> None:
+def _archive(ctx: "Context", msg) -> None:
     """Archive a message, logging errors but never raising."""
     if ctx.skip_archive:
         return
@@ -95,7 +98,7 @@ def _archive(ctx, msg) -> None:
 
 
 
-async def _maybe_compact(ctx, config, history, prompt_tokens) -> None:
+async def _maybe_compact(ctx: "Context", config, history, prompt_tokens) -> None:
     """Run the lightweight tool-result clear pass, then trigger
     full compaction if the token budget is exceeded.
 
@@ -175,7 +178,7 @@ def _extract_call_signatures(tool_calls, messages) -> list[CallSignature]:
 # -- Agent turn helpers --------------------------------------------------------
 
 
-def _check_cancelled(ctx, history):
+def _check_cancelled(ctx: "Context", history):
     """Check if the agent turn has been cancelled. Returns ToolResult or None.
 
     Appends an in-memory marker to history so the iteration loop's
@@ -196,7 +199,7 @@ def _check_cancelled(ctx, history):
     return None
 
 
-def _note_cancel_observed(ctx) -> None:
+def _note_cancel_observed(ctx: "Context") -> None:
     """Tell the manager the agent observed the cancel signal cleanly,
     so the normal-completion path persists the marker. No-op when no
     manager is attached (e.g. unit tests calling the helper directly).
@@ -226,7 +229,7 @@ class ReflectionOutcome:
     should_retry: bool
 
 
-def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
+def _should_reflect(ctx: "Context", config, content: str, reflection_retries: int) -> bool:
     """Check whether reflection should run on this response."""
     if not config.reflection.enabled:
         return False
@@ -241,7 +244,7 @@ def _should_reflect(ctx, config, content: str, reflection_retries: int) -> bool:
     return True
 
 
-async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
+async def _handle_widget_input_pause(ctx: "Context", signal: WidgetInputPause
                                      ) -> str | None:
     """Pause the agent turn on an input widget and resume with the
     user's answer formatted as a synthetic user-message string.
@@ -341,7 +344,7 @@ async def _handle_widget_input_pause(ctx, signal: WidgetInputPause
     return default_inject_message(response.data)
 
 
-async def _handle_end_turn_confirm(ctx, action: EndTurnConfirm) -> bool:
+async def _handle_end_turn_confirm(ctx: "Context", action: EndTurnConfirm) -> bool:
     """Handle an EndTurnConfirm action via the event bus.
 
     Publishes a confirmation request and waits for the user to click
@@ -362,7 +365,7 @@ async def _handle_end_turn_confirm(ctx, action: EndTurnConfirm) -> bool:
     return result.get("approved", False)
 
 
-async def _call_llm_with_events(ctx, config, messages, tools,
+async def _call_llm_with_events(ctx: "Context", config, messages, tools,
                                 model_name=None,
                                 llm_url=None, llm_model=None,
                                 llm_api_key=None) -> dict:
@@ -421,7 +424,7 @@ async def _call_llm_with_events(ctx, config, messages, tools,
 # -- Turn setup helpers ---------------------------------------------------------
 
 
-async def _setup_turn_state(ctx, config, history) -> dict[str, str]:
+async def _setup_turn_state(ctx: "Context", config, history) -> dict[str, str]:
     """Restore persisted skill/model state and resolve model overrides.
 
     Handles:
@@ -1302,7 +1305,7 @@ class TurnRunner:
                 log.debug("skill state persistence failed for %s: %s", conv_id, exc)
 
 
-async def run_agent_turn(ctx, user_message: str, history: list,
+async def run_agent_turn(ctx: "Context", user_message: str, history: list,
                          archive_text: str = "",
                          attachments: list[dict] | None = None) -> "ToolResult":
     """Process a single user message through the agent loop.

--- a/src/decafclaw/commands.py
+++ b/src/decafclaw/commands.py
@@ -3,8 +3,12 @@
 import logging
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from .skills import SkillInfo, find_command, list_commands
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -190,7 +194,7 @@ class CommandResult:
     skill: SkillInfo | None = None
 
 
-async def _execute_mcp_prompt_command(ctx, server_name: str, prompt_name: str,
+async def _execute_mcp_prompt_command(ctx: "Context", server_name: str, prompt_name: str,
                                        arguments: str, prefix: str = "!") -> CommandResult:
     """Execute an MCP prompt as a user-invokable command."""
     import asyncio
@@ -276,7 +280,7 @@ async def _execute_mcp_prompt_command(ctx, server_name: str, prompt_name: str,
                          display_text=f"{prefix}{cmd_display} {arguments}".strip())
 
 
-async def dispatch_command(ctx, text: str, prefixes: list[str] | None = None,
+async def dispatch_command(ctx: "Context", text: str, prefixes: list[str] | None = None,
                            ) -> CommandResult:
     """Detect, validate, and execute a command from user text.
 
@@ -355,7 +359,7 @@ async def dispatch_command(ctx, text: str, prefixes: list[str] | None = None,
                          display_text=display, skill=skill)
 
 
-async def execute_command(ctx, skill: SkillInfo, arguments: str) -> tuple[str, str]:
+async def execute_command(ctx: "Context", skill: SkillInfo, arguments: str) -> tuple[str, str]:
     """Execute a user-invoked command.
 
     Sets up the context (preapproved tools, required skills) and either

--- a/src/decafclaw/compaction.py
+++ b/src/decafclaw/compaction.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .archive import read_archive, read_compacted_history, write_compacted_history
 from .compaction_decisions import (
@@ -16,6 +17,9 @@ from .compaction_decisions import (
 from .llm import call_llm
 from .prompts import wrap_xml
 from .util import estimate_tokens
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +39,7 @@ def _build_sweep_user_input(flattened: str) -> str:
     return wrap_xml("messages_to_compact", flattened)
 
 
-async def _run_memory_sweep(ctx, old_messages: list[dict]) -> None:
+async def _run_memory_sweep(ctx: "Context", old_messages: list[dict]) -> None:
     """Run a background memory sweep over messages about to be compacted.
 
     Fires off an isolated child agent turn with vault tools to save
@@ -272,7 +276,7 @@ def flatten_messages(messages: list[dict]) -> str:
     return "\n".join(lines)
 
 
-async def _single_summarize(ctx, config, flattened_text: str, prompt: str) -> str:
+async def _single_summarize(ctx: "Context", config, flattened_text: str, prompt: str) -> str:
     """Summarize a single block of flattened text."""
     summary_messages = [
         {"role": "system", "content": prompt},
@@ -293,7 +297,7 @@ async def _single_summarize(ctx, config, flattened_text: str, prompt: str) -> st
     return response.get("content", "")
 
 
-async def _chunked_summarize(ctx, config, turns: list[list[dict]],
+async def _chunked_summarize(ctx: "Context", config, turns: list[list[dict]],
                               prompt: str, budget: int) -> str:
     """Summarize turns in chunks that fit the compaction LLM's context window."""
     chunks = []
@@ -510,7 +514,7 @@ def _rebuild_history(
     )
 
 
-async def compact_history(ctx, history: list) -> bool:
+async def compact_history(ctx: "Context", history: list) -> bool:
     """Compact conversation history using the archive as source.
 
     If a previous compaction exists, performs incremental compaction:

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -14,6 +14,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from decafclaw.skills.background.tools import format_status_text
 from decafclaw.skills.vault.tools import (
@@ -47,6 +48,9 @@ from .tools.tool_registry import (
     get_fetched_tools,
 )
 from .util import estimate_tokens
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -304,7 +308,7 @@ class ContextComposer:
 
     async def compose(
         self,
-        ctx,
+        ctx: "Context",
         user_message: str,
         history: list,
         *,

--- a/src/decafclaw/eval/runner.py
+++ b/src/decafclaw/eval/runner.py
@@ -97,7 +97,7 @@ class _EvalConversationManager(ConversationManager):
         self.subscribe(conv_id, _resolver)
 
 
-async def _setup_skills(ctx, test_case: dict):
+async def _setup_skills(ctx: "Context", test_case: dict):
     """Pre-activate skills specified in setup.skills."""
     setup = _setup_of(test_case)
     skill_names = setup.get("skills", [])

--- a/src/decafclaw/interactive_terminal.py
+++ b/src/decafclaw/interactive_terminal.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from .config import resolve_streaming
 from .tools import TOOL_DEFINITIONS
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +41,7 @@ def _print_banner(config) -> None:
 # -- Interactive mode ----------------------------------------------------------
 
 
-async def run_interactive(ctx):
+async def run_interactive(ctx: "Context"):
     """Run the agent in interactive terminal mode (stdin/stdout)."""
     from .conversation_manager import ConversationManager
     from .heartbeat import run_heartbeat_timer

--- a/src/decafclaw/mattermost.py
+++ b/src/decafclaw/mattermost.py
@@ -413,7 +413,7 @@ class MattermostClient:
                                 app_ctx, manager)
 
         # Transport-specific context setup
-        def context_setup(ctx):
+        def context_setup(ctx: "Context"):
             from .media import MattermostMediaHandler
             ctx.media_handler = MattermostMediaHandler(self._http, channel_id=channel_id)
             ctx.channel_id = channel_id

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -10,6 +10,7 @@ import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from croniter import croniter
@@ -21,6 +22,9 @@ from .skills import (
     _resolve_extra_skill_paths,
     _split_frontmatter,
 )
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -611,7 +615,7 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
     task_model = task.model
     email_recipients = task.email_recipients or None
 
-    async def setup_schedule_ctx(ctx) -> None:
+    async def setup_schedule_ctx(ctx: "Context") -> None:
         """Apply per-task settings (model, tools, skills) to the context."""
         if task_model:
             ctx.active_model = task_model

--- a/src/decafclaw/skills/__init__.py
+++ b/src/decafclaw/skills/__init__.py
@@ -6,8 +6,12 @@ import re
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -586,7 +590,7 @@ def build_catalog_text(skills: list[SkillInfo]) -> str:
     return "\n".join(lines)
 
 
-async def activate_always_loaded(ctx) -> None:
+async def activate_always_loaded(ctx: "Context") -> None:
     """Activate every always-loaded discovered skill against `ctx`.
 
     Fail-soft per skill — a failed activation logs but does not block

--- a/src/decafclaw/skills/background/tools.py
+++ b/src/decafclaw/skills/background/tools.py
@@ -6,10 +6,13 @@ import time
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from decafclaw.media import ToolResult
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -439,7 +442,7 @@ class BackgroundJobManager:
 _managers: dict[str, BackgroundJobManager] = {}
 
 
-def _get_job_manager(ctx) -> BackgroundJobManager:
+def _get_job_manager(ctx: "Context") -> BackgroundJobManager:
     """Get or create the per-conversation BackgroundJobManager."""
     conv_id = ctx.conv_id or ctx.context_id
     if conv_id not in _managers:
@@ -454,7 +457,7 @@ def _get_job_manager(ctx) -> BackgroundJobManager:
 
 # -- Tool functions -----------------------------------------------------------
 
-async def tool_shell_background_start(ctx, command: str,
+async def tool_shell_background_start(ctx: "Context", command: str,
                                       completion_tail_lines: int | None = None) -> ToolResult:
     """Start a background process. Returns immediately with a job ID."""
     log.info(f"[tool:shell_background_start] command={command[:80]}")
@@ -507,7 +510,7 @@ async def tool_shell_background_start(ctx, command: str,
     )
 
 
-async def tool_shell_background_status(ctx, job_id: str) -> ToolResult:
+async def tool_shell_background_status(ctx: "Context", job_id: str) -> ToolResult:
     """Check the status of a background job and get recent output."""
     log.info(f"[tool:shell_background_status] job_id={job_id}")
 
@@ -558,7 +561,7 @@ async def tool_shell_background_status(ctx, job_id: str) -> ToolResult:
     )
 
 
-async def tool_shell_background_stop(ctx, job_id: str) -> ToolResult:
+async def tool_shell_background_stop(ctx: "Context", job_id: str) -> ToolResult:
     """Terminate a background job."""
     log.info(f"[tool:shell_background_stop] job_id={job_id}")
 
@@ -589,7 +592,7 @@ async def tool_shell_background_stop(ctx, job_id: str) -> ToolResult:
     )
 
 
-async def tool_shell_background_list(ctx) -> ToolResult:
+async def tool_shell_background_list(ctx: "Context") -> ToolResult:
     """List all background jobs for the current conversation."""
     log.info("[tool:shell_background_list]")
 

--- a/src/decafclaw/skills/claude_code/permissions.py
+++ b/src/decafclaw/skills/claude_code/permissions.py
@@ -4,8 +4,12 @@ import fnmatch
 import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from claude_code_sdk import PermissionResultAllow, PermissionResultDeny
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +58,7 @@ def matches_allowlist(tool_name: str, patterns: list[str]) -> bool:
     return False
 
 
-def make_permission_handler(ctx, config):
+def make_permission_handler(ctx: "Context", config):
     """Create a can_use_tool callback that bridges to DecafClaw's confirmation flow.
 
     Returns an async function compatible with ClaudeCodeOptions.can_use_tool.

--- a/src/decafclaw/skills/claude_code/tools.py
+++ b/src/decafclaw/skills/claude_code/tools.py
@@ -6,6 +6,7 @@ import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from claude_code_sdk import (
     AssistantMessage,
@@ -21,6 +22,9 @@ from claude_code_sdk import (
 from decafclaw.media import ToolResult
 from decafclaw.skills.claude_code.output import SessionLogger
 from decafclaw.skills.claude_code.sessions import SessionManager
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -242,7 +246,7 @@ async def _capture_git_diff(cwd: str, baseline_ref: str | None) -> str | None:
         return None
 
 
-async def tool_claude_code_start(ctx, cwd: str, description: str = "",
+async def tool_claude_code_start(ctx: "Context", cwd: str, description: str = "",
                                   model: str = "", budget_usd: float = 0,
                                   setup_command: str = "",
                                   instructions: str = "") -> ToolResult:
@@ -468,7 +472,7 @@ def _summarize_tool_result(tool_name: str, content: "str | list | None",
     return f"{tool_name} — {first_line}" if first_line else f"{tool_name} — done"
 
 
-async def tool_claude_code_send(ctx, session_id: str, prompt: str,
+async def tool_claude_code_send(ctx: "Context", session_id: str, prompt: str,
                                 context: str = "",
                                 include_diff: bool = True) -> ToolResult:
     """Send a prompt to an active Claude Code session."""
@@ -665,7 +669,7 @@ async def tool_claude_code_send(ctx, session_id: str, prompt: str,
     return ToolResult(text=summary, data=data, display_short_text=short_text)
 
 
-async def tool_claude_code_exec(ctx, session_id: str, command: str,
+async def tool_claude_code_exec(ctx: "Context", session_id: str, command: str,
                                 timeout: int = 30) -> ToolResult:
     """Run a shell command in a session's cwd without an LLM turn."""
     log.info(f"[tool:claude_code_exec] session={session_id} command={command[:80]}")
@@ -779,7 +783,7 @@ async def tool_claude_code_exec(ctx, session_id: str, command: str,
     return ToolResult(text="\n".join(parts), data=data)
 
 
-async def tool_claude_code_push_file(ctx, session_id: str, source_path: str,
+async def tool_claude_code_push_file(ctx: "Context", session_id: str, source_path: str,
                                      dest_name: str = "") -> ToolResult:
     """Copy a file from the parent's workspace into the session's cwd."""
     log.info(f"[tool:claude_code_push_file] session={session_id} source={source_path}")
@@ -840,7 +844,7 @@ async def tool_claude_code_push_file(ctx, session_id: str, source_path: str,
     )
 
 
-async def tool_claude_code_pull_file(ctx, session_id: str, source_name: str,
+async def tool_claude_code_pull_file(ctx: "Context", session_id: str, source_name: str,
                                      dest_path: str = "") -> ToolResult:
     """Copy a file from the session's cwd to the parent's workspace."""
     log.info(f"[tool:claude_code_pull_file] session={session_id} source={source_name}")
@@ -901,7 +905,7 @@ async def tool_claude_code_pull_file(ctx, session_id: str, source_name: str,
     )
 
 
-async def tool_claude_code_stop(ctx, session_id: str) -> str | ToolResult:
+async def tool_claude_code_stop(ctx: "Context", session_id: str) -> str | ToolResult:
     """Stop a Claude Code session and clean up."""
     log.info(f"[tool:claude_code_stop] session={session_id}")
     manager = _get_manager()
@@ -921,7 +925,7 @@ async def tool_claude_code_stop(ctx, session_id: str) -> str | ToolResult:
     )
 
 
-async def tool_claude_code_sessions(ctx) -> str:
+async def tool_claude_code_sessions(ctx: "Context") -> str:
     """List active Claude Code sessions."""
     log.info("[tool:claude_code_sessions]")
     manager = _get_manager()

--- a/src/decafclaw/skills/garden/tools.py
+++ b/src/decafclaw/skills/garden/tools.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from decafclaw import backlinks, retrieval_telemetry
 from decafclaw.frontmatter import get_frontmatter_field, parse_frontmatter
 from decafclaw.media import ToolResult
 from decafclaw.skills.vault.tools import tool_vault_update_frontmatter
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -119,7 +122,7 @@ def compute_importance_scores(config) -> dict[str, float]:
     }
 
 
-async def tool_vault_recompute_importance(ctx, dry_run: bool = False) -> ToolResult:
+async def tool_vault_recompute_importance(ctx: "Context", dry_run: bool = False) -> ToolResult:
     """Recompute every agent page's importance score deterministically.
 
     Scores come from `compute_importance_scores` (retrieval frequency +

--- a/src/decafclaw/skills/mcp/tools.py
+++ b/src/decafclaw/skills/mcp/tools.py
@@ -1,13 +1,17 @@
 """MCP management tools — status, resources, prompts, restart."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from decafclaw.media import ToolResult
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
 
-async def tool_mcp_status(ctx, action: str = "status", server: str = "") -> str | ToolResult:
+async def tool_mcp_status(ctx: "Context", action: str = "status", server: str = "") -> str | ToolResult:
     """Show MCP server status or restart servers."""
     from decafclaw.mcp_client import get_registry
 
@@ -43,7 +47,7 @@ async def tool_mcp_status(ctx, action: str = "status", server: str = "") -> str 
     return "\n".join(lines)
 
 
-async def _restart(ctx, registry, server_name) -> str | ToolResult:
+async def _restart(ctx: "Context", registry, server_name) -> str | ToolResult:
     """Restart MCP servers by scheduling a restart and reporting status.
 
     Due to anyio/asyncio cancel scope incompatibilities, MCP servers
@@ -90,7 +94,7 @@ async def _restart(ctx, registry, server_name) -> str | ToolResult:
         return ToolResult(text=f"[error: MCP restart failed: {e}]")
 
 
-async def tool_mcp_list_resources(ctx) -> str | ToolResult:
+async def tool_mcp_list_resources(ctx: "Context") -> str | ToolResult:
     """List all MCP resources and resource templates."""
     from decafclaw.mcp_client import get_registry
 
@@ -137,7 +141,7 @@ async def tool_mcp_list_resources(ctx) -> str | ToolResult:
     return "\n".join(lines)
 
 
-async def tool_mcp_read_resource(ctx, server: str = "", uri: str = "") -> str | ToolResult:
+async def tool_mcp_read_resource(ctx: "Context", server: str = "", uri: str = "") -> str | ToolResult:
     """Read a resource from an MCP server by URI."""
     import asyncio
 
@@ -170,7 +174,7 @@ async def tool_mcp_read_resource(ctx, server: str = "", uri: str = "") -> str | 
         return ToolResult(text=f"[error: failed to read resource: {e}]")
 
 
-async def tool_mcp_list_prompts(ctx) -> str | ToolResult:
+async def tool_mcp_list_prompts(ctx: "Context") -> str | ToolResult:
     """List all MCP prompts from connected servers."""
     from decafclaw.mcp_client import get_registry
 
@@ -206,7 +210,7 @@ async def tool_mcp_list_prompts(ctx) -> str | ToolResult:
     return "\n".join(lines)
 
 
-async def tool_mcp_get_prompt(ctx, server: str = "", name: str = "",
+async def tool_mcp_get_prompt(ctx: "Context", server: str = "", name: str = "",
                                arguments: str = "{}") -> str | ToolResult:
     """Get a prompt from an MCP server and return its messages."""
     import asyncio

--- a/src/decafclaw/skills/newsletter/tools.py
+++ b/src/decafclaw/skills/newsletter/tools.py
@@ -6,11 +6,15 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from decafclaw.conversation_paths import iter_conversation_archives
 from decafclaw.mail import send_mail
 from decafclaw.media import ToolResult
 from decafclaw.skills.vault.tools import collect_recent_pages
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -163,7 +167,7 @@ def _extract_activity(path: Path) -> tuple[str, list[str]]:
     return final_text, touched
 
 
-def _collect_scheduled_activity(ctx, hours: int = 24) -> list[dict]:
+def _collect_scheduled_activity(ctx: "Context", hours: int = 24) -> list[dict]:
     """Gather scheduled-task activity records. Returns the raw list
     used by newsletter_list_scheduled_activity."""
     cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
@@ -220,7 +224,7 @@ async def newsletter_list_scheduled_activity(
     )
 
 
-def _collect_vault_changes(ctx, hours: int = 24) -> list[dict]:
+def _collect_vault_changes(ctx: "Context", hours: int = 24) -> list[dict]:
     """Gather vault markdown files modified in the last `hours` (mtime-based).
 
     Returns a list of {path (str, relative to vault root), mtime (ISO-8601), size (int)}.
@@ -273,7 +277,7 @@ async def newsletter_list_vault_changes(
 
 
 async def newsletter_publish(
-    ctx,
+    ctx: "Context",
     markdown: str,
     subject_hint: str | None = None,
     has_content: bool = True,

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from decafclaw import sticky as sticky_mod
 from decafclaw.media import EndTurnConfirm, ToolResult
@@ -35,6 +36,9 @@ from decafclaw.skills.project.state import (
     validate_transition,
 )
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -53,17 +57,17 @@ def _load_prompt(name: str, **kwargs) -> str:
     return text
 
 
-def _get_current_project(ctx) -> str | None:
+def _get_current_project(ctx: "Context") -> str | None:
     return (ctx.skills.data or {}).get("current_project")
 
 
-def _set_current_project(ctx, slug: str) -> None:
+def _set_current_project(ctx: "Context", slug: str) -> None:
     if ctx.skills.data is None:
         ctx.skills.data = {}
     ctx.skills.data["current_project"] = slug
 
 
-def _resolve_project(ctx, project: str = "") -> str:
+def _resolve_project(ctx: "Context", project: str = "") -> str:
     if project:
         return project
     current = _get_current_project(ctx)
@@ -82,7 +86,7 @@ def _load_or_error(config, project: str) -> ProjectInfo | ToolResult:
     return info
 
 
-def _load_current(ctx) -> ProjectInfo | ToolResult:
+def _load_current(ctx: "Context") -> ProjectInfo | ToolResult:
     """Load the current project or return an error."""
     try:
         project = _resolve_project(ctx)
@@ -91,7 +95,7 @@ def _load_current(ctx) -> ProjectInfo | ToolResult:
     return _load_or_error(ctx.config, project)
 
 
-def _emit_for_ctx(ctx):
+def _emit_for_ctx(ctx: "Context"):
     manager = getattr(ctx, "manager", None)
     if manager is None:
         return None
@@ -124,7 +128,7 @@ def _progress_data_from_plan(info: ProjectInfo, steps: list[Step]) -> dict:
     return {"steps": widget_steps, "title": info.description, "summary": summary}
 
 
-async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
+async def _emit_project_progress(ctx: "Context", info: ProjectInfo) -> None:
     """Mirror an EXECUTING project's plan into the sticky slot. Fail-open."""
     if info.status != ProjectState.EXECUTING:
         return
@@ -148,7 +152,7 @@ async def _emit_project_progress(ctx, info: ProjectInfo) -> None:
         log.warning("project sticky emit failed", exc_info=True)
 
 
-async def _clear_project_progress(ctx) -> None:
+async def _clear_project_progress(ctx: "Context") -> None:
     """Clear the sticky slot for a project. Fail-open."""
     try:
         result = await sticky_mod.clear_sticky(
@@ -163,7 +167,7 @@ async def _clear_project_progress(ctx) -> None:
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-async def tool_project_create(ctx, description: str, slug: str = "") -> str | ToolResult:
+async def tool_project_create(ctx: "Context", description: str, slug: str = "") -> str | ToolResult:
     """Create a new structured project."""
     info = create_project(ctx.config, description, slug=slug)
     _set_current_project(ctx, info.slug)
@@ -175,7 +179,7 @@ async def tool_project_create(ctx, description: str, slug: str = "") -> str | To
     )
 
 
-async def tool_project_next_task(ctx) -> str | ToolResult:
+async def tool_project_next_task(ctx: "Context") -> str | ToolResult:
     """Get the current instruction for the project phase.
 
     Returns what to do right now. Does NOT advance phases — call
@@ -234,7 +238,7 @@ async def tool_project_next_task(ctx) -> str | ToolResult:
     return ToolResult(text=f"[error: unexpected state '{info.status.value}']")
 
 
-async def tool_project_task_done(ctx) -> str | ToolResult:
+async def tool_project_task_done(ctx: "Context") -> str | ToolResult:
     """Signal that the current phase's work is complete and advance.
 
     Call this after you've done the work for the current phase:
@@ -370,7 +374,7 @@ def _next_execution_step(info: ProjectInfo) -> str:
         )
 
 
-async def tool_project_status(ctx) -> str | ToolResult:
+async def tool_project_status(ctx: "Context") -> str | ToolResult:
     """Check the current state of a project."""
     result = _load_current(ctx)
     if isinstance(result, ToolResult):
@@ -398,7 +402,7 @@ async def tool_project_status(ctx) -> str | ToolResult:
     return "\n".join(lines)
 
 
-async def tool_project_list(ctx) -> str | ToolResult:
+async def tool_project_list(ctx: "Context") -> str | ToolResult:
     """List all projects with their status."""
     projects = list_projects(ctx.config)
     if not projects:
@@ -410,7 +414,7 @@ async def tool_project_list(ctx) -> str | ToolResult:
     return "\n".join(lines)
 
 
-async def tool_project_switch(ctx, project: str) -> str | ToolResult:
+async def tool_project_switch(ctx: "Context", project: str) -> str | ToolResult:
     """Switch the current project context."""
     result = _load_or_error(ctx.config, project)
     if isinstance(result, ToolResult):
@@ -420,7 +424,7 @@ async def tool_project_switch(ctx, project: str) -> str | ToolResult:
     return f"Switched to project '{info.slug}' ({info.status.value}). Call project_next_task."
 
 
-async def tool_project_update_spec(ctx, spec_text: str) -> str | ToolResult:
+async def tool_project_update_spec(ctx: "Context", spec_text: str) -> str | ToolResult:
     """Write or update the project spec."""
 
     result = _load_current(ctx)
@@ -463,7 +467,7 @@ async def tool_project_update_spec(ctx, spec_text: str) -> str | ToolResult:
     )
 
 
-async def tool_project_update_plan(ctx, plan_text: str) -> str | ToolResult:
+async def tool_project_update_plan(ctx: "Context", plan_text: str) -> str | ToolResult:
     """Write or update the project plan."""
 
     result = _load_current(ctx)
@@ -579,7 +583,7 @@ async def tool_project_add_steps(
     return f"Added {len(steps)} step(s) after step {after_step}. Plan now has {total} steps."
 
 
-async def tool_project_advance(ctx, target_status: str = "") -> str | ToolResult:
+async def tool_project_advance(ctx: "Context", target_status: str = "") -> str | ToolResult:
     """Go back to an earlier phase (e.g. replanning). Use project_task_done to go forward."""
 
     result = _load_current(ctx)
@@ -616,7 +620,7 @@ async def tool_project_advance(ctx, target_status: str = "") -> str | ToolResult
     return f"Project reverted to {target.value}. Call project_next_task."
 
 
-async def tool_project_note(ctx, note_text: str) -> str | ToolResult:
+async def tool_project_note(ctx: "Context", note_text: str) -> str | ToolResult:
     """Append a timestamped note to the project."""
 
     result = _load_current(ctx)
@@ -842,7 +846,7 @@ def _tools_for_phase(phase: ProjectState | None) -> tuple[dict, list]:
     return tools, defs
 
 
-def get_tools(ctx) -> tuple[dict, list]:
+def get_tools(ctx: "Context") -> tuple[dict, list]:
     """Dynamic tool provider — returns phase-appropriate tools each turn."""
     slug = _get_current_project(ctx)
     if not slug:

--- a/src/decafclaw/skills/tabstack/tools.py
+++ b/src/decafclaw/skills/tabstack/tools.py
@@ -8,11 +8,15 @@ discriminated union of events (`event` discriminator + typed `.data` payload), a
 import json
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from tabstack import APIStatusError, AsyncTabstack
 
 from decafclaw.media import ToolResult
 from decafclaw.tools.confirmation import request_confirmation
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +52,7 @@ def _get_client() -> AsyncTabstack:
 
 # -- Read / extract tools ---------------------------------------------------
 
-async def tool_tabstack_extract_markdown(ctx, url: str) -> ToolResult:
+async def tool_tabstack_extract_markdown(ctx: "Context", url: str) -> ToolResult:
     """Extract clean Markdown from a web page or PDF."""
     log.info(f"[tool:tabstack_extract_markdown] {url}")
     try:
@@ -61,7 +65,7 @@ async def tool_tabstack_extract_markdown(ctx, url: str) -> ToolResult:
         return ToolResult(text=f"[error: {e}]")
 
 
-async def tool_tabstack_extract_json(ctx, url: str, json_schema: dict) -> ToolResult:
+async def tool_tabstack_extract_json(ctx: "Context", url: str, json_schema: dict) -> ToolResult:
     """Extract structured JSON data from a web page or PDF."""
     log.info(f"[tool:tabstack_extract_json] {url}")
     try:
@@ -75,7 +79,7 @@ async def tool_tabstack_extract_json(ctx, url: str, json_schema: dict) -> ToolRe
         return ToolResult(text=f"[error: {e}]")
 
 
-async def tool_tabstack_generate(ctx, url: str, json_schema: dict, instructions: str) -> str:
+async def tool_tabstack_generate(ctx: "Context", url: str, json_schema: dict, instructions: str) -> str:
     """Transform web/PDF content into structured JSON using LLM instructions."""
     log.info(f"[tool:tabstack_generate] {url}")
     try:
@@ -100,7 +104,7 @@ _AUTOMATE_FORM_EVENTS = frozenset(
 
 
 async def tool_tabstack_automate(
-    ctx,
+    ctx: "Context",
     task: str,
     url: str | None = None,
     data: dict | None = None,
@@ -264,7 +268,7 @@ def _compose_automate_result(
     return "\n\n".join(parts)
 
 
-async def _handle_form_request(ctx, client, event, data: dict) -> str | None:
+async def _handle_form_request(ctx: "Context", client, event, data: dict) -> str | None:
     """Answer (or cancel) an interactive form-data request.
 
     Returns a human-readable note to fold into the tool result, or None.
@@ -375,7 +379,7 @@ async def _safe_input(client, request_id, *, fields=None, cancelled=False) -> No
 
 # -- Research ---------------------------------------------------------------
 
-async def tool_tabstack_research(ctx, query: str, mode: str = "balanced") -> ToolResult:
+async def tool_tabstack_research(ctx: "Context", query: str, mode: str = "balanced") -> ToolResult:
     """Search the web, analyze multiple sources, and synthesize an answer."""
     log.info(f"[tool:tabstack_research] query={query} mode={mode}")
     try:

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from decafclaw.media import ToolResult, WidgetRequest
 from decafclaw.skills.vault._events import (
@@ -34,6 +35,9 @@ from decafclaw.skills.vault._sections import (
 )
 from decafclaw.tags import collect_all_tags, extract_tags, normalize_tag, pages_with_tags
 from decafclaw.tools.confirmation import request_confirmation
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -173,7 +177,7 @@ def _is_in_user_writable_paths(config, path: Path) -> bool:
     return False
 
 
-def _check_user_write_allowed(ctx, path: Path) -> GateOutcome:
+def _check_user_write_allowed(ctx: "Context", path: Path) -> GateOutcome:
     """Decide how to handle a vault write/delete/rename for the given path.
 
     Returns:
@@ -193,7 +197,7 @@ def _check_user_write_allowed(ctx, path: Path) -> GateOutcome:
 
 
 async def _run_gate_or_confirm(
-    ctx,
+    ctx: "Context",
     outcomes: list[GateOutcome],
     *,
     tool_name: str,
@@ -305,7 +309,7 @@ def _source_type_for_path(config, path: Path) -> str:
 # Tools
 # ---------------------------------------------------------------------------
 
-async def tool_vault_read(ctx, page: str) -> str | ToolResult:
+async def tool_vault_read(ctx: "Context", page: str) -> str | ToolResult:
     """Read a vault page by name or path."""
     log.info(f"[tool:vault_read] page={page}")
     path = resolve_page(ctx.config, page)
@@ -330,7 +334,7 @@ async def tool_vault_read(ctx, page: str) -> str | ToolResult:
     )
 
 
-async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
+async def tool_vault_write(ctx: "Context", page: str, content: str) -> str | ToolResult:
     """Create or overwrite a vault page."""
     log.info(f"[tool:vault_write] page={page}")
     path = _safe_write_path(ctx.config, page)
@@ -390,7 +394,7 @@ async def tool_vault_write(ctx, page: str, content: str) -> str | ToolResult:
     )
 
 
-async def tool_vault_delete(ctx, page: str) -> ToolResult:
+async def tool_vault_delete(ctx: "Context", page: str) -> ToolResult:
     """Delete a vault page. Agent pages allow direct delete; user pages
     require confirmation per call (or grant/allowlist short-circuit)."""
     log.info(f"[tool:vault_delete] page={page}")
@@ -445,7 +449,7 @@ async def tool_vault_delete(ctx, page: str) -> ToolResult:
     return ToolResult(text=f"Vault page '{page}' deleted.")
 
 
-async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
+async def tool_vault_rename(ctx: "Context", page: str, rename_to: str) -> ToolResult:
     """Rename or move a vault page. Agent pages allow direct rename; user pages
     require confirmation per call (or grant/allowlist short-circuit). A single
     confirmation covers both source and target paths."""
@@ -520,7 +524,7 @@ async def tool_vault_rename(ctx, page: str, rename_to: str) -> ToolResult:
     return ToolResult(text=f"Vault page '{page}' renamed to '{rename_to}'.")
 
 
-async def tool_vault_grant_folder(ctx, folder: str, reason: str) -> ToolResult:
+async def tool_vault_grant_folder(ctx: "Context", folder: str, reason: str) -> ToolResult:
     """Request per-conversation trust for a vault folder.
 
     The folder is normalized via `normalize_folder` (leading `/` stripped,
@@ -600,7 +604,7 @@ async def tool_vault_grant_folder(ctx, folder: str, reason: str) -> ToolResult:
     return ToolResult(text=f"Folder '{rel}' trusted for this conversation.")
 
 
-async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolResult:
+async def tool_vault_journal_append(ctx: "Context", tags: list[str], content: str) -> ToolResult:
     """Append a timestamped entry to today's journal file."""
     log.info(f"[tool:vault_journal_append] tags={tags}")
     now = datetime.now()
@@ -671,7 +675,7 @@ async def tool_vault_journal_append(ctx, tags: list[str], content: str) -> ToolR
     )
 
 
-async def tool_vault_search(ctx, query: str = "", source_type: str = "",
+async def tool_vault_search(ctx: "Context", query: str = "", source_type: str = "",
                             days: int = 0, folder: str = "",
                             tags: list[str] | None = None,
                             any_tag: bool = False) -> str | ToolResult:
@@ -998,7 +1002,7 @@ def _substring_results_widget(query: str,
     )
 
 
-async def tool_vault_list(ctx, folder: str = "", pattern: str = "") -> str | ToolResult:
+async def tool_vault_list(ctx: "Context", folder: str = "", pattern: str = "") -> str | ToolResult:
     """List vault pages, optionally filtered by folder and pattern."""
     log.info(f"[tool:vault_list] folder={folder} pattern={pattern}")
     if folder:
@@ -1145,7 +1149,7 @@ def format_recent_journal_for_context(
     return f"{header}\n\n{body}"
 
 
-async def tool_vault_recent(ctx, days: int = 7, folder: str = "",
+async def tool_vault_recent(ctx: "Context", days: int = 7, folder: str = "",
                             source_type: str = "") -> str | ToolResult:
     """List vault pages modified within the last `days`, newest first."""
     log.info(f"[tool:vault_recent] days={days} folder={folder} "
@@ -1204,7 +1208,7 @@ async def tool_vault_recent(ctx, days: int = 7, folder: str = "",
     )
 
 
-async def tool_vault_tags(ctx) -> ToolResult:
+async def tool_vault_tags(ctx: "Context") -> ToolResult:
     """List all tags currently in use across the vault, with usage counts."""
     log.info("[tool:vault_tags]")
     tag_map = collect_all_tags(ctx.config)
@@ -1224,7 +1228,7 @@ async def tool_vault_tags(ctx) -> ToolResult:
 _WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
 
-async def tool_vault_backlinks(ctx, page: str) -> str:
+async def tool_vault_backlinks(ctx: "Context", page: str) -> str:
     """Find all vault pages that link to the given page via [[wiki-links]]."""
     log.info(f"[tool:vault_backlinks] page={page}")
     from decafclaw.backlinks import _build_page_lookup, _resolve_link_target, load_index
@@ -1304,7 +1308,7 @@ async def tool_vault_show_sections(
     return ToolResult(text="\n".join(numbered))
 
 
-async def _reindex_page(ctx, path: Path) -> None:
+async def _reindex_page(ctx: "Context", path: Path) -> None:
     """Reindex a single vault page in the embedding index (fail-open)."""
     try:
         from decafclaw.embeddings import delete_entries, index_entry
@@ -1386,7 +1390,7 @@ async def tool_vault_update_frontmatter(
 
 
 async def tool_vault_section(
-    ctx,
+    ctx: "Context",
     page: str,
     action: str,
     section: str | None = None,
@@ -1474,7 +1478,7 @@ async def tool_vault_section(
 
 
 async def tool_vault_move_lines(
-    ctx,
+    ctx: "Context",
     from_page: str,
     to_page: str,
     lines: str,

--- a/src/decafclaw/tool_definitions.py
+++ b/src/decafclaw/tool_definitions.py
@@ -14,6 +14,7 @@ pulling in execution internals.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from .tools import TOOL_DEFINITIONS
 from .tools.search_tools import SEARCH_TOOL_DEFINITIONS
@@ -22,6 +23,9 @@ from .tools.tool_registry import (
     classify_tools,
     get_fetched_tools,
 )
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +39,7 @@ def invalidate_skill_cache(config) -> None:
     _skill_def_cache.pop(id(config), None)
 
 
-def refresh_dynamic_tools(ctx) -> None:
+def refresh_dynamic_tools(ctx: "Context") -> None:
     """Call dynamic tool providers to refresh skill tools for this turn.
 
     Skills that export get_tools(ctx) have their tools and definitions
@@ -82,7 +86,7 @@ def refresh_dynamic_tools(ctx) -> None:
         ctx.tools.extra_definitions.extend(tool_defs)
 
 
-def collect_all_tool_defs(ctx) -> list:
+def collect_all_tool_defs(ctx: "Context") -> list:
     """Gather all available tool definitions (core + skill + MCP + extra).
 
     Does NOT apply allowed_tools filter — returns the full unfiltered set
@@ -166,7 +170,7 @@ def _dedupe_by_name(tool_defs: list) -> list:
     return deduped
 
 
-def build_tool_list(ctx) -> tuple[list, str | None]:
+def build_tool_list(ctx: "Context") -> tuple[list, str | None]:
     """Build the tool list, with optional deferred mode.
 
     Returns (tool_definitions, deferred_text) where deferred_text is

--- a/src/decafclaw/tool_execution.py
+++ b/src/decafclaw/tool_execution.py
@@ -17,10 +17,14 @@ import json
 import logging
 import re as _re
 import time
+from typing import TYPE_CHECKING
 
 from .archive import append_message
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause
 from .tools import execute_tool
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -33,12 +37,12 @@ log = logging.getLogger(__name__)
 # and the helpers should change together if they change at all.
 
 
-def _conv_id(ctx) -> str:
+def _conv_id(ctx: "Context") -> str:
     """Get conversation ID from context."""
     return ctx.conv_id or ctx.channel_id or "unknown"
 
 
-def _archive(ctx, msg) -> None:
+def _archive(ctx: "Context", msg) -> None:
     """Archive a message, logging errors but never raising."""
     if ctx.skip_archive:
         return
@@ -48,7 +52,7 @@ def _archive(ctx, msg) -> None:
         log.error(f"Archive write failed: {e}")
 
 
-def _check_cancelled(ctx, history):
+def _check_cancelled(ctx: "Context", history):
     """Check if the agent turn has been cancelled. Returns ToolResult or None."""
     if ctx.cancelled and ctx.cancelled.is_set():
         log.info("Agent turn cancelled by user")
@@ -68,7 +72,7 @@ def _media_placeholder_pattern(filename: str) -> _re.Pattern:
     )
 
 
-async def process_tool_media(ctx, result: ToolResult) -> list[str]:
+async def process_tool_media(ctx: "Context", result: ToolResult) -> list[str]:
     """Process media items on a tool result — save/upload and replace placeholders.
 
     For handlers returning workspace_ref: replaces placeholder text with markdown refs.
@@ -289,7 +293,7 @@ async def execute_single_tool(call_ctx, tc, semaphore):
     return tool_msg, result.end_turn
 
 
-async def execute_tool_calls(ctx, tool_calls, history, messages):
+async def execute_tool_calls(ctx: "Context", tool_calls, history, messages):
     """Execute tool calls concurrently, add results to history.
 
     Returns (ToolResult, False) if cancelled, (None, end_turn_signal) otherwise.

--- a/src/decafclaw/tools/__init__.py
+++ b/src/decafclaw/tools/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import difflib
 import inspect
 import logging
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult
 from .attachment_tools import ATTACHMENT_TOOL_DEFINITIONS, ATTACHMENT_TOOLS
@@ -25,6 +26,9 @@ from .shell_tools import SHELL_TOOL_DEFINITIONS, SHELL_TOOLS
 from .skill_tools import SKILL_TOOL_DEFINITIONS, SKILL_TOOLS
 from .sticky_tools import STICKY_TOOL_DEFINITIONS, STICKY_TOOLS
 from .workspace_tools import WORKSPACE_TOOL_DEFINITIONS, WORKSPACE_TOOLS
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -114,7 +118,7 @@ async def _run_with_cancel(coro, cancel_event, timeout_sec=None, tool_name=""):
 _MISSING = object()
 
 
-def _resolve_tool_timeout(ctx, name: str) -> int | None:
+def _resolve_tool_timeout(ctx: "Context", name: str) -> int | None:
     """Resolve the wall-clock timeout for `name`.
 
     Walks skill-provided defs first, then the global TOOL_DEFINITIONS,
@@ -207,7 +211,7 @@ def _format_suggestions(suggestions: list[str]) -> str:
     return f" Did you mean: {', '.join(suggestions)}."
 
 
-def _typeerror_result(ctx, name: str, fn, arguments: dict, exc: TypeError) -> ToolResult:
+def _typeerror_result(ctx: "Context", name: str, fn, arguments: dict, exc: TypeError) -> ToolResult:
     """Attribute a TypeError to either the call arguments or the tool body.
 
     The call and the entire tool body sit inside one `except TypeError`, so
@@ -255,7 +259,7 @@ def _typeerror_result(ctx, name: str, fn, arguments: dict, exc: TypeError) -> To
     )
 
 
-async def execute_tool(ctx, name: str, arguments: dict) -> ToolResult:
+async def execute_tool(ctx: "Context", name: str, arguments: dict) -> ToolResult:
     """Execute a tool by name and return the result.
 
     Returns a ToolResult with text (for LLM history) and optional media

--- a/src/decafclaw/tools/attachment_tools.py
+++ b/src/decafclaw/tools/attachment_tools.py
@@ -1,12 +1,16 @@
 """Attachment tools — list and retrieve conversation file attachments."""
 
 import json
+from typing import TYPE_CHECKING
 
 from ..attachments import list_conversation_attachments, read_attachment_base64
 from ..media import ToolResult
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
-async def tool_list_attachments(ctx) -> str | ToolResult:
+
+async def tool_list_attachments(ctx: "Context") -> str | ToolResult:
     """List files uploaded to the current conversation."""
     conv_id = ctx.conv_id or ctx.channel_id
     if not conv_id:
@@ -19,7 +23,7 @@ async def tool_list_attachments(ctx) -> str | ToolResult:
     return json.dumps(items, indent=2)
 
 
-async def tool_get_attachment(ctx, filename: str) -> str | ToolResult:
+async def tool_get_attachment(ctx: "Context", filename: str) -> str | ToolResult:
     """Retrieve a file's content from the conversation uploads."""
     conv_id = ctx.conv_id or ctx.channel_id
     if not conv_id:

--- a/src/decafclaw/tools/canvas_tools.py
+++ b/src/decafclaw/tools/canvas_tools.py
@@ -7,15 +7,19 @@ full state for grounding.
 """
 
 import logging
+from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from .. import canvas as canvas_mod
 from ..media import ToolResult
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def _emit_for_ctx(ctx):
+def _emit_for_ctx(ctx: "Context"):
     manager = getattr(ctx, "manager", None)
     if manager is None:
         return None
@@ -29,7 +33,7 @@ def _canvas_url(conv_id: str, tab_id: str | None = None) -> str:
     return base
 
 
-async def tool_canvas_new_tab(ctx,
+async def tool_canvas_new_tab(ctx: "Context",
                               widget_type: str,
                               data: dict,
                               label: str | None = None) -> ToolResult:
@@ -48,7 +52,7 @@ async def tool_canvas_new_tab(ctx,
     )
 
 
-async def tool_canvas_update(ctx, tab_id: str, data: dict) -> ToolResult:
+async def tool_canvas_update(ctx: "Context", tab_id: str, data: dict) -> ToolResult:
     """Replace data of an existing tab. Preserves widget_type + label."""
     log.info("[tool:canvas_update] tab=%s", tab_id)
     result = await canvas_mod.update_tab(
@@ -59,7 +63,7 @@ async def tool_canvas_update(ctx, tab_id: str, data: dict) -> ToolResult:
     return ToolResult(text=result.text)
 
 
-async def tool_canvas_close_tab(ctx, tab_id: str) -> ToolResult:
+async def tool_canvas_close_tab(ctx: "Context", tab_id: str) -> ToolResult:
     """Close a single tab by id. If it was active, the panel switches or hides."""
     log.info("[tool:canvas_close_tab] tab=%s", tab_id)
     result = await canvas_mod.close_tab(
@@ -70,7 +74,7 @@ async def tool_canvas_close_tab(ctx, tab_id: str) -> ToolResult:
     return ToolResult(text=result.text)
 
 
-async def tool_canvas_clear(ctx) -> ToolResult:
+async def tool_canvas_clear(ctx: "Context") -> ToolResult:
     """Close all canvas tabs and hide the panel."""
     log.info("[tool:canvas_clear]")
     state = canvas_mod.read_canvas_state(ctx.config, ctx.conv_id)
@@ -85,7 +89,7 @@ async def tool_canvas_clear(ctx) -> ToolResult:
     return ToolResult(text=result.text)
 
 
-async def tool_canvas_read(ctx) -> ToolResult:
+async def tool_canvas_read(ctx: "Context") -> ToolResult:
     """Return the full canvas state including all tabs and active_tab."""
     log.info("[tool:canvas_read]")
     state = canvas_mod.read_canvas_state(ctx.config, ctx.conv_id)

--- a/src/decafclaw/tools/checklist_tools.py
+++ b/src/decafclaw/tools/checklist_tools.py
@@ -12,15 +12,19 @@ The mirror is fail-open — a sticky failure never breaks the checklist.
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from .. import checklist
 from .. import sticky as sticky_mod
 from ..media import ToolResult
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def _emit_for_ctx(ctx):
+def _emit_for_ctx(ctx: "Context"):
     manager = getattr(ctx, "manager", None)
     if manager is None:
         return None
@@ -57,7 +61,7 @@ def _progress_data_from_checklist(items: list[dict]) -> dict:
     return {"steps": steps, "title": "Checklist", "summary": summary}
 
 
-async def _mirror_to_sticky(ctx, conv_id: str) -> None:
+async def _mirror_to_sticky(ctx: "Context", conv_id: str) -> None:
     """Sync the sticky slot with current checklist state. Fail-open.
 
     Clears the slot when there is no active checklist or every step is
@@ -83,7 +87,7 @@ async def _mirror_to_sticky(ctx, conv_id: str) -> None:
                     exc_info=True)
 
 
-async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
+async def tool_checklist_create(ctx: "Context", steps: list[str]) -> ToolResult:
     """Create a checklist and return the first step."""
     conv_id = ctx.conv_id or "default"
     if not steps:
@@ -99,7 +103,7 @@ async def tool_checklist_create(ctx, steps: list[str]) -> ToolResult:
     )
 
 
-async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
+async def tool_checklist_step_done(ctx: "Context", note: str = "") -> ToolResult:
     """Mark current step done and advance. end_turn=True only when all complete."""
     conv_id = ctx.conv_id or "default"
     next_item = await asyncio.to_thread(
@@ -124,7 +128,7 @@ async def tool_checklist_step_done(ctx, note: str = "") -> ToolResult:
     )
 
 
-async def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
+async def tool_checklist_abort(ctx: "Context", reason: str = "") -> ToolResult:
     """Abandon the current checklist."""
     conv_id = ctx.conv_id or "default"
     items = await asyncio.to_thread(
@@ -140,7 +144,7 @@ async def tool_checklist_abort(ctx, reason: str = "") -> ToolResult:
     return ToolResult(text=msg)
 
 
-def tool_checklist_status(ctx) -> ToolResult:
+def tool_checklist_status(ctx: "Context") -> ToolResult:
     """Show current checklist progress."""
     conv_id = ctx.conv_id or "default"
     items = checklist.checklist_status(ctx.config, conv_id)

--- a/src/decafclaw/tools/confirmation.py
+++ b/src/decafclaw/tools/confirmation.py
@@ -8,6 +8,10 @@ legacy event-bus pattern.
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +33,7 @@ def _get_tool_action_map():
     return _TOOL_ACTION_MAP
 
 
-async def _request_via_manager(ctx, tool_name, command, message, timeout,
+async def _request_via_manager(ctx: "Context", tool_name, command, message, timeout,
                                **extra_event_fields) -> dict:
     """Bridge to the ConversationManager's confirmation flow."""
     from ..confirmations import ConfirmationAction, ConfirmationRequest
@@ -64,7 +68,7 @@ async def _request_via_manager(ctx, tool_name, command, message, timeout,
     return result
 
 
-async def _request_via_event_bus(ctx, tool_name, command, message, timeout,
+async def _request_via_event_bus(ctx: "Context", tool_name, command, message, timeout,
                                  **extra_event_fields) -> dict:
     """Legacy event-bus confirmation flow."""
     confirm_event = asyncio.Event()
@@ -104,7 +108,7 @@ async def _request_via_event_bus(ctx, tool_name, command, message, timeout,
 
 
 async def request_confirmation(
-    ctx,
+    ctx: "Context",
     tool_name: str,
     command: str,
     message: str,

--- a/src/decafclaw/tools/conversation_tools.py
+++ b/src/decafclaw/tools/conversation_tools.py
@@ -3,12 +3,16 @@
 import heapq
 import json
 import logging
+from typing import TYPE_CHECKING
 
 import snowballstemmer
 
 from ..conversation_paths import iter_conversation_archives
 from ..media import ToolResult
 from ..preempt_search import tokenize
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +34,7 @@ def _stemmed_tokens(text: str) -> set[str]:
     return {_STEMMER.stemWord(t) for t in tokenize(text)}
 
 
-def tool_conversation_search(ctx, query: str) -> str:
+def tool_conversation_search(ctx: "Context", query: str) -> str:
     """Search conversation archives by stemmed-token overlap plus substring."""
     log.info(f"[tool:conversation_search] query={query}")
 
@@ -94,7 +98,7 @@ def tool_conversation_search(ctx, query: str) -> str:
     return f"Found {len(results)} matching conversation entries:\n\n" + "\n\n".join(results)
 
 
-async def tool_conversation_compact(ctx) -> str | ToolResult:
+async def tool_conversation_compact(ctx: "Context") -> str | ToolResult:
     """Manually trigger conversation compaction."""
     log.info("[tool:conversation_compact]")
     from ..compaction import compact_history

--- a/src/decafclaw/tools/core.py
+++ b/src/decafclaw/tools/core.py
@@ -2,16 +2,20 @@
 
 import json
 import logging
+from typing import TYPE_CHECKING
 
 import httpx
 
 from ..media import ToolResult, WidgetRequest
 from ..util import estimate_tokens
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-async def tool_web_fetch(ctx, url: str) -> str | ToolResult:
+async def tool_web_fetch(ctx: "Context", url: str) -> str | ToolResult:
     """Fetch a URL and return the raw response body as text."""
     log.info(f"[tool:web_fetch] {url}")
     try:
@@ -26,7 +30,7 @@ async def tool_web_fetch(ctx, url: str) -> str | ToolResult:
         return ToolResult(text=f"[error: {e}]")
 
 
-def tool_debug_context(ctx) -> str | ToolResult:
+def tool_debug_context(ctx: "Context") -> str | ToolResult:
     """Dump the current conversation context for debugging."""
     log.info("[tool:debug_context]")
     messages = ctx.messages
@@ -113,14 +117,14 @@ def tool_debug_context(ctx) -> str | ToolResult:
 
 
 
-def tool_current_time(ctx) -> str | ToolResult:
+def tool_current_time(ctx: "Context") -> str | ToolResult:
     """Return the current date and time."""
     from datetime import datetime
     now = datetime.now()
     return now.strftime("%Y-%m-%d %H:%M:%S (%A)")
 
 
-async def tool_wait(ctx, seconds: int = 30) -> str | ToolResult:
+async def tool_wait(ctx: "Context", seconds: int = 30) -> str | ToolResult:
     """Wait for the specified number of seconds before returning.
 
     Use this when waiting for a background process or external operation
@@ -192,7 +196,7 @@ def _default_multiple_choice_callback(options: list[dict],
     return _cb
 
 
-async def tool_ask_user_multiple_choice(ctx, prompt: str, options: list,
+async def tool_ask_user_multiple_choice(ctx: "Context", prompt: str, options: list,
                                         allow_multiple: bool = False) -> ToolResult:
     """Pause the turn and ask the user to pick from a fixed list of options."""
     log.info(f"[tool:ask_user_multiple_choice] prompt={prompt!r} "
@@ -296,7 +300,7 @@ def _default_text_input_callback(field_keys: list[str]):
     return _cb
 
 
-async def tool_ask_user_text(ctx, prompt: str, fields: list | None = None,
+async def tool_ask_user_text(ctx: "Context", prompt: str, fields: list | None = None,
                              submit_label: str = "Submit") -> ToolResult:
     """Pause the turn and ask the user for free-form text input."""
     log.info(f"[tool:ask_user_text] prompt={prompt!r} "
@@ -332,7 +336,7 @@ async def tool_ask_user_text(ctx, prompt: str, fields: list | None = None,
     )
 
 
-def tool_context_stats(ctx) -> str | ToolResult:
+def tool_context_stats(ctx: "Context") -> str | ToolResult:
     """Report token budget statistics for the current conversation."""
     log.info("[tool:context_stats]")
 

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -6,9 +6,12 @@ import logging
 import re
 import secrets
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ..media import ToolResult
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -114,7 +117,7 @@ def _parse_structured_output(text: str) -> tuple[Any | None, str]:
     return parsed, prose
 
 
-async def run_child_turn(parent_ctx, task, model: str = "",
+async def run_child_turn(parent_ctx: "Context", task, model: str = "",
                          max_iterations: int = 0,
                          *,
                          allowed_tools: list[str] | None = None,
@@ -202,7 +205,7 @@ async def run_child_turn(parent_ctx, task, model: str = "",
     child_conv_id = f"{parent_conv}--child-{secrets.token_hex(4)}"
     parent_event_id = parent_ctx.event_context_id or parent_ctx.context_id
 
-    def setup(child_ctx):
+    def setup(child_ctx: "Context"):
         # Swap in the child-specific config (smaller iteration budget + child
         # system prompt). Context was already built with parent's config by
         # Context.for_task, so we overwrite here.
@@ -298,7 +301,7 @@ async def run_child_turn(parent_ctx, task, model: str = "",
 
 
 async def tool_delegate_task(
-    ctx,
+    ctx: "Context",
     task: str,
     model: str = "",
     allow_vault_retrieval: bool = False,
@@ -349,7 +352,7 @@ async def tool_delegate_task(
 
 
 async def _run_one_delegated(
-    parent_ctx,
+    parent_ctx: "Context",
     *,
     task: str,
     idx: int,
@@ -423,7 +426,7 @@ async def _run_one_delegated(
 
 
 async def tool_delegate_tasks(
-    ctx,
+    ctx: "Context",
     tasks: list[str],
     model: str = "",
     allow_vault_retrieval: bool = False,

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -409,10 +409,11 @@ async def _run_one_delegated(
             progress["done"] += 1
             done = progress["done"]
         try:
-            await parent_ctx.publish("tool_status", {
-                "tool": "delegate_tasks",
-                "message": f"{done}/{total} subtasks complete",
-            })
+            await parent_ctx.publish(
+                "tool_status",
+                tool="delegate_tasks",
+                message=f"{done}/{total} subtasks complete",
+            )
         except Exception:
             log.debug(
                 "delegate_tasks: failed to publish progress event "

--- a/src/decafclaw/tools/health.py
+++ b/src/decafclaw/tools/health.py
@@ -8,6 +8,10 @@ import logging
 import resource
 import sys
 import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -319,7 +323,7 @@ def _heartbeat_section(config) -> list[str]:
     return lines
 
 
-def _tools_section(ctx) -> list[str]:
+def _tools_section(ctx: "Context") -> list[str]:
     """Gather tool deferral stats."""
     from . import TOOL_DEFINITIONS
     from .tool_registry import classify_tools, estimate_tool_tokens
@@ -382,7 +386,7 @@ def _schedule_section(config) -> list[str]:
     return lines
 
 
-async def tool_health_status(ctx) -> str:
+async def tool_health_status(ctx: "Context") -> str:
     """Show agent health and diagnostic status."""
     log.info("[tool:health_status]")
 

--- a/src/decafclaw/tools/heartbeat_tools.py
+++ b/src/decafclaw/tools/heartbeat_tools.py
@@ -2,10 +2,14 @@
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 import httpx
 
 from ..media import ToolResult
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -13,7 +17,7 @@ log = logging.getLogger(__name__)
 _heartbeat_lock = asyncio.Lock()
 
 
-async def tool_heartbeat_trigger(ctx) -> str | ToolResult:
+async def tool_heartbeat_trigger(ctx: "Context") -> str | ToolResult:
     """Manually trigger a heartbeat cycle, posting results to the configured channel."""
     log.info("[tool:heartbeat_trigger]")
 

--- a/src/decafclaw/tools/http_tools.py
+++ b/src/decafclaw/tools/http_tools.py
@@ -5,11 +5,15 @@ import json
 import logging
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
 
 from ..media import ToolResult
 from .confirmation import request_confirmation
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -79,7 +83,7 @@ def _suggest_pattern(url: str) -> str:
 
 # -- Tool function ------------------------------------------------------------
 
-async def tool_http_request(ctx, url: str, method: str = "GET",
+async def tool_http_request(ctx: "Context", url: str, method: str = "GET",
                             headers: dict | None = None,
                             body: str = "",
                             max_response_size: int = _DEFAULT_MAX_RESPONSE_SIZE,

--- a/src/decafclaw/tools/model_tools.py
+++ b/src/decafclaw/tools/model_tools.py
@@ -5,13 +5,17 @@ Not registered in the agent's tool registry (cost control — see #245).
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
 
-async def tool_set_model(ctx, model: str) -> str | ToolResult:
+async def tool_set_model(ctx: "Context", model: str) -> str | ToolResult:
     """Change the active model for this conversation."""
     log.info("[tool:set_model] model=%s", model)
 

--- a/src/decafclaw/tools/notes_tools.py
+++ b/src/decafclaw/tools/notes_tools.py
@@ -9,14 +9,18 @@ them. See ``docs/notes.md``.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from .. import notes as notes_core
 from ..media import ToolResult
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def _resolve_conv_id(ctx) -> str:
+def _resolve_conv_id(ctx: "Context") -> str:
     """Match the fallback chain `_compose_notes` uses so writes and
     reads always target the same file. ``ctx.conv_id`` may be empty
     in contexts that key off ``channel_id`` instead (top-level
@@ -24,7 +28,7 @@ def _resolve_conv_id(ctx) -> str:
     return ctx.conv_id or ctx.channel_id or "default"
 
 
-def tool_notes_append(ctx, text: str) -> ToolResult:
+def tool_notes_append(ctx: "Context", text: str) -> ToolResult:
     """Append one entry to the conversation's scratchpad."""
     if not ctx.config.notes.enabled:
         return ToolResult(text="[error: notes are disabled in this config]")
@@ -48,7 +52,7 @@ def tool_notes_append(ctx, text: str) -> ToolResult:
     )
 
 
-def tool_notes_read(ctx, limit: int = 20) -> ToolResult:
+def tool_notes_read(ctx: "Context", limit: int = 20) -> ToolResult:
     """Return the most recent N notes."""
     if not ctx.config.notes.enabled:
         return ToolResult(text="[error: notes are disabled in this config]")

--- a/src/decafclaw/tools/search_tools.py
+++ b/src/decafclaw/tools/search_tools.py
@@ -2,14 +2,18 @@
 
 import json
 import logging
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult
 from .tool_registry import add_fetched_tools, get_description
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def tool_search(ctx, query: str, max_results: int = 10) -> ToolResult:
+def tool_search(ctx: "Context", query: str, max_results: int = 10) -> ToolResult:
     """Search for tools / skills and load matched tool definitions.
 
     Matches against:

--- a/src/decafclaw/tools/shell_tools.py
+++ b/src/decafclaw/tools/shell_tools.py
@@ -6,9 +6,13 @@ import logging
 import os
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult
 from .confirmation import request_confirmation
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -133,7 +137,7 @@ def _suggest_pattern(command: str) -> str:
     return command
 
 
-async def check_shell_approval(ctx, command: str, tool_name: str = "shell",
+async def check_shell_approval(ctx: "Context", command: str, tool_name: str = "shell",
                                message: str = "") -> dict:
     """Check whether a shell command is approved (shared by shell + background tools).
 
@@ -173,7 +177,7 @@ async def check_shell_approval(ctx, command: str, tool_name: str = "shell",
     return result
 
 
-async def tool_shell(ctx, command: str) -> ToolResult:
+async def tool_shell(ctx: "Context", command: str) -> ToolResult:
     """Run a shell command after user confirmation."""
     log.info(f"[tool:shell] requesting confirmation for: {command}")
 
@@ -185,7 +189,7 @@ async def tool_shell(ctx, command: str) -> ToolResult:
     return _execute_command(ctx, command)
 
 
-def _execute_command(ctx, command: str) -> ToolResult:
+def _execute_command(ctx: "Context", command: str) -> ToolResult:
     """Execute a shell command and return the output."""
     log.info(f"[tool:shell] executing command: {command}")
     # Expose the runtime workspace explicitly so skill scripts can place
@@ -209,7 +213,7 @@ def _execute_command(ctx, command: str) -> ToolResult:
         return ToolResult(text="[error: command timed out after 30 seconds]")
 
 
-async def tool_shell_patterns(ctx, action: str = "list", pattern: str = "") -> str | ToolResult:
+async def tool_shell_patterns(ctx: "Context", action: str = "list", pattern: str = "") -> str | ToolResult:
     """Manage shell command allow patterns."""
     log.info(f"[tool:shell_patterns] action={action} pattern={pattern}")
 

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult
 from ..skills import (
@@ -17,6 +18,9 @@ from ..skills import (
     validate_skill_md,
 )
 from .confirmation import request_confirmation
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -525,7 +529,7 @@ async def _call_init(module, config, skill_name: str = "") -> None:
             await asyncio.to_thread(init_fn, config)
 
 
-async def restore_skills(ctx) -> None:
+async def restore_skills(ctx: "Context") -> None:
     """Re-activate skills recorded in ctx.skills.activated, without permission checks.
 
     Called at the start of each web gateway turn to restore skills that were
@@ -583,7 +587,7 @@ def _find_skill(discovered, name: str):
     return None
 
 
-async def tool_activate_skill(ctx, name: str) -> str | ToolResult:
+async def tool_activate_skill(ctx: "Context", name: str) -> str | ToolResult:
     """Activate a skill to make its capabilities available in this conversation."""
     log.info(f"[tool:activate_skill] name={name}")
 
@@ -660,7 +664,7 @@ async def tool_activate_skill(ctx, name: str) -> str | ToolResult:
     return result
 
 
-def _retract_skill_tools(ctx, name: str) -> None:
+def _retract_skill_tools(ctx: "Context", name: str) -> None:
     """Remove the tools a previous activation of `name` registered.
 
     Called after a successful re-import and before registering the new
@@ -714,7 +718,7 @@ def _retract_skill_tools(ctx, name: str) -> None:
         )
 
 
-def _register_skill_tools(ctx, name: str, tools: dict, tool_defs: list) -> None:
+def _register_skill_tools(ctx: "Context", name: str, tools: dict, tool_defs: list) -> None:
     """Retract a skill's previous generation, then register this one.
 
     The single registration path for both activation and post-restart restore.
@@ -741,7 +745,7 @@ def _register_skill_tools(ctx, name: str, tools: dict, tool_defs: list) -> None:
     ctx.tools.skill_contributions[name] = (dict(tools), list(tool_defs))
 
 
-async def activate_skill_internal(ctx, skill_info, reloading: bool = False) -> str | ToolResult:
+async def activate_skill_internal(ctx: "Context", skill_info, reloading: bool = False) -> str | ToolResult:
     """Activate a skill: load tools, register on ctx, mark active.
 
     Shared by tool_activate_skill (with permission checks) and
@@ -882,7 +886,7 @@ async def activate_skill_internal(ctx, skill_info, reloading: bool = False) -> s
     return "\n".join(result_parts)
 
 
-async def _request_skill_confirmation(ctx, skill_name: str) -> tuple[bool, bool]:
+async def _request_skill_confirmation(ctx: "Context", skill_name: str) -> tuple[bool, bool]:
     """Request user confirmation for skill activation.
 
     Returns (approved, always) tuple.
@@ -896,7 +900,7 @@ async def _request_skill_confirmation(ctx, skill_name: str) -> tuple[bool, bool]
     return result.get("approved", False), result.get("always", False)
 
 
-def tool_skill_validate(ctx, path: str) -> ToolResult:
+def tool_skill_validate(ctx: "Context", path: str) -> ToolResult:
     """Pre-flight validate a single workspace skill directory."""
     log.info(f"[tool:skill_validate] {path}")
     workspace = ctx.config.workspace_path.resolve()
@@ -973,7 +977,7 @@ def rediscover_skills(config) -> list:
     return rejections
 
 
-def tool_refresh_skills(ctx) -> str | ToolResult:
+def tool_refresh_skills(ctx: "Context") -> str | ToolResult:
     """Re-discover skills and update the system prompt catalog."""
     log.info("[tool:refresh_skills]")
     config = ctx.config

--- a/src/decafclaw/tools/sticky_tools.py
+++ b/src/decafclaw/tools/sticky_tools.py
@@ -7,21 +7,25 @@ directly; these tools are the agent's explicit surface.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 from .. import sticky as sticky_mod
 from ..media import ToolResult
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def _emit_for_ctx(ctx):
+def _emit_for_ctx(ctx: "Context"):
     manager = getattr(ctx, "manager", None)
     if manager is None:
         return None
     return manager.emit
 
 
-async def tool_widget_pin_sticky(ctx, widget_type: str, data: dict) -> ToolResult:
+async def tool_widget_pin_sticky(ctx: "Context", widget_type: str, data: dict) -> ToolResult:
     """Pin a widget into the sticky slot above the chat input."""
     log.info("[tool:widget_pin_sticky] widget=%s", widget_type)
     result = await sticky_mod.set_sticky(
@@ -31,7 +35,7 @@ async def tool_widget_pin_sticky(ctx, widget_type: str, data: dict) -> ToolResul
     return ToolResult(text=result.text)
 
 
-async def tool_widget_unpin_sticky(ctx) -> ToolResult:
+async def tool_widget_unpin_sticky(ctx: "Context") -> ToolResult:
     """Clear the sticky slot."""
     log.info("[tool:widget_unpin_sticky]")
     result = await sticky_mod.clear_sticky(

--- a/src/decafclaw/tools/tool_registry.py
+++ b/src/decafclaw/tools/tool_registry.py
@@ -3,8 +3,12 @@
 import json
 import logging
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from ..util import estimate_tokens
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -292,7 +296,7 @@ def build_deferred_list_text(
 # -- Fetched tools helpers (list↔set for JSON serialization) -----------------
 
 
-def get_fetched_tools(ctx) -> set[str]:
+def get_fetched_tools(ctx: "Context") -> set[str]:
     """Read the fetched tools set from ctx.skills.data."""
     skill_data = ctx.skills.data
     raw = skill_data.get("fetched_tools", [])
@@ -301,7 +305,7 @@ def get_fetched_tools(ctx) -> set[str]:
     return set(raw)
 
 
-def add_fetched_tools(ctx, names: set[str]) -> None:
+def add_fetched_tools(ctx: "Context", names: set[str]) -> None:
     """Add tool names to the fetched set in ctx.skills.data."""
     existing = get_fetched_tools(ctx)
     ctx.skills.data["fetched_tools"] = sorted(existing | names)

--- a/src/decafclaw/tools/workspace_tools.py
+++ b/src/decafclaw/tools/workspace_tools.py
@@ -7,8 +7,12 @@ import fnmatch
 import logging
 import re
 from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
 
 from ..media import ToolResult, WidgetRequest
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -84,7 +88,7 @@ def _resolve_safe(config, path_str: str) -> Path | None:
     return target
 
 
-def tool_workspace_read(ctx, path: str, start_line: int | None = None,
+def tool_workspace_read(ctx: "Context", path: str, start_line: int | None = None,
                         end_line: int | None = None) -> str | ToolResult:
     """Read a file from the agent's workspace, optionally a line range."""
     log.info(f"[tool:workspace_read] {path}")
@@ -145,7 +149,7 @@ def tool_workspace_read(ctx, path: str, start_line: int | None = None,
 _MARKDOWN_EXTS = (".md", ".markdown")
 
 
-def tool_workspace_preview_markdown(ctx, path: str) -> ToolResult:
+def tool_workspace_preview_markdown(ctx: "Context", path: str) -> ToolResult:
     """Read a workspace markdown file and return it as an inline markdown widget.
 
     The web UI renders the content as rich markdown via the
@@ -203,7 +207,7 @@ def tool_workspace_preview_markdown(ctx, path: str) -> ToolResult:
     )
 
 
-def tool_workspace_write(ctx, path: str, content: str) -> str | ToolResult:
+def tool_workspace_write(ctx: "Context", path: str, content: str) -> str | ToolResult:
     """Write content to a file in the agent's workspace."""
     log.info(f"[tool:workspace_write] {path}")
     resolved = _resolve_safe(ctx.config, path)
@@ -217,7 +221,7 @@ def tool_workspace_write(ctx, path: str, content: str) -> str | ToolResult:
         return _file_error(e, path)
 
 
-def tool_workspace_list(ctx, path: str = ".") -> str | ToolResult:
+def tool_workspace_list(ctx: "Context", path: str = ".") -> str | ToolResult:
     """List files and directories in the agent's workspace."""
     log.info(f"[tool:workspace_list] {path}")
     resolved = _resolve_safe(ctx.config, path)
@@ -252,7 +256,7 @@ def tool_workspace_list(ctx, path: str = ".") -> str | ToolResult:
         return _file_error(e, path)
 
 
-def tool_file_share(ctx, path: str, message: str = "") -> "ToolResult":
+def tool_file_share(ctx: "Context", path: str, message: str = "") -> "ToolResult":
     """Share a file from the workspace as an attachment."""
     import mimetypes
 
@@ -281,7 +285,7 @@ def tool_file_share(ctx, path: str, message: str = "") -> "ToolResult":
         return _file_error(e, path)
 
 
-def tool_workspace_move(ctx, path: str, destination: str) -> str | ToolResult:
+def tool_workspace_move(ctx: "Context", path: str, destination: str) -> str | ToolResult:
     """Move or rename a file within the workspace."""
     log.info(f"[tool:workspace_move] {path} -> {destination}")
     resolved_src = _resolve_safe(ctx.config, path)
@@ -302,7 +306,7 @@ def tool_workspace_move(ctx, path: str, destination: str) -> str | ToolResult:
         return _file_error(e, path)
 
 
-def tool_workspace_delete(ctx, path: str) -> str | ToolResult:
+def tool_workspace_delete(ctx: "Context", path: str) -> str | ToolResult:
     """Delete a file from the workspace."""
     log.info(f"[tool:workspace_delete] {path}")
     resolved = _resolve_safe(ctx.config, path)
@@ -319,7 +323,7 @@ def tool_workspace_delete(ctx, path: str) -> str | ToolResult:
         return _file_error(e, path)
 
 
-def tool_workspace_edit(ctx, path: str, old_text: str, new_text: str,
+def tool_workspace_edit(ctx: "Context", path: str, old_text: str, new_text: str,
                        replace_all: bool = False) -> str | ToolResult:
     """Edit a file by replacing exact text matches."""
     log.info(f"[tool:workspace_edit] {path}")
@@ -352,7 +356,7 @@ def tool_workspace_edit(ctx, path: str, old_text: str, new_text: str,
     return summary
 
 
-def tool_workspace_insert(ctx, path: str, line_number: int, content: str) -> str | ToolResult:
+def tool_workspace_insert(ctx: "Context", path: str, line_number: int, content: str) -> str | ToolResult:
     """Insert text at a specific line number in a workspace file."""
     log.info(f"[tool:workspace_insert] {path} at line {line_number}")
     resolved = _resolve_safe(ctx.config, path)
@@ -382,7 +386,7 @@ def tool_workspace_insert(ctx, path: str, line_number: int, content: str) -> str
     return summary
 
 
-def tool_workspace_replace_lines(ctx, path: str, start_line: int, end_line: int,
+def tool_workspace_replace_lines(ctx: "Context", path: str, start_line: int, end_line: int,
                                  content: str = "") -> str | ToolResult:
     """Replace a range of lines in a workspace file."""
     log.info(f"[tool:workspace_replace_lines] {path} lines {start_line}-{end_line}")
@@ -418,7 +422,7 @@ def tool_workspace_replace_lines(ctx, path: str, start_line: int, end_line: int,
     return summary
 
 
-def tool_workspace_append(ctx, path: str, content: str) -> str | ToolResult:
+def tool_workspace_append(ctx: "Context", path: str, content: str) -> str | ToolResult:
     """Append content to a file in the agent's workspace."""
     log.info(f"[tool:workspace_append] {path}")
     resolved = _resolve_safe(ctx.config, path)
@@ -438,7 +442,7 @@ def tool_workspace_append(ctx, path: str, content: str) -> str | ToolResult:
         return _file_error(e, path)
 
 
-def tool_workspace_diff(ctx, path1: str, path2: str, context_lines: int = 3) -> str | ToolResult:
+def tool_workspace_diff(ctx: "Context", path1: str, path2: str, context_lines: int = 3) -> str | ToolResult:
     """Show a unified diff between two workspace files."""
     log.info(f"[tool:workspace_diff] {path1} vs {path2}")
     resolved1 = _resolve_safe(ctx.config, path1)
@@ -466,7 +470,7 @@ def tool_workspace_diff(ctx, path1: str, path2: str, context_lines: int = 3) -> 
     return "".join(diff)
 
 
-def tool_workspace_search(ctx, pattern: str, path: str = ".",
+def tool_workspace_search(ctx: "Context", pattern: str, path: str = ".",
                           glob: str = "*", context_lines: int = 2) -> str | ToolResult:
     """Search for a regex pattern across workspace files."""
     log.info(f"[tool:workspace_search] pattern={pattern!r} path={path} glob={glob}")
@@ -559,7 +563,7 @@ def tool_workspace_search(ctx, pattern: str, path: str = ".",
     return ToolResult(text=result, data=base_data)
 
 
-def tool_workspace_glob(ctx, pattern: str, path: str = ".") -> str | ToolResult:
+def tool_workspace_glob(ctx: "Context", pattern: str, path: str = ".") -> str | ToolResult:
     """Find files by glob pattern in the workspace."""
     log.info(f"[tool:workspace_glob] pattern={pattern!r} path={path}")
     resolved = _resolve_safe(ctx.config, path)

--- a/src/decafclaw/web/websocket.py
+++ b/src/decafclaw/web/websocket.py
@@ -12,6 +12,7 @@ import os
 import re
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
@@ -30,6 +31,9 @@ from decafclaw.web.message_types import (
     WSMessageType,
     WSSendCallable,
 )
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -345,7 +349,7 @@ async def _handle_send(ws_send: WSSendCallable, index, username, msg, state) -> 
         if name in workflow_commands():
             wf_trigger = name
     if wf_trigger:
-        def context_setup(ctx):
+        def context_setup(ctx: "Context"):
             from ..media import LocalFileMediaHandler
             ctx.media_handler = LocalFileMediaHandler(state["config"])
             ctx.channel_name = "web"
@@ -419,7 +423,7 @@ async def _handle_send(ws_send: WSSendCallable, index, username, msg, state) -> 
     _subscribe_to_conv(state, conv_id)
 
     # Transport-specific context setup
-    def context_setup(ctx):
+    def context_setup(ctx: "Context"):
         from ..media import LocalFileMediaHandler
         ctx.media_handler = LocalFileMediaHandler(state["config"])
         ctx.channel_name = "web"

--- a/src/decafclaw/workflow/engine.py
+++ b/src/decafclaw/workflow/engine.py
@@ -6,11 +6,14 @@ input, or errored. The orchestrator itself is plain async Python.
 """
 import dataclasses
 import logging
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from .errors import WorkflowNonDeterministic, WorkflowSuspended
 from .handle import WorkflowHandle
 from .journal import Journal, save_journal
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +27,7 @@ class WorkflowOutcome:
 
 
 async def run_workflow(
-    ctx,
+    ctx: "Context",
     workflow_fn: Callable[[WorkflowHandle], Awaitable[Any]],
     journal: Journal,
     *,

--- a/src/decafclaw/workflow/handle.py
+++ b/src/decafclaw/workflow/handle.py
@@ -18,7 +18,7 @@ Replay invariants the orchestrator author must respect:
 """
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine
 
 from decafclaw.tools import delegate as _delegate
 from decafclaw.tools import execute_tool
@@ -31,10 +31,13 @@ from .errors import (
 )
 from .journal import fingerprint, save_journal
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
-async def _default_llm_call(ctx, **kw):
+async def _default_llm_call(ctx: "Context", **kw):
     return await wf_llm.call_structured(ctx, **kw)
 
 

--- a/src/decafclaw/workflow/llm.py
+++ b/src/decafclaw/workflow/llm.py
@@ -6,13 +6,17 @@ vertex-gemini-flash by the #255 spike.
 """
 import json
 import logging
+from typing import TYPE_CHECKING
 
 from decafclaw.llm import call_llm
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
 
-async def call_structured(ctx, *, system: str, user_msg: str, schema: dict,
+async def call_structured(ctx: "Context", *, system: str, user_msg: str, schema: dict,
                           tool_name: str, model: str, description: str = "",
                           retries: int = 1) -> dict:
     """Force a structured response. Returns parsed tool args, or raises."""

--- a/src/decafclaw/workflow/resume.py
+++ b/src/decafclaw/workflow/resume.py
@@ -6,6 +6,7 @@ ConfirmationRegistry; it fires via the confirmation *recovery* path
 (no awaiting waiter) because a workflow suspend ends the turn.
 """
 import logging
+from typing import TYPE_CHECKING
 
 from decafclaw.confirmations import (
     ConfirmationAction,
@@ -23,6 +24,9 @@ from .errors import WorkflowSkillActivationFailed
 from .journal import Journal, load_journal, path_from_any, path_to_str, save_journal
 from .registry import get_workflow
 
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+
 log = logging.getLogger(__name__)
 
 
@@ -32,7 +36,7 @@ def _render_artifact(result) -> str:
     return str(result)
 
 
-async def run_workflow_turn(ctx, manager, *,
+async def run_workflow_turn(ctx: "Context", manager, *,
                             workflow_name: str, resume: bool) -> ToolResult:
     spec = get_workflow(workflow_name)
     if spec is None:

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -540,12 +540,15 @@ class TestDelegateTasks:
         """Three tasks all return prose; result has ok entries in
         input order, summary counts match, and the parent emits one
         progress event per child."""
-        published: list[tuple] = []
-
-        async def fake_publish(event_type, payload):
-            published.append((event_type, payload))
-
-        ctx.publish = fake_publish
+        # Subscribe to the real bus rather than replacing ctx.publish. An
+        # earlier version of this test installed a fake `publish(event_type,
+        # payload)` accepting a positional dict — which is exactly how
+        # delegate.py called it, and exactly what Context.publish does NOT
+        # accept. The mock encoded the bug as the contract, so the assertions
+        # below passed for two months while no event ever reached the bus
+        # in production (#721).
+        published: list[dict] = []
+        ctx.event_bus.subscribe(lambda event: published.append(event))
 
         async def fake_run(parent_ctx, task, **kwargs):
             return (f"result for {task}", None)
@@ -564,10 +567,17 @@ class TestDelegateTasks:
         assert results[1]["text"] == "result for b"
         assert results[2]["text"] == "result for c"
         assert "3 subtasks" in result.text
-        # One progress event per completion.
-        statuses = [p for p in published if p[0] == "tool_status"]
-        assert len(statuses) == 3
-        assert all(p[1]["tool"] == "delegate_tasks" for p in statuses)
+        # One progress event per completion, as delivered by the real bus.
+        statuses = [e for e in published if e.get("type") == "tool_status"]
+        assert len(statuses) == 3, (
+            f"expected 3 tool_status events on the bus, got {len(statuses)}: "
+            f"{published}"
+        )
+        assert all(e["tool"] == "delegate_tasks" for e in statuses)
+        # Payload keys must be top-level on the event — that is where every
+        # consumer reads them (web/websocket.py reads event["tool"]), and a
+        # positional dict would nest them under an argument instead.
+        assert all("subtasks complete" in e["message"] for e in statuses)
 
     @pytest.mark.asyncio
     async def test_mixed_failures(self, ctx):


### PR DESCRIPTION
Closes #721.

`delegate_tasks` published no progress events at all. The one-line cause is less interesting than why nothing caught it.

## The bug

`_run_one_delegated` called:

```python
await parent_ctx.publish("tool_status", {"tool": ..., "message": ...})
```

`Context.publish` is `(self, event_type: str, **kwargs)` — no second positional parameter. Every call raised `TypeError`, and the surrounding `except Exception: log.debug(...)` swallowed it. Users got no incremental progress on the one tool where a long wait makes it matter most.

Fixed to the `**kwargs` form every other call site uses. The broad `except` stays: progress publishing is fail-open by design, and narrowing it would not catch a signature error anyway.

## Why `make check` was green for two months

Two independent guards were both blind.

**The test asserted the bug.** `test_happy_path_three_tasks` installed `ctx.publish = fake_publish` with signature `(event_type, payload)` — the buggy shape — then asserted three events arrived. It passed while production published nothing. Rewritten to subscribe to the real `EventBus` and assert the payload keys land top-level on the event, which is where consumers read them (`web/websocket.py` reads `event["tool"]`). Confirmed failing before the fix: `expected 3 tool_status events on the bus, got 0`.

**pyright could not see the call.** `parent_ctx` was unannotated, so it inferred `Any`. That was true of the entire tool layer: **175 `ctx` params across 44 files, zero annotations.** So the second commit annotates them as `ctx: "Context"`.

Verified the sweep has teeth by reintroducing the bug on top of it:

```
delegate.py:415 - error: Expected 1 positional argument (reportCallIssue)
```

Before the sweep that same code was clean.

## Two gotchas that shaped the annotation form

Both found by breaking the build, both now in CLAUDE.md.

**The import must be `TYPE_CHECKING`-guarded.** `decafclaw.context` → `context_composer` → skill modules → `Context` is a real cycle; a runtime import raises `cannot import name 'Context' from partially initialized module`. pyright cannot see this — the test suite found it.

**Annotations are quoted rather than adding `from __future__ import annotations`.** The future import breaks the skill loader, via a genuinely obscure path: the loader `exec`s modules without registering them in `sys.modules`, and CPython's `dataclasses._is_type` resolves *string* annotations through `sys.modules.get(cls.__module__).__dict__`. So the future import turns any `@dataclass` in a skill's `tools.py` into `AttributeError: 'NoneType' object has no attribute '__dict__'`. It surfaces as three skills silently absent from the tool catalog, not as an error at the annotation.

That loader behavior is a latent trap for any skill author who reaches for the future import, independent of this PR — I'll file it separately rather than widen this one.

## Also

Removes three now-redundant function-level `Context` imports and one duplicate in `eval/runner.py`. `conversation_manager.py` keeps its function-level import (no module-level one); `compaction.py` and `websocket.py` keep theirs because they construct `Context` at runtime, not just annotate.

The sweep was applied by a one-shot script, reviewed, then deleted. It took three iterations to get right — it first collapsed lines by dropping trailing newlines, then inserted imports inside multi-line `from x import (...)` blocks and inside a module docstring whose prose begins a line with `from `. Worth knowing that the intermediate states reported **224 pyright errors** that looked like real findings and were entirely self-inflicted; the true count was 7.

## Verification

- `make test` — 3606 passed, 2 skipped (no change in count; one test rewritten, not added)
- `make check` — ruff clean, pyright 0 errors, tsc clean
- `python -c "import decafclaw.context, decafclaw.compaction, decafclaw.web.websocket"` — no cycle
- Teeth confirmed in both directions: the test fails without the fix, pyright fails without the annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)