### PR TITLE
Web UI: @ references for workspace files and MCP resources + autocomplete

### DIFF
--- a/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/notes.md
+++ b/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/notes.md
@@ -1,0 +1,1 @@
+# Notes: 726-mention-autocomplete

--- a/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/plan.md
+++ b/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/plan.md
@@ -1,0 +1,230 @@
+# Web UI Mentions Autocomplete & Context Injection Implementation Plan
+
+**Goal:** Allow users to mention workspace files, MCP resources, and vault pages in the composer with `@` autocomplete, and inject their full content into the LLM conversation context with smart size truncation.
+
+**Approach:**
+1. Implement `/api/autocomplete?q=...` backend endpoint that searches workspace files, active MCP resources, and vault pages.
+2. Update `ContextComposer` to parse `@` references from the user message, retrieve their contents, and inject them as system/user-reference messages, keeping them under an 8KB (~200 lines) limit and appending truncation warnings.
+3. Update the frontend `chat-input.js` element to trigger an autocomplete dropdown when a `@` token is typed, fetch matches from `/api/autocomplete`, and insert the chosen reference with correct syntax.
+
+**Tech stack:** Python, Starlette, Lit (frontend Web Components), Pytest, Vitest.
+
+---
+
+## Phase 1: Backend Autocomplete Endpoint
+
+This phase delivers the unified backend endpoint `/api/autocomplete?q=...` that prefix-matches and searches across workspace files, active MCP resources, and vault pages, returning formatted JSON for the UI to render.
+
+**Files:**
+- Modify: `src/decafclaw/http_server.py` — Register the autocomplete route, import/write matching logic for workspace, MCP, and vault pages.
+- Create: `tests/test_autocomplete.py` — Comprehensive pytest unit tests for the `/api/autocomplete` endpoint.
+
+**Key changes:**
+- `autocomplete(request: Request, username: str) -> JSONResponse`: The Starlette route handler for `/api/autocomplete`.
+- In `http_server.py`:
+  ```python
+  Route("/api/autocomplete", autocomplete, methods=["GET"]),
+  ```
+
+### Non-trivial Logic Snippet
+
+```python
+@_authenticated
+async def autocomplete(request: Request, username: str) -> JSONResponse:
+    query = request.query_params.get("q", "").strip()
+    if query.startswith("@"):
+        query = query[1:]
+    
+    results = []
+    
+    # 1. Search Vault Pages
+    config = request.app.state.config
+    vault_root = config.vault_root
+    if vault_root.is_dir():
+        # Look for .md files in the vault (excluding hidden directories/files starting with .)
+        try:
+            # We run in a thread because rglob can block
+            def _find_vault_pages():
+                matches = []
+                for p in vault_root.rglob("*.md"):
+                    if any(part.startswith(".") for part in p.parts):
+                        continue
+                    rel = p.relative_to(vault_root)
+                    page_name = str(rel.with_suffix(""))
+                    if not query or query.lower() in page_name.lower():
+                        matches.append({
+                            "type": "vault",
+                            "id": page_name,
+                            "label": page_name,
+                            "description": f"Vault Page"
+                        })
+                matches.sort(key=lambda x: x["label"].lower())
+                return matches[:20]
+            
+            vault_matches = await asyncio.to_thread(_find_vault_pages)
+            results.extend(vault_matches)
+        except Exception as e:
+            log.warning("Autocomplete vault page search failed: %s", e)
+
+    # 2. Search MCP Resources
+    from .mcp_client import get_registry
+    registry = get_registry()
+    if registry:
+        try:
+            mcp_resources = registry.get_resources()
+            mcp_matches = []
+            for server_name, res in mcp_resources:
+                uri = str(getattr(res, "uri", ""))
+                name = str(getattr(res, "name", uri))
+                desc = str(getattr(res, "description", ""))
+                # Match against server name, resource name, or uri
+                mcp_id = f"{server_name}/{name}"
+                if not query or any(query.lower() in val.lower() for val in [server_name, name, uri]):
+                    mcp_matches.append({
+                        "type": "mcp",
+                        "id": mcp_id,
+                        "label": f"mcp/{server_name}/{name}",
+                        "description": desc or f"MCP Resource: {uri}"
+                    })
+            mcp_matches.sort(key=lambda x: x["label"].lower())
+            results.extend(mcp_matches[:20])
+        except Exception as e:
+            log.warning("Autocomplete MCP search failed: %s", e)
+
+    # 3. Search Workspace Files
+    workspace_root = config.workspace_path
+    if workspace_root.is_dir():
+        try:
+            def _find_workspace_files():
+                matches = []
+                workspace_resolved = workspace_root.resolve()
+                for dirpath, dirnames, filenames in os.walk(workspace_root):
+                    # Prune hidden or ignored dirs in-place
+                    dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "node_modules"]
+                    for fname in filenames:
+                        if fname.startswith("."):
+                            continue
+                        fpath = Path(dirpath) / fname
+                        try:
+                            resolved = fpath.resolve()
+                            rel = resolved.relative_to(workspace_resolved)
+                            rel_str = rel.as_posix()
+                        except (OSError, ValueError):
+                            continue
+                        
+                        if not query or query.lower() in rel_str.lower():
+                            matches.append({
+                                "type": "file",
+                                "id": rel_str,
+                                "label": rel_str,
+                                "description": f"Workspace File"
+                            })
+                matches.sort(key=lambda x: x["label"].lower())
+                return matches[:20]
+
+            workspace_matches = await asyncio.to_thread(_find_workspace_files)
+            results.extend(workspace_matches)
+        except Exception as e:
+            log.warning("Autocomplete workspace search failed: %s", e)
+
+    return JSONResponse({"results": results[:50]})
+```
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] `pytest tests/test_autocomplete.py` passes
+
+**Verification — manual:**
+- [ ] None for this backend phase (fully covered by unit tests).
+
+---
+
+## Phase 2: Context Injection and Truncation in ContextComposer
+
+Update the context composer to extract `@path/to/file` and `@mcp/server/resource` mentions, load their content, truncate if larger than 8KB, and inject them as `workspace_references` and `mcp_references` roles.
+
+**Files:**
+- Modify: `src/decafclaw/context_composer.py` — Update `ROLE_REMAP` and add bare mentions parsing & injection logic.
+- Create: `tests/test_mentions_injection.py` — Comprehensive pytest unit tests for the parsing and content injection of bare mentions.
+
+**Key changes:**
+- Update `ROLE_REMAP` to include:
+  ```python
+  "workspace_references": "user",
+  "mcp_references": "user",
+  ```
+- Implement `_compose_mentions_references(self, ctx, config, user_message: str, history: list, mode: ComposerMode) -> tuple[list[dict], SourceEntry | None]` method on `ContextComposer`.
+- Update `ContextComposer.compose` to call `_compose_mentions_references` and merge results into `combined` list of messages.
+
+### Non-trivial Logic Snippet
+
+```python
+_MENTION_RE = re.compile(r'(?<!\w)@([a-zA-Z0-9_./+-]+)')
+
+def parse_bare_mentions(user_message: str) -> list[dict]:
+    """Parse bare mentions starting with @, distinguishing between files and MCP.
+    
+    Ignores vault mentions like @[[Page]].
+    """
+    # Exclude @[[PageName]] pattern from matching first
+    # This is easily handled since _MENTION_RE won't match [ character
+    results = []
+    seen = set()
+    for match in _MENTION_RE.finditer(user_message):
+        val = match.group(1).strip()
+        if val.startswith("[["): # double bracket
+            continue
+        if val in seen:
+            continue
+        seen.add(val)
+        
+        if val.startswith("mcp/"):
+            parts = val.split("/", 2)
+            if len(parts) >= 3:
+                results.append({
+                    "type": "mcp",
+                    "server": parts[1],
+                    "resource": parts[2],
+                    "raw": val
+                })
+        else:
+            results.append({
+                "type": "file",
+                "path": val,
+                "raw": val
+            })
+    return results
+```
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] `pytest tests/test_mentions_injection.py` passes
+
+**Verification — manual:**
+- [ ] None for this logic phase (fully covered by unit tests).
+
+---
+
+## Phase 3: Frontend Autocomplete UI
+
+Implement the trigger context, fetching from `/api/autocomplete`, selection commit, and dropdown menu rendering in the Web UI.
+
+**Files:**
+- Modify: `src/decafclaw/web/static/components/chat-input.js` — Update the autocomplete menu to handle `@` mentions.
+- Modify: `src/decafclaw/web/static/styles/chat-input.css` — Add any necessary styling if needed for mention hints.
+- Modify: `src/decafclaw/web/static/components/chat-input.test.js` — Add Vitest tests for the `@` autocomplete feature.
+
+**Key changes:**
+- Add `_mentionMatches: { type: Array, state: true }` in `properties` and initialize it.
+- Modify `#triggerContext()` to detect `MENTION_TRIGGER_RE`.
+- Implement `_mentionMatches` fetching in `#syncMenu()`.
+- Update `#commitAutocomplete(item)` to format and replace selected references.
+- Update `render()` to draw the mention dropdown list using `_mentionMatches`.
+
+**Verification — automated:**
+- [ ] `make check-js` passes
+- [ ] `make test-js` passes
+
+**Verification — manual:**
+- [ ] Open the Web UI, type `@` in the chat input, and verify the dropdown lists workspace files, MCP resources, and vault pages.
+- [ ] Select a workspace file (e.g. `@CLAUDE.md`), type a prompt, and verify that the backend correctly injects its content and replies with context of the file.

