### PR TITLE
fix(#746): re-confirm workspace skills on code change during restore

### DIFF
--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -442,9 +442,10 @@ async def _setup_turn_state(ctx: "Context", config, history) -> dict[str, str]:
     conv_id = ctx.conv_id or ctx.channel_id
     if conv_id:
         persisted = read_skills_state(config, conv_id)
-        existing = set(ctx.skills.activated)
-        if persisted - existing:
-            ctx.skills.activated = existing | persisted
+        existing = ctx.skills.activated
+        merged = {**persisted, **existing}
+        if merged != existing:
+            ctx.skills.activated = merged
         # Restore skill_data (e.g. vault base path) from sidecar
         persisted_data = read_skill_data(config, conv_id)
         existing_data = ctx.skills.data

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -75,7 +75,7 @@ class ToolState:
 @dataclass
 class SkillState:
     """Skill activation state for the current conversation."""
-    activated: set[str] = field(default_factory=set)
+    activated: dict[str, str] = field(default_factory=dict)
     data: dict[str, Any] = field(default_factory=dict)
     # Skill names surfaced for this turn by pre-emptive keyword matching
     # against the current user message + prior assistant response. Skills

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -156,7 +156,9 @@ _PERSISTED_BINDINGS: dict[str, tuple[Callable[[Any], Any], Callable[[Any, Any], 
     ),
     "activated_skills": (
         lambda ctx: ctx.skills.activated,
-        lambda ctx, v: setattr(ctx.skills, "activated", v),
+        lambda ctx, v: setattr(
+            ctx.skills, "activated", v if isinstance(v, dict) else {name: "" for name in v}
+        ),
     ),
     "skip_vault_retrieval": (
         lambda ctx: ctx.skip_vault_retrieval,

--- a/src/decafclaw/persistence.py
+++ b/src/decafclaw/persistence.py
@@ -13,22 +13,27 @@ def _skills_path(config, conv_id: str) -> Path:
     return sidecar_path(config, conv_id, "skills.json")
 
 
-def write_skills_state(config, conv_id: str, skills: set[str]) -> None:
-    """Persist activated skill names for a conversation to a sidecar file."""
+def write_skills_state(config, conv_id: str, skills: dict[str, str]) -> None:
+    """Persist activated skill names and hashes for a conversation to a sidecar file."""
     path = _skills_path(config, conv_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(sorted(skills)) + "\n")
+    path.write_text(json.dumps(skills, indent=2) + "\n")
 
 
-def read_skills_state(config, conv_id: str) -> set[str]:
-    """Read persisted activated skill names, or empty set if none."""
+def read_skills_state(config, conv_id: str) -> dict[str, str]:
+    """Read persisted activated skill states, or empty dict if none."""
     path = _skills_path(config, conv_id)
     if not path.exists():
-        return set()
+        return {}
     try:
-        return set(json.loads(path.read_text()))
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return data
+        elif isinstance(data, list):
+            return {name: "" for name in data}
+        return {}
     except (json.JSONDecodeError, OSError):
-        return set()
+        return {}
 
 
 def _skill_data_path(config, conv_id: str) -> Path:

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -246,7 +246,7 @@ async def run_child_turn(parent_ctx: "Context", task, model: str = "",
         child_ctx.skills.data = parent_ctx.skills.data
 
         # Clear skill state so children can't activate new skills
-        child_ctx.skills.activated = set()
+        child_ctx.skills.activated = dict()
         # Propagate command pre-approved tools and scoped shell patterns to child
         child_ctx.tools.preapproved = parent_ctx.tools.preapproved
         child_ctx.tools.preapproved_shell_patterns = parent_ctx.tools.preapproved_shell_patterns

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -2,6 +2,7 @@
 
 import ast
 import asyncio
+import hashlib
 import importlib.util
 import inspect
 import json
@@ -21,6 +22,8 @@ from .confirmation import request_confirmation
 
 if TYPE_CHECKING:
     from decafclaw.context import Context
+
+    from ..skills import SkillInfo
 
 log = logging.getLogger(__name__)
 
@@ -216,6 +219,20 @@ def _phantom_tool_calls(source: str, tool_names: set[str]) -> list[str]:
     return list(dict.fromkeys(problems))
 
 
+def _compute_skill_hash(skill_info: "SkillInfo") -> str:
+    """Hash the tools.py content. Empty string if no native tools."""
+    if not skill_info.has_native_tools:
+        return ""
+    tools_path = skill_info.location / "tools.py"
+    if not tools_path.exists():
+        return ""
+    try:
+        content = tools_path.read_bytes()
+        return hashlib.sha256(content).hexdigest()
+    except OSError:
+        return ""
+
+
 def _permissions_path(config) -> Path:
     """Path to the skill permissions file (outside workspace, read-only to agent)."""
     return config.agent_path / "skill_permissions.json"
@@ -233,7 +250,7 @@ def _load_permissions(config) -> dict:
         return {}
 
 
-def _save_permission(config, skill_name: str, value: str) -> None:
+def _save_permission(config, skill_name: str, value: dict | str) -> None:
     """Save a skill permission. Called by the host-side confirmation handler."""
     path = _permissions_path(config)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -541,16 +558,27 @@ async def restore_skills(ctx: "Context") -> None:
     discovered = ctx.config.discovered_skills
     skill_map = {s.name: s for s in discovered}
     existing_tools = set(ctx.tools.extra.keys())
-    for name in skill_names:
+    for name in list(skill_names):
         skill_info = skill_map.get(name)
         if not skill_info or not skill_info.has_native_tools:
             continue
+
+        current_hash = _compute_skill_hash(skill_info)
+        if skill_info.trust_tier == "workspace":
+            recorded_hash = ctx.skills.activated.get(name)
+            if recorded_hash != current_hash:
+                log.warning(f"Skill '{name}' code changed since activation. Skipping restore.")
+                del ctx.skills.activated[name]
+                continue
+
+        # Skip if these tools are already loaded (e.g. from persisted skill state)
+        stale = ctx.tools.skill_tool_names.get(name)
+        if stale and all(t in existing_tools for t in stale):
+            log.debug(f"Skill '{name}' tools already loaded, skipping restore")
+            continue
+
         try:
             tools, tool_defs, module = _load_native_tools(skill_info)
-            # Skip if these tools are already loaded (e.g. from persisted skill state)
-            if all(t in existing_tools for t in tools):
-                log.debug(f"Skill '{name}' tools already loaded, skipping restore")
-                continue
             await _call_init(module, ctx.config, name)
             _register_skill_tools(ctx, name, tools, tool_defs)
 
@@ -635,10 +663,17 @@ async def tool_activate_skill(ctx: "Context", name: str) -> str | ToolResult:
     # cannot give it, so it gets a denial rather than an unanswerable prompt.
     is_trusted_tier = skill_info.trust_tier != "workspace"
     perms = _load_permissions(ctx.config)
-    if perms.get(name) == "deny":
+    perm_val = perms.get(name)
+    perm_status = perm_val.get("status") if isinstance(perm_val, dict) else perm_val
+    perm_hash = perm_val.get("hash") if isinstance(perm_val, dict) else ""
+
+    if perm_status == "deny":
         return ToolResult(text=f"[error: activation of skill '{name}' was denied by user]")
+
+    current_hash = _compute_skill_hash(skill_info)
+
     if (not is_trusted_tier
-            and perms.get(name) != "always"
+            and not (perm_status == "always" and perm_hash == current_hash)
             and not skill_info.auto_approve):
         # Need confirmation (workspace tier only at this point)
         if ctx.is_unattended:
@@ -648,14 +683,14 @@ async def tool_activate_skill(ctx: "Context", name: str) -> str | ToolResult:
             log.warning(
                 f"[tool:activate_skill] denied on unattended turn "
                 f"(task_mode={ctx.task_mode!r}): workspace-tier skill "
-                f"'{name}' has no standing grant")
+                f"'{name}' has no standing grant or its code was modified")
             return ToolResult(
                 text=f"[error: activation of skill '{name}' was denied by user]")
         approved, always = await _request_skill_confirmation(ctx, name)
         if not approved:
             return ToolResult(text=f"[error: activation of skill '{name}' was denied by user]")
         if always:
-            _save_permission(ctx.config, name, "always")
+            _save_permission(ctx.config, name, {"status": "always", "hash": current_hash})
 
     # Activate the skill (shared logic)
     result = await activate_skill_internal(ctx, skill_info)
@@ -882,7 +917,7 @@ async def activate_skill_internal(ctx: "Context", skill_info, reloading: bool = 
     else:
         log.info(f"Activated shell-based skill '{name}'")
 
-    ctx.skills.activated.add(name)
+    ctx.skills.activated[name] = _compute_skill_hash(skill_info)
     return "\n".join(result_parts)
 
 

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -244,7 +244,10 @@ def _load_permissions(config) -> dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text())
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {}
+        return data
     except (json.JSONDecodeError, OSError) as e:
         log.warning(f"Could not read skill permissions: {e}")
         return {}
@@ -579,6 +582,11 @@ async def restore_skills(ctx: "Context") -> None:
 
         try:
             tools, tool_defs, module = _load_native_tools(skill_info)
+            # Skip if these tools are already loaded (e.g. from persisted skill state
+            # but skill_tool_names was lost across restarts)
+            if all(t in existing_tools for t in tools):
+                log.debug(f"Skill '{name}' tools already loaded, skipping restore")
+                continue
             await _call_init(module, ctx.config, name)
             _register_skill_tools(ctx, name, tools, tool_defs)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -194,7 +194,7 @@ class TestExecuteCommand:
             name="test-cmd", description="Test", location=Path("."),
             body="Do stuff", context="inline",
         )
-        ctx.skills.activated.add("test-cmd")
+        ctx.skills.activated["test-cmd"] = ""
         # Should not error even though activation logic isn't called
         mode, result = await execute_command(ctx, skill, "")
         assert mode == "inline"
@@ -234,7 +234,7 @@ class TestExecuteCommand:
             name="tabstack", description="Tabstack", location=Path("."),
         )
         ctx.config.discovered_skills = [dep_skill]
-        ctx.skills.activated.add("tabstack")
+        ctx.skills.activated["tabstack"] = ""
 
         skill = SkillInfo(
             name="test-cmd", description="Test", location=Path("."),

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1783,7 +1783,7 @@ def test_save_restore_round_trip(manager, config):
     save_ctx = Context(config=config, event_bus=manager.event_bus)
     save_ctx.tools.extra = {"sentinel_tool": lambda c: None}
     save_ctx.tools.extra_definitions = [{"name": "sentinel_tool"}]
-    save_ctx.skills.activated = {"sentinel_skill"}
+    save_ctx.skills.activated = {"sentinel_skill": ""}
     save_ctx.skip_vault_retrieval = True
     manager.set_flag("rt-conv", "active_model", "sentinel-model")
 
@@ -1795,7 +1795,7 @@ def test_save_restore_round_trip(manager, config):
 
     assert restore_ctx.tools.extra == {"sentinel_tool": save_ctx.tools.extra["sentinel_tool"]}
     assert restore_ctx.tools.extra_definitions == [{"name": "sentinel_tool"}]
-    assert restore_ctx.skills.activated == {"sentinel_skill"}
+    assert restore_ctx.skills.activated == {"sentinel_skill": ""}
     assert restore_ctx.skip_vault_retrieval is True
     assert restore_ctx.active_model == "sentinel-model"
 

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -257,6 +257,6 @@ class TestSkillResults:
     ):
         """A skill already in ctx.skills.activated isn't surfaced — its
         tools are already in the active set, so re-activating is noise."""
-        search_ctx_with_skill.skills.activated.add("writing-clearly")
+        search_ctx_with_skill.skills.activated["writing-clearly"] = ""
         result = tool_search(search_ctx_with_skill, "writing-clearly")
         assert "No matches" in result.text

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -854,7 +854,7 @@ async def test_activate_already_active(ctx, tmp_path):
     """Re-activating returns 'already active'."""
     skill = _make_skill_info(tmp_path)
     ctx.config.discovered_skills = [skill]
-    ctx.skills.activated = {skill.name}
+    ctx.skills.activated = {skill.name: _compute_skill_hash(skill)}
     _save_permission(ctx.config, skill.name, {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name=skill.name)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -20,6 +20,8 @@ from decafclaw.skills import (
     validate_skill_md,
 )
 from decafclaw.tools.skill_tools import (
+    _compute_skill_hash,
+    _find_skill,
     _load_permissions,
     _rejection_display_path,
     _save_permission,
@@ -808,18 +810,18 @@ def test_load_permissions_missing_file(config):
 
 def test_save_and_load_permission(config):
     """Saves a permission and loads it back."""
-    _save_permission(config, "tabstack", "always")
+    _save_permission(config, "tabstack", {"status": "always", "hash": ""})
     perms = _load_permissions(config)
-    assert perms["tabstack"] == "always"
+    assert perms["tabstack"] == {"status": "always", "hash": ""}
 
 
 def test_save_permission_preserves_existing(config):
     """Saving a new permission preserves existing ones."""
-    _save_permission(config, "alpha", "always")
-    _save_permission(config, "beta", "always")
+    _save_permission(config, "alpha", {"status": "always", "hash": ""})
+    _save_permission(config, "beta", {"status": "always", "hash": ""})
     perms = _load_permissions(config)
-    assert perms["alpha"] == "always"
-    assert perms["beta"] == "always"
+    assert perms["alpha"] == {"status": "always", "hash": ""}
+    assert perms["beta"] == {"status": "always", "hash": ""}
 
 
 # -- activation tests --
@@ -853,7 +855,7 @@ async def test_activate_already_active(ctx, tmp_path):
     skill = _make_skill_info(tmp_path)
     ctx.config.discovered_skills = [skill]
     ctx.skills.activated = {skill.name}
-    _save_permission(ctx.config, skill.name, "always")
+    _save_permission(ctx.config, skill.name, {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name=skill.name)
     assert "already active" in _text(result)
@@ -864,7 +866,7 @@ async def test_activate_with_always_permission(ctx, tmp_path):
     """Skill with 'always' permission activates without confirmation."""
     skill = _make_skill_info(tmp_path)
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, skill.name, "always")
+    _save_permission(ctx.config, skill.name, {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name=skill.name)
     assert "Instructions here." in _text(result)
@@ -985,7 +987,7 @@ async def test_activate_substitutes_skill_dir_in_body(ctx, tmp_path):
         body="Run: $SKILL_DIR/fetch.sh",
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, skill.name, "always")
+    _save_permission(ctx.config, skill.name, {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name=skill.name)
     text = _text(result)
@@ -1031,7 +1033,7 @@ async def test_activate_native_skill(ctx, tmp_path):
         has_native_tools=True,
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "native-skill", "always")
+    _save_permission(ctx.config, "native-skill", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name="native-skill")
     assert "Native instructions." in _text(result)
@@ -1071,7 +1073,7 @@ async def test_reactivate_reloads_edited_tools(ctx, tmp_path):
         ),
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "editable", "always")
+    _save_permission(ctx.config, "editable", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="editable")
     assert "v1" in ctx.tools.extra
@@ -1108,7 +1110,7 @@ async def test_reactivate_reloads_changed_tool_body(ctx, tmp_path):
         ),
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "samename", "always")
+    _save_permission(ctx.config, "samename", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="samename")
     assert ctx.tools.extra["go"](ctx) == "before"
