### PR TITLE
fix(web): implement full refetch state reconciliation on WebSocket reconnect

### DIFF
--- a/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/notes.md
+++ b/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/notes.md
@@ -1,0 +1,14 @@
+# Notes — 750-web-ui-state-resync-on-reconnect
+
+## Session Summary
+Successfully implemented the full-refetch state reconciliation design on WebSocket reconnect in the Web UI.
+
+## Verification Results
+- **JS Unit Tests (`make test-js`):**
+  `119 passed (119)`
+  All 119 Javascript unit tests passed successfully, including our updated reconnect test in `conversation-store.test.js`.
+- **Linter & Typechecking (`make check`):**
+  Passed cleanly.
+- **Python Unit Tests (`make test`):**
+  `3781 passed, 2 skipped`
+  Passed cleanly with zero errors/warnings.

--- a/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/plan.md
+++ b/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/plan.md
@@ -1,0 +1,20 @@
+# Plan — 750-web-ui-state-resync-on-reconnect
+
+## Phase 1: Setup
+- Create git worktree for isolated branch development under `fix/issue-750`.
+- Install dependencies via `uv sync`.
+- Verify the Javascript and Python baseline tests pass successfully.
+
+## Phase 2: Implementation
+- **Refetch History in `conversation-store.js`:**
+  - Clear `#messageStore` and `#toolStatusStore` and send `LOAD_HISTORY` to the socket in the `#resubscribe()` reconnection callback.
+- **Auto-refetch Canvas State in `canvas-state.js`:**
+  - Add a window listener on the `ws-connected` event. If there is an active conversation, call `setActiveConv(_state.active)` to refetch and publish.
+- **Auto-refetch Sticky State in `sticky-state.js`:**
+  - Add a window listener on the `ws-connected` event. If there is an active conversation, call `setActiveConv(_state.active)` to refetch and publish.
+
+## Phase 3: Verification
+- Update the reconnection test in `conversation-store.test.js` to align with the new full-refetch history behavior.
+- Run `make test-js` and verify all tests pass.
+- Run `make check` and verify typechecking and linting are fully green.
+- Run `make test` and verify Python unit tests pass cleanly.

--- a/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/spec.md
+++ b/docs/dev-sessions/2026-08-06-2100-750-web-ui-state-resync-on-reconnect/spec.md
@@ -1,0 +1,17 @@
+# Specification — 750-web-ui-state-resync-on-reconnect
+
+## Goal
+Implement a full-refetch design on WebSocket reconnect in the Web UI to reconcile all states (messages, canvas, and sticky) that may have changed during an outage, preventing silent staleness of the client.
+
+## Requirements
+1. Clear and refetch conversation messages/history on WebSocket reconnection.
+2. Automatically refetch canvas state for the active conversation when the WebSocket reconnects.
+3. Automatically refetch sticky state for the active conversation when the WebSocket reconnects.
+
+## Design Decisions
+- **`conversation-store.js`:** Clear `MessageStore` and `ToolStatusStore` and re-send `LOAD_HISTORY` inside the `#resubscribe()` reconnection handler.
+- **`canvas-state.js` & `sticky-state.js`:** Register a window-level listener for the `ws-connected` event (emitted when the WebSocket reopens), and automatically call `setActiveConv(_state.active)` to refetch and republish their latest state via REST.
+- **`conversation-store.test.js`:** Update the existing reconnection test (`keeps already-loaded messages when the socket reopens`) to expect the full refetch behavior instead of detaching history reloading.
+
+## What we are NOT doing
+- We are not implementing advanced since-cursors or delta synchronization. Full refetch is selected as the designated simple and robust recovery strategy.

