### PR TITLE
fix(#727): name only tools the reading phase can dispatch

### DIFF
--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
@@ -158,4 +158,19 @@ per `frozen-checks.md` it costs no tier downgrade:
 
 ## Tamper verdict
 
-(Recorded at `pr.md` step 5.)
+**`clean`** — recorded at `pr.md` step 5, taken against the tree that ships.
+
+- `git diff a985978 -- tests/test_project_tools.py` → **empty.** No frozen check changed since the
+  re-freeze.
+- `git diff eb32b8a -- tests/test_project_tools.py` → non-empty, and every hunk is amendment A1
+  and nothing else. Independently confirmed by the verifier subagent (fresh context, `checks.md`
+  and the repo only): no test deleted or renamed, no assertion weakened, no `skip`/`xfail`
+  introduced, G2–G4 untouched. A1's added `fixture error:` assertions make the check stricter.
+- `Check files` is non-empty, so this is a real `clean`, not `clean-by-substitute`.
+- Both `eb32b8a` and `a985978` are **ancestors of the pushed head** (verified with
+  `git merge-base --is-ancestor`), so a reviewer can re-run either diff rather than trusting this
+  record. The branch was pushed unsquashed for exactly that reason.
+
+**Teeth, verified independently after the amendment:** the amended criteria fail 6-for-6 against
+the pre-fix source (`git checkout eb32b8a -- src/decafclaw/skills/project/`), matching the original
+AT FREEZE set exactly. The replacement oracle is no weaker than the one it replaced.

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
@@ -70,7 +70,50 @@ diff.
 
 (Append-only.)
 
-**None.** One **clarification** was logged — it changes no criterion's verdict at either tree, so
+### PROPOSED — NOT APPROVED, NOT APPLIED. Blocks the run.
+
+**Criteria:** C1 and C2 (both source their site table from `TestPhaseInstructionConsistency._sites`).
+
+**What the check asserts today:** `_sites()` produces `tool_project_switch`'s text **once** — from a
+freshly created, therefore `BRAINSTORMING`, project — and grades that single sample against all six
+`ProjectState` values. Likewise `tool_project_advance`, produced once with
+`target_status="planning"` and graded against all of `TRANSITIONS[EXECUTING]`.
+
+**What the criterion says:** "…naming a `project_*` tool that is not dispatchable in **the phase
+which reads that text**."
+
+**Why the check fails to test the criterion:** the two differ the moment the message becomes
+phase-dependent. The check grades the `BRAINSTORMING` text against the `DONE` tool set — a pairing
+that never occurs at runtime. Measured: an implementation whose every phase emits a hint
+dispatchable in that phase (0 failures under a faithful per-phase grading) is still reported as 4
+failures by the frozen check. A check that fails an implementation satisfying its own criterion is
+the amendment trigger. Consequence: the check permits only `project_status` at the switch site
+(the intersection of all six phase tool sets) and so mandates a phase-*independent* hint.
+
+**Origin:** the check-author's brief asserted "the text is invariant over the switched-to status,
+so you can produce it once" — a true statement about the *pre-fix* code that got encoded into the
+oracle. The brief described the code being replaced instead of the criterion.
+
+**Proposed replacement:** `_sites()` produces switch's and advance's text **per reading phase**
+(set the project's status, then invoke) and grades each against its own phase. C1 and C2 otherwise
+unchanged; sites 1 and 4 unchanged.
+
+**Amendment test, run against both trees** (freeze tree via `git stash push -- src/decafclaw/skills/project/`):
+
+| tree | old wording | new wording |
+|---|---|---|
+| freeze `eb32b8a` | FAIL — 4 pairs | FAIL — identical 4 pairs |
+| current implementation | FAIL — 4 pairs | PASS — 0 |
+
+Same verdict at freeze, differs against the implementation → **amendment**, not clarification.
+
+**Required before applying:** Les's confirmation, and a tier downgrade of this run to
+`needs-review`. Neither has happened, so the check stands unmodified and the run is parked. See
+`notes.md` for the alternative (Option A) that needs no amendment.
+
+---
+
+Otherwise **none**. One **clarification** was logged — it changes no criterion's verdict at either tree, so
 per `frozen-checks.md` it costs no tier downgrade:
 
 - **C1 prose said "all seven `ProjectState` values"; `ProjectState` has six members**

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
@@ -1,0 +1,89 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/727
+**Frozen at:** (recorded in the follow-up commit)
+**Check files — read-only from Phase 1 onward:**
+- `tests/test_project_tools.py`
+
+Note: this file is *both* the check file and guard G1's target. The frozen check is the new
+`TestPhaseInstructionConsistency` class added in the freeze commit; G1 covers the 36 pre-existing
+tests in the same file. The tamper diff runs from the freeze commit forward, so it must be empty —
+the freeze commit already contains the added class.
+
+## C1
+
+CRITERION: The project skill SHALL NOT emit instruction text naming a `project_*` tool that is not
+dispatchable in the phase which reads that text.
+
+CHECK: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool`
+
+AT FREEZE: fails — 6 mismatched (site, phase) pairs, exactly the set the issue enumerates:
+
+```
+_next_execution_step (empty plan)  phase=executing    not-dispatchable=['project_update_plan']
+tool_project_switch                phase=spec_review  not-dispatchable=['project_next_task']
+tool_project_switch                phase=plan_review  not-dispatchable=['project_next_task']
+tool_project_switch                phase=done         not-dispatchable=['project_next_task']
+tool_project_advance               phase=done         not-dispatchable=['project_next_task']
+prompts/plan_no_steps.md           phase=plan_review  not-dispatchable=['project_next_task']
+```
+
+Collected 1 test, 1 failed. Correct reason: the behaviour is genuinely absent, not a setup error.
+
+## C2
+
+CRITERION: Each of the four sites SHALL still name at least one `project_*` tool that **is**
+dispatchable in every phase that reads it.
+
+CHECK: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_every_instruction_names_a_dispatchable_tool`
+
+AT FREEZE: fails — the same 6 (site, phase) pairs have an *empty* intersection between the tokens
+found and `_PHASE_TOOLS[phase]` (each site currently names exactly one tool, and that tool is the
+non-dispatchable one). Collected 1 test, 1 failed. Correct reason.
+
+## Guards
+
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- G1: `uv run pytest tests/test_project_tools.py -q` — invariant: no test lost, newly skipped, or
+  newly failing. **Passed at freeze: 36 passed** (pre-freeze baseline, before the frozen class was
+  added). The issue recorded `34 passed` at triage on 2026-07-29; the file has gained two tests
+  since, which is drift in the file, not a violation of the invariant.
+- G2 (**enforces the spec's design decision**): the deliberate exclusions in `_PHASE_TOOLS` are
+  preserved — `SPEC_REVIEW`, `PLAN_REVIEW` and `DONE` still exclude `project_next_task`, and
+  `EXECUTING` still excludes `project_update_plan`. Blocks the degenerate fix of widening the gates.
+  Passed at freeze (all four exclusions hold — that is why the six mismatches exist).
+- G3: phase gating remains real — no `ProjectState` exposes the entire `TOOLS` registry. Blocks the
+  other degenerate fix, making `_tools_for_phase` return everything. Passed at freeze.
+- G4: `TRANSITIONS` (`skills/project/state.py`) is unchanged —
+  `EXECUTING → {DONE, PLANNING, BRAINSTORMING}`. Altering the state machine to dodge the `DONE`
+  case would satisfy the criteria for the wrong reason. Passed at freeze.
+- G5 (invariant): full suite green. **Passed at freeze: 3675 passed, 2 skipped** — the issue left
+  this UNRUN; it was run at session setup on the worktree baseline and again at the freeze.
+
+G2, G3 and G4 are executable as pytest nodes in the same frozen class
+(`test_guard_phase_tools_exclusions_preserved`, `test_guard_phase_gating_remains_real`,
+`test_guard_transitions_unchanged`) so the verifier can run each by name rather than eyeballing a
+diff.
+
+## Amendments
+
+(Append-only.)
+
+**None.** One **clarification** was logged — it changes no criterion's verdict at either tree, so
+per `frozen-checks.md` it costs no tier downgrade:
+
+- **C1 prose said "all seven `ProjectState` values"; `ProjectState` has six members**
+  (`BRAINSTORMING`, `SPEC_REVIEW`, `PLANNING`, `PLAN_REVIEW`, `EXECUTING`, `DONE`). The runnable
+  reading is "every `ProjectState` value", which is what the check does. The "seven" reading is not
+  runnable at all — there is no seventh member to iterate — so no verdict can differ at the freeze
+  tree or the implementation tree. Verified: iterating all six values reproduces exactly the 6
+  mismatches the issue's own table predicts, so the criterion's intent and its arithmetic disagree
+  only in the count, not in the result. (`_PHASE_TOOLS` does have seven keys — the six states plus
+  `None` for "no current project" — which is the likely origin of the miscount. `None` is correctly
+  excluded from `project_switch`'s reader set: a switch always leaves a current project selected,
+  so the next turn is never the `None` phase.)
+
+## Tamper verdict
+
+(Recorded at `pr.md` step 5.)

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
@@ -1,7 +1,7 @@
 # Frozen acceptance checks
 
 **Source:** https://github.com/lmorchard/decafclaw/issues/727
-**Frozen at:** (recorded in the follow-up commit)
+**Frozen at:** `eb32b8a` (2026-08-01)
 **Check files — read-only from Phase 1 onward:**
 - `tests/test_project_tools.py`
 

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md
@@ -1,7 +1,9 @@
 # Frozen acceptance checks
 
 **Source:** https://github.com/lmorchard/decafclaw/issues/727
-**Frozen at:** `eb32b8a` (2026-08-01)
+**Frozen at:** `eb32b8a` (2026-08-01) — **re-frozen at `a985978` (2026-08-02) after amendment A1.**
+Tamper diffs run from the re-freeze sha; `eb32b8a` remains the original baseline and is still an
+ancestor of the branch, so both are re-runnable by a reviewer.
 **Check files — read-only from Phase 1 onward:**
 - `tests/test_project_tools.py`
 
@@ -29,6 +31,9 @@ prompts/plan_no_steps.md           phase=plan_review  not-dispatchable=['project
 ```
 
 Collected 1 test, 1 failed. Correct reason: the behaviour is genuinely absent, not a setup error.
+
+**Post-amendment (A1):** the amended check reproduces the same 6 failures at the freeze tree, so
+the recorded AT FREEZE evidence above still stands as written.
 
 ## C2
 
@@ -70,7 +75,7 @@ diff.
 
 (Append-only.)
 
-### PROPOSED — NOT APPROVED, NOT APPLIED. Blocks the run.
+### A1 — APPROVED BY LES 2026-08-02 · APPLIED
 
 **Criteria:** C1 and C2 (both source their site table from `TestPhaseInstructionConsistency._sites`).
 
@@ -107,9 +112,33 @@ unchanged; sites 1 and 4 unchanged.
 
 Same verdict at freeze, differs against the implementation → **amendment**, not clarification.
 
-**Required before applying:** Les's confirmation, and a tier downgrade of this run to
-`needs-review`. Neither has happened, so the check stands unmodified and the run is parked. See
-`notes.md` for the alternative (Option A) that needs no amendment.
+**Approval:** Les chose Option B (the phase-aware hint) and approved this amendment on
+2026-08-02. The approval lifted the read-only rule for `tests/test_project_tools.py` and for this
+change only; every other frozen artifact stayed read-only.
+
+**Applied:** `_sites()` now returns one `(label, text, phase)` triple per reading phase, producing
+switch's and advance's text with the project actually in that phase (asserted, so the fixture
+cannot silently miss). C1 and C2 lost their inner phase loop and otherwise read the same. Sites 1
+and 4 are unchanged in substance.
+
+**Teeth re-verified after amending** — the replacement must not be weaker than what it replaced.
+Ran the amended class against the freeze-tree source (`git checkout eb32b8a -- src/decafclaw/skills/project/`,
+restored from `HEAD` after):
+
+| | at freeze `eb32b8a` | against implementation |
+|---|---|---|
+| C1 amended | **FAIL — 6 pairs** (the full original set, incl. sites 1 and 4) | PASS |
+| C2 amended | **FAIL — 6 pairs** (same) | PASS |
+
+So the amended oracle discriminates *identically* to the original at the freeze tree — 6 for 6 —
+and additionally grades the pairing that actually occurs at runtime. It is strictly no weaker.
+
+**Re-frozen at:** `a985978` (2026-08-02). Tamper diffs for `tests/test_project_tools.py` run from
+this sha, not from `eb32b8a`.
+
+**Tier consequence:** this run is downgraded to `needs-review`, per `frozen-checks.md`. An amended
+oracle was not authored independently before implementation, so it no longer supports an
+autonomous merge — regardless of how green the checks are.
 
 ---
 

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/notes.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/notes.md
@@ -1,0 +1,126 @@
+# Session notes — #727 phase-consistent project-skill instructions
+
+**Status: PARKED at 2c/execute, pending one decision from Les.** No PR opened. The branch and
+worktree are intact and either resolution resumes cheaply from here.
+
+## What happened
+
+Phases 0 (freeze) and the plan completed cleanly. Implementation fixed 2 of the 4 sites outright.
+The other 2 hit a **frozen check that fails an implementation which satisfies its own criterion** —
+the amendment trigger in `frozen-checks.md`. That is a mandatory stop at either tier.
+
+## The defect in the frozen check
+
+The check-author subagent was briefed (by me) with this sentence about `tool_project_switch`:
+
+> "The text is invariant over the switched-to status, so you can produce it once and evaluate it
+> against every `ProjectState`."
+
+That is a true statement about the **buggy** code, and I put it in the brief. The check-author
+faithfully encoded it: `_sites()` produces switch's text **once** (from a freshly-created,
+therefore `BRAINSTORMING`, project) and grades that single sample against all six phases. Same for
+`tool_project_advance`, produced once with `target_status="planning"`.
+
+So the oracle inherited an implementation detail of the pre-fix code. It now asserts something
+stronger than, and different from, the criterion: *one fixed string must be safe in every reading
+phase*, rather than *the string emitted for phase P must be safe in P*.
+
+This is the failure mode `frozen-checks.md` warns about from the other direction — not a weakened
+oracle, but one that was over-fitted to current behaviour at authoring time. Worth remembering: a
+check-author brief should describe the *criterion*, never the shape of the code being replaced.
+
+## Consequence — the check permits only one implementation
+
+Measured (`/tmp/probe727b.py`), the intersection of tool sets across every reading phase:
+
+- **switch** (readable in all 6 phases) — the frozen check permits only **`project_status`**
+- **advance** (readable in `{brainstorming, done, planning}`) — permits only
+  `project_note` / `project_status`
+
+So the frozen check mandates a phase-*independent* hint at both sites, and forbids a phase-*aware*
+one, even though the phase-aware one is strictly more accurate.
+
+## Amendment test — run, not reasoned
+
+`/tmp/probe727c.py` implements both wordings and was run against both trees (freeze tree reached
+via `git stash push -- src/decafclaw/skills/project/`, restored with `git stash pop`).
+
+- **OLD wording** = produce the text once, grade against every reading phase
+- **NEW wording** = produce the text for each reading phase, grade each against its own phase
+
+| tree | OLD | NEW |
+|---|---|---|
+| freeze `eb32b8a` | FAIL — 4 pairs | FAIL — identical 4 pairs |
+| current implementation | FAIL — 4 pairs | **PASS** — 0 |
+
+Verdict **same at freeze**, **differs against the implementation** → the bottom-left cell of
+`frozen-checks.md`'s four-cell table → **amendment**, not clarification. Amendments require human
+confirmation regardless of tier and downgrade the run to `needs-review`.
+
+## The decision Les needs to make
+
+Two honest implementations exist. Neither weakens anything; they differ in quality and in cost.
+
+**Option A — phase-independent hint. No amendment. Stays `auto-ok`.**
+Make switch and advance both emit `Call project_status …`. Passes the frozen check as written,
+ships today, tier unchanged. Cost: an agent switching into a `BRAINSTORMING` / `PLANNING` /
+`EXECUTING` project is told to call `project_status` where `project_next_task` was both correct
+*and* the more useful instruction. It trades a mild regression in the three common paths for
+correctness in the three broken ones. Not degenerate — `project_status` is real, dispatchable, and
+gives a next action.
+
+**Option B — phase-aware hint. Needs the amendment; downgrades this run to `needs-review`.**
+Already implemented and in the working tree. A `_next_action_hint(phase)` helper reads
+`_PHASE_TOOLS` and returns the best tool that phase can actually dispatch, so every phase gets the
+most useful accurate instruction (`project_next_task` where available, `project_status` +
+`project_task_done` in review phases, `project_status` in `DONE`). Verified: all six phases emit a
+hint dispatchable in their own phase. Cost: `_sites()` in the frozen test must be amended to
+produce each phase's own text, plus Les's confirmation and the tier downgrade.
+
+My read, for what it's worth: **B is the better code and A is the cheaper path.** I did not pick,
+because the spec pinned only "fix the messages, don't widen the gates" and said "exact wording is
+the implementer's" solely about the `_next_execution_step` site — it never delegated whether
+switch/advance become phase-aware, and choosing B unattended would mean editing the oracle to fit
+my own implementation, which is the exact thing the freeze exists to prevent.
+
+## Current state of the tree
+
+Committed: freeze (`eb32b8a`), freeze-sha + plan (`f847d56`). The implementation is committed on
+the branch as work-in-progress so nothing is lost under either option.
+
+- `_next_execution_step` empty-plan branch → now routes to `project_advance` (dispatchable in
+  `EXECUTING`). **Fixed, graded correctly by the frozen check, passing.**
+- `prompts/plan_no_steps.md` → now names `project_update_plan` + `project_task_done`, both
+  dispatchable in `PLANNING` *and* `PLAN_REVIEW`. **Fixed, graded correctly, passing.**
+- `tool_project_switch`, `tool_project_advance` → phase-aware via `_next_action_hint` (Option B).
+  Correct per the criterion; rejected by the frozen check as written.
+
+Verification at the parked state:
+
+- C1 `test_no_instruction_names_undispatchable_tool` — **fail**, 4 pairs (down from 6 at freeze).
+  All 4 are the switch/advance mis-grading described above.
+- C2 `test_every_instruction_names_a_dispatchable_tool` — **fail**, same 4.
+- Guards G2/G3/G4 — `3 passed`.
+- G1 `uv run pytest tests/test_project_tools.py -q` — `2 failed, 39 passed`; no pre-existing test
+  lost, skipped, or newly failing (the 2 failures are the frozen criteria themselves).
+- `make check` — green (0 errors, 0 warnings; JS clean).
+- Phase 2 (docs) — **not started.** `docs/project-skill.md:52-67` lists all twelve tools flatly
+  with no mention that the set is phase-gated; the planned subsection is still owed and its wording
+  depends on which option ships.
+
+## Resuming
+
+- **If A:** replace `_next_action_hint` calls at the two sites with fixed `project_status` text (or
+  drop the helper), run the two criteria nodes, do Phase 2, then `pr`. Tier stays `auto-ok`.
+- **If B:** amend `_sites()` in `tests/test_project_tools.py` so switch/advance text is produced
+  per reading phase; log the amendment in `checks.md`; re-freeze that file; set tier
+  `needs-review (downgraded: C1/C2 check amended)`; do Phase 2, then `pr`.
+
+## Carried forward (not acted on — out of scope)
+
+- The spec recorded `34 passed` for `tests/test_project_tools.py` at triage (2026-07-29); the file
+  was at **36** at session start. Drift in the file, not a guard violation, but the guard's recorded
+  baseline is worth re-reading rather than trusting.
+- The spec's C1 says "all seven `ProjectState` values"; there are **six**. Logged as a clarification
+  in `checks.md` (no verdict change at either tree, so no tier cost). `_PHASE_TOOLS` has seven keys
+  — the six states plus `None` — which is the likely origin of the miscount.

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/notes.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/notes.md
@@ -1,7 +1,46 @@
 # Session notes — #727 phase-consistent project-skill instructions
 
-**Status: PARKED at 2c/execute, pending one decision from Les.** No PR opened. The branch and
-worktree are intact and either resolution resumes cheaply from here.
+**Status: RESUMED and completed.** Les chose **Option B** (the phase-aware hint) on 2026-08-02 and
+approved amendment A1. The run continued from 2c through the merge gate. Tier is now
+`needs-review` — the amendment's cost, not a reassessment of risk.
+
+The parked analysis below is kept verbatim as the record of why the stop happened; read it as
+history, not as current state. What changed after the approval:
+
+- `_sites()` amended to return one `(label, text, phase)` triple per reading phase, producing
+  switch's and advance's text with the project actually in that phase (asserted, so the fixture
+  can't silently miss the branch). C1/C2 lost their inner phase loop.
+- **Teeth re-verified before trusting the green:** ran the amended class against the freeze-tree
+  source (`git checkout eb32b8a -- src/decafclaw/skills/project/`). It fails there with **6** pairs
+  — the full original set — so the replacement discriminates identically to what it replaced and is
+  strictly no weaker. A replacement that had gone green at freeze would have been a defanged guard.
+- Re-frozen at `a985978`. Tier set to `needs-review` in `spec.md` (one `## Tier:` heading).
+- Phase 2 done: `docs/project-skill.md` gained a "Phase-gated tool exposure" subsection.
+
+### Incident during the resume — read this before probing again
+
+The first teeth probe was run as `git stash push -- src/decafclaw/skills/project/` followed by
+`git stash pop`. **The implementation was already committed**, so the push had nothing to save and
+created no stash entry. The pop therefore applied — and dropped — a *pre-existing, unrelated* stash
+from another session (`On 419-sticky-widget-slot`, touching `http_server.py` and
+`websocket-client.js`), silently mixing another session's WIP into this worktree. The probe result
+was also meaningless, since it ran against the committed implementation rather than the freeze tree.
+
+Recovered: the dropped stash was re-attached with `git stash store 850ca62` (it is back on the
+stack, now at `stash@{0}`; note the *ordering* changed relative to the other stash), and the two
+foreign files were reverted with `git restore` after confirming the working-tree diff matched the
+stash exactly and that no legitimate uncommitted work existed in them.
+
+Two lessons, both worth carrying:
+
+1. **`git stash push -- <path>` is silently a no-op when that path is clean, and the paired `pop`
+   then targets whatever unrelated stash is on top.** Never pair a conditional push with an
+   unconditional pop. Check `git stash list` before and after, or don't use the stash stack for
+   probes at all.
+2. **To probe "does this check still fail against the old code?", check out the old code
+   explicitly** — `git checkout <freeze-sha> -- <paths>`, then `git checkout HEAD -- <paths>`. It
+   is unambiguous, it can't touch a shared stack, and it is safe precisely when the paths have no
+   uncommitted changes (verify that first).
 
 ## What happened
 

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/plan.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/plan.md
@@ -3,8 +3,10 @@
 **Goal:** Make every instruction the project skill emits name only tools the reading phase can
 actually dispatch, while still naming a real next action.
 
-**Source issue:** https://github.com/lmorchard/decafclaw/issues/727 — **Tier:** `auto-ok`
-(both criteria are concrete-example assertions over pure in-process data; no risk-gated path)
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/727 — **Tier:** `needs-review`
+(filed `auto-ok`; downgraded 2026-08-02 when amendment A1 to the C1/C2 check was approved and
+applied — see `checks.md`. The work's risk profile is unchanged; the downgrade is the amendment's
+cost.)
 
 **Approach:** Fix the four instruction sites, do **not** widen `_PHASE_TOOLS`. Two sites
 (`tool_project_switch`, `tool_project_advance`) currently emit an unconditional
@@ -70,7 +72,7 @@ def _next_action_hint(phase: ProjectState) -> str:
     if "project_next_task" in names:
         return "Call project_next_task."
     if "project_task_done" in names:
-        return "Call project_task_done when the review is complete, or project_status to review."
+        return "Call project_status to review, then project_task_done when it looks right."
     if "project_status" in names:
         return "Call project_status to see where the project stands."
     return "Call project_list to see available projects."
@@ -136,17 +138,17 @@ Site-by-site:
    non-empty in both.
 
 **Verification — automated:**
-- [ ] C1's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool`
-- [ ] C2's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_every_instruction_names_a_dispatchable_tool`
-- [ ] G1: `uv run pytest tests/test_project_tools.py -q` — no test lost, newly skipped, or newly
+- [x] C1's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool`
+- [x] C2's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_every_instruction_names_a_dispatchable_tool`
+- [x] G1: `uv run pytest tests/test_project_tools.py -q` — no test lost, newly skipped, or newly
       failing (41 nodes: 36 pre-existing + 5 frozen)
-- [ ] G2/G3/G4: `uv run pytest tests/test_project_tools.py -q -k "guard_"` → 3 passed
-- [ ] G5: `make test` — full suite green, no regression
-- [ ] `make check` passes (lint + pyright + JS)
+- [x] G2/G3/G4: `uv run pytest tests/test_project_tools.py -q -k "guard_"` → 3 passed
+- [x] G5: `make test` — full suite green, no regression
+- [x] `make check` passes (lint + pyright + JS)
 
 **Verification — manual:**
-- None. Both criteria are mechanical; the tier is `auto-ok` precisely because no human judgment
-  is involved.
+- None. Both criteria are mechanical — no human judgment is involved in grading them. (The
+  `needs-review` tier comes from amendment A1, not from any criterion needing a human eye.)
 
 ---
 
@@ -175,8 +177,8 @@ to `TestPhaseInstructionConsistency` as the enforcing test and a note that a new
 must be added to that test's table.
 
 **Verification — automated:**
-- [ ] `make check` passes
-- [ ] No claim in the subsection contradicts `_PHASE_TOOLS` — cross-read against
+- [x] `make check` passes
+- [x] No claim in the subsection contradicts `_PHASE_TOOLS` — cross-read against
       `tools.py:825-848`
 
 ---

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/plan.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/plan.md
@@ -1,0 +1,190 @@
+# Phase-consistent project-skill instructions — Implementation Plan
+
+**Goal:** Make every instruction the project skill emits name only tools the reading phase can
+actually dispatch, while still naming a real next action.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/727 — **Tier:** `auto-ok`
+(both criteria are concrete-example assertions over pure in-process data; no risk-gated path)
+
+**Approach:** Fix the four instruction sites, do **not** widen `_PHASE_TOOLS`. Two sites
+(`tool_project_switch`, `tool_project_advance`) currently emit an unconditional
+`Call project_next_task.` while the *reading* phase varies — make each one phase-aware. One site
+(`_next_execution_step`) names a tool `EXECUTING` does not have — route the agent to
+`project_advance` back to `PLANNING`, which is dispatchable there. One prompt file
+(`plan_no_steps.md`) is read in both `PLANNING` and `PLAN_REVIEW` — name a tool dispatchable in both.
+
+**Criteria:** C1 no instruction names an undispatchable `project_*` tool · C2 every instruction still
+names at least one dispatchable one.
+
+Full text + checks live in `checks.md`. Ids are assigned there.
+
+---
+
+## Phase 0: Freeze the acceptance checks — DONE
+
+Written and committed as `eb32b8a`. No implementation in it.
+
+**Files:**
+- Created: `docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md`
+- Modified: `tests/test_project_tools.py` — added `TestPhaseInstructionConsistency`
+  (2 criteria nodes + 3 guard nodes)
+
+**Verification — automated:**
+- [x] C1 fails for the expected reason — 6 mismatched (site, phase) pairs, pytest exit 1
+      (not 5), from a real assertion over invoked code
+- [x] C2 fails for the expected reason — same 6 pairs, empty intersection, exit 1
+- [x] Guards pass: `uv run pytest tests/test_project_tools.py -q -k "guard_"` → 3 passed
+- [x] G1 pre-freeze baseline: `uv run pytest tests/test_project_tools.py -q` → 36 passed
+- [x] G5: `make test` → 3675 passed, 2 skipped
+- [x] Freeze commit made (`eb32b8a`); sha recorded in `checks.md` in this follow-up commit
+
+---
+
+## Phase 1: Make the four instruction sites phase-accurate
+
+One vertical slice — the four sites are the same defect and share one oracle, and splitting them
+would leave C1 and C2 red at every intermediate commit without buying independent value.
+
+**Advances:** C1, C2 (both fully)
+
+**Files:**
+- Modify: `src/decafclaw/skills/project/tools.py` — `_next_execution_step`,
+  `tool_project_switch`, `tool_project_advance`
+- Modify: `src/decafclaw/skills/project/prompts/plan_no_steps.md` — the one prompt template
+- **Read-only (frozen):** `tests/test_project_tools.py` — a failing node here means the
+  implementation is wrong, never the check
+
+**Key changes:**
+
+A shared helper, so the four sites derive the instruction from `_PHASE_TOOLS` rather than
+each hardcoding a guess. Placed next to `_PHASE_TOOLS` (below it, since it reads it):
+
+```python
+def _next_action_hint(phase: ProjectState) -> str:
+    """Name a tool the given phase can actually dispatch.
+
+    Instruction text is read on the *next* turn, when the phase's tool set is what
+    `get_tools` returns for `phase` — so a hardcoded tool name goes stale silently (#727).
+    """
+    names = _PHASE_TOOLS.get(phase, [])
+    if "project_next_task" in names:
+        return "Call project_next_task."
+    if "project_task_done" in names:
+        return "Call project_task_done when the review is complete, or project_status to review."
+    if "project_status" in names:
+        return "Call project_status to see where the project stands."
+    return "Call project_list to see available projects."
+```
+
+The ladder is ordered by usefulness, and every rung is checked against `_PHASE_TOOLS` at call
+time, so the helper cannot name a tool the phase lacks. `DONE` has no `project_next_task` and no
+`project_task_done`, so it lands on `project_status` — accurate, and meaningful for a finished
+project.
+
+Site-by-site:
+
+1. **`tool_project_switch`** — the switched-to project's own status governs the next turn, and
+   `info.status` is in hand:
+
+   ```python
+   return (
+       f"Switched to project '{info.slug}' ({info.status.value}). "
+       f"{_next_action_hint(info.status)}"
+   )
+   ```
+
+2. **`tool_project_advance`** — `target` is the phase that reads the message:
+
+   ```python
+   return f"Project reverted to {target.value}. {_next_action_hint(target)}"
+   ```
+
+   Note `EXECUTING → DONE` is a permitted (forward) transition, which is the case that fails
+   today. `_next_action_hint(DONE)` resolves to `project_status`.
+
+3. **`_next_execution_step`**, empty/missing-plan branch — the reading phase is always
+   `EXECUTING`, which has no plan-writing tool at all. Route to the recovery that *is*
+   dispatchable there, per the spec's second design decision:
+
+   ```python
+   if not content.strip():
+       return (
+           "No plan found — the plan file is empty or missing. "
+           "Call project_advance with target_status='planning' to go back and rewrite it."
+       )
+   ```
+
+   `project_advance` is in `_PHASE_TOOLS[EXECUTING]`, so C1 and C2 both clear here.
+
+4. **`prompts/plan_no_steps.md`** — read in both `PLANNING` and `PLAN_REVIEW`. `project_next_task`
+   is in `PLANNING` only; `project_update_plan` and `project_task_done` are in **both**. The
+   template is static text with no phase in scope, so it must name a tool dispatchable in both:
+
+   ```markdown
+   The plan was written but has no parseable steps.
+
+   Rewrite it with project_update_plan using checkbox format:
+   ```
+   - [ ] 1. First step
+   - [ ] 2. Second step
+   ```
+
+   Then call project_task_done to submit it for review.
+   ```
+
+   Both named tools are in `PLANNING` and `PLAN_REVIEW`, so C1 holds and C2's intersection is
+   non-empty in both.
+
+**Verification — automated:**
+- [ ] C1's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool`
+- [ ] C2's check passes: `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_every_instruction_names_a_dispatchable_tool`
+- [ ] G1: `uv run pytest tests/test_project_tools.py -q` — no test lost, newly skipped, or newly
+      failing (41 nodes: 36 pre-existing + 5 frozen)
+- [ ] G2/G3/G4: `uv run pytest tests/test_project_tools.py -q -k "guard_"` → 3 passed
+- [ ] G5: `make test` — full suite green, no regression
+- [ ] `make check` passes (lint + pyright + JS)
+
+**Verification — manual:**
+- None. Both criteria are mechanical; the tier is `auto-ok` precisely because no human judgment
+  is involved.
+
+---
+
+## Phase 2: Document the phase-gated tool set
+
+`docs/project-skill.md:52-67` lists all twelve tools in one flat table with no indication that the
+set is **per-phase** — which is the fact this whole issue turns on. Close that gap and record the
+invariant the frozen test now enforces.
+
+**Advances:** neither C1 nor C2 — resolved deliberately rather than left ambiguous. The plan
+template asks whether a phase advancing no criterion is scope creep or a missing criterion; it is
+neither here. It is the repo's own docs convention (`CLAUDE.md`: "When changing a feature: update
+its `docs/` page **as part of the same PR**, not a follow-up"), which applies to every PR
+regardless of criteria. Scope is bounded to the phase-gating fact and the instruction invariant —
+no rewrite of the page.
+
+**Files:**
+- Modify: `docs/project-skill.md` — add a short "Phase-gated tool exposure" subsection after the
+  Tools table
+
+**Key changes:** a subsection stating that `get_tools` recomputes the dispatchable set each turn
+from the project's saved status via `_PHASE_TOOLS`, that review phases deliberately withhold
+`project_next_task` and `EXECUTING` deliberately withholds `project_update_plan`, and that
+instruction text must therefore name only tools the *reading* phase can dispatch — with a pointer
+to `TestPhaseInstructionConsistency` as the enforcing test and a note that a new instruction site
+must be added to that test's table.
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] No claim in the subsection contradicts `_PHASE_TOOLS` — cross-read against
+      `tools.py:825-848`
+
+---
+
+## Notes on scope
+
+- **No widening of `_PHASE_TOOLS`.** Pinned by the spec's design decision and enforced by guard G2.
+- **`SKILL.md:37`'s mention of `project_update_plan`** stays as-is — always-loaded context is
+  phase-independent, explicitly out of scope.
+- **No control-flow analysis.** The site→phase mapping is a hand-maintained table in the test, the
+  sanctioned approach per the issue.

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/spec.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/spec.md
@@ -1,0 +1,143 @@
+# project skill instructs the agent to call tools its phase does not expose
+
+**Goal:** Stop the project skill telling the agent to call tools that its current phase does not expose.
+Six instructions across four sites name a tool that is not dispatchable on the turn that reads them,
+leaving the agent at a dead end.
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/727 — surfaced by agent-session:triage while
+scanning #525 (2026-07-29). #525 was closed as stale — its own failure signatures no longer reproduce —
+but this defect is real, independent of it, and deterministic. Filed separately so it isn't lost on a
+closed issue. Plausibly a contributor to the `project_next_task` thrash that #525's eval was actually
+catching.
+
+## Current state
+
+The project skill exposes a different tool set per phase. `_PHASE_TOOLS`
+(`src/decafclaw/skills/project/tools.py:815-838`) maps each `ProjectState` to its allowed tool names;
+`_tools_for_phase` (`:841`) filters, and `get_tools` (`:849`) is the dynamic provider that recomputes the
+set each turn from the project's saved status.
+
+Separately, several tools return **instruction text naming the next tool to call.** Nothing checks those
+names against the phase that will read them, and **six do not match.** Verified by probe, 2026-07-29:
+
+| Site | Phase(s) reading it | Names | Dispatchable there? |
+|---|---|---|---|
+| `tools.py:352` `_next_execution_step` | `EXECUTING` | `project_update_plan` | **no** |
+| `tools.py:424` `tool_project_switch` | `SPEC_REVIEW`, `PLAN_REVIEW`, `DONE` | `project_next_task` | **no** (3 phases) |
+| `tools.py:620` `tool_project_advance` | `DONE` | `project_next_task` | **no** |
+| `prompts/plan_no_steps.md` | `PLAN_REVIEW` | `project_next_task` | **no** |
+
+Probe output for the first one, which is the clearest:
+
+```
+returned: 'No plan found. Use project_update_plan to write one.'
+phase=executing  names=['project_update_plan']  NOT-DISPATCHABLE=['project_update_plan']
+```
+
+Why each is reachable:
+
+- **`_next_execution_step`** — a project in `EXECUTING` whose plan file is empty or missing. `EXECUTING`
+  is normally entered from `PLAN_REVIEW` approval, which requires a non-empty plan with ≥1 step, so this
+  is reached when the plan file is edited or removed on disk afterwards. These are user-facing files, so
+  that is an ordinary situation, not a contrived one. The agent is then told to write a plan with a tool
+  it cannot call, and `EXECUTING` offers no plan-writing tool at all.
+- **`tool_project_switch`** — returns `"Switched to project 'x' (<status>). Call project_next_task."`
+  **unconditionally**, while the switched-to project's own phase governs the next turn.
+  `SPEC_REVIEW`, `PLAN_REVIEW` and `DONE` all lack `project_next_task`.
+- **`tool_project_advance`** — returns `"Project reverted to <target>. Call project_next_task."`
+  unconditionally. `project_advance` is `EXECUTING`-only, and `TRANSITIONS`
+  (`skills/project/state.py`) permits `EXECUTING → {DONE, PLANNING, BRAINSTORMING}`. `PLANNING` and
+  `BRAINSTORMING` are fine; **`DONE` is not.**
+- **`prompts/plan_no_steps.md`** — returned from the `PLANNING`/`PLAN_REVIEW` branch of
+  `project_task_done` (`tools.py:302`) *before* any status change, so the phase on the next turn is
+  whatever it already was. In `PLANNING` it is fine; in `PLAN_REVIEW` it is not.
+
+Related but out of scope: `SKILL.md:37` names `project_update_plan` in always-loaded context, which is
+phase-independent by nature.
+
+## Design decisions
+
+- **Decision: fix the instructions, do not widen the phase gates.**
+  - **Why:** the gating is deliberate — review phases intentionally restrict to approve / revise / status,
+    and `project_next_task` in `DONE` is meaningless. The defect is that the *messages* are wrong, not
+    that the gates are.
+  - **Rejected:** adding `project_next_task` to `SPEC_REVIEW`/`PLAN_REVIEW`/`DONE` and
+    `project_update_plan` to `EXECUTING`. That would also satisfy the criteria below, which is why this
+    is pinned here rather than left open — it would let the agent skip review phases, a change to the
+    workflow's strictness rather than a bug fix.
+  - The guards below enforce this decision mechanically, so the choice cannot silently drift.
+- **Decision: `EXECUTING` with an empty plan should route the agent somewhere real** rather than name a
+  plan-writing tool. `project_advance` back to `PLANNING` is dispatchable in `EXECUTING` and is the
+  natural recovery. Exact wording is the implementer's.
+
+## Verifiable acceptance criteria
+
+- CRITERION: The project skill SHALL NOT emit instruction text naming a `project_*` tool that is not
+  dispatchable in the phase which reads that text.
+  CHECK: a pytest node — e.g.
+  `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool`
+  — that, for each of the four sites above, extracts every `\bproject_[a-z_]+\b` token from the emitted
+  text and asserts it is a member of `_PHASE_TOOLS[phase]` for every phase that can read it (including,
+  for `project_switch`, all seven `ProjectState` values, and for `project_advance`, each valid
+  `TRANSITIONS[EXECUTING]` target).
+  VERIFIED DISCRIMINATING: **6 mismatches today**, enumerated in the table above, produced by a probe run
+  at triage. Fails now; passes only when every instruction is accurate.
+
+- CRITERION: Each of the four sites SHALL still name at least one `project_*` tool that **is**
+  dispatchable in every phase that reads it.
+  CHECK: the same node, asserting a non-empty intersection between the tokens found and
+  `_PHASE_TOOLS[phase]`.
+  VERIFIED DISCRIMINATING: fails today at the same four sites (each currently names exactly one tool, and
+  that tool is the non-dispatchable one — so the intersection is empty).
+  **Why this second criterion exists:** without it, the cheapest way to make the first one green is to
+  **delete the tool name from the message**, which removes the misdirection but strands the agent with no
+  next action. The pair forces an accurate instruction rather than a silent one.
+
+## Regression guards
+
+Pass today; must keep passing.
+
+- GUARD: `uv run pytest tests/test_project_tools.py -q` — invariant: no test lost, newly skipped, or
+  newly failing. Observed at triage: `34 passed in 1.69s`.
+- GUARD (**enforces the design decision above**): the deliberate exclusions in `_PHASE_TOOLS` are
+  preserved — `SPEC_REVIEW`, `PLAN_REVIEW` and `DONE` still exclude `project_next_task`, and `EXECUTING`
+  still excludes `project_update_plan`. This is the guard that matters: **it blocks the degenerate fix of
+  widening the gates until the mismatch disappears.** All four exclusions hold today (that is precisely
+  why the six mismatches exist).
+- GUARD: phase gating remains real — no `ProjectState` exposes the entire `TOOLS` registry. Blocks the
+  other degenerate fix, making `_tools_for_phase` return everything.
+- GUARD: `TRANSITIONS` (`skills/project/state.py`) is unchanged — the criterion's phase-reachability
+  reasoning for `project_advance` depends on `EXECUTING → {DONE, PLANNING, BRAINSTORMING}`. Altering the
+  state machine to dodge the `DONE` case would satisfy the criteria for the wrong reason.
+- GUARD (invariant): full suite green. **UNRUN (needs a serial run)** — not verified here.
+
+## Tier: `auto-ok`
+
+Neither trigger fires.
+
+**Trigger 1:** both criteria are concrete-example assertions over pure, in-process data — `_PHASE_TOOLS`,
+`TRANSITIONS`, a prompt file, and three string literals. The oracle exists today
+(`tests/test_project_tools.py`, 34 passing, with the `ctx`/`SimpleNamespace` fixture pattern at `:37`), the
+checks were **run at triage and produced 6 concrete failures**, and neither is satisfiable without the
+work — the first rules out inaccurate instructions, the second rules out deleting them. No human judgment
+is involved: what counts as "dispatchable" is `_PHASE_TOOLS` membership, not taste. **Not
+harness-dependent** — nothing reads `load_config()`, a live registry, the network, or the developer's
+`data/` directory; the probe that produced the six failures used only imports and a tmp path.
+
+**Trigger 2:** no risk-gated path — `src/decafclaw/skills/project/` application code plus one prompt
+template. No auth/authorization, secrets, data migration or deletion, deploy/infra/CI config, or
+dependency change.
+
+The one open implementation choice (fix messages vs. widen gates) is **pinned by the design decision
+above and enforced by a guard**, so it is not a withheld decision that changes which criteria apply.
+
+## What we're NOT doing
+
+- **Widening `_PHASE_TOOLS`** — see the design decision; a guard blocks it.
+- **`SKILL.md:37`'s mention of `project_update_plan`** — always-loaded context is phase-independent, so it
+  is not part of this invariant.
+- **Making the check fully automatic via control-flow analysis.** The prompt-site → phase mapping is
+  derived by reading the code and is encoded as a table in the test. A general analysis would be fragile
+  and is not worth it for four sites; if a fifth is added, the test should be extended along with it.
+- Re-litigating #525's eval flakiness. That issue is closed; this is the deterministic defect that was
+  found underneath it.

--- a/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/spec.md
+++ b/docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/spec.md
@@ -111,7 +111,16 @@ Pass today; must keep passing.
   state machine to dodge the `DONE` case would satisfy the criteria for the wrong reason.
 - GUARD (invariant): full suite green. **UNRUN (needs a serial run)** — not verified here.
 
-## Tier: `auto-ok`
+## Tier: needs-review
+
+**Downgraded — C1/C2 check amended.** Filed as `auto-ok`; downgraded during execution on
+2026-08-02 when amendment A1 (see `checks.md`) was approved and applied. An amended oracle was not
+authored independently before implementation, so per `frozen-checks.md` it no longer supports an
+autonomous merge, however green the checks are. The original derivation is preserved below, and
+neither of its two triggers fired — the downgrade comes from the amendment alone, not from a
+reassessment of the work's risk.
+
+### Original derivation at intake (`auto-ok`)
 
 Neither trigger fires.
 

--- a/docs/project-skill.md
+++ b/docs/project-skill.md
@@ -66,6 +66,34 @@ While a project is in the `executing` phase, `project_next_task`, `project_updat
 | `project_add_steps` | Insert new steps into the plan |
 | `project_note` | Append a timestamped note |
 
+### Phase-gated tool exposure
+
+The table above is the full registry, but the agent never sees all of it at once. `get_tools`
+(the skill's dynamic provider) recomputes the dispatchable set **every turn** from the current
+project's saved status, filtering through `_PHASE_TOOLS` in `skills/project/tools.py`. With no
+current project selected, only `project_create` / `project_list` / `project_switch` are offered.
+
+The exclusions are deliberate, not incidental:
+
+- The **review phases** (`spec_review`, `plan_review`) withhold `project_next_task`, so the agent
+  can only approve, revise, or check status — it cannot skip the review by asking for the next task.
+- **`executing`** withholds `project_update_plan`: the plan is settled by the time execution starts,
+  and reshaping it mid-flight is what `project_advance` back to `planning` is for.
+- **`done`** withholds both, keeping a finished project read-only apart from notes and switching.
+
+**Instruction text must name only tools the *reading* phase can dispatch.** Several tools return
+text telling the agent what to call next, and that text is read on the *following* turn — when the
+available tools are whatever `get_tools` returns for the phase in effect *then*. A hardcoded tool
+name therefore goes stale silently and dead-ends the agent, which is what [#727](https://github.com/lmorchard/decafclaw/issues/727)
+fixed at four sites. Where the reading phase is known at emit time (`project_switch` knows the
+switched-to project's status; `project_advance` knows its target), derive the hint from
+`_PHASE_TOOLS` via `_next_action_hint` rather than hardcoding. Where it isn't — a static prompt
+template read from more than one phase — name a tool dispatchable in *all* of them.
+
+`TestPhaseInstructionConsistency` in `tests/test_project_tools.py` enforces this. It carries a
+hand-maintained table of (instruction site → the phases that read it); **a new instruction site
+must be added to that table**, or it goes ungraded.
+
 ## User commands
 
 - `!project` / `/project` — list or show status

--- a/src/decafclaw/skills/project/prompts/plan_no_steps.md
+++ b/src/decafclaw/skills/project/prompts/plan_no_steps.md
@@ -1,9 +1,9 @@
 The plan was written but has no parseable steps.
 
-Rewrite it using checkbox format:
+Rewrite it with project_update_plan using checkbox format:
 ```
 - [ ] 1. First step
 - [ ] 2. Second step
 ```
 
-Then call project_next_task.
+Then call project_task_done to submit it for review.

--- a/src/decafclaw/skills/project/prompts/plan_no_steps.md
+++ b/src/decafclaw/skills/project/prompts/plan_no_steps.md
@@ -6,4 +6,4 @@ Rewrite it with project_update_plan using checkbox format:
 - [ ] 2. Second step
 ```
 
-Then call project_task_done to submit it for review.
+project_update_plan submits the rewritten plan for review on its own — nothing else to call.

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -350,7 +350,12 @@ def _next_execution_step(info: ProjectInfo) -> str:
     """Build the next-step instruction for execution phase."""
     content = info.plan_path.read_text() if info.plan_path.exists() else ""
     if not content.strip():
-        return "No plan found. Use project_update_plan to write one."
+        # EXECUTING has no plan-writing tool at all, so don't name one (#727).
+        # project_advance back to PLANNING is the recovery available here.
+        return (
+            "No plan found — the plan file is empty or missing. Call project_advance "
+            "with target_status='planning' to go back and rewrite it."
+        )
 
     _, steps, _ = parse_plan(content)
     done, total = plan_progress(steps)
@@ -431,7 +436,12 @@ async def tool_project_switch(ctx: "Context", project: str) -> str | ToolResult:
             await _clear_project_progress(ctx)
 
     _set_current_project(ctx, info.slug)
-    return f"Switched to project '{info.slug}' ({info.status.value}). Call project_next_task."
+    # The switched-to project's own phase governs the next turn, so the hint
+    # has to come from that phase rather than being fixed text (#727).
+    return (
+        f"Switched to project '{info.slug}' ({info.status.value}). "
+        f"{_next_action_hint(info.status)}"
+    )
 
 
 async def tool_project_update_spec(ctx: "Context", spec_text: str) -> str | ToolResult:
@@ -627,7 +637,9 @@ async def tool_project_advance(ctx: "Context", target_status: str = "") -> str |
     save_project(info)
     if was_executing and target != ProjectState.EXECUTING:
         await _clear_project_progress(ctx)
-    return f"Project reverted to {target.value}. Call project_next_task."
+    # `target` is the phase that reads this message next turn. EXECUTING -> DONE is a
+    # permitted transition and DONE has no project_next_task, so derive the hint (#727).
+    return f"Project reverted to {target.value}. {_next_action_hint(target)}"
 
 
 async def tool_project_note(ctx: "Context", note_text: str) -> str | ToolResult:
@@ -846,6 +858,24 @@ _PHASE_TOOLS: dict[ProjectState | None, list[str]] = {
         "project_status", "project_list", "project_switch", "project_note",
     ],
 }
+
+
+def _next_action_hint(phase: ProjectState) -> str:
+    """Name a tool the given phase can actually dispatch.
+
+    Instruction text is read on the *next* turn, when the available tools are whatever
+    `get_tools` returns for `phase` — so a hardcoded tool name goes stale silently and
+    strands the agent at a dead end (#727). Every rung of this ladder is checked against
+    `_PHASE_TOOLS`, so the hint cannot name a tool the phase lacks.
+    """
+    names = _PHASE_TOOLS.get(phase, [])
+    if "project_next_task" in names:
+        return "Call project_next_task."
+    if "project_task_done" in names:
+        return "Call project_status to review, then project_task_done when it looks right."
+    if "project_status" in names:
+        return "Call project_status to see where the project stands."
+    return "Call project_list to see available projects."
 
 
 def _tools_for_phase(phase: ProjectState | None) -> tuple[dict, list]:

--- a/src/decafclaw/skills/project/tools.py
+++ b/src/decafclaw/skills/project/tools.py
@@ -860,22 +860,33 @@ _PHASE_TOOLS: dict[ProjectState | None, list[str]] = {
 }
 
 
+# Most-useful-first. Every entry is checked against the phase's own tool list before
+# being offered, so no rung can name a tool the reading phase lacks.
+_NEXT_ACTION_HINTS: list[tuple[str, str]] = [
+    ("project_next_task", "Call project_next_task."),
+    ("project_task_done",
+     "Call project_status to review, then project_task_done when it looks right."),
+    ("project_status", "Call project_status to see where the project stands."),
+    ("project_list", "Call project_list to see available projects."),
+]
+
+
 def _next_action_hint(phase: ProjectState) -> str:
     """Name a tool the given phase can actually dispatch.
 
     Instruction text is read on the *next* turn, when the available tools are whatever
     `get_tools` returns for `phase` — so a hardcoded tool name goes stale silently and
-    strands the agent at a dead end (#727). Every rung of this ladder is checked against
-    `_PHASE_TOOLS`, so the hint cannot name a tool the phase lacks.
+    strands the agent at a dead end (#727).
+
+    Falls through to naming no tool rather than guessing: every phase currently offers
+    `project_status`, so that is unreachable today, but a future phase that offered none
+    of these should surface as a caught test failure, not as another wrong instruction.
     """
     names = _PHASE_TOOLS.get(phase, [])
-    if "project_next_task" in names:
-        return "Call project_next_task."
-    if "project_task_done" in names:
-        return "Call project_status to review, then project_task_done when it looks right."
-    if "project_status" in names:
-        return "Call project_status to see where the project stands."
-    return "Call project_list to see available projects."
+    for tool, hint in _NEXT_ACTION_HINTS:
+        if tool in names:
+            return hint
+    return "No further project tools are available in this phase."
 
 
 def _tools_for_phase(phase: ProjectState | None) -> tuple[dict, list]:

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -11,6 +11,7 @@ from decafclaw.skills.project.state import (
     ProjectInfo,
     ProjectState,
     load_project,
+    save_project,
 )
 from decafclaw.skills.project.tools import (
     _PHASE_TOOLS,
@@ -537,14 +538,22 @@ class TestPhaseInstructionConsistency:
     """
 
     @staticmethod
-    async def _sites(ctx) -> list[tuple[str, str, list[ProjectState]]]:
-        """Build the (label, emitted text, phases that read it) table.
+    async def _sites(ctx) -> list[tuple[str, str, ProjectState]]:
+        """Build the (label, emitted text, the phase that reads it) table.
+
+        One entry per (site, reading phase) pair. Where a site's text varies
+        with the reading phase, the text is produced *for that phase* — grading
+        the text emitted for one phase against a different phase's tool set
+        describes a pairing that never occurs at runtime (see the amendment
+        logged in the session's checks.md).
 
         A general control-flow analysis is out of scope for #727; new
         instruction sites get appended to this table by hand.
         """
+        sites: list[tuple[str, str, ProjectState]] = []
+
         # 1. _next_execution_step, empty/missing-plan branch. Only EXECUTING
-        #    reaches it.
+        #    reaches it, and the text does not vary.
         no_plan_info = ProjectInfo(
             slug="pic-no-plan",
             description="Project whose plan file is missing",
@@ -557,58 +566,71 @@ class TestPhaseInstructionConsistency:
         assert not no_plan_info.plan_path.exists(), (
             "fixture error: this ProjectInfo must hit the missing-plan branch"
         )
-        no_plan_text = _next_execution_step(no_plan_info)
+        sites.append(
+            ("_next_execution_step", _next_execution_step(no_plan_info),
+             ProjectState.EXECUTING)
+        )
 
         # 2. tool_project_switch. The switched-to project's own status governs
-        #    the next turn, so any phase can read this text. The text does not
-        #    vary with that status, so produce it once.
-        await tool_project_create(ctx, "Switch target", slug="pic-switch")
-        switch_text = _text(await tool_project_switch(ctx, project="pic-switch"))
+        #    the next turn, so produce the text once per phase, with the target
+        #    project actually in that phase.
+        for i, phase in enumerate(ProjectState):
+            slug = f"pic-switch-{i}"
+            await tool_project_create(ctx, f"Switch target {i}", slug=slug)
+            info = load_project(ctx.config, slug)
+            assert info is not None, f"fixture error: {slug} did not persist"
+            info.status = phase
+            save_project(info)
+            text = _text(await tool_project_switch(ctx, project=slug))
+            assert phase.value in text, (
+                f"fixture error: switch text for {slug} does not report "
+                f"'{phase.value}' — the project was not in that phase"
+            )
+            sites.append(("tool_project_switch", text, phase))
 
         # 3. tool_project_advance success. The target phase reads it on the next
-        #    turn. The message is invariant over which target it names, so
-        #    produce it once and grade it against every state reachable from
-        #    EXECUTING — including the forward transition to DONE.
-        await _advance_to_executing(ctx, slug="pic-advance")
-        advance_text = _text(
-            await tool_project_advance(ctx, target_status="planning")
-        )
+        #    turn, so produce the text once per reachable target — including the
+        #    forward transition to DONE, which is the case #727 was filed for.
+        for i, target in enumerate(
+            sorted(TRANSITIONS[ProjectState.EXECUTING], key=lambda s: s.value)
+        ):
+            slug = f"pic-advance-{i}"
+            await tool_project_create(ctx, f"Advance source {i}", slug=slug)
+            info = load_project(ctx.config, slug)
+            assert info is not None, f"fixture error: {slug} did not persist"
+            info.status = ProjectState.EXECUTING
+            save_project(info)
+            await tool_project_switch(ctx, project=slug)
+            text = _text(await tool_project_advance(ctx, target_status=target.value))
+            assert target.value in text, (
+                f"fixture error: advance to '{target.value}' did not succeed; "
+                f"got {text!r}"
+            )
+            sites.append(("tool_project_advance", text, target))
 
         # 4. plan_no_steps.md. Returned from the PLANNING/PLAN_REVIEW branch of
         #    project_task_done before any status change, so the reading phase is
-        #    whichever of the two it already was.
+        #    whichever of the two it already was. Static file, same text for both.
         no_steps_text = _load_prompt("plan_no_steps")
+        for phase in (ProjectState.PLANNING, ProjectState.PLAN_REVIEW):
+            sites.append(("plan_no_steps", no_steps_text, phase))
 
-        return [
-            ("_next_execution_step", no_plan_text, [ProjectState.EXECUTING]),
-            ("tool_project_switch", switch_text, list(ProjectState)),
-            (
-                "tool_project_advance",
-                advance_text,
-                sorted(TRANSITIONS[ProjectState.EXECUTING], key=lambda s: s.value),
-            ),
-            (
-                "plan_no_steps",
-                no_steps_text,
-                [ProjectState.PLANNING, ProjectState.PLAN_REVIEW],
-            ),
-        ]
+        return sites
 
     @pytest.mark.asyncio
     async def test_no_instruction_names_undispatchable_tool(self, ctx):
         """C1: no instruction names a tool the reading phase cannot dispatch."""
         problems = []
-        for label, text, phases in await self._sites(ctx):
+        for label, text, phase in await self._sites(ctx):
             named = set(_PROJECT_TOOL_RE.findall(text))
-            for phase in phases:
-                dispatchable = set(_PHASE_TOOLS[phase])
-                undispatchable = sorted(named - dispatchable)
-                if undispatchable:
-                    problems.append(
-                        f"{label} → phase '{phase.value}' names "
-                        f"{', '.join(undispatchable)}; dispatchable there: "
-                        f"{', '.join(sorted(dispatchable))}"
-                    )
+            dispatchable = set(_PHASE_TOOLS[phase])
+            undispatchable = sorted(named - dispatchable)
+            if undispatchable:
+                problems.append(
+                    f"{label} → phase '{phase.value}' names "
+                    f"{', '.join(undispatchable)}; dispatchable there: "
+                    f"{', '.join(sorted(dispatchable))}"
+                )
         assert not problems, (
             f"{len(problems)} instruction/phase mismatch(es):\n  "
             + "\n  ".join(problems)
@@ -618,17 +640,16 @@ class TestPhaseInstructionConsistency:
     async def test_every_instruction_names_a_dispatchable_tool(self, ctx):
         """C2: every instruction still points at a usable next action."""
         problems = []
-        for label, text, phases in await self._sites(ctx):
+        for label, text, phase in await self._sites(ctx):
             named = set(_PROJECT_TOOL_RE.findall(text))
-            for phase in phases:
-                dispatchable = set(_PHASE_TOOLS[phase])
-                if not named & dispatchable:
-                    problems.append(
-                        f"{label} → phase '{phase.value}' names "
-                        f"{', '.join(sorted(named)) or '(no project_* tool)'}, "
-                        f"none of which is dispatchable there; dispatchable: "
-                        f"{', '.join(sorted(dispatchable))}"
-                    )
+            dispatchable = set(_PHASE_TOOLS[phase])
+            if not named & dispatchable:
+                problems.append(
+                    f"{label} → phase '{phase.value}' names "
+                    f"{', '.join(sorted(named)) or '(no project_* tool)'}, "
+                    f"none of which is dispatchable there; dispatchable: "
+                    f"{', '.join(sorted(dispatchable))}"
+                )
         assert not problems, (
             f"{len(problems)} instruction(s) leave the agent with no next "
             f"action:\n  " + "\n  ".join(problems)

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -1,12 +1,22 @@
 """Integration tests for project skill tools."""
 
+import re
 from types import SimpleNamespace
 
 import pytest
 
 from decafclaw.media import EndTurnConfirm, ToolResult
-from decafclaw.skills.project.state import ProjectState, load_project
+from decafclaw.skills.project.state import (
+    TRANSITIONS,
+    ProjectInfo,
+    ProjectState,
+    load_project,
+)
 from decafclaw.skills.project.tools import (
+    _PHASE_TOOLS,
+    TOOLS,
+    _load_prompt,
+    _next_execution_step,
     get_tools,
     tool_project_add_steps,
     tool_project_advance,
@@ -513,3 +523,146 @@ class TestProgressTrackerEmit:
         assert "pt-create-b" in _text(result).lower()
         # The sticky slot should have been cleared when leaving the EXECUTING project
         assert clear_mock.await_count >= 1
+
+
+# Any `project_*` token appearing in instruction text.
+_PROJECT_TOOL_RE = re.compile(r"\bproject_[a-z_]+\b")
+
+
+class TestPhaseInstructionConsistency:
+    """#727 — instruction text must name tools the reading phase can dispatch.
+
+    Each site's text is obtained by invoking the code that produces it, so the
+    assertions track the real source instead of a copy of the strings.
+    """
+
+    @staticmethod
+    async def _sites(ctx) -> list[tuple[str, str, list[ProjectState]]]:
+        """Build the (label, emitted text, phases that read it) table.
+
+        A general control-flow analysis is out of scope for #727; new
+        instruction sites get appended to this table by hand.
+        """
+        # 1. _next_execution_step, empty/missing-plan branch. Only EXECUTING
+        #    reaches it.
+        no_plan_info = ProjectInfo(
+            slug="pic-no-plan",
+            description="Project whose plan file is missing",
+            status=ProjectState.EXECUTING,
+            mode="normal",
+            created_at="2026-01-01T00:00:00+00:00",
+            updated_at="2026-01-01T00:00:00+00:00",
+            directory=ctx.config.workspace_path,
+        )
+        assert not no_plan_info.plan_path.exists(), (
+            "fixture error: this ProjectInfo must hit the missing-plan branch"
+        )
+        no_plan_text = _next_execution_step(no_plan_info)
+
+        # 2. tool_project_switch. The switched-to project's own status governs
+        #    the next turn, so any phase can read this text. The text does not
+        #    vary with that status, so produce it once.
+        await tool_project_create(ctx, "Switch target", slug="pic-switch")
+        switch_text = _text(await tool_project_switch(ctx, project="pic-switch"))
+
+        # 3. tool_project_advance success. The target phase reads it on the next
+        #    turn. The message is invariant over which target it names, so
+        #    produce it once and grade it against every state reachable from
+        #    EXECUTING — including the forward transition to DONE.
+        await _advance_to_executing(ctx, slug="pic-advance")
+        advance_text = _text(
+            await tool_project_advance(ctx, target_status="planning")
+        )
+
+        # 4. plan_no_steps.md. Returned from the PLANNING/PLAN_REVIEW branch of
+        #    project_task_done before any status change, so the reading phase is
+        #    whichever of the two it already was.
+        no_steps_text = _load_prompt("plan_no_steps")
+
+        return [
+            ("_next_execution_step", no_plan_text, [ProjectState.EXECUTING]),
+            ("tool_project_switch", switch_text, list(ProjectState)),
+            (
+                "tool_project_advance",
+                advance_text,
+                sorted(TRANSITIONS[ProjectState.EXECUTING], key=lambda s: s.value),
+            ),
+            (
+                "plan_no_steps",
+                no_steps_text,
+                [ProjectState.PLANNING, ProjectState.PLAN_REVIEW],
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_instruction_names_undispatchable_tool(self, ctx):
+        """C1: no instruction names a tool the reading phase cannot dispatch."""
+        problems = []
+        for label, text, phases in await self._sites(ctx):
+            named = set(_PROJECT_TOOL_RE.findall(text))
+            for phase in phases:
+                dispatchable = set(_PHASE_TOOLS[phase])
+                undispatchable = sorted(named - dispatchable)
+                if undispatchable:
+                    problems.append(
+                        f"{label} → phase '{phase.value}' names "
+                        f"{', '.join(undispatchable)}; dispatchable there: "
+                        f"{', '.join(sorted(dispatchable))}"
+                    )
+        assert not problems, (
+            f"{len(problems)} instruction/phase mismatch(es):\n  "
+            + "\n  ".join(problems)
+        )
+
+    @pytest.mark.asyncio
+    async def test_every_instruction_names_a_dispatchable_tool(self, ctx):
+        """C2: every instruction still points at a usable next action."""
+        problems = []
+        for label, text, phases in await self._sites(ctx):
+            named = set(_PROJECT_TOOL_RE.findall(text))
+            for phase in phases:
+                dispatchable = set(_PHASE_TOOLS[phase])
+                if not named & dispatchable:
+                    problems.append(
+                        f"{label} → phase '{phase.value}' names "
+                        f"{', '.join(sorted(named)) or '(no project_* tool)'}, "
+                        f"none of which is dispatchable there; dispatchable: "
+                        f"{', '.join(sorted(dispatchable))}"
+                    )
+        assert not problems, (
+            f"{len(problems)} instruction(s) leave the agent with no next "
+            f"action:\n  " + "\n  ".join(problems)
+        )
+
+    def test_guard_phase_tools_exclusions_preserved(self):
+        """Widening the phase gates is not an acceptable fix for #727."""
+        for phase in (
+            ProjectState.SPEC_REVIEW,
+            ProjectState.PLAN_REVIEW,
+            ProjectState.DONE,
+        ):
+            assert "project_next_task" not in _PHASE_TOOLS[phase], (
+                f"'{phase.value}' must not gain project_next_task"
+            )
+        assert "project_update_plan" not in _PHASE_TOOLS[ProjectState.EXECUTING], (
+            "'executing' must not gain project_update_plan"
+        )
+
+    def test_guard_phase_gating_remains_real(self):
+        """No phase may expose the whole registry — that would defeat gating."""
+        for phase, names in _PHASE_TOOLS.items():
+            if not isinstance(phase, ProjectState):
+                continue
+            withheld = set(TOOLS) - set(names)
+            assert withheld, (
+                f"'{phase.value}' exposes every tool in TOOLS; phase gating "
+                f"must stay real"
+            )
+
+    def test_guard_transitions_unchanged(self):
+        """The states reachable from EXECUTING define who reads advance's text."""
+        assert TRANSITIONS[ProjectState.EXECUTING] == {
+            ProjectState.DONE,
+            ProjectState.PLANNING,
+            ProjectState.BRAINSTORMING,
+        }


### PR DESCRIPTION
## Summary

- The project skill told the agent to call tools its current phase does not expose. Six
  (instruction site, reading phase) pairs across four sites named a `project_*` tool that was not
  dispatchable on the turn that read the text, leaving the agent at a dead end.
- The skill's tool set is phase-gated (`_PHASE_TOOLS` → `_tools_for_phase` → `get_tools`, recomputed
  every turn from the project's saved status), but nothing checked the *instruction text* against the
  phase that would read it. The messages were wrong, not the gates.

## Design Decisions

- **Fix the instructions; do not widen the phase gates.** The gating is deliberate — review phases
  restrict to approve/revise/status, and `project_next_task` in `done` is meaningless. Widening
  `_PHASE_TOOLS` would also make the criteria green, which is why guard G2 pins the four exclusions
  and blocks that degenerate fix.
- **Derive the hint where the reading phase is known.** `project_switch` knows the switched-to
  project's status; `project_advance` knows its target. Both now call `_next_action_hint(phase)`,
  which looks the name up in `_PHASE_TOOLS` and so *cannot* name a tool the phase lacks. Where the
  reading phase isn't known at emit time — a static prompt template read from two phases — the text
  names a tool dispatchable in both.
- **`executing` with an empty plan routes somewhere real.** That phase has no plan-writing tool at
  all, so naming one was the dead end. It now points at `project_advance` back to `planning`, which
  is dispatchable there and is the natural recovery.

## Changes

**`src/decafclaw/skills/project/tools.py`**
- New `_next_action_hint(phase)` + `_NEXT_ACTION_HINTS` ladder, checked against `_PHASE_TOOLS` at
  call time; falls through to naming no tool rather than guessing.
- `_next_execution_step` empty-plan branch → `project_advance` instead of `project_update_plan`.
- `tool_project_switch` → phase-aware hint from `info.status`.
- `tool_project_advance` → phase-aware hint from `target` (covers `executing → done`, the case that
  fails today).

**`src/decafclaw/skills/project/prompts/plan_no_steps.md`** — names `project_update_plan` +
`project_task_done`, both dispatchable in `planning` *and* `plan_review`.

**`tests/test_project_tools.py`** — new `TestPhaseInstructionConsistency`: two criteria nodes plus
three guard nodes. Each site's text is obtained by *invoking* the code that emits it, not by copying
strings into the test.

**`docs/project-skill.md`** — new "Phase-gated tool exposure" subsection. The page listed all twelve
tools flatly with no indication the set is per-phase, which is the fact this issue turns on.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | no instruction names a `project_*` tool the reading phase cannot dispatch | `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_no_instruction_names_undispatchable_tool` | pass |
| C2 | every instruction still names at least one tool the reading phase *can* dispatch | `uv run pytest tests/test_project_tools.py::TestPhaseInstructionConsistency::test_every_instruction_names_a_dispatchable_tool` | pass |

Guards: G1 `41 passed` (36 pre-existing + 5 frozen; none lost, skipped or newly failing) · G2/G3/G4
`3 passed` · G5 `make test` → `3680 passed, 2 skipped`.

Verified by an independent verifier (fresh context, `checks.md` and the repo only — not the plan, not
the notes). Frozen at `eb32b8a`, re-frozen at `a985978` after amendment A1; tamper diff clean against
the re-freeze, and the diff against the original freeze is exactly A1 and nothing else. Both freeze
commits are ancestors of the pushed head, so the tamper diff stays re-runnable — the branch was
pushed unsquashed for that reason.

## Amendment A1 — why this run is `needs-review`

The issue was filed `auto-ok`. **It was downgraded during execution**, per
`agent-session/references/frozen-checks.md`, because a frozen check had to be amended.

The check-author's brief (mine) described the *pre-fix* code: "the switch text is invariant over the
switched-to status, so you can produce it once and grade it against every phase." That assumption got
encoded into the oracle. It is harmless while the message is phase-independent — and wrong the moment
it isn't: the check graded the `brainstorming` text against the `done` tool set, a pairing that never
occurs at runtime, and so **rejected an implementation that satisfies the criterion**. Concretely, it
permitted only `project_status` at the switch site (the intersection of all six phase tool sets),
mandating a phase-*independent* hint.

Amendment test, run against both trees rather than reasoned about:

| | at freeze `eb32b8a` | against the implementation |
|---|---|---|
| old wording | FAIL — 4 pairs | FAIL — 4 pairs |
| new wording | FAIL — identical 4 | **PASS** |

Same verdict at freeze, differs against the implementation → amendment, not clarification. Approved
by Les on 2026-08-02; the approval lifted the read-only rule for that one file and that one change.

**Teeth re-verified after amending, independently:** the amended criteria fail **6-for-6** against the
pre-fix source, matching the original AT FREEZE set exactly. The replacement discriminates identically
to what it replaced and is strictly no weaker — checked by the verifier subagent, not self-reported.

## Notes

No eval case added. Tool *descriptions* are unchanged, and the behaviour here is deterministic and
fully covered by unit tests — there is no LLM-driven decision for an eval to grade. (Per
`docs/eval-loop.md` and the repo's "skip evals for non-LLM-visible work" convention. The issue also
explicitly rules out re-litigating #525's eval flakiness.)

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: needs-review (downgraded: C1/C2 check amended)
checks: C1 pass · C2 pass
guards: G1 pass · G2 pass · G3 pass · G4 pass · G5 pass
tamper: clean
freeze: eb32b8a (re-frozen a985978 after amendment A1)
project-gates: make check green
ci: 2/2 pass @ d6bf7df
threads: 0 unresolved
risk-paths: none
amendments: A1 — C1/C2 site table graded one text sample against all reading phases; now grades each phase's own emitted text
verdict: human-merge-required
reason: tier is needs-review — amendment A1 altered a frozen check after implementation began, so the oracle was not independently authored end-to-end
```

## References
- Spec: `docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/spec.md`
- Checks: `docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/checks.md`
- Plan: `docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/plan.md`
- Notes: `docs/dev-sessions/2026-08-01-1944-727-phase-instruction-consistency/notes.md`
- Closes #727

