### PR TITLE
fix(workspace): strengthen workspace_delete description against ambiguous file deletion guessing (#693)

### DIFF
--- a/src/decafclaw/tools/workspace_tools.py
+++ b/src/decafclaw/tools/workspace_tools.py
@@ -912,7 +912,7 @@ WORKSPACE_TOOL_DEFINITIONS = [
         "priority": "normal",
         "function": {
             "name": "workspace_delete",
-            "description": "Delete a file from the workspace. Cannot delete directories.",
+            "description": "Delete a file from the workspace. Cannot delete directories. NEVER guess a filename if a target is described ambiguously (e.g. 'the Q1 report' with multiple matching files) — use workspace_list to check existing files or ask the user for clarification first.",
             "parameters": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
Fixes #693 by updating  tool description to explicitly forbid guessing filenames on ambiguous targets and instruct the agent to check files via  or ask for clarification first.