--- a/src/decafclaw/web/static/lib/canvas-state.js
+++ b/src/decafclaw/web/static/lib/canvas-state.js
@@ -233,3 +233,11 @@ export async function closeTabFromUi(tabId) {
   if (!window.confirm(msg)) return;
   await closeTabById(convId, tabId);
 }
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('ws-connected', () => {
+    if (_state.active) {
+      setActiveConv(_state.active);
+    }
+  });
+}

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -466,6 +466,10 @@ export class ConversationStore extends EventTarget {
     // Re-ask every time, not once: an MCP server that connected while we were
     // disconnected contributes prompts the cached list has never seen.
     this.#ws.send({ type: MESSAGE_TYPES.LIST_COMMANDS });
+    // Full refetch of history for the active conversation
+    this.#messageStore.clear();
+    this.#toolStatusStore.clear();
+    this.#ws.send({ type: MESSAGE_TYPES.LOAD_HISTORY, conv_id: this.#currentConvId, limit: 50 });
   }
 
   /**

--- a/src/decafclaw/web/static/lib/conversation-store.js
+++ b/src/decafclaw/web/static/lib/conversation-store.js
@@ -467,6 +467,7 @@ export class ConversationStore extends EventTarget {
     // disconnected contributes prompts the cached list has never seen.
     this.#ws.send({ type: MESSAGE_TYPES.LIST_COMMANDS });
     // Full refetch of history for the active conversation
+    this.#busy = false;
     this.#messageStore.clear();
     this.#toolStatusStore.clear();
     this.#ws.send({ type: MESSAGE_TYPES.LOAD_HISTORY, conv_id: this.#currentConvId, limit: 50 });

--- a/src/decafclaw/web/static/lib/conversation-store.test.js
+++ b/src/decafclaw/web/static/lib/conversation-store.test.js
@@ -178,10 +178,9 @@ describe('ConversationStore reconnect handling', () => {
     expectResubscribed(2);
   });
 
-  // G4a: rules out the naive `addEventListener('open', () => this.select(id))`
-  // fix — selectConversation() clears the message store, so a transient blip
-  // would blank the transcript the user is reading.
-  it('keeps already-loaded messages when the socket reopens', async () => {
+  // G4a: Web UI resync — a reconnect re-sends SELECT_CONV, LIST_COMMANDS, and LOAD_HISTORY
+  // to ensure that any changes made during the outage are fully refetched and reconciled.
+  it('refetches history and updates the transcript when the socket reopens', async () => {
     const store = makeStore(ws);
 
     store.selectConversation('c1');
@@ -199,40 +198,17 @@ describe('ConversationStore reconnect handling', () => {
     });
     expect(store.currentMessages.map((m) => m.content)).toEqual(['hello', 'hi there']);
 
-    /**
-     * The transcript, the selection, and the absence of a refetch all have to
-     * survive a reopen. Content alone is not enough: a
-     * `selectConversation(id, {resubscribeOnly: true})` that skips
-     * `messageStore.clear()` but still fires LOAD_HISTORY leaves the array
-     * intact while re-pulling 50 messages on every transient blip, and one that
-     * nulls `#currentConvId` leaves the array intact while detaching every
-     * subsequent `msg.conv_id === this.#currentConvId` check.
-     * @param {number} round
-     */
-    const expectUndisturbed = (round) => {
-      const where = `reconnect #${round}`;
-      expect(store.currentMessages.map((m) => m.content), where).toEqual(['hello', 'hi there']);
-      expect(store.currentConvId, `${where}: selection lost`).toBe('c1');
-      const historyRequests = ws.sent.filter(
-        (m) => /** @type {any} */ (m).type === MESSAGE_TYPES.LOAD_HISTORY,
-      );
-      expect(
-        historyRequests,
-        `${where}: refetched history — the transcript is already loaded`,
-      ).toHaveLength(0);
-      ws.sent = [];
-    };
-
-    // Drop the initial select_conv/load_history pair from selectConversation().
+    // Reopen/Reconnect
     ws.sent = [];
-
     ws.fireOpen();
     await flush();
-    expectUndisturbed(1);
 
-    ws.fireOpen();
-    await flush();
-    expectUndisturbed(2);
+    expect(store.currentConvId).toBe('c1');
+    const historyRequests = ws.sent.filter(
+      (m) => /** @type {any} */ (m).type === MESSAGE_TYPES.LOAD_HISTORY,
+    );
+    expect(historyRequests).toHaveLength(1);
+    expect(/** @type {any} */ (historyRequests[0]).conv_id).toBe('c1');
   });
 
   // G4b: with nothing selected there is nothing to resubscribe to, so the

--- a/src/decafclaw/web/static/lib/conversation-store.test.js
+++ b/src/decafclaw/web/static/lib/conversation-store.test.js
@@ -209,6 +209,24 @@ describe('ConversationStore reconnect handling', () => {
     );
     expect(historyRequests).toHaveLength(1);
     expect(/** @type {any} */ (historyRequests[0]).conv_id).toBe('c1');
+
+    // Messages should be cleared to prevent stale rendering
+    expect(store.currentMessages).toHaveLength(0);
+
+    // New history arrives (representing what was produced during the outage)
+    ws.fireMessage({
+      type: MESSAGE_TYPES.CONV_HISTORY,
+      conv_id: 'c1',
+      has_more: false,
+      messages: [
+        { role: 'user', content: 'hello', timestamp: '2026-01-01T00:00:00Z' },
+        { role: 'assistant', content: 'hi there', timestamp: '2026-01-01T00:00:01Z' },
+        { role: 'assistant', content: 'new message', timestamp: '2026-01-01T00:00:02Z' },
+      ],
+    });
+
+    // The transcript should contain all messages including the new one
+    expect(store.currentMessages.map((m) => m.content)).toEqual(['hello', 'hi there', 'new message']);
   });
 
   // G4b: with nothing selected there is nothing to resubscribe to, so the

--- a/src/decafclaw/web/static/lib/sticky-state.js
+++ b/src/decafclaw/web/static/lib/sticky-state.js
@@ -105,3 +105,11 @@ export function toggleCollapsed() {
   _saveCollapsed(_state.active, s.collapsed);
   _publish();
 }
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('ws-connected', () => {
+    if (_state.active) {
+      setActiveConv(_state.active);
+    }
+  });
+}


### PR DESCRIPTION
Closes #750. Implements a full refetch design for conversation history, canvas, and sticky states when the Web UI reconnects to ensure no state updates are missed.