### PR TITLE
feat: message history navigation in chat-input

### DIFF
--- a/src/decafclaw/web/static/components/chat-input.js
+++ b/src/decafclaw/web/static/components/chat-input.js
@@ -49,6 +49,9 @@ export class ChatInput extends LitElement {
     _trigger: { type: Object, state: true },
     _highlight: { type: Number, state: true },
     _mentionMatches: { type: Array, state: true },
+    _history: { type: Array, state: true },
+    _historyIndex: { type: Number, state: true },
+    _draft: { type: String, state: true },
   };
 
   createRenderRoot() { return this; }
@@ -87,6 +90,9 @@ export class ChatInput extends LitElement {
     this._trigger = null;
     this._highlight = 0;
     this._mentionMatches = [];
+    this._history = [];
+    this._historyIndex = -1;
+    this._draft = '';
     this._lastFetchedQuery = '';
     this._fetchTimeout = null;
   }
@@ -283,6 +289,44 @@ export class ChatInput extends LitElement {
       // Enter deliberately falls through: it sends, it never commits.
     }
 
+    const textarea = this.querySelector('textarea');
+    if (e.key === 'ArrowUp' && this._history.length > 0) {
+      const isFirstLine = textarea.selectionStart === textarea.selectionEnd &&
+        textarea.value.slice(0, textarea.selectionStart).indexOf('\n') === -1;
+
+      if (isFirstLine) {
+        e.preventDefault();
+        if (this._historyIndex === -1) {
+          this._draft = textarea.value;
+        }
+        if (this._historyIndex < this._history.length - 1) {
+          this._historyIndex++;
+          textarea.value = this._history[this._history.length - 1 - this._historyIndex];
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+        }
+        return;
+      }
+    }
+
+    if (e.key === 'ArrowDown' && this._historyIndex !== -1) {
+      const isLastLine = textarea.selectionStart === textarea.selectionEnd &&
+        textarea.value.slice(textarea.selectionEnd).indexOf('\n') === -1;
+
+      if (isLastLine) {
+        e.preventDefault();
+        this._historyIndex--;
+        if (this._historyIndex === -1) {
+          textarea.value = this._draft;
+        } else {
+          textarea.value = this._history[this._history.length - 1 - this._historyIndex];
+        }
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
+        return;
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       this.#handleSend();
@@ -310,6 +354,14 @@ export class ChatInput extends LitElement {
       bubbles: true,
       composed: true,
     }));
+    if (text) {
+      // Don't record duplicates of the immediate previous message
+      if (this._history[this._history.length - 1] !== text) {
+        this._history = [...this._history, text];
+      }
+    }
+    this._historyIndex = -1;
+    this._draft = '';
     textarea.value = '';
     textarea.style.height = 'auto';
     this.#closeMenu();

--- a/src/decafclaw/web/static/components/chat-input.test.js
+++ b/src/decafclaw/web/static/components/chat-input.test.js
@@ -330,6 +330,94 @@ describe('chat-input existing send/stop behaviour (menu closed)', () => {
   });
 });
 
+describe('chat-input message history navigation', () => {
+  it('navigates backward through history on ArrowUp and forward on ArrowDown', async () => {
+    const el = await mount();
+    
+    // Send two messages
+    await type(el, 'first message');
+    await press(el, 'Enter');
+    await type(el, 'second message');
+    await press(el, 'Enter');
+
+    // Type a draft
+    await type(el, 'current draft');
+    expect(textareaOf(el).value).toBe('current draft');
+
+    // ArrowUp goes to second message
+    await press(el, 'ArrowUp');
+    expect(textareaOf(el).value).toBe('second message');
+
+    // ArrowUp goes to first message
+    await press(el, 'ArrowUp');
+    expect(textareaOf(el).value).toBe('first message');
+
+    // ArrowUp stops at first message (no wrap)
+    await press(el, 'ArrowUp');
+    expect(textareaOf(el).value).toBe('first message');
+
+    // ArrowDown goes back to second message
+    await press(el, 'ArrowDown');
+    expect(textareaOf(el).value).toBe('second message');
+
+    // ArrowDown goes back to draft
+    await press(el, 'ArrowDown');
+    expect(textareaOf(el).value).toBe('current draft');
+
+    // ArrowDown stops at draft
+    await press(el, 'ArrowDown');
+    expect(textareaOf(el).value).toBe('current draft');
+  });
+
+  it('only navigates when cursor is on the first/last line respectively', async () => {
+    const el = await mount();
+    await type(el, 'history message');
+    await press(el, 'Enter');
+
+    // Type a multi-line draft
+    await type(el, 'line 1\nline 2');
+    const ta = textareaOf(el);
+    
+    // Move cursor to end of line 2
+    ta.selectionStart = ta.selectionEnd = ta.value.length;
+    await press(el, 'ArrowUp');
+    // Shouldn't navigate because not on first line
+    expect(ta.value).toBe('line 1\nline 2');
+
+    // Move cursor to line 1
+    ta.selectionStart = ta.selectionEnd = 0;
+    await press(el, 'ArrowUp');
+    // Now it navigates
+    expect(ta.value).toBe('history message');
+
+    // Since 'history message' is single line, it's also the last line.
+    // Move cursor to start of it.
+    ta.selectionStart = ta.selectionEnd = 0;
+    await press(el, 'ArrowDown');
+    // Navigates forward because single line is also last line
+    expect(ta.value).toBe('line 1\nline 2');
+  });
+
+  it('resets history navigation when sending a new message', async () => {
+    const el = await mount();
+    
+    await type(el, 'first message');
+    await press(el, 'Enter');
+
+    await type(el, 'draft');
+    await press(el, 'ArrowUp');
+    expect(textareaOf(el).value).toBe('first message');
+
+    // Send the history message again
+    await press(el, 'Enter');
+    expect(textareaOf(el).value).toBe('');
+
+    // Send should reset draft and history index. ArrowUp should now show 'first message' again
+    await press(el, 'ArrowUp');
+    expect(textareaOf(el).value).toBe('first message');
+  });
+});
+
 describe('chat-input mention autocomplete', () => {
   it('triggers autocomplete on "@" anywhere and fetches suggestions', async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary
- Adds message history navigation to `ChatInput` using the Up/Down arrow keys.
- Fulfills the user requirement to retry/regenerate without a backend "regenerate" protocol, keeping it simple.

## Design Decisions
- Decided to maintain `_history` state locally inside `chat-input.js` to cycle through previously sent messages.
- The arrow keys cycle through history only when the text cursor is on the first line (Up) or last line (Down) so it won't interrupt normal multi-line text navigation.

## Changes
- `src/decafclaw/web/static/components/chat-input.js`: Added history state arrays and keydown handling for `ArrowUp`/`ArrowDown`.
- `src/decafclaw/web/static/components/chat-input.test.js`: Added Vitest assertions covering the acceptance criteria.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | ArrowUp cycles backward through history | `vitest run chat-input` | pass |
| C2 | ArrowDown cycles forward through history | `vitest run chat-input` | pass |

Verified by unit tests. Task was treated as Small/Tactical threshold so no independent frozen checks manifest was created.

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass · C2 pass
guards: G1 pass
tamper: clean-by-substitute — tactical task, no frozen manifest
freeze: none
project-gates: make check green
ci: pending
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: pending
reason: CI checks are pending
```

## References
- Closes #64
