### PR TITLE
fix(security): eliminate executable path bypass for arbitrary python/venv paths (#92)

### DIFF
--- a/src/decafclaw/security_monitor.py
+++ b/src/decafclaw/security_monitor.py
@@ -238,12 +238,8 @@ def evaluate_command(
                 if token_path in ALLOWED_DEVICES:
                     continue
 
-                # If token is the executable command (idx 0), allow system and user binaries
-                if idx == 0 and (
-                    any(token_path.is_relative_to(sys_dir) for sys_dir in SYSTEM_EXEC_DIRS)
-                    or token_path.name in ("python", "python3", "pytest", "node", "npm", "uv")
-                    or "venv" in token_path.parts
-                ):
+                # If token is the executable command (idx 0), allow trusted system and user binary dirs
+                if idx == 0 and any(token_path.is_relative_to(sys_dir) for sys_dir in SYSTEM_EXEC_DIRS):
                     continue
 
                 # Allowed temporary directories (unless token uses relative '..' traversal)

--- a/tests/test_security_monitor.py
+++ b/tests/test_security_monitor.py
@@ -38,6 +38,8 @@ def test_evaluates_out_of_workspace_operations_as_ask(tmp_path: Path):
         "ls /var/log",
         "mv file.txt ../outside.txt",
         "cat </etc/passwd",
+        "/var/log/python script.py",
+        "/opt/custom/venv/bin/python script.py",
     ]
 
     for cmd in out_of_workspace_commands:


### PR DESCRIPTION
## Summary
Follow-up fix for post-merge review feedback on PR #805:

- **Eliminated loose executable path checks**: Removed `token_path.name in ("python", "python3", "pytest", "node", "npm", "uv")` and `"venv" in token_path.parts` from token 0 (executable) path evaluation. Previously, arbitrary out-of-workspace paths like `/tmp/malicious/python` or `/opt/untrusted/venv/bin/python` bypassed the out-of-workspace `ASK` decision because of these loose name/part matches.
- **Trusted binary paths preserved**: Executables in workspace (e.g. `<workspace>/.venv/bin/python`), system directories, and standard tool locations (`SYSTEM_EXEC_DIRS`, e.g. `~/.cargo/bin`, `~/.local/bin`, `~/.local/share/uv`, `~/.pyenv/shims`, etc.) continue to be permitted without triggering out-of-workspace prompts.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | Out-of-workspace executable paths like `/var/log/python` or `/opt/custom/venv/bin/python` trigger `ASK` | `uv run pytest tests/test_security_monitor.py::test_evaluates_out_of_workspace_operations_as_ask` | pass |

### Regression guards
- `uv run pytest` passed (3810 passed, 2 skipped).
- `make lint` and `make typecheck` passed cleanly.