### PR TITLE
feat(skills): auto-refresh skills at the start of every agent turn (#280)

### DIFF
--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -232,6 +232,7 @@ class AgentConfig:
     tool_timeout_sec: int = 180
     turn_on_new_message: str = "queue"  # "queue" or "cancel"
     show_context_status: bool = True
+    auto_refresh_skills: bool = True
     preemptive_search: PreemptiveSearchConfig = field(default_factory=PreemptiveSearchConfig)
 
 

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -326,6 +326,14 @@ class ContextComposer:
         via the messages_to_archive list.
         """
         config = ctx.config
+        if getattr(config.agent, "auto_refresh_skills", True):
+            from .tools.skill_tools import rediscover_skills
+            old_prompt = config.system_prompt
+            rediscover_skills(config)
+            if config.system_prompt != old_prompt:
+                log.debug("Auto-refreshed skills: catalog text changed")
+            else:
+                log.debug("Auto-refreshed skills: catalog text unchanged")
         sources: list[SourceEntry] = []
         to_archive: list[dict] = []
 

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -7,6 +7,7 @@ Tracks per-turn diagnostics (what was included, token estimates, actuals).
 
 from __future__ import annotations
 
+import asyncio
 import enum
 import html
 import json
@@ -326,10 +327,10 @@ class ContextComposer:
         via the messages_to_archive list.
         """
         config = ctx.config
-        if getattr(config.agent, "auto_refresh_skills", True):
+        if config.agent.auto_refresh_skills:
             from .tools.skill_tools import rediscover_skills
             old_prompt = config.system_prompt
-            rediscover_skills(config)
+            await asyncio.to_thread(rediscover_skills, config)
             if config.system_prompt != old_prompt:
                 log.debug("Auto-refreshed skills: catalog text changed")
             else:

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -1023,7 +1023,7 @@ def rediscover_skills(config) -> list:
     from ..tool_definitions import invalidate_skill_cache  # deferred: circular dep
 
     rejections: list = []
-    if not config.system_prompt or "<soul>" in config.system_prompt or "<agent_role>" in config.system_prompt:
+    if not config.system_prompt or "<skill_catalog>" in config.system_prompt:
         config.system_prompt, config.discovered_skills = load_system_prompt(
             config, rejections=rejections
         )

--- a/src/decafclaw/tools/skill_tools.py
+++ b/src/decafclaw/tools/skill_tools.py
@@ -1019,13 +1019,16 @@ def rediscover_skills(config) -> list:
     a disconnected copy.
     """
     from ..prompts import load_system_prompt
-    from ..skills import build_skill_tool_owners
+    from ..skills import build_skill_tool_owners, discover_skills
     from ..tool_definitions import invalidate_skill_cache  # deferred: circular dep
 
     rejections: list = []
-    config.system_prompt, config.discovered_skills = load_system_prompt(
-        config, rejections=rejections
-    )
+    if not config.system_prompt or "<soul>" in config.system_prompt or "<agent_role>" in config.system_prompt:
+        config.system_prompt, config.discovered_skills = load_system_prompt(
+            config, rejections=rejections
+        )
+    else:
+        config.discovered_skills = discover_skills(config, rejections=rejections)
     config.skill_tool_owners = build_skill_tool_owners(config.discovered_skills)
     invalidate_skill_cache(config)
     return rejections

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -153,7 +153,7 @@ class TestAutoRefreshSkills:
     async def test_compose_auto_refreshes_skill_catalog(self, ctx, config):
         ws_skills = config.workspace_path / "skills"
         ws_skills.mkdir(parents=True, exist_ok=True)
-        
+
         composer = ContextComposer()
         await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
         assert "late-skill" not in config.system_prompt
@@ -170,7 +170,7 @@ class TestAutoRefreshSkills:
         config.agent.auto_refresh_skills = False
         ws_skills = config.workspace_path / "skills"
         ws_skills.mkdir(parents=True, exist_ok=True)
-        
+
         composer = ContextComposer()
         await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
 

--- a/tests/test_context_composer.py
+++ b/tests/test_context_composer.py
@@ -148,6 +148,40 @@ class TestGetContextWindowSize:
         assert composer._get_context_window_size(config) == 100000
 
 
+class TestAutoRefreshSkills:
+    @pytest.mark.asyncio
+    async def test_compose_auto_refreshes_skill_catalog(self, ctx, config):
+        ws_skills = config.workspace_path / "skills"
+        ws_skills.mkdir(parents=True, exist_ok=True)
+        
+        composer = ContextComposer()
+        await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+        assert "late-skill" not in config.system_prompt
+
+        skill_dir = ws_skills / "late-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: late-skill\ndescription: A late skill.\n---\nLate body.")
+
+        await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+        assert "late-skill" in config.system_prompt
+
+    @pytest.mark.asyncio
+    async def test_compose_skips_refresh_when_disabled(self, ctx, config):
+        config.agent.auto_refresh_skills = False
+        ws_skills = config.workspace_path / "skills"
+        ws_skills.mkdir(parents=True, exist_ok=True)
+        
+        composer = ContextComposer()
+        await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+
+        skill_dir = ws_skills / "disabled-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: disabled-skill\ndescription: Disabled skill.\n---\nBody.")
+
+        await composer.compose(ctx, "hello", [], mode=ComposerMode.INTERACTIVE)
+        assert "disabled-skill" not in config.system_prompt
+
+
 # -- Memory context ------------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #280. Automatically refreshes skill discovery and system prompt catalog at the start of every agent turn via ContextComposer, configurable via  (default ).