--- a/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/plan.md
+++ b/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/plan.md
@@ -31,111 +31,15 @@ This phase delivers the unified backend endpoint `/api/autocomplete?q=...` that 
 ```python
 @_authenticated
 async def autocomplete(request: Request, username: str) -> JSONResponse:
-    query = request.query_params.get("q", "").strip()
-    if query.startswith("@"):
-        query = query[1:]
-    
-    results = []
-    
-    # 1. Search Vault Pages
-    config = request.app.state.config
-    vault_root = config.vault_root
-    if vault_root.is_dir():
-        # Look for .md files in the vault (excluding hidden directories/files starting with .)
-        try:
-            # We run in a thread because rglob can block
-            def _find_vault_pages():
-                matches = []
-                for p in vault_root.rglob("*.md"):
-                    if any(part.startswith(".") for part in p.parts):
-                        continue
-                    rel = p.relative_to(vault_root)
-                    page_name = str(rel.with_suffix(""))
-                    if not query or query.lower() in page_name.lower():
-                        matches.append({
-                            "type": "vault",
-                            "id": page_name,
-                            "label": page_name,
-                            "description": f"Vault Page"
-                        })
-                matches.sort(key=lambda x: x["label"].lower())
-                return matches[:20]
-            
-            vault_matches = await asyncio.to_thread(_find_vault_pages)
-            results.extend(vault_matches)
-        except Exception as e:
-            log.warning("Autocomplete vault page search failed: %s", e)
-
-    # 2. Search MCP Resources
-    from .mcp_client import get_registry
-    registry = get_registry()
-    if registry:
-        try:
-            mcp_resources = registry.get_resources()
-            mcp_matches = []
-            for server_name, res in mcp_resources:
-                uri = str(getattr(res, "uri", ""))
-                name = str(getattr(res, "name", uri))
-                desc = str(getattr(res, "description", ""))
-                # Match against server name, resource name, or uri
-                mcp_id = f"{server_name}/{name}"
-                if not query or any(query.lower() in val.lower() for val in [server_name, name, uri]):
-                    mcp_matches.append({
-                        "type": "mcp",
-                        "id": mcp_id,
-                        "label": f"mcp/{server_name}/{name}",
-                        "description": desc or f"MCP Resource: {uri}"
-                    })
-            mcp_matches.sort(key=lambda x: x["label"].lower())
-            results.extend(mcp_matches[:20])
-        except Exception as e:
-            log.warning("Autocomplete MCP search failed: %s", e)
-
-    # 3. Search Workspace Files
-    workspace_root = config.workspace_path
-    if workspace_root.is_dir():
-        try:
-            def _find_workspace_files():
-                matches = []
-                workspace_resolved = workspace_root.resolve()
-                for dirpath, dirnames, filenames in os.walk(workspace_root):
-                    # Prune hidden or ignored dirs in-place
-                    dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "node_modules"]
-                    for fname in filenames:
-                        if fname.startswith("."):
-                            continue
-                        fpath = Path(dirpath) / fname
-                        try:
-                            resolved = fpath.resolve()
-                            rel = resolved.relative_to(workspace_resolved)
-                            rel_str = rel.as_posix()
-                        except (OSError, ValueError):
-                            continue
-                        
-                        if not query or query.lower() in rel_str.lower():
-                            matches.append({
-                                "type": "file",
-                                "id": rel_str,
-                                "label": rel_str,
-                                "description": f"Workspace File"
-                            })
-                matches.sort(key=lambda x: x["label"].lower())
-                return matches[:20]
-
-            workspace_matches = await asyncio.to_thread(_find_workspace_files)
-            results.extend(workspace_matches)
-        except Exception as e:
-            log.warning("Autocomplete workspace search failed: %s", e)
-
-    return JSONResponse({"results": results[:50]})
+    # ...
 ```
 
 **Verification — automated:**
-- [ ] `make check` passes
-- [ ] `pytest tests/test_autocomplete.py` passes
+- [x] `make check` passes — **Passed perfectly**
+- [x] `pytest tests/test_autocomplete.py` passes — **5 passed**
 
 **Verification — manual:**
-- [ ] None for this backend phase (fully covered by unit tests).
+- [x] None for this backend phase (fully covered by unit tests).
 
 ---
 
@@ -148,60 +52,16 @@ Update the context composer to extract `@path/to/file` and `@mcp/server/resource
 - Create: `tests/test_mentions_injection.py` — Comprehensive pytest unit tests for the parsing and content injection of bare mentions.
 
 **Key changes:**
-- Update `ROLE_REMAP` to include:
-  ```python
-  "workspace_references": "user",
-  "mcp_references": "user",
-  ```
-- Implement `_compose_mentions_references(self, ctx, config, user_message: str, history: list, mode: ComposerMode) -> tuple[list[dict], SourceEntry | None]` method on `ContextComposer`.
-- Update `ContextComposer.compose` to call `_compose_mentions_references` and merge results into `combined` list of messages.
-
-### Non-trivial Logic Snippet
-
-```python
-_MENTION_RE = re.compile(r'(?<!\w)@([a-zA-Z0-9_./+-]+)')
-
-def parse_bare_mentions(user_message: str) -> list[dict]:
-    """Parse bare mentions starting with @, distinguishing between files and MCP.
-    
-    Ignores vault mentions like @[[Page]].
-    """
-    # Exclude @[[PageName]] pattern from matching first
-    # This is easily handled since _MENTION_RE won't match [ character
-    results = []
-    seen = set()
-    for match in _MENTION_RE.finditer(user_message):
-        val = match.group(1).strip()
-        if val.startswith("[["): # double bracket
-            continue
-        if val in seen:
-            continue
-        seen.add(val)
-        
-        if val.startswith("mcp/"):
-            parts = val.split("/", 2)
-            if len(parts) >= 3:
-                results.append({
-                    "type": "mcp",
-                    "server": parts[1],
-                    "resource": parts[2],
-                    "raw": val
-                })
-        else:
-            results.append({
-                "type": "file",
-                "path": val,
-                "raw": val
-            })
-    return results
-```
+- Update `ROLE_REMAP` to include `workspace_references` and `mcp_references`.
+- Implement `_compose_mentions_references` method on `ContextComposer`.
+- Update `ContextComposer.compose` to call `_compose_mentions_references` and merge results.
 
 **Verification — automated:**
-- [ ] `make check` passes
-- [ ] `pytest tests/test_mentions_injection.py` passes
+- [x] `make check` passes — **Passed perfectly**
+- [x] `pytest tests/test_mentions_injection.py` passes — **4 passed**
 
 **Verification — manual:**
-- [ ] None for this logic phase (fully covered by unit tests).
+- [x] None for this logic phase (fully covered by unit tests).
 
 ---
 
@@ -215,16 +75,16 @@ Implement the trigger context, fetching from `/api/autocomplete`, selection comm
 - Modify: `src/decafclaw/web/static/components/chat-input.test.js` — Add Vitest tests for the `@` autocomplete feature.
 
 **Key changes:**
-- Add `_mentionMatches: { type: Array, state: true }` in `properties` and initialize it.
+- Add `_mentionMatches` property.
 - Modify `#triggerContext()` to detect `MENTION_TRIGGER_RE`.
-- Implement `_mentionMatches` fetching in `#syncMenu()`.
-- Update `#commitAutocomplete(item)` to format and replace selected references.
-- Update `render()` to draw the mention dropdown list using `_mentionMatches`.
+- Implement `_mentionMatches` fetching.
+- Update `#commitAutocomplete` to format and replace selected references.
+- Update `render()` to draw the mention dropdown list.
 
 **Verification — automated:**
-- [ ] `make check-js` passes
-- [ ] `make test-js` passes
+- [x] `make check-js` passes — **Passed perfectly**
+- [x] `make test-js` passes — **123 passed**
 
 **Verification — manual:**
-- [ ] Open the Web UI, type `@` in the chat input, and verify the dropdown lists workspace files, MCP resources, and vault pages.
-- [ ] Select a workspace file (e.g. `@CLAUDE.md`), type a prompt, and verify that the backend correctly injects its content and replies with context of the file.
+- [x] Open the Web UI, type `@` in the chat input, and verify the dropdown lists workspace files, MCP resources, and vault pages.
+- [x] Select a workspace file (e.g. `@CLAUDE.md`), type a prompt, and verify that the backend correctly injects its content.

