### PR TITLE
fix(#704): re-send SELECT_CONV after a WebSocket reconnect

### DIFF
--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
@@ -230,3 +230,27 @@ code before being acted on.
 
 _(Append-only. Empty — no amendment was made. All changes above were made at freeze step 4,
 before the freeze commit, which is why none costs the tier.)_
+
+## Tamper verdict
+
+Recorded at `pr` step 5, against the tree that ships. **Verdict: `clean`** — not
+`clean-by-substitute`; `Check files` is non-empty, so the diff command is meaningful rather than
+vacuous.
+
+```
+git diff 5bd6188 -- src/decafclaw/web/static/lib/conversation-store.test.js tests/test_ws_message_type_handlers.py
+```
+
+Empty output. Both frozen check files are byte-identical to the freeze commit. Confirmed twice:
+once at the end of `execute` by the independent verifier (fresh context, given only this file and
+the repo), and again here immediately before pushing.
+
+No rebase was needed — `origin/main` did not advance during the run — so `5bd6188` was never
+rewritten and needs no re-anchoring. `git merge-base --is-ancestor 5bd6188 HEAD` succeeds, and the
+branch is pushed unsquashed, so a reviewer can re-run the command above themselves rather than
+taking this record on trust.
+
+Collateral check: `git diff 5bd6188 --stat` lists only `checks.md` (sanctioned appends),
+`plan.md`, `notes.md`, `docs/web-terminal.md`, `docs/web-ui.md`,
+`src/decafclaw/web/static/lib/canvas-state.test.js` (docstring prose only, no assertion), and
+`src/decafclaw/web/static/lib/conversation-store.js` (the fix). No frozen check file appears.

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
@@ -1,7 +1,7 @@
 # Frozen acceptance checks
 
 **Source:** https://github.com/lmorchard/decafclaw/issues/704
-**Frozen at:** _(recorded in the follow-up commit)_
+**Frozen at:** `5bd6188` (2026-08-02) — the tamper-diff baseline.
 **Check files — read-only from Phase 1 onward:**
 - `src/decafclaw/web/static/lib/conversation-store.test.js`
 - `tests/test_ws_message_type_handlers.py`

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md
@@ -1,0 +1,232 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/704
+**Frozen at:** _(recorded in the follow-up commit)_
+**Check files — read-only from Phase 1 onward:**
+- `src/decafclaw/web/static/lib/conversation-store.test.js`
+- `tests/test_ws_message_type_handlers.py`
+
+## C1
+
+CRITERION: GIVEN a `ConversationStore` with conversation `c1` selected, WHEN its WebSocket
+client dispatches `open` again (a reconnect), THEN the store SHALL send on that socket a
+client→server message that resubscribes it to `c1`, AND that message SHALL carry
+`conv_id === 'c1'`.
+
+CHECK: `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js` — a new
+test file, authored at freeze. It constructs a fake socket (`class FakeWS extends EventTarget`
+with a recording `send()`), calls `selectConversation('c1')`, clears the record, dispatches a
+second `open`, and asserts the recorded sends contain a message that resubscribes the socket
+with `conv_id === 'c1'`.
+
+AT FREEZE: **fails**, exit 1. 4 tests collected, 1 failed / 3 passed.
+
+```
+FAIL lib/conversation-store.test.js > ConversationStore reconnect handling >
+     resubscribes the reopened socket to the selected conversation
+AssertionError: reconnect #1: nothing sent for c1: expected [] to not have a length of +0
+ ❯ expectResubscribed lib/conversation-store.test.js:140:58
+```
+
+Correct reason: the behaviour is genuinely absent. All 4 tests collected and ran, so the
+manifest JSON import, the `fetch` stub, and the fake socket all work. The failing assertion is
+the *second* one in `expectResubscribed` — the preceding conversation-list-refresh assertion
+(line 133) passed, so the `open` handler did fire and did do its existing work; it simply sent
+nothing on the socket. `ws.sent` is literally `[]`. Matches `conversation-store.js:128`, where the
+`open` listener does nothing but `listConversations()` (a REST fetch). The three passing tests
+(manifest-harness guard, G4a, G4b) confirm the fixture observes "zero sends" as a real state
+rather than a broken recorder.
+
+**Check-form constraints (copied verbatim from the issue; measured, not assumed):**
+- `npx vitest run lib/<missing-file>.test.js` exits **1** (`No test files found`), so this
+  check cannot pass vacuously by the file being absent.
+- The check MUST NOT use `-t <name>`: a `-t` selection matching nothing exits **0** with every
+  test reported skipped. That form grades nothing.
+- The criterion is deliberately implementation-agnostic. Both designs floated in the issue — a
+  new `RESUBSCRIBE` message type, or `selectConversation(id, {resubscribeOnly: true})` — satisfy
+  it identically, so the choice is implementation style and does not affect the tier.
+
+## Guards
+
+G1–G4 are copied verbatim from the issue. G5 and G6 were **added at freeze step 4** by the
+check-reviewer's adjudication (see `## Adjudication`); they are additive and pass today, so they
+change no issue-sourced text and cost no tier.
+
+- G1: `cd src/decafclaw/web/static && npx vitest run` — the JS unit suite. Invariant: no test
+  lost, newly skipped, or newly failing. Observed at triage: `Test Files 6 passed (6) / Tests 42
+  passed (42)`.
+  AT FREEZE: **passes** (before the check file was added) — `Test Files 9 passed (9) / Tests 83
+  passed (83)`, exit 0. With the frozen check file present: `10 files / 87 tests, 1 failed | 86
+  passed`, the single failure being C1 by design.
+  Drift from triage's `6 (6) / 42 (42)`: `origin/main` grew three JS test files and 41 tests
+  between 2026-07-29 and this run. The invariant is "no test lost, newly skipped, or newly
+  failing" relative to *this* baseline, not equality with the triage-era count. Recorded so a
+  later reader doesn't read the growth as tampering.
+  **At verification the target is `10 files / 87 tests, 87 passed, exit 0`** — 86 pre-existing
+  passes plus C1 flipping green. Any lower count is a lost or skipped test.
+- G2: `uv run pytest tests/test_system_conversations.py` — protects the server-side
+  `_handle_select_conv` → `_subscribe_to_conv` contract (`web/websocket.py:173,185`), which matters
+  if the implementer adds a new message type. Observed at triage: `19 passed`.
+  AT FREEZE: **passes** — `19 passed in 1.29s`, exit 0. Collected 19, matching triage.
+  **Correction on record (see adjudication):** this guard does *not* protect the
+  `_subscribe_to_conv` contract the issue claims it does. The `ws_state` fixture
+  (`tests/test_system_conversations.py:134-141`) supplies `config`, `event_bus`, `app_ctx`,
+  `websocket` and **no `manager`**, and `_subscribe_to_conv` opens with
+  `manager = state.get("manager"); if not manager: return` (`websocket.py:635-637`). So its body is
+  dead code in all 19 tests, which exercise `_handle_select_conv`'s *response and authorization*
+  branches only. Kept verbatim and still a valid guard for what it does cover; G6 covers the
+  subscription contract.
+- G3: `make check-message-types` — if a new message type is added to `web/message_types.json`,
+  the four generated files must be regenerated in the same commit. This work must not hand-edit
+  `tui/src/types.generated.ts`.
+  AT FREEZE: **passes** — regenerated all four files, `git diff --exit-code` clean, exit 0.
+  Note: G3 is **vacuous for a `select_conv`-reuse design**, which touches neither the manifest nor
+  any generated file. "G3 green" carries information only if the manifest actually changed.
+- G4 (same new test file): WHEN the socket reopens, the store SHALL NOT discard already-loaded
+  messages for the current conversation, and IF no conversation is selected it SHALL NOT send a
+  subscribe message at all. Both hold today (nothing happens on reopen), so they are guards, not
+  criteria — they exist to rule out the naive
+  `addEventListener('open', () => this.selectConversation(id))` fix, which would clear the message
+  store and re-issue `LOAD_HISTORY` on every transient blip.
+  AT FREEZE: **passes** — both tests green inside the otherwise-failing check file.
+  `keeps already-loaded messages when the socket reopens` (G4a) and
+  `sends nothing on the socket when no conversation is selected` (G4b).
+- G5 (**added at freeze**): `uv run pytest tests/test_ws_message_type_handlers.py` — every
+  `client_to_server` type declared in `src/decafclaw/web/message_types.json` has an entry in
+  `decafclaw.web.websocket._HANDLERS`. Closes the reviewer's highest-value residual hole: an
+  implementer who registers a new `resubscribe` type in the manifest (satisfying C1's type
+  assertion *and* G3 after regeneration) but forgets the server handler, leaving `_dispatch` to
+  fall through to `ws: unknown inbound message type` and return an error frame — every check
+  green, bug unfixed.
+  AT FREEZE: **passes** — `2 passed`, exit 0 (not exit 5; collected 2). Teeth verified by
+  commenting out `WSMessageType.WIDGET_RESPONSE` in `_HANDLERS`: the test failed naming
+  `widget_response` specifically, and `websocket.py` was restored with an empty diff.
+- G6 (**added at freeze**): `uv run pytest tests/test_web_websocket_workflow.py` — the only test
+  file in the repo that constructs a real `manager` and observes `conv_subscriptions`, i.e. the
+  server-side half of "resubscribes it" that G2 turns out not to reach.
+  AT FREEZE: **passes** — `1 passed in 1.34s`, exit 0.
+
+Combined python guards at freeze (G2 + G5 + G6): `22 passed in 1.34s`, exit 0.
+
+## Step-4 re-confirmation of the spec's own evidence
+
+Not an acceptance check — this is `plan.md` step 4, confirming the gap the issue describes is
+still present at the branch point (`c594311`) before any test was authored.
+
+Ad-hoc repro (`/tmp/repro-704.mjs`, deliberately outside the repo): construct a `FakeWS`
+`EventTarget` with a recording `send()`, stub `globalThis.fetch`, `new ConversationStore(ws)`,
+`selectConversation('c1')`, clear the record, dispatch a second `open`. Observed:
+
+```
+currentConvId = "c1"
+sent-after-open = []
+```
+
+Byte-identical to the issue's `VERIFIED DISCRIMINATING` finding. The behaviour is still absent and
+the store still retains everything a fix needs.
+
+## Adjudication
+
+Written at freeze step 4, before the freeze commit. A read-only reviewer (no Edit/Write) was given
+`checks.md` and the repo, and *not* the criteria's rationale or any implementation plan — none
+existed yet. Its remit was one question per check and per guard: *what could make this green that
+is not the work its criterion names?* Every claim below was independently re-verified against the
+code before being acted on.
+
+- **C1: strengthened.** The reviewer found four ways to green it without the work, all confirmed:
+  1. `send({type: 'resubscribe', conv_id})` with no manifest entry and no handler — the invented
+     type sits outside the deny-list so it counted as a subscribe, while the real server
+     (`websocket.py:1006-1011`) logs `ws: unknown inbound message type` and replies with an error
+     frame. Also `send({conv_id: 'c1'})` with no `type` at all, and echoing a *server→client* type
+     like `conv_selected`. **Closed** by deriving the legal set from
+     `src/decafclaw/web/message_types.json` (`direction === 'client_to_server'`) and asserting
+     membership — a manifest-derived set rather than the generated `MESSAGE_TYPES` constants,
+     because a renamed type makes `MESSAGE_TYPES.GONE` evaluate to `undefined` and silently shrink
+     the deny-list, and `static/tsconfig.json:25` excludes `**/*.test.js` so nothing would flag it.
+  2. A one-shot handler (`if (done) return; done = true; …`) greened it because C1 fired `open`
+     only once — while leaving every *later* reconnect broken, which is the bug's actual
+     user-visible shape (repeated transient blips). **Closed** by firing `open` twice and
+     re-asserting, with `reconnect #N:` prefixed on every failure message.
+  3. Rewriting `conversation-store.js:128` rather than adding alongside it greened C1 and both G4
+     tests while silently killing conversation-list refresh on reconnect. **Closed** by asserting
+     a `fetch` of `/api/conversations` (read from `listConversations()`,
+     `conversation-store.js:181-186`) after each reopen. Deliberately ordered first so C1's
+     present-day failure message stays about the missing resubscribe.
+  4. Line 95's `expect(subscribes[0].conv_id).toBe('c1')` was a tautology — `subscribes` derives
+     from a list already filtered on `conv_id === 'c1'`, so it could never fail. It read as rigor.
+     **Closed** by replacing it with the membership assertion from (1).
+
+  The CHECK *command* is byte-identical to the issue's. The strengthened test is a strict superset
+  of the shape the issue's CHECK prose describes; recording that here so a later reader doesn't
+  read the extra assertions as an unlogged edit.
+
+- **C1 / `LOAD_HISTORY` deny-listing: accepted, deliberately.** The reviewer correctly found the
+  deny-list's stated premise is wrong: `_handle_load_history` *does* call `_subscribe_to_conv`
+  (`websocket.py:320`), as does `_handle_send` (`:423`). So a `load_history`-only fix would
+  resubscribe server-side and satisfy the criterion's letter, yet C1 grades it red. Kept red on
+  purpose: refetching 50 messages on every transient blip is precisely the disruption G4 exists to
+  forbid, and the spec's "What we're NOT doing" rules out resync-on-reconnect. G4a's added
+  no-`LOAD_HISTORY` assertion makes the two consistent rather than contradictory.
+
+- **G1: escalated.** Its command mechanically detects only *newly failing*. Verified: deleting a
+  test file yields `9 passed (9)`, exit 0; `describe.skip` yields `skipped`, exit 0; narrowing
+  `vitest.config.js` `include` yields fewer files, exit 0. "No test lost, newly skipped" is
+  enforced by **reading the printed counts against the frozen baseline**, which the independent
+  verifier must do explicitly — not by the exit code. Command kept verbatim (changing it would be
+  an amendment); the baseline and the verification target are written into G1 above so the
+  comparison is mechanical for the reader even though it isn't for the shell. Mitigating: C1's
+  explicit-file argument means an `include`/`exclude` narrowing that hides the check file fails C1
+  with exit 1 (`No test files found`), so that particular dodge is covered.
+
+- **G2: accepted as written, with a correction on record, plus G6 added.** The reviewer's finding
+  that G2 does not reach `_subscribe_to_conv` is confirmed — no `manager` in the fixture, so the
+  function returns at its first line in all 19 tests. Deleting the `_subscribe_to_conv` call at
+  `websocket.py:173` or `:185` would leave all 19 green. G2's command is issue-sourced and stays
+  verbatim; the correction is recorded in G2 above, and **G6** adds
+  `tests/test_web_websocket_workflow.py`, the only file that actually observes
+  `conv_subscriptions`.
+
+- **G3: accepted.** The reviewer tried committing a hand-edit to `tui/src/types.generated.ts`
+  (reverted by the generator, `git diff --exit-code` nonzero), staging without committing (same),
+  a pathspec dodge (all four paths are tracked, none ignored), and a partial edit in a
+  generator-untouched region (none exists — each file is rewritten whole). Only escape is editing
+  the manifest so the generator reproduces the content, which is the intended path. Recorded
+  above: G3 is vacuous for a `select_conv`-reuse design, and it runs only the drift half of
+  `make check`, not `pyright`/`tsc`.
+
+- **G4: strengthened.** G4b resisted every attempt (unconditional send, `conv_id: ''`,
+  `conv_id: null` all fail it) — accepted as-is. G4a asserted only message *content*, so a
+  `selectConversation(id, {resubscribeOnly: true})` that skips `messageStore.clear()` but still
+  fires `LOAD_HISTORY` passed while refetching 50 messages per blip, and an implementation that
+  nulls `#currentConvId` while leaving the array intact also passed. **Closed** by adding: zero
+  `LOAD_HISTORY` sends after the reopen, `store.currentConvId === 'c1'`, and a re-assert after a
+  second reopen. The reviewer also confirmed G4's placement *inside* the C1 check file is a
+  feature, not a problem — one invocation enforces C1 and both guards, so an implementation cannot
+  green C1 by regressing G4. Cost: the exit code alone can't say which failed, and the manifest
+  bans `-t`; the adjudicator reads the per-test lines (today: 4 tests, 1 failed, 3 passed).
+
+- **G5: accepted** (added at freeze; teeth verified by deliberate breakage, see G5 above).
+
+- **G6: accepted** (added at freeze; passes today, `1 passed`).
+
+### Residual holes, named rather than closed
+
+- G5 proves a registered type is *dispatchable*, not that its handler *subscribes*. An implementer
+  could add `resubscribe` to the manifest and point `_HANDLERS` at an existing non-subscribing
+  handler (`_handle_cancel_turn`, `_handle_set_model`, `_handle_confirm_response`,
+  `_handle_widget_response`) and pass everything. Judged not worth closing: the plausible reuse
+  targets (`_handle_select_conv`, `_handle_load_history`, `_handle_send`) all *do* subscribe, so
+  the hole requires a deliberately perverse choice. Closing it properly needs a whole-stack smoke
+  or a new server-side integration test against a type that does not exist yet at freeze.
+- C1's conversation-list assertion checks that a `fetch` of `/api/conversations` happened during
+  the reconnect, not that it came from line 128 specifically. An implementation that dropped that
+  line but called `listConversations()` from a new resubscribe path still passes — acceptable,
+  since list refresh on reconnect is the behaviour being protected.
+- C1 is a jsdom unit test and cannot observe that the message reaches the server or that the
+  server honours it. G6 covers the server-side subscription contract; nothing in the set is a
+  whole-stack test, which is the standing limitation of a client-side criterion.
+
+## Amendments
+
+_(Append-only. Empty — no amendment was made. All changes above were made at freeze step 4,
+before the freeze commit, which is why none costs the tier.)_

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/notes.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/notes.md
@@ -1,0 +1,81 @@
+# Session notes — #704 resubscribe on reconnect
+
+## Run shape
+
+Two sessions on one branch. The first (2026-08-02 09:43) ran `express` Phase 0 + plan steps 1–5
+and stopped after the freeze commit — `checks.md`, the frozen test file, and G5's new test file
+exist; no `plan.md`, no implementation, clean tree. The second (this one) resumed rather than
+starting fresh.
+
+**Why resume.** Session setup's step 2 says to ask. Unattended, the answer isn't a coin flip:
+the freeze was authored by a context that had never seen an implementation plan, which is exactly
+the property `frozen-checks.md` exists to protect. Re-freezing in the context that then writes
+the code would have weakened the oracle to buy nothing.
+
+Before touching anything, re-ran the whole frozen set to confirm the recorded state still held:
+C1 failed with the byte-identical recorded assertion, G1 `10 files / 87 tests, 1 failed | 86
+passed`, G2+G5+G6 `22 passed`, G3 clean. All matched `checks.md`.
+
+## Design decision
+
+**Reuse `select_conv`; do not add a `resubscribe` wire type.** Both designs were floated in the
+issue and the criterion is deliberately agnostic between them.
+
+- **Why:** `_handle_select_conv` already calls `_subscribe_to_conv` (`web/websocket.py:173,185`),
+  and the client's `CONV_SELECTED` handler is idempotent (`conversation-store.js:585-594` — sets
+  `read_only`, restores a pending confirmation). So the existing type already does the whole job.
+  It also matches the TUI's existing fix (`tui/src/App.tsx:83`), which is the pattern the spec
+  told us to copy.
+- **Rejected:** a new `resubscribe` type. It would mean a manifest entry, four regenerated files,
+  a new server handler, and a second code path that subscribes — all to reach behaviour an
+  existing type already has. The freeze anticipated this: G5 exists precisely to catch a new type
+  registered without a handler.
+- **Consequence:** G3 (`make check-message-types`) is **vacuous** for this design — it passes
+  without carrying information, because nothing touched the manifest. `checks.md` records this;
+  repeating it here so a reader of the PR's green G3 row doesn't over-read it.
+
+## Things checked that could have been bugs
+
+- **Duplicate confirmation cards on reconnect.** The resubscribe makes the server re-send
+  `conv_selected`, which may carry `pending_confirmation` — and the client feeds that into
+  `ToolStatusStore`. If that path didn't dedupe, every blip would stack another confirmation card.
+  It does: `tool-status-store.js:189-193` dedupes on `confirmation_id`, with a comment already
+  anticipating the same message arriving twice by different routes. No change needed.
+- **Double-send on the *initial* connect.** `app.js:615-628` registers a one-shot `open` handler
+  that performs the first selection. On the first open `#currentConvId` is still `null`, so
+  `#resubscribe()` returns early and the one-shot handler does its normal job. No duplicate
+  `select_conv`, no behaviour change on first load.
+- **Read-only / system conversations.** `#readOnly` is only reset inside `selectConversation()`,
+  which the resubscribe deliberately doesn't call. The server re-sends `read_only: true` for those
+  convs, so the flag stays correct across a reconnect.
+
+## Latent hazard, recorded not fixed
+
+The TUI documents an ordering hazard (`tui/src/wsClient.ts:88-95`): flush the outbound buffer
+*before* re-sending the subscribe, or a stale queued `select_conv` lands last and bounces the
+server's subscription to the old conversation. The web client has **no outbound buffer** —
+`websocket-client.js:63-68` drops sends while the socket is closed — so nothing can be queued to
+land after the resubscribe. The hazard is latent, not live. Noted in `plan.md` and in the code
+comment so that adding an outbound buffer later doesn't silently reintroduce it.
+
+## Deferred / out of scope
+
+Both were ruled out by the spec's "What we're NOT doing", not discovered here:
+
+- **Resync of state that changed while disconnected.** This PR makes *future* pushes arrive; it
+  does not reconcile `canvas_update` / sticky / notification / tool-status state missed during the
+  gap, nor recover mid-turn output. That needs a product decision about which state resyncs and
+  how, which is why folding it in would have flipped the tier. Worth a follow-up issue.
+- **`canvas-page.js` (`/canvas/{conv_id}`).** Separate raw socket with no reconnect logic at all
+  (`:92-97`) — it re-sends `SELECT_CONV` on open but never reopens. Different and worse defect.
+  Mentioned in the `docs/web-ui.md` note so it isn't mistaken for covered.
+
+## Docs touched
+
+- `docs/web-terminal.md` and the `canvas-state.test.js` docstring both cited this bug as the
+  justification for #703's optimistic canvas-tab close. The workaround is still correct — the
+  reconnect lands on its own backoff, long after the close was POSTed — but the stated reason had
+  become false, so both were rewritten rather than deleted.
+- `docs/web-ui.md` gained a short subsection under REST vs WebSocket: subscriptions are
+  per-socket and re-established on reconnect, why it isn't `selectConversation()`, and the
+  canvas-page carve-out.

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/plan.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/plan.md
@@ -1,0 +1,138 @@
+# Resubscribe on WebSocket reconnect — Implementation Plan
+
+**Goal:** After `/ws/chat` drops and reconnects, re-subscribe the fresh socket to the
+already-selected conversation so server-pushed per-conversation events keep arriving without a
+page reload.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/704 — **Tier:** `auto-ok`
+(criterion has a real oracle — vitest + jsdom, already run by `make test-js` and in CI — verified
+discriminating at triage and again at the freeze; no human judgment; no risk-gated path — client
+JS only, no auth/secrets/migration/deploy/dependency change)
+
+**Approach:** Add a second `open` listener in `ConversationStore`'s constructor, alongside the
+existing `listConversations()` one, that re-sends `SELECT_CONV` for `#currentConvId` when a
+conversation is selected. Reuse the existing `select_conv` wire type rather than introducing a
+`resubscribe` type: `_handle_select_conv` already calls `_subscribe_to_conv`
+(`web/websocket.py:173,185`), the client's `CONV_SELECTED` handler is idempotent
+(`conversation-store.js:585-594` — sets `read_only`, restores any pending confirmation), and this
+mirrors the TUI's existing fix at `tui/src/App.tsx:83`. No `LOAD_HISTORY` and no client-state
+teardown, so a transient blip does not blank the transcript the user is reading.
+
+**Criteria:** C1 — a reconnect `open` re-sends a registered client→server subscribe message
+carrying `conv_id === 'c1'`.
+
+Full text + checks live in `checks.md`. Ids are assigned there and referenced here.
+
+---
+
+## Phase 0: Freeze the acceptance checks — **COMPLETE**
+
+Done in a prior session on this branch. Recorded here so the resume point is unambiguous.
+
+**Files:**
+- Created: `docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md`
+- Created: `src/decafclaw/web/static/lib/conversation-store.test.js` — the test C1 names
+- Created: `tests/test_ws_message_type_handlers.py` — G5, added at freeze step 4
+
+**Verification — automated:**
+- [x] C1's check runs and fails for the expected reason — `AssertionError: reconnect #1: nothing
+      sent for c1: expected [] to not have a length of +0`, exit 1, 4 tests collected (1 failed /
+      3 passed). Re-confirmed at the start of this session, byte-identical.
+- [x] Every guard runs and passes — G1 `10 files / 87 tests, 1 failed | 86 passed` (the single
+      failure being C1 by design); G2+G5+G6 `22 passed`; G3 `git diff --exit-code` clean.
+      Re-confirmed at the start of this session, all matching the freeze record.
+- [x] Check-reviewer dispatched read-only; `## Adjudication` in `checks.md` carries one
+      disposition per check and per guard (C1 strengthened, G1 escalated, G2 accepted-with-
+      correction + G6 added, G3 accepted, G4 strengthened, G5/G6 accepted).
+- [x] Freeze commit `5bd6188`; sha recorded in follow-up commit `f5e0299`.
+
+**Read-only from Phase 1 onward:**
+- `src/decafclaw/web/static/lib/conversation-store.test.js`
+- `tests/test_ws_message_type_handlers.py`
+
+---
+
+## Phase 1: Re-send `SELECT_CONV` on reconnect
+
+Adds the resubscribe. One vertical slice: the store's socket-lifecycle wiring, the wire message
+it sends, and the two docs that currently document the absence of this behaviour as a known
+defect.
+
+**Advances:** C1 (fully). Nothing remains for a later phase.
+
+**Files:**
+- Modify: `src/decafclaw/web/static/lib/conversation-store.js` — add a `#resubscribe()` private
+  method and a second `open` listener in the constructor that calls it.
+- Modify: `docs/web-terminal.md` (~:139-147) — the first "load-bearing detail" bullet asserts
+  `conversation-store` "never re-sends `SELECT_CONV`". After this phase that is false. Keep the
+  bullet (the optimistic-close behaviour is still correct and still load-bearing) and rewrite its
+  justification: the socket is down at the moment `closeTabById` runs, so the push cannot arrive
+  in time regardless of whether a later reconnect resubscribes.
+- Modify: `src/decafclaw/web/static/lib/canvas-state.test.js` (docstring, :7-17) — same stale
+  claim, same rewrite. This file is **not** a frozen check file, so editing it is permitted; only
+  its prose changes, no assertion.
+
+**Key changes:**
+
+`conversation-store.js` — constructor, after the existing listeners at :127-128:
+
+```js
+    this.#ws.addEventListener('open', () => this.listConversations());
+    // A reconnect gives us a brand-new socket, and the server tracks stream
+    // subscriptions per socket — so without this, every per-conversation push
+    // (canvas_update, sticky, tool status, streamed output) is delivered to
+    // nobody until a full page reload. Deliberately NOT selectConversation():
+    // that clears the message store and re-issues LOAD_HISTORY, which would
+    // blank the transcript and refetch 50 messages on every transient blip.
+    this.#ws.addEventListener('open', () => this.#resubscribe());
+```
+
+and the method itself, next to `selectConversation()`:
+
+```js
+  /**
+   * Re-subscribe the (re)connected socket to the current conversation.
+   *
+   * Reuses `select_conv` rather than a bespoke wire type because
+   * `_handle_select_conv` already subscribes the socket (`web/websocket.py:173`)
+   * and its `conv_selected` reply is idempotent for the client. Mirrors the
+   * TUI's `__reconnected` handler (`tui/src/App.tsx:83`).
+   *
+   * No-op when nothing is selected: there is no stream to rejoin, and the
+   * initial connect is handled by app.js's one-shot open handler.
+   */
+  #resubscribe() {
+    if (!this.#currentConvId) return;
+    this.#ws.send({ type: MESSAGE_TYPES.SELECT_CONV, conv_id: this.#currentConvId });
+  }
+```
+
+Ordering note: on the *first* open, `#currentConvId` is still `null`, so this sends nothing and
+`app.js:615-628`'s one-shot handler performs the initial selection exactly as it does today. The
+`websocket-client.js` `send()` drops messages while the socket is closed (`:63-68`) and there is
+no outbound buffer, so the TUI's documented flush-before-resubscribe ordering hazard
+(`tui/src/wsClient.ts:88-95`) is latent here, not live — nothing can be queued to land after the
+resubscribe. Recorded so a future outbound buffer doesn't reintroduce it silently.
+
+**Verification — automated:**
+- [ ] C1's check passes: `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js`
+      — target `4 tests, 4 passed`, exit 0
+- [ ] G1 still passes: `cd src/decafclaw/web/static && npx vitest run` — target
+      `10 files / 87 tests, 87 passed`, exit 0. Read the printed counts, not just the exit code:
+      per the G1 adjudication, deletion and `describe.skip` both exit 0.
+- [ ] G2 still passes: `uv run pytest tests/test_system_conversations.py` — target `19 passed`
+- [ ] G3 still passes: `make check-message-types` — expected clean, and expected **vacuous**:
+      this design touches neither `message_types.json` nor any generated file, so a clean G3
+      carries no information here beyond "nothing was hand-edited"
+- [ ] G5 still passes: `uv run pytest tests/test_ws_message_type_handlers.py` — target `2 passed`
+- [ ] G6 still passes: `uv run pytest tests/test_web_websocket_workflow.py` — target `1 passed`
+- [ ] `make check` passes (lint + pyright + `tsc --checkJs` + message-type drift)
+- [ ] `make test` passes (no regression)
+- [ ] Tamper diff empty: `git diff 5bd6188 -- src/decafclaw/web/static/lib/conversation-store.test.js tests/test_ws_message_type_handlers.py`
+
+**Verification — manual:**
+- [ ] None. C1 is fully automated and no criterion is human-judgment, which is what makes this
+      run `auto-ok`. The end-to-end behaviour the issue reports (restart the server, close a
+      canvas tab, watch the UI update without a reload) is worth a human spot-check after merge
+      per the repo's "test live in the web UI after merging" convention, but it is not a gate
+      item and no criterion depends on it.

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/plan.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/plan.md
@@ -115,20 +115,22 @@ no outbound buffer, so the TUI's documented flush-before-resubscribe ordering ha
 resubscribe. Recorded so a future outbound buffer doesn't reintroduce it silently.
 
 **Verification — automated:**
