### PR TITLE
fix(schedules): reject unrecognized patch keys in write_overlay with 400 (#735)

### DIFF
--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -102,6 +102,12 @@ _KNOWN_FRONTMATTER_KEYS = frozenset({
     "allowed-tools", "pre_script", "required-skills", "email-recipients",
 })
 
+# Valid patch keys accepted by `write_overlay`. Any other key raises ValueError.
+VALID_PATCH_KEYS = frozenset({
+    "enabled", "schedule", "body", "channel", "allowed_tools",
+    "required_skills", "shell_patterns", "email_recipients", "model", "pre_script",
+})
+
 
 def parse_schedule_file(path: Path) -> ScheduleTask | None:
     """Parse a schedule markdown file. Returns None if invalid."""
@@ -312,6 +318,12 @@ def write_overlay(config, name: str, patch: dict) -> ScheduleTask:
 
     # Treat null (None) values as "leave unchanged" rather than overwriting.
     patch = {k: v for k, v in patch.items() if v is not None}
+
+    # Reject unrecognized patch keys.
+    unknown = set(patch) - VALID_PATCH_KEYS
+    if unknown:
+        keys_str = ", ".join(sorted(unknown))
+        raise ValueError(f"unrecognized patch key(s): {keys_str}")
 
     # Validate cron expression before touching disk.
     if "schedule" in patch:

--- a/tests/test_schedule_wire_drift.py
+++ b/tests/test_schedule_wire_drift.py
@@ -282,6 +282,13 @@ def test_exemption_sets_name_only_real_fields(config):
     assert set(WIRE_RENAMES) <= names, f"stale: {set(WIRE_RENAMES) - names}"
 
 
+def test_valid_patch_keys_matches_dataclass_fields():
+    """VALID_PATCH_KEYS must match patchable fields derived from ScheduleTask."""
+    from decafclaw.schedules import VALID_PATCH_KEYS
+    expected = {f.name for f in fields(ScheduleTask) if f.name not in NOT_PATCHABLE}
+    assert VALID_PATCH_KEYS == expected
+
+
 def test_frontmatter_raw_is_the_file_not_a_reserialization(config):
     """The raw view exists to show keys the parser drops."""
     path = config.workspace_path / "schedules" / "raw-probe.md"

--- a/tests/test_schedules_api.py
+++ b/tests/test_schedules_api.py
@@ -1,0 +1,13 @@
+"""REST API schedule tests for issue #735 verification."""
+
+import pytest
+
+pytest_plugins = ["tests.test_web_schedules_api"]
+
+
+@pytest.mark.asyncio
+async def test_update_schedule_rejects_unrecognized_patch_keys(client):
+    r = await client.put("/api/schedules/dream", json={"allowed_tool": ["vault_read"]})
+    assert r.status_code == 400
+    assert "unrecognized patch key" in r.json()["error"].lower()
+    assert "allowed_tool" in r.json()["error"]

--- a/tests/test_web_schedules_api.py
+++ b/tests/test_web_schedules_api.py
@@ -199,6 +199,14 @@ class TestSchedulesAPI:
         assert r.status_code == 400
 
     @pytest.mark.asyncio
+    async def test_put_400_on_unrecognized_patch_keys(self, client):
+        """PUT /api/schedules/{name} rejects unrecognized patch keys."""
+        r = await client.put("/api/schedules/dream", json={"allowed_tool": ["vault_read"]})
+        assert r.status_code == 400
+        assert "unrecognized patch key" in r.json()["error"].lower()
+        assert "allowed_tool" in r.json()["error"]
+
+    @pytest.mark.asyncio
     async def test_put_accepts_content_as_alias_for_body(self, client):
         r = await client.put(
             "/api/schedules/dream",


### PR DESCRIPTION
Closes #735

## Summary

`PUT /api/schedules/{name}` now rejects unrecognized patch keys with HTTP 400 Bad Request listing the invalid keys, rather than silently dropping them.

## Acceptance Criteria

- CRITERION: WHEN `PUT /api/schedules/{name}` receives a patch payload containing unrecognized keys, THE SYSTEM SHALL return HTTP 400 Bad Request listing the unrecognized keys.
  CHECK: `uv run pytest tests/test_schedules_api.py::test_update_schedule_rejects_unrecognized_patch_keys`
  VERDICT: PASSED

### Regression guards
- GUARD: `uv run pytest tests/test_schedules.py tests/test_http_server.py`
  VERDICT: PASSED
- GUARD: `make check`
  VERDICT: PASSED

## Tier: `auto-ok`
All criteria covered by automated tests.

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass
tamper: clean
freeze: fa13e33
project-gates: make check green
ci: 2/2 pass @ fa13e33
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: all acceptance criteria checks passed; tier auto-ok
```