@@ -1136,7 +1138,7 @@ async def test_reactivate_updates_dynamic_provider(ctx, tmp_path):
         ),
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "dyn", "always")
+    _save_permission(ctx.config, "dyn", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="dyn")
     first = ctx.tools.dynamic_providers["dyn"]
@@ -1165,7 +1167,7 @@ async def test_reactivate_broken_edit_keeps_working_tools(ctx, tmp_path):
         ),
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "breakable", "always")
+    _save_permission(ctx.config, "breakable", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="breakable")
     (skill_dir / "tools.py").write_text("def broken(\n")  # SyntaxError
@@ -1192,7 +1194,7 @@ async def test_reactivate_same_size_edit_is_not_served_from_bytecode(ctx, tmp_pa
 
     skill = _native_skill(skill_dir, name="samesize", tools_py=before)
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "samesize", "always")
+    _save_permission(ctx.config, "samesize", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="samesize")
     assert ctx.tools.extra["t"](ctx) == "aaa"
@@ -1212,7 +1214,7 @@ async def test_activation_writes_no_pycache_into_the_skill_dir(ctx, tmp_path):
         tools_py="TOOLS = {'c': lambda ctx: 'x'}\nTOOL_DEFINITIONS = []\n",
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "clean", "always")
+    _save_permission(ctx.config, "clean", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="clean")
     assert not (skill_dir / "__pycache__").exists()