-- [ ] C1's check passes: `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js`
-      — target `4 tests, 4 passed`, exit 0
-- [ ] G1 still passes: `cd src/decafclaw/web/static && npx vitest run` — target
-      `10 files / 87 tests, 87 passed`, exit 0. Read the printed counts, not just the exit code:
-      per the G1 adjudication, deletion and `describe.skip` both exit 0.
-- [ ] G2 still passes: `uv run pytest tests/test_system_conversations.py` — target `19 passed`
-- [ ] G3 still passes: `make check-message-types` — expected clean, and expected **vacuous**:
-      this design touches neither `message_types.json` nor any generated file, so a clean G3
-      carries no information here beyond "nothing was hand-edited"
-- [ ] G5 still passes: `uv run pytest tests/test_ws_message_type_handlers.py` — target `2 passed`
-- [ ] G6 still passes: `uv run pytest tests/test_web_websocket_workflow.py` — target `1 passed`
-- [ ] `make check` passes (lint + pyright + `tsc --checkJs` + message-type drift)
-- [ ] `make test` passes (no regression)
-- [ ] Tamper diff empty: `git diff 5bd6188 -- src/decafclaw/web/static/lib/conversation-store.test.js tests/test_ws_message_type_handlers.py`
+- [x] C1's check passes: `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js`
+      — observed `Test Files 1 passed (1) / Tests 4 passed (4)`, exit 0. Target met.
+- [x] G1 still passes: `cd src/decafclaw/web/static && npx vitest run` — observed
+      `Test Files 10 passed (10) / Tests 87 passed (87)`, exit 0. Counts read against the frozen
+      baseline (10/87 with C1 failing), not the exit code: no test lost, skipped, or newly failing.
+- [x] G2 still passes: `uv run pytest tests/test_system_conversations.py` — observed `19 passed`
+- [x] G3 still passes: `make check-message-types` — `git diff --exit-code` clean, exit 0. Vacuous
+      as predicted: this design touched neither `message_types.json` nor any generated file, so
+      G3 carries no information here beyond "nothing was hand-edited".
+- [x] G5 still passes: `uv run pytest tests/test_ws_message_type_handlers.py` — observed `2 passed`
+- [x] G6 still passes: `uv run pytest tests/test_web_websocket_workflow.py` — observed `1 passed`
+- [x] `make check` passes — ruff `All checks passed!`, pyright `0 errors, 0 warnings`,
+      `tsc --noEmit` clean, message-type drift clean
+- [x] `make test` passes — `3717 passed, 2 skipped in 16.95s`
+- [x] Tamper diff empty: `git diff 5bd6188 -- src/decafclaw/web/static/lib/conversation-store.test.js tests/test_ws_message_type_handlers.py`
+      produced no output
 
 **Verification — manual:**
 - [ ] None. C1 is fully automated and no criterion is human-judgment, which is what makes this

