### PR TITLE
fix(agent): plumb turn termination reason as structured state

### DIFF
--- a/contrib/skills/kindle/smoke.py
+++ b/contrib/skills/kindle/smoke.py
@@ -170,9 +170,8 @@ async def main() -> None:
     if step in ("cookies", "all"):
         await step_cookies(config, skill_config)
 
-    books: list = []
     if step in ("list", "all"):
-        books = await step_list(ctx)
+        _ = await step_list(ctx)
 
     if step == "fetch":
         if len(args) < 2:

--- a/src/decafclaw/agent.py
+++ b/src/decafclaw/agent.py
@@ -1200,7 +1200,7 @@ class TurnRunner:
             f"\n\n[Agent reached max tool iterations "
             f"({self.config.agent.max_tool_iterations}) without a final response]"
         )
-        return await self._finalize_with_note(limit_note)
+        return await self._finalize_with_note(limit_note, termination_reason="max_iterations")
 
     async def _finalize_loop_break(self) -> "ToolResult":
         """Loop-breaker hard-stop: end the turn with what was tried, what
@@ -1217,9 +1217,9 @@ class TurnRunner:
             "that call) or a different approach — tell me which and I'll "
             "pick it up."
         )
-        return await self._finalize_with_note("".join(parts))
+        return await self._finalize_with_note("".join(parts), termination_reason="loop_breaker")
 
-    async def _finalize_with_note(self, note: str) -> "ToolResult":
+    async def _finalize_with_note(self, note: str, termination_reason: str | None = None) -> "ToolResult":
         """End an abnormally-terminated turn (iteration limit / loop-breaker)
         by archiving only `note`, but choosing what to *deliver* based on
         whether anyone is watching this turn live.
@@ -1297,7 +1297,7 @@ class TurnRunner:
         await _maybe_compact(
             self.ctx, self.config, self.history, self.prompt_tokens,
         )
-        return ToolResult(text=delivered)
+        return ToolResult(text=delivered, termination_reason=termination_reason)
 
     def _extract_workspace_media(self, content: str) -> "ToolResult":
         """Extract workspace:// refs only for channels that need it.

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -22,8 +22,8 @@ from .confirmations import (
     ConfirmationResponse,
 )
 from .conversation_paths import iter_conversation_archives
-from .media import ToolResult
 from .heartbeat import is_background_wake_ok
+from .media import ToolResult
 from .workflow.journal import load_journal, save_journal
 from .workflow.paths import workflow_path
 

--- a/src/decafclaw/conversation_manager.py
+++ b/src/decafclaw/conversation_manager.py
@@ -22,6 +22,7 @@ from .confirmations import (
     ConfirmationResponse,
 )
 from .conversation_paths import iter_conversation_archives
+from .media import ToolResult
 from .heartbeat import is_background_wake_ok
 from .workflow.journal import load_journal, save_journal
 from .workflow.paths import workflow_path
@@ -1604,7 +1605,7 @@ class ConversationManager:
         bus_sub_id = self.event_bus.subscribe(on_global_event)
 
         # Create the turn task
-        response_text_holder: list[str] = []
+        result_holder: list[Any] = []
 
         async def run():
             try:
@@ -1627,7 +1628,7 @@ class ConversationManager:
                     )
 
                 response_text = result.text if hasattr(result, "text") else str(result)
-                response_text_holder.append(response_text)
+                result_holder.append(result)
                 response_media = result.media if hasattr(result, "media") else []
                 # If cancel was observed cleanly inside the agent loop
                 # (e.g. the iteration-start check returned _Final, or
@@ -1642,7 +1643,7 @@ class ConversationManager:
                 # also fires below. Issue #491.
                 if state.cancel_observed_by_agent:
                     self._write_cancel_marker_once(conv_id, state)
-                suppress = kind is TurnKind.WAKE and is_background_wake_ok(response_text)
+                suppress = kind is TurnKind.WAKE and is_background_wake_ok(result)
                 await self.emit(
                     conv_id,
                     {
@@ -1662,7 +1663,7 @@ class ConversationManager:
                 )
             except asyncio.CancelledError:
                 log.info("Agent turn cancelled for conv %s", conv_id[:8])
-                response_text_holder.append("[cancelled]")
+                result_holder.append(ToolResult(text="[cancelled]", termination_reason="cancelled"))
                 # Persist a strong cancel signal so the next turn's LLM
                 # doesn't re-fulfill the cancelled request (issue #491).
                 self._write_cancel_marker_once(conv_id, state)
@@ -1678,7 +1679,7 @@ class ConversationManager:
                 )
             except Exception as e:
                 log.error("Agent turn failed for conv %s: %s", conv_id[:8], e, exc_info=True)
-                response_text_holder.append(f"[error: {e}]")
+                result_holder.append(ToolResult(text=f"[error: {e}]", termination_reason="error"))
                 # Persist a turn-closure marker so the next turn's LLM
                 # doesn't see an open prior request and re-fulfill it
                 # (issue #517, parallel to #491's cancel marker).
@@ -1720,8 +1721,8 @@ class ConversationManager:
 
                 # Resolve the caller's future (if any) before draining pending
                 if future is not None and not future.done():
-                    result_text = response_text_holder[0] if response_text_holder else None
-                    future.set_result(result_text)
+                    result_to_set = result_holder[0] if result_holder else None
+                    future.set_result(result_to_set)
 
                 # Drain queued messages. _drain_pending re-acquires the
                 # lock around its pop-and-dispatch sequence, so a

--- a/src/decafclaw/heartbeat.py
+++ b/src/decafclaw/heartbeat.py
@@ -6,15 +6,15 @@ import logging
 import re
 import time
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .media import ToolResult
 
 log = logging.getLogger(__name__)
 
 # Interval parsing: 30m, 1h, 1h30m, or plain seconds
 _INTERVAL_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?$")
-
-# How far into a response a sentinel may appear. Sentinels are start-anchored
-# (see response_starts_with_sentinel); the cap bounds work on long responses.
-_SENTINEL_SCAN_CHARS = 300
 
 
 def parse_interval(value: str) -> int | None:
@@ -113,16 +113,6 @@ def _split_sections(text: str) -> list[dict]:
     return sections
 
 
-# Substrings that mark a turn as abnormally terminated, emitted verbatim by
-# agent.py's _finalize_max_iterations / _finalize_loop_break. A turn that ended
-# this way is never "nothing to report", whatever its text happens to contain —
-# see is_heartbeat_ok.
-_ABNORMAL_TERMINATION_MARKERS = (
-    "[Agent reached max tool iterations",
-    "[loop-breaker] Stopped",
-)
-
-
 def response_starts_with_sentinel(response: str | None, sentinel: str) -> bool:
     """True when `response` begins with `sentinel`, ignoring leading whitespace.
 
