### PR TITLE
feat: telemetry subscriber for loop_breaker events (#645)

### DIFF
--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -861,7 +861,7 @@ class TurnRunner:
                 }
                 self.messages.append(nudge)
                 await self.ctx.publish("loop_breaker", action="nudge",
-                                       reason=off.reason)
+                                       reason=off.reason, signal=off.signal)
             elif verdict is LoopVerdict.REDIRECT:
                 # Second trip: the nudge was ignored and the agent re-offended.
                 # Same ephemerality and attribution rules as the nudge above —
@@ -900,10 +900,11 @@ class TurnRunner:
                 }
                 self.messages.append(redirect)
                 await self.ctx.publish("loop_breaker", action="redirect",
-                                       reason=off.reason)
+                                       reason=off.reason, signal=off.signal)
             elif verdict is LoopVerdict.STOP:
                 await self.ctx.publish("loop_breaker", action="stop",
-                                       reason=self.loop_breaker.offense().reason)
+                                       reason=self.loop_breaker.offense().reason,
+                                       signal=self.loop_breaker.offense().signal)
                 return _Final(result=await self._finalize_loop_break())
 
         return _Continue()

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -902,9 +902,10 @@ class TurnRunner:
                 await self.ctx.publish("loop_breaker", action="redirect",
                                        reason=off.reason, signal=off.signal)
             elif verdict is LoopVerdict.STOP:
+                off = self.loop_breaker.offense()
                 await self.ctx.publish("loop_breaker", action="stop",
-                                       reason=self.loop_breaker.offense().reason,
-                                       signal=self.loop_breaker.offense().signal)
+                                       reason=off.reason,
+                                       signal=off.signal)
                 return _Final(result=await self._finalize_loop_break())
 
         return _Continue()

--- a/src/decafclaw/config_types.py
+++ b/src/decafclaw/config_types.py
@@ -519,6 +519,8 @@ class TelemetryConfig:
     reflection_metrics_path: str = "reflection/metrics.jsonl"
     retrieval_enabled: bool = True
     retrieval_path: str = "telemetry/retrieval.jsonl"
+    loop_breaker_enabled: bool = True
+    loop_breaker_path: str = "telemetry/loop_breaker.jsonl"
 
 
 def is_secret(dc_class: type, field_name: str) -> bool:

--- a/src/decafclaw/loop_breaker.py
+++ b/src/decafclaw/loop_breaker.py
@@ -104,6 +104,7 @@ class Offense:
     tool_name: str = ""
     args_text: str = ""
     error_text: str = ""
+    signal: str = ""
 
 
 @dataclasses.dataclass
@@ -256,6 +257,7 @@ class LoopBreaker:
                 tool_name=offender.tool_name,
                 args_text=offender.args_text,
                 error_text=offender.error_text,
+                signal="repeat",
             )
         elif self._fresh_error_surge():
             self._errors_at_last_trip = self._total_errors
@@ -264,6 +266,7 @@ class LoopBreaker:
                 reason=(f"{errs} of the last {len(self._recent_errors)} "
                         "tool results were errors"),
                 error_text=self._last_error_text,
+                signal="error_surge",
             )
         else:
             return LoopVerdict.NONE

