### PR TITLE
feat: workspace directory management tools and organizational guidance

### DIFF
--- a/src/decafclaw/prompts/AGENT.md
+++ b/src/decafclaw/prompts/AGENT.md
@@ -243,6 +243,12 @@ A sandboxed directory where you can read, write, search, and edit
 files. All `workspace_*` tools operate within this directory. Your
 to-do lists, working files, and editable skills live here.
 
+**Workspace organization:**
+- `tmp/` — scratch space for the current turn or a very short series. Files here can be deleted freely at any time.
+- `projects/<name>/` — working files grouped by project or topic. When you start a multi-file effort, use workspace_mkdir to create a folder for it rather than dropping files in the root.
+- `drafts/` — in-progress writing (blog posts, docs) before they land in the vault or an external repo.
+- Do not leave the workspace root cluttered — periodically sweep or organize.
+
 **Prefer surgical, line-based tools over string-match edits and
 full rewrites:**
 

--- a/src/decafclaw/tools/workspace_tools.py
+++ b/src/decafclaw/tools/workspace_tools.py
@@ -309,20 +309,71 @@ def tool_workspace_move(ctx: "Context", path: str, destination: str) -> str | To
         return _file_error(e, path)
 
 
-def tool_workspace_delete(ctx: "Context", path: str) -> str | ToolResult:
-    """Delete a file from the workspace."""
-    log.info(f"[tool:workspace_delete] {path}")
+def tool_workspace_mkdir(ctx: "Context", path: str) -> str | ToolResult:
+    """Create an empty directory (and parents) in the workspace."""
+    log.info(f"[tool:workspace_mkdir] {path}")
+    resolved = _resolve_safe(ctx.config, path)
+    if resolved is None:
+        return ToolResult(text=f"[error: path '{path}' is outside the workspace]")
+    try:
+        if resolved.exists():
+            return f"Directory {path} already exists"
+        resolved.mkdir(parents=True, exist_ok=True)
+        invalidate_workspace_file_cache(ctx.config)
+        return f"Created directory {path}"
+    except PermissionError as e:
+        return _file_error(e, path)
+
+
+def tool_workspace_copy(ctx: "Context", source: str, destination: str) -> str | ToolResult:
+    """Copy a file within the workspace."""
+    import shutil
+    log.info(f"[tool:workspace_copy] {source} -> {destination}")
+    resolved_src = _resolve_safe(ctx.config, source)
+    if resolved_src is None:
+        return ToolResult(text=f"[error: source path '{source}' is outside the workspace]")
+    resolved_dst = _resolve_safe(ctx.config, destination)
+    if resolved_dst is None:
+        return ToolResult(text=f"[error: destination '{destination}' is outside the workspace]")
+    if not resolved_src.exists():
+        return ToolResult(text=f"[error: source file not found: {source}]")
+    if resolved_src.is_dir():
+        return ToolResult(text=f"[error: source '{source}' is a directory, workspace_copy only copies files]")
+    if resolved_dst.exists():
+        return ToolResult(text=f"[error: destination already exists: {destination}]")
+    try:
+        resolved_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(resolved_src, resolved_dst)
+        invalidate_workspace_file_cache(ctx.config)
+        return f"Copied {source} -> {destination}"
+    except PermissionError as e:
+        return _file_error(e, destination)
+
+
+def tool_workspace_delete(ctx: "Context", path: str, recursive: bool = False) -> str | ToolResult:
+    """Delete a file or directory from the workspace."""
+    import shutil
+    log.info(f"[tool:workspace_delete] {path} recursive={recursive}")
     resolved = _resolve_safe(ctx.config, path)
     if resolved is None:
         return ToolResult(text=f"[error: path '{path}' is outside the workspace]")
     if not resolved.exists():
         return ToolResult(text=f"[error: file not found: {path}]")
-    if resolved.is_dir():
-        return ToolResult(text=f"[error: '{path}' is a directory. Use shell to remove directories.]")
     try:
-        resolved.unlink()
-        invalidate_workspace_file_cache(ctx.config)
-        return f"Deleted {path}"
+        if resolved.is_dir():
+            is_empty = not any(resolved.iterdir())
+            if not is_empty and not recursive:
+                return ToolResult(text=f"[error: '{path}' is a directory. Use recursive=true to remove non-empty directories, or use shell to remove directories.]")
+            if not is_empty:
+                shutil.rmtree(resolved)
+            else:
+                resolved.rmdir()
+            invalidate_workspace_file_cache(ctx.config)
+            return f"Deleted directory {path}"
+        else:
+            resolved.unlink()
+            invalidate_workspace_file_cache(ctx.config)
+            return f"Deleted {path}"
     except PermissionError as e:
         return _file_error(e, path)
 