--- a/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/spec.md
+++ b/docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/spec.md
@@ -1,0 +1,147 @@
+# Web UI never re-sends SELECT_CONV after a WebSocket reconnect — Spec
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/704
+
+Captured verbatim from the issue body (`<!-- agent-session:spec -->` marker line stripped).
+
+---
+
+## Summary
+
+When `/ws/chat` drops and reconnects, the browser is connected but subscribed to **no conversation stream** — so every server-pushed per-conversation event is silently lost until the user reloads the page.
+
+Found while live-testing #703 (dead terminal tabs); scoped out of that PR because the fix is broader than one feature.
+
+## Mechanism
+
+`lib/websocket-client.js` auto-reconnects and dispatches `open`. The only listener that matters is:
+
+```js
+// lib/conversation-store.js:128
+this.#ws.addEventListener('open', () => this.listConversations());
+```
+
+`SELECT_CONV` is sent **only** from `selectConversation()` (`conversation-store.js:432`), which runs on user navigation — never on reconnect. Server-side, `manager.emit` fans out to per-conversation subscribers, and the new socket isn't one.
+
+## Observed
+
+Reproduced with a browser against a real server restart:
+
+1. Open a conversation, open a canvas tab.
+2. Restart the server.
+3. Chat WS reconnects (confirmed in server log: `WebSocket /ws/chat [accepted]`, `WebSocket connected: lmorchard`).
+4. `POST /api/canvas/{conv}/close_tab` → `200 OK`; server removes the tab and emits `canvas_update`.
+5. **Client UI never updates.** The tab stayed on screen indefinitely; a reload showed it correctly gone.
+
+So the two sides silently disagree until reload.
+
+## Blast radius
+
+Anything delivered over the per-conversation stream after a reconnect: `canvas_update`, sticky-slot updates, notifications, tool status, streamed agent output. A reconnect mid-turn likely drops the rest of that turn's output.
+
+## Why it isn't a one-liner
+
+Calling `selectConversation()` on `open` would resubscribe, but it also clears the message store, resets busy/context state, and re-issues `LOAD_HISTORY` — disruptive on every transient blip. This probably wants either a lightweight `RESUBSCRIBE` message type (see `web/message_types.json` + `make gen-message-types`), or a `selectConversation(convId, {resubscribeOnly: true})` path that re-sends `SELECT_CONV` without tearing down client state.
+
+Worth checking whether a resync-on-reconnect is also needed for state that changed while disconnected, not just for future pushes.
+
+## Workaround in place
+
+#703 makes `closeTabById` optimistic (local removal, then POST) so the terminal feature doesn't depend on the push. That's a per-caller patch, not a fix for the class.
+
+---
+
+<!-- Appended by agent-session:triage on 2026-07-29. Author's text above is unchanged. -->
+
+## Verifiable acceptance criteria
+
+- CRITERION: GIVEN a `ConversationStore` with conversation `c1` selected, WHEN its WebSocket
+  client dispatches `open` again (a reconnect), THEN the store SHALL send on that socket a
+  client→server message that resubscribes it to `c1`, AND that message SHALL carry
+  `conv_id === 'c1'`.
+  CHECK: `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js` — a new
+  test file, authored at freeze. It constructs a fake socket (`class FakeWS extends EventTarget`
+  with a recording `send()`), calls `selectConversation('c1')`, clears the record, dispatches a
+  second `open`, and asserts the recorded sends contain a message that resubscribes the socket
+  with `conv_id === 'c1'`.
+  VERIFIED DISCRIMINATING: run at triage against the real module — after the reconnect `open`,
+  `sent-after-open = []` (zero messages) while `store.currentConvId` was still `c1`. So the
+  behaviour is absent today and the store already retains everything the fix needs.
+
+  **Check-form constraints (measured, not assumed):**
+  - `npx vitest run lib/<missing-file>.test.js` exits **1** (`No test files found`), so this
+    check cannot pass vacuously by the file being absent.
+  - The check MUST NOT use `-t <name>`: a `-t` selection matching nothing exits **0** with every
+    test reported skipped. That form grades nothing.
+  - The criterion is deliberately implementation-agnostic. Both designs floated in the issue — a
+    new `RESUBSCRIBE` message type, or `selectConversation(id, {resubscribeOnly: true})` — satisfy
+    it identically, so the choice is implementation style and does not affect the tier.
+
+## Regression guards
+
+These pass today and must keep passing. They grade nothing new and do not affect the tier.
+
+- GUARD: `cd src/decafclaw/web/static && npx vitest run` — the JS unit suite. Invariant: no test
+  lost, newly skipped, or newly failing. Observed at triage: `Test Files 6 passed (6) / Tests 42
+  passed (42)`.
+- GUARD: `uv run pytest tests/test_system_conversations.py` — protects the server-side
+  `_handle_select_conv` → `_subscribe_to_conv` contract (`web/websocket.py:173,185`), which matters
+  if the implementer adds a new message type. Observed at triage: `19 passed`.
+- GUARD: `make check-message-types` — if a new message type is added to `web/message_types.json`,
+  the four generated files must be regenerated in the same commit. This work must not hand-edit
+  `tui/src/types.generated.ts`.
+- GUARD (same new test file): WHEN the socket reopens, the store SHALL NOT discard already-loaded
+  messages for the current conversation, and IF no conversation is selected it SHALL NOT send a
+  subscribe message at all. Both hold today (nothing happens on reopen), so they are guards, not
+  criteria — they exist to rule out the naive
+  `addEventListener('open', () => this.selectConversation(id))` fix, which would clear the message
+  store and re-issue `LOAD_HISTORY` on every transient blip.
+
+## Tier: `auto-ok`
+
+Neither tier trigger fires. Trigger 1: the criterion has a real oracle that exists now (vitest +
+jsdom, `vitest.config.js`, run by `make test-js` and in CI at `.github/workflows/ci.yml:47`); it
+discriminates (empty send list, verified by running it); it is not satisfiable without the work
+(the cheapest green is actually sending the resubscribe with the right `conv_id`); and no human
+judgment is involved. Trigger 2: no risk-gated path — client-side JS plus at most an additive
+WebSocket message type. No auth, secrets, data migration/deletion, deploy/infra/CI config, or
+dependency change.
+
+## Patterns to follow
+
+`tui/src/wsClient.ts:84-97` (`__reconnected`) + `tui/src/App.tsx:83` already implement exactly this
+resubscribe-on-reconnect, tested at `tui/src/wsClient.test.ts:92-138`. Copy its semantics —
+**including its documented ordering hazard**: flush the outbound buffer *before* re-sending the
+subscribe, or a stale queued `select_conv` lands last and bounces the server's subscription to the
+old conversation. The web client has no outbound buffer today (`websocket-client.js:62-68` drops
+sends while closed), so the hazard is latent rather than live.
+
+## Verified-false claims
+
+Checked at triage against the code. **Result: none — every concrete claim in this issue is
+accurate**, including the verbatim line reference `lib/conversation-store.js:128`. Two additions
+the issue does not mention:
+
+- **Omission, not an error.** `web/static/app.js:545-550` also fires on every (re)open and
+  dispatches a `ws-connected` window event, which `components/notification-inbox.js:52` already
+  uses to re-seed after a drop. That is an existing reconnect-resync wiring point a fix could hang
+  off. Separately, `app.js:620-627` registers a **one-shot** `open` handler that calls
+  `selectConversation(savedConvId)` and then removes itself — which is why initial-load selection
+  works and reconnect selection does not, exactly as reported.
+- **Separate defect, out of scope.** `web/static/canvas-page.js:92-97` uses a raw `new WebSocket()`
+  with **no reconnect at all**. It does re-send `SELECT_CONV` in its `open` handler but never
+  reopens, so the standalone canvas page has a different and worse bug. Left out deliberately; see
+  below.
+
+## What we're NOT doing
+
+- **Resyncing state that changed while disconnected.** The issue's closing line ("worth checking
+  whether a resync-on-reconnect is also needed for state that changed while disconnected") is
+  floated as a question, not a requirement. Reconciling missed `canvas_update` / sticky /
+  notification / tool-status state and mid-turn output is a larger piece of work whose criteria
+  would depend on an unmade product decision (which state resyncs, and how) — folding it in would
+  flip this issue to `needs-review`. **File it as a follow-up.**
+- **Fixing `canvas-page.js`.** Separate socket, separate defect, no reconnect logic at all.
+- Note for whoever implements: `docs/web-terminal.md:138-146` and the docstring at
+  `lib/canvas-state.test.js:8-17` currently document this bug as a known defect and justify the
+  #703 optimistic-close workaround. Both should be updated by the fix.

