### PR TITLE
fix(vault): support source_type filtering in vault_search substring strategy (#759)

### DIFF
--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -730,18 +730,11 @@ async def tool_vault_search(ctx: "Context", query: str = "", source_type: str = 
     # every markdown file, so a truthiness test here would let `query=" "`
     # return the whole vault — the exact defect this guard exists to stop, one
     # character away from the refused call.
-    #
-    # The message deliberately does NOT offer `source_type` as a way to satisfy
-    # the guard, even though the condition accepts it: `_substring_search` takes
-    # no `source_type` parameter, so on the default substring strategy that axis
-    # narrows nothing and would hand the model a one-token route back to a full
-    # dump. Accepting it keeps the criterion's boundary; not recommending it
-    # keeps the advice honest. See the `source_type` follow-up issue.
     if (not query.strip() and not req_tags and not folder
             and not source_type and days <= 0):
         return ToolResult(
             text=("[error: vault_search needs at least one of `query`, `tags`, "
-                  "`folder` or `days`. A call with none of them is not a "
+                  "`folder`, `source_type` or `days`. A call with none of them is not a "
                   "search — it would return every page in the vault. Use "
                   "`vault_list` to enumerate pages, or retry with a query.]"),
             display_short_text="no search criteria",
@@ -828,7 +821,8 @@ async def tool_vault_search(ctx: "Context", query: str = "", source_type: str = 
 
     # Substring search across vault
     return _substring_search(ctx.config, query, days=days, folder=folder,
-                             req_tags=req_tags, any_tag=any_tag)
+                             req_tags=req_tags, any_tag=any_tag,
+                             source_type=source_type)
 
 
 def _semantic_result_matches_tags(config, result: dict, req_tags: set[str],
@@ -911,7 +905,8 @@ def _tag_filter_search(config, req_tags: set[str], any_tag: bool,
 
 def _substring_search(config, query: str, days: int = 0, folder: str = "",
                       req_tags: set[str] | None = None,
-                      any_tag: bool = False) -> str | ToolResult:
+                      any_tag: bool = False,
+                      source_type: str = "") -> str | ToolResult:
     """Substring search across vault markdown files."""
     vault = _vault_root(config)
     search_root = vault / folder if folder else vault
@@ -931,6 +926,8 @@ def _substring_search(config, query: str, days: int = 0, folder: str = "",
     lines: list[str] = []
     rows: list[dict] = []
     for path in sorted(search_root.rglob("*.md")):
+        if source_type and _source_type_for_path(config, path) != source_type:
+            continue
         if cutoff:
             mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
             if mtime < cutoff:

--- a/tests/test_vault_search_tags_only.py
+++ b/tests/test_vault_search_tags_only.py
@@ -211,19 +211,31 @@ async def test_empty_query_with_days_is_not_refused(ctx, tagged_pages):
 
 @pytest.mark.asyncio
 async def test_empty_query_with_source_type_is_not_refused(ctx, tagged_pages):
-    """`source_type` alone must not trip the refusal.
-
-    Deliberately narrow: this asserts only that the call is NOT refused, and
-    says nothing about whether `source_type` actually filters. It currently
-    does not on the substring path — `_substring_search` takes no
-    `source_type` parameter and the call site (tools.py) never passes one, so
-    this returns the whole vault today. That is a pre-existing bug and out of
-    scope for #673; widening this assertion would smuggle a second fix into a
-    boundary guard. The weak assertion is the point, not an oversight.
-    """
+    """`source_type` alone must not trip the refusal."""
     result = await tool_vault_search(ctx, "", source_type="page")
     text = result if isinstance(result, str) else result.text
     assert "[error:" not in text
+
+
+@pytest.mark.asyncio
+async def test_source_type_filters_on_substring_strategy(ctx, config):
+    """vault_search with source_type='page' excludes journal entries on substring search."""
+    pages_dir = config.vault_agent_pages_dir
+    journal_dir = config.vault_agent_journal_dir
+    pages_dir.mkdir(parents=True, exist_ok=True)
+    journal_dir.mkdir(parents=True, exist_ok=True)
+
+    (pages_dir / "page-file.md").write_text("Hello unique_substring_abc")
+    (journal_dir / "journal-file.md").write_text("Hello unique_substring_abc")
+
+    # Force substring strategy
+    config.embedding.search_strategy = "substring"
+
+    result = await tool_vault_search(ctx, "unique_substring_abc", source_type="page")
+    text = result.text if hasattr(result, "text") else str(result)
+    assert "page-file" in text
+    assert "journal-file" not in text
+
 
 
 # -- schema must not contradict the signature --


### PR DESCRIPTION
Fixes #759 by ensuring  accepts and applies  filtering, matching the semantic and tag-filter search paths.