@@ -630,6 +681,8 @@ WORKSPACE_TOOLS = {
     "workspace_search": tool_workspace_search,
     "workspace_glob": tool_workspace_glob,
     "workspace_move": tool_workspace_move,
+    "workspace_mkdir": tool_workspace_mkdir,
+    "workspace_copy": tool_workspace_copy,
     "workspace_delete": tool_workspace_delete,
     "workspace_diff": tool_workspace_diff,
 }
@@ -916,14 +969,58 @@ WORKSPACE_TOOL_DEFINITIONS = [
         "type": "function",
         "priority": "normal",
         "function": {
-            "name": "workspace_delete",
-            "description": "Delete a file from the workspace. Cannot delete directories. NEVER guess a filename if a target is described ambiguously (e.g. 'the Q1 report' with multiple matching files) — use workspace_list to check existing files or ask the user for clarification first.",
+            "name": "workspace_mkdir",
+            "description": "Create an empty directory (and its parents) in the workspace. No-op if it exists. Useful for scaffolding project layouts up front.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Relative path of the file to delete",
+                        "description": "Relative path of the directory to create",
+                    },
+                },
+                "required": ["path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "priority": "normal",
+        "function": {
+            "name": "workspace_copy",
+            "description": "Copy a file within the workspace. Fails if the destination already exists.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Current relative path of the file",
+                    },
+                    "destination": {
+                        "type": "string",
+                        "description": "New relative path for the copied file",
+                    },
+                },
+                "required": ["source", "destination"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "priority": "normal",
+        "function": {
+            "name": "workspace_delete",
+            "description": "Delete a file or directory from the workspace. By default, it will only delete files or empty directories. To delete a non-empty directory and its contents, you must set recursive to true. NEVER guess a filename if a target is described ambiguously (e.g. 'the Q1 report' with multiple matching files) — use workspace_list to check existing files or ask the user for clarification first.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path of the file or directory to delete",
+                    },
+                    "recursive": {
+                        "type": "boolean",
+                        "description": "If true, delete directory and all its contents recursively. Default is false.",
                     },
                 },
                 "required": ["path"],

