### PR TITLE
feat: Context Management - Managed Tool Output Files

### DIFF
--- a/src/decafclaw/config.py
+++ b/src/decafclaw/config.py
@@ -179,6 +179,7 @@ class Config:
     model_configs: dict[str, ModelConfig] = field(default_factory=dict)
     default_model: str = ""
     extra_skill_paths: list[str] = field(default_factory=list)
+    max_tool_output_bytes: int | None = 51200
     # Skill names to treat as always-loaded regardless of frontmatter.
     # Lets a user opt a trusted-tier skill (bundled / admin / extra)
     # into the system prompt without editing its SKILL.md. Workspace

--- a/src/decafclaw/tool_execution.py
+++ b/src/decafclaw/tool_execution.py
@@ -20,6 +20,7 @@ import time
 from typing import TYPE_CHECKING
 
 from .archive import append_message
+from .conversation_paths import conversation_dir
 from .media import EndTurnConfirm, ToolResult, WidgetInputPause
 from .tools import execute_tool
 
@@ -280,6 +281,20 @@ async def execute_single_tool(call_ctx, tc, semaphore):
         except (TypeError, ValueError) as e:
             log.warning(f"Failed to serialize ToolResult.data for {fn_name}: {e}")
             content += "\n\n[structured data omitted: serialization error]"
+
+    max_bytes = call_ctx.config.max_tool_output_bytes
+    if max_bytes is not None:
+        content_bytes = content.encode("utf-8")
+        if len(content_bytes) > max_bytes:
+            tool_outputs_dir = conversation_dir(call_ctx.config, call_ctx.conv_id, create=True) / "tool_outputs"
+            tool_outputs_dir.mkdir(parents=True, exist_ok=True)
+            filepath = tool_outputs_dir / f"{tool_call_id}.txt"
+            filepath.write_bytes(content_bytes)
+
+            truncated_bytes = content_bytes[:max_bytes]
+            content = truncated_bytes.decode("utf-8", errors="replace")
+            content += f"\n\n[Output truncated. Full output saved to {filepath}. Use the 'read' tool to inspect it.]"
+
     tool_msg = {
         "role": "tool",
         "tool_call_id": tool_call_id,

--- a/tests/test_tool_output_store.py
+++ b/tests/test_tool_output_store.py
@@ -1,0 +1,82 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from decafclaw.media import ToolResult
+from decafclaw.tool_execution import execute_single_tool
+
+
+@pytest.mark.asyncio
+async def test_tool_output_exceeding_limit_is_managed(ctx):
+    ctx.config.max_tool_output_bytes = 100
+
+    # 150 bytes text
+    long_text = "A" * 150
+    mock_result = ToolResult(text=long_text)
+
+    tc = {
+        "id": "call_123",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+    semaphore = asyncio.Semaphore(1)
+
+    with patch("decafclaw.tool_execution.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg, _ = await execute_single_tool(ctx, tc, semaphore)
+
+    content = tool_msg["content"]
+    assert "Output truncated" in content
+    assert "Full output saved to" in content
+    assert "Use the 'read' tool to inspect it." in content
+
+    # Verify the truncated size
+    # The file path logic puts it in:
+    # workspace/conversations/{conv_id}/tool_outputs/{tool_call_id}.txt
+    from decafclaw.conversation_paths import conversation_dir
+    tool_outputs_dir = conversation_dir(ctx.config, ctx.conv_id, create=False) / "tool_outputs"
+    filepath = tool_outputs_dir / "call_123.txt"
+
+    assert str(filepath) in content
+    assert filepath.exists()
+    assert filepath.read_text() == long_text
+
+
+@pytest.mark.asyncio
+async def test_read_managed_tool_output_file(ctx):
+    # Setup test file
+    ctx.config.max_tool_output_bytes = 100
+    long_text = "B" * 150
+
+    from decafclaw.conversation_paths import conversation_dir
+    tool_outputs_dir = conversation_dir(ctx.config, ctx.conv_id, create=True) / "tool_outputs"
+    tool_outputs_dir.mkdir(parents=True, exist_ok=True)
+    filepath = tool_outputs_dir / "call_123.txt"
+    filepath.write_text(long_text)
+
+    # Test reading the file using the read tool
+    from decafclaw.tools.workspace_tools import tool_workspace_read
+
+    result = tool_workspace_read(ctx, path=str(filepath))
+    assert result.text.strip() == f"1| {long_text}"
+
+
+@pytest.mark.asyncio
+async def test_tool_output_under_limit_is_unmodified(ctx):
+    ctx.config.max_tool_output_bytes = 100
+
+    # 50 bytes text
+    short_text = "A" * 50
+    mock_result = ToolResult(text=short_text)
+
+    tc = {
+        "id": "call_124",
+        "function": {"name": "test_tool", "arguments": "{}"},
+    }
+    semaphore = asyncio.Semaphore(1)
+
+    with patch("decafclaw.tool_execution.execute_tool", new_callable=AsyncMock, return_value=mock_result):
+        tool_msg, _ = await execute_single_tool(ctx, tc, semaphore)
+
+    content = tool_msg["content"]
+    assert content == short_text
+    assert "Output truncated" not in content


### PR DESCRIPTION
## Summary
- Modifies `tool_execution.execute_single_tool` to automatically write full tool outputs to disk if they exceed `config.max_tool_output_bytes`.
- Returns a truncated preview to the LLM with a reference to the saved filepath.
- Addresses the need to handle very large tool outputs gracefully without flooding the context window or relying purely on tool-specific truncation.

## Design Decisions
- `max_tool_output_bytes` is configured in the root `Config` (defaults to 51,200).
- Tool outputs are written to `workspace/conversations/{conv_id}/tool_outputs/{tool_call_id}.txt`.
- The `read` tool (via `tool_workspace_read`) can retrieve the saved file for inspection.

## Changes
- `src/decafclaw/config.py`: Added `max_tool_output_bytes` to `Config`.
- `src/decafclaw/tool_execution.py`: Implemented length check, file writing, and truncation logic in `execute_single_tool`.
- `tests/test_tool_output_store.py`: Added tests to verify the file writing and truncation behavior.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | Write full output to disk and return truncated preview | `pytest tests/test_tool_output_store.py::test_tool_output_exceeding_limit_is_managed` | pass |
| C2 | Truncated file can be read via 'read' tool | `pytest tests/test_tool_output_store.py::test_read_managed_tool_output_file` | pass |

Verified by tests passing locally. No frozen checks were required due to Ceremony Threshold (Small/Tactical).

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass · C2 pass
guards: G1 pass
tamper: clean-by-substitute — no frozen checks (small/tactical)
freeze: none
project-gates: make check green
ci: no checks configured
threads: 0 unresolved
risk-paths: none
amendments: none
verdict: eligible-for-auto-merge
reason: 
```

## References
- Closes #777
