### PR TITLE
fix(#733): coerce vault frontmatter to JSON-safe values at the wire boundary

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -128,6 +128,16 @@ whole block through `yaml.dump`, which alphabetizes keys and drops comments. If
 a page's frontmatter is hand-curated, edit it through the raw editor rather than
 the typed controls.
 
+The parsed `frontmatter` object in a GET or PUT response is JSON-coerced through
+`to_json_safe` before it goes on the wire. Frontmatter is arbitrary user YAML,
+and PyYAML's implicit resolvers produce Python objects JSON has no type for — an
+unquoted `date: 2026-06-22` becomes a `datetime.date`, and one such line used to
+500 the whole page view. So dates and times arrive as ISO strings, `!!set` values
+as arrays, non-string mapping keys as strings, `.nan` / `.inf` as strings, and
+anything more exotic as its `str()`. The coercion is wire-only: `frontmatter_raw`
+and the file on disk keep the original bytes, and a typed-control patch re-dumps
+the native value, so a real date stays unquoted in the page.
+
 ## Tools
 
 The vault skill is **always loaded** — its tools are available in every conversation.

--- a/src/decafclaw/frontmatter.py
+++ b/src/decafclaw/frontmatter.py
@@ -6,7 +6,9 @@ at the start of a markdown file. Pure utility functions, no codebase dependencie
 
 from __future__ import annotations
 
+import datetime
 import logging
+import math
 import re
 
 import yaml
@@ -100,6 +102,44 @@ def parse_frontmatter_block(raw_yaml: str | None) -> tuple[dict, str | None]:
     if not isinstance(parsed, dict):
         return {}, "frontmatter is not a mapping"
     return parsed, None
+
+
+def to_json_safe(value):
+    """Coerce a parsed-YAML value into something ``json.dumps`` will accept.
+
+    Frontmatter is arbitrary user-authored YAML, and PyYAML's implicit
+    resolvers turn ordinary-looking lines into Python objects JSON has no
+    equivalent for. The one that bit us: ``date: 2026-06-22`` resolves to a
+    ``datetime.date``, so a single such line in a vault page made
+    ``GET /api/vault/<page>`` raise ``TypeError`` and 500 — the page simply
+    could not be viewed. Same for ``2026: notes`` (int key), ``!!set``,
+    ``!!binary``, and ``.nan`` / ``.inf`` (Starlette renders with
+    ``allow_nan=False``, so those are a ``ValueError``).
+
+    Coercion belongs here, at the JSON boundary, and NOT in the parser: the
+    write path re-dumps parsed metadata through ``yaml.dump``, which round-trips
+    a real ``date`` back to an unquoted ``2026-06-22``. Stringifying at parse
+    time would instead rewrite the user's file as ``'2026-06-22'`` the first
+    time anyone edited an unrelated field.
+
+    Dates/times become ISO strings, sequences and sets become lists, mapping
+    keys become strings, and anything else unrecognized falls back to ``str()``
+    — lossy, but a readable value beats a dead endpoint.
+    """
+    if isinstance(value, dict):
+        return {str(k): to_json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [to_json_safe(v) for v in value]
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        # json.dumps emits bare NaN/Infinity, which is invalid JSON; Starlette
+        # passes allow_nan=False and raises instead.
+        return value if math.isfinite(value) else str(value)
+    # datetime.datetime is a datetime.date subclass, so this covers both.
+    if isinstance(value, (datetime.date, datetime.time)):
+        return value.isoformat()
+    return str(value)
 
 
 def get_frontmatter_field(metadata: dict, field: str, default=None):

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -22,6 +22,7 @@ from .frontmatter import (
     merge_frontmatter,
     parse_frontmatter_block,
     split_frontmatter,
+    to_json_safe,
 )
 from .mattermost_ui import get_token_registry
 from .schedules import (
@@ -1278,7 +1279,8 @@ async def vault_read(request: Request, username: str) -> JSONResponse:
     payload = {
         "title": resolved.stem,
         "path": str(rel.with_suffix("")),
-        "frontmatter": metadata,
+        # Arbitrary user YAML: dates/sets/NaN would otherwise 500 the render.
+        "frontmatter": to_json_safe(metadata),
         # Always the real bytes: the raw editor has replace semantics, so
         # re-serializing the parsed dict would reorder keys and drop comments
         # the moment anyone opened the panel.
@@ -1497,7 +1499,9 @@ async def vault_write(request: Request, username: str) -> JSONResponse:
     return JSONResponse({
         "ok": True,
         "modified": target.stat().st_mtime,
-        "frontmatter": result_meta,
+        # Coerced for the wire only — `new_raw` above was already written to
+        # disk, so a real date stays unquoted in the user's file.
+        "frontmatter": to_json_safe(result_meta),
         # Returned so the client can reseed its raw editor without a second
         # GET. The metadata paths validate before writing, so they always leave
         # a parseable block — but a body-only write splices an existing block

--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -320,14 +320,18 @@ async def tool_vault_read(ctx: "Context", page: str) -> str | ToolResult:
     # Body intentionally NOT echoed here — it's already in `text` and would
     # double the tool-result token cost. Frontmatter is small and useful for
     # filtering / sorting in scripts.
-    from decafclaw.frontmatter import parse_frontmatter
+    from decafclaw.frontmatter import parse_frontmatter, to_json_safe
     frontmatter, body = parse_frontmatter(content)
     return ToolResult(
         text=content,
         display_short_text=page,
         data={
             "path": page,
-            "frontmatter": frontmatter,
+            # ToolResult.data is json.dumps'd into a fenced block, and a
+            # `date:` line parses to a datetime.date. Without this the whole
+            # data block was dropped with a warning (fail-open in
+            # tool_execution), silently costing the agent its structured view.
+            "frontmatter": to_json_safe(frontmatter),
             "body_size": len(body),
             "body_lines": body.count("\n") + (0 if body.endswith("\n") or not body else 1),
         },

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,5 +1,9 @@
 """Tests for YAML frontmatter parsing and serialization."""
 
+import datetime
+import json
+from pathlib import Path
+
 import pytest
 
 from decafclaw.frontmatter import (
@@ -11,6 +15,7 @@ from decafclaw.frontmatter import (
     parse_frontmatter_block,
     serialize_frontmatter,
     split_frontmatter,
+    to_json_safe,
 )
 
 # -- parse_frontmatter ---------------------------------------------------------
@@ -352,3 +357,63 @@ class TestMergeFrontmatter:
         coerces to None, so the key still ends up present but null."""
         merged = merge_frontmatter({}, {"summary": None}, overwrite=False)
         assert merged == {"summary": None}
+
+
+# -- to_json_safe --------------------------------------------------------------
+
+
+class TestToJsonSafe:
+    """Coercion of parsed-YAML values into shapes ``json.dumps`` accepts.
+
+    PyYAML's implicit resolvers turn ordinary-looking frontmatter into Python
+    objects JSON has no equivalent for; every case below is something a user
+    can write in a vault page without knowing they did anything unusual.
+    """
+
+    def test_plain_scalars_pass_through_unchanged(self):
+        value = {"title": "W26", "importance": 0.7, "n": 3,
+                 "flag": True, "empty": None}
+        assert to_json_safe(value) == value
+
+    def test_date_becomes_iso_string(self):
+        meta, _ = parse_frontmatter("---\ndate: 2026-06-22\n---\nBody\n")
+        assert isinstance(meta["date"], datetime.date)
+        assert to_json_safe(meta) == {"date": "2026-06-22"}
+
+    def test_datetime_becomes_iso_string(self):
+        meta, _ = parse_frontmatter("---\nwhen: 2026-06-22 14:30:00\n---\nB\n")
+        assert to_json_safe(meta)["when"].startswith("2026-06-22T14:30:00")
+
+    def test_nested_dates_in_lists_and_dicts(self):
+        value = {"outer": {"date": datetime.date(2026, 6, 22)},
+                 "seen": [datetime.date(2026, 1, 1), "x"]}
+        assert to_json_safe(value) == {
+            "outer": {"date": "2026-06-22"},
+            "seen": ["2026-01-01", "x"],
+        }
+
+    def test_tuples_and_sets_become_lists(self):
+        assert to_json_safe(("a", "b")) == ["a", "b"]
+        assert to_json_safe({"tags": frozenset(["only"])}) == {"tags": ["only"]}
+
+    def test_non_string_keys_become_strings(self):
+        """`2026: notes` parses to an int key, which JSON objects can't hold."""
+        meta, _ = parse_frontmatter("---\n2026: notes\n---\nBody\n")
+        assert to_json_safe(meta) == {"2026": "notes"}
+
+    def test_nan_and_infinity_become_strings(self):
+        """Starlette renders with allow_nan=False, so these raise ValueError."""
+        out = to_json_safe({"a": float("nan"), "b": float("inf")})
+        assert out == {"a": "nan", "b": "inf"}
+
+    def test_unknown_objects_fall_back_to_str(self):
+        assert to_json_safe({"p": Path("/tmp/x")}) == {"p": "/tmp/x"}
+
+    def test_result_actually_serializes(self):
+        """The whole point: the output survives a real json.dumps."""
+        meta, _ = parse_frontmatter(
+            "---\ndate: 2026-06-22\ntags: [blog]\nimportance: 0.5\n---\nB\n"
+        )
+        with pytest.raises(TypeError):
+            json.dumps(meta)
+        assert json.loads(json.dumps(to_json_safe(meta)))["date"] == "2026-06-22"

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -172,6 +172,67 @@ async def test_vault_read_malformed_frontmatter(client, http_config):
 
 
 @pytest.mark.asyncio
+async def test_vault_read_date_frontmatter_serializes(client, http_config):
+    """An unquoted ISO date must not 500 the read.
+
+    PyYAML resolves `date: 2026-06-22` to a `datetime.date`, which
+    `json.dumps` rejects — so a single such line took down the whole page
+    view with a 500 rather than degrading. Dates come back as ISO strings.
+    """
+    pages_dir = http_config.vault_agent_pages_dir
+    (pages_dir / "Dated.md").write_text(
+        "---\ndate: 2026-06-22\nweek: 2026-W26\ntags:\n- blog\n---\nBody.\n"
+    )
+    resp = await client.get("/api/vault/agent/pages/Dated")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["frontmatter"] == {
+        "date": "2026-06-22",
+        # Not a YAML timestamp, so it was always a plain string.
+        "week": "2026-W26",
+        "tags": ["blog"],
+    }
+    assert data["body"] == "Body.\n"
+    # The raw block is still the real bytes, unquoted, for the raw editor.
+    assert "date: 2026-06-22" in data["frontmatter_raw"]
+
+
+@pytest.mark.asyncio
+async def test_vault_read_nested_date_serializes(client, http_config):
+    """Dates nested under a mapping/sequence are coerced too, not just top level."""
+    pages_dir = http_config.vault_agent_pages_dir
+    (pages_dir / "Nested.md").write_text(
+        "---\nreview:\n  due: 2026-07-01\nseen:\n- 2026-01-01\n---\nBody.\n"
+    )
+    resp = await client.get("/api/vault/agent/pages/Nested")
+    assert resp.status_code == 200
+    assert resp.json()["frontmatter"] == {
+        "review": {"due": "2026-07-01"},
+        "seen": ["2026-01-01"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_vault_write_date_frontmatter_serializes(client, http_config):
+    """The write response echoes frontmatter, so it had the same 500.
+
+    The date must survive in the file unquoted — coercion is a JSON-boundary
+    concern, so it must not leak back into what gets written to disk.
+    """
+    path = http_config.vault_agent_pages_dir / "DatedWrite.md"
+    path.write_text("---\ndate: 2026-06-22\n---\nOld body.\n")
+
+    resp = await client.put(
+        "/api/vault/agent/pages/DatedWrite",
+        json={"frontmatter": {"summary": "A summary."}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["frontmatter"] == {"date": "2026-06-22", "summary": "A summary."}
+    assert "date: 2026-06-22" in path.read_text()
+
+
+@pytest.mark.asyncio
 async def test_vault_read_by_stem(client, http_config):
     """Read a page by stem name (without full path)."""
     pages_dir = http_config.vault_agent_pages_dir

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -132,6 +132,28 @@ class TestVaultRead:
         assert "not found" in result.text
 
     @pytest.mark.asyncio
+    async def test_read_date_frontmatter_survives_json_serialization(
+        self, ctx, vault_dir,
+    ):
+        """`data` is json.dumps'd into a fenced block by tool_execution.
+
+        A `date:` line parses to a datetime.date, which used to make that dump
+        raise — tool_execution catches it, so the agent silently lost the whole
+        structured block instead of crashing. Assert it serializes for real.
+        """
+        import json
+
+        (vault_dir / "Dated.md").write_text(
+            "---\ndate: 2026-06-22\ntags:\n- blog\n---\n# Dated\n\nBody.\n"
+        )
+        result = await tool_vault_read(ctx, "Dated")
+        assert result.data is not None
+        assert json.loads(json.dumps(result.data))["frontmatter"] == {
+            "date": "2026-06-22",
+            "tags": ["blog"],
+        }
+
+    @pytest.mark.asyncio
     async def test_read_in_subdirectory(self, ctx, agent_pages):
         sub = agent_pages / "people"
         sub.mkdir()


### PR DESCRIPTION
Closes #733

## The bug

An unquoted ISO date in a vault page's frontmatter made the page unviewable:

```
GET /api/vault/agent/pages/blog-ideas/2026-W26 HTTP/1.1" 500 Internal Server Error
  File "src/decafclaw/http_server.py", line 1291, in vault_read
    return JSONResponse(payload)
TypeError: Object of type date is not JSON serializable
```

PyYAML's implicit `!!timestamp` resolver turns `date: 2026-06-22` into a `datetime.date`, and `vault_read` hands the parsed metadata dict straight to `JSONResponse`.

## What changed

`to_json_safe` in `frontmatter.py`, applied at every point a parsed metadata dict crosses a JSON boundary:

| Surface | Before |
|---|---|
| `vault_read` (`http_server.py`) | 500, page unviewable — the reported bug |
| `vault_write` (`http_server.py`) | echoes `frontmatter` in its response, so **saving** such a page 500s too |
| `vault_read` tool (`skills/vault/tools.py`) | `ToolResult.data` is `json.dumps`'d by `tool_execution`, which is fail-open — the agent silently lost the entire structured block to a logged warning |

Dates/times become ISO strings, sequences and sets become lists, mapping keys become strings, and anything else unrecognized falls back to `str()`. `.nan` / `.inf` are stringified too, since Starlette renders with `allow_nan=False` and those raise `ValueError` rather than `TypeError`.

## Why the JSON edge and not the parser

Stringifying dates in `parse_frontmatter` would have been a one-line fix that covered every consumer at once, but it has a bad side effect. The typed-control write path re-dumps parsed metadata through `yaml.dump`, which round-trips a real `date` back to an unquoted `2026-06-22`. Coerce at parse time and the first person to edit an unrelated field rewrites their own file as `'2026-06-22'`.

So the coercion is wire-only. `test_vault_write_date_frontmatter_serializes` pins both halves: the response carries `"2026-06-22"`, and the file on disk still says `date: 2026-06-22`.

## Verification

- 13 new tests, all confirmed to have teeth — neutering `to_json_safe` fails every one of them, and the three API tests fail with the exact production `TypeError`.
- `make check` clean (ruff, pyright, tsc).
- `make test`: 3625 passed, 2 skipped.
- `docs/vault.md` gets the wire-contract note in the same PR.

No evals — nothing here is LLM-visible beyond the `vault_read` tool regaining a data block it was already supposed to have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)