--- a/tests/test_workspace_tools.py
+++ b/tests/test_workspace_tools.py
@@ -10,12 +10,14 @@ from decafclaw.tools.workspace_tools import (
     _resolve_safe,
     tool_file_share,
     tool_workspace_append,
+    tool_workspace_copy,
     tool_workspace_delete,
     tool_workspace_diff,
     tool_workspace_edit,
     tool_workspace_glob,
     tool_workspace_insert,
     tool_workspace_list,
+    tool_workspace_mkdir,
     tool_workspace_move,
     tool_workspace_preview_markdown,
     tool_workspace_read,
@@ -170,6 +172,62 @@ def test_read_large_file_with_range_not_capped(ctx):
     assert "showing first" not in _text(result).lower()
 
 
+# -- workspace_mkdir tests --
+
+
+def test_workspace_mkdir(ctx):
+    result = tool_workspace_mkdir(ctx, "new_dir/nested")
+    assert "Created directory" in _text(result)
+    assert ctx.config.workspace_path.joinpath("new_dir/nested").is_dir()
+
+def test_workspace_mkdir_exists(ctx):
+    ctx.config.workspace_path.joinpath("existing_dir").mkdir(parents=True)
+    result = tool_workspace_mkdir(ctx, "existing_dir")
+    assert "already exists" in _text(result).lower()
+
+def test_workspace_mkdir_escape_blocked(ctx):
+    result = tool_workspace_mkdir(ctx, "../../evil_dir")
+    assert "outside" in _text(result).lower()
+
+
+# -- workspace_copy tests --
+
+
+def test_workspace_copy(ctx):
+    tool_workspace_write(ctx, "src.txt", "copy me")
+    result = tool_workspace_copy(ctx, "src.txt", "dest.txt")
+    assert "Copied" in _text(result)
+    assert ctx.config.workspace_path.joinpath("src.txt").read_text() == "copy me"
+    assert ctx.config.workspace_path.joinpath("dest.txt").read_text() == "copy me"
+
+def test_workspace_copy_not_found(ctx):
+    result = tool_workspace_copy(ctx, "nope.txt", "dest.txt")
+    assert "error" in _text(result).lower()
+    assert "not found" in _text(result).lower()
+
+def test_workspace_copy_destination_exists(ctx):
+    tool_workspace_write(ctx, "src.txt", "src")
+    tool_workspace_write(ctx, "dest.txt", "dest")
+    result = tool_workspace_copy(ctx, "src.txt", "dest.txt")
+    assert "error" in _text(result).lower()
+    assert "already exists" in _text(result).lower()
+
+def test_workspace_copy_directory_blocked(ctx):
+    ctx.config.workspace_path.joinpath("srcdir").mkdir(parents=True, exist_ok=True)
+    result = tool_workspace_copy(ctx, "srcdir", "destdir")
+    assert "error" in _text(result).lower()
+    assert "is a directory" in _text(result).lower()
+
+def test_workspace_copy_escape_blocked_src(ctx):
+    result = tool_workspace_copy(ctx, "../../evil.txt", "dest.txt")
+    assert "outside" in _text(result).lower()
+
+def test_workspace_copy_escape_blocked_dst(ctx):
+    tool_workspace_write(ctx, "ok.txt", "data")
+    result = tool_workspace_copy(ctx, "ok.txt", "../../evil.txt")
+    assert "outside" in _text(result).lower()
+
+
 # -- workspace_move tests --
 
 
@@ -228,11 +286,29 @@ def test_delete_not_found(ctx):
     assert "not found" in _text(result).lower()
 
 
-def test_delete_directory_blocked(ctx):
-    ctx.config.workspace_path.joinpath("mydir").mkdir(parents=True)
-    result = tool_workspace_delete(ctx, "mydir")
+def test_workspace_delete_directory(ctx):
+    # Test deleting non-empty directory without recursive flag fails
+    dir_path = ctx.config.workspace_path.joinpath("mydir")
+    dir_path.mkdir(parents=True)
+    (dir_path / "file.txt").write_text("data")
+
+    result = tool_workspace_delete(ctx, "mydir", recursive=False)
     assert "error" in _text(result).lower()
     assert "directory" in _text(result).lower()
+    assert "recursive=true" in _text(result).lower()
+    assert dir_path.exists()
+
+    # Test deleting non-empty directory with recursive flag succeeds
+    result = tool_workspace_delete(ctx, "mydir", recursive=True)
+    assert "Deleted directory" in _text(result)
+    assert not dir_path.exists()
+
+def test_delete_empty_directory_succeeds(ctx):
+    dir_path = ctx.config.workspace_path.joinpath("emptydir")
+    dir_path.mkdir(parents=True)
+    result = tool_workspace_delete(ctx, "emptydir", recursive=False)
+    assert "Deleted directory" in _text(result)
+    assert not dir_path.exists()
 
 
 def test_delete_escape_blocked(ctx):


### PR DESCRIPTION
## Summary
- Added `workspace_mkdir` and `workspace_copy` tools to manage directories.
- Extended `workspace_delete` to safely handle non-empty directories via the `recursive` flag.
- Added "Workspace organization" guidance to `AGENT.md` to recommend better filesystem usage.
- Why: The agent workspace accumulates clutter and lacks tools to construct directories or manage them directly without falling back to shell.

## Design Decisions
- `workspace_mkdir` will create parent directories seamlessly and is a no-op if the directory already exists.
- `workspace_delete` will refuse to delete non-empty directories without `recursive: true` set.

## Acceptance criteria
| id | criterion | check | result |
|---|---|---|---|
| C1 | `workspace_mkdir` creates directories correctly | `pytest tests/test_workspace_tools.py::test_workspace_mkdir` | pass |
| C2 | `workspace_copy` copies files correctly | `pytest tests/test_workspace_tools.py::test_workspace_copy` | pass |
| C3 | `workspace_delete` handles directories via `recursive` | `pytest tests/test_workspace_tools.py::test_workspace_delete_directory` | pass |

## Merge gate

```yaml
tier: auto-ok
checks: C1 pass · C2 pass · C3 pass
guards: none
tamper: clean-by-substitute — small tactical task skipped freeze ceremony, manifest integrity checks matched
freeze: none
project-gates: make check green (Python only)
ci: pending
threads: no review yet
risk-paths: none
amendments: none
verdict: pending
```

## References
- Closes #281
