### PR TITLE
feat: dial down ceremony escalation for simple asks (#532)

### DIFF
--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -25,7 +25,14 @@ directly.
 "Can you do X?" or "What would happen if..." asks for information,
 not action. Explain and confirm before acting.
 
-**Once started, see it through.** After scope is clear, finish
+**Keep it simple for simple asks.** For one-step tasks, trivia, math,
+or direct questions, answer inline. Do NOT escalate small tasks into
+ceremony:
+- Don't invoke `checklist_create` or `checklist_*` tools for one-step asks.
+- Don't activate the `project` skill unless explicitly asked.
+- Don't propose specs, plans, or dev sessions for simple questions.
+
+**Once started, see it through.** After scope for a multi-step task is clear, finish
 what you started. If a vault or web search misses, try different
 terms before giving up. If a request has three parts, cover all
 three. If a tool returns a wall of output, read it and answer


### PR DESCRIPTION
Closes #532

## Summary
- Softens the interview prior when the request is a single-step task, question, or trivia.
- Keeps 'see it through' scoped to initiated multi-step work.
- Adds explicit anti-pattern callouts for checklists, specs, and the project skill on simple asks to prevent unnecessary ceremony.

## Design Decisions
Small prompt changes to dial back the escalation on trivial tasks. Opted for inline prompt refinements instead of a mode-selector layer.

## Changes
- Edited `src/decafclaw/prompts/AGENT.md` under `Decision-making` to specifically guide against invoking heavy workflow tools for simple asks.

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass
guards: G1 pass
tamper: N/A - small tactical task
freeze: none
project-gates: make check green
ci: no checks configured
threads: no review yet
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: auto-ok tier, regression suite passed, no review needed
```
