### PR TITLE
feat(#591): shared reflection verifier_model, resolved via model_configs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -209,13 +209,14 @@ Semantic search embedding settings. Empty `url`/`api_key` fall back to `llm` gro
 
 ### `reflection`
 
-Self-reflection judge settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. See [Self-Reflection](reflection.md) for full details.
+Self-reflection judge settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. `verifier_model` is a [`model_configs`](#model_configs) key that takes precedence over all of them — see [Judge model](reflection.md#judge-model). See [Self-Reflection](reflection.md) for full details.
 
 | Field | Type | Default | Env Var | Secret |
 |-------|------|---------|---------|--------|
 | `enabled` | bool | `true` | `REFLECTION_ENABLED` | |
 | `url` | str | (from llm) | `REFLECTION_URL` | |
 | `model` | str | (from llm) | `REFLECTION_MODEL` | |
+| `verifier_model` | str | `""` | `REFLECTION_VERIFIER_MODEL` | |
 | `api_key` | str | (from llm) | `REFLECTION_API_KEY` | yes |
 | `max_retries` | int | `2` | `REFLECTION_MAX_RETRIES` | |
 | `visibility` | str | `hidden` | `REFLECTION_VISIBILITY` | |

--- a/docs/config.md
+++ b/docs/config.md
@@ -209,7 +209,7 @@ Semantic search embedding settings. Empty `url`/`api_key` fall back to `llm` gro
 
 ### `reflection`
 
-Self-reflection judge settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. `verifier_model` is a [`model_configs`](#model_configs) key that takes precedence over all of them — see [Judge model](reflection.md#judge-model). See [Self-Reflection](reflection.md) for full details.
+Self-reflection judge settings. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. `verifier_model` is a [`model_configs`](#model_configs) key; when it is set **and** names an entry in `model_configs` it outranks every other judge-model setting, and otherwise it is ignored and resolution continues down the chain — see [Judge model](reflection.md#judge-model) for the full order. See [Self-Reflection](reflection.md) for full details.
 
 | Field | Type | Default | Env Var | Secret |
 |-------|------|---------|---------|--------|

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
@@ -198,8 +198,61 @@ fails.
   explicit end-state count `3720 passed, 2 skipped`.
   → *greenable without the work by:* n/a — cannot be green today.
 
+## Independent verifier report
+
+Dispatched with a fresh context, given `checks.md` and the repo only — not the plan, not the notes,
+not the spec. Run against the implemented tree.
+
+| id | observed | exit | verdict |
+|---|---|---|---|
+| C1 | `1 item` collected, `1 passed in 1.20s` | 0 | **pass** |
+| C2 | `1 item` collected, `1 passed in 1.22s` | 0 | **pass** |
+| C3 | `1 item` collected, `1 passed in 1.19s` | 0 | **pass** |
+| G1 | `44 passed in 1.37s`, none skipped | 0 | **pass** — invariant met exactly |
+| G2 | `73 passed in 1.43s`, 0 skipped | 0 | **FAIL against the stated invariant** (`71 passed`) |
+| G3 | `11 passed in 1.99s`, none skipped | 0 | **pass** — invariant met exactly |
+| G4 | `3724 items`, `3722 passed, 2 skipped in 13.20s` | 0 | **FAIL against the stated invariant** (`3720 passed, 2 skipped`) |
+
+**Tamper verdict: clean.** `git merge-base --is-ancestor e99c860 HEAD` → `0`, so the freeze commit is
+a real ancestor and the diff is meaningful. `git diff e99c860 -- tests/test_reflection.py` → **empty**.
+`git diff e99c860 --stat` shows 8 files, none of them a check file; the only change to `checks.md`
+itself is the one-line `Frozen at` sha, a sanctioned write.
+
+**Project gate:** `make check` exit 0 — message-types drift clean, `ruff: All checks passed!`,
+`pyright: 0 errors, 0 warnings`, `tsc --noEmit` clean.
+
+**Verifier's discriminating-power assessment of this diff** (asked because a green check is not by
+itself evidence): C1 **could not** be green without the routing work — the diff contains the real
+membership-checked branch, and a field-only no-op still fails C1. C2 and C3 **could** be green
+without it; both are explained by the dataclass field alone. This matches the freeze-time
+adjudication exactly. C1 carries the gate.
+
+### The two guard failures — NOT amended, surfaced for a human
+
+Both are the same defect, and it is in the **manifest's wording**, not in the implementation: G2 and
+G4 were frozen with *exact pass counts* as their invariants (`71 passed`, `3720 passed`). The
+implementation then added two legitimate tests to `tests/test_config.py`
+(`test_reflection_verifier_model_env_override`, `test_reflection_verifier_model_defaults_empty`),
+which close the env-var coverage gap the check-reviewer logged at freeze. Both counts moved +2. The
+verifier confirms **no test was lost and none newly skipped** — the deviation is purely additive.
+
+The substantive invariant the issue actually wrote was *"no test lost, newly skipped, or newly
+failing."* Hardening that into an exact count was done at freeze, in this manifest, by the
+implementer's side of the run — and it is now too tight to survive adding a test.
+
+**This has NOT been fixed, deliberately.** Restating the invariant would change the guard's verdict
+against the current tree (fail → pass) while leaving it unchanged at the freeze tree, which lands in
+the *amendment* cell of `frozen-checks.md`'s four-cell table, not the clarification cell. The
+amendment path requires a human, and an amendment downgrades the run's tier. So the guards stand as
+frozen, both are reported as **failing**, and the gate reads `human-merge-required` on that basis.
+
+The proposed amendment, for a human to accept or reject, is in the PR body. Deleting the two tests
+to make the numbers match was considered and rejected: removing real coverage to satisfy a
+bookkeeping artifact is the exact cheat guards exist to catch.
+
 ## Amendments
 
 (Append-only. Empty unless an amendment was made.)
 
-None.
+None. One amendment is **proposed and unapproved** — see the section above. Nothing in this manifest
+has been altered since the freeze except the `Frozen at` sha and these appended verdicts.

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
@@ -1,7 +1,7 @@
 # Frozen acceptance checks
 
 **Source:** https://github.com/lmorchard/decafclaw/issues/591
-**Frozen at:** (pending — recorded in the follow-up commit)
+**Frozen at:** `e99c860` (2026-08-02)
 **Check files — read-only from Phase 1 onward:**
 - `tests/test_reflection.py`
 

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md
@@ -1,0 +1,205 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/591
+**Frozen at:** (pending — recorded in the follow-up commit)
+**Check files — read-only from Phase 1 onward:**
+- `tests/test_reflection.py`
+
+Criteria and checks are copied verbatim from the issue body.
+
+> **Read C1/C2/C3 as ONE gate.** Only C1 discriminates the routing behavior. C2 and C3 flip green
+> the moment the dataclass field exists, with zero routing logic — their fail-first at freeze is
+> **field-derived, not behavior-derived** (both fail on
+> `TypeError: ReflectionConfig.__init__() got an unexpected keyword argument 'verifier_model'`).
+> A green C2 or C3 is therefore NOT evidence the feature works. C3 still earns its place: it kills
+> the membership-check-free shortcut. If these are ever evaluated separately, C2 and C3 certify
+> nothing. Established by the check-reviewer's decisive experiment, recorded under `## Adjudication`.
+
+## C1
+
+CRITERION: WHERE `reflection.verifier_model` is set to a key present in `config.model_configs`, WHEN
+`evaluate_response` runs, the reflection judge SHALL issue its LLM call with
+`model_name=<verifier_model>` AND SHALL NOT use `default_model` or the legacy url/model/api_key override.
+CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+— constructs `Config` inline with `model_configs={'author':…, 'judge':…}`, `default_model='author'`,
+`reflection.model=''`, `reflection.verifier_model='judge'`, patches `decafclaw.reflection.call_llm`,
+and asserts `call_args.kwargs == {'model_name': 'judge'}`.
+
+AT FREEZE: fails, exit 1 — `TypeError: ReflectionConfig.__init__() got an unexpected keyword
+argument 'verifier_model'` (`tests/test_reflection.py:561`). Confirmed behavior-derived as well as
+field-derived: with the field simulated (constructor monkeypatched, `reflection.py` untouched) it
+still fails `AssertionError: assert {'model_name': 'author'} == {'model_name': 'judge'}`.
+`1 failed in 0.07s`.
+
+## C2
+
+CRITERION: WHEN `reflection.verifier_model` is unset (empty), the reflection judge SHALL resolve
+exactly as today — `reflection.model` if in `model_configs` → `config.default_model` → legacy
+`reflection.resolved(config)` url/model/api_key.
+CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
+— asserts **all three branches** on the patched `call_llm`: (a) `reflection.model='judge'` in
+`model_configs` → `{'model_name':'judge'}`; (b) `reflection.model=''`, `default_model='author'` →
+`{'model_name':'author'}`; (c) `model_configs={}`, `default_model=''`,
+`reflection.model='cheap-judge-model'` → kwargs contain `llm_model='cheap-judge-model'`.
+
+AT FREEZE: fails, exit 1 — same `TypeError` (`tests/test_reflection.py:594`).
+**Fail-first is field-derived only.** With the field simulated and `reflection.py` untouched, C2
+passes. It is a preservation criterion; treat its green as "the existing chain still works," never
+as "the feature works."
+
+## C3
+
+CRITERION: IF `reflection.verifier_model` names a key that is **NOT** in `config.model_configs`, THEN
+the reflection judge SHALL fall back to today's chain AND SHALL NOT pass the unknown name as
+`model_name`.
+CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back`
+
+AT FREEZE: fails, exit 1 — same `TypeError` (`tests/test_reflection.py:652`).
+**Fail-first is field-derived only**, but C3 is a live coupling constraint on C1's implementation:
+against the naive `if vm: call_llm(..., model_name=vm)` shortcut it fails with
+`AssertionError: assert {'model_name': 'no-such-model'} == {'model_name': 'author'}`.
+Must never be evaluated as a standalone criterion.
+
+## Guards
+
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- **G1:** the pre-existing judge suite, with the three criterion nodes deselected:
+
+  ```
+  uv run pytest tests/test_reflection.py -q \
+    --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call" \
+    --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain" \
+    --deselect "tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back"
+  ```
+
+  Invariant: **44 passed, none skipped, none lost.** (Scoped at freeze per the check-reviewer: the
+  issue's unscoped `pytest tests/test_reflection.py -q` became a strict superset of C1–C3 the moment
+  the checks were authored into that file, so it cannot be red-to-green-neutral and cannot
+  distinguish "a pre-existing judge test regressed" from "a criterion isn't done yet.")
+
+- **G2:** `uv run pytest tests/test_config.py tests/test_config_cli.py -q` — protects the generic
+  `load_sub_config` loader (`config.py:99-131`) and the generic `config set` CLI
+  (`config_cli.py`, generic over `fields()`). Invariant: **71 passed, none skipped.**
+  (`tests/test_config_cli.py` added at freeze; the issue's G2 named only `tests/test_config.py`
+  while claiming to cover `config set`, which lives in a module that file never imports.
+  **Overclaim removed:** nothing under `tests/` asserts `REFLECTION_VERIFIER_MODEL` — a repo-wide
+  grep for `REFLECTION_[A-Z_]+` in `tests/` returns zero hits — so a green G2 is *not* evidence the
+  env var reaches the new field. See "Coverage gap" below.)
+
+- **G3:** `uv run pytest tests/test_agent_turn.py -q -k reflection` — protects the agent-loop
+  integration of `evaluate_response` (`agent.py`). Invariant: **11 passed, none skipped.**
+  Disjoint from the criterion nodes, so it is a real invariant.
+
+- **G4 (invariant):** full suite, `make test`. **Evaluable only after C1–C3 are green** — `make test`
+  collects `tests/test_reflection.py`, so today it necessarily reports the three known-failing
+  criterion nodes. Invariant at the end of the run: **3720 passed, 2 skipped** (3717 pre-existing +
+  the 3 criterion nodes), no test lost and no test newly skipped.
+
+## Evidence at freeze
+
+Re-run in this worktree at `2fab896` (branch base), before any implementation.
+
+**Precondition (the gap is still there):**
+
+```
+uv run python -c "...dataclasses.fields(ReflectionConfig)..."
+FIELDS ['enabled', 'url', 'model', 'api_key', 'max_retries', 'visibility', 'max_tool_result_len']
+HAS_VERIFIER_MODEL False
+```
+
+**Criterion nodes absent before authoring** (all three, one invocation):
+`ERROR: not found: …::test_verifier_model_routes_judge_call` (× 3 nodes), `no tests ran in 0.03s`,
+**exit 4**. The issue recorded exit 5; exit 4 is what pytest returns when *explicitly named* node ids
+don't resolve (usage error) versus 5 for an empty collection. Same absence, different invocation
+shape — recorded as observed rather than as filed.
+
+**Guards at freeze (all pass, with counts), using the scoped commands above:**
+
+| Guard | Observed |
+|---|---|
+| G1 | `44 passed in 1.54s` |
+| G2 | `71 passed in 1.39s` |
+| G3 | `11 passed in 2.05s` |
+| G4 | `3717 passed, 2 skipped in 27.39s` (pre-authoring baseline) |
+
+## Coverage gap (a PR review note, not a criterion)
+
+No check or guard asserts that `REFLECTION_VERIFIER_MODEL` (env) or
+`decafclaw config set reflection.verifier_model` reach the new field. Both are *derived* from the
+dataclass field by generic machinery (`config.py:461-462` calls
+`load_sub_config(ReflectionConfig, file_data.get("reflection", {}), "REFLECTION")`;
+`config_cli.py` iterates `fields()`), so they should come for free — but "should" is the word
+doing the work, and nothing in the frozen set proves it. The implementer should add a unit test
+covering it; that test is **implementer scaffolding, freely editable**, not part of the frozen set.
+
+## Adjudication
+
+Written at freeze, before the freeze commit, by a read-only check-reviewer subagent that was given
+`checks.md` and the repo but not the plan, the spec, or the criteria's rationale.
+
+Its decisive experiment: monkeypatch `ReflectionConfig.__init__` to accept and store
+`verifier_model`, leave `reflection.py` untouched, run the three nodes → `1 failed, 2 passed`.
+Second experiment: the membership-check-free shortcut `if vm: call_llm(..., model_name=vm)` → C3
+fails.
+
+- **C1: accepted** — the only check with teeth. Tried and failed to green it cheaply: field-only
+  no-op → still fails; unconditional `model_name="judge"` hardcode → defeated by C2(b)/C2(c)/C3 in
+  the same gate; a raising stub → `call_args` is `None` because `evaluate_response` is fail-open, so
+  it fails too. Assertion shape is right: positive destination, equality (not membership) so a stray
+  legacy override alongside `model_name` fails. *Noted and judged non-load-bearing:* `call_llm`'s
+  overrides are positional-capable, so `call_llm(cfg, msgs, None, url, model, key, model_name="judge")`
+  would green C1 while violating the SHALL-NOT half; closing it fully needs
+  `assert len(call_args.args) == 2`. Left as-is because every `call_llm` call site in the repo passes
+  those three by keyword. Recorded so it is not rediscovered as a surprise.
+  → *greenable without the work by:* nothing constructible short of the real membership-checked branch.
+
+- **C2: strengthened** (annotation, not assertion) — the reviewer's finding is that C2 has **no
+  teeth against any routing behavior** and no added assertion can give it any, because there is no
+  input on which today's behavior and the intended behavior differ on the `verifier_model=''` path.
+  It recommended reclassifying it as a guard. **Declined the reclassification, took the fallback
+  remedy it named**: C2 is an independently-authored criterion copied verbatim from the issue, and
+  the implementer demoting it would be the implementer editing its own oracle. Instead the manifest
+  now states, at the top and under C2, that its fail-first is field-derived and its green is not
+  evidence of the feature. The three branch assertions themselves were judged well-shaped —
+  equality on (a) and (b), and (c) correctly pairs positive `llm_model` with negative
+  `'model_name' not in kwargs`.
+  → *greenable without the work by:* adding `verifier_model: str = ""` and changing nothing else
+  (verified: 2 passed).
+
+- **C3: strengthened** (annotation) — same field-derived fail-first, but the reviewer confirmed it
+  discriminates the most likely wrong implementation (routing on `verifier_model` without the
+  `in config.model_configs` membership check). Assertion shape is the strong form: names the
+  concrete fallback destination (`author`) rather than only asserting the unknown name is absent.
+  Manifest now records that it is a coupling constraint on C1 and must not be evaluated standalone.
+  → *greenable without the work by:* the field-only no-op (verified) — hence the coupling note.
+
+- **G1: strengthened** — as filed in the issue it **did not pass at freeze** (`3 failed, 44 passed`),
+  because authoring the checks into `tests/test_reflection.py` made the guard a superset of its own
+  criteria. Command scoped with three `--deselect`s and the invariant restated as `44 passed`.
+  Verified after scoping: `44 passed in 1.54s`.
+  → *greenable without the work by:* n/a — the opposite problem; unscoped it could not be green today.
+
+- **G2: strengthened** — passed as filed (`55 passed`) but overclaimed. `tests/test_config.py` never
+  imports `config_cli.py`, so it cannot protect `config set`; and nothing under `tests/` asserts any
+  `REFLECTION_*` env var. Added `tests/test_config_cli.py` to the command (`71 passed`) and removed
+  the env-var claim from the guard's text, logging it instead as a coverage gap above.
+  → *greenable without the work by:* it is green today and stays green even if the field is never
+  added — which is exactly why the overclaim had to come out.
+
+- **G3: accepted** — `11 passed`. All eleven nodes are agent-loop integration around
+  `evaluate_response`, the one function being edited. Claims only blast-radius protection and
+  delivers exactly that; disjoint from the criterion nodes.
+  → *no cheaper green found.*
+
+- **G4: strengthened** — same structural defect as G1: `make test` collects the criterion nodes, so
+  the invariant was being measured against a suite containing three known failures
+  (`3 failed, 3717 passed, 2 skipped`). Restated as evaluable only post-implementation, with the
+  explicit end-state count `3720 passed, 2 skipped`.
+  → *greenable without the work by:* n/a — cannot be green today.
+
+## Amendments
+
+(Append-only. Empty unless an amendment was made.)
+
+None.

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/notes.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/notes.md
@@ -8,6 +8,26 @@
 - Tier: `auto-ok` (read from the spec's `## Tier:` heading)
 - Readiness variant applied: **augmented existing issue**
 
+## Scope call made during branch self-review
+
+Documenting the true resolution order in `docs/reflection.md` made a **pre-existing** contradiction
+visible for the first time: the Quick start at `docs/reflection.md:50` recommends
+`config set reflection.model gemini-2.5-flash`, which the new table 20 lines below shows is silently
+discarded whenever `default_model` is set (the #752 latent bug).
+
+I did **not** fix the bug — the issue forbids it, and fixing it would change what frozen check C2
+branch (b) asserts. I did add a one-sentence caveat pointing at #752 and at `verifier_model`, on the
+grounds that shipping a page which contradicts itself is worse than the scope cost of one sentence,
+and that CLAUDE.md requires the feature's docs to be correct in the same PR. No behavior change, no
+check affected. Flagged in the PR body so the call is visible rather than buried.
+
+## Coverage gap carried forward (from the check-reviewer)
+
+`tests/test_config_cli.py` is generic over `fields()`, so `config set reflection.verifier_model`
+works by derivation but has no verifier-specific assertion. The env-var half is now covered by
+`test_reflection_verifier_model_env_override`. Left as-is; noted so it isn't rediscovered as a
+surprise.
+
 ### Setup deviation
 
 `HTTP_PORT` was **not** added to the worktree `.env` (the append was blocked by the sandbox in

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/notes.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/notes.md
@@ -1,0 +1,16 @@
+# Notes — #591 reflection verifier_model
+
+## Setup
+
+- Branch: `feat/591-reflection-verifier-model` (from `origin/main` @ `2fab896`)
+- Worktree: `.claude/worktrees/feat-591-reflection-verifier-model`
+- Baseline: `make test` → **3717 passed, 2 skipped in 27.39s** (green)
+- Tier: `auto-ok` (read from the spec's `## Tier:` heading)
+- Readiness variant applied: **augmented existing issue**
+
+### Setup deviation
+
+`HTTP_PORT` was **not** added to the worktree `.env` (the append was blocked by the sandbox in
+this unattended run). Harmless here — this change is unit-test-only and no server is started from
+this worktree. If anyone runs `make dev` from it, set `HTTP_PORT` first to avoid colliding with
+the main clone's `18884`.

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
@@ -1,0 +1,193 @@
+# Reflection `verifier_model` Implementation Plan
+
+**Goal:** Give the reflection judge a shared, opt-in `verifier_model` config ref so judges can run on
+a model distinct from the author's, without changing any default behavior.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/591 — **Tier:** `auto-ok`
+(all three criteria pair with concrete unit tests whose harness exists and which fail today; no
+risk-gated path — `verifier_model` is a `model_configs` key, not a credential).
+
+**Approach:** Add one field to `ReflectionConfig` and one branch at the head of the existing routing
+chain in `evaluate_response`. The branch fires only when the field is non-empty **and** the name is a
+key in `config.model_configs`; otherwise control falls through to today's chain untouched. Env var
+(`REFLECTION_VERIFIER_MODEL`) and `config set reflection.verifier_model` come for free from the
+generic `load_sub_config` / `config_cli` machinery — but "for free" is a claim, so Phase 1 adds a unit
+test that proves it.
+
+**Criteria:** C1 set-and-known → routes to it · C2 unset → today's chain unchanged · C3 set-but-unknown
+→ falls back, never passed as `model_name`.
+Full text, checks, guards, and adjudication live in `checks.md`. Ids are assigned there.
+
+**Read `checks.md`'s gate note before executing.** Only C1 discriminates the routing behavior; C2 and
+C3 go green on the dataclass field alone. Do not read "2 of 3 passing" as progress.
+
+---
+
+## Phase 0: Freeze the acceptance checks — DONE
+
+Written and committed before any implementation, per `references/frozen-checks.md`.
+
+**Files:**
+- Created: `docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md`
+- Created: `docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/spec.md`
+- Modified: `tests/test_reflection.py` — the three tests C1–C3 name (**read-only from Phase 1 onward**)
+
+**Verification — automated:**
+- [x] Every criterion's check runs and fails for the expected reason — all three fail exit 1 with
+      `TypeError: ReflectionConfig.__init__() got an unexpected keyword argument 'verifier_model'`;
+      C1 additionally confirmed behavior-derived (`{'model_name': 'author'} != {'model_name': 'judge'}`
+      with the field simulated)
+- [x] Every guard runs and passes — G1 `44 passed`, G2 `71 passed`, G3 `11 passed`, G4 `3717 passed,
+      2 skipped`. G1 and G4 were **rescoped at freeze** (see the adjudication): as filed they were
+      supersets of their own criteria and could not pass.
+- [x] Check-reviewer dispatched read-only, without this plan or the criteria's rationale;
+      `## Adjudication` carries one disposition per check and per guard
+- [x] Freeze commit `e99c860`; sha recorded in `checks.md` by follow-up commit `034e739`
+
+---
+
+## Phase 1: `verifier_model` field + routing branch + docs
+
+One vertical slice: config dataclass → routing logic → the derived config surfaces → user-facing docs.
+Kept as a single phase because the change has one behavior and splitting it would leave a phase
+advancing no criterion.
+
+**Advances:** C1, C2, C3 — completely. Nothing remains for a later phase.
+
+**Files:**
+- Modify: `src/decafclaw/config_types.py` — add `verifier_model` to `ReflectionConfig` (~line 239)
+- Modify: `src/decafclaw/reflection.py` — new leading branch in `evaluate_response`'s routing block
+  (~line 291)
+- Modify: `docs/config.md` — add the field to the `reflection` table (~line 214)
+- Modify: `docs/reflection.md` — document the judge-model convention under "Judge model" (~line 71)
+- Test: `tests/test_config.py` — **new** unit test that `REFLECTION_VERIFIER_MODEL` reaches the field.
+  Implementer scaffolding, freely editable. NOT part of the frozen set. This closes the coverage gap
+  the check-reviewer logged: nothing under `tests/` asserts any `REFLECTION_*` env var today.
+- **Do NOT modify** `tests/test_reflection.py` — frozen at `e99c860`. A failing frozen check is a
+  report-back, not a fix-up.
+
+**Key changes:**
+
+`ReflectionConfig` gains one field. Placed after `model` so the two model knobs read together:
+
+```python
+@dataclass
+class ReflectionConfig:
+    enabled: bool = True
+    url: str = ""       # empty = resolve from llm
+    model: str = ""     # empty = resolve from llm
+    # A model_configs key. When set AND present in config.model_configs, every
+    # reflection judge routes through it, so the author does not grade its own
+    # homework (#591). Empty = today's chain (model -> default_model -> legacy).
+    verifier_model: str = ""
+    api_key: str = field(default="", metadata={"secret": True})
+    ...
+```
+
+`evaluate_response`'s routing block gains one leading branch. The rest is **unchanged** — that is
+what C2 asserts:
+
+```python
+        # Route through named model config:
+        #   verifier_model > reflection.model > default_model > legacy
+        verifier = config.reflection.verifier_model
+        rc_model = config.reflection.model
+        if verifier and verifier in config.model_configs:
+            response = await call_llm(config, messages, model_name=verifier)
+        elif rc_model and rc_model in config.model_configs:
+            response = await call_llm(config, messages, model_name=rc_model)
+        elif config.default_model:
+            response = await call_llm(config, messages, model_name=config.default_model)
+        else:
+            rc = config.reflection.resolved(config)
+            response = await call_llm(
+                config, messages,
+                llm_url=rc.url, llm_model=rc.model, llm_api_key=rc.api_key,
+            )
+```
+
+The `and verifier in config.model_configs` half is load-bearing, not defensive: C3 fails without it
+(verified at freeze — the shortcut routes `no-such-model` through as `model_name`). It also matches
+the issue's own wording, "set **and present in** `config.model_configs`".
+
+`verifier_model` wins over `reflection.model` when both are set. The issue flagged this as its one
+ambiguity and pinned it: C1's assertion assumes `verifier_model` wins.
+
+The new config test:
+
+Mirrors `test_vault_guide_env_override` (`tests/test_config.py:109-116`) exactly — same
+`(self, tmp_path, monkeypatch)` signature, same `DATA_HOME` pin, same bare `load_config()`:
+
+```python
+    def test_reflection_verifier_model_env_override(self, tmp_path, monkeypatch):
+        """Env prefix REFLECTION_* reaches the new verifier_model field."""
+        monkeypatch.setenv("REFLECTION_VERIFIER_MODEL", "judge")
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.reflection.verifier_model == "judge"
+```
+
+Place it in the same env-override test class the `vault_guide` case lives in.
+
+**Docs — say what the convention IS, not just that the field exists.** The check-reviewer noted the
+only available check here is a keyword grep, which is satisfiable by typing the word; the issue
+deliberately rejected it as a criterion and left it a PR review note. So:
+- `docs/config.md`: one table row, `verifier_model | str | `""` | REFLECTION_VERIFIER_MODEL |`.
+- `docs/reflection.md`, under "Judge model": state that `verifier_model` is a `model_configs` key that
+  takes precedence over `reflection.model`; that it exists so the judge can differ from the author;
+  and that future specialized judges (#529 source-grounding, #530 edit-safety, #589 adversarial)
+  inherit it unless they set a more specific override.
+
+**Out of scope — do not touch:**
+- The latent branch-order bug at `reflection.py:292-296` (a set-but-unknown `reflection.model` is
+  silently discarded when `default_model` is set, killing the documented "cheap judge model" escape
+  hatch). Pre-existing; the issue says explicitly not to fold it in, and fixing it would change what
+  C2 branch (b) asserts. **File a follow-up issue instead** — see Phase 2.
+- `src/decafclaw/eval/reflect.py`'s `--judge-model` CLI arg. A separate grader-model mechanism that
+  reads no config field; the issue puts it out of scope.
+- Any extraction of routing into a shared helper. The issue's scope notes are explicit: with
+  #529/#530/#589 unimplemented there is exactly one consumer, so a "shared primitive" abstraction is
+  unfreezable today. Let #529 prove the reuse.
+
+**Verification — automated:**
+- [ ] C1's check passes:
+      `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+- [ ] C2's check passes:
+      `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
+- [ ] C3's check passes:
+      `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back`
+- [ ] G1 passes, `44 passed`, none skipped:
+      `uv run pytest tests/test_reflection.py -q --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call" --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain" --deselect "tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back"`
+- [ ] G2 passes, ≥71 passed (72 with the new env test), none skipped:
+      `uv run pytest tests/test_config.py tests/test_config_cli.py -q`
+- [ ] G3 passes, `11 passed`: `uv run pytest tests/test_agent_turn.py -q -k reflection`
+- [ ] G4: `make test` — `3721 passed, 2 skipped` (3717 baseline + 3 criterion nodes + 1 new config
+      test), none lost, none newly skipped
+- [ ] `make check` passes (lint + pyright + JS)
+- [ ] Tamper diff empty: `git diff e99c860 -- tests/test_reflection.py`
+
+**Verification — manual:**
+- [ ] No human-judgment criterion in this set — nothing to grade at the gate on behavior.
+- [ ] Read `docs/reflection.md`'s new paragraph as a user: does it explain the *convention*
+      (`verifier_model` beats `reflection.model`; #529/#530/#589 inherit it), or does it just name
+      the field? This is the issue's deliberately-rejected criterion, carried as a PR review note.
+
+---
+
+## Phase 2: File the follow-up issue for the latent branch-order bug
+
+Not a code phase. The issue instructs that the latent bug be surfaced separately rather than fixed
+here, and "surface it" is only done when there is a record.
+
+**Advances:** no criterion — deliberately. This is the issue's own out-of-scope instruction being
+honored, not scope creep; it ships zero code and touches zero file in the repo.
+
+**Files:** none.
+
+**Verification — automated:**
+- [ ] A GitHub issue exists describing: at `reflection.py:292-296`, a `reflection.model` that is set
+      but is not a `model_configs` key is silently discarded whenever `default_model` is set, so the
+      documented escape hatch at `docs/reflection.md:53`
+      (`decafclaw config set reflection.model gemini-2.5-flash`) is dead on any modern config. Note
+      that `test_uses_reflection_model` only passes because its fixture leaves `default_model` empty.
+- [ ] The new issue number is linked from PR #591's body.

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
@@ -188,7 +188,8 @@ honored, not scope creep; it ships zero code and touches zero file in the repo.
 **Files:** none.
 
 **Verification — automated:**
-- [ ] A GitHub issue exists describing: at `reflection.py:292-296`, a `reflection.model` that is set
+- [x] **Filed as https://github.com/lmorchard/decafclaw/issues/752.** A GitHub issue exists
+      describing: at `reflection.py:292-296`, a `reflection.model` that is set
       but is not a `model_configs` key is silently discarded whenever `default_model` is set, so the
       documented escape hatch at `docs/reflection.md:53`
       (`decafclaw config set reflection.model gemini-2.5-flash`) is dead on any modern config. Note

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md
@@ -150,21 +150,24 @@ deliberately rejected it as a criterion and left it a PR review note. So:
   unfreezable today. Let #529 prove the reuse.
 
 **Verification — automated:**
-- [ ] C1's check passes:
+- [x] C1's check passes — `1 passed in 0.03s`:
       `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
-- [ ] C2's check passes:
+- [x] C2's check passes — `1 passed in 0.03s`:
       `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
-- [ ] C3's check passes:
+- [x] C3's check passes — `1 passed in 0.02s`:
       `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back`
-- [ ] G1 passes, `44 passed`, none skipped:
+- [x] G1 passes — **`44 passed in 1.21s`**, none skipped:
       `uv run pytest tests/test_reflection.py -q --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call" --deselect "tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain" --deselect "tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back"`
-- [ ] G2 passes, ≥71 passed (72 with the new env test), none skipped:
+- [x] G2 passes — **`73 passed in 1.59s`**, none skipped:
       `uv run pytest tests/test_config.py tests/test_config_cli.py -q`
-- [ ] G3 passes, `11 passed`: `uv run pytest tests/test_agent_turn.py -q -k reflection`
-- [ ] G4: `make test` — `3721 passed, 2 skipped` (3717 baseline + 3 criterion nodes + 1 new config
-      test), none lost, none newly skipped
-- [ ] `make check` passes (lint + pyright + JS)
-- [ ] Tamper diff empty: `git diff e99c860 -- tests/test_reflection.py`
+      (73, not the predicted 72: two config tests were added, not one — the env-override case plus a
+      default-is-empty case. Recorded as observed.)
+- [x] G3 passes — **`11 passed in 2.12s`**: `uv run pytest tests/test_agent_turn.py -q -k reflection`
+- [x] G4: `make test` — **`3722 passed, 2 skipped in 13.44s`** (3717 baseline + 3 criterion nodes +
+      2 new config tests), none lost, none newly skipped
+- [x] `make check` passes — `ruff: All checks passed!`, `pyright: 0 errors, 0 warnings`,
+      message-types drift check clean, `tsc --noEmit` clean
+- [x] Tamper diff empty: `git diff e99c860 -- tests/test_reflection.py` → no output
 
 **Verification — manual:**
 - [ ] No human-judgment criterion in this set — nothing to grade at the gate on behavior.

--- a/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/spec.md
+++ b/docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/spec.md
@@ -1,0 +1,170 @@
+# Reflection: shared verifier_model config (resolved through model_configs)
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/591
+
+Captured verbatim from the issue body (agent-session:spec marker stripped).
+
+## Context
+
+Multiple reflection judges want to run on a model *distinct from the author* so the author isn't grading its own homework (cf. Osmani, ["loop engineering"](https://addyosmani.com/blog/loop-engineering/)). Today `evaluate_response` (`reflection.py`) resolves the judge model as `reflection.model` → else `config.default_model` → else legacy, which in practice means **same model as the author**.
+
+There are now three consumers that all want a distinct verifier model:
+- #529 — source-grounding judge
+- #530 — pre-write edit-safety judge
+- #589 — adversarial reflection mode
+
+That's the threshold where a shared primitive is warranted. This issue establishes it so the three judges can be worked in any order without each re-inventing model routing.
+
+## Proposal
+
+- Add `reflection.verifier_model` to `ReflectionConfig` — a `model_configs` ref (named-model indirection, matching how `reflection.model` is intended to resolve).
+- Resolution: when `verifier_model` is set and present in `config.model_configs`, all reflection judges route their LLM call through it. When unset, fall back to today's behavior (`reflection.model` → `default_model` → legacy) so nothing changes by default.
+- Document the convention: the specialized judges (#529/#530) and adversarial reflection (#589) inherit `verifier_model` unless they set a more specific override.
+
+## Acceptance
+
+- `reflection.verifier_model` on `ReflectionConfig`, resolved through `model_configs`.
+- Unit test: with `verifier_model` set, `evaluate_response`'s LLM call provably routes to it; with it unset, existing fallback chain is unchanged.
+- No behavioral eval needed here (pure config/routing, no new LLM-visible behavior) — the judges that consume it carry the evals.
+
+## Related
+
+- #589 — adversarial reflection mode (blocked-by this)
+- #529, #530 — specialized judges (inherit this)
+- #409 — reflection telemetry
+
+---
+
+<!-- Appended by agent-session:triage on 2026-07-29. Author's text above is unchanged. -->
+
+## Verified-false claims
+
+**None — every stated fact checked out.** Verified individually at triage:
+
+- `evaluate_response` exists at `src/decafclaw/reflection.py:264`.
+- "resolves the judge model as `reflection.model` → else `config.default_model` → else legacy" is
+  **exact** — `reflection.py:292-302`, where the comment literally reads
+  `# Route through named model config: explicit > default_model > legacy`.
+- "in practice means same model as the author" — verified by probe: with `reflection.model` unset and
+  `default_model="author"`, the patched `call_llm` received `{'model_name': 'author'}`.
+- `reflection.verifier_model` is genuinely **absent** today. `ReflectionConfig` fields are
+  `['enabled', 'url', 'model', 'api_key', 'max_retries', 'visibility', 'max_tool_result_len']`.
+- The three consumers #529/#530/#589 all exist and are OPEN; **none of their code exists yet**
+  (`rg source_grounding|edit_safety|adversarial src/` → no hits), so today there is exactly one
+  reflection judge call site.
+- `model_configs` / `default_model` on `Config` at `config.py:179-180`; `reflection.model` doubles as
+  either a `model_configs` key or a raw legacy model name.
+
+**Oracle preconditions, both verified:** model resolution is a **pure function** —
+`resolve_model()` at `src/decafclaw/config.py:281-308` does dict lookups over `config.model_configs` /
+`config.providers`, raises `KeyError`, no I/O. **No credentials or network are needed** to check any
+criterion below: `resolve_model` never inspects `ProviderConfig.api_key`, and the criteria patch
+`decafclaw.reflection.call_llm` so the harness-state-dependent provider registry
+(`llm/registry.py`'s module-global `_providers`, populated by `init_providers(config)`) is never
+consulted. Each test constructs `Config(...)` inline and never calls `load_config()`.
+
+## Verifiable acceptance criteria
+
+- CRITERION: WHERE `reflection.verifier_model` is set to a key present in `config.model_configs`, WHEN
+  `evaluate_response` runs, the reflection judge SHALL issue its LLM call with
+  `model_name=<verifier_model>` AND SHALL NOT use `default_model` or the legacy url/model/api_key override.
+  CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+  — constructs `Config` inline with `model_configs={'author':…, 'judge':…}`, `default_model='author'`,
+  `reflection.model=''`, `reflection.verifier_model='judge'`, patches `decafclaw.reflection.call_llm`,
+  and asserts `call_args.kwargs == {'model_name': 'judge'}`.
+  VERIFIED DISCRIMINATING: `no tests ran in 2.19s`, **exit 5**. Supporting evidence the field is absent:
+  `uv run python -c "...fields(ReflectionConfig)..."` → `HAS_VERIFIER_MODEL False`.
+  ORACLE_EXISTS: yes — the `TestEvaluateResponse` harness is at `tests/test_reflection.py:454-462`
+  (fixture) with the `patch("decafclaw.reflection.call_llm")` pattern at `:465-537`. An equivalent
+  probe was run in-process at triage and worked.
+
+- CRITERION: WHEN `reflection.verifier_model` is unset (empty), the reflection judge SHALL resolve
+  exactly as today — `reflection.model` if in `model_configs` → `config.default_model` → legacy
+  `reflection.resolved(config)` url/model/api_key.
+  CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
+  — asserts **all three branches** on the patched `call_llm`: (a) `reflection.model='judge'` in
+  `model_configs` → `{'model_name':'judge'}`; (b) `reflection.model=''`, `default_model='author'` →
+  `{'model_name':'author'}`; (c) `model_configs={}`, `default_model=''`,
+  `reflection.model='cheap-judge-model'` → kwargs contain `llm_model='cheap-judge-model'`.
+  VERIFIED DISCRIMINATING: node absent today → exit 5. Branches (a) and (b) were confirmed to be
+  current behaviour by probe; branch (c) is already covered by the existing `test_uses_reflection_model`
+  (`tests/test_reflection.py:503-513`), which passes today.
+  Not satisfiable without the work — a stub would not produce these three distinct kwarg dicts.
+
+- CRITERION: IF `reflection.verifier_model` names a key that is **NOT** in `config.model_configs`, THEN
+  the reflection judge SHALL fall back to today's chain AND SHALL NOT pass the unknown name as
+  `model_name`.
+  CHECK: `uv run pytest tests/test_reflection.py::TestEvaluateResponse::test_unknown_verifier_model_falls_back`
+  VERIFIED DISCRIMINATING: node absent today → exit 5.
+  This is the issue's own wording ("set **and present in** `config.model_configs`") turned into an
+  assertion. **Without it, the cheapest implementation silently hands an unknown name to `_resolve`,
+  which logs a warning and falls through to the default provider** (`llm/__init__.py:106-107`).
+
+### Deliberately rejected as a criterion
+
+"Document the convention that #529/#530/#589 inherit `verifier_model`" (Proposal bullet 3). The only
+available check is `rg -q 'verifier_model' docs/config.md docs/reflection.md` — **a keyword grep,
+satisfiable by typing the word**; whether the *convention* is explained is a human read. There is also
+no docs↔dataclass sync test in this repo (`rg -ln config.md tests/` → no hits), and `docs/config.md:214-221`
+already omits the existing `max_tool_result_len` field, so no existing gate would catch it either.
+**Treat as a review note on the PR, not a criterion.**
+
+## Regression guards
+
+- GUARD: `uv run pytest tests/test_reflection.py -q` — protects the whole judge path including the
+  existing fallback-chain test. Observed at triage: `44 passed in 2.76s`. Invariant: no test lost,
+  newly skipped, or newly failing.
+- GUARD: `uv run pytest tests/test_config.py -q` — protects the generic `load_sub_config` loader
+  (`config.py:99-131`), which derives the `REFLECTION_VERIFIER_MODEL` env var and
+  `config set reflection.verifier_model` **for free** from the dataclass field, so nothing should need
+  registering. Observed at triage: `55 passed in 2.47s`.
+- GUARD: `uv run pytest tests/test_agent_turn.py -q -k reflection` — protects the agent-loop
+  integration of `evaluate_response` (`agent.py:1008-1045`). Observed at triage: `11 passed in 2.49s`.
+- GUARD (invariant): full suite — no test lost, newly skipped, or newly failing.
+  **UNRUN (needs a serial full-suite run).** Do not read as verified.
+
+## Tier: `auto-ok`
+
+Neither trigger fires.
+
+**Trigger 1:** all three criteria pair with concrete-example unit tests whose harness exists today —
+verified by running an equivalent probe in-process (inline `Config`, patched `call_llm`, no
+`load_config()`, no provider registry, no network, no API key). Each fails today (exit 5, node absent),
+and none is satisfiable by a stub because the criterion **states the exact kwargs to assert**.
+
+**Trigger 2:** no risk-gated path. `verifier_model` is a `model_configs` key, **not a credential**;
+provider credentials keep resolving through the unchanged `config.providers` mechanism
+(`resolve_model`, `config.py:299-306`), and `ReflectionConfig.api_key`'s `metadata={"secret": True}` is
+untouched. No migration/deletion, no CI/infra, no dependency change.
+
+## One clarification worth a one-line answer
+
+When **both** `reflection.verifier_model` and `reflection.model` are set, the Proposal says
+`verifier_model` wins ("all reflection judges route their LLM call through it"), while the
+document-the-convention bullet says judges inherit it "unless they set a more specific override" —
+which could be read as `reflection.model` winning for the base judge. **The first criterion above
+assumes `verifier_model` wins.** If that reading is wrong, its assertion flips.
+
+## Latent bug found while verifying — do NOT fold into this issue
+
+Pre-existing, not claimed by the issue, and **this issue's work will run straight through it**: at
+`reflection.py:292-296`, if `reflection.model` is set but is **not** a `model_configs` key while
+`default_model` **is** set, the branch order silently discards `reflection.model` and uses
+`default_model`. **The documented "cheap judge model" escape hatch (`docs/reflection.md:53`,
+`decafclaw config set reflection.model gemini-2.5-flash`) is therefore dead on any modern config.**
+The existing `test_uses_reflection_model` only passes because its fixture leaves `default_model` empty.
+
+Worth its own issue. **Do not fix it silently here** — "fixing" it would change the second criterion's
+branch (b), which is exactly the amendment-vs-clarification trap.
+
+## Scope notes
+
+- With #529/#530/#589 all unimplemented, "shared primitive" has **exactly one consumer today**. A
+  structural criterion ("resolution lives in one helper, no judge re-implements it") is **not freezable
+  now** — the second consumer does not exist, so any grep count is 1 either way. Leave the extraction
+  shape to the implementer and let #529 be the issue that proves reuse.
+- The eval-loop judge (`src/decafclaw/eval/reflect.py:96-100`, driven by `--judge-model`, a CLI arg at
+  `eval/__main__.py:96`) is a **separate** grader-model mechanism that reads no config field. If the
+  intent is one verifier convention repo-wide, that call site is out of scope as written and should be
+  named explicitly in a follow-up rather than assumed.
+- Board size S looks right: one dataclass field + one branch + three test cases.

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -72,6 +72,27 @@ All settings live under the `reflection` group in `config.json`. See [Configurat
 
 The judge can use a separate model from the main LLM. Empty `url`/`model`/`api_key` fall back to the `llm` group values via `config.reflection.resolved(config)`. This lets you run an expensive model for the agent and a cheap/fast one as the judge.
 
+#### `verifier_model` — the shared verifier convention
+
+`reflection.verifier_model` names a key in [`model_configs`](config.md#model_configs), and it is the setting to reach for when what you want is *a judge that isn't the author*. Cost is a side benefit; the point is independence. Left at its default (`""`), nothing changes.
+
+```bash
+decafclaw config set reflection.verifier_model claude-haiku
+```
+
+Resolution order, highest first:
+
+| Setting | Wins when |
+|---|---|
+| `reflection.verifier_model` | set **and** present in `model_configs` |
+| `reflection.model` | set **and** present in `model_configs` |
+| `default_model` | set — this is why an unset judge grades its own homework |
+| `reflection.resolved(config)` | legacy `url`/`model`/`api_key` fallback |
+
+A `verifier_model` naming a key that isn't in `model_configs` is ignored, and resolution continues down the table. It is not passed through to the provider layer, which would only log a warning and quietly use the default provider — indistinguishable from the setting having worked.
+
+**The convention:** `verifier_model` is shared across *every* reflection judge, not just the base one. Specialized judges — source-grounding ([#529](https://github.com/lmorchard/decafclaw/issues/529)), pre-write edit-safety ([#530](https://github.com/lmorchard/decafclaw/issues/530)), and adversarial reflection ([#589](https://github.com/lmorchard/decafclaw/issues/589)) — inherit it, so setting it once routes all of them off the author's model. A judge may declare a more specific override of its own; absent one, it inherits. Anyone adding a judge should route through this rather than re-inventing model selection.
+
 ## Visibility modes
 
 Configured via `reflection.visibility`:

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -53,6 +53,8 @@ To use a cheaper model for the judge (recommended):
 decafclaw config set reflection.model gemini-2.5-flash
 ```
 
+> **Caveat:** this only takes effect if the name is a [`model_configs`](config.md#model_configs) key, *or* if `default_model` is unset — otherwise `default_model` wins and the setting is silently discarded. See [Judge model](#judge-model) for the full resolution order, and [#752](https://github.com/lmorchard/decafclaw/issues/752) for the fix. To pin the judge to a specific model regardless, use [`verifier_model`](#verifier_model--the-shared-verifier-convention).
+
 ## Configuration
 
 All settings live under the `reflection` group in `config.json`. See [Configuration Reference](config.md#reflection) for the full table.

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -240,6 +240,10 @@ class ReflectionConfig:
     enabled: bool = True
     url: str = ""       # empty = resolve from llm
     model: str = ""     # empty = resolve from llm
+    # A model_configs key. When set AND present in config.model_configs, every
+    # reflection judge routes through it, so the author does not grade its own
+    # homework (#591). Empty = today's chain (model -> default_model -> legacy).
+    verifier_model: str = ""
     api_key: str = field(default="", metadata={"secret": True})
     max_retries: int = 2
     visibility: str = "hidden"  # hidden | visible | debug

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -242,7 +242,10 @@ class ReflectionConfig:
     model: str = ""     # empty = resolve from llm
     # A model_configs key. When set AND present in config.model_configs, every
     # reflection judge routes through it, so the author does not grade its own
-    # homework (#591). Empty = today's chain (model -> default_model -> legacy).
+    # homework (#591). Otherwise resolution continues down the existing chain:
+    # `model` if it too is a model_configs key -> default_model -> the legacy
+    # resolved() url/model/api_key. Note a `model` that is NOT a model_configs
+    # key loses to default_model rather than reaching the legacy rung (#752).
     verifier_model: str = ""
     api_key: str = field(default="", metadata={"secret": True})
     max_retries: int = 2

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -288,9 +288,17 @@ async def evaluate_response(
 
         messages = [{"role": "user", "content": prompt}]
 
-        # Route through named model config: explicit > default_model > legacy
+        # Route through named model config:
+        #   verifier_model > explicit > default_model > legacy
+        # The `in config.model_configs` half of the verifier branch is
+        # load-bearing, not defensive: an unknown name handed to the provider
+        # layer only logs a warning and falls through to the default provider,
+        # which would silently look like the judge honoured the setting (#591).
+        verifier = config.reflection.verifier_model
         rc_model = config.reflection.model
-        if rc_model and rc_model in config.model_configs:
+        if verifier and verifier in config.model_configs:
+            response = await call_llm(config, messages, model_name=verifier)
+        elif rc_model and rc_model in config.model_configs:
             response = await call_llm(config, messages, model_name=rc_model)
         elif config.default_model:
             response = await call_llm(config, messages, model_name=config.default_model)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,23 @@ class TestDefaults:
         assert c.vault_guide.enabled is False
         assert c.vault_guide.path == "protocols/GUIDE.md"
 
+    def test_reflection_verifier_model_env_override(self, tmp_path, monkeypatch):
+        """REFLECTION_VERIFIER_MODEL reaches the field via load_sub_config (#591).
+
+        The env var and `config set reflection.verifier_model` are both derived
+        from the dataclass field by generic machinery, so they need no
+        registration — but "derived for free" is a claim, and nothing else under
+        tests/ asserts any REFLECTION_* env var.
+        """
+        monkeypatch.setenv("REFLECTION_VERIFIER_MODEL", "judge")
+        monkeypatch.setenv("DATA_HOME", str(tmp_path))
+        c = load_config()
+        assert c.reflection.verifier_model == "judge"
+
+    def test_reflection_verifier_model_defaults_empty(self):
+        """Unset by default, so the existing fallback chain is untouched (#591)."""
+        assert Config().reflection.verifier_model == ""
+
 
 class TestJsonFileLoading:
     def test_loads_from_json(self, tmp_path, monkeypatch):

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from decafclaw.config import Config
-from decafclaw.config_types import AgentConfig, LlmConfig, ReflectionConfig
+from decafclaw.config_types import (
+    AgentConfig,
+    LlmConfig,
+    ModelConfig,
+    ProviderConfig,
+    ReflectionConfig,
+)
 from decafclaw.reflection import (
     _BUNDLED_PROMPT,
     ReflectionResult,
@@ -532,6 +538,126 @@ class TestEvaluateResponse:
             await evaluate_response(config, "hello", "Hi!", "")
         prompt = mock_call.call_args[0][1][0]["content"]
         assert "Tools used in prior turns:" not in prompt
+
+    # -- verifier_model routing (#591) ------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_verifier_model_routes_judge_call(self, tmp_path):
+        """WHERE reflection.verifier_model names a key in model_configs, the
+        judge call SHALL route to it — not default_model, not the legacy
+        url/model/api_key override."""
+        config = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers={"p": ProviderConfig(type="openai-compat",
+                                           url="http://test/v1",
+                                           api_key="test-key")},
+            model_configs={
+                "author": ModelConfig(provider="p", model="author-model"),
+                "judge": ModelConfig(provider="p", model="judge-model"),
+            },
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True, model="",
+                                        verifier_model="judge"),
+        )
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config, "hello", "Hi!", "")
+        # Equality (not membership) so a stray llm_url/llm_model/llm_api_key
+        # override alongside model_name still fails.
+        assert mock_call.call_args.kwargs == {"model_name": "judge"}
+
+    @pytest.mark.asyncio
+    async def test_verifier_model_unset_preserves_fallback_chain(self, tmp_path):
+        """WHEN reflection.verifier_model is empty, resolution SHALL be
+        unchanged: reflection.model (if in model_configs) -> default_model ->
+        legacy reflection.resolved(config)."""
+        providers = {"p": ProviderConfig(type="openai-compat",
+                                         url="http://test/v1",
+                                         api_key="test-key")}
+        model_configs = {
+            "author": ModelConfig(provider="p", model="author-model"),
+            "judge": ModelConfig(provider="p", model="judge-model"),
+        }
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+
+        # (a) reflection.model names a key in model_configs -> wins
+        config_a = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers=providers,
+            model_configs=model_configs,
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True, model="judge",
+                                        verifier_model=""),
+        )
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config_a, "hello", "Hi!", "")
+        assert mock_call.call_args.kwargs == {"model_name": "judge"}
+
+        # (b) reflection.model empty -> default_model
+        config_b = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers=providers,
+            model_configs=model_configs,
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True, model="",
+                                        verifier_model=""),
+        )
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config_b, "hello", "Hi!", "")
+        assert mock_call.call_args.kwargs == {"model_name": "author"}
+
+        # (c) no model_configs, no default_model -> legacy resolved() override
+        config_c = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            model_configs={},
+            default_model="",
+            reflection=ReflectionConfig(enabled=True,
+                                        model="cheap-judge-model",
+                                        verifier_model=""),
+        )
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config_c, "hello", "Hi!", "")
+        kwargs_c = mock_call.call_args.kwargs
+        assert kwargs_c["llm_model"] == "cheap-judge-model"
+        assert "model_name" not in kwargs_c
+
+    @pytest.mark.asyncio
+    async def test_unknown_verifier_model_falls_back(self, tmp_path):
+        """IF reflection.verifier_model is not a key in model_configs, THEN
+        the judge SHALL fall back to today's chain and SHALL NOT pass the
+        unknown name as model_name."""
+        config = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers={"p": ProviderConfig(type="openai-compat",
+                                           url="http://test/v1",
+                                           api_key="test-key")},
+            model_configs={
+                "author": ModelConfig(provider="p", model="author-model"),
+            },
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True, model="",
+                                        verifier_model="no-such-model"),
+        )
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config, "hello", "Hi!", "")
+        # Concrete fallback destination: default_model, via the normal chain.
+        assert mock_call.call_args.kwargs == {"model_name": "author"}
 
 
 class TestReflectionPromptStructure:


### PR DESCRIPTION
## Summary

- Adds `reflection.verifier_model` — a `model_configs` key that routes **every** reflection judge to a model distinct from the author's, so the author stops grading its own homework.
- Today the judge resolves `reflection.model` → `default_model` → legacy, which on any modern config means *the same model that wrote the response*. Three queued judges (#529 source-grounding, #530 edit-safety, #589 adversarial) all want a distinct verifier; three consumers is the threshold where the shared knob beats each one re-inventing model routing.
- Unset by default. Nothing changes for anyone who doesn't set it.

## Design decisions

- **`verifier_model` beats `reflection.model`.** The issue flagged this as its one ambiguity and pinned it; C1's assertion encodes that reading.
- **The `in config.model_configs` membership half is load-bearing, not defensive.** An unknown name handed to the provider layer only logs a warning and falls through to the default provider — which is indistinguishable from the setting having worked. C3 exists to kill the shortcut that omits it.
- **No shared-helper extraction.** With #529/#530/#589 unimplemented there is exactly one judge call site today, so a "shared primitive" abstraction can't be verified. Let #529 prove the reuse.

## Changes

| Component | Change |
|---|---|
| `src/decafclaw/config_types.py` | `ReflectionConfig.verifier_model: str = ""` |
| `src/decafclaw/reflection.py` | One leading branch in `evaluate_response`'s routing chain. Everything below it is byte-identical. |
| `tests/test_config.py` | Two tests: `REFLECTION_VERIFIER_MODEL` reaches the field, and the default is empty. Closes a gap the freeze-time check-reviewer found — nothing under `tests/` asserted *any* `REFLECTION_*` env var. |
| `docs/config.md`, `docs/reflection.md` | The field, the full resolution order, and the inheritance convention for #529/#530/#589. |

`REFLECTION_VERIFIER_MODEL` and `decafclaw config set reflection.verifier_model` are derived from the dataclass field by the generic loader and CLI — no registration needed, and now with a test proving it rather than asserting it.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | set + known key → judge routes to it, and not via `default_model` or the legacy override | `pytest …::test_verifier_model_routes_judge_call` | **pass** (1 collected, 1 passed) |
| C2 | unset → today's chain unchanged, all three rungs | `pytest …::test_verifier_model_unset_preserves_fallback_chain` | **pass** (1 collected, 1 passed) |
| C3 | set + unknown key → falls back, never passed as `model_name` | `pytest …::test_unknown_verifier_model_falls_back` | **pass** (1 collected, 1 passed) |

Verified by an independent verifier (fresh context, `checks.md` and the repo only — no plan, no notes, no spec). Frozen at `e99c860`; tamper diff on `tests/test_reflection.py` **empty**, and the freeze commit is a confirmed ancestor of the head, so anyone can re-run the diff themselves.

**Read the three as one gate.** Only C1 discriminates the routing behavior — C2 and C3 flip green on the dataclass field alone, which the freeze-time check-reviewer established by experiment and which the independent verifier confirmed against this diff. C3 still earns its place: it kills the membership-check-free implementation. Do not read "3/3 green" as three independent confirmations.

## ⚠️ Two guards fail their frozen invariants — a human decision is needed

The verifier reports **G2 and G4 as failing**, and I have deliberately not fixed them.

Both are the same defect, and it's in the **manifest's wording**, not the code:

| Guard | Frozen invariant | Observed | Delta |
|---|---|---|---|
| G2 | `71 passed, none skipped` | `73 passed`, 0 skipped | +2 |
| G4 | `3720 passed, 2 skipped` | `3722 passed, 2 skipped` | +2 |

Both deltas are the two `tests/test_config.py` tests added by this PR. **No test was lost and none was newly skipped** — the change is purely additive, and the verifier confirmed that independently.

The invariant the issue actually wrote was *"no test lost, newly skipped, or newly failing."* Hardening that into an **exact pass count** happened at freeze, on the implementer's side of this run, and it turns out to be too tight to survive adding a test — which the very same freeze-time review recommended doing.

**Why this wasn't just fixed:** restating the invariant changes the guard's verdict against the current tree (fail → pass) while leaving it unchanged at the freeze tree. Per `frozen-checks.md`'s four-cell test that is an **amendment**, not a clarification — it needs human sign-off and it downgrades the run's tier. An unattended run doesn't get to make that call about its own oracle. Deleting the two tests to make the numbers match was also considered and rejected: dropping real coverage to satisfy a bookkeeping artifact is precisely the cheat guards exist to catch.

**Proposed amendment, for a human to accept or reject:**

> G2: `71 passed, none skipped` → `≥71 passed, none skipped, none lost`
> G4: `3720 passed, 2 skipped` → `≥3720 passed, 2 skipped, none lost, none newly skipped`

Accepting it makes both guards pass and the tier becomes `needs-review (downgraded: amendment)`. Rejecting it leaves the verdict where it is. Either way this PR stays `human-merge-required`.

## Review cycle

Copilot reviewed and left two comments, both valid accuracy catches on wording I wrote. Both **fixed** in `117e109`, both threads replied to and resolved:

1. `src/decafclaw/config_types.py` — the inline comment described the fallback chain as `model -> default_model -> legacy` without the caveat that a `model` which is *not* a `model_configs` key loses to `default_model` rather than reaching the legacy rung. Now spelled out, pointing at #752.
2. `docs/config.md` — "takes precedence over all of them" overstated the rule; it now carries the "set **and** names an entry in `model_configs`" condition the code actually enforces.

The independent verifier was re-dispatched after these fixes (fresh context again) and re-derived every row below from its own commands.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass · C2 pass · C3 pass
guards: G1 pass · G2 REGRESSED · G3 pass · G4 REGRESSED
tamper: clean
freeze: e99c860
project-gates: make check green
ci: 2/2 pass @ 117e1098e4c2cd85af0c58907a4ab00533219ad4
threads: 0 unresolved
risk-paths: none
amendments: none (one proposed, unapproved — see above)
verdict: human-merge-required
reason: G2 and G4 fail their frozen exact-count invariants (73 vs 71, 3722 vs 3720). Purely additive — the verifier confirmed no test lost and none newly skipped — but restating the invariant is an amendment, which needs a human and downgrades the tier. Not made unattended.
```

**Every other row is green.** C1–C3 pass per the independent verifier, tamper diff empty with the freeze commit a confirmed ancestor of the head (re-runnable by anyone), `make check` clean, CI 2/2, no unresolved threads, no risk-gated paths, tier `auto-ok` and un-downgraded. The single blocking row is the guard-invariant wording described above, and accepting the proposed amendment clears it.

## Scope calls made, so they're visible rather than buried

- **The #752 latent bug was NOT fixed here**, per the issue's explicit instruction — fixing it would change what C2 branch (b) asserts. Filed as #752 instead. But documenting the true resolution order made a *pre-existing* contradiction visible: the Quick start recommends `config set reflection.model gemini-2.5-flash`, which the new table shows is silently discarded whenever `default_model` is set. I added a one-sentence caveat pointing at #752 rather than ship a page that contradicts itself. No behavior change, no check affected.
- **The "document the convention" bullet is a review note, not a criterion** — the issue rejected it because the only available check is a keyword grep, satisfiable by typing the word. So please actually read the new `docs/reflection.md` section and judge whether it explains the convention or merely names the field.
- **Remaining coverage gap:** `config set reflection.verifier_model` works by derivation through `config_cli.py`'s generic `fields()` iteration, but no test asserts it specifically. The env-var half is now covered.

## References

- Spec: `docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/spec.md`
- Checks: `docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/checks.md`
- Plan: `docs/dev-sessions/2026-08-02-1603-591-reflection-verifier-model/plan.md`
- Follow-up filed: #752
- Unblocks: #589 · inherited by #529, #530
- Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
