### PR TITLE
Fix #685: Child agents of unattended turns inherit unattended status and deny without stalling

### DIFF
--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -116,6 +116,7 @@ class Context:
         self.event_context_id: str = ""  # publish events under this ID instead of context_id
         self._current_iteration: int = 1
         self.is_child: bool = False
+        self.parent_is_unattended: bool = False
         self.skip_reflection: bool = False
         self.skip_vault_retrieval: bool = False
         self.skip_archive: bool = False
@@ -141,7 +142,7 @@ class Context:
     @property
     def is_unattended(self) -> bool:
         """True when a confirmation prompt on this turn cannot reach a human."""
-        return self.task_mode in self.UNATTENDED_TASK_MODES
+        return self.task_mode in self.UNATTENDED_TASK_MODES or self.parent_is_unattended
 
     @classmethod
     def for_task(

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -254,6 +254,7 @@ async def run_child_turn(parent_ctx: "Context", task, model: str = "",
         # No streaming or reflection for child agents
         child_ctx.on_stream_chunk = None
         child_ctx.is_child = True
+        child_ctx.parent_is_unattended = parent_ctx.is_unattended
         child_ctx.skip_reflection = True
         # Default-deny vault retrieval (#396); the parent opts in via
         # `allow_vault_retrieval=True` on `delegate_task`.

--- a/tests/test_unattended_approval.py
+++ b/tests/test_unattended_approval.py
@@ -265,3 +265,56 @@ async def test_interactive_still_prompts(ctx):
     assert result.get("approved"), (
         f"interactive turn did not honor the user's approval: {result!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_child_agent_of_unattended_turn_denies_without_prompting(ctx):
+    """A child agent spawned from an unattended parent turn inherits unattended
+    status and denies unapproved commands without prompting."""
+    for task_mode, user_id in UNATTENDED_TURNS:
+        _unattended(ctx, task_mode, user_id)
+        # Simulate child context construction as delegate.py does
+        child_ctx = ctx.fork(
+            task_mode="child_agent",
+            is_child=True,
+            parent_is_unattended=ctx.is_unattended,
+            request_confirmation=ctx.request_confirmation,
+        )
+        assert child_ctx.is_unattended, "child of unattended parent must be unattended"
+        spy = ctx.request_confirmation
+
+        result = await check_shell_approval(child_ctx, UNSAFE_COMMAND)
+        assert len(spy.calls) == 0, (
+            f"child of unattended turn (task_mode={task_mode!r}) issued "
+            f"{len(spy.calls)} confirmation prompt(s)"
+        )
+        assert not result.get("approved"), (
+            f"child of unattended turn did not deny {UNSAFE_COMMAND!r}: {result!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_child_agent_of_interactive_turn_still_prompts(ctx):
+    """A child agent spawned from an interactive parent turn is not unattended
+    and still prompts for confirmation on unapproved commands."""
+    ctx.task_mode = ""
+    ctx.user_id = "testuser"
+    spy = ConfirmSpy(approved=True)
+    ctx.request_confirmation = spy
+
+    child_ctx = ctx.fork(
+        task_mode="child_agent",
+        is_child=True,
+        parent_is_unattended=ctx.is_unattended,
+        request_confirmation=ctx.request_confirmation,
+    )
+    assert not child_ctx.is_unattended, "child of interactive parent must not be unattended"
+
+    result = await check_shell_approval(child_ctx, UNSAFE_COMMAND)
+    assert len(spy.calls) == 1, (
+        f"child of interactive turn issued {len(spy.calls)} confirmation prompt(s); expected 1"
+    )
+    assert result.get("approved"), (
+        f"child of interactive turn did not honor approval: {result!r}"
+    )
+


### PR DESCRIPTION
Fixes #685. Child agents spawned from unattended parent turns (like heartbeat or scheduled tasks) now correctly inherit unattended status via `parent_is_unattended`, denying unapproved commands immediately without waiting 60s on an unanswerable confirmation prompt. Children of interactive turns continue to prompt correctly.