@@ -1241,7 +1243,7 @@ async def test_reactivate_text_only_skill_is_idempotent(ctx, tmp_path):
         body="Just prose.", has_native_tools=False,
     )
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "texty", "always")
+    _save_permission(ctx.config, "texty", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="texty")
     result = await tool_activate_skill(ctx, name="texty")
@@ -1338,7 +1340,7 @@ async def test_activate_always_loaded_runs_each_skill_once(ctx, tmp_path, monkey
 
     async def fake_activate(ctx_arg, info):
         calls.append(info.name)
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -1347,7 +1349,7 @@ async def test_activate_always_loaded_runs_each_skill_once(ctx, tmp_path, monkey
     await activate_always_loaded(ctx)
 
     assert calls == ["alpha", "beta"]
-    assert ctx.skills.activated == {"alpha", "beta"}
+    assert set(ctx.skills.activated.keys()) == {"alpha", "beta"}
 
 
 @pytest.mark.asyncio
@@ -1367,7 +1369,7 @@ async def test_activate_always_loaded_skips_workspace_tier(
 
     async def fake_activate(ctx_arg, info):
         calls.append(info.name)
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -1417,7 +1419,7 @@ async def test_activate_always_loaded_fails_soft(
     async def fake_activate(ctx_arg, info):
         if info.name == "boomer":
             raise RuntimeError("boom")
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -1449,7 +1451,7 @@ async def test_activate_skills_for_workflow_succeeds(ctx, tmp_path, monkeypatch)
 
     async def fake_activate(ctx_arg, info):
         calls.append(info)
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -1457,7 +1459,7 @@ async def test_activate_skills_for_workflow_succeeds(ctx, tmp_path, monkeypatch)
 
     await activate_skills_for_workflow(ctx, ["alpha", "beta"])
 
-    assert ctx.skills.activated == {"alpha", "beta"}
+    assert set(ctx.skills.activated.keys()) == {"alpha", "beta"}
     assert len(calls) == 2
     assert calls[0] is skill_a
     assert calls[1] is skill_b
@@ -1481,7 +1483,7 @@ async def test_activate_skills_for_workflow_unknown_skill_raises(
         await activate_skills_for_workflow(ctx, ["bogus-skill"])
 
     assert "bogus-skill" in str(exc_info.value)
-    assert ctx.skills.activated == set()
+    assert ctx.skills.activated == {}
 
 
 @pytest.mark.asyncio
@@ -1582,7 +1584,7 @@ async def test_activate_skills_for_workflow_permits_workspace_tier(
 
     async def fake_activate(ctx_arg, info):
         calls.append(info.name)
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -1972,7 +1974,7 @@ async def test_activate_skill_rediscovers_when_missing_from_catalog(ctx):
                     body="Latecomer body.")
     # Pre-approve: this test is about the catalog miss, not the workspace-tier
     # confirmation gate that would otherwise block activation.
-    _save_permission(ctx.config, "latecomer", "always")
+    _save_permission(ctx.config, "latecomer", {"status": "always", "hash": ""})
     # Simulate the stale snapshot: the skill exists on disk but the catalog
     # this call sees predates it.
     ctx.config.discovered_skills = []
@@ -2016,8 +2018,8 @@ async def test_activation_warns_when_skill_tool_shadows_core_tool(ctx):
             "'function': {'name': 'debug_context'}}]\n"
         ),
     )
-    _save_permission(ctx.config, "shadower", "always")
     ctx.config.discovered_skills = discover_skills(ctx.config)
+    _save_permission(ctx.config, "shadower", {"status": "always", "hash": _compute_skill_hash(_find_skill(ctx.config.discovered_skills, "shadower"))})
 
     result = _text(await tool_activate_skill(ctx, name="shadower"))
 
@@ -2047,8 +2049,8 @@ async def test_shadow_warnings_are_ordered_deterministically(ctx):
             "]\n"
         ),
     )
-    _save_permission(ctx.config, "multishadow", "always")
     ctx.config.discovered_skills = discover_skills(ctx.config)
+    _save_permission(ctx.config, "multishadow", {"status": "always", "hash": _compute_skill_hash(_find_skill(ctx.config.discovered_skills, "multishadow"))})
 
     result = _text(await tool_activate_skill(ctx, name="multishadow"))
 
@@ -2282,7 +2284,7 @@ async def test_reactivate_does_not_duplicate_mismatched_definition_names(ctx, tm
     )
     skill = _native_skill(skill_dir, name="mismatch", tools_py=src)
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "mismatch", "always")
+    _save_permission(ctx.config, "mismatch", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="mismatch")
     await tool_activate_skill(ctx, name="mismatch")  # reload, same source
