### PR TITLE
feat(llm): auto-detect context window size from provider API (#249)

### DIFF
--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from decafclaw.skills.background.tools import format_status_text
 from decafclaw.skills.vault.tools import (
@@ -326,6 +326,8 @@ class ContextComposer:
         via the messages_to_archive list.
         """
         config = ctx.config
+        from .llm import ensure_model_context_window
+        await ensure_model_context_window(config, getattr(ctx, "active_model", ""))
         sources: list[SourceEntry] = []
         to_archive: list[dict] = []
 
@@ -467,7 +469,7 @@ class ContextComposer:
         response_reserve = 4096
 
         # Dynamic budget for scored candidates
-        window_size = self._get_context_window_size(config)
+        window_size = self._get_context_window_size(config, ctx)
         remaining_budget = max(0, window_size - fixed_tokens - response_reserve)
 
         # Fall back to fixed max_tokens if remaining budget is unreasonable
@@ -553,7 +555,7 @@ class ContextComposer:
 
         # -- Context status note (for agent self-regulation) --
         if config.agent.show_context_status:
-            effective_window = self._get_context_window_size(config)
+            effective_window = self._get_context_window_size(config, ctx)
             status_line = self._build_context_status(
                 total_tokens, effective_window, history_msg_count,
             )
@@ -1304,14 +1306,21 @@ class ContextComposer:
         )
         return active, deferred, deferred_text, entry
 
-    def _get_context_window_size(self, config) -> int:
+    def _get_context_window_size(self, config, ctx: Any = None) -> int:
         """Return the effective context window size.
 
-        Prefers the explicit context_window_size if set, otherwise falls back
+        Prefers the explicit context_window_size if set on active model config,
+        or config.llm.context_window_size, otherwise falls back
         to compaction_max_tokens as a conservative proxy.
 
         Used by compose() for dynamic budget allocation.
         """
+        model_name = getattr(ctx, "active_model", "") or getattr(config, "default_model", "")
+        if model_name and model_name in config.model_configs:
+            mc = config.model_configs[model_name]
+            if mc.context_window_size and mc.context_window_size > 0:
+                return mc.context_window_size
+
         window = config.llm.context_window_size
         if window and window > 0:
             return window

--- a/src/decafclaw/llm/__init__.py
+++ b/src/decafclaw/llm/__init__.py
@@ -137,6 +137,9 @@ def _resolve(
     return provider, model, timeout
 
 
+_failed_model_info: set[tuple[str, str]] = set()
+
+
 async def ensure_model_context_window(config: Any, model_name: str | None = None) -> int:
     """Get context window size for a model, querying provider API if not configured (0)."""
     model_name = model_name or getattr(config, "default_model", "")
@@ -145,23 +148,28 @@ async def ensure_model_context_window(config: Any, model_name: str | None = None
         if mc.context_window_size and mc.context_window_size > 0:
             return mc.context_window_size
 
-        try:
-            provider = get_provider(mc.provider)
-            info = await provider.get_model_info(mc.model)
-            if info:
-                limit = (
-                    info.get("inputTokenLimit")
-                    or info.get("input_token_limit")
-                    or info.get("contextWindow")
-                    or info.get("context_window_size")
-                )
-                if limit:
-                    mc.context_window_size = int(limit)
-                    log.info("Auto-detected context window size for model %r (%r): %d",
-                             model_name, mc.model, mc.context_window_size)
-                    return mc.context_window_size
-        except Exception as e:
-            log.debug("Failed to auto-detect context window size for %r: %s", model_name, e)
+        cache_key = (mc.provider, mc.model)
+        if cache_key not in _failed_model_info:
+            try:
+                provider = get_provider(mc.provider)
+                if hasattr(provider, "get_model_info"):
+                    info = await provider.get_model_info(mc.model)
+                    if info:
+                        limit = (
+                            info.get("inputTokenLimit")
+                            or info.get("input_token_limit")
+                            or info.get("contextWindow")
+                            or info.get("context_window_size")
+                        )
+                        if limit:
+                            mc.context_window_size = int(limit)
+                            log.info("Auto-detected context window size for model %r (%r): %d",
+                                     model_name, mc.model, mc.context_window_size)
+                            return mc.context_window_size
+                _failed_model_info.add(cache_key)
+            except Exception as e:
+                log.debug("Failed to auto-detect context window size for %r: %s", model_name, e)
+                _failed_model_info.add(cache_key)
 
         if mc.context_window_size and mc.context_window_size > 0:
             return mc.context_window_size

--- a/src/decafclaw/llm/__init__.py
+++ b/src/decafclaw/llm/__init__.py
@@ -135,3 +135,37 @@ def _resolve(
         provider = OpenAICompatProvider(url=config.llm.url, api_key=config.llm.api_key)
 
     return provider, model, timeout
+
+
+async def ensure_model_context_window(config: Any, model_name: str | None = None) -> int:
+    """Get context window size for a model, querying provider API if not configured (0)."""
+    model_name = model_name or getattr(config, "default_model", "")
+    if model_name and model_name in config.model_configs:
+        mc = config.model_configs[model_name]
+        if mc.context_window_size and mc.context_window_size > 0:
+            return mc.context_window_size
+
+        try:
+            provider = get_provider(mc.provider)
+            info = await provider.get_model_info(mc.model)
+            if info:
+                limit = (
+                    info.get("inputTokenLimit")
+                    or info.get("input_token_limit")
+                    or info.get("contextWindow")
+                    or info.get("context_window_size")
+                )
+                if limit:
+                    mc.context_window_size = int(limit)
+                    log.info("Auto-detected context window size for model %r (%r): %d",
+                             model_name, mc.model, mc.context_window_size)
+                    return mc.context_window_size
+        except Exception as e:
+            log.debug("Failed to auto-detect context window size for %r: %s", model_name, e)
+
+        if mc.context_window_size and mc.context_window_size > 0:
+            return mc.context_window_size
+
+    if config.llm.context_window_size and config.llm.context_window_size > 0:
+        return config.llm.context_window_size
+    return config.compaction.max_tokens

--- a/src/decafclaw/llm/providers/openai_compat.py
+++ b/src/decafclaw/llm/providers/openai_compat.py
@@ -7,6 +7,7 @@ that implements the OpenAI chat completions API.
 import asyncio
 import json
 import logging
+from typing import Any
 
 import httpx
 
@@ -36,6 +37,16 @@ class OpenAICompatProvider:
     def __init__(self, url: str, api_key: str = ""):
         self.url = url
         self.api_key = api_key
+
+    async def get_model_info(
+        self,
+        model: str,
+        *,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> dict[str, Any] | None:
+        """Get model metadata (e.g. token limits), or None if unsupported."""
+        return None
 
     def _headers(self) -> dict[str, str]:
         return {

--- a/src/decafclaw/llm/providers/vertex.py
+++ b/src/decafclaw/llm/providers/vertex.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import uuid
+from typing import Any
 
 import httpx
 
@@ -234,6 +235,25 @@ class VertexProvider:
             except Exception as e:
                 log.error("Vertex embedding failed: %s", e)
                 return None
+        return None
+
+    async def get_model_info(
+        self,
+        model: str,
+        *,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> dict[str, Any] | None:
+        url = self._base_url(model)
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    url, headers=await self._headers(), timeout=timeout,
+                )
+            if resp.status_code == 200:
+                return resp.json()
+        except Exception as e:
+            log.debug("Failed to get model info for %s from Vertex: %s", model, e)
         return None
 
 

--- a/src/decafclaw/llm/types.py
+++ b/src/decafclaw/llm/types.py
@@ -61,3 +61,13 @@ class Provider(Protocol):
     ) -> list[float] | None:
         """Embed text and return the vector, or None on failure."""
         ...
+
+    async def get_model_info(
+        self,
+        model: str,
+        *,
+        timeout: int = 30,
+        **kwargs: Any,
+    ) -> dict[str, Any] | None:
+        """Get model metadata (e.g. token limits), or None if unsupported."""
+        ...

--- a/src/decafclaw/llm/types.py
+++ b/src/decafclaw/llm/types.py
@@ -70,4 +70,4 @@ class Provider(Protocol):
         **kwargs: Any,
     ) -> dict[str, Any] | None:
         """Get model metadata (e.g. token limits), or None if unsupported."""
-        ...
+        return None

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -158,15 +158,18 @@ class TestGetContextWindowSize:
                 return {"inputTokenLimit": 2097152}
 
         from decafclaw.config_types import ModelConfig
-        from decafclaw.llm.registry import register_provider
-        register_provider("mock", MockProvider())
-        config.model_configs["test-model"] = ModelConfig(provider="mock", model="gemini-test", context_window_size=0)
-        config.default_model = "test-model"
+        from decafclaw.llm.registry import clear_providers, register_provider
+        try:
+            register_provider("mock", MockProvider())
+            config.model_configs["test-model"] = ModelConfig(provider="mock", model="gemini-test", context_window_size=0)
+            config.default_model = "test-model"
 
-        from decafclaw.llm import ensure_model_context_window
-        size = await ensure_model_context_window(config, "test-model")
-        assert size == 2097152
-        assert config.model_configs["test-model"].context_window_size == 2097152
+            from decafclaw.llm import ensure_model_context_window
+            size = await ensure_model_context_window(config, "test-model")
+            assert size == 2097152
+            assert config.model_configs["test-model"].context_window_size == 2097152
+        finally:
+            clear_providers()
 
 
 # -- Memory context ------------------------------------------------------------

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -147,6 +147,27 @@ class TestGetContextWindowSize:
         composer = ContextComposer()
         assert composer._get_context_window_size(config) == 100000
 
+    @pytest.mark.asyncio
+    async def test_auto_detects_context_window_size(self, config):
+        class MockProvider:
+            async def complete(self, *args, **kwargs):
+                return {}
+            async def embed(self, *args, **kwargs):
+                return []
+            async def get_model_info(self, model: str, **kwargs):
+                return {"inputTokenLimit": 2097152}
+
+        from decafclaw.config_types import ModelConfig
+        from decafclaw.llm.registry import register_provider
+        register_provider("mock", MockProvider())
+        config.model_configs["test-model"] = ModelConfig(provider="mock", model="gemini-test", context_window_size=0)
+        config.default_model = "test-model"
+
+        from decafclaw.llm import ensure_model_context_window
+        size = await ensure_model_context_window(config, "test-model")
+        assert size == 2097152
+        assert config.model_configs["test-model"].context_window_size == 2097152
+
 
 # -- Memory context ------------------------------------------------------------
 


### PR DESCRIPTION
Closes #249. Auto-detects model context window size from provider API when context_window_size is 0, implemented for Vertex.