### PR TITLE
test(embeddings): globally mock embed_text to prevent network timeouts in CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,3 +38,17 @@ def ctx(config):
     context.channel_id = "test-channel"
     context.user_id = "testuser"
     return context
+
+
+@pytest.fixture(autouse=True)
+def mock_embed_text(monkeypatch, config):
+    """Globally mock embed_text to prevent real network calls and return a dummy vector."""
+    from unittest.mock import AsyncMock
+    dimensions = getattr(getattr(config, "embedding", None), "dimensions", 768)
+    dummy_vec = [0.0] * dimensions
+    mock_embed = AsyncMock(return_value=dummy_vec)
+    monkeypatch.setattr("decafclaw.embeddings.embed_text", mock_embed)
+    monkeypatch.setattr("decafclaw.llm.embed_text", mock_embed)
+    monkeypatch.setattr("decafclaw.memory_context.embed_text", mock_embed)
+    return mock_embed
+


### PR DESCRIPTION
Globally mocks `embed_text` in `conftest.py` to prevent unmocked embedding API network calls from leaking into the test suite. This fixes a major CI bottleneck where tests hanging on private-IP network requests to `192.168.0.199:4000` (the default config) would wait for the full 30-second connection timeout, taking many minutes in GitHub Actions.