### PR TITLE
fix(vertex): route region "global" to the unprefixed aiplatform host

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -69,6 +69,8 @@ export GOOGLE_APPLICATION_CREDENTIALS=/etc/decafclaw/vertex-sa.json
 
 **Regions:** Gemini models are available in `us-central1`, `us-east4`, `europe-west1`, and others. Check [Vertex AI regions](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations) for availability.
 
+Set `"region": "global"` to use the multi-region global endpoint. Newer Gemini models are often global-only and 404 on every regional endpoint, so `global` is the safer default unless you have a data-residency requirement. Note that `global` is a *location*, not a host prefix — the provider dispatches it to `aiplatform.googleapis.com` rather than `global-aiplatform.googleapis.com` (which does not exist).
+
 ### OpenAI
 
 Direct access to OpenAI's API.

--- a/src/decafclaw/llm/providers/vertex.py
+++ b/src/decafclaw/llm/providers/vertex.py
@@ -60,8 +60,14 @@ class VertexProvider:
         return self._credentials.token
 
     def _base_url(self, model: str) -> str:
+        # "global" is a location, not a regional host prefix — there is no
+        # global-aiplatform.googleapis.com. Google serves it from the bare host.
+        host = (
+            "aiplatform.googleapis.com" if self.region == "global"
+            else f"{self.region}-aiplatform.googleapis.com"
+        )
         return (
-            f"https://{self.region}-aiplatform.googleapis.com/v1/"
+            f"https://{host}/v1/"
             f"projects/{self.project}/locations/{self.region}/"
             f"publishers/google/models/{model}"
         )

--- a/tests/test_vertex_endpoint.py
+++ b/tests/test_vertex_endpoint.py
@@ -1,0 +1,28 @@
+"""Tests for Vertex endpoint URL construction."""
+
+from decafclaw.llm.providers.vertex import VertexProvider
+
+
+def test_regional_endpoint_uses_region_prefixed_host():
+    p = VertexProvider(project="proj", region="us-central1")
+    assert p._base_url("gemini-2.5-flash") == (
+        "https://us-central1-aiplatform.googleapis.com/v1/"
+        "projects/proj/locations/us-central1/"
+        "publishers/google/models/gemini-2.5-flash"
+    )
+
+
+def test_global_region_uses_unprefixed_host():
+    """`global` is not a region prefix — there is no global-aiplatform host.
+
+    Google serves the global endpoint from the bare aiplatform.googleapis.com
+    with `locations/global` in the path. Prefixing produced a DNS-level 404 for
+    every model, and the Gemini 3.x models are global-only, so they are
+    unreachable without this.
+    """
+    p = VertexProvider(project="proj", region="global")
+    assert p._base_url("gemini-3.1-pro-preview") == (
+        "https://aiplatform.googleapis.com/v1/"
+        "projects/proj/locations/global/"
+        "publishers/google/models/gemini-3.1-pro-preview"
+    )


### PR DESCRIPTION
## Problem

`VertexProvider._base_url` built `https://{region}-aiplatform.googleapis.com`. For `"region": "global"` that yields `global-aiplatform.googleapis.com`, which does not exist — Google's frontend returns an HTML 404 for every request. All Vertex models fail through this path.

`global` is a *location*, not a host prefix. The global endpoint is served from the bare `aiplatform.googleapis.com` with `locations/global` in the path.

This isn't cosmetic: the Gemini 3.x models are global-only. Probing `moz-fx-future-products-nonprod` with a real service account:

| model | `locations/global` | `us-central1` |
|---|---|---|
| `gemini-2.5-flash` | ✅ | ✅ |
| `gemini-2.5-pro` | ✅ | — |
| `gemini-3.1-pro-preview` | ✅ | — |
| `gemini-3.1-flash-lite` | ✅ | — |
| `gemini-3.5-flash` | ✅ | ❌ |
| `gemini-3.5-flash-lite` | ✅ | ❌ |
| `gemini-3.6-flash` | ✅ | ❌ |

So there is no regional workaround for the 3.x models — the fix is required to reach them at all.

## Change

- `_base_url` dispatches `global` to the unprefixed host; regional behavior unchanged.
- `tests/test_vertex_endpoint.py` covers both branches (the global case fails on `main`).
- `docs/providers.md` documents `region: "global"` and why it isn't a host prefix.

`make check` and `make test` (3762 passed) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)