### PR TITLE
fix: use resolved skill location for both body and pre-approved patterns

### DIFF
--- a/src/decafclaw/commands.py
+++ b/src/decafclaw/commands.py
@@ -416,10 +416,12 @@ async def execute_command(ctx: "Context", skill: SkillInfo, arguments: str) -> t
     # unaffected and still applies at every tier. Nothing is assigned at an
     # untrusted tier rather than assigning empty, so the ctx defaults stand
     # and no grant is implied to have been computed.
+    skill_dir = str(skill.location.resolve())
+
     if grants_capability(skill):
         ctx.tools.preapproved = set(skill.allowed_tools)
         ctx.tools.preapproved_shell_patterns = [
-            p.replace("$SKILL_DIR", str(skill.location))
+            p.replace("$SKILL_DIR", skill_dir)
             for p in skill.shell_patterns
         ]
     elif skill.allowed_tools or skill.shell_patterns:
@@ -469,7 +471,7 @@ async def execute_command(ctx: "Context", skill: SkillInfo, arguments: str) -> t
 
     # Substitute arguments and skill directory into the body
     body = substitute_body(skill.body, arguments,
-                           skill_dir=str(skill.location.resolve()))
+                           skill_dir=skill_dir)
 
     if skill.context == "fork":
         from .tools.delegate import run_child_turn

--- a/tests/test_scoped_shell.py
+++ b/tests/test_scoped_shell.py
@@ -239,32 +239,44 @@ async def test_blanket_shell_still_works(ctx):
 # -- $SKILL_DIR expansion tests --
 
 
-def test_skill_dir_expansion_in_commands():
-    """$SKILL_DIR in patterns is expanded when setting up context."""
+@pytest.mark.asyncio
+async def test_command_skill_dir_and_body_stay_in_sync(ctx, tmp_path):
+    """$SKILL_DIR expansion in pre-approved patterns matches prompt body.
+
+    The value substituted into the prompt body must be the same one the
+    shell pattern expanded to. If they drift, the agent is pointed at
+    a directory whose scripts are not pre-approved.
+    """
     from decafclaw.commands import execute_command
+
+    # Create a symlink to test resolution
+    real_dir = tmp_path / "real_skills" / "ingest"
+    real_dir.mkdir(parents=True)
+    link_dir = tmp_path / "linked_skills" / "ingest"
+    link_dir.parent.mkdir(parents=True)
+    link_dir.symlink_to(real_dir)
 
     skill = SkillInfo(
         name="ingest",
         description="Ingest",
-        location=Path("/opt/skills/ingest"),
-        body="Do the thing.",
+        location=link_dir,  # unresolved location
+        body="Run scripts in $SKILL_DIR.",
+        allowed_tools=["shell"],
         shell_patterns=["$SKILL_DIR/fetch.sh"],
+        trust_tier="admin",  # required for grants_capability to be true
     )
 
-    from decafclaw.context import Context
-    from decafclaw.events import EventBus
+    # Actually call execute_command to see what it does to ctx and what it returns
+    mode, body = await execute_command(ctx, skill, "")
 
-    ctx = Context(config=None, event_bus=EventBus())
-    ctx.tools.preapproved = set()
+    assert mode == "inline"
 
-    # Simulate what execute_command does
-    ctx.tools.preapproved = set(skill.allowed_tools)
-    skill_dir = str(skill.location)
-    ctx.tools.preapproved_shell_patterns = [
-        p.replace("$SKILL_DIR", skill_dir) for p in skill.shell_patterns
-    ]
+    # Pre-approved pattern should use the resolved path
+    expected_resolved = str(real_dir.resolve())
+    assert ctx.tools.preapproved_shell_patterns == [f"{expected_resolved}/fetch.sh"]
 
-    assert ctx.tools.preapproved_shell_patterns == ["/opt/skills/ingest/fetch.sh"]
+    # Body should use the exact same resolved path
+    assert f"Run scripts in {expected_resolved}." in body
 
 
 # -- shell metacharacter rejection tests --


### PR DESCRIPTION
## Summary
- Uses the resolved skill path (`skill.location.resolve()`) for pre-approved shell patterns instead of the raw `skill.location`.
- This ensures the pattern `execute_command` authorizes matches the path injected as `$SKILL_DIR` into the prompt body, fixing a discrepancy where the agent might be asked to run a command the system refuses.

## Changes
- `src/decafclaw/commands.py`: `skill.location.resolve()` is now computed once and reused for both `ctx.tools.preapproved_shell_patterns` generation and `substitute_body`.
- `tests/test_scoped_shell.py`: Added `test_command_skill_dir_and_body_stay_in_sync` which ensures `$SKILL_DIR` expands correctly and identically in both locations.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | WHEN `execute_command` processes a skill, THE SYSTEM SHALL expand `$SKILL_DIR` in pre-approved shell patterns using the resolved path | `pytest tests/test_scoped_shell.py` | pass |

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass
tamper: clean-by-substitute — tactical issue, no frozen artifacts
freeze: none
project-gates: make check green
ci: pending
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
```

## References
- Closes #747