--- a/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/research.md
+++ b/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/research.md
@@ -1,0 +1,1 @@
+# Research: 726-mention-autocomplete

--- a/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/spec.md
+++ b/docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/spec.md
@@ -1,0 +1,22 @@
+# Spec: Web UI: @ references for workspace files and MCP resources + autocomplete
+
+**Goal:** Let a user reference workspace files and MCP resources from the composer, and autocomplete those references.
+
+## Approved Design Decisions
+
+### 1. Mention Syntax
+- **Workspace files:** Bare paths prefixed with `@`, e.g., `@src/agent.py` or `@tests/test_agent.py` (any path under the workspace).
+- **MCP resources:** Segment-prefixed bare names, e.g., `@mcp/server_name/resource_name`.
+- **Vault pages:** Keep the existing bracket-wrapped syntax `@[[PageName]]`. When selected from the `@` autocomplete dropdown list, it should insert `@[[PageName]]`.
+
+### 2. Autocomplete Server API
+- Build a unified backend endpoint `/api/autocomplete?q=...` that queries:
+  - **Workspace files:** Recursive prefix search on filenames/paths under the workspace tree (ignoring hidden or ignored directories like `.git`, `.venv`, `.ocx`, `node_modules`).
+  - **MCP resources:** Matches from active MCP servers' resources.
+  - **Vault pages:** Matches from the vault.
+- Returns segment/reference type (`file`, `mcp`, `vault`) and labels for UI rendering.
+
+### 3. Context Injection & Truncation Strategy
+- In `ContextComposer.compose()`, parse bare mentions from the user's message.
+- Retrieve the full contents of the referenced workspace file or MCP resource and inline them directly into the conversation context as a system/user-reference message.
+- **Oversize Strategy:** If a file/resource is larger than **8KB (~200 lines)**, truncate the content and append a clear truncation notice: `[Truncated: only first 8KB of src/agent.py inlined]`.

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -914,7 +914,7 @@ class ContextComposer:
             return [], None
 
         from .mcp_client import _convert_resource_response, get_registry
-        from .web.workspace_paths import detect_kind, resolve_safe
+        from .web.workspace_paths import detect_kind, is_secret, resolve_safe
 
         mentions = parse_bare_mentions(user_message)
         if not mentions:
@@ -946,9 +946,13 @@ class ContextComposer:
                 resolved = resolve_safe(config.workspace_path, rel_path)
                 if not resolved or not resolved.is_file() or detect_kind(resolved) != "text":
                     text = f"[Workspace file '{rel_path}' not found or not readable as text]"
+                elif is_secret(rel_path):
+                    text = f"[Workspace file '{rel_path}' is a secret and cannot be inlined]"
                 else:
                     try:
-                        content = resolved.read_text(encoding="utf-8")
+                        # Only read up to 8193 characters to optimize memory/speed for huge files
+                        with resolved.open("r", encoding="utf-8") as f:
+                            content = f.read(8193)
                         # Truncate to 8KB (~8192 chars) if larger
                         if len(content) > 8192:
                             content = content[:8192] + f"\n\n[Truncated: only first 8KB of {rel_path} inlined]"
@@ -998,7 +1002,7 @@ class ContextComposer:
                             content = tool_res.text
                             # Truncate to 8KB if larger
                             if len(content) > 8192:
-                                content = content[:8192] + f"\n\n[Truncated: only first 8KB of mcp/{raw_ref} inlined]"
+                                content = content[:8192] + f"\n\n[Truncated: only first 8KB of {raw_ref} inlined]"
                             text = f"[Referenced MCP resource: {raw_ref}]\n\n{content}"
                         except asyncio.TimeoutError:
                             text = f"[Error: reading MCP resource '{resource_name}' timed out after {timeout_s}s]"

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -32,6 +32,7 @@ from .memory_context import (
     format_memory_headlines,
     get_already_injected_pages,
     parse_wiki_references,
+    parse_bare_mentions,
     read_wiki_page,
     retrieve_memory_context,
 )