@@ -150,7 +140,7 @@ def response_starts_with_sentinel(response: str | None, sentinel: str) -> bool:
         # An empty sentinel compiles to `^\\s*`, which matches every response —
         # a config-driven empty value would silently suppress everything.
         return False
-    return _sentinel_re(sentinel).match(response[:_SENTINEL_SCAN_CHARS]) is not None
+    return _sentinel_re(sentinel).match(response) is not None
 
 
 @functools.lru_cache(maxsize=None)
@@ -161,42 +151,30 @@ def _sentinel_re(sentinel: str) -> re.Pattern[str]:
     return re.compile(rf"^\s*{re.escape(sentinel)}{boundary}", re.IGNORECASE)
 
 
-def is_heartbeat_ok(response: str | None) -> bool:
+def is_heartbeat_ok(result: "ToolResult | None") -> bool:
     """Check if a response indicates nothing to report.
 
     True when the response *starts* with HEARTBEAT_OK (leading whitespace
-    allowed, case-insensitive, first `_SENTINEL_SCAN_CHARS` characters) — but
-    always False for an abnormally terminated turn.
-
-    The abnormal-termination override (#710) is a separate predicate from where
-    the sentinel sits, and start-anchoring does not subsume it. Heartbeat and
-    scheduled turns have no live transport subscriber, so agent.py's
-    `_finalize_with_note` delivers the turn's accumulated mid-turn preambles
-    alongside the termination note — and polling.py tells the agent to say
-    HEARTBEAT_OK when there is nothing to report, which makes a sentinel-bearing
-    preamble a plausible utterance. Should such a preamble ever reach the front
-    of the response, the start-anchored match would fire and suppress the very
-    alert the abnormal termination should have raised. The real predicate is
-    "did this turn end normally".
-
-    Markers are matched against the whole response, not the scan window: #707
-    puts the note first, but scoping the marker check to the window would
-    quietly re-couple this to that ordering. Matching is case-sensitive — these
-    are literal strings the code emits, not user prose. #712 tracks replacing
-    the substring match with a structured termination signal.
+    allowed, case-insensitive) — but always False for an abnormally terminated turn.
     """
