### PR TITLE
refactor: extract duplicated _emit_for_ctx helper into events.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ Full doc index: [docs/index.md](docs/index.md). Hot files for navigation:
 - `conversation_manager.py` — Central orchestrator: TurnKind dispatch, confirmation persistence, per-conversation event streams
 - `context.py` — Forkable runtime context (TokenUsage, ToolState, SkillState, ComposerState)
 - `context_composer.py` — Unified context assembly, relevance scoring, dynamic budget allocation
-- `events.py` — Pub/sub event bus
+- `events.py` — Pub/sub event bus; also hosts the shared `emit_for_ctx(ctx)` helper (the manager's `emit` or `None`) that canvas / sticky / checklist / project all import rather than replicate
 - `runner.py` — Top-level orchestrator: MCP, HTTP, Mattermost, heartbeat as parallel tasks
 - `tool_definitions.py` — Tool-registry assembly: classification, deferral, dynamic-skill providers (`build_tool_list`, `collect_all_tool_defs`, `refresh_dynamic_tools`)
 - `tool_execution.py` — Concurrent tool-call execution: media handling, widget validation, end-turn signals (`execute_tool_calls`, `execute_single_tool`, `process_tool_media`, `resolve_widget`)

--- a/docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md
+++ b/docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md
@@ -16,6 +16,7 @@
 - `ToolResult(text="[error: ...]")` for tool errors, never bare strings/raises.
 - **Auto-emit is fail-open:** wrap every `set_sticky`/`clear_sticky` call in `try/except Exception: log.warning(...)`; the checklist/project tool returns its normal result regardless.
 - Skills use **absolute imports** (`from decafclaw...`). Do not import private helpers across modules — replicate the 3-line `_emit_for_ctx` locally where needed.
+  - **Superseded by [#657](https://github.com/lmorchard/decafclaw/issues/657) (2026-07-29).** The "replicate locally" instruction was a deliberate scope limit for *this* session, and it left four identical copies behind. The helper is now public and shared as `emit_for_ctx` in `src/decafclaw/events.py`; import it rather than replicating it. The absolute-imports-in-skills rule still stands, and is exactly why the shared version is imported as `from decafclaw.events import emit_for_ctx` in `skills/project/tools.py`.
 - `execute_tool` auto-detects sync vs async, so making the checklist tools async is runtime-safe.
 - Sticky emit in non-web (terminal/Mattermost) conversations is a harmless no-op (web-only surface; sidecar write is cheap).
 - Commit after each task. Run `make check` + `make test` green before the PR.

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Acceptance check C1 for issue #657.
+
+CRITERION: The codebase SHALL contain exactly one definition of the `emit_for_ctx`
+helper, AND each of the four consumer modules SHALL obtain it by import rather than
+by local definition.
+
+Static, stdlib-only probe. Counts:
+  DEFS    -- `def _?emit_for_ctx` definitions anywhere under src/decafclaw
+  IMPORTS -- how many of the four named consumers import the name into scope
+  USES    -- how many of the four named consumers still have a call-shaped use
+
+Asserts DEFS == 1, IMPORTS == 4, USES == 4.
+
+Host-agnostic on purpose: the helper may live in events.py, context.py, or a brand
+new module, and all spellings must pass identically -- so no host module name is
+hardcoded. Consumer paths ARE hardcoded with no fixture setup and no try/except, so
+that a renamed consumer raises FileNotFoundError loudly instead of passing silently.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src" / "decafclaw"
+
+# Hardcoded, verbatim from the issue. Do not glob these. Do not guard them.
+CONSUMERS = [
+    "src/decafclaw/tools/sticky_tools.py",
+    "src/decafclaw/tools/canvas_tools.py",
+    "src/decafclaw/tools/checklist_tools.py",
+    "src/decafclaw/skills/project/tools.py",
+]
+
+NAMES = {"emit_for_ctx", "_emit_for_ctx"}
+
+# Accepts either spelling of the definition.
+DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+_?emit_for_ctx\b")
+
+# A call-shaped use: the helper name followed by an open paren.
+CALL_RE = re.compile(r"\b_?emit_for_ctx\s*\(")
+
+
+def count_definitions() -> tuple[int, list[str]]:
+    """Count `def _?emit_for_ctx` lines across every .py file under src/decafclaw."""
+    hits = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if DEF_RE.match(line):
+                hits.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+    return len(hits), hits
+
+
+def imports_symbol(text: str) -> bool:
+    """True if an import statement brings emit_for_ctx/_emit_for_ctx into scope.
+
+    Uses ast so parenthesized/multiline imports and `as` aliases are handled, and
+    so a `def` line can never be mistaken for an import.
+    """
+    tree = ast.parse(text)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                if bound in NAMES or alias.name in NAMES:
+                    return True
+    return False
+
+
+def calls_symbol(text: str) -> bool:
+    """True if a non-definition line contains a call-shaped use of the helper."""
+    for line in text.splitlines():
+        if DEF_RE.match(line):
+            continue
+        if CALL_RE.search(line):
+            return True
+    return False
+
+
+def main() -> None:
+    defs_count, def_sites = count_definitions()
+
+    importers = []
+    callers = []
+    for rel in CONSUMERS:
+        # Hardcoded path, no try/except: a rename must raise FileNotFoundError.
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        if imports_symbol(text):
+            importers.append(rel)
+        if calls_symbol(text):
+            callers.append(rel)
+
+    print(f"DEFS = {defs_count} {def_sites}")
+    print(f"IMPORTS = {len(importers)} {importers}")
+    print(f"USES = {len(callers)} {callers}")
+
+    assert defs_count == 1, f"expected 1 definition, found {defs_count}: {def_sites}"
+    assert len(importers) == 4, (
+        f"expected all 4 consumers to import the helper, found {len(importers)}: "
+        f"{importers} (missing: {[c for c in CONSUMERS if c not in importers]})"
+    )
+    assert len(callers) == 4, (
+        f"expected all 4 consumers to still call the helper, found {len(callers)}: "
+        f"{callers} (missing: {[c for c in CONSUMERS if c not in callers]})"
+    )
+
+    print("PASS: one definition, imported and used by all four consumers.")
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/checks.md
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/checks.md
@@ -1,0 +1,155 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/657
+**Frozen at:** `39f5ff5` (2026-07-29)
+**Branch base:** `origin/main` @ `637a8db`
+
+**Check files — read-only from Phase 1 onward:**
+- `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py`
+- `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py`
+- `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py`
+
+The issue states C1's check as a *described* probe ("a stdlib-only static probe that counts …")
+rather than a literal command line, so the probe script had to be authored at freeze. It was
+written by a **check-author subagent** given the criterion text and the loud-fail / host-agnostic
+constraints, and explicitly **not** given any implementation approach — the plan below was written
+after the freeze, for that reason. G2 and G3 are likewise described-not-literal in the issue and
+were authored the same way. G1 and G4 *are* literal commands in the issue and are reproduced here
+byte-identically.
+
+Because `Check files` is non-empty, the real `git diff <freeze-sha> -- <check files>` tamper check
+applies to C1/G2/G3 rather than the command-only substitutes.
+
+---
+
+## C1
+
+CRITERION: The codebase SHALL contain exactly one definition of the `emit_for_ctx` helper, AND each
+of the four consumer modules SHALL obtain it by import rather than by local definition.
+
+CHECK (single exit-coded command, run from the repo root):
+```
+uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py
+```
+a stdlib-only static probe that counts `def _?emit_for_ctx` definitions under `src/decafclaw`,
+counts which of the four named consumers import the symbol, and counts which still call it —
+asserting `DEFS == 1`, `IMPORTS == 4`, `USES == 4`.
+
+AT FREEZE: **fails, for the correct reason** — exit 1, genuine `AssertionError` on the definition
+count, not an import error / typo'd path / missing fixture:
+
+```
+DEFS = 4 ['src/decafclaw/skills/project/tools.py:98', 'src/decafclaw/tools/canvas_tools.py:22',
+          'src/decafclaw/tools/checklist_tools.py:27', 'src/decafclaw/tools/sticky_tools.py:21']
+IMPORTS = 0 []
+USES = 4 [all four consumers]
+AssertionError: expected 1 definition, found 4
+exit=1
+```
+
+This reproduces the issue's `VERIFIED DISCRIMINATING` record exactly (`DEFS = 4`, `IMPORTS = 0 []`,
+`USES = 4`, exit 1), so the gap the issue describes is still present at `637a8db`.
+
+**Teeth, verified at freeze by the check-author:**
+- Adding an import while keeping the local definition leaves `DEFS` at 4; the definition assertion
+  fires first, before `IMPORTS` is consulted. Cannot be satisfied by adding imports on top.
+- Removing all calls from any one consumer drops `USES` to 3 and fails, naming the file.
+- Host-agnostic: `decafclaw.events`, `decafclaw.context`, an aliased import, and a brand-new module
+  all register as imports. No host module name appears in the probe.
+- A `def` line counts as neither an import nor a call, so a local definition cannot masquerade as
+  half-satisfying the criterion.
+
+**Known granularity limit, recorded rather than papered over:** `USES` is a count of *consumers that
+still call*, not of call expressions — which is what the criterion says ("counts which of the four
+named consumers … still call it") and what the triage run's `USES = 4` over four files reports. So
+deleting *one of several* calls inside a file that has others leaves `USES` at 4. C1 is therefore not
+a per-call-site regression guard; **G1 is** — `tests/test_canvas_tools.py` asserts the emit wiring is
+actually awaited. This is the criterion-plus-guard pair the issue says not to freeze one half of.
+
+---
+
+## Guards
+
+Pass today; must keep passing. Not criteria — they can't fail at freeze.
+
+- **G1** (the behavioural pair for C1) — literal command from the issue:
+  `uv run pytest tests/test_canvas_tools.py tests/test_sticky_tools.py tests/test_checklist_tools.py tests/test_project_tools.py -q`
+  Protects the helper's semantics on both branches: `tests/test_canvas_tools.py` asserts
+  `manager_mock.emit.assert_awaited_once()` (manager-present), and `tests/test_project_tools.py`
+  builds its ctx with `manager=None` plus `test_emit_failure_is_fail_open` (None / fail-open).
+  **AT FREEZE: passes — `69 passed in 1.64s`, exit 0.**
+  (Triage observed 67; `origin/main` has advanced to `637a8db` since, adding two. The invariant is
+  "no test lost, newly skipped, or newly failing" — **69 is this run's baseline**, not 67.)
+
+- **G2** (skill-loader import path — the `CLAUDE.md:63` rule):
+  `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py`
+  Execs the project skill's `tools.py` through the real loader (`_import_tools_module` →
+  `spec_from_file_location`, no package context) and confirms the helper resolves *and* behaves on
+  both branches. Catches the specific regression this refactor invites: a **relative** import would
+  satisfy C1 and pass an ordinary package import, but break under the real loader.
+  **AT FREEZE: passes — `loader-path exec OK`, `emit helper present: True ['_emit_for_ctx']`,
+  `helper semantics OK under loader-exec`, exit 0.**
+
+- **G3** (no import cycle):
+  `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py`
+  Imports all four consumers plus `decafclaw.events` and `decafclaw.context` in a fresh interpreter.
+  `events.py` imports nothing from `context`/`tools` today, so hosting the helper there is cycle-free;
+  this pins that.
+  **AT FREEZE: passes — `imports OK, no cycle`, exit 0.**
+
+- **G4** (types/lint on touched files) — literal commands from the issue:
+  `uv run pyright` over the four consumers + `events.py` + `context.py`, and
+  `uv run ruff check src/decafclaw/tools/ src/decafclaw/skills/project/ src/decafclaw/events.py`.
+  Live concern from the issue: the helper's `ctx: "Context"` annotation sits behind `TYPE_CHECKING`,
+  so the shared version must keep its forward ref resolvable from the new host.
+  **AT FREEZE: passes — pyright `0 errors, 0 warnings, 0 informations`; ruff `All checks passed!`.**
+
+- **G5** (full-suite invariant): `make test` — no test lost, newly skipped, or newly failing.
+  The issue marked this **UNRUN** and said not to read it as verified. **It has now been run:**
+  **AT FREEZE: passes — `3608 passed, 2 skipped in 21.40s`.** That is this run's baseline.
+
+---
+
+## Pre-squash tamper verdict
+
+Recorded here because `git reset --soft origin/main` collapses the freeze commit away: afterwards
+`39f5ff5` is a dangling local object, not an ancestor of the branch and absent from `origin`, so
+nobody downstream can re-run the command. **This record is the evidence.**
+
+**Verdict: `clean`** — and clean by the real mechanism, not by substitute. `Check files` is non-empty
+(three authored probe scripts), so the genuine tamper diff applies:
+
+```
+git diff 39f5ff5 -- <the three Check files>   →  empty (0 bytes)
+```
+
+None of `check_c1_emit_for_ctx.py`, `guard_g2_skill_loader.py`, `guard_g3_no_cycle.py` changed after
+the freeze. Independently confirmed by the verifier subagent, which ran the same diff from a fresh
+context.
+
+`git diff 39f5ff5 --stat` — 10 files, all accounted for, **no file under `tests/`**:
+
+| File | Accounted for as |
+|---|---|
+| `src/decafclaw/events.py` | the single new definition (+ its docstring) |
+| `src/decafclaw/tools/{canvas,checklist,sticky}_tools.py` | consumers: local def out, import in, calls renamed |
+| `src/decafclaw/skills/project/tools.py` | same, with the absolute import form |
+| `CLAUDE.md` | key-files line for `events.py` (self-review addition) |
+| `docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md` | the stale "replicate locally" line, annotated superseded |
+| `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/plan.md` | this session's plan — checkboxes ticked from observed output |
+| `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/notes.md` | this session's notes. **Added after the first draft of this table said "9 files"** — the miscount was caught by the post-squash verifier re-run, not by me, and is corrected here rather than left standing. A tamper record that miscounts its own diff is worth less than one that doesn't. |
+| `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/checks.md` | this manifest: the sanctioned `Frozen at` sha append, plus this section. No CRITERION line, CHECK command, or guard command differs from the freeze version. |
+
+**Could the diff satisfy C1 without doing the work?** Assessed by the verifier, since the probe is a
+static text probe and therefore the gameable kind. Answer: **no, concretely not** on this diff. The
+extracted body is the same three statements in the same order as the four removed copies
+(`getattr(ctx, "manager", None)` → `if manager is None: return None` → `return manager.emit`); the
+only changes are the dropped underscore and an added docstring. All 10 call sites remain in the
+`emit=` keyword position they held before — no result discarded, no `emit=` argument dropped or
+replaced with a literal. The theoretical cheap pass (stub helper + unused imports + broken wiring)
+is what G1 and G2 exist to catch, and both ran green **unmodified**.
+
+## Amendments
+
+Append-only. **Empty** — no amendment was made during this run, so the `auto-ok` tier stands
+undowngraded.

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Guard G2 for issue #657 — the skill-loader import path (CLAUDE.md:63 rule).
+
+Execs src/decafclaw/skills/project/tools.py through the SAME loader the real
+skill system uses (`_import_tools_module`, which wraps
+`importlib.util.spec_from_file_location` with no package context) and confirms
+the emit helper resolves in the loaded module's namespace.
+
+Why this guard exists: a *relative* import (`from ..events import emit_for_ctx`)
+would satisfy criterion C1 and would pass an ordinary package import, but raises
+under the real loader because the module has no package context. That regression
+is exactly what this refactor invites.
+
+Exits 0 on success, nonzero via AssertionError otherwise.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from decafclaw.tools.skill_tools import _import_tools_module  # noqa: E402
+
+TOOLS_PATH = REPO_ROOT / "src" / "decafclaw" / "skills" / "project" / "tools.py"
+
+# Hardcoded path, no existence guard: a rename must raise loudly.
+module = _import_tools_module("decafclaw_skill_project", TOOLS_PATH)
+print("loader-path exec OK")
+
+names = [n for n in vars(module) if n.endswith("emit_for_ctx")]
+print(f"emit helper present: {bool(names)} {names}")
+
+assert names, (
+    "no emit_for_ctx helper resolved in the loader-exec'd project skill module; "
+    "a relative import would produce exactly this"
+)
+
+resolved = vars(module)[names[0]]
+assert callable(resolved), f"{names[0]} resolved to a non-callable: {resolved!r}"
+
+# The helper must actually work under the loader-exec'd module, not merely be
+# bound — a name bound to a broken forward ref would still pass the checks above.
+class _NoManager:
+    pass
+
+
+class _WithManager:
+    def __init__(self):
+        self.manager = self
+
+    def emit(self):  # pragma: no cover - identity is all that's checked
+        pass
+
+
+assert resolved(_NoManager()) is None, "expected None when ctx has no manager attribute"
+holder = _WithManager()
+assert resolved(holder) == holder.emit, "expected manager.emit when manager is present"
+print("helper semantics OK under loader-exec (None-branch and manager.emit branch)")
+
+print("PASS: G2 skill-loader import path")
+sys.exit(0)

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Guard G3 for issue #657 — no import cycle.
+
+Imports all four consumer modules plus decafclaw.events in a fresh interpreter.
+`events.py` imports nothing from `context`/`tools` today, so hosting the shared
+helper there is cycle-free; this pins that. If the helper lands somewhere that
+reintroduces the documented `context -> context_composer -> skill modules` cycle,
+one of these imports raises ImportError ("cannot import name ... from partially
+initialized module") and this guard fails.
+
+Exits 0 on success, nonzero on any ImportError.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+MODULES = [
+    "decafclaw.events",
+    "decafclaw.context",
+    "decafclaw.tools.sticky_tools",
+    "decafclaw.tools.canvas_tools",
+    "decafclaw.tools.checklist_tools",
+    "decafclaw.skills.project.tools",
+]
+
+import importlib  # noqa: E402
+
+for name in MODULES:
+    importlib.import_module(name)
+    print(f"  imported {name}")
+
+print("imports OK, no cycle")
+print("PASS: G3 no import cycle")
+sys.exit(0)

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/notes.md
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/notes.md
@@ -1,0 +1,75 @@
+# Session notes — #657 extract `emit_for_ctx`
+
+Run by `agent-session express`, unattended, invoked by the board-driver.
+
+## What happened
+
+Straight run through 2a–2i with no amendment and no tier downgrade. The issue's triage augmentation
+was accurate enough that Phase 0 mostly reproduced its recorded evidence rather than discovering
+anything new: all four `file:line` refs still pointed exactly where they claimed, all four helper
+bodies were still character-identical, and C1's probe failed at freeze with the same
+`AssertionError: expected 1 definition, found 4` the triage run recorded.
+
+Host chosen: `events.py`, the issue's stated preference. It imports nothing from `context` or
+`tools`, so it cannot participate in the `context → context_composer → skill modules` cycle. G3 pins
+that.
+
+## Things worth remembering
+
+- **The issue's two cosmetic miscounts are both harmless, but worth naming.** It calls the helper
+  "3-line" (it's 4 statements, 5 lines with the `def`) and says "11 call sites" while its own
+  enumeration lists 10 (`canvas 4 + sticky 2 + checklist 2 + project 2`). The real count is 10.
+  Triage caught the first and flagged it as cosmetic; it did not catch the second. No criterion
+  depends on either — C1 counts *consumers that call*, not call expressions.
+
+- **The one real defect this session produced was in a docstring I wrote, not in the code.** The
+  first draft justified the `getattr` form by claiming the producers "are also reached with
+  lightweight stand-in ctx objects that carry no `manager` attribute." That is false:
+  `Context.__init__` always sets `self.manager = None` (`context.py:131`) and every production
+  caller passes a real `Context`. The only ctx-likes lacking the attribute are test doubles. I had
+  invented a plausible-sounding production reason for a form I was told to preserve. Caught by the
+  whole-branch self-review (2f), verified by grep before rewriting rather than after.
+
+  Worth generalising: the issue *told* me to preserve `getattr` verbatim and *told* me no test would
+  catch a change. Being handed a "do this, and here's why it matters" instruction is apparently an
+  invitation to write a confident-sounding rationale into a docstring. The instruction was right; my
+  gloss on it was not.
+
+- **C1's granularity limit is real and was recorded rather than smoothed over.** `USES` counts
+  consumers-that-call, not call expressions, so deleting one of several calls inside a file that has
+  others leaves `USES` at 4 and passes. That is faithful to the criterion as written and to the
+  triage-observed `USES = 4` over four files. G1 is the per-call-site guard (`test_canvas_tools.py`
+  asserts `manager_mock.emit.assert_awaited_once()`), which is exactly the criterion-plus-guard pair
+  the issue warned not to freeze half of.
+
+- **G2 earned its place.** It execs the project skill's `tools.py` through the real loader
+  (`_import_tools_module` → `spec_from_file_location`, no package context). A relative import
+  (`from ..events import ...`) would have satisfied C1 *and* passed an ordinary package import while
+  breaking in production. No pre-existing test covers that path — I checked `tests/` for
+  `spec_from_file_location` before authoring it, and the two hits are unrelated.
+
+## Deviations from the plan, and why
+
+- **`CLAUDE.md` was not in the plan's file list.** Added during self-review: the key-files line for
+  `events.py` read only "Pub/sub event bus", which under-describes it in precisely the way that
+  invites the next person to re-replicate the helper — the regression #657 exists to undo. Recorded
+  in its own commit with the reason rather than folded in silently.
+
+- **`HTTP_PORT` was not appended to the worktree's `.env`.** Writes to `.env` are blocked under this
+  run's permission mode. No impact: a pure refactor starts no server. Flagged rather than
+  worked around.
+
+## Board note (not a code issue)
+
+Issue #657 was in **Backlog**, not **Ready**, when the driver handed it over. The driver's contract
+is to pick from Ready. Moved to In progress as setup requires, but the discrepancy is worth a look —
+either the driver's query is wider than Ready, or the issue never got moved after triage.
+
+## For a future session
+
+Nothing deferred and nothing skipped. The stale-doc sweep found only historical dev-session
+transcripts beyond the one line the issue named (`2026-07-23-1545-sticky-widget-slot/plan.md`,
+`2026-04-27-0928-widgets-phase-3-388/plan.md`, `2026-04-27-1615-widgets-phase-4-389/plan.md`,
+and other spots in `2026-07-24-1133-progress-tracker/`), which the issue explicitly says to leave
+alone — they are records of what was decided at the time, and rewriting them would be falsifying
+history rather than fixing drift.

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/plan.md
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/plan.md
@@ -1,0 +1,174 @@
+# Extract the duplicated `_emit_for_ctx` helper — Implementation Plan
+
+**Goal:** Replace four character-identical copies of the `_emit_for_ctx` helper with one shared
+`emit_for_ctx` in `events.py`, imported absolutely by all four consumers.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/657 — **Tier:** `auto-ok`
+(the criterion's oracle is a stdlib static probe that exists and fails today; no touched path is
+auth / secrets / migration / deploy / dependency)
+
+**Approach:** Add `emit_for_ctx` to `src/decafclaw/events.py` — the issue's stated preferred host,
+and the right one on current structure: `events.py` imports nothing from `context` or `tools`, so it
+cannot participate in the documented `context → context_composer → skill modules` cycle. Delete the
+four local definitions and replace each with an absolute import. The 11 call sites keep their exact
+shape; only the name loses its leading underscore.
+
+**Criteria:** C1 — exactly one definition of the helper, obtained by import in all four consumers.
+
+Full text + checks live in `checks.md`. Ids are assigned there and referenced here.
+
+---
+
+## Phase 0: Freeze the acceptance checks — **DONE**
+
+Written before this plan, per `references/frozen-checks.md`, so no check was authored with the
+implementation approach in view.
+
+**Files:**
+- Created: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/checks.md`
+- Created: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py`
+- Created: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py`
+- Created: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py`
+
+**Verification — automated:**
+- [x] C1's check runs and **fails for the expected reason** — exit 1, `AssertionError: expected 1
+      definition, found 4`; matches the issue's recorded discriminating failure exactly
+- [x] Every guard runs and **passes** — G1 `69 passed`, G2 exit 0, G3 exit 0, G4 pyright
+      `0 errors, 0 warnings, 0 informations` + ruff `All checks passed!`, G5 `3608 passed, 2 skipped`
+- [x] Freeze commit made (`39f5ff5`); sha recorded in `checks.md` in follow-up commit `aef51e2`
+
+---
+
+## Phase 1: Extract `emit_for_ctx` into `events.py` and re-point all four consumers
+
+One vertical slice. The issue says explicitly: *"Size XS is right … Do not split."* Splitting the
+host-module addition from the consumer updates would leave an intermediate commit with five
+definitions, which is strictly worse than one atomic move.
+
+**Advances:** C1 (fully).
+
+**Files:**
+- Modify: `src/decafclaw/events.py` — add the public `emit_for_ctx` helper plus the
+  `TYPE_CHECKING`-guarded `Context` import it needs for the forward ref
+- Modify: `src/decafclaw/tools/sticky_tools.py` — delete local def (line 21), add import
+- Modify: `src/decafclaw/tools/canvas_tools.py` — delete local def (line 22), add import
+- Modify: `src/decafclaw/tools/checklist_tools.py` — delete local def (line 27), add import
+- Modify: `src/decafclaw/skills/project/tools.py` — delete local def (line 98), add **absolute**
+  import
+- Modify: `docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md` — line 18 instructs
+  "replicate the 3-line `_emit_for_ctx` locally where needed", which this issue reverses. Annotate
+  it as superseded rather than rewriting history. Other `docs/dev-sessions/**` hits are historical
+  transcripts and are left alone.
+- Test: none added. **TDD opt-out, deliberate:** this is a pure refactor with no behaviour delta —
+  the four bodies are character-identical, so there is no new behaviour to drive out with a test.
+  Coverage already exists on both branches of the helper and is pinned as G1 + G2.
+
+**Key changes:**
+
+In `src/decafclaw/events.py`, appended after `EventBus`:
+
+```python
+def emit_for_ctx(ctx: "Context"):
+    """The manager's emit callable for this ctx, or None when there's no manager.
+
+    Shared by every producer that mirrors state into a UI surface (canvas,
+    sticky slot, checklist, project skill) so the fail-open None case is
+    written once. Kept as `getattr` rather than `ctx.manager` on purpose:
+    the sticky/canvas producers are also called with lightweight stand-in
+    ctx objects that carry no manager attribute at all.
+    """
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit
+```
+
+and the guarded import `events.py` does not currently have:
+
+```python
+if TYPE_CHECKING:
+    from decafclaw.context import Context
+```
+
+Three constraints on that, all from `CLAUDE.md`:
+- The `Context` import **must** stay `TYPE_CHECKING`-guarded. `events.py` is imported by
+  `context.py`, so a runtime import here would create a hard cycle.
+- The annotation **must** stay quoted (`ctx: "Context"`), and `from __future__ import annotations`
+  must **not** be added — the skill loader `exec`s modules without registering them in
+  `sys.modules`, which breaks string-annotation resolution for any `@dataclass` in such a file.
+- The `getattr(..., None)` form is **preserved verbatim**. The issue flags this specifically: every
+  test ctx currently carries a `manager` attribute, so the default is unreachable-by-test
+  defensiveness and "simplifying" it to `ctx.manager` would pass every existing test. Not
+  simplified.
+
+In the three `tools/*.py` consumers, the local def is replaced by a relative-package import beside
+the existing `from .. import …` lines:
+
+```python
+from ..events import emit_for_ctx
+```
+
+In `skills/project/tools.py` the import **must be absolute**, beside the existing
+`from decafclaw import sticky as sticky_mod`:
+
+```python
+from decafclaw.events import emit_for_ctx
+```
+
+The 11 call sites change only by dropping the leading underscore: `_emit_for_ctx(ctx)` →
+`emit_for_ctx(ctx)`. Canvas `44, 59, 70, 85`; sticky `32, 42`; checklist `75, 82`; project
+`148, 159`.
+
+**Verification — automated:**
+- [x] C1's check passes: `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py`
+      → `DEFS = 1 ['src/decafclaw/events.py:43']`, `IMPORTS = 4`, `USES = 4`, exit 0
+- [x] G1 passes: `uv run pytest tests/test_canvas_tools.py tests/test_sticky_tools.py tests/test_checklist_tools.py tests/test_project_tools.py -q`
+      → `69 passed in 1.40s`, exit 0 (same 69 as freeze; none lost, none newly skipped)
+- [x] G2 passes: `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g2_skill_loader.py`
+      → `emit helper present: True ['emit_for_ctx']` (public spelling, resolved through the real
+      loader), `helper semantics OK under loader-exec`, exit 0. This is the guard that would have
+      caught a relative import; the absolute import passes it.
+- [x] G3 passes: `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/guard_g3_no_cycle.py`
+      → all six modules import, `imports OK, no cycle`, exit 0
+- [x] G4 passes: `uv run pyright` over the four consumers + `events.py` + `context.py`
+      → `0 errors, 0 warnings, 0 informations`; and
+      `uv run ruff check src/decafclaw/tools/ src/decafclaw/skills/project/ src/decafclaw/events.py`
+      → `All checks passed!`, exit 0
+- [x] G5 passes: `make test` → `3608 passed, 2 skipped in 17.18s` — byte-identical counts to the
+      freeze baseline
+- [x] `make check` passes — ruff `All checks passed!`, pyright `0 errors`, message-types drift check
+      clean, `tsc --noEmit` clean; ran to completion with no `make: *** Error`
+
+**Verification — manual:**
+- None. C1 is fully mechanical and no criterion is human-judgment, which is why the tier is
+  `auto-ok`. Nothing here needs eyeballing.
+
+---
+
+## Plan self-review
+
+Ran per `phases/plan.md` step 10. Findings, and what was done about them:
+
+1. **Criteria coverage, both directions** — C1 is the only criterion and Phase 1 advances it fully.
+   Phase 1 advances C1, so no phase advances nothing. Phase 0 is the freeze, which the template
+   exempts. **Clean, no fix needed.**
+2. **Checks cited by command** — every automated checkbox in Phase 1 carries the exact command from
+   `checks.md`, not "tests pass". **Clean.**
+3. **Placeholder scan** — no TBD/TODO; the helper body and both import forms are shown literally
+   rather than described. **Clean.**
+4. **Type consistency** — one symbol, one spelling throughout: `emit_for_ctx` (public, no leading
+   underscore) in the definition, in all four imports, and in all 11 call sites. The private
+   `_emit_for_ctx` spelling appears in this plan only when naming what is being *deleted*.
+   **Clean.**
+5. **Fixed inline during self-review:** the first draft named only `events.py` and the four
+   consumers under **Files**, omitting the stale
+   `docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md:18` line that the issue explicitly
+   asks to update in the same pass. Added, with the "annotate as superseded, don't rewrite history"
+   decision recorded — an unannotated historical plan that instructs the opposite of current
+   convention is exactly the doc-drift Copilot catches.
+6. **Scope discipline** — no drive-by cleanup. `events.py` gains one function and one guarded
+   import and nothing else. The 11 call sites change only in the name's leading underscore. No test
+   is added, and the opt-out is stated with its reason rather than left implicit.
+
+No design decision surfaced that the spec doesn't cover, so per `express` this run continues
+without stopping.

--- a/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/spec.md
+++ b/docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/spec.md
@@ -1,0 +1,130 @@
+# Refactor: extract duplicated `_emit_for_ctx` helper
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/657
+
+Captured verbatim from the issue body (marker line stripped). This is an issue augmented in
+place by `agent-session:triage`, not a spec written to the full template — the readiness gate
+applied was the *augmented existing issue* variant.
+
+---
+
+Follow-up from #414 (PR #653).
+
+The 3-line `_emit_for_ctx(ctx)` helper (`getattr(ctx, 'manager', None)` → `manager.emit`) is now duplicated across four modules: `tools/canvas_tools.py`, `tools/sticky_tools.py`, `tools/checklist_tools.py`, and `skills/project/tools.py`. At four copies this is past the extract-at-third-callsite threshold.
+
+Extract to a single shared helper (e.g. `emit_for_ctx` in `events.py` or `context.py`) importable by both tools and skills (skills need an absolute import), and replace the four local copies. Kept local during #414 to avoid editing unrelated `canvas_tools.py`; this issue is the deliberate cleanup pass.
+
+Flagged by both Copilot and the #414 whole-branch review.
+
+---
+
+<!-- Appended by agent-session:triage on 2026-07-29. Author's text above is unchanged. -->
+
+## Verified-false claims
+
+**None — every claim in this issue checks out.** Verified individually at triage:
+
+- All four named paths exist and each holds a definition. **Count is exactly 4**, no fifth site.
+- All four bodies are **character-identical** (confirmed by md5 over the extracted function bodies:
+  `6de7e2806fade2122d6674a3ffc536ba` × 4). This is a true copy-paste duplication, not four
+  near-variants that would need reconciling.
+- "Follow-up from #414 (PR #653)" — PR 653 is MERGED ("feat(widgets): progress_tracker widget +
+  checklist/project auto-emit (#414)"); issue 414 is CLOSED. Correct lineage.
+- "skills need an absolute import" — corroborated by `CLAUDE.md:63` and by the loader at
+  `src/decafclaw/tools/skill_tools.py:110` (`spec_from_file_location` with no package context).
+- Both suggested host modules exist: `src/decafclaw/events.py` (37 lines, `EventBus` only) and
+  `src/decafclaw/context.py`.
+- Cosmetic only: the issue calls it a "3-line helper"; the body is 4 statements (5 lines with the
+  `def`). No criterion depends on this.
+
+**Actual duplicate sites (4 definitions):** `src/decafclaw/tools/sticky_tools.py:21`,
+`src/decafclaw/tools/canvas_tools.py:22`, `src/decafclaw/tools/checklist_tools.py:27`,
+`src/decafclaw/skills/project/tools.py:98`.
+**11 call sites** across those same four files: canvas `44, 59, 70, 85`; sticky `32, 42`; checklist
+`75, 82`; project `148, 159`. No other module in `src/`, `tests/` or `tui/` inlines
+`getattr(ctx, "manager", ...)` — **the four definitions are the complete population.**
+
+## Verifiable acceptance criteria
+
+- CRITERION: The codebase SHALL contain exactly one definition of the `emit_for_ctx` helper, AND each
+  of the four consumer modules SHALL obtain it by import rather than by local definition.
+  CHECK (single exit-coded command, run from the repo root):
+  a stdlib-only static probe that counts `def _?emit_for_ctx` definitions under `src/decafclaw`,
+  counts which of the four named consumers import the symbol, and counts which still call it —
+  asserting `DEFS == 1`, `IMPORTS == 4`, `USES == 4`.
+  VERIFIED DISCRIMINATING: run at triage →
+  `DEFS = 4` (the four sites above), `IMPORTS = 0 []`, `USES = 4`, exit 1
+  (`AssertionError: expected 1 definition, found 4`).
+
+  **Why the criterion is stated this way rather than as a bare count:** it is an invariant over *where
+  the logic lives*, so "touch the count" does not satisfy it — deleting a call site drops `USES` below
+  4 and fails; adding an import while keeping the local definition leaves `DEFS` at 4 and fails.
+  It is also **host-agnostic**: `events.py`, `context.py`, or a new module all pass identically, so
+  that open choice is implementation style and does not affect the tier.
+  **Fail mode is loud, not vacuous:** it reads files by hardcoded path with zero fixture setup, so if
+  a consumer is renamed it raises `FileNotFoundError` rather than passing silently. No
+  `-k`-matches-nothing or uninitialised-registry false green is reachable.
+  The one thing this criterion cannot see is a **wrong body** in the extracted helper — which is
+  exactly what the first guard covers. They are a pair; do not freeze one without the other.
+
+## Regression guards
+
+- GUARD (**the behavioural pair for the criterion**):
+  `uv run pytest tests/test_canvas_tools.py tests/test_sticky_tools.py tests/test_checklist_tools.py tests/test_project_tools.py -q`
+  — protects the helper's semantics on **both** branches. `tests/test_canvas_tools.py:72` asserts
+  `manager_mock.emit.assert_awaited_once()` (manager-present branch genuinely wired), and
+  `tests/test_project_tools.py:37` builds its ctx with `manager=None` plus
+  `TestProgressTrackerEmit::test_emit_failure_is_fail_open` (`:444`) covering the None/fail-open
+  branch. Observed at triage: `67 passed in 2.05s`. Invariant: no test lost, newly skipped, or newly
+  failing.
+- GUARD (**skill-loader import path — the `CLAUDE.md:63` rule**): exec
+  `src/decafclaw/skills/project/tools.py` through `spec_from_file_location` the way the real loader
+  does, and confirm the helper resolves. This protects against the specific regression this refactor
+  invites: **a *relative* import (`from ..events import ...`) would still satisfy the criterion and
+  still pass an ordinary package import, but breaks under the real skill loader.** Observed at triage:
+  `loader-path exec OK; emit helper present: True`.
+- GUARD (**no import cycle**): importing all four consumers plus `decafclaw.events` succeeds.
+  `events.py` currently imports nothing from `context`/`tools`, so hosting the helper there is
+  cycle-free; this pins that. Observed at triage: `imports OK, no cycle`.
+- GUARD (**types/lint on touched files**): `uv run pyright` over the four consumers + `events.py` +
+  `context.py` → observed `0 errors, 0 warnings, 0 informations`; and `uv run ruff check` over
+  `src/decafclaw/tools/`, `src/decafclaw/skills/project/`, `src/decafclaw/events.py` → observed
+  `All checks passed!`. Live concern: the helper's `ctx: "Context"` annotation sits behind
+  `TYPE_CHECKING`, so the shared version must keep its forward ref resolvable from the new host — and
+  HEAD (`28d2f38`) was itself a pyright/ctx fix.
+- GUARD (invariant): full suite — no test lost, newly skipped, or newly failing versus HEAD.
+  **UNRUN (needs a serial full-suite run)** — deliberately not attempted. **Do not read this as verified.**
+
+## Tier: `auto-ok`
+
+Neither trigger fires.
+
+**Trigger 1:** the criterion's oracle is a stdlib-only static probe that exists and runs today; it
+failed today; its cheapest green is the extraction itself; and its answer does not depend on unwritten
+harness state. The one decision the issue leaves open — host module, `events.py` vs `context.py` —
+**does not change which criteria apply**, so it is implementation style, not a withheld goal.
+
+**Trigger 2:** touched paths are `src/decafclaw/tools/` and `src/decafclaw/skills/project/` plus one
+host module. No auth/authorization, no secrets/credentials, no data migration or deletion, no
+deploy/infra/CI config, no dependency change (the helper uses stdlib `getattr` only).
+
+## Notes for the implementer
+
+- **Naming:** the four copies are private (`_emit_for_ctx`); the shared one must be **public**
+  (`emit_for_ctx`) to be imported across packages. The criterion's regex accepts either spelling so it
+  does not over-constrain, but a leading underscore on a cross-module import would trip ruff
+  conventions in review.
+- **Preserve the `getattr` form verbatim.** Every test ctx already carries a `manager` attribute (real
+  `Context` via `tests/conftest.py:33`; the `SimpleNamespace` at `tests/test_project_tools.py:37`), and
+  `Context.__init__` sets `self.manager = None` at `src/decafclaw/context.py:131` — so the
+  `getattr(..., None)` default is currently unreachable-by-test defensiveness. **If it is "simplified"
+  to `ctx.manager`, no existing test would catch the difference.** No check enforces this; it is stated
+  here deliberately.
+- **Preferred host (non-blocking):** `events.py` is the better fit on current structure — already
+  dependency-free, no cycle risk, and `context.py` is what the annotation forward-refs. The criterion
+  passes either way.
+- **Stale doc to update in the same pass:**
+  `docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md:18` explicitly instructs "replicate the
+  3-line `_emit_for_ctx` locally where needed", which this issue reverses. Other `docs/dev-sessions/**`
+  hits are historical plan transcripts and should be left alone.
+- Size XS is right: 4 deletions, 1 addition, 4 import lines, 11 call sites unchanged in shape. Do not split.

--- a/src/decafclaw/events.py
+++ b/src/decafclaw/events.py
@@ -3,7 +3,11 @@
 import asyncio
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -34,3 +38,24 @@ class EventBus:
                     callback(event)
             except Exception:
                 log.exception(f"Subscriber {sub_id} raised an exception")
+
+
+def emit_for_ctx(ctx: "Context"):
+    """The manager's emit callable for this ctx, or None when there's no manager.
+
+    Shared by every producer that mirrors state into a UI surface — the canvas
+    tools, the sticky slot, the checklist loop, and the project skill — so the
+    fail-open "no manager, no emit" case is written once instead of four times.
+
+    ``getattr`` rather than ``ctx.manager``, kept verbatim from the four local
+    copies this replaced (#657). A real ``Context`` always has the attribute
+    (``Context.__init__`` sets ``self.manager = None``), so the default only
+    matters for ctx-*like* objects — which today means test doubles such as the
+    ``SimpleNamespace`` in ``tests/test_project_tools.py``. Tolerating those is
+    the point: narrowing this to ``ctx.manager`` would be a behaviour change
+    that no existing test could catch, so it stays as-is.
+    """
+    manager = getattr(ctx, "manager", None)
+    if manager is None:
+        return None
+    return manager.emit

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from decafclaw import sticky as sticky_mod
+from decafclaw.events import emit_for_ctx
 from decafclaw.media import EndTurnConfirm, ToolResult
 from decafclaw.skills.project.plan_parser import (
     Step,
@@ -95,13 +96,6 @@ def _load_current(ctx: "Context") -> ProjectInfo | ToolResult:
     return _load_or_error(ctx.config, project)
 
 
-def _emit_for_ctx(ctx: "Context"):
-    manager = getattr(ctx, "manager", None)
-    if manager is None:
-        return None
-    return manager.emit
-
-
 def _flatten_leaf_steps(steps: list[Step]) -> list[Step]:
     """Depth-first list of leaf steps (those without children)."""
     out: list[Step] = []
@@ -145,7 +139,7 @@ async def _emit_project_progress(ctx: "Context", info: ProjectInfo) -> None:
         data = _progress_data_from_plan(info, steps)
         result = await sticky_mod.set_sticky(
             ctx.config, ctx.conv_id, "progress_tracker", data,
-            emit=_emit_for_ctx(ctx))
+            emit=emit_for_ctx(ctx))
         if result is not None and not result.ok:
             log.warning("project sticky set failed: %s", result.error)
     except Exception:
@@ -156,7 +150,7 @@ async def _clear_project_progress(ctx: "Context") -> None:
     """Clear the sticky slot for a project. Fail-open."""
     try:
         result = await sticky_mod.clear_sticky(
-            ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx))
+            ctx.config, ctx.conv_id, emit=emit_for_ctx(ctx))
         if result is not None and not result.ok:
             log.warning("project sticky clear failed: %s", result.error)
     except Exception:

--- a/src/decafclaw/tools/canvas_tools.py
+++ b/src/decafclaw/tools/canvas_tools.py
@@ -11,19 +11,13 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from .. import canvas as canvas_mod
+from ..events import emit_for_ctx
 from ..media import ToolResult
 
 if TYPE_CHECKING:
     from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
-
-
-def _emit_for_ctx(ctx: "Context"):
-    manager = getattr(ctx, "manager", None)
-    if manager is None:
-        return None
-    return manager.emit
 
 
 def _canvas_url(conv_id: str, tab_id: str | None = None) -> str:
@@ -41,7 +35,7 @@ async def tool_canvas_new_tab(ctx: "Context",
     log.info("[tool:canvas_new_tab] widget=%s label=%r", widget_type, label)
     result = await canvas_mod.new_tab(
         ctx.config, ctx.conv_id, widget_type, data,
-        label=label, emit=_emit_for_ctx(ctx),
+        label=label, emit=emit_for_ctx(ctx),
     )
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")
@@ -56,7 +50,7 @@ async def tool_canvas_update(ctx: "Context", tab_id: str, data: dict) -> ToolRes
     """Replace data of an existing tab. Preserves widget_type + label."""
     log.info("[tool:canvas_update] tab=%s", tab_id)
     result = await canvas_mod.update_tab(
-        ctx.config, ctx.conv_id, tab_id, data, emit=_emit_for_ctx(ctx),
+        ctx.config, ctx.conv_id, tab_id, data, emit=emit_for_ctx(ctx),
     )
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")
@@ -67,7 +61,7 @@ async def tool_canvas_close_tab(ctx: "Context", tab_id: str) -> ToolResult:
     """Close a single tab by id. If it was active, the panel switches or hides."""
     log.info("[tool:canvas_close_tab] tab=%s", tab_id)
     result = await canvas_mod.close_tab(
-        ctx.config, ctx.conv_id, tab_id, emit=_emit_for_ctx(ctx),
+        ctx.config, ctx.conv_id, tab_id, emit=emit_for_ctx(ctx),
     )
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")
@@ -82,7 +76,7 @@ async def tool_canvas_clear(ctx: "Context") -> ToolResult:
         return ToolResult(text="canvas already empty")
     # Reuse canvas_mod.clear_canvas (existing) — emits kind="clear".
     result = await canvas_mod.clear_canvas(
-        ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx),
+        ctx.config, ctx.conv_id, emit=emit_for_ctx(ctx),
     )
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")

--- a/src/decafclaw/tools/checklist_tools.py
+++ b/src/decafclaw/tools/checklist_tools.py
@@ -16,19 +16,13 @@ from typing import TYPE_CHECKING
 
 from .. import checklist
 from .. import sticky as sticky_mod
+from ..events import emit_for_ctx
 from ..media import ToolResult
 
 if TYPE_CHECKING:
     from decafclaw.context import Context
 
 log = logging.getLogger(__name__)
-
-
-def _emit_for_ctx(ctx: "Context"):
-    manager = getattr(ctx, "manager", None)
-    if manager is None:
-        return None
-    return manager.emit
 
 
 def _progress_data_from_checklist(items: list[dict]) -> dict:
@@ -72,14 +66,14 @@ async def _mirror_to_sticky(ctx: "Context", conv_id: str) -> None:
             checklist.checklist_status, ctx.config, conv_id)
         if not items or all(i["done"] for i in items):
             result = await sticky_mod.clear_sticky(
-                ctx.config, conv_id, emit=_emit_for_ctx(ctx))
+                ctx.config, conv_id, emit=emit_for_ctx(ctx))
             if result is not None and not result.ok:
                 log.warning("checklist sticky clear failed: %s", result.error)
             return
         data = _progress_data_from_checklist(items)
         result = await sticky_mod.set_sticky(
             ctx.config, conv_id, "progress_tracker", data,
-            emit=_emit_for_ctx(ctx))
+            emit=emit_for_ctx(ctx))
         if result is not None and not result.ok:
             log.warning("checklist sticky set failed: %s", result.error)
     except Exception:

--- a/src/decafclaw/tools/sticky_tools.py
+++ b/src/decafclaw/tools/sticky_tools.py
@@ -10,6 +10,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .. import sticky as sticky_mod
+from ..events import emit_for_ctx
 from ..media import ToolResult
 
 if TYPE_CHECKING:
@@ -18,18 +19,11 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-def _emit_for_ctx(ctx: "Context"):
-    manager = getattr(ctx, "manager", None)
-    if manager is None:
-        return None
-    return manager.emit
-
-
 async def tool_widget_pin_sticky(ctx: "Context", widget_type: str, data: dict) -> ToolResult:
     """Pin a widget into the sticky slot above the chat input."""
     log.info("[tool:widget_pin_sticky] widget=%s", widget_type)
     result = await sticky_mod.set_sticky(
-        ctx.config, ctx.conv_id, widget_type, data, emit=_emit_for_ctx(ctx))
+        ctx.config, ctx.conv_id, widget_type, data, emit=emit_for_ctx(ctx))
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")
     return ToolResult(text=result.text)
@@ -39,7 +33,7 @@ async def tool_widget_unpin_sticky(ctx: "Context") -> ToolResult:
     """Clear the sticky slot."""
     log.info("[tool:widget_unpin_sticky]")
     result = await sticky_mod.clear_sticky(
-        ctx.config, ctx.conv_id, emit=_emit_for_ctx(ctx))
+        ctx.config, ctx.conv_id, emit=emit_for_ctx(ctx))
     if not result.ok:
         return ToolResult(text=f"[error: {result.error}]")
     return ToolResult(text=result.text)


### PR DESCRIPTION
## Summary

- Four **character-identical** copies of the private `_emit_for_ctx` helper — in `tools/canvas_tools.py`, `tools/sticky_tools.py`, `tools/checklist_tools.py`, and `skills/project/tools.py` — become one public `emit_for_ctx` in `events.py`, imported by all four consumers.
- The copies were left local during #414 (PR #653) to avoid editing unrelated `canvas_tools.py`. At four copies that's well past the extract-at-third-callsite threshold, and both Copilot and the #414 whole-branch review flagged it. This is the deliberate cleanup pass.

## Design Decisions

**Host is `events.py`, not `context.py`.** `events.py` imports nothing from `context` or `tools`, so it cannot participate in the real `context → context_composer → skill modules` cycle. Guard G3 pins that. The issue left the host open and noted it doesn't affect which criteria apply — C1 is host-agnostic and passes identically for `events.py`, `context.py`, or a new module.

**The `getattr(ctx, "manager", None)` form is preserved verbatim, not narrowed to `ctx.manager`.** A real `Context` always has the attribute (`context.py:131` sets `self.manager = None`), so the default only matters for ctx-*like* objects — today, test doubles such as the `SimpleNamespace` in `tests/test_project_tools.py`. That makes narrowing it a behaviour change **no existing test could catch**, which is exactly why it stays. The issue called this out specifically and no check enforces it.

**The import in the skill is absolute** (`from decafclaw.events import emit_for_ctx`), per the skill-loader rule in CLAUDE.md. This is the regression the refactor most invites: a *relative* import would satisfy C1 **and** pass an ordinary package import while breaking under the real loader. Guard G2 exists solely to catch it, and no pre-existing test covered that path.

## Changes

**Source (5 files):** `events.py` gains the helper plus a `TYPE_CHECKING`-guarded `Context` import (quoted annotation; no `from __future__ import annotations`, per the skill-loader constraint). The four consumers drop their local definition, add the import, and their 10 call sites lose the leading underscore — every one stays in the same `emit=` keyword position.

**Docs (2 files, both in-scope for this issue):**

- `docs/dev-sessions/2026-07-24-1133-progress-tracker/plan.md:18` instructed "replicate the 3-line `_emit_for_ctx` locally where needed" — the exact thing this reverses. Annotated as superseded rather than rewritten; it's a record of what was decided then.
- `CLAUDE.md`'s key-files entry for `events.py` read only "Pub/sub event bus", under-describing it in the way that invites re-replication. Added during self-review, not in the original plan.

**Session docs:** spec / plan / checks / notes plus the three authored check probes.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | exactly one definition of `emit_for_ctx`, obtained by import in all four consumers | `uv run python docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/check_c1_emit_for_ctx.py` | pass — `DEFS=1`, `IMPORTS=4`, `USES=4` |

Failed at freeze with `AssertionError: expected 1 definition, found 4` (`DEFS=4`, `IMPORTS=0`), reproducing the triage-recorded discriminating failure exactly.

**Guards** — all five green, none modified:

| id | guard | result |
|---|---|---|
| G1 | the four consumers' test suites (both helper branches) | pass — 69 passed |
| G2 | skill-loader import path via `spec_from_file_location` | pass — public spelling resolves, semantics OK on both branches |
| G3 | no import cycle across all four consumers + `events`/`context` | pass |
| G4 | pyright + ruff over the touched files | pass — `0 errors`, `All checks passed!` |
| G5 | full suite invariant | pass — `3608 passed, 2 skipped`, identical to baseline |

G5 was marked **UNRUN** in the issue with "do not read this as verified" — it has now been run, at freeze and after.

Verified by an independent verifier subagent (fresh context, `checks.md` and the repo only). Frozen at `39f5ff5`; tamper diff over the frozen check files **empty**, no test file touched.

The verifier also assessed the specific risk that C1 is a static text probe, i.e. the gameable kind: could this diff satisfy the check *without* doing the work? Concretely no — the extracted body is the same three statements in the same order as the four removed copies, and all 10 call sites remain in their `emit=` position with no result discarded. The theoretical cheap pass (stub helper, unused imports, broken wiring) is what G1 and G2 catch, and both ran green unmodified.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass · G3 pass · G4 pass · G5 pass
tamper: clean
freeze: 39f5ff5
project-gates: make check green
ci: not yet graded
threads: not yet queried
risk-paths: none
amendments: none
verdict: pending
reason: CI not settled and review cycle not run; verifier re-run in flight for the squashed head
```

## References

- Spec: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/spec.md`
- Checks: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/checks.md`
- Plan: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/plan.md`
- Notes: `docs/dev-sessions/2026-07-29-1541-657-emit-for-ctx/notes.md`
- Follow-up from #414 (PR #653)
- Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
