### PR TITLE
fix(#752): honor a non-model_configs reflection.model over default_model

### DIFF
--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
@@ -1,0 +1,134 @@
+# Frozen acceptance checks
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/752
+**Frozen at:** (recorded in the follow-up commit — a commit cannot contain its own hash)
+**Check files — read-only from Phase 1 onward:**
+- `tests/test_reflection.py`
+
+Guard ids were assigned after the pre-freeze review, which added one guard (G2) and re-scoped
+two others. The set below is the frozen one.
+
+## C1
+
+CRITERION: GIVEN a config where `reflection.model` names a model absent from `model_configs`
+AND `default_model` is set, WHEN `evaluate_response` runs, THEN the judge call SHALL route to
+`reflection.model` via the legacy `resolved()` url/model/api_key rung, and SHALL NOT use
+`default_model`.
+
+CHECK: `pytest tests/test_reflection.py::TestEvaluateResponse::test_nonconfig_reflection_model_beats_default_model`
+— asserting the `call_llm` kwargs carry the configured reflection model rather than the
+`default_model` key.
+
+AT FREEZE: **fails — 1 collected, 1 failed** (exit 1, not exit 5), 2026-08-03.
+Observed: `AssertionError: assert {'model_name': 'author'} == {'llm_api_key': 'test-key',
+'llm_model': 'cheap-judge-model', 'llm_url': 'http://test/v1/chat/completions'}` at
+`tests/test_reflection.py:694`. Correct reason: the body ran all the way through
+`evaluate_response` and `call_count == 1` passed immediately before the failing line, so this
+is the routing defect — not an import error, missing fixture, or `Config` construction problem.
+
+The check has two configs. The first is the issue's reported case. The second sets
+`reflection.url` / `reflection.api_key` to values *distinct* from `config.llm`, closing the hole
+the pre-freeze review found: with them left empty, `resolved()` backfills both from `config.llm`,
+so an implementation that skips `resolved()` and reads `config.llm` directly emits byte-identical
+kwargs and passes while silently discarding two documented settings — one of them a secret.
+Both configs also pin `call_count == 1`, since `call_args` reads only the last call and judging
+twice would still bill the author's model.
+
+## Guards
+
+(Pass today; must keep passing. Not criteria — they can't fail at freeze.)
+
+- **G1:** the legacy-rung path and the `verifier_model` path both keep working.
+  CHECK: `pytest tests/test_reflection.py::TestEvaluateResponse::test_uses_reflection_model tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+  AT FREEZE: **2 passed** (2 collected), 2026-08-03.
+  Scope note from the pre-freeze review: `test_uses_reflection_model` uses the shared `config`
+  fixture, which has **no** `model_configs` and **no** `default_model` — so it exercises the
+  *legacy* rung, not the `model_configs` rung. The clause "a `reflection.model` that IS a
+  `model_configs` key still routes to it" is pinned by **G3** case (a), not by this pair. Recorded
+  so the guard is read as what it actually covers.
+
+- **G2:** WHERE `verifier_model` names a key in `model_configs` AND `reflection.model` is set but
+  absent from `model_configs`, `verifier_model` SHALL still win. Added by the pre-freeze review:
+  no test in the suite set both fields non-empty, so the cheapest edit greening C1 could hoist the
+  `reflection.model` branch above the `verifier_model` branch, inverting #591's documented
+  precedence (`docs/reflection.md`: `verifier_model` "outranks every other judge-model setting")
+  with the whole suite green.
+  CHECK: `pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_outranks_nonconfig_reflection_model`
+  AT FREEZE: **1 passed** (1 collected), 2026-08-03 — confirming this precedence is current
+  behaviour, so it is a true regression guard and not a second criterion.
+
+- **G3:** `test_verifier_model_unset_preserves_fallback_chain` keeps passing **unmodified.**
+  If landing the fix requires editing this test, that is a signal the change reached further
+  than intended.
+  CHECK: `pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
+  plus: `git diff <freeze-sha> -- tests/test_reflection.py` shows **no hunk whose range falls
+  between `def test_verifier_model_unset_preserves_fallback_chain` and the next `def`.** (Stated
+  at function granularity rather than whole-file, because C1's own test already adds hunks to this
+  file and a whole-file diff would be non-empty by construction.)
+  AT FREEZE: **1 passed** (1 collected), 2026-08-03.
+
+- **G4:** the stale documentation of the *old* precedence is corrected in the same change rather
+  than left contradicting the code. The pre-freeze review widened this from one site to four —
+  a reviewer following the original one-site wording would have fixed the comment and shipped
+  three contradicting docs, including the exact passage users act on.
+  1. `src/decafclaw/config_types.py:243-250` — the `verifier_model` comment, whose last sentence
+     states the #752 misordering as intended.
+  2. `docs/reflection.md:56` — the caveat under `decafclaw config set reflection.model ...`,
+     including the now-stale *"see #752 for the fix"* pointer the spec calls out.
+  3. `docs/reflection.md:88-92` — the resolution-order table; the `reflection.model` and
+     `default_model` rows both change under branch (a).
+  4. `docs/config.md:212` — a pointer into that table. Verify; it may need no edit, since its own
+     claim is about `verifier_model` and stays true.
+  CHECK: none — human read at review. Deliberately not graded: its only mechanical check would be
+  a keyword grep, which is satisfied by deleting the sentence and writing nothing accurate in its
+  place. Recorded so it is not dropped.
+  AT FREEZE: n/a (not a runnable check).
+
+- **G5:** no test lost, newly skipped, newly deselected, or newly failing.
+  CHECK: `make test` reports **`passed >= 3732`**, **`skipped == 2`**, **`failed == 0`**.
+  AT FREEZE: **3732 passed, 2 skipped**, 2026-08-03.
+  A floor-plus-ceiling rather than "an invariant, not a pinned count" — the review showed that
+  wording leaves the only mechanical "no test lost" signal unread. Two ways to lose a test under
+  the looser rule: delete one (`3731 passed`, no failure, no skip rise), or mark it
+  `@pytest.mark.integration`, which `addopts`' `-m "not integration"` silently deselects — and
+  under `-n auto` the deselected count is not printed at all. The floor costs nothing, since new
+  tests only push it up. The two skips are `contrib/skills/rss-ingest/test_fetch_feeds.py` on a
+  missing `feedparser`; the ceiling is what catches a newly-broken optional import.
+
+## Adjudication
+
+Reviewed before the freeze commit by a read-only context (no Edit/Write), given `checks.md` and
+the repo but not the implementation approach or the criteria's rationale. One disposition per
+check and per guard, including the ones it cleared.
+
+- **C1: strengthened** — two holes. (i) The criterion names `resolved()`, but with
+  `reflection.url`/`api_key` left empty the fixture cannot distinguish `resolved()` from a direct
+  `config.llm` read; a second config with distinct values was added. (ii) The assertion reads
+  `call_args`, the last call, so a double-judge implementation would pass while still billing the
+  author's model; `call_count == 1` was added. What the review *cleared*: the branch ordering
+  itself is well pinned — collapsing the two `rc_model` branches breaks G3 case (a), and deleting
+  the `default_model` rung breaks G3 case (b), so neither is a cheap way through.
+- **G1: strengthened** — re-scoped, not re-checked. The guard claimed two protections; the review
+  found `test_uses_reflection_model` exercises the legacy rung rather than the `model_configs`
+  rung, so the second clause is really G3's. The wording now says what the pair covers, and the
+  clause it does not cover names its real home.
+- **G2: strengthened** — this guard did not exist. Added in response to the review's finding that
+  no test set `verifier_model` and `model` both non-empty, leaving #591's precedence unpinned
+  against exactly the reorder this change performs. Authored, run, and confirmed passing today.
+- **G3: strengthened** — the diff half was tightened from whole-file to function-range granularity
+  (see the CHECK above). The review's other point, that the freeze sha must be in `checks.md`
+  before the freeze commit lands, is **noted rather than adopted**: a commit cannot contain its own
+  hash, which is why the procedure records it in a follow-up commit. The substance — that the
+  baseline must be written down for anyone else to re-run the diff — is satisfied there. The
+  pytest half was cleared: all three cases use full-dict equality, a `skip` marker would flip the
+  recorded `1 passed` and trip G5, and deleting or renaming makes the nodeid uncollectable.
+- **G4: strengthened** — widened from one site to four (enumerated above). The review agreed it
+  cannot be graded mechanically and that escalating has nowhere to go; the fix was to make the
+  human read a checklist instead of a pointer.
+- **G5: strengthened** — replaced "invariant, not a pinned count" with an explicit floor and
+  ceiling, closing the silent-deletion and silent-deselection vectors (rationale above). The
+  skipped-count invariant as originally written was cleared as well chosen.
+
+## Amendments
+
+(Append-only. Empty unless an amendment was made.)

--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
@@ -131,6 +131,27 @@ check and per guard, including the ones it cleared.
   ceiling, closing the silent-deletion and silent-deselection vectors (rationale above). The
   skipped-count invariant as originally written was cleared as well chosen.
 
+## Tamper verdict
+
+**clean**, recorded 2026-08-03 before push, and re-runnable by anyone: the freeze commit
+`d34c9df` is an ancestor of the pushed head, and the branch was not squashed.
+
+```
+git diff d34c9df -- tests/test_reflection.py
+```
+
+Empty (0 bytes). The frozen check file was not touched after the freeze. `git diff d34c9df --stat`
+shows four other files — `checks.md` (the sanctioned `Frozen at` sha append plus this section),
+`plan.md` (new session artifact), and the two source files plus `docs/reflection.md` that Phase 1
+named. No collateral edits. `origin/main` did not advance during the run, so no rebase occurred
+and the freeze sha needed no re-anchoring.
+
+Independently verified by a fresh context given only `checks.md` and the repo — not the plan, not
+the implementation notes. Its per-check results: C1 pass (1 collected), G1 pass (2), G2 pass (1),
+G3 pass (1) + empty diff, G5 3734 passed / 2 skipped / 0 failed (3736 collected). Every run
+exited 0, none exited 5.
+
 ## Amendments
 
-(Append-only. Empty unless an amendment was made.)
+(Append-only.) **None.** No frozen check was edited, relaxed, or replaced at any point, so the
+run's `auto-ok` tier stands undowngraded.

--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md
@@ -1,7 +1,9 @@
 # Frozen acceptance checks
 
 **Source:** https://github.com/lmorchard/decafclaw/issues/752
-**Frozen at:** (recorded in the follow-up commit — a commit cannot contain its own hash)
+**Frozen at:** `d34c9df` (2026-08-03) — recorded in the follow-up commit, since a commit cannot
+contain its own hash. Re-anchor if the branch is rebased; the freeze commit must stay an ancestor
+of the pushed head so the tamper diff is re-runnable by a reviewer.
 **Check files — read-only from Phase 1 onward:**
 - `tests/test_reflection.py`
 

--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/notes.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/notes.md
@@ -1,0 +1,65 @@
+# Session notes — #752 reflection judge-model precedence
+
+Unattended `agent-session express` run, 2026-08-03. Tier `auto-ok`, stopped at the merge gate.
+
+## What shipped
+
+Branch (a) of the three the issue laid out: an explicitly set `reflection.model` now outranks
+`default_model` whether or not it names a `model_configs` key. One added conjunct
+(`elif config.default_model and not rc_model:`) plus the docs that promised the old order.
+
+## Decisions worth keeping
+
+**The four-branch shape over the five-branch one.** The obvious implementation adds a fifth
+branch (`elif rc_model:`) with its own `resolved()` call above `default_model`. Behaviourally
+identical, but it duplicates the one call site that reads `reflection.api_key`, a field marked
+`metadata={"secret": True}`. Adding a conjunct to the `default_model` rung keeps the credential
+read at a single site. Caught in plan self-review, before any code was written.
+
+**#591's session `checks.md` was deliberately left alone.** It contains a line describing the old
+chain, which now reads as wrong. It is a frozen historical record of a merged run's evidence;
+editing it would rewrite what that run actually verified. Same reasoning as not amending a frozen
+check after the fact.
+
+**`docs/config.md` needed no edit** — checked, not assumed. Its only ordering claim is about
+`verifier_model`, which is unchanged, and it defers the full order to the `reflection.md` table.
+
+## What the pre-freeze review caught
+
+The read-only check-reviewer earned its dispatch three times over, and all three were holes in the
+*oracle*, not the code — they would have let a wrong implementation ship green:
+
+1. **C1 couldn't see `resolved()`.** With `reflection.url`/`api_key` left empty, `resolved()`
+   backfills both from `config.llm`, so an implementation that skipped `resolved()` entirely and
+   read `config.llm` directly produced byte-identical kwargs. It would have shipped with the right
+   model pointed at the wrong endpoint with the wrong key — the same class of silent-discard bug as
+   #752 itself. Fixed by a second config with distinct values.
+2. **No test set `verifier_model` and `model` both non-empty.** Every existing test zeroed one or
+   the other, so the cheapest edit greening C1 could have hoisted `reflection.model` above
+   `verifier_model`, inverting #591's documented precedence with the whole suite green. This became
+   guard G2. It passes today, confirming it is a genuine regression guard.
+3. **G5's "invariant, not a pinned count" left the only mechanical signal unread.** A test can be
+   lost two ways with no failure and no skip-count change: delete it, or mark it
+   `@pytest.mark.integration`, which `addopts`' `-m "not integration"` deselects — and under
+   `-n auto` the deselected count isn't printed at all. Replaced with a floor
+   (`passed >= 3732`) plus a ceiling (`skipped == 2`, `failed == 0`).
+
+The general lesson: every one of these was a check that *looked* rigorous. Full-dict equality
+assertions and a named skip-count invariant both read as careful. What found them was a context
+that had not been told the author's intent and was asked one question — *what could make this green
+that isn't the work?*
+
+## Answered along the way
+
+The issue's "still open, but not tier-bearing" question — does `reflection.model` beat an
+*unresolvable* `verifier_model`? Yes, and it needs no code of its own: an unresolvable
+`verifier_model` fails its membership test and the `rc_model` rung is now next.
+`test_unknown_verifier_model_falls_back` keeps passing because it sets `model=""`.
+
+## Environment friction (not project-specific)
+
+The unattended `dontAsk` permission floor denied shell redirects (`>`, `>>`), `cp` in compound
+commands, bare `python`, and `rm`. Workarounds that did work: `uv run --directory <path> …` for
+anything needing the venv, `make -C <path>`, and the Write tool in place of redirects. One
+consequence worth knowing: the worktree `.env` did not get its `HTTP_PORT` line, since appending
+to it was blocked. Harmless here (no server run needed) but it would bite a UI change.

--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/plan.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/plan.md
@@ -1,0 +1,176 @@
+# Reflection judge-model precedence (#752) Implementation Plan
+
+**Goal:** Honor `reflection.model` even when it is not a `model_configs` key, so the documented
+escape hatch (`decafclaw config set reflection.model gemini-2.5-flash`) actually moves the judge.
+
+**Source issue:** https://github.com/lmorchard/decafclaw/issues/752 — **Tier:** `auto-ok`
+(every criterion is machine-checkable and was verified to fail today; no risk-gated path — judge
+model routing is not auth, secrets, data migration, deploy/CI, or a dependency change).
+
+**Approach:** Branch (a) from the issue, chosen by Les on 2026-08-03: reorder the chain so a
+`reflection.model` that is *not* a `model_configs` key reaches the legacy `resolved()` rung
+instead of losing to `default_model`. `verifier_model` keeps its position at the top —
+unconditionally, per #591 — so the only rung that moves is `reflection.model`'s non-`model_configs`
+case, which today is unreachable whenever `default_model` is set. Branches (b) and (c) from the
+issue are explicitly not the deliverable.
+
+**Criteria:** C1 — a `reflection.model` absent from `model_configs` beats `default_model` and
+routes via the legacy `resolved()` url/model/api_key rung.
+
+Full text + checks live in `checks.md`. Ids are assigned there and referenced here.
+
+---
+
+## Phase 0: Freeze the acceptance checks — COMPLETE
+
+Frozen at `d34c9df`; sha recorded in `65bf103`. No implementation in this phase.
+
+**Files:**
+- Created: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md`
+- Created: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/spec.md`
+- Modified: `tests/test_reflection.py` — C1's test plus the new G2 guard (99 insertions, 0 deletions)
+
+**Verification — automated:**
+- [x] C1's check runs and fails for the expected reason — 1 collected, 1 failed,
+      `assert {'model_name': 'author'} == {...legacy kwargs...}` at `tests/test_reflection.py:694`,
+      with `call_count == 1` passing immediately before it (so: routing defect, not a setup error)
+- [x] Every guard runs and passes — G1 2 passed, G2 1 passed, G3 1 passed, G5 3732 passed /
+      2 skipped. G4 is a human read, not runnable.
+- [x] Check-reviewer dispatched read-only (no Edit/Write), given `checks.md` and the repo but not
+      this plan and not the criteria's rationale; `## Adjudication` carries one disposition per
+      check and per guard
+- [x] Freeze commit made; sha recorded in the follow-up commit
+
+---
+
+## Phase 1: Reorder the chain, and correct every place that documents the old order
+
+One slice: the routing change, the inline comment that currently states the old behaviour as
+intended, and the user-facing docs that promise the order this changes. They ship together because
+the docs *are* the reported harm — the issue is that `docs/reflection.md` documents an escape hatch
+that does nothing.
+
+**Advances:** C1 (fully). Satisfies G4, which is a guard rather than a criterion because it can
+only be graded by a human read.
+
+**Files:**
+
+- Modify: `src/decafclaw/reflection.py` (~line 291-310) — move the non-`model_configs`
+  `reflection.model` case above the `default_model` rung.
+- Modify: `src/decafclaw/config_types.py:243-250` — the `verifier_model` comment's last sentence
+  currently states the #752 misordering as intended-for-now. (G4 site 1.)
+- Modify: `docs/reflection.md:56` — the caveat under `decafclaw config set reflection.model ...`,
+  including the stale *"see #752 for the fix"* pointer. (G4 site 2.)
+- Modify: `docs/reflection.md:88-92` — the resolution-order table; the `reflection.model` and
+  `default_model` rows both change. (G4 site 3.)
+- Verify: `docs/config.md:212` — a pointer into that table. Its own claim is about `verifier_model`
+  and stays true, so it likely needs no edit; confirm rather than assume. (G4 site 4.)
+- Test: none added. The frozen acceptance tests already cover this slice and are **read-only from
+  here on** — `tests/test_reflection.py` is the frozen check file.
+
+**Key changes:**
+
+The current chain in `evaluate_response`:
+
+```python
+        verifier = config.reflection.verifier_model
+        rc_model = config.reflection.model
+        if verifier and verifier in config.model_configs:
+            response = await call_llm(config, messages, model_name=verifier)
+        elif rc_model and rc_model in config.model_configs:
+            response = await call_llm(config, messages, model_name=rc_model)
+        elif config.default_model:
+            response = await call_llm(config, messages, model_name=config.default_model)
+        else:
+            rc = config.reflection.resolved(config)
+            response = await call_llm(
+                config, messages,
+                llm_url=rc.url, llm_model=rc.model, llm_api_key=rc.api_key,
+            )
+```
+
+becomes — the only structural change is one added conjunct on the `default_model` rung, which
+demotes it below an explicitly configured `reflection.model`:
+
+```python
+        verifier = config.reflection.verifier_model
+        rc_model = config.reflection.model
+        if verifier and verifier in config.model_configs:
+            response = await call_llm(config, messages, model_name=verifier)
+        elif rc_model and rc_model in config.model_configs:
+            response = await call_llm(config, messages, model_name=rc_model)
+        elif config.default_model and not rc_model:
+            response = await call_llm(config, messages, model_name=config.default_model)
+        else:
+            # Reached two ways: reflection.model is set but is not a
+            # model_configs key — a legacy raw model name, which outranks
+            # default_model, because moving the judge off the author's model is
+            # the whole point of setting it (#752) — or nothing above resolved
+            # and resolved() supplies the llm-group fallback.
+            rc = config.reflection.resolved(config)
+            response = await call_llm(
+                config, messages,
+                llm_url=rc.url, llm_model=rc.model, llm_api_key=rc.api_key,
+            )
+```
+
+**Self-review changed this shape.** The first draft added a fifth branch (`elif rc_model:` with
+its own `resolved()` call) above `default_model`. Behaviourally identical, but it duplicates the
+legacy call site — and that is the one rung that reads `reflection.api_key`, a field marked
+`metadata={"secret": True}`. Two call sites for a credential read is a worse trade than one
+slightly compound condition, so the added conjunct wins. The four cases both shapes must agree on:
+`rc_model` in `model_configs` → rung 2; `rc_model` set but absent → legacy; `rc_model` empty with
+`default_model` → rung 3; `rc_model` empty without `default_model` → legacy.
+
+Two properties this shape preserves deliberately:
+
+- **`verifier_model` stays on top and stays conditional on `model_configs` membership.** G2 pins
+  this. An unresolvable `verifier_model` still falls through, which is what
+  `test_unknown_verifier_model_falls_back` asserts.
+- **The `resolved()` call is what routes**, not a direct read of `config.llm`. C1's second config
+  pins this: `reflection.url` / `reflection.api_key`, when set, must reach the provider.
+
+The duplicated `else` tail is acceptable at this size; collapsing it would mean restructuring the
+chain further than the criterion asks, and scope discipline says no. It is two calls with
+identical bodies, both reached only when `resolved()` is the answer.
+
+**Verification — automated:**
+- [ ] C1's check passes: `pytest tests/test_reflection.py::TestEvaluateResponse::test_nonconfig_reflection_model_beats_default_model`
+- [ ] G1 passes: `pytest tests/test_reflection.py::TestEvaluateResponse::test_uses_reflection_model tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+- [ ] G2 passes: `pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_outranks_nonconfig_reflection_model`
+- [ ] G3 passes: `pytest tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_unset_preserves_fallback_chain`
+- [ ] G3's diff half: `git diff d34c9df -- tests/test_reflection.py` shows no hunk between
+      `def test_verifier_model_unset_preserves_fallback_chain` and the next `def`
+- [ ] G5: `make test` reports `passed >= 3732`, `skipped == 2`, `failed == 0`
+- [ ] `make lint` passes
+- [ ] `make check` passes (lint + pyright + JS typecheck)
+
+**Verification — manual:**
+- [ ] G4 (human read, four sites): `config_types.py:243-250`, `docs/reflection.md:56`,
+      `docs/reflection.md:88-92`, `docs/config.md:212`. Each must describe the new order, and no
+      remaining text may point at #752 as an open fix.
+- [ ] The "still open, but not tier-bearing" question from the spec is answered in the PR body
+      rather than left to be discovered in the diff: under branch (a), does `reflection.model`
+      also beat an *unresolvable* `verifier_model`? (It does, and that falls out of the branch
+      order rather than needing its own code: an unresolvable `verifier_model` fails its
+      membership test, and the `rc_model` rung is now next. `test_unknown_verifier_model_falls_back`
+      keeps passing because it sets `model=""`.)
+
+**Evals:** none. Per `CLAUDE.md`, evals cover LLM-driven decisions; this is deterministic routing
+with no change to any tool description or system prompt. No `tool_choice` case applies.
+
+---
+
+## Phase 2: Independent verification
+
+Dispatch a verifier subagent with a fresh context, given only `checks.md` and the repo — not this
+plan, not the implementation notes. It runs each criterion and guard by its own command and reports
+observed output plus the tamper diff against `d34c9df`.
+
+**Advances:** C1 — grades it; does not implement it. (This phase advances no criterion by writing
+code, deliberately: it is the gate, and per `frozen-checks.md` the grading context must not be the
+one that wrote the code.)
+
+**Verification — automated:**
+- [ ] Verifier's report carries a per-criterion command + observed output + pass/fail
+- [ ] Tamper diff `git diff d34c9df -- tests/test_reflection.py` is empty

--- a/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/spec.md
+++ b/docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/spec.md
@@ -1,0 +1,137 @@
+# Spec — Reflection: a non-model_configs `reflection.model` is silently discarded when `default_model` is set
+
+**Source:** https://github.com/lmorchard/decafclaw/issues/752
+
+_Captured verbatim from the issue body (marker line stripped) at session setup, 2026-08-03._
+
+---
+
+Found while verifying #591 at triage, and deliberately **not** folded into that PR — fixing it
+would change what #591's frozen check C2 branch (b) asserts.
+
+## The bug
+
+`evaluate_response` (`src/decafclaw/reflection.py`) resolves the judge model as:
+
+```
+verifier_model (new, #591) > reflection.model if in model_configs > default_model > legacy resolved()
+```
+
+If `reflection.model` is set to something that is **not** a `model_configs` key, and `default_model`
+**is** set, the branch order silently discards `reflection.model` and uses `default_model`. The
+legacy `reflection.resolved(config)` rung is only reachable when `default_model` is empty.
+
+## Why it matters
+
+`docs/reflection.md` documents exactly this as the recommended escape hatch:
+
+```bash
+decafclaw config set reflection.model gemini-2.5-flash
+```
+
+On any config that has a `default_model` — which is every modern config — that command does
+nothing observable. The user believes they moved the judge to a cheap model; the judge keeps
+running on the author's model, at the author's price.
+
+## Why no existing test catches it
+
+`tests/test_reflection.py::TestEvaluateResponse::test_uses_reflection_model` passes only because its
+fixture leaves `default_model` empty, which routes it down the legacy rung. Add a `default_model` to
+that fixture and it fails.
+
+## Deciding the fix
+
+Needs a judgment call rather than a patch, which is why it's its own issue:
+
+- **(a)** Treat a non-`model_configs` `reflection.model` as a legacy raw model name and honor it over
+  `default_model` — matches the documented behavior, but reorders the chain.
+- **(b)** Keep the order and fix the docs to say `reflection.model` must be a `model_configs` key.
+- **(c)** Warn at config load when `reflection.model` is set but unresolvable.
+
+(b) is the smallest change; (a) is what the docs currently promise. Worth picking deliberately.
+
+Related: #591 (introduced `verifier_model` above this rung), #529, #530, #589.
+
+---
+
+## Decision (Les, 2026-08-03): branch (a) — reorder the chain
+
+Recorded in the body rather than a comment, because downstream modes read the body only.
+
+**Branch (a) is the work: honor `reflection.model` even when it is not a `model_configs` key.**
+Branches (b) and (c) are not the deliverable. Two notes that informed the call:
+
+- **(b) is already substantially done.** `docs/reflection.md:90` states the `model_configs`
+  constraint and line 56 already carries a caveat naming this issue, both landed during #591's
+  triage. Choosing (b) would have meant closing with no code change, which is not what this issue
+  is for. The stale *"see #752 for the fix"* pointer should be removed as part of (a).
+- **(c) is coherent but separate.** Warning when `reflection.model` resolves nowhere at all is a
+  reasonable second criterion in `config.py`; it is deliberately **not** in scope here. File it
+  separately if wanted.
+
+## Acceptance criteria
+
+*Added by `agent-session` triage, 2026-08-03. Checks were run against `main` at scan time and the
+observed result is recorded.*
+
+- **CRITERION:** GIVEN a config where `reflection.model` names a model absent from `model_configs`
+  AND `default_model` is set, WHEN `evaluate_response` runs, THEN the judge call SHALL route to
+  `reflection.model` via the legacy `resolved()` url/model/api_key rung, and SHALL NOT use
+  `default_model`.
+
+  **CHECK:** `pytest tests/test_reflection.py::TestEvaluateResponse::test_nonconfig_reflection_model_beats_default_model`
+  — to be authored at freeze, asserting the `call_llm` kwargs carry the configured reflection model
+  rather than the `default_model` key.
+
+  **OBSERVED (2026-08-03): fails today — discriminates.** Reproduced directly: with
+  `reflection.model="gemini-2.5-flash"` (absent from `model_configs`) and
+  `default_model="big-author"`, the patched `call_llm` received `{'model_name': 'big-author'}`.
+  The configured reflection model was discarded, exactly as reported.
+
+## Regression guards
+
+- **GUARD:** the two already-covered judge-routing paths are preserved — a `verifier_model` present
+  in `model_configs` still wins, and a `reflection.model` that *is* a `model_configs` key still
+  routes to it.
+  **CHECK:** `pytest tests/test_reflection.py::TestEvaluateResponse::test_uses_reflection_model tests/test_reflection.py::TestEvaluateResponse::test_verifier_model_routes_judge_call`
+  **OBSERVED:** 2 passed.
+
+- **GUARD:** `test_verifier_model_unset_preserves_fallback_chain` keeps passing **unmodified.**
+  Checked deliberately, because #591's write-up says the fallback chain must be "unchanged" and
+  that sounded like it would block this fix. It does not: that test covers (a) `reflection.model`
+  *in* `model_configs`, (b) `reflection.model` *empty*, and (c) *no* `model_configs` — it never
+  exercises the buggy case, which is `reflection.model` set but **absent** from `model_configs`
+  with `default_model` set. This fix fills a gap in the chain rather than contradicting a pinned
+  one. **If landing the fix requires editing this test, that is a signal the change reached
+  further than intended.**
+
+- **GUARD:** `ReflectionConfig.verifier_model`'s docstring (`src/decafclaw/config_types.py:243-250`)
+  currently *documents this misordering as intended-for-now*. It must be updated in the same change
+  rather than left contradicting the code.
+  **CHECK:** none — this is a human read at review. Recorded so it is not dropped; deliberately not
+  graded, because its only mechanical check would be a keyword grep.
+
+- **GUARD:** no test lost, newly skipped, or newly failing (invariant, not a pinned count).
+  **CHECK:** `make test` — **UNRUN at scan time** (triage runs targeted commands only). Not
+  verified; the freeze phase must run it.
+
+## Still open, but not tier-bearing
+
+Under (a), does `reflection.model` also beat `verifier_model` when *the latter* is unresolvable?
+Current code drops both to `default_model`. The issue is silent. This does not change which
+criteria apply above, so it does not affect the tier — but answer it at review rather than
+discovering it in a diff.
+
+## Tier: auto-ok
+
+**Trigger 1 no longer fires.** It did when this issue was scanned — the three-way fork was a goal
+the loop would have had to pick rather than implement. Branch (a) is now chosen, and its criterion
+was verified to fail today against a real reproduction, with the oracle (`tests/test_reflection.py`
+and its `call_llm` patching idiom) already present.
+
+**Trigger 2 does not fire.** Judge-model routing is not auth, secrets, data migration/deletion,
+deploy/CI config, or a dependency change, and decafclaw's `CLAUDE.md` marks nothing here off-limits.
+One thing for a reviewer's eye rather than a gate: `reflection.api_key` is marked
+`metadata={"secret": True}`, and branch (a) newly routes through the legacy `resolved()` rung that
+reads it. That is an existing code path being reached under a new condition, not a credentials
+change.

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -53,7 +53,7 @@ To use a cheaper model for the judge (recommended):
 decafclaw config set reflection.model gemini-2.5-flash
 ```
 
-> **Caveat:** this only takes effect if the name is a [`model_configs`](config.md#model_configs) key, *or* if `default_model` is unset — otherwise `default_model` wins and the setting is silently discarded. See [Judge model](#judge-model) for the full resolution order, and [#752](https://github.com/lmorchard/decafclaw/issues/752) for the fix. To pin the judge to a specific model regardless, use [`verifier_model`](#verifier_model--the-shared-verifier-convention).
+The name may be a [`model_configs`](config.md#model_configs) key or a raw model name; either way it outranks `default_model`. A raw name routes through the legacy `url`/`model`/`api_key` fallback, so set [`reflection.url`](config.md#reflection) and `reflection.api_key` too if the judge lives somewhere other than the `llm` group. See [Judge model](#judge-model) for the full resolution order. To route the judge through a named model config specifically, use [`verifier_model`](#verifier_model--the-shared-verifier-convention), which outranks this.
 
 ## Configuration
 
@@ -84,12 +84,15 @@ decafclaw config set reflection.verifier_model claude-haiku
 
 Resolution order, highest first:
 
-| Setting | Wins when |
-|---|---|
-| `reflection.verifier_model` | set **and** present in `model_configs` |
-| `reflection.model` | set **and** present in `model_configs` |
-| `default_model` | set — this is why an unset judge grades its own homework |
-| `reflection.resolved(config)` | legacy `url`/`model`/`api_key` fallback |
+| Setting | Wins when | Routed as |
+|---|---|---|
+| `reflection.verifier_model` | set **and** present in `model_configs` | named model config |
+| `reflection.model` | set **and** present in `model_configs` | named model config |
+| `reflection.model` | set and **not** in `model_configs` — a legacy raw model name | `reflection.resolved(config)` |
+| `default_model` | set **and** `reflection.model` is unset — this is why an unset judge grades its own homework | named model config |
+| `reflection.resolved(config)` | nothing above matched | legacy `url`/`model`/`api_key` fallback |
+
+The third row is the one that changed in [#752](https://github.com/lmorchard/decafclaw/issues/752). It used to sit *below* `default_model`, which made it unreachable on any config with a `default_model` set — so `decafclaw config set reflection.model gemini-2.5-flash` did nothing observable and the judge kept billing at the author's model. Any explicitly set `reflection.model` now outranks `default_model`.
 
 A `verifier_model` naming a key that isn't in `model_configs` is ignored, and resolution continues down the table. It is not passed through to the provider layer, which would only log a warning and quietly use the default provider — indistinguishable from the setting having worked.
 

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -242,10 +242,11 @@ class ReflectionConfig:
     model: str = ""     # empty = resolve from llm
     # A model_configs key. When set AND present in config.model_configs, every
     # reflection judge routes through it, so the author does not grade its own
-    # homework (#591). Otherwise resolution continues down the existing chain:
-    # `model` if it too is a model_configs key -> default_model -> the legacy
-    # resolved() url/model/api_key. Note a `model` that is NOT a model_configs
-    # key loses to default_model rather than reaching the legacy rung (#752).
+    # homework (#591). Otherwise resolution continues down the chain: `model`
+    # if it too is a model_configs key -> `model` as a legacy raw name via
+    # resolved() -> default_model -> the legacy resolved() llm-group fallback.
+    # Any explicitly set `model` outranks default_model, whether or not it
+    # names a model_configs key (#752).
     verifier_model: str = ""
     api_key: str = field(default="", metadata={"secret": True})
     max_retries: int = 2

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -300,9 +300,14 @@ async def evaluate_response(
             response = await call_llm(config, messages, model_name=verifier)
         elif rc_model and rc_model in config.model_configs:
             response = await call_llm(config, messages, model_name=rc_model)
-        elif config.default_model:
+        elif config.default_model and not rc_model:
             response = await call_llm(config, messages, model_name=config.default_model)
         else:
+            # Reached two ways: reflection.model is set but is not a
+            # model_configs key — a legacy raw model name, which outranks
+            # default_model, because moving the judge off the author's model is
+            # the whole point of setting it (#752) — or nothing above resolved
+            # and resolved() supplies the llm-group fallback.
             rc = config.reflection.resolved(config)
             response = await call_llm(
                 config, messages,

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -296,9 +296,13 @@ async def evaluate_response(
         #   5. nothing set                                      -> resolved()
         # Only rungs 1, 2 and 4 route through a named model config. Any
         # explicitly set reflection.model outranks default_model, whether or
-        # not it names one (#752) — rung 3 used to sit below rung 4, which made
-        # it unreachable on every config with a default_model set. Keep rung 3
-        # above rung 4 if this chain is ever reordered.
+        # not it names one (#752): before that fix, rung 3 was unreachable on
+        # every config with a default_model set.
+        # Note rung 3 is NOT a branch of its own — it shares the terminal else
+        # with rung 5, so it sits lexically *below* rung 4. What ranks it above
+        # rung 4 is the `and not rc_model` guard on the default_model branch.
+        # Drop that guard and #752 comes back; branch order alone will not
+        # preserve this.
         # The `in config.model_configs` half of the verifier branch is
         # load-bearing, not defensive: an unknown name handed to the provider
         # layer only logs a warning and falls through to the default provider,

--- a/src/decafclaw/reflection.py
+++ b/src/decafclaw/reflection.py
@@ -288,8 +288,17 @@ async def evaluate_response(
 
         messages = [{"role": "user", "content": prompt}]
 
-        # Route through named model config:
-        #   verifier_model > explicit > default_model > legacy
+        # Judge-model resolution, highest first:
+        #   1. verifier_model, when it is a model_configs key   -> named config
+        #   2. reflection.model, when it is a model_configs key -> named config
+        #   3. reflection.model as a legacy raw name            -> resolved()
+        #   4. default_model                                    -> named config
+        #   5. nothing set                                      -> resolved()
+        # Only rungs 1, 2 and 4 route through a named model config. Any
+        # explicitly set reflection.model outranks default_model, whether or
+        # not it names one (#752) — rung 3 used to sit below rung 4, which made
+        # it unreachable on every config with a default_model set. Keep rung 3
+        # above rung 4 if this chain is ever reordered.
         # The `in config.model_configs` half of the verifier branch is
         # load-bearing, not defensive: an unknown name handed to the provider
         # layer only logs a warning and falls through to the default provider,

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -659,6 +659,105 @@ class TestEvaluateResponse:
         # Concrete fallback destination: default_model, via the normal chain.
         assert mock_call.call_args.kwargs == {"model_name": "author"}
 
+    # -- reflection.model precedence over default_model (#752) ------------
+
+    @pytest.mark.asyncio
+    async def test_nonconfig_reflection_model_beats_default_model(self, tmp_path):
+        """GIVEN reflection.model names a model absent from model_configs AND
+        default_model is set, the judge call SHALL route to reflection.model
+        via the legacy resolved() url/model/api_key rung — NOT default_model."""
+        config = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers={"p": ProviderConfig(type="openai-compat",
+                                           url="http://test/v1",
+                                           api_key="test-key")},
+            model_configs={
+                "author": ModelConfig(provider="p", model="author-model"),
+            },
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True,
+                                        model="cheap-judge-model",
+                                        verifier_model=""),
+        )
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config, "hello", "Hi!", "")
+        # call_args is the LAST call, so pin the count too: judging once on
+        # default_model and again on the reflection model would still bill the
+        # author's model, which is the harm #752 describes.
+        assert mock_call.call_count == 1
+        # Equality (not membership) so a stray model_name alongside the legacy
+        # override — or a route to default_model — still fails.
+        assert mock_call.call_args.kwargs == {
+            "llm_url": "http://test/v1/chat/completions",
+            "llm_model": "cheap-judge-model",
+            "llm_api_key": "test-key",
+        }
+
+        # Same criterion, but with reflection.url / reflection.api_key set to
+        # values distinct from config.llm. Above, resolved() backfills both
+        # from config.llm, so an implementation that skips resolved() and
+        # reads config.llm directly emits byte-identical kwargs. Here it does
+        # not: routing must carry the judge's own endpoint and key.
+        config_distinct = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers={"p": ProviderConfig(type="openai-compat",
+                                           url="http://test/v1",
+                                           api_key="test-key")},
+            model_configs={
+                "author": ModelConfig(provider="p", model="author-model"),
+            },
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True,
+                                        url="http://judge/v1/chat/completions",
+                                        model="cheap-judge-model",
+                                        api_key="judge-key",
+                                        verifier_model=""),
+        )
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config_distinct, "hello", "Hi!", "")
+        assert mock_call.call_count == 1
+        assert mock_call.call_args.kwargs == {
+            "llm_url": "http://judge/v1/chat/completions",
+            "llm_model": "cheap-judge-model",
+            "llm_api_key": "judge-key",
+        }
+
+    @pytest.mark.asyncio
+    async def test_verifier_model_outranks_nonconfig_reflection_model(self, tmp_path):
+        """Regression guard for #591's precedence: WHERE verifier_model names a
+        key in model_configs AND reflection.model is set but absent from
+        model_configs, verifier_model SHALL still win. Fixing #752 must not
+        hoist the reflection.model branch above the verifier_model branch."""
+        config = Config(
+            agent=AgentConfig(data_home=str(tmp_path), id="test"),
+            llm=LlmConfig(url="http://test/v1/chat/completions",
+                          model="legacy-model", api_key="test-key"),
+            providers={"p": ProviderConfig(type="openai-compat",
+                                           url="http://test/v1",
+                                           api_key="test-key")},
+            model_configs={
+                "author": ModelConfig(provider="p", model="author-model"),
+                "judge": ModelConfig(provider="p", model="judge-model"),
+            },
+            default_model="author",
+            reflection=ReflectionConfig(enabled=True,
+                                        model="cheap-judge-model",
+                                        verifier_model="judge"),
+        )
+        mock_response = {"content": '{"pass": true, "critique": ""}'}
+        with patch("decafclaw.reflection.call_llm", new_callable=AsyncMock,
+                   return_value=mock_response) as mock_call:
+            await evaluate_response(config, "hello", "Hi!", "")
+        assert mock_call.call_count == 1
+        assert mock_call.call_args.kwargs == {"model_name": "judge"}
+
 
 class TestReflectionPromptStructure:
     """Assert the bundled REFLECTION.md wraps each dynamic input in its tag."""


### PR DESCRIPTION
## Summary

- `decafclaw config set reflection.model gemini-2.5-flash` — the escape hatch `docs/reflection.md` recommends — did nothing observable on any config with a `default_model` set, which is every modern config.
- The legacy `resolved()` rung sat *below* `default_model`, so a `reflection.model` that was not a `model_configs` key could never reach it. Users believed they had moved the judge to a cheap model; the judge kept running on the author's model, at the author's price.

## Design Decisions

**Branch (a) of the three the issue laid out**, chosen by Les on 2026-08-03 and recorded in the issue body: honor `reflection.model` even when it is not a `model_configs` key. Branch (b) (fix the docs to match the code) would have closed the issue with no code change; branch (c) (warn at config load) is coherent but deliberately out of scope — file separately if wanted.

**The four-branch shape over the five-branch one.** The obvious implementation adds a fifth branch (`elif rc_model:`) with its own `resolved()` call above `default_model`. Behaviourally identical, but it duplicates the one call site that reads `reflection.api_key`, a field marked `metadata={"secret": True}`. Adding a conjunct to the `default_model` rung keeps the credential read at a single site. Caught in plan self-review, before any code was written.

**`verifier_model` keeps its position at the top, unconditionally** (#591). New guard G2 pins that against exactly this reorder — see below.

**Answering the issue's open question:** under branch (a), `reflection.model` also beats an *unresolvable* `verifier_model`. That falls out of the branch order rather than needing its own code — an unresolvable `verifier_model` fails its membership test and the `rc_model` rung is now next. `test_unknown_verifier_model_falls_back` keeps passing because it sets `model=""`.

## Changes

- `src/decafclaw/reflection.py` — `elif config.default_model:` → `elif config.default_model and not rc_model:`, plus a rewritten header comment enumerating all five rungs.
- `src/decafclaw/config_types.py` — the `verifier_model` comment stated the #752 misordering as intended-for-now.
- `docs/reflection.md` — the escape-hatch caveat (including its now-stale *"see #752 for the fix"* pointer) and the resolution-order table, which gains the previously unreachable row plus a `Routed as` column.
- `docs/config.md` — **checked, no edit needed.** Its only ordering claim is about `verifier_model`, which is unchanged, and it defers the full order to the table above.

Two things deliberately *not* changed: `#591`'s session `checks.md` contains a line describing the old chain, but it is a frozen historical record of that run's evidence and rewriting it would falsify what that run verified. And no eval was added — per `CLAUDE.md`, evals cover LLM-driven decisions; this is deterministic routing with no tool-description or system-prompt change.

## Acceptance criteria

| id | criterion | check | result |
|---|---|---|---|
| C1 | a `reflection.model` absent from `model_configs` beats `default_model`, routing via the legacy `resolved()` rung | `pytest tests/test_reflection.py::TestEvaluateResponse::test_nonconfig_reflection_model_beats_default_model` | pass (1 collected) |

Guards:

| id | guard | check | result |
|---|---|---|---|
| G1 | the legacy-rung and `verifier_model` paths keep working | `pytest …::test_uses_reflection_model …::test_verifier_model_routes_judge_call` | pass (2 collected) |
| G2 | `verifier_model` still outranks a non-`model_configs` `reflection.model` | `pytest …::test_verifier_model_outranks_nonconfig_reflection_model` | pass (1 collected) |
| G3 | `test_verifier_model_unset_preserves_fallback_chain` passes **unmodified** | that node + no hunk in its function range since freeze | pass (1 collected; diff empty) |
| G4 | the old order is corrected everywhere it was documented (4 sites) | none — human read, deliberately ungraded | **evidence below, ungraded** |
| G5 | no test lost, newly skipped, deselected, or failing | `make test` → `passed >= 3732`, `skipped == 2`, `failed == 0` | pass (3736 collected; 3734 passed, 2 skipped) |

Results come from an independent verifier re-run **after** the review-cycle fixes (fresh context, `checks.md` and the repo only — not the plan, not the implementation notes). Every run exited 0; none exited 5. Frozen at `d34c9df`; tamper diff empty and re-runnable by anyone, since the freeze commit is an ancestor of this head and the branch was not squashed.

**G4 evidence for the human read.** This is the one row a human should eyeball. G4 has no runnable check by design — its only mechanical form would be a keyword grep, which is satisfied by deleting a sentence and writing nothing accurate in its place. The verifier reported factually at each of the four sites; all four were confirmed to no longer state the old order:

- `src/decafclaw/config_types.py:243-250` — rewritten; the "loses to default_model" sentence is gone.
- `docs/reflection.md:56` — caveat and stale #752 pointer removed.
- `docs/reflection.md:87-95` — table rewritten, with a paragraph marking the old order as history.
- `docs/config.md:212` — unchanged; its claim is about `verifier_model` and stays true.

## What the pre-freeze check review caught

Worth a reviewer's attention, because all three were holes in the **oracle** rather than the code — each would have let a wrong implementation ship green:

1. **C1 couldn't see `resolved()`.** With `reflection.url`/`api_key` left empty, `resolved()` backfills both from `config.llm`, so an implementation that skipped `resolved()` entirely and read `config.llm` directly emitted byte-identical kwargs. That would ship the right model pointed at the wrong endpoint with the wrong key — the same class of silent-discard bug as #752 itself. C1 gained a second config with distinct values.
2. **No test set `verifier_model` and `model` both non-empty.** Every existing test zeroed one or the other, so the cheapest edit greening C1 could have inverted #591's documented precedence with the whole suite green. That became **G2**, which passes today — confirming it is a true regression guard, not a second criterion.
3. **G5's original "invariant, not a pinned count" left the only mechanical signal unread.** A test can be lost with no failure and no skip-count change two ways: delete it, or mark it `@pytest.mark.integration`, which `addopts`' `-m "not integration"` deselects — and under `-n auto` the deselected count is not printed at all. Replaced with a floor plus a ceiling.

## Review cycle

Copilot left one inline comment, and it was right: the resolution-chain header comment still read *"Route through named model config: verifier_model > explicit > default_model > legacy"*. Both halves were stale — a non-`model_configs` `reflection.model` does **not** route through a named model config, and "explicit" collapsed the two `reflection.model` rungs this change splits apart. Fixed in `110acb5`.

That fix then had a defect of its own, caught by the post-review verifier and fixed in `36d6147`: it said *"Keep rung 3 above rung 4 if this chain is ever reordered,"* which misnames the mechanism. Rung 3 is not a branch of its own — it shares the terminal `else` with rung 5 and sits lexically *below* rung 4. What ranks it is the `and not rc_model` guard on the `default_model` branch. Someone preserving branch order while dropping that guard would have reintroduced #752 having followed the comment exactly.

Nothing was skipped or deferred. One thread, fixed and resolved.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass · G3 pass · G4 evidence-presented-ungraded · G5 pass
tamper: clean
freeze: d34c9df
project-gates: make check green
ci: 2/2 pass @ 36d614729fbaaf2466604d40f18cb627df640bc7
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: >
  All rows derived mechanically after the final push; head is unchanged at 36d6147, the sha CI
  graded. G4 is a guard, not a criterion, and carries no runnable check by design — the tier
  derivation at triage accounted for it and still read auto-ok, since guards do not enter into
  the tier. It is reported as evidence-presented rather than pass so the block does not
  self-grade a human read; the four-site evidence is above and is the one thing to eyeball.
```

## References

- Spec: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/spec.md`
- Checks: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/checks.md`
- Plan: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/plan.md`
- Notes: `docs/dev-sessions/2026-08-03-1758-752-reflection-model-precedence/notes.md`
- Related: #591 (introduced `verifier_model` above this rung), #529, #530, #589
- Closes #752