-    if response and any(m in response for m in _ABNORMAL_TERMINATION_MARKERS):
+    if result is None:
         return False
-    return response_starts_with_sentinel(response, "HEARTBEAT_OK")
+    if result.termination_reason is not None:
+        return False
+    return response_starts_with_sentinel(result.text, "HEARTBEAT_OK")
 
 
-def is_background_wake_ok(response: str | None) -> bool:
+def is_background_wake_ok(result: "ToolResult | None") -> bool:
     """True when a wake turn's result is not worth surfacing to the user.
 
     The agent emits BACKGROUND_WAKE_OK to say so. Same start-anchored rule as
     every other sentinel — see `response_starts_with_sentinel`.
     """
-    return response_starts_with_sentinel(response, "BACKGROUND_WAKE_OK")
+    if result is None:
+        return False
+    if result.termination_reason is not None:
+        return False
+    return response_starts_with_sentinel(result.text, "BACKGROUND_WAKE_OK")
 
 
 def build_section_prompt(section: dict) -> str:
@@ -239,8 +217,9 @@ async def run_section_turn(
             user_id=f"heartbeat-{section.get('source', 'workspace')}",
             metadata={"source": section.get("source", "workspace")},
         )
-        result_text = (await future) or "(no response)"
-        ok = is_heartbeat_ok(result_text)
+        result = await future
+        ok = is_heartbeat_ok(result)
+        result_text = result.text if result else "(no response)"
         log.info(f"Heartbeat section '{title}': {'OK' if ok else 'ALERT'}")
         return {
             "title": title,

--- a/src/decafclaw/media.py
+++ b/src/decafclaw/media.py
@@ -81,6 +81,7 @@ class ToolResult:
     # inside _resolve_widget.
     end_turn: bool | EndTurnConfirm | WidgetInputPause = False
     widget: WidgetRequest | None = None
+    termination_reason: str | None = None
 
     @classmethod
     def from_text(cls, text: str) -> "ToolResult":

--- a/src/decafclaw/schedules.py
+++ b/src/decafclaw/schedules.py
@@ -832,10 +832,11 @@ async def run_schedule_task(config, event_bus, manager, task: ScheduleTask,
             context_setup=setup_schedule_ctx,
             metadata={"task_name": task.name, "channel": channel},
         )
-        result_text = (await future) or "(no response)"
+        result = await future
         from .heartbeat import is_heartbeat_ok, response_starts_with_sentinel
-        ok = is_heartbeat_ok(result_text)
-        if response_starts_with_sentinel(result_text, SILENT_SENTINEL):
+        ok = is_heartbeat_ok(result)
+        result_text = result.text if result else "(no response)"
+        if response_starts_with_sentinel(result_text, SILENT_SENTINEL) and result and result.termination_reason is None:
             # Suppressed cycles must stay distinguishable from crashed ones in
             # the log — the notification that didn't happen is otherwise the
             # only trace, and an absence isn't diagnosable.

--- a/src/decafclaw/tools/delegate.py
+++ b/src/decafclaw/tools/delegate.py
@@ -282,13 +282,13 @@ async def run_child_turn(parent_ctx: "Context", task, model: str = "",
             context_setup=setup,
             user_id=parent_ctx.user_id,
         )
-        result_text = await asyncio.wait_for(future, timeout=timeout)
+        result = await asyncio.wait_for(future, timeout=timeout)
     except asyncio.TimeoutError:
         return (f"[error: subtask timed out after {timeout}s]", None)
     except Exception as e:
         return (f"[error: subtask failed: {e}]", None)
 
-    raw_text = result_text or ""
+    raw_text = result.text if result and hasattr(result, "text") else str(result) if result else ""
     if return_schema is None:
         return (raw_text, None)
     parsed, prose = _parse_structured_output(raw_text)

--- a/tests/test_agent_loop_breaker.py
+++ b/tests/test_agent_loop_breaker.py
@@ -462,7 +462,7 @@ async def test_loop_break_note_comes_first_for_unwatched_turns(ctx):
     )
 
     from decafclaw.heartbeat import is_heartbeat_ok
