### PR TITLE
fix(vault): substring branch does not fail open when extract_tags raises

### DIFF
--- a/src/decafclaw/skills/vault/tools.py
+++ b/src/decafclaw/skills/vault/tools.py
@@ -949,8 +949,12 @@ def _substring_search(config, query: str, days: int = 0, folder: str = "",
         name = path.stem
         if query_lower in name.lower() or query_lower in text.lower():
             if req_tags:
-                file_tags = extract_tags(
-                    text, _source_type_for_path(config, path))
+                try:
+                    file_tags = extract_tags(
+                        text, _source_type_for_path(config, path))
+                except Exception as exc:
+                    log.debug(f"vault_search: failed reading/tagging {path} for tag filter: {exc}")
+                    continue
                 matches = (bool(file_tags & req_tags) if any_tag
                           else req_tags <= file_tags)
                 if not matches:

--- a/tests/test_vault_tools.py
+++ b/tests/test_vault_tools.py
@@ -1157,6 +1157,32 @@ class TestVaultSearchTags:
         assert "RecentRust" in result.text
         assert "StaleRust" not in result.text
 
+    @pytest.mark.asyncio
+    async def test_fail_open_excludes_candidate_when_extract_tags_raises(
+        self, ctx, agent_pages, monkeypatch
+    ):
+        from decafclaw.tags import extract_tags
+
+        (agent_pages / "AsyncPage.md").write_text(
+            "# AsyncPage\n\nWidget notes about async work. #async")
+        (agent_pages / "BadPage.md").write_text(
+            "# BadPage\n\nWidget notes. #async")
+
+        real_extract_tags = extract_tags
+
+        def fake_extract_tags(content, source_type):
+            if "BadPage" in content:
+                raise ValueError("boom")
+            return real_extract_tags(content, source_type)
+
+        monkeypatch.setattr(
+            "decafclaw.skills.vault.tools.extract_tags", fake_extract_tags)
+
+        result = await tool_vault_search(ctx, "widget", tags=["async"])
+
+        assert "AsyncPage" in result.text
+        assert "BadPage" not in result.text
+
 
 class TestVaultSearchTagsSemantic:
     """Tag filtering on the SEMANTIC branch of vault_search (#318 phase 4


### PR DESCRIPTION
## Summary
- Fixes `vault_search`'s `_substring_search` branch to fail-open when `extract_tags` raises an exception for a candidate file.
- Previously, the substring path was completely unguarded against exceptions from `extract_tags`, causing the entire search to fail if one file had unparseable tags. This aligns the substring branch with the semantic branch's existing fail-open behavior.

## Changes
- Wrapped `extract_tags` in a `try...except` block in `_substring_search` in `src/decafclaw/skills/vault/tools.py`.
- Added a test `test_fail_open_excludes_candidate_when_extract_tags_raises` to `TestVaultSearchTags` to verify `vault_search` returns other matching pages and excludes the failing candidate when `extract_tags` raises.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | substring vault_search fails open if extract_tags raises | `pytest tests/test_vault_tools.py::TestVaultSearchTags::test_fail_open_excludes_candidate_when_extract_tags_raises` | pass |

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass · G2 pass
tamper: clean
freeze: none
project-gates: make check green
ci: 2/2 pass @ 079713d38efb9a0eb0b0b35858cdb6be2aafb534
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: 
```

## References
- Closes #756