@@ -61,6 +62,8 @@ log = logging.getLogger(__name__)
 ROLE_REMAP: dict[str, str] = {
     "vault_retrieval": "user",
     "vault_references": "user",
+    "workspace_references": "user",
+    "mcp_references": "user",
     "conversation_notes": "user",
     "recent_journal": "user",
     "cancel_marker": "user",
@@ -369,6 +372,17 @@ class ContextComposer:
         if wiki_entry:
             sources.append(wiki_entry)
 
+        # -- Mentions context (injected before user message in history) --
+        # Explicit @file and @mcp references
+        mention_msgs, mention_entry = await self._compose_mentions_references(
+            ctx, config, user_message, history, mode,
+        )
+        for mm in mention_msgs:
+            to_archive.append(mm)
+            await ctx.publish("mention_references", text=mm["content"], ref=mm.get("workspace_file") or mm.get("mcp_resource"))
+        if mention_entry:
+            sources.append(mention_entry)
+
         # -- Per-conversation scratchpad notes (#299) --
         # Auto-inject the recent notes block so the agent doesn't pay a
         # tool call per turn to read them.
@@ -507,7 +521,7 @@ class ContextComposer:
         # recent journal → memory → user message. The combined list is
         # what the LLM sees.
         combined = [
-            *history, *wiki_msgs, *notes_msgs, *recent_journal_msgs,
+            *history, *wiki_msgs, *mention_msgs, *notes_msgs, *recent_journal_msgs,
             *memory_msgs, user_msg,
         ]
         llm_history = []
@@ -882,6 +896,126 @@ class ContextComposer:
         tokens = sum(estimate_tokens(m["content"]) for m in messages)
         entry = SourceEntry(
             source="wiki",
+            tokens_estimated=tokens,
+            items_included=len(messages),
+            items_truncated=skipped,
+        )
+        return messages, entry
+
+    async def _compose_mentions_references(
+        self, ctx, config, user_message: str, history: list, mode: ComposerMode,
+    ) -> tuple[list[dict], SourceEntry | None]:
+        """Build context messages for referenced workspace files and MCP resources.
+
+        Returns (messages_to_inject, source_entry).
+        """
+        skip_modes = {ComposerMode.HEARTBEAT, ComposerMode.SCHEDULED, ComposerMode.CHILD_AGENT}
+        if mode in skip_modes:
+            return [], None
+
+        from .web.workspace_paths import resolve_safe, detect_kind
+        from .mcp_client import get_registry, _convert_resource_response
+
+        mentions = parse_bare_mentions(user_message)
+        if not mentions:
+            return [], None
+
+        # Gather already injected files and mcp resources from history to deduplicate
+        already_injected_files = set()
+        already_injected_mcp = set()
+        for msg in history:
+            if msg.get("role") == "workspace_references":
+                f = msg.get("workspace_file")
+                if f:
+                    already_injected_files.add(f)
+            elif msg.get("role") == "mcp_references":
+                r = msg.get("mcp_resource")
+                if r:
+                    already_injected_mcp.add(r)
+
+        messages = []
+        skipped = 0
+
+        for ref in mentions:
+            if ref["type"] == "file":
+                rel_path = ref["path"]
+                if rel_path in already_injected_files:
+                    skipped += 1
+                    continue
+
+                resolved = resolve_safe(config.workspace_path, rel_path)
+                if not resolved or not resolved.is_file() or detect_kind(resolved) != "text":
+                    text = f"[Workspace file '{rel_path}' not found or not readable as text]"
+                else:
+                    try:
+                        content = resolved.read_text(encoding="utf-8")
+                        # Truncate to 8KB (~8192 chars) if larger
+                        if len(content) > 8192:
+                            content = content[:8192] + f"\n\n[Truncated: only first 8KB of {rel_path} inlined]"
+                        text = f"[Referenced workspace file: {rel_path}]\n\n{content}"
+                    except Exception as e:
+                        text = f"[Error reading workspace file '{rel_path}': {e}]"
+
+                messages.append({
+                    "role": "workspace_references",
+                    "content": text,
+                    "workspace_file": rel_path,
+                })
+
+            elif ref["type"] == "mcp":
+                server_name = ref["server"]
+                resource_name = ref["resource"]
+                raw_ref = ref["raw"]
+                if raw_ref in already_injected_mcp:
+                    skipped += 1
+                    continue
+
+                registry = get_registry()
+                state = registry.servers.get(server_name) if registry else None
+                if not state or state.status != "connected" or not state.session:
+                    text = f"[MCP server '{server_name}' is not connected to retrieve '{resource_name}']"
+                else:
+                    # Find matching resource by name, uri, or ending
+                    target_res = None
+                    for r in state.resources:
+                        if getattr(r, "name", "") == resource_name or str(getattr(r, "uri", "")) == resource_name or str(getattr(r, "uri", "")).endswith("/" + resource_name):
+                            target_res = r
+                            break
+
+                    if not target_res:
+                        text = f"[MCP resource '{resource_name}' not found on server '{server_name}']"
+                    else:
+                        from pydantic import AnyUrl
+                        import asyncio
+                        try:
+                            timeout_s = state.config.timeout / 1000
+                            result = await asyncio.wait_for(
+                                state.session.read_resource(AnyUrl(str(target_res.uri))),
+                                timeout=timeout_s,
+                            )
+                            tool_res = _convert_resource_response(result)
+                            content = tool_res.text
+                            # Truncate to 8KB if larger
+                            if len(content) > 8192:
+                                content = content[:8192] + f"\n\n[Truncated: only first 8KB of mcp/{raw_ref} inlined]"
+                            text = f"[Referenced MCP resource: {raw_ref}]\n\n{content}"
+                        except asyncio.TimeoutError:
+                            text = f"[Error: reading MCP resource '{resource_name}' timed out after {timeout_s}s]"
+                        except Exception as e:
+                            text = f"[Error reading MCP resource '{resource_name}': {e}]"
+
+                messages.append({
+                    "role": "mcp_references",
+                    "content": text,
+                    "mcp_resource": raw_ref,
+                })
+
+        if not messages and skipped == 0:
+            return [], None
+
+        tokens = sum(estimate_tokens(m["content"]) for m in messages)
+        entry = SourceEntry(
+            source="mentions",
             tokens_estimated=tokens,
             items_included=len(messages),
             items_truncated=skipped,

--- a/src/decafclaw/context_composer.py
+++ b/src/decafclaw/context_composer.py
@@ -31,8 +31,8 @@ from .memory_context import (
     format_memory_context,
     format_memory_headlines,
     get_already_injected_pages,
-    parse_wiki_references,
     parse_bare_mentions,
+    parse_wiki_references,
     read_wiki_page,
     retrieve_memory_context,
 )
@@ -913,8 +913,8 @@ class ContextComposer:
         if mode in skip_modes:
             return [], None
 
-        from .web.workspace_paths import resolve_safe, detect_kind
-        from .mcp_client import get_registry, _convert_resource_response
+        from .mcp_client import _convert_resource_response, get_registry
+        from .web.workspace_paths import detect_kind, resolve_safe
 
         mentions = parse_bare_mentions(user_message)
         if not mentions:
@@ -985,8 +985,9 @@ class ContextComposer:
                     if not target_res:
                         text = f"[MCP resource '{resource_name}' not found on server '{server_name}']"
                     else:
-                        from pydantic import AnyUrl
                         import asyncio
+
+                        from pydantic import AnyUrl
                         try:
                             timeout_s = state.config.timeout / 1000
                             result = await asyncio.wait_for(

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -1181,6 +1181,125 @@ async def workspace_recent(request: Request, username: str) -> JSONResponse:
     return JSONResponse({"files": files})
 
 
+@_authenticated
+async def autocomplete(request: Request, username: str) -> JSONResponse:
+    """Return autocomplete suggestions for files, MCP resources, and vault pages."""
+    query = request.query_params.get("q", "").strip()
+    if query.startswith("@"):
+        query = query[1:]
+
+    results = []
+
+    # 1. Search Vault Pages
+    config = request.app.state.config
+    vault_root = config.vault_root
+    if vault_root.is_dir():
+        try:
+            def _find_vault_pages():
+                matches = []
+                for p in vault_root.rglob("*.md"):
+                    if any(part.startswith(".") for part in p.parts):
+                        continue
+                    try:
+                        rel = p.relative_to(vault_root)
+                        page_name = str(rel.with_suffix(""))
+                        if not query or query.lower() in page_name.lower():
+                            matches.append({
+                                "type": "vault",
+                                "id": page_name,
+                                "label": page_name,
+                                "description": "Vault Page",
+                            })
+                    except (OSError, ValueError):
+                        continue
+                matches.sort(key=lambda x: x["label"].lower())
+                return matches[:20]
+
+            vault_matches = await asyncio.to_thread(_find_vault_pages)
+            results.extend(vault_matches)
+        except Exception as e:
+            log.warning("Autocomplete vault page search failed: %s", e)
+
+    # 2. Search MCP Resources
+    from .mcp_client import get_registry
+    registry = get_registry()
+    if registry:
+        try:
+            mcp_resources = registry.get_resources()
+            mcp_matches = []
+            for server_name, res in mcp_resources:
+                uri = str(getattr(res, "uri", ""))
+                name = str(getattr(res, "name", uri))
+                desc = str(getattr(res, "description", ""))
+                mcp_id = f"{server_name}/{name}"
+                if not query or any(query.lower() in val.lower() for val in [server_name, name, uri]):
+                    mcp_matches.append({
+                        "type": "mcp",
+                        "id": mcp_id,
+                        "label": f"mcp/{server_name}/{name}",
+                        "description": desc or f"MCP Resource: {uri}",
+                    })
+            mcp_matches.sort(key=lambda x: x["label"].lower())
+            results.extend(mcp_matches[:20])
+        except Exception as e:
+            log.warning("Autocomplete MCP search failed: %s", e)
+
+    # 3. Search Workspace Files
+    workspace_root = config.workspace_path
+    if workspace_root.is_dir():
+        try:
+            def _find_workspace_files():
+                matches = []
+                workspace_resolved = workspace_root.resolve()
+                vault_resolved = None
+                try:
+                    vault_resolved = config.vault_root.resolve()
+                except Exception:
+                    pass
+
+                for dirpath, dirnames, filenames in os.walk(workspace_root):
+                    # Prune hidden or ignored dirs, and the vault directory if it is inside the workspace
+                    dirnames[:] = [
+                        d for d in dirnames
+                        if not d.startswith(".") and d != "node_modules" and (not vault_resolved or (Path(dirpath) / d).resolve() != vault_resolved)
+                    ]
+                    # Also skip this dir if it is inside the vault
+                    try:
+                        dirpath_path = Path(dirpath).resolve()
+                        if vault_resolved and (dirpath_path == vault_resolved or dirpath_path.is_relative_to(vault_resolved)):
+                            continue
+                    except Exception:
+                        pass
+
+                    for fname in filenames:
+                        if fname.startswith("."):
+                            continue
+                        fpath = Path(dirpath) / fname
+                        try:
+                            resolved = fpath.resolve()
+                            rel = resolved.relative_to(workspace_resolved)
+                            rel_str = rel.as_posix()
+                        except (OSError, ValueError):
+                            continue
+
+                        if not query or query.lower() in rel_str.lower():
+                            matches.append({
+                                "type": "file",
+                                "id": rel_str,
+                                "label": rel_str,
+                                "description": "Workspace File",
+                            })
+                matches.sort(key=lambda x: x["label"].lower())
+                return matches[:20]
+
+            workspace_matches = await asyncio.to_thread(_find_workspace_files)
+            results.extend(workspace_matches)
+        except Exception as e:
+            log.warning("Autocomplete workspace search failed: %s", e)
+
+    return JSONResponse({"results": results[:50]})
+
+
 # -- Vault routes -------------------------------------------------------------
 
 
@@ -2290,6 +2409,7 @@ def create_app(config, event_bus, app_ctx=None, manager=None) -> Starlette:
         Route("/api/workspace", workspace_list, methods=["GET"]),
         Route("/api/workspace", workspace_create, methods=["POST"]),
         Route("/api/workspace/recent", workspace_recent, methods=["GET"]),
+        Route("/api/autocomplete", autocomplete, methods=["GET"]),
         Route("/api/workspace-file/{path:path}", workspace_read_json, methods=["GET"]),
         Route("/api/workspace/{path:path}", serve_workspace_file, methods=["GET"]),
         Route("/api/workspace/{path:path}", workspace_write, methods=["PUT"]),

--- a/src/decafclaw/http_server.py
+++ b/src/decafclaw/http_server.py
@@ -1258,6 +1258,8 @@ async def autocomplete(request: Request, username: str) -> JSONResponse:
                     pass
 
                 for dirpath, dirnames, filenames in os.walk(workspace_root):
+                    if len(matches) >= 20:
+                        break
                     # Prune hidden or ignored dirs, and the vault directory if it is inside the workspace
                     dirnames[:] = [
                         d for d in dirnames
@@ -1272,6 +1274,8 @@ async def autocomplete(request: Request, username: str) -> JSONResponse:
                         pass
 
                     for fname in filenames:
+                        if len(matches) >= 20:
+                            break
                         if fname.startswith("."):
                             continue
                         fpath = Path(dirpath) / fname

--- a/src/decafclaw/memory_context.py
+++ b/src/decafclaw/memory_context.py
@@ -309,6 +309,43 @@ def _excerpt_for_headline(text: str, max_chars: int) -> str:
 _WIKI_MENTION_RE = re.compile(r'@\[\[([^\]]+)\]\]')
 
 
+# Matches @ followed by word/path-like characters. Does NOT match @[[Page]].
+_MENTION_RE = re.compile(r'(?<!\w)@([a-zA-Z0-9_./+-]+)')
+
+
+def parse_bare_mentions(user_message: str) -> list[dict]:
+    """Parse bare mentions starting with @, distinguishing between files and MCP.
+
+    Ignores vault mentions like @[[PageName]].
+    """
+    results = []
+    seen = set()
+    for match in _MENTION_RE.finditer(user_message):
+        val = match.group(1).strip()
+        if val.startswith("[[") or val.endswith("]]"):
+            continue
+        if val in seen:
+            continue
+        seen.add(val)
+
+        if val.startswith("mcp/"):
+            parts = val.split("/", 2)
+            if len(parts) >= 3:
+                results.append({
+                    "type": "mcp",
+                    "server": parts[1],
+                    "resource": parts[2],
+                    "raw": val,
+                })
+        else:
+            results.append({
+                "type": "file",
+                "path": val,
+                "raw": val,
+            })
+    return results
+
+
 def parse_wiki_references(
     user_message: str, wiki_page: str | None = None,
 ) -> list[dict]:

--- a/src/decafclaw/web/static/components/chat-input.js
+++ b/src/decafclaw/web/static/components/chat-input.js
@@ -5,7 +5,7 @@ import { uploadFile } from '../lib/upload-client.js';
 const TRIGGER_RE = /^([/!])(\S*)$/;
 
 /** An `@` mention token ending at the caret. */
-const MENTION_TRIGGER_RE = /(?:^|\s)@([a-zA-Z0-9_./+-]*)$/;
+const MENTION_TRIGGER_RE = /(?<!\w)@([a-zA-Z0-9_./+-]*)$/;
 
 /**
  * Score `name` as an ordered-subsequence match for `query`.
@@ -79,6 +79,7 @@ export class ChatInput extends LitElement {
     this._trigger = null;
     this._highlight = 0;
     this._mentionMatches = [];
+    this._lastFetchedQuery = '';
   }
 
   /** Focus the textarea. */
@@ -127,14 +128,21 @@ export class ChatInput extends LitElement {
   }
 
   async #fetchMentions(query) {
+    this._lastFetchedQuery = query;
     try {
       const res = await fetch(`/api/autocomplete?q=${encodeURIComponent(query)}`);
+      if (this._lastFetchedQuery !== query) return;
       if (res.ok) {
         const data = await res.json();
         this._mentionMatches = data.results || [];
+      } else {
+        this._mentionMatches = [];
       }
     } catch (err) {
       console.warn('Autocomplete fetch failed:', err);
+      if (this._lastFetchedQuery === query) {
+        this._mentionMatches = [];
+      }
     }
   }
 
@@ -218,8 +226,9 @@ export class ChatInput extends LitElement {
 
   /** @param {KeyboardEvent} e */
   #handleKeydown(e) {
-    const isMention = this._trigger?.prefix === '@';
-    const matches = this.#triggerContext()
+    const ctx = this.#triggerContext();
+    const isMention = ctx?.prefix === '@';
+    const matches = ctx
       ? (isMention ? (this._mentionMatches || []) : this.#matchingCommands())
       : [];
     if (matches.length) {

--- a/src/decafclaw/web/static/components/chat-input.js
+++ b/src/decafclaw/web/static/components/chat-input.js
@@ -4,6 +4,9 @@ import { uploadFile } from '../lib/upload-client.js';
 /** A `/` or `!` command token filling the current line up to the caret. */
 const TRIGGER_RE = /^([/!])(\S*)$/;
 
+/** An `@` mention token ending at the caret. */
+const MENTION_TRIGGER_RE = /(?:^|\s)@([a-zA-Z0-9_./+-]*)$/;
+
 /**
  * Score `name` as an ordered-subsequence match for `query`.
  *
@@ -45,6 +48,7 @@ export class ChatInput extends LitElement {
     _dragOver: { type: Boolean, state: true },
     _trigger: { type: Object, state: true },
     _highlight: { type: Number, state: true },
+    _mentionMatches: { type: Array, state: true },
   };
 
   createRenderRoot() { return this; }
@@ -71,9 +75,10 @@ export class ChatInput extends LitElement {
     this.commands = [];
     this._pendingAttachments = [];
     this._dragOver = false;
-    /** @type {{prefix: string, query: string}|null} */
+    /** @type {{prefix: string, query: string, start: number}|null} */
     this._trigger = null;
     this._highlight = 0;
+    this._mentionMatches = [];
   }
 
   /** Focus the textarea. */
@@ -86,17 +91,16 @@ export class ChatInput extends LitElement {
     this.#handleFiles(files);
   }
 
-  // -- Command autocomplete -----------------------------------------------------
+  // -- Command / Mention autocomplete -----------------------------------------------------
 
   /**
-   * The command token the caret sits in, read from the live textarea.
+   * The command or mention token the caret sits in, read from the live textarea.
    *
-   * Scoped to the current *line*, not the whole value: `hello\n/mc` is a
-   * trigger, `see /mc` is not. Recomputed on demand rather than cached so a
-   * commit always rewrites what is actually in the box.
+   * Scoped to the current *line* for commands, but anywhere on the line for mentions.
+   * Recomputed on demand rather than cached so a commit always rewrites what is actually in the box.
    *
    * @returns {{textarea: HTMLTextAreaElement, caret: number, lineStart: number,
-   *            prefix: string, query: string}|null}
+   *            prefix: string, query: string, start: number}|null}
    */
   #triggerContext() {
     const ta = /** @type {HTMLTextAreaElement|null} */ (this.querySelector('textarea'));
@@ -104,9 +108,34 @@ export class ChatInput extends LitElement {
     const caret = ta.selectionStart ?? ta.value.length;
     const before = ta.value.slice(0, caret);
     const lineStart = before.lastIndexOf('\n') + 1;
-    const match = TRIGGER_RE.exec(before.slice(lineStart));
-    if (!match) return null;
-    return { textarea: ta, caret, lineStart, prefix: match[1], query: match[2] };
+
+    // 1. Command Autocomplete
+    const cmdMatch = TRIGGER_RE.exec(before.slice(lineStart));
+    if (cmdMatch) {
+      return { textarea: ta, caret, lineStart, prefix: cmdMatch[1], query: cmdMatch[2], start: lineStart };
+    }
+
+    // 2. Mention Autocomplete
+    const mentionMatch = MENTION_TRIGGER_RE.exec(before);
+    if (mentionMatch) {
+      const query = mentionMatch[1];
+      const start = caret - query.length - 1; // start index of '@'
+      return { textarea: ta, caret, lineStart, prefix: '@', query, start };
+    }
+
+    return null;
+  }
+
+  async #fetchMentions(query) {
+    try {
+      const res = await fetch(`/api/autocomplete?q=${encodeURIComponent(query)}`);
+      if (res.ok) {
+        const data = await res.json();
+        this._mentionMatches = data.results || [];
+      }
+    } catch (err) {
+      console.warn('Autocomplete fetch failed:', err);
+    }
   }
 
   /**
@@ -115,10 +144,7 @@ export class ChatInput extends LitElement {
    * Runs on `input` and also on `keyup` / `click`, so a caret moved without
    * typing (arrow keys, a mouse click) closes a menu that no longer belongs to
    * where the caret is. Resets the highlight ONLY when the token actually
-   * changed: keyup fires after every ArrowDown/ArrowUp keydown, so resetting
-   * unconditionally would snap the highlight back to 0 on each press and break
-   * arrow navigation in a real browser — invisibly, since a synthetic `press()`
-   * in a test dispatches no keyup.
+   * changed.
    */
   #syncMenu() {
     const ctx = this.#triggerContext();
@@ -126,13 +152,21 @@ export class ChatInput extends LitElement {
       // Left the token entirely — a later `/` gets a fresh menu.
       this.#dismissed = false;
       this._trigger = null;
+      this._mentionMatches = [];
       return;
     }
     if (this.#dismissed) return;
     const changed = this._trigger?.prefix !== ctx.prefix
       || this._trigger?.query !== ctx.query;
-    this._trigger = { prefix: ctx.prefix, query: ctx.query };
-    if (changed) this._highlight = 0;
+    this._trigger = { prefix: ctx.prefix, query: ctx.query, start: ctx.start };
+    if (changed) {
+      this._highlight = 0;
+      if (ctx.prefix === '@') {
+        this.#fetchMentions(ctx.query);
+      } else {
+        this._mentionMatches = [];
+      }
+    }
   }
 
   /** Commands matching the open trigger, best first. @returns {any[]} */
@@ -149,36 +183,45 @@ export class ChatInput extends LitElement {
     return scored.map((s) => s.cmd);
   }
 
-  /** Replace the trigger token with the chosen command. @param {any} cmd */
-  #commitCommand(cmd) {
+  /** Replace the trigger token with the chosen command or mention. @param {any} item */
+  #commitAutocomplete(item) {
     const ctx = this.#triggerContext();
-    if (!ctx || !cmd) return;
+    if (!ctx || !item) return;
     const { textarea } = ctx;
-    const insert = `${ctx.prefix}${cmd.name} `;
-    textarea.value = textarea.value.slice(0, ctx.lineStart)
+    let insert = '';
+    if (ctx.prefix === '@') {
+      if (item.type === 'vault') {
+        insert = `@[[${item.id}]] `;
+      } else if (item.type === 'mcp') {
+        insert = `@mcp/${item.id} `;
+      } else {
+        insert = `@${item.id} `;
+      }
+    } else {
+      insert = `${ctx.prefix}${item.name} `;
+    }
+    textarea.value = textarea.value.slice(0, ctx.start)
       + insert + textarea.value.slice(ctx.caret);
-    const caret = ctx.lineStart + insert.length;
+    const caret = ctx.start + insert.length;
     textarea.selectionStart = textarea.selectionEnd = caret;
     this.#closeMenu();
     textarea.focus();
+    // Dispatch input event to let textarea adjust size
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
   }
 
   #closeMenu() {
     this.#dismissed = false;
     this._trigger = null;
+    this._mentionMatches = [];
   }
 
   /** @param {KeyboardEvent} e */
   #handleKeydown(e) {
-    // Gate on the LIVE caret, not on `_trigger` alone. `_trigger` is only
-    // recomputed on `input`, so a caret moved by ArrowLeft/ArrowRight or a
-    // mouse click leaves it stale: with `hello /mc` and the caret clicked back
-    // to after `hello`, the cache still says a `/mc` token is open, so Tab
-    // would be swallowed here and then do nothing (`#commitCommand`
-    // recomputes the context and early-returns) — you could not tab out of the
-    // composer. Asking `#triggerContext()` makes the interception decision use
-    // the same source of truth the commit does.
-    const matches = this.#triggerContext() ? this.#matchingCommands() : [];
+    const isMention = this._trigger?.prefix === '@';
+    const matches = this.#triggerContext()
+      ? (isMention ? (this._mentionMatches || []) : this.#matchingCommands())
+      : [];
     if (matches.length) {
       const highlight = Math.min(this._highlight, matches.length - 1);
       if (e.key === 'ArrowDown') {
@@ -193,13 +236,14 @@ export class ChatInput extends LitElement {
       }
       if (e.key === 'Tab') {
         e.preventDefault();
-        this.#commitCommand(matches[highlight]);
+        this.#commitAutocomplete(matches[highlight]);
         return;
       }
       if (e.key === 'Escape') {
         e.preventDefault();
         this.#dismissed = true;
         this._trigger = null;
+        this._mentionMatches = [];
         return;
       }
       // Enter deliberately falls through: it sends, it never commits.
@@ -335,29 +379,52 @@ export class ChatInput extends LitElement {
 
   render() {
     const hasAttachments = this._pendingAttachments.length > 0;
-    const matches = this.#matchingCommands();
+    const isMention = this._trigger?.prefix === '@';
+    const matches = isMention ? (this._mentionMatches || []) : this.#matchingCommands();
     const highlight = Math.min(this._highlight, matches.length - 1);
     return html`
       ${matches.length ? html`
         <div class="command-menu" role="listbox">
-          ${matches.map((cmd, i) => html`
-            <div class="command-menu-item ${i === highlight ? 'highlighted' : ''}"
-              role="option"
-              aria-selected=${i === highlight}
-              data-command=${cmd.name}
-              @mousedown=${(/** @type {MouseEvent} */ e) => {
-                e.preventDefault();  // keep focus in the textarea
-                this.#commitCommand(cmd);
-              }}>
-              <span class="command-menu-name">${cmd.name}</span>
-              ${cmd.argument_hint
-                ? html`<span class="command-menu-hint">${cmd.argument_hint}</span>`
-                : nothing}
-              ${cmd.description
-                ? html`<span class="command-menu-desc">${cmd.description}</span>`
-                : nothing}
-            </div>
-          `)}
+          ${matches.map((item, i) => {
+            const isHighlighted = i === highlight;
+            if (isMention) {
+              return html`
+                <div class="command-menu-item ${isHighlighted ? 'highlighted' : ''}"
+                  role="option"
+                  aria-selected=${isHighlighted}
+                  data-mention-id=${item.id}
+                  @mousedown=${(/** @type {MouseEvent} */ e) => {
+                    e.preventDefault();  // keep focus in the textarea
+                    this.#commitAutocomplete(item);
+                  }}>
+                  <span class="command-menu-name">${item.label}</span>
+                  <span class="command-menu-hint">${item.type}</span>
+                  ${item.description
+                    ? html`<span class="command-menu-desc">${item.description}</span>`
+                    : nothing}
+                </div>
+              `;
+            } else {
+              return html`
+                <div class="command-menu-item ${isHighlighted ? 'highlighted' : ''}"
+                  role="option"
+                  aria-selected=${isHighlighted}
+                  data-command=${item.name}
+                  @mousedown=${(/** @type {MouseEvent} */ e) => {
+                    e.preventDefault();  // keep focus in the textarea
+                    this.#commitAutocomplete(item);
+                  }}>
+                  <span class="command-menu-name">${item.name}</span>
+                  ${item.argument_hint
+                    ? html`<span class="command-menu-hint">${item.argument_hint}</span>`
+                    : nothing}
+                  ${item.description
+                    ? html`<span class="command-menu-desc">${item.description}</span>`
+                    : nothing}
+                </div>
+              `;
+            }
+          })}
         </div>
       ` : nothing}
       ${hasAttachments ? html`

--- a/src/decafclaw/web/static/components/chat-input.test.js
+++ b/src/decafclaw/web/static/components/chat-input.test.js
@@ -329,3 +329,80 @@ describe('chat-input existing send/stop behaviour (menu closed)', () => {
     expect(onStop).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('chat-input mention autocomplete', () => {
+  it('triggers autocomplete on "@" anywhere and fetches suggestions', async () => {
+    // Mock global fetch
+    const mockResults = {
+      results: [
+        { type: 'file', id: 'src/agent.py', label: 'src/agent.py', description: 'Workspace File' },
+        { type: 'vault', id: 'TestPage', label: 'TestPage', description: 'Vault Page' },
+        { type: 'mcp', id: 'demo/notes', label: 'mcp/demo/notes', description: 'MCP Resource' }
+      ]
+    };
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResults)
+      })
+    );
+
+    const el = await mount();
+    await type(el, 'Check @');
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/autocomplete?q=');
+    
+    // Set the state manually to simulate async resolution since updateComplete won't wait for fetch inside click/input
+    el._mentionMatches = mockResults.results;
+    await el.updateComplete;
+
+    expect(el.querySelector(MENU)).not.toBeNull();
+    const rows = el.querySelectorAll(ROW);
+    expect(rows).toHaveLength(3);
+    expect(rows[0].getAttribute('data-mention-id')).toBe('src/agent.py');
+    expect(rows[1].getAttribute('data-mention-id')).toBe('TestPage');
+    expect(rows[2].getAttribute('data-mention-id')).toBe('demo/notes');
+  });
+
+  it('inserts correct syntax when selecting a file mention', async () => {
+    const el = await mount();
+    await type(el, 'Check @');
+    el._mentionMatches = [
+      { type: 'file', id: 'src/agent.py', label: 'src/agent.py', description: 'Workspace File' }
+    ];
+    await el.updateComplete;
+
+    await press(el, 'Tab');
+
+    expect(textareaOf(el).value).toBe('Check @src/agent.py ');
+    expect(el.querySelector(MENU)).toBeNull();
+  });
+
+  it('inserts bracketed syntax when selecting a vault page mention', async () => {
+    const el = await mount();
+    await type(el, 'See @');
+    el._mentionMatches = [
+      { type: 'vault', id: 'TestPage', label: 'TestPage', description: 'Vault Page' }
+    ];
+    await el.updateComplete;
+
+    await press(el, 'Tab');
+
+    expect(textareaOf(el).value).toBe('See @[[TestPage]] ');
+    expect(el.querySelector(MENU)).toBeNull();
+  });
+
+  it('inserts prefixed syntax when selecting an MCP resource mention', async () => {
+    const el = await mount();
+    await type(el, 'Inspect @');
+    el._mentionMatches = [
+      { type: 'mcp', id: 'demo/notes', label: 'mcp/demo/notes', description: 'MCP Resource' }
+    ];
+    await el.updateComplete;
+
+    await press(el, 'Tab');
+
+    expect(textareaOf(el).value).toBe('Inspect @mcp/demo/notes ');
+    expect(el.querySelector(MENU)).toBeNull();
+  });
+});

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -2,8 +2,9 @@
 
 import os
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
-from unittest.mock import MagicMock, AsyncMock
 from httpx import ASGITransport, AsyncClient
 
 from decafclaw.events import EventBus
@@ -22,7 +23,7 @@ def http_config(config, monkeypatch, tmp_path):
     config.agent.data_home = "data"
     config.vault.vault_path = "workspace/vault/"
     config.vault.agent_folder = "agent/"
-    
+
     config.agent_path.mkdir(parents=True, exist_ok=True)
     config.workspace_path.mkdir(parents=True, exist_ok=True)
     config.vault_root.mkdir(parents=True, exist_ok=True)
@@ -76,7 +77,7 @@ async def test_autocomplete_vault_pages(client, http_config):
     vault = http_config.vault_root
     (vault / "TestPage.md").write_text("# Test Page")
     (vault / "OtherPage.md").write_text("# Other Page")
-    
+
     # Matching query
     resp = await client.get("/api/autocomplete?q=test")
     assert resp.status_code == 200
@@ -131,7 +132,7 @@ async def test_autocomplete_mcp_resources(client, monkeypatch):
     """MCP resource searches should match server and resource names."""
     # Mock MCP Registry
     mock_registry = MagicMock()
-    
+
     # Mock resource object
     class MockResource:
         def __init__(self, name, uri, description=""):
@@ -141,7 +142,7 @@ async def test_autocomplete_mcp_resources(client, monkeypatch):
 
     mock_res1 = MockResource("summary", "demo://summary", "Resource Summary")
     mock_res2 = MockResource("notes", "demo://notes", "Resource Notes")
-    
+
     mock_registry.get_resources.return_value = [
         ("demo_server", mock_res1),
         ("demo_server", mock_res2),

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -1,0 +1,160 @@
+"""Tests for autocomplete API endpoints."""
+
+import os
+from pathlib import Path
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from httpx import ASGITransport, AsyncClient
+
+from decafclaw.events import EventBus
+from decafclaw.http_server import create_app
+from decafclaw.web.auth import create_token
+
+
+@pytest.fixture
+def http_config(config, monkeypatch, tmp_path):
+    config.http.enabled = True
+    config.http.secret = "test-secret"
+    config.http.host = "127.0.0.1"
+    config.http.port = 18880
+    config.http.base_url = ""
+    monkeypatch.chdir(tmp_path)
+    config.agent.data_home = "data"
+    config.vault.vault_path = "workspace/vault/"
+    config.vault.agent_folder = "agent/"
+    
+    config.agent_path.mkdir(parents=True, exist_ok=True)
+    config.workspace_path.mkdir(parents=True, exist_ok=True)
+    config.vault_root.mkdir(parents=True, exist_ok=True)
+    return config
+
+
+@pytest.fixture
+def bus():
+    return EventBus()
+
+
+@pytest.fixture
+def app(http_config, bus):
+    return create_app(http_config, bus)
+
+
+@pytest.fixture
+async def client(app, http_config):
+    """Client with a valid auth cookie."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        token = create_token(http_config, "testuser")
+        resp = await c.post("/api/auth/login", json={"token": token})
+        c.cookies = resp.cookies
+        yield c
+
+
+# -- Autocomplete --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_requires_auth(app):
+    """Accessing the endpoint without auth should return 401."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/api/autocomplete")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_empty(client):
+    """Empty query / empty state should return empty results array."""
+    resp = await client.get("/api/autocomplete")
+    assert resp.status_code == 200
+    assert resp.json() == {"results": []}
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_vault_pages(client, http_config):
+    """Vault page searches should match pages by title/path."""
+    vault = http_config.vault_root
+    (vault / "TestPage.md").write_text("# Test Page")
+    (vault / "OtherPage.md").write_text("# Other Page")
+    
+    # Matching query
+    resp = await client.get("/api/autocomplete?q=test")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["type"] == "vault"
+    assert results[0]["id"] == "TestPage"
+    assert results[0]["label"] == "TestPage"
+
+    # Match all (no query)
+    resp_all = await client.get("/api/autocomplete")
+    assert resp_all.status_code == 200
+    results_all = resp_all.json()["results"]
+    assert len(results_all) == 2
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_workspace_files(client, http_config):
+    """Workspace file searches should find matching text files, ignoring hidden/node_modules."""
+    ws = http_config.workspace_path
+    (ws / "src").mkdir(parents=True, exist_ok=True)
+    (ws / "node_modules").mkdir(parents=True, exist_ok=True)
+    (ws / ".git").mkdir(parents=True, exist_ok=True)
+
+    (ws / "src" / "agent.py").write_text("print('hello')")
+    (ws / "src" / "config.py").write_text("config = {}")
+    (ws / "node_modules" / "foo.js").write_text("ignored")
+    (ws / ".git" / "config").write_text("ignored")
+    (ws / "src" / ".hidden.py").write_text("ignored")
+
+    # Match a file
+    resp = await client.get("/api/autocomplete?q=agent")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["type"] == "file"
+    assert results[0]["id"] == "src/agent.py"
+
+    # Ignore node_modules, .git, and hidden files
+    resp_all = await client.get("/api/autocomplete")
+    assert resp_all.status_code == 200
+    ids = [item["id"] for item in resp_all.json()["results"]]
+    assert "src/agent.py" in ids
+    assert "src/config.py" in ids
+    assert "node_modules/foo.js" not in ids
+    assert ".git/config" not in ids
+    assert "src/.hidden.py" not in ids
+
+
+@pytest.mark.asyncio
+async def test_autocomplete_mcp_resources(client, monkeypatch):
+    """MCP resource searches should match server and resource names."""
+    # Mock MCP Registry
+    mock_registry = MagicMock()
+    
+    # Mock resource object
+    class MockResource:
+        def __init__(self, name, uri, description=""):
+            self.name = name
+            self.uri = uri
+            self.description = description
+
+    mock_res1 = MockResource("summary", "demo://summary", "Resource Summary")
+    mock_res2 = MockResource("notes", "demo://notes", "Resource Notes")
+    
+    mock_registry.get_resources.return_value = [
+        ("demo_server", mock_res1),
+        ("demo_server", mock_res2),
+    ]
+
+    monkeypatch.setattr("decafclaw.mcp_client.get_registry", lambda: mock_registry)
+
+    # Match resource name
+    resp = await client.get("/api/autocomplete?q=summary")
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["type"] == "mcp"
+    assert results[0]["id"] == "demo_server/summary"
+    assert results[0]["label"] == "mcp/demo_server/summary"
+    assert results[0]["description"] == "Resource Summary"

--- a/tests/test_mentions_injection.py
+++ b/tests/test_mentions_injection.py
@@ -1,10 +1,11 @@
 """Tests for bare mentions parsing, context injection, and truncation."""
 
-import pytest
-from unittest.mock import MagicMock, AsyncMock
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
-from decafclaw.context_composer import ContextComposer, ComposerMode
+import pytest
+
+from decafclaw.context_composer import ComposerMode, ContextComposer
 from decafclaw.memory_context import parse_bare_mentions
 
 
@@ -12,13 +13,13 @@ def test_parse_bare_mentions():
     """Verify that bare @ mentions are parsed correctly, ignoring @[[PageName]]."""
     text = "Please check @src/agent.py and @mcp/demo/resource, but NOT @[[TestPage]]."
     mentions = parse_bare_mentions(text)
-    
+
     assert len(mentions) == 2
-    
+
     # First match
     assert mentions[0]["type"] == "file"
     assert mentions[0]["path"] == "src/agent.py"
-    
+
     # Second match
     assert mentions[1]["type"] == "mcp"
     assert mentions[1]["server"] == "demo"
@@ -68,13 +69,13 @@ async def test_compose_mentions_references_file(ctx, config, tmp_path):
 async def test_compose_mentions_references_mcp(ctx, config, monkeypatch):
     """Verify active MCP resources mentioned with @ are resolved and injected."""
     composer = ContextComposer()
-    
+
     # Mock MCP Registry
     mock_registry = MagicMock()
     mock_state = MagicMock()
     mock_state.status = "connected"
     mock_state.config.timeout = 5000
-    
+
     class MockResource:
         def __init__(self, name, uri):
             self.name = name
@@ -82,14 +83,14 @@ async def test_compose_mentions_references_mcp(ctx, config, monkeypatch):
 
     mock_res = MockResource("notes", "demo://notes")
     mock_state.resources = [mock_res]
-    
+
     # Mock session and read_resource
     mock_session = AsyncMock()
-    
+
     class MockResult:
         def __init__(self, contents):
             self.contents = contents
-            
+
     class MockContent:
         def __init__(self, text):
             self.text = text
@@ -100,7 +101,7 @@ async def test_compose_mentions_references_mcp(ctx, config, monkeypatch):
     mock_result = MockResult([MockContent("MCP Notes Content")])
     mock_session.read_resource.return_value = mock_result
     mock_state.session = mock_session
-    
+
     mock_registry.servers = {"demo_server": mock_state}
     monkeypatch.setattr("decafclaw.mcp_client.get_registry", lambda: mock_registry)
 
@@ -137,7 +138,7 @@ async def test_compose_mentions_references_dedup(ctx, config, tmp_path):
     messages, entry = await composer._compose_mentions_references(
         ctx, config, "Read @small.txt please", history, ComposerMode.INTERACTIVE
     )
-    
+
     # Should be skipped
     assert len(messages) == 0
     assert entry is not None

--- a/tests/test_mentions_injection.py
+++ b/tests/test_mentions_injection.py
@@ -1,0 +1,145 @@
+"""Tests for bare mentions parsing, context injection, and truncation."""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from pathlib import Path
+
+from decafclaw.context_composer import ContextComposer, ComposerMode
+from decafclaw.memory_context import parse_bare_mentions
+
+
+def test_parse_bare_mentions():
+    """Verify that bare @ mentions are parsed correctly, ignoring @[[PageName]]."""
+    text = "Please check @src/agent.py and @mcp/demo/resource, but NOT @[[TestPage]]."
+    mentions = parse_bare_mentions(text)
+    
+    assert len(mentions) == 2
+    
+    # First match
+    assert mentions[0]["type"] == "file"
+    assert mentions[0]["path"] == "src/agent.py"
+    
+    # Second match
+    assert mentions[1]["type"] == "mcp"
+    assert mentions[1]["server"] == "demo"
+    assert mentions[1]["resource"] == "resource"
+    assert mentions[1]["raw"] == "mcp/demo/resource"
+
+
+@pytest.mark.asyncio
+async def test_compose_mentions_references_file(ctx, config, tmp_path):
+    """Verify workspace files mentioned with @ are resolved and injected."""
+    composer = ContextComposer()
+    config.agent.data_home = str(tmp_path / "data")
+    config.agent_path.mkdir(parents=True, exist_ok=True)
+    config.workspace_path.mkdir(parents=True, exist_ok=True)
+
+    # 1. Create a small file
+    small_file = config.workspace_path / "small.txt"
+    small_file.write_text("Hello World", encoding="utf-8")
+
+    # 2. Create a large file > 8KB (8192 chars)
+    large_file = config.workspace_path / "large.txt"
+    large_content = "A" * 9000
+    large_file.write_text(large_content, encoding="utf-8")
+
+    # Verify small file injection
+    messages, entry = await composer._compose_mentions_references(
+        ctx, config, "Read @small.txt please", [], ComposerMode.INTERACTIVE
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "workspace_references"
+    assert "Hello World" in messages[0]["content"]
+    assert "small.txt" == messages[0]["workspace_file"]
+    assert entry.items_included == 1
+    assert entry.items_truncated == 0
+
+    # Verify large file injection and truncation
+    messages_large, entry_large = await composer._compose_mentions_references(
+        ctx, config, "Read @large.txt please", [], ComposerMode.INTERACTIVE
+    )
+    assert len(messages_large) == 1
+    assert messages_large[0]["role"] == "workspace_references"
+    assert len(messages_large[0]["content"]) < 9000
+    assert "[Truncated: only first 8KB of large.txt inlined]" in messages_large[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_compose_mentions_references_mcp(ctx, config, monkeypatch):
+    """Verify active MCP resources mentioned with @ are resolved and injected."""
+    composer = ContextComposer()
+    
+    # Mock MCP Registry
+    mock_registry = MagicMock()
+    mock_state = MagicMock()
+    mock_state.status = "connected"
+    mock_state.config.timeout = 5000
+    
+    class MockResource:
+        def __init__(self, name, uri):
+            self.name = name
+            self.uri = uri
+
+    mock_res = MockResource("notes", "demo://notes")
+    mock_state.resources = [mock_res]
+    
+    # Mock session and read_resource
+    mock_session = AsyncMock()
+    
+    class MockResult:
+        def __init__(self, contents):
+            self.contents = contents
+            
+    class MockContent:
+        def __init__(self, text):
+            self.text = text
+            self.blob = None
+            self.uri = "demo://notes"
+            self.mimeType = "text/plain"
+
+    mock_result = MockResult([MockContent("MCP Notes Content")])
+    mock_session.read_resource.return_value = mock_result
+    mock_state.session = mock_session
+    
+    mock_registry.servers = {"demo_server": mock_state}
+    monkeypatch.setattr("decafclaw.mcp_client.get_registry", lambda: mock_registry)
+
+    # Verify MCP resource injection
+    messages, entry = await composer._compose_mentions_references(
+        ctx, config, "Check @mcp/demo_server/notes", [], ComposerMode.INTERACTIVE
+    )
+    assert len(messages) == 1
+    assert messages[0]["role"] == "mcp_references"
+    assert "MCP Notes Content" in messages[0]["content"]
+    assert messages[0]["mcp_resource"] == "mcp/demo_server/notes"
+
+
+@pytest.mark.asyncio
+async def test_compose_mentions_references_dedup(ctx, config, tmp_path):
+    """Verify that already injected mentions are skipped."""
+    composer = ContextComposer()
+    config.agent.data_home = str(tmp_path / "data")
+    config.agent_path.mkdir(parents=True, exist_ok=True)
+    config.workspace_path.mkdir(parents=True, exist_ok=True)
+
+    small_file = config.workspace_path / "small.txt"
+    small_file.write_text("Hello World", encoding="utf-8")
+
+    # History already contains this workspace_references
+    history = [
+        {
+            "role": "workspace_references",
+            "content": "[Referenced workspace file: small.txt]\n\nHello World",
+            "workspace_file": "small.txt"
+        }
+    ]
+
+    messages, entry = await composer._compose_mentions_references(
+        ctx, config, "Read @small.txt please", history, ComposerMode.INTERACTIVE
+    )
+    
+    # Should be skipped
+    assert len(messages) == 0
+    assert entry is not None
+    assert entry.items_truncated == 1
+    assert entry.items_included == 0

--- a/tests/test_mentions_injection.py
+++ b/tests/test_mentions_injection.py
@@ -44,6 +44,10 @@ async def test_compose_mentions_references_file(ctx, config, tmp_path):
     large_content = "A" * 9000
     large_file.write_text(large_content, encoding="utf-8")
 
+    # 3. Create a secret file
+    secret_file = config.workspace_path / "secret.key"
+    secret_file.write_text("my-secret-key", encoding="utf-8")
+
     # Verify small file injection
     messages, entry = await composer._compose_mentions_references(
         ctx, config, "Read @small.txt please", [], ComposerMode.INTERACTIVE
@@ -63,6 +67,13 @@ async def test_compose_mentions_references_file(ctx, config, tmp_path):
     assert messages_large[0]["role"] == "workspace_references"
     assert len(messages_large[0]["content"]) < 9000
     assert "[Truncated: only first 8KB of large.txt inlined]" in messages_large[0]["content"]
+
+    # Verify secret file exclusion
+    messages_secret, entry_secret = await composer._compose_mentions_references(
+        ctx, config, "Read @secret.key please", [], ComposerMode.INTERACTIVE
+    )
+    assert len(messages_secret) == 1
+    assert "is a secret and cannot be inlined" in messages_secret[0]["content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Introduces mentions autocomplete in the chat composer to let users reference workspace files and active MCP resources with `@` autocomplete.
- Retrieves and inlines the full contents of referenced workspace files or MCP resources directly into the turn context as a system/user-reference message before sending to the LLM, implementing smart size truncation and warning notices for oversized files (> 8KB).

## Design Decisions
- **Mention Syntax:** Bare paths prefixed with `@` for files (e.g. `@src/agent.py`), segment-prefixed bare names for MCP resources (e.g. `@mcp/server/resource`), and bracketed syntax `@[[PageName]]` for vault pages.
- **Unified Backend Autocomplete Endpoint:** `/api/autocomplete?q=...` searches across vault pages, active MCP resources, and workspace files (ignoring hidden/ignored directories and vault folder itself).
- **Size Truncation:** Files and MCP resources larger than 8KB (~200 lines) are truncated to 8KB with a clear truncation warning to manage context window cost.
- **Deduplication:** Already-injected files and resources are scanned from prior history and not re-injected on subsequent turns.

## Changes
- **Backend:**
  - `src/decafclaw/http_server.py`: Added the `autocomplete` route handler and `/api/autocomplete` route.
  - `src/decafclaw/context_composer.py`: Added bare mentions parsing & injection in `_compose_mentions_references`, mapped roles to `"user"` in `ROLE_REMAP`.
  - `src/decafclaw/memory_context.py`: Added `parse_bare_mentions` helper.
- **Frontend:**
  - `src/decafclaw/web/static/components/chat-input.js`: Added autocomplete trigger, asynchronous querying of `/api/autocomplete`, item selection/commit, and dropdown list render.
- **Tests:**
  - `tests/test_autocomplete.py`: Unit tests for the autocomplete endpoint.
  - `tests/test_mentions_injection.py`: Unit tests for mentions parsing, injection, truncation, and deduplication.
  - `src/decafclaw/web/static/components/chat-input.test.js`: Vitest tests for the frontend autocomplete trigger and insert syntax.

## Test Plan
- [x] `make test` — All 3790 Python tests passed.
- [x] `make test-js` — All 123 Vitest tests passed.
- [x] `make check` — Ruff linter, Pyright, and JS type-checks all passed cleanly.

## References
- Spec: `docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/spec.md`
- Plan: `docs/dev-sessions/2026-08-06-2123-726-mention-autocomplete/plan.md`
- Closes #726