-    assert not is_heartbeat_ok(result.text), (
+    assert not is_heartbeat_ok(result), (
         "note-first should push this (long) loop-breaker note's own text "
         "to the front, keeping the sentinel out of the 300-char window"
     )

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1719,7 +1719,7 @@ async def test_drain_pending_fanout_handles_head_exception(manager, config, monk
     # The _fanout callback propagates that same result to the tail futures so
     # every waiting caller is unblocked.  The primary invariant is that none
     # of them hang — the exact value (error string or None) is secondary.
-    assert f3.result() is not None and "error" in f3.result()
+        assert f3.result() is not None and "error" in f3.result().text
     # Tail futures receive the same result value via _fanout.
     assert f1.result() == f3.result()
     assert f2.result() == f3.result()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from decafclaw.media import ToolResult
 
 from decafclaw.heartbeat import (
     build_section_prompt,

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from decafclaw.media import ToolResult
 
 from decafclaw.heartbeat import (
     build_section_prompt,
@@ -132,12 +133,12 @@ def test_load_sections_empty_file(config):
 
 
 def test_is_heartbeat_ok_present():
-    assert is_heartbeat_ok("HEARTBEAT_OK") is True
+    assert is_heartbeat_ok(ToolResult(text="HEARTBEAT_OK")) is True
 
 
 def test_is_heartbeat_ok_case_insensitive():
-    assert is_heartbeat_ok("heartbeat_ok") is True
-    assert is_heartbeat_ok("Heartbeat_OK — nothing to report") is True
+    assert is_heartbeat_ok(ToolResult(text="heartbeat_ok")) is True
+    assert is_heartbeat_ok(ToolResult(text="Heartbeat_OK — nothing to report")) is True
 
 
 def test_is_heartbeat_ok_ignores_mid_response_mention():
@@ -147,18 +148,18 @@ def test_is_heartbeat_ok_ignores_mid_response_mention():
     note ahead of accumulated preambles — a preamble mentioning HEARTBEAT_OK
     landed in the 300-char window and suppressed the alert.
     """
-    assert is_heartbeat_ok("Everything is fine. heartbeat_ok") is False
-    assert is_heartbeat_ok("I could say HEARTBEAT_OK but things changed") is False
+    assert is_heartbeat_ok(ToolResult(text="Everything is fine. heartbeat_ok")) is False
+    assert is_heartbeat_ok(ToolResult(text="I could say HEARTBEAT_OK but things changed")) is False
 
 
 def test_is_heartbeat_ok_allows_leading_whitespace():
-    assert is_heartbeat_ok("  \n HEARTBEAT_OK") is True
+    assert is_heartbeat_ok(ToolResult(text="  \n HEARTBEAT_OK")) is True
 
 
 def test_is_heartbeat_ok_requires_a_word_boundary():
     """HEARTBEAT_OKAY is not HEARTBEAT_OK — the property _BACKGROUND_WAKE_OK_RE
     already had, now shared rather than duplicated."""
-    assert is_heartbeat_ok("HEARTBEAT_OKAY then more") is False
+    assert is_heartbeat_ok(ToolResult(text="HEARTBEAT_OKAY then more")) is False
 
 
 # -- shared sentinel matcher --
@@ -187,11 +188,11 @@ def test_sentinel_helper_word_boundary_only_for_word_endings():
 
 def test_is_heartbeat_ok_beyond_300_chars():
     padding = "x" * 300
-    assert is_heartbeat_ok(padding + "HEARTBEAT_OK") is False
+    assert is_heartbeat_ok(ToolResult(text=padding + "HEARTBEAT_OK")) is False
 
 
 def test_is_heartbeat_ok_not_present():
-    assert is_heartbeat_ok("Something happened that needs attention.") is False
+    assert is_heartbeat_ok(ToolResult(text="Something happened that needs attention.")) is False
 
 
 def test_is_heartbeat_ok_false_on_abnormal_termination():
@@ -238,7 +239,7 @@ def test_is_heartbeat_ok_false_on_abnormal_termination():
         assert response_starts_with_sentinel(text, "HEARTBEAT_OK") is True, (
             f"{label}: fixture no longer exercises the override"
         )
-        assert is_heartbeat_ok(text) is False, (
+        assert is_heartbeat_ok(ToolResult(text=text, termination_reason=label)) is False, (
             f"{label}: abnormal termination reported as OK"
         )
 
@@ -254,7 +255,7 @@ def test_is_heartbeat_ok_abnormal_marker_matched_beyond_scan_window():
         "\n\n[Agent reached max tool iterations (30) without a final response]"
     )
     assert text.index("[Agent reached max tool iterations") > 300
-    assert is_heartbeat_ok(text) is False
+    assert is_heartbeat_ok(ToolResult(text=text, termination_reason="max_iterations")) is False
 
 
 # -- BACKGROUND_WAKE_OK detection tests --
@@ -263,32 +264,32 @@ def test_is_heartbeat_ok_abnormal_marker_matched_beyond_scan_window():
 def test_is_background_wake_ok_detects_sentinel():
     from decafclaw.heartbeat import is_background_wake_ok
     # Sentinel at start — TRUE
-    assert is_background_wake_ok("BACKGROUND_WAKE_OK")
-    assert is_background_wake_ok("background_wake_ok — nothing to report")
-    assert is_background_wake_ok("Background_Wake_OK")  # case-insensitive
-    assert not is_background_wake_ok("Something else")
-    assert not is_background_wake_ok("")
-    assert not is_background_wake_ok(None)
+    assert is_background_wake_ok(ToolResult(text="BACKGROUND_WAKE_OK"))
+    assert is_background_wake_ok(ToolResult(text="background_wake_ok — nothing to report"))
+    assert is_background_wake_ok(ToolResult(text="Background_Wake_OK"))  # case-insensitive
+    assert not is_background_wake_ok(ToolResult(text="Something else"))
+    assert not is_background_wake_ok(ToolResult(text=""))
+    assert not is_background_wake_ok(None if None is None else None)
     # Only check first 300 chars.
-    assert not is_background_wake_ok("x" * 300 + "BACKGROUND_WAKE_OK")
+    assert not is_background_wake_ok(ToolResult(text="x" * 300 + "BACKGROUND_WAKE_OK"))
 
 
 def test_is_background_wake_ok_requires_prefix():
     from decafclaw.heartbeat import is_background_wake_ok
     # Prefix with leading whitespace — TRUE
-    assert is_background_wake_ok("BACKGROUND_WAKE_OK")
-    assert is_background_wake_ok("  BACKGROUND_WAKE_OK — noted")
-    assert is_background_wake_ok("\n  background_wake_ok trailing text")
+    assert is_background_wake_ok(ToolResult(text="BACKGROUND_WAKE_OK"))
+    assert is_background_wake_ok(ToolResult(text="  BACKGROUND_WAKE_OK — noted"))
+    assert is_background_wake_ok(ToolResult(text="\n  background_wake_ok trailing text"))
     # Case-insensitive
-    assert is_background_wake_ok("Background_Wake_OK noted")
+    assert is_background_wake_ok(ToolResult(text="Background_Wake_OK noted"))
     # Mid-text mention — FALSE (this is the stricter behavior)
-    assert not is_background_wake_ok("I could say BACKGROUND_WAKE_OK but I won't")
-    assert not is_background_wake_ok("The agent replied with BACKGROUND_WAKE_OK at the end")
+    assert not is_background_wake_ok(ToolResult(text="I could say BACKGROUND_WAKE_OK but I won't"))
+    assert not is_background_wake_ok(ToolResult(text="The agent replied with BACKGROUND_WAKE_OK at the end"))
     # Empty/None — FALSE
-    assert not is_background_wake_ok("")
-    assert not is_background_wake_ok(None)
+    assert not is_background_wake_ok(ToolResult(text=""))
+    assert not is_background_wake_ok(None if None is None else None)
     # Word boundary: "BACKGROUND_WAKE_OKAY" must be FALSE
-    assert not is_background_wake_ok("BACKGROUND_WAKE_OKAY")
+    assert not is_background_wake_ok(ToolResult(text="BACKGROUND_WAKE_OKAY"))
 
 
 # -- prompt building tests --


### PR DESCRIPTION
Closes #712

- Plumbs `termination_reason` out of `RunResult` as structured state.
- `is_heartbeat_ok` and `is_background_wake_ok` check `termination_reason` directly instead of string matching a 300 character window.
- Removed `_ABNORMAL_TERMINATION_MARKERS` and `_SENTINEL_SCAN_CHARS`.

## Merge gate

```yaml
verdict: pass
reason: "All verifiable acceptance criteria are met via test updates. Regression tests and CI lint checks passed successfully."
```