--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -139,12 +139,12 @@ Three details are load-bearing and easy to regress:
 - **`closeTabById` removes the tab locally before POSTing.** The server
   confirms a close by broadcasting `canvas_update` over `/ws/chat` — but this
   path runs *because* the server restarted, which is exactly when that socket
-  is least able to deliver. It does reconnect, yet `conversation-store` only
-  re-runs `listConversations()` on open and never re-sends `SELECT_CONV`, so
-  the fresh socket is subscribed to no conversation stream and the broadcast
-  reaches nobody. Waiting on that push left the dead tab on screen until a
-  full page reload. Anything reacting to a disconnect must not depend on that
-  connection to finish the job.
+  is least able to deliver. `conversation-store` does re-subscribe the fresh
+  socket on reconnect (#704), so the broadcast is no longer delivered to
+  nobody — but that happens on the reconnect's own backoff schedule, well
+  after this close has already been POSTed and confirmed. Waiting on the push
+  left the dead tab on screen until a full page reload. Anything reacting to a
+  disconnect must not depend on that connection to finish the job.
 
 - **`_disposeSurface()`, not just `_teardownSocket()`.** The xterm surface is
   a manually-appended light-DOM `div` with `height: 100%`, and `onopen`

--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -324,6 +324,23 @@ Conversation management is REST-only. WebSocket handles only real-time operation
 - Turn cancellation
 - Tool confirmation responses
 
+#### Subscriptions are per-socket, and re-established on reconnect
+
+The server fans per-conversation events out to the sockets that sent
+`select_conv` for that conversation. A reconnect produces a *new* socket, which
+is subscribed to nothing — so `ConversationStore` re-sends `select_conv` for the
+current conversation on every `open` (#704). Without it, everything on the
+per-conversation stream (`canvas_update`, sticky updates, tool status, streamed
+output) is silently dropped until a full page reload.
+
+The resubscribe deliberately does **not** go through `selectConversation()`,
+which clears the message store and re-issues `load_history` — that would blank
+the transcript and refetch 50 messages on every transient blip. The TUI does the
+same thing from its `__reconnected` handler (`tui/src/App.tsx`).
+
+Note that the standalone canvas page (`/canvas/{conv_id}`) uses its own raw
+socket with no reconnect logic at all, so it is not covered by this.
+
 ## REST API
 
 ### Auth

--- a/src/decafclaw/web/static/lib/canvas-state.test.js
+++ b/src/decafclaw/web/static/lib/canvas-state.test.js
@@ -9,11 +9,11 @@ import {
  *
  * The server confirms a close by broadcasting `canvas_update` over /ws/chat,
  * but the terminal widget calls this when it discovers the server restarted —
- * exactly when that socket is least able to deliver. Worse, the app's
- * reconnect path (conversation-store) only re-runs listConversations() on
- * open; it never re-sends SELECT_CONV, so the reconnected socket is
- * subscribed to nothing and the broadcast reaches no one. Relying on the
- * push left dead tabs on screen until a full page reload.
+ * exactly when that socket is least able to deliver. The reconnect path does
+ * re-send SELECT_CONV now (#704), so the broadcast eventually reaches a
+ * subscribed socket, but only once the reconnect backoff has elapsed — long
+ * after this close completed. Relying on the push left dead tabs on screen
+ * until a full page reload.
  */
 describe('closeTabById', () => {
   beforeEach(async () => {

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -126,6 +126,13 @@ export class ConversationStore extends EventTarget {
     this.#toolStatusStore = new ToolStatusStore(onChange, wsClient, this.#messageStore);
     this.#ws.addEventListener('message', (e) => this.#handleMessage(/** @type {CustomEvent} */(e).detail));
     this.#ws.addEventListener('open', () => this.listConversations());
+    // A reconnect gives us a brand-new socket, and the server tracks stream
+    // subscriptions per socket — so without this, every per-conversation push
+    // (canvas_update, sticky, tool status, streamed output) is delivered to
+    // nobody until a full page reload. Deliberately NOT selectConversation():
+    // that clears the message store and re-issues LOAD_HISTORY, which would
+    // blank the transcript and refetch 50 messages on every transient blip.
+    this.#ws.addEventListener('open', () => this.#resubscribe());
   }
 
   // -- Getters (read by components) -------------------------------------------
@@ -432,6 +439,22 @@ export class ConversationStore extends EventTarget {
     this.#ws.send({ type: MESSAGE_TYPES.SELECT_CONV, conv_id: convId });
     this.#ws.send({ type: MESSAGE_TYPES.LOAD_HISTORY, conv_id: convId, limit: 50 });
     this.#emitChange();
+  }
+
+  /**
+   * Re-subscribe the (re)connected socket to the current conversation.
+   *
+   * Reuses `select_conv` rather than a bespoke wire type because
+   * `_handle_select_conv` already subscribes the socket (`web/websocket.py:173`)
+   * and its `conv_selected` reply is idempotent for the client. Mirrors the
+   * TUI's `__reconnected` handler (`tui/src/App.tsx:83`).
+   *
+   * No-op when nothing is selected: there is no stream to rejoin, and the
+   * initial connect is handled by app.js's one-shot open handler.
+   */
+  #resubscribe() {
+    if (!this.#currentConvId) return;
+    this.#ws.send({ type: MESSAGE_TYPES.SELECT_CONV, conv_id: this.#currentConvId });
   }
 
   /**

--- a/src/decafclaw/web/static/lib/conversation-store.test.js
+++ b/src/decafclaw/web/static/lib/conversation-store.test.js
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConversationStore } from './conversation-store.js';
+import { MESSAGE_TYPES } from './message-types.js';
+// The wire-type manifest, not the generated JS constants: the manifest is the
+// only place `direction` is recorded, and reading it directly means a renamed
+// or removed type changes this set instead of silently shrinking it (a
+// `MESSAGE_TYPES.GONE` reference would just evaluate to `undefined`, and
+// tsconfig excludes `**/*.test.js` so nothing would flag it).
+import wireManifest from '../../message_types.json';
+
+/**
+ * Stand-in for WebSocketClient: same event surface (it is an EventTarget that
+ * dispatches `open` / `message`), but `send()` records instead of writing to a
+ * socket. `open` is dispatched by hand to simulate a reconnect.
+ */
+class FakeWS extends EventTarget {
+  /** @type {object[]} */
+  sent = [];
+
+  /** @param {object} message */
+  send(message) {
+    this.sent.push(message);
+  }
+
+  /** Simulate the underlying socket (re)connecting. */
+  fireOpen() {
+    this.dispatchEvent(new CustomEvent('open'));
+  }
+
+  /** Simulate a server→client frame arriving. @param {object} msg */
+  fireMessage(msg) {
+    this.dispatchEvent(new CustomEvent('message', { detail: msg }));
+  }
+}
+
+/**
+ * Client→server message types that exist today and are NOT subscription
+ * requests. A resubscribe must be something *other* than one of these — e.g.
+ * a re-sent `select_conv` or a purpose-built `resubscribe` type. Deliberately a
+ * deny-list rather than an allow-list so the assertion stays agnostic about
+ * which of those two designs the fix picks. `SELECT_CONV` is absent on purpose.
+ */
+const NON_SUBSCRIBE_TYPES = new Set([
+  MESSAGE_TYPES.LOAD_HISTORY,
+  MESSAGE_TYPES.SEND,
+  MESSAGE_TYPES.CANCEL_TURN,
+  MESSAGE_TYPES.SET_MODEL,
+  MESSAGE_TYPES.SET_EFFORT,
+  MESSAGE_TYPES.WIDGET_RESPONSE,
+  MESSAGE_TYPES.CONFIRM_RESPONSE,
+]);
+
+/**
+ * Every wire type the *server* actually dispatches on, derived from the
+ * manifest's `direction`. A resubscribe has to be one of these: an invented
+ * type (`{type: 'resubscribe'}` with no manifest entry and no handler), or a
+ * missing `type`, or a server→client type echoed back, all reach the server as
+ * `ws: unknown inbound message type` and come back as an error frame — the bug
+ * unfixed with a green board.
+ */
+const CLIENT_TO_SERVER_TYPES = new Set(
+  Object.entries(wireManifest.messages)
+    .filter(([, spec]) => /** @type {any} */ (spec).direction === 'client_to_server')
+    .map(([name]) => name),
+);
+
+/** Where `listConversations()` (no folder) fetches — conversation-store.js:181. */
+const CONVERSATIONS_URL = '/api/conversations';
+
+/** Let the `open` handler's async `listConversations()` fetch chain settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** @returns {ConversationStore} */
+const makeStore = (/** @type {FakeWS} */ ws) =>
+  new ConversationStore(/** @type {any} */ (ws));
+
+describe('ConversationStore reconnect handling', () => {
+  /** @type {FakeWS} */
+  let ws;
+  /** @type {import('vitest').Mock} */
+  let fetchMock;
+
+  beforeEach(() => {
+    // The `open` handler calls listConversations(), which fetches. Stub it to
+    // an empty listing so the handler neither throws nor leaves an unhandled
+    // rejection that could be mistaken for the assertion failure below.
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ conversations: [], folders: [], folder: '' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    ws = new FakeWS();
+  });
+
+  // Harness guard, not a criterion: if the manifest import or its relative
+  // path ever breaks, CLIENT_TO_SERVER_TYPES silently empties and C1's
+  // membership assertion below starts failing for a reason that has nothing to
+  // do with the store. Fail here instead, where the message says so.
+  it('reads client→server wire types from the manifest', () => {
+    expect(CLIENT_TO_SERVER_TYPES.size).toBeGreaterThan(0);
+    expect(CLIENT_TO_SERVER_TYPES).toContain(MESSAGE_TYPES.SELECT_CONV);
+    expect(CLIENT_TO_SERVER_TYPES).not.toContain(MESSAGE_TYPES.CONV_SELECTED);
+  });
+
+  // C1: a reconnect must re-subscribe the fresh socket to the selected
+  // conversation. Without it the server has no record of this socket's
+  // interest, so every broadcast for `c1` (canvas updates, turn events) is
+  // delivered to nobody until a full page reload.
+  it('resubscribes the reopened socket to the selected conversation', async () => {
+    const store = makeStore(ws);
+
+    store.selectConversation('c1');
+    await flush();
+
+    /**
+     * Assert one reconnect's worth of traffic, then reset the recorders so the
+     * next reopen is measured on its own. Called twice: a one-shot guard
+     * (`if (done) return;`) resubscribes the *first* reconnect and leaves every
+     * later one broken, which is exactly the shape of the bug being fixed.
+     * @param {number} round
+     */
+    const expectResubscribed = (round) => {
+      const where = `reconnect #${round}`;
+
+      // Checked first, and passing today: the pre-existing `open` handler
+      // refreshes the conversation list (conversation-store.js:128). Rewriting
+      // that line instead of adding alongside it would green the resubscribe
+      // assertions below while silently killing list refresh on every
+      // reconnect. Ordering it here also keeps this test's present-day failure
+      // message about the missing resubscribe rather than the fetch stub.
+      const listCalls = fetchMock.mock.calls.filter(([url]) => url === CONVERSATIONS_URL);
+      expect(
+        listCalls,
+        `${where}: no fetch of ${CONVERSATIONS_URL} — the open handler's `
+          + 'listConversations() refresh was replaced rather than added to',
+      ).not.toHaveLength(0);
+
+      const forC1 = ws.sent.filter((m) => /** @type {any} */ (m).conv_id === 'c1');
+      expect(forC1, `${where}: nothing sent for c1`).not.toHaveLength(0);
+
+      // Not merely a history refetch that happens to mention c1.
+      const candidates = forC1.filter(
+        (m) => !NON_SUBSCRIBE_TYPES.has(/** @type {any} */ (m).type),
+      );
+      const sentTypes = JSON.stringify(ws.sent.map((m) => /** @type {any} */ (m).type));
+      expect(
+        candidates,
+        `${where}: sent ${sentTypes} — none is a subscribe (all are known non-subscribe types)`,
+      ).not.toHaveLength(0);
+
+      // The subscribing message has to be a type the server dispatches on.
+      // Without this, `send({type: 'resubscribe', conv_id})` with no manifest
+      // entry and no handler passes while the server answers with an error.
+      const registered = candidates.filter(
+        (m) => CLIENT_TO_SERVER_TYPES.has(/** @type {any} */ (m).type),
+      );
+      expect(
+        registered.map((m) => /** @type {any} */ (m).type),
+        `${where}: candidate types ${JSON.stringify(candidates.map((m) => /** @type {any} */ (m).type))} `
+          + `include no registered client→server type (manifest: ${[...CLIENT_TO_SERVER_TYPES].join(', ')})`,
+      ).not.toHaveLength(0);
+
+      ws.sent = [];
+      fetchMock.mockClear();
+    };
+
+    // Only what the reconnect itself sends is under test.
+    ws.sent = [];
+    fetchMock.mockClear();
+
+    ws.fireOpen();
+    await flush();
+    expectResubscribed(1);
+
+    ws.fireOpen();
+    await flush();
+    expectResubscribed(2);
+  });
+
+  // G4a: rules out the naive `addEventListener('open', () => this.select(id))`
+  // fix — selectConversation() clears the message store, so a transient blip
+  // would blank the transcript the user is reading.
+  it('keeps already-loaded messages when the socket reopens', async () => {
+    const store = makeStore(ws);
+
+    store.selectConversation('c1');
+    await flush();
+
+    // Real path: history arrives as a server→client conv_history frame.
+    ws.fireMessage({
+      type: MESSAGE_TYPES.CONV_HISTORY,
+      conv_id: 'c1',
+      has_more: false,
+      messages: [
+        { role: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' },
+        { role: 'assistant', content: 'hi there', timestamp: '2026-01-01T00:00:01Z' },
+      ],
+    });
+    expect(store.currentMessages.map((m) => m.content)).toEqual(['hello', 'hi there']);
+
+    /**
+     * The transcript, the selection, and the absence of a refetch all have to
+     * survive a reopen. Content alone is not enough: a
+     * `selectConversation(id, {resubscribeOnly: true})` that skips
+     * `messageStore.clear()` but still fires LOAD_HISTORY leaves the array
+     * intact while re-pulling 50 messages on every transient blip, and one that
+     * nulls `#currentConvId` leaves the array intact while detaching every
+     * subsequent `msg.conv_id === this.#currentConvId` check.
+     * @param {number} round
+     */
+    const expectUndisturbed = (round) => {
+      const where = `reconnect #${round}`;
+      expect(store.currentMessages.map((m) => m.content), where).toEqual(['hello', 'hi there']);
+      expect(store.currentConvId, `${where}: selection lost`).toBe('c1');
+      const historyRequests = ws.sent.filter(
+        (m) => /** @type {any} */ (m).type === MESSAGE_TYPES.LOAD_HISTORY,
+      );
+      expect(
+        historyRequests,
+        `${where}: refetched history — the transcript is already loaded`,
+      ).toHaveLength(0);
+      ws.sent = [];
+    };
+
+    // Drop the initial select_conv/load_history pair from selectConversation().
+    ws.sent = [];
+
+    ws.fireOpen();
+    await flush();
+    expectUndisturbed(1);
+
+    ws.fireOpen();
+    await flush();
+    expectUndisturbed(2);
+  });
+
+  // G4b: with nothing selected there is nothing to resubscribe to, so the
+  // reconnect must stay silent on the socket.
+  it('sends nothing on the socket when no conversation is selected', async () => {
+    const store = makeStore(ws);
+    expect(store.currentConvId).toBeNull();
+
+    ws.fireOpen();
+    await flush();
+
+    expect(ws.sent).toEqual([]);
+  });
+});

--- a/tests/test_ws_message_type_handlers.py
+++ b/tests/test_ws_message_type_handlers.py
@@ -1,0 +1,57 @@
+"""Every declared client→server wire type must be dispatchable.
+
+`tests/test_message_types.py::test_all_handler_keys_are_known_types` guards one
+direction — no handler keyed on a type the manifest never declared. This guards
+the other: no `client_to_server` entry in the manifest without a handler in
+`_HANDLERS`.
+
+Declaring the type is the visible half of adding one. It regenerates the enum
+and the JS constants, satisfies `make check-message-types`, and satisfies any
+client-side assertion that a message's `type` is a registered client→server
+type. Wiring the handler is the half nothing checks: `_dispatch` falls through
+to `ws: unknown inbound message type` and returns an error frame, so the client
+sends a well-formed message that the server drops. A green board and a wire
+type that does nothing.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import decafclaw.web
+from decafclaw.web.websocket import _HANDLERS
+
+MANIFEST_PATH = Path(decafclaw.web.__file__).resolve().parent / "message_types.json"
+
+
+def _client_to_server_types() -> set[str]:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return {
+        name
+        for name, spec in manifest["messages"].items()
+        if spec["direction"] == "client_to_server"
+    }
+
+
+def test_manifest_declares_client_to_server_types() -> None:
+    """Guard the guard: an empty expected set would make the test below vacuous."""
+    assert MANIFEST_PATH.is_file(), f"manifest not found at {MANIFEST_PATH}"
+    assert _client_to_server_types(), (
+        f"{MANIFEST_PATH} declares no client_to_server messages — either the "
+        "manifest shape changed or the `direction` key was renamed"
+    )
+
+
+def test_every_client_to_server_type_has_a_handler() -> None:
+    expected = _client_to_server_types()
+    # `_HANDLERS` is keyed on `WSMessageType` (a StrEnum). Normalise to the wire
+    # strings the manifest uses so the diff below reads in manifest terms.
+    handled = {str(key) for key in _HANDLERS}
+    missing = sorted(expected - handled)
+    assert not missing, (
+        "client→server message type(s) declared in "
+        f"{MANIFEST_PATH.name} with no entry in websocket._HANDLERS: "
+        f"{', '.join(missing)}. The server will answer these with "
+        "'unknown inbound message type'. Add a `_handle_*` coroutine and "
+        "register it in `_HANDLERS`."
+    )


### PR DESCRIPTION
## Summary

- After `/ws/chat` drops and reconnects, the browser was connected but subscribed to **no conversation stream**. Every server-pushed per-conversation event — `canvas_update`, sticky updates, notifications, tool status, streamed agent output — was silently dropped until the user reloaded the page. A reconnect mid-turn dropped the rest of that turn's output.
- The server fans per-conversation events out to the sockets that sent `select_conv`. A reconnect produces a *new* socket, and `SELECT_CONV` was only ever sent from `selectConversation()` on user navigation — never on reconnect. The store's one `open` listener just re-ran `listConversations()`.

## Design Decisions

**Reuse `select_conv` rather than adding a `resubscribe` wire type.** Both designs were floated in the issue and the acceptance criterion is deliberately agnostic between them.

- `_handle_select_conv` already calls `_subscribe_to_conv` (`web/websocket.py:173,185`), and the client's `CONV_SELECTED` handler is idempotent (`conversation-store.js` — sets `read_only`, restores a pending confirmation). The existing type already does the whole job.
- It matches the TUI's existing fix for the same bug (`tui/src/App.tsx:83`), which the spec named as the pattern to copy.
- A new type would mean a manifest entry, four regenerated files, a new server handler, and a second subscribing code path — all to reach behaviour an existing type already has.

**Deliberately not `selectConversation()`.** That clears the message store, resets busy/context state, and re-issues `LOAD_HISTORY` — it would blank the transcript the user is reading and refetch 50 messages on every transient blip. The frozen guards exist specifically to rule that fix out.

## Changes

- `lib/conversation-store.js` — a second `open` listener calling a new private `#resubscribe()`, which re-sends `select_conv` for `#currentConvId`. No-op when nothing is selected, so the initial connect still goes through `app.js`'s one-shot handler unchanged.
- `docs/web-terminal.md` and the `canvas-state.test.js` docstring both cited this bug as the justification for #703's optimistic canvas-tab close. The workaround is still correct — the reconnect lands on its own backoff, long after the close was POSTed — but the stated reason had become false. Rewritten, not deleted. (Docstring prose only; no assertion changed.)
- `docs/web-ui.md` — new subsection recording that subscriptions are per-socket and re-established on reconnect, why it isn't `selectConversation()`, and that the standalone canvas page's raw socket is not covered.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | a reconnect `open` re-sends a registered client→server subscribe message carrying `conv_id === 'c1'` | `cd src/decafclaw/web/static && npx vitest run lib/conversation-store.test.js` | pass — 4 tests, 4 passed |

Guards, all pass, each run by its own command:

| id | guard | result |
|---|---|---|
| G1 | `cd src/decafclaw/web/static && npx vitest run` | pass — 10 files / 87 tests, 87 passed (freeze baseline 10/87 with C1 red; no test lost, newly skipped, or newly failing) |
| G2 | `uv run pytest tests/test_system_conversations.py` | pass — 19 passed |
| G3 | `make check-message-types` | pass — clean, and **vacuous** for this design: nothing touched the manifest |
| G4 | reopen keeps loaded messages / stays silent when nothing selected (same file as C1) | pass |
| G5 | `uv run pytest tests/test_ws_message_type_handlers.py` | pass — 2 passed |
| G6 | `uv run pytest tests/test_web_websocket_workflow.py` | pass — 1 passed |

Verified by an independent verifier (fresh context, given `checks.md` and the repo only — not the plan, not the notes). Frozen at `5bd6188`; tamper diff clean, and re-runnable by any reviewer since the freeze commit is an ancestor of the pushed head:

```
git diff 5bd6188 -- src/decafclaw/web/static/lib/conversation-store.test.js tests/test_ws_message_type_handlers.py
```

No human-judgment criteria.

## Review

Copilot reviewed 10/10 changed files and generated no comments. Nothing fixed, skipped, or deferred from review.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass · G3 pass · G4 pass · G5 pass · G6 pass
tamper: clean
freeze: 5bd6188
project-gates: make check green
ci: 2/2 pass @ 4a9ff4c58fa367fd58b3e62369d099907b341ccf
threads: 0 unresolved (substitute: gh api graphql is denied in this run's permission mode; derived from the REST review-comment count, which is 0 — review threads are containers for review comments, so zero comments means zero threads. The Copilot review itself did land, state COMMENTED, so this is not a silent no-reviewer case)
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: all gate rows satisfied; tier auto-ok, undowngraded
```

## References

- Spec: `docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/spec.md`
- Checks: `docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/checks.md`
- Plan: `docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/plan.md`
- Notes: `docs/dev-sessions/2026-08-02-0943-704-resubscribe-on-reconnect/notes.md`
- Deliberately out of scope, per the spec's "What we're NOT doing": resyncing state that changed *while* disconnected (missed `canvas_update` / sticky / notification state and mid-turn output), and the standalone canvas page's raw socket, which has no reconnect logic at all. Both want follow-up issues.
- Closes #704