### PR TITLE
feat: implement synchronous interception hooks for plugins

### DIFF
--- a/docs/agent-ledger.md
+++ b/docs/agent-ledger.md
@@ -1,0 +1,2 @@
+## Architectural Patterns
+- **Synchronous Context Mutation:** Use `Context.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, hook)` for deterministic context mutation before LLM calls, avoiding race conditions inherent in async EventBus mutation (introduced in #812).

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 from .archive import append_message
 from .compaction import compact_history
 from .config_types import LoopBreakerConfig
+from .context import TurnLifecycle
 from .context_cleanup import clear_old_tool_results
 from .context_composer import ComposerMode, ContextComposer
 from .iteration_budget import IterationBudget
@@ -690,6 +691,12 @@ class TurnRunner:
         elif self.deferred_msg is not None and self.deferred_msg in self.messages:
             self.messages.remove(self.deferred_msg)
             self.deferred_msg = None
+
+        for hook in self.ctx.get_interceptors(TurnLifecycle.BEFORE_LLM_CALL):
+            try:
+                hook(self.ctx, self.messages, all_tools)
+            except Exception as exc:
+                log.exception("BEFORE_LLM_CALL interceptor failed: %s", exc)
 
         response = await _call_llm_with_events(
             self.ctx, self.config, self.messages, all_tools,

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import json
 import logging
 import re as _re
@@ -694,7 +695,10 @@ class TurnRunner:
 
         for hook in self.ctx.get_interceptors(TurnLifecycle.BEFORE_LLM_CALL):
             try:
-                hook(self.ctx, self.messages, all_tools)
+                res = hook(self.ctx, self.messages, all_tools)
+                if inspect.iscoroutine(res):
+                    res.close()
+                    log.warning("BEFORE_LLM_CALL interceptor %s returned a coroutine. Async hooks are not supported.", hook)
             except Exception as exc:
                 log.exception("BEFORE_LLM_CALL interceptor failed: %s", exc)
 

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import asyncio
 import copy
 from dataclasses import dataclass, field, replace
-from typing import Any
+from enum import Enum, auto
+from typing import Any, Callable
 from uuid import uuid4
 
 from .context_composer import ComposerState
+
+
+class TurnLifecycle(Enum):
+    """Lifecycle phases for synchronous context interception."""
+    BEFORE_LLM_CALL = auto()
+
 
 
 @dataclass
@@ -131,6 +138,17 @@ class Context:
         self.request_confirmation: Any = None  # set by ConversationManager
         self.manager: Any = None  # set by ConversationManager
         self.terminal_registry: Any = None  # AgentTerminalHandle, set by ConversationManager
+        self._interceptors: dict[TurnLifecycle, list[Callable]] = {}
+
+    def add_interceptor(self, phase: TurnLifecycle, hook: Callable) -> None:
+        """Register a synchronous hook for a lifecycle phase."""
+        if phase not in self._interceptors:
+            self._interceptors[phase] = []
+        self._interceptors[phase].append(hook)
+
+    def get_interceptors(self, phase: TurnLifecycle) -> list[Callable]:
+        """Get all registered hooks for a lifecycle phase in registration order."""
+        return self._interceptors.get(phase, [])
 
     # Turn kinds where no human can answer a confirmation prompt: it is emitted
     # only to subscribers of an ephemeral conv_id, so it blocks for the full 60s
@@ -208,6 +226,7 @@ class Context:
         )
         for key, value in overrides.items():
             setattr(child, key, value)
+        child._interceptors = {k: list(v) for k, v in self._interceptors.items()}
         return child
 
     def fork_for_tool_call(self, tool_call_id: str) -> "Context":

--- a/src/decafclaw/context.py
+++ b/src/decafclaw/context.py
@@ -148,7 +148,7 @@ class Context:
 
     def get_interceptors(self, phase: TurnLifecycle) -> list[Callable]:
         """Get all registered hooks for a lifecycle phase in registration order."""
-        return self._interceptors.get(phase, [])
+        return list(self._interceptors.get(phase, []))
 
     # Turn kinds where no human can answer a confirmation prompt: it is emitted
     # only to subscribers of an ephemeral conv_id, so it blocks for the full 60s
@@ -224,9 +224,9 @@ class Context:
             config=config,
             event_bus=self.event_bus,
         )
