### PR TITLE
fix(#729): warn on unrecognized model names instead of silently ignoring

### DIFF
--- a/contrib/skills/blog-ideas/SCHEDULE.md
+++ b/contrib/skills/blog-ideas/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "0 6 * * *"
-model: strong
 required-skills:
   - blog-ideas
   - vault

--- a/contrib/skills/linkding-ingest/SCHEDULE.md
+++ b/contrib/skills/linkding-ingest/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "45 */12 * * *"
-model: default
 required-skills:
   - linkding-ingest
   - tabstack

--- a/contrib/skills/mastodon-ingest/SCHEDULE.md
+++ b/contrib/skills/mastodon-ingest/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "30 */12 * * *"
-model: default
 required-skills:
   - mastodon-ingest
 allowed-tools: shell($SKILL_DIR/fetch.sh*), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, current_time

--- a/contrib/skills/meta-ingest/SCHEDULE.md
+++ b/contrib/skills/meta-ingest/SCHEDULE.md
@@ -1,7 +1,6 @@
 ---
 schedule: "15 */12 * * *"
 enabled: false
-model: default
 required-skills:
   - meta-ingest
   - tabstack

--- a/contrib/skills/rss-ingest/SCHEDULE.md
+++ b/contrib/skills/rss-ingest/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "0 */4 * * *"
-model: default
 required-skills:
   - rss-ingest
 allowed-tools: shell($SKILL_DIR/fetch.sh*), vault_read, vault_write, vault_search, vault_list, vault_backlinks, vault_journal_append, current_time

--- a/docs/model-selection.md
+++ b/docs/model-selection.md
@@ -106,3 +106,12 @@ At the start of each agent turn, the active model is resolved through the provid
 ## Migration from effort levels
 
 The old effort system (`fast`/`default`/`strong`, `set_effort` tool, `!think-harder` commands) has been replaced. If your `config.json` has an `llm` section but no `providers`/`model_configs`, the system auto-generates a "default" openai-compat provider and model config from the old values.
+
+Effort levels are not model names. A leftover `model: strong` in a `SCHEDULE.md` or a forked skill's frontmatter resolves to nothing and the turn runs on `default_model`. This used to be silent; it now warns:
+
+```
+WARNING Unknown model 'strong' requested — falling back to vertex-gemini-flash.
+        Configured model_configs: vertex-gemini-flash, vertex-gemini-pro
+```
+
+Grep your schedules and skill frontmatter for `fast` / `default` / `strong` after upgrading (#729).

--- a/docs/schedules.md
+++ b/docs/schedules.md
@@ -74,7 +74,6 @@ Any skill (bundled, admin-level, or contrib/`extra_skill_paths`) may ship a `SCH
 ```markdown
 ---
 schedule: "0 3 * * *"
-model: strong
 required-skills:
   - vault
 ---
@@ -85,6 +84,8 @@ Review recent journal entries ...
 ```
 
 The three bundled skills `dream`, `garden`, and `newsletter` each ship a `SCHEDULE.md` this way.
+
+**Bundled and contrib SCHEDULE.md do not declare `model`.** Model config names are per-deployment — `vertex-gemini-pro` is a key in one agent's `config.json` and absent from another's — so a shipped skill has no portable name to reference. A task that wants a stronger model than `default_model` gets one through the admin overlay, where the names are known to exist. See [Model selection](#model-selection).
 
 **Contrib default-disable:** Skills discovered from `extra_skill_paths` have their `enabled` flag forced to `false` regardless of what the SCHEDULE.md says. Installing a contrib skill should not silently activate a cron job. Users opt in via the admin overlay (see below).
 
@@ -200,6 +201,15 @@ model: gemini-flash   # use a specific named model config
 
 Omit to use the `default_model` from config. See [Model Selection](model-selection.md).
 
+The value must be a key in `model_configs`. An unrecognized name falls back to `default_model` and logs:
+
+```
+WARNING Unknown model 'strong' requested — falling back to vertex-gemini-flash.
+        Configured model_configs: vertex-gemini-flash, vertex-gemini-pro
+```
+
+Watch for this after upgrading. The old effort levels (`fast` / `default` / `strong`) are not model names and have not been since the effort system was removed — before the warning existed they were accepted and silently discarded (#729).
+
 ### Tool restrictions
 
 Use `allowed-tools` to limit what the task can do:
@@ -307,7 +317,7 @@ Returns all discovered schedules with metadata.
       "enabled": true,
       "schedule": "0 3 * * *",
       "channel": "",
-      "model": "strong",
+      "model": "",
       "allowed_tools": [],
       "required_skills": ["vault"],
       "body": "# Memory Consolidation\n...",

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -467,12 +467,37 @@ async def _setup_turn_state(ctx: "Context", config, history) -> dict[str, str]:
                     ctx.active_model = name
                     break
 
-    # Build model override for the LLM call
+    return _resolve_model_override(ctx, config)
+
+
+def _resolve_model_override(ctx: "Context", config) -> dict[str, str]:
+    """Turn ``ctx.active_model`` into LLM config overrides.
+
+    An ``active_model`` that isn't a key in ``config.model_configs`` warns
+    rather than silently falling back. Model names reach here from several
+    unvalidated sources — a schedule's ``model:`` frontmatter, a forked
+    skill's ``model:``, ``delegate_task``'s ``model`` argument — and a
+    stale one is otherwise indistinguishable from no selection at all
+    (#729: bundled ``dream``/``garden`` carried ``model: strong``, a
+    leftover from the removed effort system, and ran on the default model
+    for months without a single log line saying so).
+    """
     model_override: dict[str, str] = {}
     if ctx.active_model and ctx.active_model in config.model_configs:
         model_override = {"model_name": ctx.active_model}
         log.info("Agent turn: model=%s", ctx.active_model)
-    elif config.default_model:
+        return model_override
+
+    if ctx.active_model:
+        known = ", ".join(sorted(config.model_configs)) or "(none configured)"
+        fallback = config.default_model or config.llm.model
+        log.warning(
+            "Unknown model %r requested — falling back to %s. "
+            "Configured model_configs: %s",
+            ctx.active_model, fallback, known,
+        )
+
+    if config.default_model:
         model_override = {"model_name": config.default_model}
         log.info("Agent turn: model=%s (default)", config.default_model)
     else:

--- a/src/decafclaw/skills/dream/SCHEDULE.md
+++ b/src/decafclaw/skills/dream/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "0 3 * * *"
-model: strong
 required-skills:
   - dream
   - vault

--- a/src/decafclaw/skills/garden/SCHEDULE.md
+++ b/src/decafclaw/skills/garden/SCHEDULE.md
@@ -1,6 +1,5 @@
 ---
 schedule: "0 3 * * 0"
-model: strong
 required-skills:
   - garden
   - vault

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 """Tests for model selection and routing (replaces old effort tests)."""
 
 import dataclasses
+import logging
 
 import pytest
 
@@ -150,3 +151,90 @@ def test_skill_model_default_empty(tmp_path):
     info = parse_skill_md(skill_md)
     assert info is not None
     assert info.model == ""
+
+
+# -- Unrecognized model names (#729) -------------------------------------------
+
+
+def _config_with_models(config):
+    """Config with two named models and a default, for override tests."""
+    return dataclasses.replace(config, providers={
+        "vertex": ProviderConfig(type="vertex", project="test"),
+    }, model_configs={
+        "vertex-gemini-flash": ModelConfig(provider="vertex", model="gemini-2.5-flash"),
+        "vertex-gemini-pro": ModelConfig(provider="vertex", model="gemini-2.5-pro"),
+    }, default_model="vertex-gemini-flash")
+
+
+def test_unrecognized_active_model_warns(ctx, caplog):
+    """An active_model that isn't a model_configs key warns loudly.
+
+    Regression for #729: `model: strong` in a SCHEDULE.md (a leftover from
+    the removed effort system) fell through to the default model with only
+    an INFO line, so bundled `dream`/`garden` ran on Flash for months.
+    """
+    from decafclaw.agent import _resolve_model_override
+
+    config = _config_with_models(ctx.config)
+    ctx.active_model = "strong"
+
+    with caplog.at_level(logging.WARNING, logger="decafclaw.agent"):
+        override = _resolve_model_override(ctx, config)
+
+    assert override == {"model_name": "vertex-gemini-flash"}
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1, f"expected one warning, got {warnings}"
+    msg = warnings[0].getMessage()
+    assert "strong" in msg
+    # The warning must name the fallback and the valid choices, or it's
+    # not actionable from a log line alone.
+    assert "vertex-gemini-flash" in msg
+    assert "vertex-gemini-pro" in msg
+
+
+def test_recognized_active_model_does_not_warn(ctx, caplog):
+    """A valid active_model is used and produces no warning."""
+    from decafclaw.agent import _resolve_model_override
+
+    config = _config_with_models(ctx.config)
+    ctx.active_model = "vertex-gemini-pro"
+
+    with caplog.at_level(logging.WARNING, logger="decafclaw.agent"):
+        override = _resolve_model_override(ctx, config)
+
+    assert override == {"model_name": "vertex-gemini-pro"}
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_empty_active_model_does_not_warn(ctx, caplog):
+    """No active_model is the normal case, not a misconfiguration."""
+    from decafclaw.agent import _resolve_model_override
+
+    config = _config_with_models(ctx.config)
+    ctx.active_model = ""
+
+    with caplog.at_level(logging.WARNING, logger="decafclaw.agent"):
+        override = _resolve_model_override(ctx, config)
+
+    assert override == {"model_name": "vertex-gemini-flash"}
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_no_bundled_schedule_declares_a_stale_model():
+    """Bundled SCHEDULE.md files must not name a model.
+
+    Model config names are per-deployment (`vertex-gemini-pro` exists in one
+    agent's config.json and not another's), so a bundled skill has nothing
+    portable to declare. Upgrading a bundled task's model is an admin-overlay
+    decision. This guards against reintroducing `model: strong`.
+    """
+    from decafclaw.schedules import parse_schedule_file
+    from decafclaw.skills import _BUNDLED_SKILLS_DIR
+
+    offenders = []
+    for sched_md in sorted(_BUNDLED_SKILLS_DIR.glob("*/SCHEDULE.md")):
+        task = parse_schedule_file(sched_md)
+        if task is not None and task.model:
+            offenders.append(f"{sched_md.parent.name}: model={task.model!r}")
+    assert offenders == []


### PR DESCRIPTION
Closes #729.

## The bug

`model:` in schedule frontmatter is silently dropped when the value isn't a key in `config.model_configs`. `agent.py` validated the name and fell through to `default_model` on an INFO line indistinguishable from "no model was requested."

Every bundled and contrib `SCHEDULE.md` in the repo carried such a value — `strong` / `default`, leftovers from the effort system removed some time ago. So no scheduled task has ever honored its `model:` declaration.

Confirmed on the deployment:

```
20:00:10,620  decafclaw.schedules INFO: Schedule 'dream' is due, executing
20:00:10,703  decafclaw.agent     INFO: Agent turn: model=vertex-gemini-flash (default)
```

83ms apart, against a `dream/SCHEDULE.md` declaring `model: strong`. Bundled `dream` (nightly memory consolidation) and `garden` (weekly vault gardening) — the two tasks most obviously wanting a stronger model — have been running on Flash.

## Changes

**Warn on unrecognized names.** Extracted `_resolve_model_override` out of `_setup_turn_state` and added a warning that names both the fallback and the configured choices:

```
WARNING Unknown model 'strong' requested — falling back to vertex-gemini-flash.
        Configured model_configs: vertex-gemini-flash, vertex-gemini-pro
```

This sits at the one chokepoint every unvalidated source flows through — schedule frontmatter, a forked skill's `model:`, `delegate_task`'s `model` argument.

**Dropped the dead `model:` lines** from all seven SCHEDULE.md files. Bundled and contrib skills now ship no `model:` at all, which is a deliberate choice rather than an omission: model config names are per-deployment (`vertex-gemini-pro` is a key in one agent's config.json and absent from another's), so a shipped skill has no portable name to reference. A task that wants a stronger model gets one through the admin overlay, where the names are known to exist. Documented in `schedules.md`.

The alternative — reintroducing a portable `strong_model` / `fast_model` alias layer in config — is noted in #729 and deliberately not taken here; it partly re-treads the ground the effort-system removal cleared.

**Guard test.** `test_no_bundled_schedule_declares_a_stale_model` fails if any bundled SCHEDULE.md reintroduces a `model:` line. Verified it has teeth by re-adding `model: strong` to dream and watching it fail.

**Docs.** `schedules.md` was propagating `model: strong` as the copy-paste example — which is how the value kept getting copied into new skills. `model-selection.md`'s migration section now says explicitly that effort levels are not model names, and shows the warning to grep for after upgrading.

## Verification

- `make check` clean (ruff, pyright 0 errors, tsc)
- `make test` — 3612 passed, 2 skipped (baseline was 3608; +4 new tests)
- Guard test probed by reverting the fix

## Follow-up outside this PR

The deployment's admin overlays (`~/.decafclaw/decafclaw/schedules/`) still say `model: strong` for `blog-ideas`. Those are data-dir files, not repo code — handling separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)