@@ -2330,7 +2332,7 @@ async def test_activation_blocked_for_workspace_skill_with_phantom_call(ctx, tmp
     skill = _tiered_skill(tmp_path / "ph", "ph", PHANTOM_TOOLS_PY, "workspace")
     ctx.config.discovered_skills = [skill]
     ctx.config.skill_tool_owners = {"shell_background_start": "background"}
-    _save_permission(ctx.config, "ph", "always")
+    _save_permission(ctx.config, "ph", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name="ph")
     text = _text(result)
@@ -2348,7 +2350,7 @@ async def test_activation_blocked_for_default_api(ctx, tmp_path):
     )
     skill = _tiered_skill(tmp_path / "da", "da", src, "workspace")
     ctx.config.discovered_skills = [skill]
-    _save_permission(ctx.config, "da", "always")
+    _save_permission(ctx.config, "da", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name="da")
     assert "default_api" in _text(result)
@@ -2383,7 +2385,7 @@ async def test_activation_unaffected_for_clean_workspace_skill(ctx, tmp_path):
     skill = _tiered_skill(tmp_path / "clean2", "clean2", src, "workspace")
     ctx.config.discovered_skills = [skill]
     ctx.config.skill_tool_owners = {"shell_background_start": "background"}
-    _save_permission(ctx.config, "clean2", "always")
+    _save_permission(ctx.config, "clean2", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     result = await tool_activate_skill(ctx, name="clean2")
     assert "go" in ctx.tools.extra
@@ -2402,7 +2404,7 @@ async def test_reload_into_a_phantom_call_keeps_working_tools(ctx, tmp_path):
     skill = _tiered_skill(skill_dir, "regress", good, "workspace")
     ctx.config.discovered_skills = [skill]
     ctx.config.skill_tool_owners = {"shell_background_start": "background"}
-    _save_permission(ctx.config, "regress", "always")
+    _save_permission(ctx.config, "regress", {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="regress")
     assert "go" in ctx.tools.extra
@@ -2550,8 +2552,8 @@ async def test_reload_of_a_shadowing_skill_restores_the_shadowed_tool(ctx, tmp_p
     shadower_dir = tmp_path / "shad"
     shadower = _two_tool_skill(shadower_dir, "shad", "shared_tool", "from-shadower")
     ctx.config.discovered_skills = [provider, shadower]
-    for n in ("prov", "shad"):
-        _save_permission(ctx.config, n, "always")
+    for skill in (provider, shadower):
+        _save_permission(ctx.config, skill.name, {"status": "always", "hash": _compute_skill_hash(skill)})
 
     await tool_activate_skill(ctx, name="prov")
     await tool_activate_skill(ctx, name="shad")
@@ -2585,7 +2587,7 @@ async def test_reload_after_restore_still_retracts(ctx, tmp_path):
     skill_dir = tmp_path / "restored"
     skill = _two_tool_skill(skill_dir, "restored", "old_name", "v1")
     ctx.config.discovered_skills = [skill]
-    ctx.skills.activated.add("restored")
+    ctx.skills.activated["restored"] = _compute_skill_hash(skill)
     await restore_skills(ctx)
     assert "old_name" in ctx.tools.extra
 
@@ -2594,7 +2596,7 @@ async def test_reload_after_restore_still_retracts(ctx, tmp_path):
         "TOOLS = {'new_name': fn}\n"
         "TOOL_DEFINITIONS = [{'type': 'function', 'function': {'name': 'new_name'}}]\n"
     )
-    _save_permission(ctx.config, "restored", "always")
+    _save_permission(ctx.config, "restored", {"status": "always", "hash": _compute_skill_hash(skill)})
     await tool_activate_skill(ctx, name="restored")
 
     assert "new_name" in ctx.tools.extra

--- a/tests/test_workflow_resume.py
+++ b/tests/test_workflow_resume.py
@@ -179,7 +179,7 @@ async def test_run_workflow_turn_activates_always_loaded_before_orchestrator(
 
     async def fake_activate(ctx_arg, info):
         ctx_arg.tools.extra["fake_tool"] = lambda *_: None
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,
@@ -234,7 +234,7 @@ async def test_run_workflow_turn_activates_requires_skills(
 
     async def fake_activate(ctx_arg, info):
         ctx_arg.tools.extra["fake_tool"] = lambda *_: None
-        ctx_arg.skills.activated.add(info.name)
+        ctx_arg.skills.activated[info.name] = ""
 
     monkeypatch.setattr(
         "decafclaw.tools.skill_tools.activate_skill_internal", fake_activate,


### PR DESCRIPTION
Closes #746.

This fixes the security gap where `restore_skills` re-executed modified workspace-tier skill code without requiring user confirmation.

Changes made:
- `SkillState.activated` (i.e. `ctx.skills.activated`) has been updated from a `set[str]` to a `dict[str, str]`, mapping the activated skill name to the hash of its `tools.py` (at the time of activation).
- `restore_skills` now validates that a workspace tier skill hasn't changed its hash since it was activated. If it has changed, it silently drops the skill from `ctx.skills.activated` and skips restoring it, meaning the next attempt to use it will prompt the user to re-confirm.
- `restore_skills` also avoids re-importing the native tools if they are already fully present in `ctx.tools.extra`.
- Standing `always` grants in `skill_permissions.json` now store a dictionary `{"status": "always", "hash": "<hash>"}` instead of just `"always"`, tying the grant to the exact code the user approved. Older "always" grants (represented by just the string) will prompt the user once to re-establish the hash.
- Test suites have been updated to reflect the new typing and permission formats. All tests pass successfully.