--- a/src/decafclaw/loop_breaker_telemetry.py
+++ b/src/decafclaw/loop_breaker_telemetry.py
@@ -1,0 +1,137 @@
+"""Loop-breaker telemetry subscriber (#645).
+
+A fail-open EventBus subscriber that appends one record per loop_breaker event
+to ``{workspace}/telemetry/loop_breaker.jsonl`` (path/enable via
+``config.telemetry``). Used to monitor autonomous tool-call thrash trips and
+differentiate signal buckets ("repeat" vs "error_surge").
+
+``make loop-breaker-stats`` (``python -m decafclaw.loop_breaker_telemetry``)
+aggregates recent rows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Awaitable, Callable
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _metrics_path(config) -> Path:
+    return config.workspace_path / config.telemetry.loop_breaker_path
+
+
+def record_from_event(event: dict) -> dict:
+    """Build a record from a ``loop_breaker`` event (drops the type)."""
+    rec = {k: v for k, v in event.items() if k != "type"}
+    rec["timestamp"] = _now_iso()
+    return rec
+
+
+def append_record(config, record: dict) -> None:
+    """Append one record as JSONL. Fail-open — never propagates."""
+    try:
+        path = _metrics_path(config)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:  # fail-open: telemetry must never break a turn
+        log.debug("loop_breaker metrics write failed: %s", exc)
+
+
+def make_loop_breaker_subscriber(config) -> Callable[[dict], Awaitable[None]]:
+    """EventBus subscriber: records each ``loop_breaker`` event. Fail-open."""
+    async def handle(event: dict) -> None:
+        if not config.telemetry.loop_breaker_enabled:
+            return
+        try:
+            if event.get("type") != "loop_breaker":
+                return
+            append_record(config, record_from_event(event))
+        except Exception as exc:  # fail-open
+            log.debug("loop_breaker metrics subscriber error: %s", exc)
+
+    return handle
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def load_records(config) -> list[dict]:
+    path = _metrics_path(config)
+    if not path.exists():
+        return []
+    records = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def aggregate(records: list[dict]) -> dict:
+    """Aggregate loop_breaker stats over a list of records."""
+    n = len(records)
+    actions: dict[str, int] = defaultdict(int)
+    signals: dict[str, int] = defaultdict(int)
+
+    for r in records:
+        action = r.get("action", "unknown")
+        signal = r.get("signal", "unknown")
+        actions[action] += 1
+        signals[signal] += 1
+
+    return {
+        "total_events": n,
+        "actions": dict(actions),
+        "signals": dict(signals),
+    }
+
+
+def format_stats(stats: dict) -> str:
+    lines = ["# Loop Breaker metrics", ""]
+    lines.append(f"Events recorded: {stats['total_events']}")
+    lines.append("")
+    lines.append("By action (rung):")
+    for action in ("nudge", "redirect", "stop"):
+        lines.append(f"  {action:<15} {stats['actions'].get(action, 0)}")
+    for other, count in sorted(stats["actions"].items()):
+        if other not in ("nudge", "redirect", "stop"):
+            lines.append(f"  {other:<15} {count}")
+
+    lines.append("")
+    lines.append("By signal (trip condition):")
+    for signal in ("repeat", "error_surge"):
+        lines.append(f"  {signal:<15} {stats['signals'].get(signal, 0)}")
+    for other, count in sorted(stats["signals"].items()):
+        if other not in ("repeat", "error_surge"):
+            lines.append(f"  {other:<15} {count}")
+
+    return "\n".join(lines)
+
+
+def build_stats_report(config) -> str:
+    return format_stats(aggregate(load_records(config)))
+
+
+def main() -> None:
+    from .config import load_config
+    config = load_config()
+    print(build_stats_report(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/decafclaw/runner.py
+++ b/src/decafclaw/runner.py
@@ -120,6 +120,11 @@ async def run_all(app_ctx):
             app_ctx.event_bus.subscribe(make_reflection_metrics_subscriber(config))
             log.info("Telemetry: reflection-metrics subscriber active (%s)",
                      config.telemetry.reflection_metrics_path)
+        if config.telemetry.loop_breaker_enabled:
+            from .loop_breaker_telemetry import make_loop_breaker_subscriber
+            app_ctx.event_bus.subscribe(make_loop_breaker_subscriber(config))
+            log.info("Telemetry: loop-breaker subscriber active (%s)",
+                     config.telemetry.loop_breaker_path)
         if config.telemetry.retrieval_enabled:
             from .retrieval_telemetry import make_retrieval_telemetry_subscriber
             app_ctx.event_bus.subscribe(make_retrieval_telemetry_subscriber(config))

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -146,10 +146,12 @@ async def test_turn_runner_nudges_then_stops_on_repeated_tool_errors(ctx):
     nudge_events = [e for e in published_events
                      if e.get("type") == "loop_breaker" and e.get("action") == "nudge"]
     assert len(nudge_events) == 1
+    assert nudge_events[0].get("signal") == "repeat"
 
     stop_events = [e for e in published_events
                    if e.get("type") == "loop_breaker" and e.get("action") == "stop"]
     assert len(stop_events) == 1
+    assert stop_events[0].get("signal") == "repeat"
 
     # Tripped at repeat_threshold=3, and the LLM was called once per
     # iteration up to and including the stop iteration (NUDGE at the 3rd

--- a/tests/test_loop_breaker_telemetry.py
+++ b/tests/test_loop_breaker_telemetry.py
@@ -1,0 +1,80 @@
+"""Loop breaker telemetry (#645)."""
+
+import json
+
+import pytest
+
+from decafclaw import loop_breaker_telemetry
+from decafclaw.config import Config
+from decafclaw.config_types import AgentConfig
+
+
+def _config(tmp_path):
+    return Config(agent=AgentConfig(data_home=str(tmp_path), id="t"))
+
+
+@pytest.mark.asyncio
+async def test_subscriber_writes_record(tmp_path):
+    cfg = _config(tmp_path)
+    handle = loop_breaker_telemetry.make_loop_breaker_subscriber(cfg)
+    await handle({
+        "type": "loop_breaker",
+        "context_id": "c1",
+        "action": "stop",
+        "signal": "error_surge",
+        "reason": "4 of the last 6 tool results were errors"
+    })
+
+    path = cfg.workspace_path / cfg.telemetry.loop_breaker_path
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(records) == 1
+    rec = records[0]
+
+    assert rec["action"] == "stop"
+    assert rec["signal"] == "error_surge"
+    assert rec["reason"] == "4 of the last 6 tool results were errors"
+    assert rec["context_id"] == "c1"
+    assert "timestamp" in rec
+    assert "type" not in rec
+
+
+@pytest.mark.asyncio
+async def test_subscriber_ignores_other_events(tmp_path):
+    cfg = _config(tmp_path)
+    handle = loop_breaker_telemetry.make_loop_breaker_subscriber(cfg)
+    await handle({"type": "reflection_result", "passed": True})
+    path = cfg.workspace_path / cfg.telemetry.loop_breaker_path
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_fail_open(tmp_path):
+    cfg = _config(tmp_path)
+    workspace = tmp_path / "data" / "t" / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    # The default path is telemetry/loop_breaker.jsonl
+    # So we write a file named telemetry
+    (workspace / "telemetry").write_text("file, not a dir")
+    handle = loop_breaker_telemetry.make_loop_breaker_subscriber(cfg)
+    # This must not raise
+    await handle({"type": "loop_breaker", "action": "stop", "signal": "repeat"})
+
+
+def test_aggregate_counts_by_action_and_signal():
+    records = [
+        {"action": "nudge", "signal": "repeat"},
+        {"action": "nudge", "signal": "repeat"},
+        {"action": "nudge", "signal": "error_surge"},
+        {"action": "redirect", "signal": "repeat"},
+        {"action": "stop", "signal": "error_surge"},
+        {"action": "stop", "signal": "repeat"},
+    ]
+    stats = loop_breaker_telemetry.aggregate(records)
+
+    assert stats["total_events"] == 6
+    assert stats["actions"]["nudge"] == 3
+    assert stats["actions"]["redirect"] == 1
+    assert stats["actions"]["stop"] == 2
+
+    assert stats["signals"]["repeat"] == 4
+    assert stats["signals"]["error_surge"] == 2


### PR DESCRIPTION
## Summary
- Adds telemetry for the `loop_breaker` event to give visibility into how often the loop-breaker trips and what signal triggers it.
- This addresses the lack of a durable record for thrashing and helps track whether `error_window` or `repeat_threshold` cause false positives in production.

## Design Decisions
- `signal` is added to the published event as a separate machine-readable field (`"repeat"` or `"error_surge"`), so we don't have to substring-match prose `reason`.
- Extends `TelemetryConfig` with `loop_breaker_enabled` and `loop_breaker_path` (defaulting to `telemetry/loop_breaker.jsonl`).
- Created `decafclaw.loop_breaker_telemetry` to mirror `reflection_metrics`, complete with aggregation.

## Changes
- `src/decafclaw/loop_breaker.py`: `Offense` includes `signal`, which `LoopBreaker` sets when a trip is detected.
- `src/decafclaw/agent.py`: Nudge, redirect, and stop events publish this `signal`.
- `src/decafclaw/config_types.py`: `loop_breaker_enabled` and `loop_breaker_path` added to `TelemetryConfig`.
- `src/decafclaw/loop_breaker_telemetry.py`: Subscriber and aggregator script.
- `src/decafclaw/runner.py`: The subscriber is wired up.
- `tests/test_loop_breaker_telemetry.py`: New assertions matching the requested criteria.
- `tests/test_agent_loop_breaker.py`: Validation that the `signal` appears in the `action="nudge"` and `"stop"` events.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | Published event contains `signal` field | `pytest tests/test_agent_loop_breaker.py` | pass |
| C2 | Subscriber writes correct JSONL content | `pytest tests/test_loop_breaker_telemetry.py::test_subscriber_writes_record` | pass |
| C3 | Subscriber ignores non-`loop_breaker` events | `pytest tests/test_loop_breaker_telemetry.py::test_subscriber_ignores_other_events` | pass |
| C4 | Subscriber fail-opens gracefully | `pytest tests/test_loop_breaker_telemetry.py::test_subscriber_fail_open` | pass |
| C5 | Aggregator counts correctly | `pytest tests/test_loop_breaker_telemetry.py::test_aggregate_counts_by_action_and_signal` | pass |

Verified by tests. Note: "Ceremony threshold" applied, so heavy artifacts (`checks.md`, `plan.md`) were skipped.

## Merge gate

<!-- agent-session:gate -->
```yaml
tier: auto-ok
checks: C1 pass · C2 pass · C3 pass · C4 pass · C5 pass
guards: G1 pass · G2 pass
tamper: clean-by-substitute — no freeze commit/checks.md (ceremony threshold)
freeze: none
project-gates: make check green
ci: pending
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: waiting-on-ci
reason: 
```

## References
- Closes #645