+        child._interceptors = {k: list(v) for k, v in self._interceptors.items()}
         for key, value in overrides.items():
             setattr(child, key, value)
-        child._interceptors = {k: list(v) for k, v in self._interceptors.items()}
         return child
 
     def fork_for_tool_call(self, tool_call_id: str) -> "Context":

--- a/tests/test_interceptor_hooks.py
+++ b/tests/test_interceptor_hooks.py
@@ -1,0 +1,71 @@
+import pytest
+
+from decafclaw.agent import TurnRunner
+from decafclaw.context import Context, TurnLifecycle
+
+
+@pytest.mark.asyncio
+async def test_before_llm_call_hook_mutates_messages(ctx, config, monkeypatch):
+    """Test that a BEFORE_LLM_CALL hook can successfully mutate the messages list in-place."""
+    called_messages = []
+
+    async def mock_call_llm(ctx, config, messages, tools, **kwargs):
+        called_messages.extend(messages)
+        return {"content": "OK", "usage": {}}
+
+    monkeypatch.setattr("decafclaw.agent._call_llm_with_events", mock_call_llm)
+
+    def mutate_messages_hook(ctx, messages, tools):
+        messages.append({"role": "system", "content": "mutated_by_hook"})
+
+    ctx.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, mutate_messages_hook)
+
+    runner = TurnRunner(
+        ctx=ctx,
+        config=config,
+        history=[],
+        user_message="Hello",
+        archive_text="",
+        attachments=None,
+    )
+
+    await runner.run()
+
+    # Verify the mutation happened.
+    assert any(
+        msg.get("role") == "system" and msg.get("content") == "mutated_by_hook"
+        for msg in called_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_interceptors_execute_in_order(ctx, config, monkeypatch):
+    """Test that multiple hooks execute in the order they were registered."""
+    async def mock_call_llm(ctx, config, messages, tools, **kwargs):
+        return {"content": "OK", "usage": {}}
+
+    monkeypatch.setattr("decafclaw.agent._call_llm_with_events", mock_call_llm)
+
+    execution_order = []
+
+    def hook1(ctx, messages, tools):
+        execution_order.append("hook1")
+
+    def hook2(ctx, messages, tools):
+        execution_order.append("hook2")
+
+    ctx.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, hook1)
+    ctx.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, hook2)
+
+    runner = TurnRunner(
+        ctx=ctx,
+        config=config,
+        history=[],
+        user_message="Hello",
+        archive_text="",
+        attachments=None,
+    )
+
+    await runner.run()
+
+    assert execution_order == ["hook1", "hook2"]


### PR DESCRIPTION
## Summary
- Implements synchronous interception hooks for the TurnLifecycle in `Context`, allowing plugins to safely modify context before an LLM call.
- Formalizes a `Context.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, my_hook)` architecture which resolves the race condition issues in the async EventBus mechanism for prompt/tool mutation.

## Design Decisions
- **Decision:** Only support the `BEFORE_LLM_CALL` phase in this initial PR.
  - **Why:** To keep the initial implementation scoped and focused as requested in the issue.
  - **Rejected:** Supporting multiple lifecycle phases at once.

## Changes
- `src/decafclaw/context.py`: Added `TurnLifecycle` enum and `_interceptors` tracking to `Context` along with `add_interceptor` and `get_interceptors`.
- `src/decafclaw/agent.py`: Integrated the hook execution inside `_run_iteration` before `_call_llm_with_events`.
- `tests/test_interceptor_hooks.py`: Added `test_before_llm_call_hook_mutates_messages` and `test_interceptors_execute_in_order`.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | `Context.add_interceptor(TurnLifecycle.BEFORE_LLM_CALL, hook)` synchronously invokes the hook with `(ctx, messages, tools)` before sending the LLM request. | `pytest tests/test_interceptor_hooks.py::test_before_llm_call_hook_mutates_messages` | pass |
| C2 | Multiple interceptors are executed synchronously in the order they were added. | `pytest tests/test_interceptor_hooks.py::test_interceptors_execute_in_order` | pass |

Verified via `pytest`.

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass · C2 pass
guards: none
tamper: clean-by-substitute — tactical implementation, no freeze commit
freeze: none
project-gates: make check green
ci: pass
threads: resolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: clean
```

## References
- Spec: `docs/dev-sessions/2026-08-08-0000-783-synchronous-hooks/spec.md`
- Closes #783
